### PR TITLE
Bug/68553 creating a calculated value project attribute marked required doesn't calculate values

### DIFF
--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -70,7 +70,7 @@ module CustomFields
     private
 
     def add_cf_to_visible_columns(custom_field)
-      Setting.enabled_projects_columns = (Setting.enabled_projects_columns + [custom_field.column_name]).uniq
+      Setting.enabled_projects_columns |= [custom_field.column_name]
     end
   end
 end

--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -60,6 +60,10 @@ module CustomFields
         add_cf_to_visible_columns(cf)
       end
 
+      if cf.field_format_calculated_value? && cf.is_required?
+        calculate_values(cf)
+      end
+
       if cf.hierarchical_list?
         CustomFields::Hierarchy::HierarchicalItemService.new.generate_root(cf)
       end
@@ -68,6 +72,17 @@ module CustomFields
     end
 
     private
+
+    def calculate_values(custom_field)
+      custom_field.class.customized_class.find_each do |customized|
+        # for create service maybe there is no need to determine affected_cfs and just use [custom_field]
+        affected_cfs = customized.available_custom_fields.affected_calculated_fields([custom_field.id])
+
+        customized.calculate_custom_fields(affected_cfs)
+
+        customized.save if customized.changed_for_autosave?
+      end
+    end
 
     def add_cf_to_visible_columns(custom_field)
       Setting.enabled_projects_columns |= [custom_field.column_name]

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -42,4 +42,129 @@ RSpec.describe CustomFields::CreateService, type: :model do
       end
     end
   end
+
+  describe "#call" do
+    let(:user) { build_stubbed(:admin) }
+    let(:contract_class) { CustomFields::CreateContract }
+    let(:contract_instance) { instance_double(contract_class, validate: true) }
+
+    let(:instance) do
+      described_class.new(user:)
+    end
+
+    subject(:instance_call) { instance.call(attributes) }
+
+    before do
+      User.current = user
+      allow(contract_class)
+        .to receive(:new).with(instance_of(ProjectCustomField), user, options: {}).and_return(contract_instance)
+    end
+
+    describe "calculated value custom field", with_flag: { calculated_value_project_attribute: true } do
+      using CustomFieldFormulaReferencing
+
+      shared_let(:project_custom_field_section) { create(:project_custom_field_section) }
+
+      shared_let(:project1) { create(:project) }
+      shared_let(:project2) { create(:project) }
+      shared_let(:project3) { create(:project) }
+      shared_let(:project4) { create(:project) }
+      shared_let(:projects) { [project1, project2, project3, project4] }
+
+      let(:common_attributes) do
+        {
+          type: "ProjectCustomField",
+          field_format: "calculated_value",
+          name: "foo",
+          custom_field_section_id: project_custom_field_section.id
+        }
+      end
+
+      before do
+        find_each = allow(Project).to receive(:find_each)
+
+        projects.each do |project|
+          find_each.and_yield project
+        end
+      end
+
+      context "when creating not a calculated value" do
+        let(:attributes) { { **common_attributes, field_format: "int" } }
+
+        it "doesn't try to calculate values" do
+          expect(subject).to be_success
+
+          expect(Project).not_to have_received(:find_each)
+        end
+      end
+
+      context "when creating without is_required mark" do
+        let(:attributes) { { **common_attributes, formula: "2 + 2" } }
+
+        it "doesn't try to calculate values" do
+          expect(subject).to be_success
+          expect(subject.result).to have_attributes(is_required: false)
+
+          expect(Project).not_to have_received(:find_each)
+        end
+      end
+
+      context "when creating with is_required mark" do
+        context "when custom field has static formula" do
+          let(:attributes) { { **common_attributes, formula: "2 + 2", is_required: true } }
+
+          it "calculates values on all objects" do
+            expect(subject).to be_success
+            expect(subject.result).to have_attributes(is_required: true)
+
+            aggregate_failures do
+              projects.each do |project|
+                expect(project.custom_value_attributes(all: true)).to eq(subject.result.id => "4")
+              end
+            end
+          end
+
+          it "saves all objects" do
+            projects.each { allow(it).to receive(:save) }
+
+            expect(subject).to be_success
+            expect(subject.result).to have_attributes(is_required: true)
+
+            expect(projects).to all(have_received(:save))
+          end
+        end
+
+        context "when custom field formula references other fields" do
+          let!(:static) { create(:integer_project_custom_field, projects: [project1, project2, project3]) }
+          let(:attributes) { { **common_attributes, formula: "#{static} * 3", is_required: true } }
+
+          before do
+            create(:custom_value, customized: project1, custom_field: static, value: 1)
+            create(:custom_value, customized: project3, custom_field: static, value: 2)
+          end
+
+          it "updates calculated values on all objects that have the static field set" do
+            expect(subject).to be_success
+            expect(subject.result).to have_attributes(is_required: true)
+
+            aggregate_failures do
+              expect(project1.custom_value_attributes).to eq(static.id => "1", subject.result.id => "3")
+              expect(project2.custom_value_attributes).to eq(static.id => nil, subject.result.id => nil)
+              expect(project3.custom_value_attributes).to eq(static.id => "2", subject.result.id => "6")
+              expect(project4.custom_value_attributes).to eq(subject.result.id => nil)
+            end
+          end
+
+          it "saves all objects" do
+            projects.each { allow(it).to receive(:save) }
+
+            expect(subject).to be_success
+            expect(subject.result).to have_attributes(is_required: true)
+
+            expect(projects).to all(have_received(:save))
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/services/custom_fields/update_service_spec.rb
+++ b/spec/services/custom_fields/update_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CustomFields::UpdateService, type: :model do
   describe "#call" do
     let(:user) { build_stubbed(:admin) }
     let(:contract_class) { CustomFields::UpdateContract }
-    let(:contract_instance) { instance_double(CustomFields::UpdateContract, validate: true) }
+    let(:contract_instance) { instance_double(contract_class, validate: true) }
 
     let(:instance) do
       described_class.new(user:,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68553

# What are you trying to accomplish?
Calculate value when project attribute is created with is_required mark

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
