### PR TITLE
[68574] Widgets titles are missing space on mobile

### DIFF
--- a/frontend/src/global_styles/content/_grid_mobile.sass
+++ b/frontend/src/global_styles/content/_grid_mobile.sass
@@ -10,6 +10,9 @@
       grid-column: 1/2 !important
       grid-row: unset !important
 
+    .op-widget-box--header:has(.grid--area-drag-handle)
+      padding-left: 1rem
+
   .grid-mx
     margin-left: 0
     margin-right: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68574

## Screenshots
Before:
<img width="316" height="363" alt="Screenshot 2025-10-28 at 18 02 14" src="https://github.com/user-attachments/assets/91913f9c-97e3-4eac-8a92-7a36ad8b5e2e" />

After:
<img width="337" height="375" alt="Screenshot 2025-10-28 at 18 01 50" src="https://github.com/user-attachments/assets/47c57942-ffe7-4107-880a-a2057647eecf" />
