### PR TITLE
[#68540] Support non-nested long text fields macro in PDF Export

### DIFF
--- a/app/models/exports/pdf/common/macro.rb
+++ b/app/models/exports/pdf/common/macro.rb
@@ -30,6 +30,10 @@
 
 module Exports::PDF::Common::Macro
   PREFORMATTED_BLOCKS = %w(pre code).freeze
+  # tables & images & markdown code blocks are not supported in nested rich text
+  UNSUPPORTED_NESTED = %w[<table <img ```].freeze
+  # markdown quotes are not supported in nested rich text
+  UNSUPPORTED_NESTED_REGEX = [/^\s>/].freeze
 
   def apply_markdown_field_macros(markdown, context)
     return markdown if markdown.blank?
@@ -72,7 +76,7 @@ module Exports::PDF::Common::Macro
   end
 
   def apply_macros_node_text(node, context)
-    formatted = apply_macro_text(node.string_content, context)
+    formatted = apply_macro_text(node.string_content, false, context)
     return if formatted == node.string_content
 
     fragment = Markly::Node.new(:inline_html)
@@ -89,16 +93,41 @@ module Exports::PDF::Common::Macro
     macros.any? { |macro| macro.applicable?(content) }
   end
 
-  def apply_macro_text(text, context)
+  def apply_macro_text(text, in_html, context)
     applicable_macros = macros.select { |macro| macro.applicable?(text) }
     return text if applicable_macros.empty?
 
     applicable_macros.each do |macro|
       text = text.gsub(macro.regexp) do |matched_string|
-        macro.process_match(Regexp.last_match, matched_string, context)
+        replacement, is_rich_text = macro.process_match(Regexp.last_match, matched_string, context)
+        in_html && is_rich_text ? build_html_replacement(replacement) : replacement
       end
     end
     text
+  end
+
+  def build_html_replacement(markdown)
+    if contains_nested_richtext?(markdown)
+      "[#{I18n.t('export.macro.nested_rich_text_unsupported')}] "
+    elsif markdown.strip.empty?
+      " "
+    else
+      markdown_to_html(markdown)
+    end
+  end
+
+  def markdown_to_html(markdown)
+    document = Markly.parse(
+      markdown,
+      flags: Markly::SMART | Markly::STRIKETHROUGH_DOUBLE_TILDE | Markly::UNSAFE | Markly::VALIDATE_UTF8,
+      extensions: %i[autolink strikethrough table tagfilter tasklist]
+    )
+    document.to_html
+  end
+
+  def contains_nested_richtext?(markdown)
+    UNSUPPORTED_NESTED.any? { |entry| markdown.include?(entry) } ||
+      UNSUPPORTED_NESTED_REGEX.any? { |regex| markdown.match?(regex) }
   end
 
   def apply_macro_html(html, context)
@@ -111,7 +140,7 @@ module Exports::PDF::Common::Macro
 
   def apply_macro_html_node(node, context)
     if node.text?
-      formatted = apply_macro_text(node.content, context)
+      formatted = apply_macro_text(node.content, true, context)
       node.replace(formatted) if formatted != node.content
     elsif PREFORMATTED_BLOCKS.exclude?(node.name)
       node.children.each { |child| apply_macro_html_node(child, context) }

--- a/app/models/exports/pdf/common/macro.rb
+++ b/app/models/exports/pdf/common/macro.rb
@@ -97,20 +97,73 @@ module Exports::PDF::Common::Macro
     applicable_macros = macros.select { |macro| macro.applicable?(text) }
     return text if applicable_macros.empty?
 
-    applicable_macros.each do |macro|
-      text = text.gsub(macro.regexp) do |matched_string|
-        replacement, is_rich_text = macro.process_match(Regexp.last_match, matched_string, context)
-        in_html && is_rich_text ? build_html_replacement(replacement) : replacement
-      end
-    end
+    applicable_macros.each { |macro| text = replace_macro(text, macro, in_html, context) }
     text
+  end
+
+  def replace_macro(text, macro, in_html, context)
+    new_text = text.dup
+    text.to_enum(:scan, macro.regexp).each do |matched_string|
+      match = Regexp.last_match
+      new_text[match.begin(0)...match.end(0)] = replace_macro_match(match, matched_string, macro, in_html, context)
+    end
+    new_text
+  end
+
+  def replace_macro_match(match, matched_string, macro, in_html, context)
+    replacement, is_rich_text = macro.process_match(match, matched_string, context)
+    if !is_rich_text
+      build_plain_replacement(replacement)
+    elsif in_html
+      build_html_replacement(replacement)
+    else
+      build_markdown_replacement(replacement, match.begin(0))
+    end
+  end
+
+  def build_markdown_replacement(markdown, position)
+    # if there is a list or other markdown structure in the markdown and the macro is placed somewhere in the line
+    # we need to add a line break before the markdown to not break the structure
+    # example: a markdown list with asterisk is only valid if the asterisk is at the beginning of the line
+    if position > 0 && has_markdown_structure_formatting?(markdown)
+      "\n#{markdown}"
+    else
+      markdown
+    end
+  end
+
+  def has_markdown_structure_formatting?(text)
+    return false if text.nil? || text.strip.empty?
+
+    # Check for headers (ATX style: # Heading or Setext style: Heading\n===)
+    return true if text.start_with?("#") ||
+                   text.match?(/\A[^\n]+\n[=-]{2,}\s*(?:\n|$)/)
+
+    # Check for blockquotes
+    return true if text.start_with?(">")
+
+    # Check for lists (unordered: *, +, - and ordered: 1., 1), a., A., etc)
+    return true if text.match?(/\A(?:[*+-]|\d+[.)]|[a-zA-Z][.)])\s+/)
+
+    # Check for code blocks (indented with 4 spaces or fenced with ``` or ~~~)
+    return true if text.match?(/\A(?:(?:.{4}|\t).*(?:\n|$)|\s*(?:```|~~~).*(?:\n|$))/)
+
+    false
+  end
+
+  def build_plain_replacement(text)
+    if text.strip.empty?
+      " " # empty replacements may break markdown formatting
+    else
+      text
+    end
   end
 
   def build_html_replacement(markdown)
     if contains_nested_richtext?(markdown)
       "[#{I18n.t('export.macro.nested_rich_text_unsupported')}] "
     elsif markdown.strip.empty?
-      " "
+      " " # empty replacements may break markdown formatting
     else
       markdown_to_html(markdown)
     end

--- a/app/models/projects/exports/pdf.rb
+++ b/app/models/projects/exports/pdf.rb
@@ -36,11 +36,11 @@ module Projects::Exports
     include Exports::PDF::Common::Markdown
     include Exports::PDF::Components::Page
     include Exports::PDF::Components::Cover
+    include Exports::PDF::Common::Macro
     include Projects::Exports::PDFExport::TableOfContent
     include Projects::Exports::PDFExport::Report
     include Projects::Exports::PDFExport::InfoMap
     include Projects::Exports::PDFExport::Styles
-
     attr_accessor :pdf
 
     def initialize(object, options = {})

--- a/app/models/projects/exports/pdf_export/report.rb
+++ b/app/models/projects/exports/pdf_export/report.rb
@@ -207,7 +207,8 @@ module Projects::Exports::PDFExport
       with_margin(styles.project_markdown_margins) do
         write_markdown!(
           apply_markdown_field_macros(value, { project:, user: User.current }),
-          styles.project_markdown_styling_yml)
+          styles.project_markdown_styling_yml
+        )
       end
     end
 

--- a/app/models/projects/exports/pdf_export/report.rb
+++ b/app/models/projects/exports/pdf_export/report.rb
@@ -191,21 +191,23 @@ module Projects::Exports::PDFExport
     end
 
     def write_formattable_attribute(project, attribute, caption)
-      write_project_markdown project.try(attribute), caption
+      write_project_markdown(project, project.try(attribute), caption)
     end
 
     def write_formattable_custom_field(project, custom_field)
       custom_field_value = project.custom_value_for(custom_field.id)
-      write_project_markdown custom_field_value.value, custom_field.name
+      write_project_markdown(project, custom_field_value.value, custom_field.name)
     end
 
-    def write_project_markdown(value, caption)
+    def write_project_markdown(project, value, caption)
       return if hide_empty_attributes? && value.blank?
 
       write_markdown_label(caption)
       value = Prawn::Text::NBSP if value.blank?
       with_margin(styles.project_markdown_margins) do
-        write_markdown!(value, styles.project_markdown_styling_yml)
+        write_markdown!(
+          apply_markdown_field_macros(value, { project:, user: User.current }),
+          styles.project_markdown_styling_yml)
       end
     end
 

--- a/app/models/work_package/exports/macros/attributes.rb
+++ b/app/models/work_package/exports/macros/attributes.rb
@@ -87,10 +87,6 @@ module WorkPackage::Exports
         msg_inline I18n.t("export.macro.error", message:)
       end
 
-      def self.msg_macro_error_rich_text
-        msg_inline I18n.t("export.macro.rich_text_unsupported")
-      end
-
       def self.msg_inline(message)
         "[#{message}]"
       end
@@ -160,13 +156,12 @@ module WorkPackage::Exports
 
       def self.resolve_value(obj, attribute, disabled_rich_text_fields)
         custom_field = find_custom_field(obj, attribute)
-        return msg_macro_error_rich_text if custom_field&.formattable?
 
         attribute_name = convert_to_attribute_name(custom_field, attribute, obj)
         return " " unless can_view_attribute?(custom_field, obj, attribute_name)
-        return msg_macro_error_rich_text if disabled_rich_text_fields.include?(attribute_name.to_sym)
 
-        format_attribute_value(attribute_name, obj.class, obj)
+        is_rich_text = custom_field&.formattable? || disabled_rich_text_fields.include?(attribute_name.to_sym)
+        [format_attribute_value(attribute_name, obj.class, obj, is_rich_text), is_rich_text]
       end
 
       def self.can_view_attribute?(custom_field, obj, attribute_name)
@@ -185,7 +180,7 @@ module WorkPackage::Exports
         obj.available_custom_fields.find { |pcf| pcf.name == attribute }
       end
 
-      def self.format_attribute_value(ar_name, model, obj)
+      def self.format_attribute_value(ar_name, model, obj, is_rich_text)
         formatter = Exports::Register.formatter_for(model, ar_name, :pdf)
         value = formatter.format(obj)
         # do NOT escape a tag for custom field link
@@ -193,7 +188,9 @@ module WorkPackage::Exports
 
         # important NOT to return empty string as this could change meaning of markdown
         # e.g. **to_be_replaced** could be rendered as **** (horizontal line and a *)
-        value.blank? ? " " : escape_tags(value)
+        return " " if value.blank?
+
+        is_rich_text ? value : escape_tags(value)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2696,7 +2696,7 @@ en:
       attribute_not_found: "attribute not found: %{attribute}"
       model_not_found: "invalid attribute model: %{model}"
       resource_not_found: "resource not found: %{resource}"
-      rich_text_unsupported: "Rich text embedding currently not supported in export"
+      nested_rich_text_unsupported: "Nested rich text embedding currently not supported in export"
     units:
       hours: h
       days: d

--- a/docs/user-guide/work-packages/exporting/README.md
+++ b/docs/user-guide/work-packages/exporting/README.md
@@ -59,6 +59,10 @@ OpenProject has multiple options for exporting work packages in PDF format. Thes
 >
 ![Example of a PDF export in OpenProject that includes lorem ipsum text in multiple languages and mathematical symbols](openproject-user-guide-wp-export-multilingual-symbols-example.png)
 
+> [!NOTE]
+>
+> Rich text can be embedded using [Macros](../../wysiwyg/#attributes), such as descriptions of other work packages. This feature is supported as long as the embedding is not within table cells, or if it only contains basic text formatting.
+
 #### PDF Table
 
 PDF Table exports the work package table displaying work packages as single rows with the selected columns for the work package table. Work package IDs are linked to the respective work packages. Clicking on a work package ID will lead you directly to the work package in OpenProject.
@@ -80,9 +84,6 @@ The table of attributes is followed by the work package description and, if nece
 
 > [!TIP]
 > If you used page breaks in work package descriptions, contents will be split into separate pages accordingly. 
-
-> [!NOTE]
-> Embedding of rich text, e.g. descriptions of other work packages, is currently not supported.
 
 ![OpenProject_pdf_report_export](openproject-pdf-export-work-plans.png)
 

--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -150,7 +150,7 @@ For work packages and users, typing `#` or `@` will open an autocomplete dropdow
 > These macros will only be expanded in the frontend. For each individual user, the correct permissions will be checked and
 > the macro will result in an error if the user is not allowed to view the respective resource.
 
-> [!INFO]
+> [!NOTE]
 > In the [PDF Export](../work-packages/exporting/#pdf-export), embedding of rich text attributes (e.g. work package description) is limited for some cases.
 > Simple text formatting or embedding outside of table cells is supported.
 

--- a/docs/user-guide/wysiwyg/README.md
+++ b/docs/user-guide/wysiwyg/README.md
@@ -150,6 +150,10 @@ For work packages and users, typing `#` or `@` will open an autocomplete dropdow
 > These macros will only be expanded in the frontend. For each individual user, the correct permissions will be checked and
 > the macro will result in an error if the user is not allowed to view the respective resource.
 
+> [!INFO]
+> In the [PDF Export](../work-packages/exporting/#pdf-export), embedding of rich text attributes (e.g. work package description) is limited for some cases.
+> Simple text formatting or embedding outside of table cells is supported.
+
 ### Embedding of a work package value by work package ID
 
 Use the `workPackageValue:ID:attribute` macros to embed attributes of a work package by its [work package ID](../work-packages). 

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -328,19 +328,44 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
-    describe "with formatted custom field" do
-      let(:markdown) { 'workPackageValue:"Custom Formatted Field"' }
+    describe "with nested formatted custom field" do
+      before do
+        work_package.custom_field_values[1].value = "a complicated **formatted** _text_ with <table></table>"
+        work_package.save
+      end
 
-      it "outputs an error message for rich text" do
-        expect(formatted).to include(I18n.t("export.macro.rich_text_unsupported"))
+      describe "with relative work package" do
+        let(:markdown) { '<table><tr><td>workPackageValue:"Custom Formatted Field"</td></tr></table>' }
+
+        it "outputs an error message for rich text" do
+          expect(formatted).to include(I18n.t("export.macro.nested_rich_text_unsupported"))
+        end
+      end
+
+      describe "with specific work package ID" do
+        let(:markdown) { "<table><tr><td>workPackageValue:#{work_package.id}:\"Custom Formatted Field\"</td></tr></table>" }
+
+        it "outputs an error message for rich text" do
+          expect(formatted).to include(I18n.t("export.macro.nested_rich_text_unsupported"))
+        end
       end
     end
 
-    describe "with specific work package ID and formatted custom field" do
-      let(:markdown) { "workPackageValue:#{work_package.id}:\"Custom Formatted Field\"" }
+    describe "with formatted custom field" do
+      describe "with relative work package" do
+        let(:markdown) { 'workPackageValue:"Custom Formatted Field"' }
 
-      it "outputs an error message for rich text" do
-        expect(formatted).to include(I18n.t("export.macro.rich_text_unsupported"))
+        it "outputs an error message for rich text" do
+          expect(formatted).to eq("**Formatted** _text_ content")
+        end
+      end
+
+      describe "with specific work package ID" do
+        let(:markdown) { "workPackageValue:#{work_package.id}:\"Custom Formatted Field\"" }
+
+        it "outputs an error message for rich text" do
+          expect(formatted).to eq("**Formatted** _text_ content")
+        end
       end
     end
 

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -71,19 +71,6 @@ RSpec.describe Exports::PDF::Common::Macro do
       custom_field_values: { project_custom_field.id => "Project custom value 2" }
     )
   end
-  shared_let(:work_package) do
-    create(
-      :work_package,
-      subject: "Work package 1",
-      type: type_task,
-      status: create(:status, name: "In Progress"),
-      project: project,
-      custom_field_values: {
-        custom_field.id => "Custom value 1",
-        formatted_custom_field.id => "**Formatted** _text_ content"
-      }
-    )
-  end
   shared_let(:other_work_package) do
     create(
       :work_package,
@@ -116,6 +103,19 @@ RSpec.describe Exports::PDF::Common::Macro do
     )
   end
   shared_let(:formatter) { Class.new { extend Exports::PDF::Common::Macro } }
+  let(:work_package) do
+    create(
+      :work_package,
+      subject: "Work package 1",
+      type: type_task,
+      status: create(:status, name: "In Progress"),
+      project: project,
+      custom_field_values: {
+        custom_field.id => "Custom value 1",
+        formatted_custom_field.id => formatted_custom_field_value
+      }
+    )
+  end
   let(:additional_permissions) { [] }
   let(:user) do
     create(
@@ -127,6 +127,7 @@ RSpec.describe Exports::PDF::Common::Macro do
     )
   end
   let(:markdown) { "" }
+  let(:formatted_custom_field_value) { "**Formatted** _text_ content" }
 
   before do
     User.current = user
@@ -135,7 +136,7 @@ RSpec.describe Exports::PDF::Common::Macro do
   subject(:formatted) do
     formatter
       .apply_markdown_field_macros(markdown, { work_package: work_package, project: project, user: })
-      .sub("\n", "")
+      .chomp
   end
 
   describe "empty text" do
@@ -160,13 +161,11 @@ RSpec.describe Exports::PDF::Common::Macro do
 
       it "loops the tag through" do
         # note: escaped backslash in the tag text for correct markdown rendering
-        expect(formatted).to eq(
-          "<mention class=\"mention\" data-id=\"#{
-                                 work_package.id
-                               }\" data-type=\"work_package\" data-text=\"##{
-                                 work_package.id
-                               }\">\\##{work_package.id}</mention>"
-        )
+        expect(formatted).to eq("<mention class=\"mention\" data-id=\"#{
+          work_package.id
+        }\" data-type=\"work_package\" data-text=\"##{
+          work_package.id
+        }\">\\##{work_package.id}</mention>")
       end
     end
 
@@ -329,10 +328,7 @@ RSpec.describe Exports::PDF::Common::Macro do
     end
 
     describe "with nested formatted custom field" do
-      before do
-        work_package.custom_field_values[1].value = "a complicated **formatted** _text_ with <table></table>"
-        work_package.save
-      end
+      let(:formatted_custom_field_value) { "a complicated **formatted** _text_ with <table></table>" }
 
       describe "with relative work package" do
         let(:markdown) { '<table><tr><td>workPackageValue:"Custom Formatted Field"</td></tr></table>' }
@@ -398,6 +394,46 @@ RSpec.describe Exports::PDF::Common::Macro do
 
       it "processes the macro inside HTML" do
         expect(formatted).to eq("<table><tr><td>Work package 1</td></tr></table>")
+      end
+    end
+
+    describe "with formatted custom field used mid-line and markdown structures" do
+      # Ensure that when a formatted custom field contains markdown that MUST start at BOL
+      # and the macro appears mid-line, a line break is inserted before the markdown.
+      context "with unordered list item" do
+        let(:markdown) { "\nPrefix workPackageValue:\"Custom Formatted Field\"" }
+        let(:formatted_custom_field_value) { "* list item" }
+
+        it "inserts a newline before the list to keep structure" do
+          expect(formatted).to eq("Prefix \n* list item")
+        end
+      end
+
+      context "with blockquote" do
+        let(:markdown) { "\nIntro workPackageValue:\"Custom Formatted Field\"" }
+        let(:formatted_custom_field_value) { "> quoted" }
+
+        it "inserts a newline before the blockquote to keep structure" do
+          expect(formatted).to eq("Intro \n> quoted")
+        end
+      end
+
+      context "with heading" do
+        let(:markdown) { "\nText workPackageValue:\"Custom Formatted Field\"" }
+        let(:formatted_custom_field_value) { "# Heading" }
+
+        it "inserts a newline before the header to keep structure" do
+          expect(formatted).to eq("Text \n# Heading")
+        end
+      end
+
+      context "with fenced code block" do
+        let(:markdown) { "\nPreamble workPackageValue:\"Custom Formatted Field\"" }
+        let(:formatted_custom_field_value) { "```\ncode\n```" }
+
+        it "inserts a newline before the fenced code block to keep structure" do
+          expect(formatted).to eq("Preamble \n```\ncode\n```")
+        end
       end
     end
   end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
   let(:project_custom_field_long_text) do
     create(:project_custom_field, :text,
            name: "Rich text project custom field",
-           default_value: "rich text field value")
+           default_value: "rich text field value with a table <table></table>")
   end
   let(:project) do
     create(:project,
@@ -61,6 +61,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
            types: [type],
            public: true,
            status_code: "on_track",
+           description: "A **rich** text description",
            active: true,
            parent: parent_project,
            custom_field_values: {
@@ -85,6 +86,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
            public: false,
            status_code: "on_track",
            active: true,
+           description: "A **rich** text description",
            parent: parent_project,
            work_package_custom_fields: [cf_long_text, cf_empty_long_text, cf_disabled_in_project, cf_global_bool, cf_link],
 
@@ -342,7 +344,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           ["status", status.name],
           ["subject", "Work package 1"],
           ["type", type.name],
-          ["description", "[#{I18n.t('export.macro.rich_text_unsupported')}]"]
+          ["description", "[#{I18n.t('export.macro.nested_rich_text_unsupported')}]"]
         ]
       end
       let(:supported_work_package_embeds_table) do
@@ -383,14 +385,19 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
         DESCRIPTION
       end
 
-      def expected_description
+      def expected_description_first
         [
           "Custom field boolean", I18n.t(:general_text_Yes),
-          "Custom field rich text", "[#{I18n.t('export.macro.rich_text_unsupported')}]",
+          "Custom field rich text", "foo   faa",
           "My link in table", "https://example.com",
-          "No replacement of:", "workPackageValue:1:assignee", " ", "workPackageLabel:assignee",
+          "No replacement of:", "workPackageValue:1:assignee", "workPackageLabel:assignee",
           "workPackageValue:2:assignee workPackageLabel:assignee",
           "workPackageValue:3:assignee", "workPackageLabel:assignee",
+        ]
+      end
+
+      def expected_description_second
+        [
           "https://example.com",
           "Work package not found:  ",
           "[#{I18n.t('export.macro.error', message:
@@ -414,8 +421,10 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
               API::Utilities::PropertyNameConverter.to_ar_name(embed[0].to_sym, context: work_package)
             ), embed[1]]
           end,
-          *expected_description,
-          "2", export_date_formatted, project.name
+          *expected_description_first,
+          "2", export_date_formatted, project.name,
+          *expected_description_second,
+          "3", export_date_formatted, project.name
         ].flatten.join(" ")
         expect(result).to eq(expected_result)
       end
@@ -425,11 +434,10 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       let(:supported_project_embeds) do
         [
           ["active", I18n.t(:general_text_Yes)],
-          ["description", "[#{I18n.t('export.macro.rich_text_unsupported')}]"],
+          ["description", "A  rich  text description"],
           ["identifier", project.identifier],
           ["name", project.name],
-          ["status", I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}")],
-          ["statusExplanation", "[#{I18n.t('export.macro.rich_text_unsupported')}]"],
+          ["status", I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}"), "statusExplanation"],
           ["parent", parent_project.name],
           ["public", I18n.t(:general_text_Yes)]
         ]
@@ -480,8 +488,6 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
         [
           *expected_details,
           label_title(:description),
-          "1", export_date_formatted, project.name,
-
           "Project attributes and labels",
           supported_project_embeds.map do |embed|
             [Project.human_attribute_name(
@@ -489,7 +495,9 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
             ), embed[1]]
           end,
           "Custom field boolean", I18n.t(:general_text_Yes),
-          "Custom field rich text", "[#{I18n.t('export.macro.rich_text_unsupported')}]",
+          "Custom field rich text", "foo",
+          "1", export_date_formatted, project.name,
+
           "Custom field hidden",
           "No replacement of:",
           "projectValue:1:status",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/68540

# What are you trying to do?

PDF export did not support macros of long text fields (work package and project) like description or custom fields of type "long text". The reason was that rich text could contain tables and other things like quotes and images which the PDF cannot insert into e.g. tables.

With this PR we allow rich text macros at save places, e.g. document root level. In short: if they are not nested. 
We also check if the Markdown includes only simple formatting and if so, allow also embedded nested.

## Screenshots

<img width="309" height="174" alt="input" src="https://github.com/user-attachments/assets/ad36a30b-2851-45ea-bcaa-26011aeb278e" />

# What approach did you choose and why?

The macro code needed to be aware of positions and content that is to be replaced, allowing replacing if the conditions are met.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
- [x] Update documentation 
