### PR TITLE
document 'required' on custom fields

### DIFF
--- a/docs/system-admin-guide/custom-fields/README.md
+++ b/docs/system-admin-guide/custom-fields/README.md
@@ -103,18 +103,18 @@ Once you have specified all items for the hierarchy custom field, you need to:
 1. [Activate this custom field for projects under the *Projects* tab](#add-a-custom-field-to-one-or-multiple-projects)
 2. [Assign a custom field to a work package type](../manage-work-packages/work-package-types/#work-package-form-configuration-enterprise-add-on) 
 
-## 'required' custom fields
+## 'Required' custom fields
 
-Custom fields can be configured as 'required'. As the name suggests, 'required' custom fields need to be filled out when a resource like a work package or a project is created. Without the user filling in a field, the user will be prevented from creating the resource.
+Custom fields can be configured as 'required'. As the name suggests, 'required' custom fields need to be filled out when a resource like a work package or a project is created. Without filling in a field, the user will be prevented from creating the resource.
 
-The 'required' flag can also be set on existing custom fields. That poses a problem for resources that existed before the flag was switched to being required. E.g. a work package might have already been created and worked with for some time. But because the field was not required before, it might not have been filled in. Once the custom field becomes 'required', the next user wanting to modify the work package needs to fill in the field. There are other scenarios where this might be necessary, among which are the activation of a required custom field for a project or a work package type.
+The 'required' flag can also be set on existing custom fields. This might lead to a problem for resources that existed before the flag was later set to required. For example, a work package might have already been created and worked with for some time. But because the field was not required before, it might not have been filled in. Once the custom field becomes 'required', the next user wanting to modify the work package *needs* to fill in the field. There are other scenarios where this might occur, for example, when the activation of a required custom field for a project or a work package type. 
 
-In the above scenario of a required custom field being absent on existing resources, OpenProject will try to minimize the times in which users are blocked from performing their intended action. A user might want to change the name of the project with no value filled in for a required custom field. Since the UI for changing the name does not display the custom fields, the user cannot provide a value at this place and OpenProject will not enforce the 'required' setting then.
+In the above scenario of a required custom field being absent on existing resources, OpenProject will try to minimize the times in which users are blocked from performing their intended action. A user might want to change the name of the project with no value filled in for a required custom field. Since the interface for changing the name does not display the custom fields, the user cannot provide a value at this point and OpenProject will not enforce the 'required' setting then.
 
-Generally speaking, OpenProject will enforce the 'required' characteristic whenever the UI displays the field, but allows modifications when it does not. When creating a new resource, it will be enforced.
+Generally speaking, OpenProject will enforce the 'required' characteristic whenever the UI displays the field but allows modifications when it does not. When creating a new resource, it will be enforced.
 
 > [!NOTE]
-> Prior to version 16.6, required custom fields would always be enforced also on existing resources. This led to some actions becoming impossible or unnecessarily hard to perform which is why the behavior was adapted.
+> Prior to version 16.6, required custom fields were always enforced, even on existing resources. This led to some actions becoming impossible or unnecessarily hard to perform, which is why the behavior was adjusted.
 
 ## Create a multi-select custom field
 

--- a/docs/system-admin-guide/custom-fields/README.md
+++ b/docs/system-admin-guide/custom-fields/README.md
@@ -103,6 +103,18 @@ Once you have specified all items for the hierarchy custom field, you need to:
 1. [Activate this custom field for projects under the *Projects* tab](#add-a-custom-field-to-one-or-multiple-projects)
 2. [Assign a custom field to a work package type](../manage-work-packages/work-package-types/#work-package-form-configuration-enterprise-add-on) 
 
+## 'required' custom fields
+
+Custom fields can be configured as 'required'. As the name suggests, 'required' custom fields need to be filled out when a resource like a work package or a project is created. Without the user filling in a field, the user will be prevented from creating the resource.
+
+The 'required' flag can also be set on existing custom fields. That poses a problem for resources that existed before the flag was switched to being required. E.g. a work package might have already been created and worked with for some time. But because the field was not required before, it might not have been filled in. Once the custom field becomes 'required', the next user wanting to modify the work package needs to fill in the field. There are other scenarios where this might be necessary, among which are the activation of a required custom field for a project or a work package type.
+
+In the above scenario of a required custom field being absent on existing resources, OpenProject will try to minimize the times in which users are blocked from performing their intended action. A user might want to change the name of the project with no value filled in for a required custom field. Since the UI for changing the name does not display the custom fields, the user cannot provide a value at this place and OpenProject will not enforce the 'required' setting then.
+
+Generally speaking, OpenProject will enforce the 'required' characteristic whenever the UI displays the field, but allows modifications when it does not. When creating a new resource, it will be enforced.
+
+> [!NOTE]
+> Prior to version 16.6, required custom fields would always be enforced also on existing resources. This led to some actions becoming impossible or unnecessarily hard to perform which is why the behavior was adapted.
 
 ## Create a multi-select custom field
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68571

Document the changed behaviour on 'required' custom fields. Since there was no documentation on the characteristic in the first place, it is added highlighting the changes done in 16.6.