### PR TITLE
eager load custom values/fields on time entries api

### DIFF
--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -180,7 +180,7 @@ module API
           end
         end
 
-        self.to_eager_load = [:user, :activity, { project: :enabled_modules }]
+        self.to_eager_load = [:user, :activity, { project: :enabled_modules }, { custom_values: :custom_field }]
 
         # entity is a polymorphic association and thus can't be eager-loaded, but it can be preloaded
         self.to_preload = [:entity]


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68641

# What are you trying to accomplish?

Reduce the number of n+1 queries related to custom values when loading the time entries via API.

The added statements have their limits. It does not help with the n+1 queries of non scalar custom fields like users, where the user will also have to be loaded.

For this, an approach similar to how it is done for [work packages using an eager loading wrapper](https://github.com/opf/openproject/blob/dev/lib/api/v3/work_packages/eager_loading/custom_value.rb) would need to be employed. 