### PR TITLE
Bug/68520 no feedback or redirect to the index page after deleting a document

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -81,12 +81,14 @@ export default class FiltersFormController extends Controller {
     outputFormat: { type: String, default: 'params' },
     performTurboRequests: { type: Boolean, default: false },
     clearButtonId: String,
+    urlPathName: String,
   };
 
   declare displayFiltersValue:boolean;
   declare outputFormatValue:string;
   declare performTurboRequestsValue:boolean;
   declare readonly clearButtonIdValue:string;
+  declare urlPathNameValue:string;
 
   private boundListener = this.sendForm.bind(this);
 
@@ -338,7 +340,8 @@ export default class FiltersFormController extends Controller {
     const ajaxIndicator = document.querySelector('#ajax-indicator') as HTMLElement;
     ajaxIndicator.style.display = '';
 
-    const url = `${window.location.pathname}?${params.toString()}`;
+    const pathName = this.urlPathNameValue || window.location.pathname;
+    const url = `${pathName}?${params.toString()}`;
 
     if (this.performTurboRequestsValue) {
       fetch(url, {

--- a/modules/documents/app/components/documents/sub_header_component.rb
+++ b/modules/documents/app/components/documents/sub_header_component.rb
@@ -45,6 +45,7 @@ module Documents
       {
         controller: "filter--filters-form",
         "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-url-path-name-value": search_project_documents_path(project),
         "filter--filters-form-output-format-value": "json",
         "filter--filters-form-clear-button-id-value": clear_button_id,
         test_selector: "documents-sub-header"

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -36,27 +36,24 @@ class DocumentsController < ApplicationController
   default_search_scope :documents
   model_object Document
 
-  before_action :find_project_by_project_id, only: %i[index new create]
-  before_action :find_model_object, except: %i[index new create]
-  before_action :find_project_from_association, except: %i[index new create]
+  before_action :find_project_by_project_id, only: %i[index search new create]
+  before_action :find_model_object, except: %i[index search new create]
+  before_action :find_project_from_association, except: %i[index search new create]
   before_action :authorize
 
-  def index # rubocop:disable Metrics/AbcSize
+  def index
     @documents = list_documents_query
       .includes(:category)
       .paginate(page: page_param, per_page: per_page_param)
+  end
 
-    respond_to do |format|
-      format.html { render }
+  def search
+    index
+    replace_via_turbo_stream component: Documents::ListComponent.new(@documents, project: @project)
+    current_url = url_for(params.permit(:controller, :filters, :sortBy).merge(action: "index"))
+    turbo_streams << turbo_stream.push_state(current_url)
 
-      format.turbo_stream do
-        replace_via_turbo_stream component: Documents::ListComponent.new(@documents, project: @project)
-        current_url = url_for(params.permit(:controller, :action, :filters, :sortBy))
-        turbo_streams << turbo_stream.push_state(current_url)
-
-        render turbo_stream: turbo_streams
-      end
-    end
+    respond_with_turbo_streams
   end
 
   def show

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -30,6 +30,7 @@
 
 class DocumentsController < ApplicationController
   include AttachableServiceCall
+  include FlashMessagesOutputSafetyHelper
   include PaginationHelper
   include OpTurbo::ComponentStream
 
@@ -99,8 +100,13 @@ class DocumentsController < ApplicationController
   end
 
   def destroy
-    @document.destroy
-    redirect_to controller: "/documents", action: "index", project_id: @project, status: :see_other
+    if @document.destroy
+      flash[:notice] = I18n.t(:notice_successful_delete)
+    else
+      flash[:error] = join_flash_messages(@document.errors.full_messages)
+    end
+
+    redirect_to project_documents_path(@project), status: :see_other
   end
 
   private

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     resources :documents, only: %i[create new index] do
       collection do
         get :menu, to: "documents/menus#show"
+        get :search
       end
     end
   end

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -53,7 +53,7 @@ module OpenProject::Documents
 
       project_module :documents do |_map|
         permission :view_documents,
-                   { documents: %i[index show download],
+                   { documents: %i[index search show download],
                      "documents/menus": %i[show] },
                    permissible_on: :project
         permission :manage_documents,

--- a/modules/documents/spec/features/documents/project/delete_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/delete_document_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+require_relative "support/documents_index_page"
+
+RSpec.describe "Delete Document",
+               :js,
+               :selenium do
+  shared_let(:project) { create(:project) }
+  shared_let(:member_role_read_only) { create(:existing_project_role, permissions: [:view_documents]) }
+  shared_let(:member_role_manage) { create(:existing_project_role, permissions: %i[view_documents manage_documents]) }
+  shared_let(:member) { create(:user, member_with_roles: { project => member_role_read_only }) }
+  shared_let(:manager) { create(:user, member_with_roles: { project => member_role_manage }) }
+  shared_let(:documents) { create_list(:document, 3, project:) }
+
+  let(:index_page) { Documents::Pages::ListPage.new(project) }
+  let(:delete_candidate) { documents.first }
+
+  context "with documents manager role" do
+    current_user { manager }
+
+    it "allows deleting documents" do
+      index_page.visit!
+
+      index_page.expect_documents_listed(documents)
+
+      click_on delete_candidate.title
+      expect(page).to have_current_path(document_path(delete_candidate))
+      accept_alert { click_on "Delete" }
+
+      expect(page).to have_content("Successful deletion.")
+      expect(page).to have_current_path(project_documents_path(project))
+      index_page.expect_documents_listed(documents.drop(1))
+    end
+
+    context "when deletion fails" do
+      before do
+        allow_any_instance_of(Document).to receive(:destroy).and_return(false) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Document).to receive_message_chain(:errors, :full_messages) # rubocop:disable RSpec/AnyInstance, RSpec/MessageChain
+          .and_return(["Deletion failed due to some error"])
+      end
+
+      it "shows an error message" do
+        index_page.visit!
+
+        index_page.expect_documents_listed(documents)
+
+        click_on delete_candidate.title
+        expect(page).to have_current_path(document_path(delete_candidate))
+        accept_alert { click_on "Delete" }
+
+        expect(page).to have_content("Deletion failed due to some error")
+        expect(page).to have_current_path(project_documents_path(project))
+      end
+    end
+  end
+
+  context "without manage documents permission" do
+    current_user { member }
+
+    it "does not allow deleting documents" do
+      index_page.visit!
+
+      index_page.expect_documents_listed(documents)
+      click_on delete_candidate.title
+
+      expect(page).to have_current_path(document_path(delete_candidate))
+      expect(page).to have_no_button("Delete")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/68520

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Fix (broken) documents delete flow

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->


https://github.com/user-attachments/assets/4fa92052-7fa9-4705-ba28-400ae91e3295



# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

I had to break apart the search functionality from the index action such the index action only responds to "html"- this is due to `turbo_method: :delete` forcing turbo stream requests which would break the redirect flow, after delete.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
