### PR TITLE
[68560] Fix parent dates not updated when updating dates on child with automatically generated subject

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -83,6 +83,12 @@ class ApplicationRecord < ActiveRecord::Base
     ActiveRecord::Base.connection.select_value(union_query)
   end
 
+  # Returns all the attribute names as symbols.
+  # @return [Array<Symbol>]
+  def attribute_keys
+    attribute_names.map(&:to_sym)
+  end
+
   # Returns the keys of the attributes that have been changed.
   # @return [Array<Symbol>]
   def changed_attribute_keys

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -82,4 +82,16 @@ class ApplicationRecord < ActiveRecord::Base
 
     ActiveRecord::Base.connection.select_value(union_query)
   end
+
+  # Returns the keys of the attributes that have been changed.
+  # @return [Array<Symbol>]
+  def changed_attribute_keys
+    changes.keys.map(&:to_sym)
+  end
+
+  # Returns the keys of the attributes that have been changed before the last save.
+  # @return [Array<Symbol>]
+  def changed_attribute_keys_before_last_save
+    previous_changes.keys.map(&:to_sym)
+  end
 end

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -64,7 +64,7 @@ class WorkPackages::CreateService < BaseServices::BaseCallable
 
     if result.success?
       # update ancestors before rescheduling, as the parent might switch to automatic mode
-      update_ancestors_all_attributes(result.all_results).each do |ancestor_result|
+      multi_update_ancestors(result.all_results).each do |ancestor_result|
         result.merge!(ancestor_result)
       end
 

--- a/app/services/work_packages/delete_service.rb
+++ b/app/services/work_packages/delete_service.rb
@@ -74,13 +74,8 @@ class WorkPackages::DeleteService < BaseServices::Delete
     # There is an issue there: the parent can be saved twice: once for the
     # rescheduling and once for the ancestor update. Ideally, it should be
     # saved only once.
-    result_of_reschedule = reschedule_related(deleted_work_package, successors)
-    result.merge!(result_of_reschedule)
-
-    results_of_update_ancestors = update_ancestors_all_attributes([deleted_work_package])
-    results_of_update_ancestors.each do |ancestor_result|
-      result.merge!(ancestor_result)
-    end
+    result.merge!(reschedule_related(deleted_work_package, successors))
+    result.merge!(update_ancestors(deleted_work_package))
   end
 
   def reschedule_related(deleted_work_package, successors)

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -299,9 +299,16 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
     # Better return and keep dates unified to have only one meaningful error.
     return if work_package_now_milestone?
 
-    # do a reschedule call to get the work package dates from the rescheduled children
+    # do a reschedule call to get the work package dates from the (potentially)
+    # rescheduled children.
+    #
+    # This happens for instance when a work package with a child gets a new
+    # parent having a predecessor. If the child is in automatic mode, it could
+    # be forced to move to a date after the grandparent's predecessor, forcing
+    # the parent to also move to the same dates. These dates are known only
+    # after the child is properly rescheduled.
     service = WorkPackages::SetScheduleService.new(user: User.current, work_package:, switching_to_automatic_mode: [work_package])
-    service.call(work_package.changes.keys.map(&:to_sym)).result
+    service.call(work_package.changed_attribute_keys).result
   end
 
   def update_dates_from_self

--- a/app/services/work_packages/shared/update_ancestors.rb
+++ b/app/services/work_packages/shared/update_ancestors.rb
@@ -31,44 +31,41 @@
 module WorkPackages
   module Shared
     module UpdateAncestors
-      def update_ancestors(changed_work_packages, changes = nil)
-        changes ||= changed_work_packages
-                  .map { |wp| wp.previous_changes.keys }
-                  .flatten
-                  .uniq
-                  .map(&:to_sym)
-
-        update_each_ancestor(changed_work_packages, changes)
-      end
-
-      def update_ancestors_all_attributes(work_packages)
-        changes = work_packages
-                  .first
-                  .attributes
-                  .keys
-                  .uniq
-                  .map(&:to_sym)
-
-        update_each_ancestor(work_packages, changes)
-      end
-
-      def update_each_ancestor(work_packages, changes)
-        updated_work_package_ids = Set.new
-        work_packages.filter_map do |wp|
-          next if updated_work_package_ids.include?(wp.id)
-
-          result = inherit_to_ancestors(wp, changes)
-          updated_work_package_ids = updated_work_package_ids.merge(result.all_results.map(&:id))
-          result
-        end
-      end
-
-      def inherit_to_ancestors(wp, changes)
+      # Update ancestors for the given work package according to the given
+      # changed attributes.
+      #
+      # @param work_package [WorkPackage] the work package to update the
+      #   ancestors of
+      # @param changed_attributes [Array<Symbol>] the attributes that have been
+      #   changed on the work package. If nil, all the attributes of the work
+      #   package will be used.
+      # @return [ServiceResult] the result of the `UpdateAncestorsService` call
+      def update_ancestors(work_package, changed_attributes = nil)
+        changed_attributes ||= work_package.attribute_keys
         WorkPackages::UpdateAncestorsService
-          .new(user:,
-               work_package: wp)
+          .new(user:, work_package:)
           .with_state(state)
-          .call(changes)
+          .call(changed_attributes)
+      end
+
+      # Update ancestors for multiple work packages, taking care of not updating
+      # the same work package twice.
+      # Always calls `UpdateAncestorsService` with changed attributes being all
+      # attributes.
+      #
+      # @param work_packages [Array<WorkPackage>] the work packages to update
+      #   the ancestors of
+      # @return [Array<ServiceResult>] the results of the
+      #   `UpdateAncestorsService` calls
+      def multi_update_ancestors(work_packages)
+        updated_work_package_ids = Set.new
+        work_packages.filter_map do |work_package|
+          next if updated_work_package_ids.include?(work_package.id)
+
+          update_ancestors(work_package).tap do |result|
+            updated_work_package_ids.merge(result.all_results.map(&:id))
+          end
+        end
       end
     end
   end

--- a/app/services/work_packages/shared/update_ancestors.rb
+++ b/app/services/work_packages/shared/update_ancestors.rb
@@ -31,8 +31,8 @@
 module WorkPackages
   module Shared
     module UpdateAncestors
-      def update_ancestors(changed_work_packages)
-        changes = changed_work_packages
+      def update_ancestors(changed_work_packages, changes = nil)
+        changes ||= changed_work_packages
                   .map { |wp| wp.previous_changes.keys }
                   .flatten
                   .uniq

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -68,10 +68,17 @@ class WorkPackages::UpdateAncestorsService < BaseServices::BaseCallable
     WorkPackages::UpdateAncestors::Loader
       .new(initiator_work_package, include_former_ancestors)
       .select do |ancestor, loader|
-        derive_attributes(ancestor, loader, attributes)
-
-        ancestor.changed?
+        changes?(ancestor) do
+          derive_attributes(ancestor, loader, attributes)
+        end
       end
+  end
+
+  def changes?(work_package)
+    changes_before = work_package.changes
+    yield
+    changes_after = work_package.changes
+    changes_before != changes_after
   end
 
   def save_updated_work_packages(updated_work_packages)

--- a/app/services/work_packages/update_ancestors_service.rb
+++ b/app/services/work_packages/update_ancestors_service.rb
@@ -68,9 +68,9 @@ class WorkPackages::UpdateAncestorsService < BaseServices::BaseCallable
     WorkPackages::UpdateAncestors::Loader
       .new(initiator_work_package, include_former_ancestors)
       .select do |ancestor, loader|
-        changes?(ancestor) do
-          derive_attributes(ancestor, loader, attributes)
-        end
+        derive_attributes(ancestor, loader, attributes)
+
+        ancestor.changed?
       end
   end
 

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -62,7 +62,7 @@ class WorkPackages::UpdateService < BaseServices::Update
   def update_related_work_packages(service_call)
     work_package = service_call.result
     changed_attributes = work_package.changed_attribute_keys_before_last_save
-    update_ancestors([work_package], changed_attributes).each do |ancestor_service_call|
+    update_ancestors(work_package, changed_attributes).tap do |ancestor_service_call|
       ancestor_service_call.dependent_results.each do |ancestor_dependent_service_call|
         service_call.add_dependent!(ancestor_dependent_service_call)
       end

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -42,6 +42,10 @@ class WorkPackages::UpdateService < BaseServices::Update
   private
 
   def set_templated_attributes
+    # TODO: code smell here: saving the automatically generated subject depends
+    # on running the UpdateAncestorsService right after. The subject gets saved
+    # only thanks to this. If the UpdateAncestorsService is not run, the subject
+    # is not saved. That's an odd coupling.
     model.type.enabled_patterns.each do |key, pattern|
       model.public_send(:"#{key}=", pattern.resolve(model))
     end
@@ -56,19 +60,24 @@ class WorkPackages::UpdateService < BaseServices::Update
   end
 
   def update_related_work_packages(service_call)
-    update_ancestors([service_call.result]).each do |ancestor_service_call|
+    work_package = service_call.result
+    changed_attributes = work_package.changed_attribute_keys_before_last_save
+    update_ancestors([work_package], changed_attributes).each do |ancestor_service_call|
       ancestor_service_call.dependent_results.each do |ancestor_dependent_service_call|
         service_call.add_dependent!(ancestor_dependent_service_call)
       end
     end
 
-    update_related(service_call.result).each do |related_service_call|
+    # update saved changes as they might have changed due to the ancestors updates
+    changed_attributes += work_package.changed_attribute_keys_before_last_save
+    changed_attributes.uniq!
+    update_related(work_package, changed_attributes).each do |related_service_call|
       service_call.add_dependent!(related_service_call)
     end
   end
 
-  def update_related(work_package)
-    consolidated_calls(update_descendants(work_package) + reschedule_related(work_package))
+  def update_related(work_package, changed_attributes)
+    consolidated_calls(update_descendants(work_package) + reschedule_related(work_package, changed_attributes))
       .each { |dependent_call| dependent_call.result.save(validate: false) }
   end
 
@@ -128,7 +137,7 @@ class WorkPackages::UpdateService < BaseServices::Update
     work_package.reset_custom_values!
   end
 
-  def reschedule_related(work_package)
+  def reschedule_related(work_package, changed_attributes)
     work_packages_to_reschedule = [work_package]
 
     # if parent changed, the former parent needs to be rescheduled too.
@@ -139,7 +148,7 @@ class WorkPackages::UpdateService < BaseServices::Update
 
     WorkPackages::SetScheduleService
       .new(user:, work_package: work_packages_to_reschedule, initiated_by: cause_of_rescheduling)
-      .call(work_package.saved_changes.keys.map(&:to_sym))
+      .call(changed_attributes)
       .dependent_results
   end
 

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -609,10 +609,10 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
   end
 
   describe "remaining work propagation" do
-    shared_let(:parent) { create(:work_package, subject: "parent") }
-    shared_let(:child) { create(:work_package, subject: "child", parent:) }
-
     context "when setting remaining work of a work package having children without any remaining work value" do
+      shared_let(:parent) { create(:work_package, subject: "parent") }
+      shared_let(:child) { create(:work_package, subject: "child", parent:) }
+
       before do
         parent.remaining_hours = 2.0
       end
@@ -705,8 +705,6 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
   end
 
   describe "% complete propagation" do
-    shared_let(:parent) { create(:work_package, subject: "parent") }
-
     context "given child with work, when remaining work being set on parent" do
       let_work_packages(<<~TABLE)
         hierarchy | work | total work | remaining work | total remaining work

--- a/spec/services/work_packages/update_ancestors_service_spec.rb
+++ b/spec/services/work_packages/update_ancestors_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe WorkPackages::UpdateAncestorsService,
   end
 
   def call_update_ancestors_service(work_package)
-    changed_attributes = work_package.changes.keys.map(&:to_sym)
+    changed_attributes = work_package.changed_attribute_keys
     described_class.new(user:, work_package:)
                     .call(changed_attributes)
   end

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1177,7 +1177,6 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       end
     end
 
-    # TODO: TODO: TODO: write the same test, but with automatically generated subjects
     context "when the work package is automatically scheduled, has a child and no dates" do
       let_work_packages(<<~TABLE)
         hierarchy              | MTWTFSS        | scheduling mode | predecessors
@@ -1200,6 +1199,38 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
           new_parent             |   X     | automatic
           work_package           |   X     | automatic
           child                  |   [     | automatic
+        TABLE
+      end
+    end
+
+    context "with work packages having automatically generated subjects, " \
+            "when the work package is automatically scheduled, has a child and no dates" do
+      before_all do
+        set_factory_default(:type, autosubject_type)
+      end
+
+      let_work_packages(<<~TABLE)
+        hierarchy              | MTWTFSS        | scheduling mode | predecessors
+        new_parent_predecessor | XXXX           | manual          |
+        new_parent             |     XXXX       | automatic       | new_parent_predecessor
+        work_package           |                | automatic       |
+          child                |                | automatic       | child_predecessor
+        child_predecessor      |                | manual          |
+      TABLE
+      let(:attributes) { { parent: new_parent } }
+
+      it "sets child start date to be soonest start (after new grandparent predecessor), " \
+         "and grandparent and work package start and due dates to be same as child start date" do
+        expect(subject).to be_success
+        expect(work_package.reload.parent).to eq new_parent
+        expect(subject.all_results.map(&:id)).to contain_exactly(child.id, work_package.id, new_parent.id)
+
+        expect_work_packages(subject.all_results + [new_parent_predecessor], <<~TABLE)
+          identifier             | MTWTFSS | scheduling mode
+          new_parent_predecessor | XXXX      | manual
+          new_parent             |     X     | automatic
+          work_package           |     X     | automatic
+          child                  |     [     | automatic
         TABLE
       end
     end

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -33,7 +33,11 @@ require "spec_helper"
 RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
   shared_let(:type) { create(:type_standard) }
   shared_let(:milestone_type) { create(:type_milestone) }
-  shared_let(:project_types) { [type, milestone_type] }
+  shared_let(:autosubject_type) do
+    create(:type, name: "Autosubject",
+                  patterns: { subject: { blueprint: "\#{{id}} by {{author}} - {{status}}", enabled: true } })
+  end
+  shared_let(:project_types) { [type, milestone_type, autosubject_type] }
   shared_let(:project) do
     create(:project, types: project_types)
   end
@@ -1173,6 +1177,7 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
       end
     end
 
+    # TODO: TODO: TODO: write the same test, but with automatically generated subjects
     context "when the work package is automatically scheduled, has a child and no dates" do
       let_work_packages(<<~TABLE)
         hierarchy              | MTWTFSS        | scheduling mode | predecessors
@@ -1227,14 +1232,8 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
     end
 
     context "with work packages having automatically generated subjects" do
-      shared_let(:type_autosubject) do
-        create(:type,
-               name: "Autosubject",
-               patterns: { subject: { blueprint: "{{author}} {{start_date}} - {{finish_date}}", enabled: true } })
-      end
-
       before_all do
-        set_factory_default(:type, type_autosubject)
+        set_factory_default(:type, autosubject_type)
       end
 
       let_work_packages(<<~TABLE)
@@ -1708,6 +1707,25 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
           work_package   |    XXX  | manual
         TABLE
       end
+    end
+  end
+
+  context "with work packages having automatically generated subjects" do
+    before_all do
+      set_factory_default(:type, autosubject_type)
+    end
+
+    shared_let(:work_package, reload: true) { create(:work_package, type: autosubject_type) }
+    let(:attributes) { { description: "new description" } }
+
+    it "updates the subject along with the requested updates" do
+      expect(subject).to be_success
+      expect(subject.result).to eq(work_package)
+
+      expect(work_package.reload).to have_attributes(
+        description: "new description",
+        subject: "##{work_package.id} by #{user.name} - #{default_status.name}"
+      )
     end
   end
 

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -1225,6 +1225,39 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
         TABLE
       end
     end
+
+    context "with work packages having automatically generated subjects" do
+      shared_let(:type_autosubject) do
+        create(:type,
+               name: "Autosubject",
+               patterns: { subject: { blueprint: "{{author}} {{start_date}} - {{finish_date}}", enabled: true } })
+      end
+
+      before_all do
+        set_factory_default(:type, type_autosubject)
+      end
+
+      let_work_packages(<<~TABLE)
+        | hierarchy      | MTWTFSS | scheduling mode
+        | parent         | XXX     | automatic
+        |   child        | XX      | manual
+        |   work_package |   X     | manual
+      TABLE
+
+      let(:attributes) { { start_date: _table.thursday, due_date: _table.friday } }
+
+      it "updates the dates of the parent" do
+        expect(subject).to be_success
+        expect(subject.all_results.pluck(:id)).to contain_exactly(work_package.id, parent.id)
+
+        expect_work_packages_after_reload([parent, child, work_package], <<~TABLE)
+          | identifier     | MTWTFSS | scheduling mode
+          | parent         | XXXXX   | automatic
+          |   child        | XX      | manual
+          |   work_package |    XX   | manual
+        TABLE
+      end
+    end
   end
 
   context "when switching scheduling mode to automatic" do

--- a/spec/support/table_helpers/column.rb
+++ b/spec/support/table_helpers/column.rb
@@ -34,6 +34,7 @@ require_relative "column_type/with_identifier_metadata"
 require_relative "column_type/days_counting"
 require_relative "column_type/duration"
 require_relative "column_type/hierarchy"
+require_relative "column_type/identifier"
 require_relative "column_type/percentage"
 require_relative "column_type/predecessor_relations"
 require_relative "column_type/related_to_relations"
@@ -56,6 +57,7 @@ module TableHelpers
       derived_done_ratio: ColumnType::Percentage,
       hierarchy: ColumnType::Hierarchy,
       ignore_non_working_days: ColumnType::DaysCounting,
+      identifier: ColumnType::Identifier,
       predecessor_relations: ColumnType::PredecessorRelations,
       related_to_relations: ColumnType::RelatedToRelations,
       schedule: ColumnType::Schedule,
@@ -106,7 +108,7 @@ module TableHelpers
         :successor_relations
       when /\s*relate[ds][ _]to\s*/
         :related_to_relations
-      when /status/, /hierarchy/
+      when /status/, /hierarchy/, /identifier/
         to_identifier(header)
       else
         attribute = to_identifier(header)

--- a/spec/support/table_helpers/column_type/identifier.rb
+++ b/spec/support/table_helpers/column_type/identifier.rb
@@ -28,28 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "spec_helper"
+module TableHelpers
+  module ColumnType
+    class Identifier < Generic
+      include WithIdentifierMetadata
 
-module TableHelpers::ColumnType
-  RSpec.describe Subject do
-    subject(:column_type) { described_class.new }
-
-    describe "#extract_data" do
-      it "extracts the identifier metadata along with the :subject attribute value" do
-        attribute = :subject
-        raw_header = "subject   "
-        work_packages_data =
-          [
-            {
-              index: 0,
-              row: { raw_header => "  Work package 2  " }
-            }
-          ]
-        work_package_data = work_packages_data.first
-
-        expect(column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data))
-          .to eq({ attributes: { subject: "Work package 2" },
-                   identifier: :work_package2 })
+      def attributes_for_raw_value(*)
+        {}
       end
     end
   end

--- a/spec/support/table_helpers/table_data.rb
+++ b/spec/support/table_helpers/table_data.rb
@@ -46,7 +46,7 @@ module TableHelpers
           attrs.merge!(column.attributes_for_work_package(work_package))
         end
         row = columns.to_h { [it.title, nil] }
-        identifier = to_identifier(work_package.subject)
+        identifier = Registry.find_identifier(work_package) || to_identifier(work_package.subject)
         {
           attributes:,
           row:,
@@ -82,6 +82,7 @@ module TableHelpers
 
     def create_work_packages
       work_packages_by_identifier, relations = Factory.new(self).create
+      Registry.store(work_packages_by_identifier)
       Table.new(work_packages_by_identifier, relations)
     end
 
@@ -129,6 +130,24 @@ module TableHelpers
         identifiers_ordered_like(other_table, identifier, acc)
       end
       acc
+    end
+
+    class Registry
+      class << self
+        def store(work_packages_by_identifier)
+          work_packages_by_identifier.each do |identifier, work_package|
+            identifiers_by_work_package_id[work_package.id] = identifier
+          end
+        end
+
+        def find_identifier(work_package)
+          identifiers_by_work_package_id[work_package.id]
+        end
+
+        def identifiers_by_work_package_id
+          @identifiers_by_work_package_id ||= {}
+        end
+      end
     end
 
     class Factory

--- a/spec/support/table_helpers/table_representer.rb
+++ b/spec/support/table_helpers/table_representer.rb
@@ -63,19 +63,20 @@ module TableHelpers
     end
 
     def get_values(column, table_data)
-      if column.attribute == :schedule
+      case column.attribute
+      when :schedule
         start_dates = table_data.values_for_attribute(:start_date)
         due_dates = table_data.values_for_attribute(:due_date)
         ignore_non_working_days_values = ignore_non_working_days_values(table_data)
         start_dates.zip(due_dates, ignore_non_working_days_values).map do |start_date, due_date, ignore_non_working_days|
           schedule_column_representer.span(start_date, due_date, ignore_non_working_days)
         end
-      elsif column.attribute == :hierarchy
+      when :hierarchy
         table_data
           .values_for_attribute(:subject)
           .zip(get_hierarchy_levels(table_data))
           .map! { |subject, level| column.format("#{'  ' * level}#{subject}") }
-      elsif column.attribute == :identifier
+      when :identifier
         table_data.work_package_identifiers
           .map! { |identifier| column.format(identifier) }
       else

--- a/spec/support/table_helpers/table_representer.rb
+++ b/spec/support/table_helpers/table_representer.rb
@@ -75,6 +75,9 @@ module TableHelpers
           .values_for_attribute(:subject)
           .zip(get_hierarchy_levels(table_data))
           .map! { |subject, level| column.format("#{'  ' * level}#{subject}") }
+      elsif column.attribute == :identifier
+        table_data.work_package_identifiers
+          .map! { |identifier| column.format(identifier) }
       else
         table_data
           .values_for_attribute(column.attribute)

--- a/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/hierarchy_spec.rb
@@ -36,31 +36,31 @@ module TableHelpers::ColumnType
 
     describe "#extract_data" do
       let(:attribute) { :hierarchy }
-      let(:subject_raw_header) { "Hierarchy    " }
+      let(:raw_header) { "Hierarchy    " }
       let(:work_packages_data) do
         [
           {
             index: 0,
-            row: { subject_raw_header => "Parent        " }
+            row: { raw_header => "Parent        " }
           },
           {
             index: 1,
-            row: { subject_raw_header => "  Child1      " }
+            row: { raw_header => "  Child1      " }
           },
           {
             index: 2,
-            row: { subject_raw_header => "  Child2      " }
+            row: { raw_header => "  Child2      " }
           },
           {
             index: 3,
-            row: { subject_raw_header => "     Grand Child" }
+            row: { raw_header => "     Grand Child" }
           }
         ]
       end
 
       it "extracts the identifier metadata along with the :subject attribute value" do
         # check first row only
-        expect(column_type.extract_data(attribute, subject_raw_header, work_packages_data.first, work_packages_data))
+        expect(column_type.extract_data(attribute, raw_header, work_packages_data.first, work_packages_data))
           .to include({ attributes: a_hash_including(subject: "Parent"),
                         identifier: :parent })
       end
@@ -69,14 +69,14 @@ module TableHelpers::ColumnType
          "and the :parent attribute value holding the identifier of the parent from previous rows" do
         # first row
         work_package_data = work_packages_data.first
-        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        row_extract = column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data)
         expect(row_extract).to include({ attributes: a_hash_including(parent: nil),
                                          hierarchy_indent: 0 })
 
         # second row
         work_package_data.deep_merge!(row_extract)
         work_package_data = work_packages_data.second
-        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        row_extract = column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data)
         expect(row_extract).to include({ attributes: a_hash_including(parent: :parent),
                                          hierarchy_indent: 2,
                                          identifier: :child1 })
@@ -84,7 +84,7 @@ module TableHelpers::ColumnType
         # third row
         work_package_data.deep_merge!(row_extract)
         work_package_data = work_packages_data.third
-        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        row_extract = column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data)
         expect(row_extract).to include({ attributes: a_hash_including(parent: :parent),
                                          hierarchy_indent: 2,
                                          identifier: :child2 })
@@ -92,7 +92,7 @@ module TableHelpers::ColumnType
         # fourth row
         work_package_data.deep_merge!(row_extract)
         work_package_data = work_packages_data.fourth
-        row_extract = column_type.extract_data(attribute, subject_raw_header, work_package_data, work_packages_data)
+        row_extract = column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data)
         expect(row_extract).to include({ attributes: a_hash_including(parent: :child2),
                                          hierarchy_indent: 5,
                                          identifier: :grand_child })

--- a/spec/support_spec/table_helpers/column_type/identifier_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/identifier_spec.rb
@@ -31,25 +31,25 @@
 require "spec_helper"
 
 module TableHelpers::ColumnType
-  RSpec.describe Subject do
+  RSpec.describe Identifier do
     subject(:column_type) { described_class.new }
 
     describe "#extract_data" do
-      it "extracts the identifier metadata along with the :subject attribute value" do
-        attribute = :subject
-        raw_header = "subject   "
+      it "extracts the identifier metadata without any attributes" do
+        attribute = :identifier
+        raw_header = "  identifier       "
         work_packages_data =
           [
             {
               index: 0,
-              row: { raw_header => "  Work package 2  " }
+              row: { raw_header => "  work_package_42  " }
             }
           ]
         work_package_data = work_packages_data.first
 
         expect(column_type.extract_data(attribute, raw_header, work_package_data, work_packages_data))
-          .to eq({ attributes: { subject: "Work package 2" },
-                   identifier: :work_package2 })
+          .to eq({ attributes: {},
+                   identifier: :work_package42 })
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68560

# What are you trying to accomplish?

Fix the following bug: if a work package has a type with automatically generated subject, updating its dates won't reschedule its ancestors and successors.

# What approach did you choose and why?

The problem was that the `WorkPackages::UpdateService` updates the related work packages in two phases:

- First it updates the ancestors, including itself. This updates work, remaining work, percent complete, switching to automatic mode, and ignore non-working days attributes.

- Second, if there are changes to dates, it updates the work packages to reschedule: the ancestors and successors. This updates the start date, finish date, and duration attributes.

This means that if something is changed in the first phase, the initiating work package will be saved and there will be no changes left to detect that a rescheduling of ancestors is needed too.

When having work packages with automatically generated subjects, that's what happens: the subject is always updated to a placeholder text ("Automatically generated through type <type name>"), leading to the `UpdateAncestorsService` always detecting a change and so always saving it. This inhibits the rescheduling of ancestors because there are no changes in the initiator work package.

~The fix is to have a stricter change detection in the `UpdateAncestorsService` to avoid saving if nothing was changed by the service itself.~

~⚠️ It's probable that modifying some attributes along with dates could lead to the same problem. For instance modifying both work (estimated hours) and dates at the same time using the REST API will probably not reschedule ancestors and successors. As long it's not attributes touched by the `UpdateAncestorsService`, it should work properly.~

Fix was not working properly because automatically generated subjects rely on `UpdateAncestorsService` to be saved.

New fix is to consider both changes from `UpdateService` and `UpdateAncestorsService` when calling `SetScheduleService`.

BTW I'm not found of this two phase approach, but the rescheduling needs some information to be saved in database so that the rescheduling can work properly. Changing that would need a bigger refactoring.

That seems correlated to [Bug 61758: Duplicated journal entries when updating attributes of related work package](https://community.openproject.org/projects/stream-planning-and-reporting/work_packages/61758) and it's possible that fixing that bug will fix the 2-phase issue.

### automatically generated subject integration test

An integration test was added to be able to detect side-effects where it's not saved. This was missing.

### Changes in the table helpers

As the subject is automatically generated in the related integration test, the subject can't be used to find the work packages having been created. So I added the ability to use only the identifier in the assertion: the ids of the work packages created during the setup phase are saved along with the identifier having been used, so that when later retrieving the work package to checking their attributes, they can be referenced by the identifier used when creating them instead of the subject (which has been automatically updated as soon as it was saved).

This was necessary to write a test in `spec/services/work_packages/update_service_integration_spec.rb` using the table helpers.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
