### PR TITLE
Load projects in selector only partially

### DIFF
--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -88,6 +88,10 @@ export class ConfigurationService {
     return this.systemPreference('maximumAttachmentFileSize');
   }
 
+  public get maximumApiV3PageSize():number {
+    return this.systemPreference('maximumAPIV3PageSize');
+  }
+
   public get perPageOptions():number[] {
     return this.systemPreference('perPageOptions');
   }

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -28,10 +28,10 @@
 
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { ChangeDetectionStrategy, Component, HostBinding, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
-import { combineLatest, Observable, ReplaySubject } from 'rxjs';
-import { debounceTime, defaultIfEmpty, filter, map, mergeMap, shareReplay, take } from 'rxjs/operators';
+import { BehaviorSubject, Observable, ReplaySubject, Subscription } from 'rxjs';
+import { map, shareReplay, take, tap } from 'rxjs/operators';
 import { IProject } from 'core-app/core/state/projects/project.model';
 import { insertInList } from 'core-app/shared/components/project-include/insert-in-list';
 import { recursiveSort } from 'core-app/shared/components/project-include/recursive-sort';
@@ -42,8 +42,6 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { IProjectData } from 'core-app/shared/components/searchable-project-list/project-data';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-import { ApiV3Filter } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
-import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Component({
@@ -57,7 +55,7 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
   ],
   standalone: false,
 })
-export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implements OnInit {
+export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @HostBinding('class.op-project-select') className = true;
 
   public dropModalOpen = false;
@@ -68,14 +66,12 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
 
   public canCreateNewProjects$ = this.currentUserService.hasCapabilities$('projects/create', 'global');
 
-  public projects$ = combineLatest([
-    this.searchableProjectListService.allProjects$,
-    this.searchableProjectListService.searchText$.pipe(debounceTime(200)),
-  ]).pipe(
+  public projects$ = this.searchableProjectListService.allProjects$.pipe(
     map(
-      ([projects, searchText]:[IProject[], string]) => projects
+      (projects:IProject[]) => projects
         .filter(
           (project) => {
+            const searchText = this.searchableProjectListService.searchText;
             if (searchText.length) {
               const matches = project.name.toLowerCase().includes(searchText.toLowerCase());
 
@@ -103,25 +99,17 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
         ),
     ),
     map((projects) => recursiveSort(projects)),
+    tap(() => {
+      if(this.dropModalOpen) {
+        // only clear loading indicator if modal is open, otherwise rendering is triggered that will cause loading of
+        // favorites while the modal is closed
+        this.loading$.next(false);
+      }
+    }),
     shareReplay(),
   );
 
-  public favorites$:Observable<string[]> = this
-    .apiV3Service
-    .projects
-    .signalled(
-      ApiV3Filter('favorited', '=', true),
-      [
-        'elements/id',
-      ],
-      { pageSize: '-1' },
-    )
-    .pipe(
-      map((collection:IHALCollection<{ id:string|number }>) => collection._embedded.elements || []),
-      map((elements) => elements.map((item) => item.id.toString())),
-      defaultIfEmpty([]),
-      shareReplay(1),
-    );
+  public favorites$:Observable<string[]> = this.searchableProjectListService.favoriteIds$;
 
   public text = {
     all: this.I18n.t('js.label_all_uppercase'),
@@ -147,23 +135,7 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
     { value: 'favorited', title: this.text.favorited },
   ];
 
-  /* This seems like a way too convoluted loading check, but there's a good reason we need it.
-   * The searchableProjectListService says fetching is "done" when the request returns.
-   * However, this causes flickering on the initial load, since `projects$` still needs
-   * to do the tree calculation. In the template, we show the project-list when `loading$ | async` is false,
-   * but if we would only make this depend on `fetchingProjects$` Angular would still wait with
-   * rendering the project-list until `projects$ | async` has also fired.
-   *
-   * To fix this, we first wait for fetchingProjects$ to be true once,
-   * then switch over to projects$, and after that has pinged once, it switches back to
-   * fetchingProjects$ as the decider for when fetching is done.
-   */
-  public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
-    filter((fetching) => fetching),
-    take(1),
-    mergeMap(() => this.projects$),
-    mergeMap(() => this.searchableProjectListService.fetchingProjects$),
-  );
+  public loading$ = new BehaviorSubject<boolean>(true);
 
   private scrollToCurrent = false;
 
@@ -182,6 +154,10 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
   ) {
     super();
 
+    if(this.currentProject.id) {
+      this.searchableProjectListService.preloadProjectIds = [this.currentProject.id];
+    }
+
     this.projects$
       .pipe(this.untilDestroyed())
       .subscribe((projects) => {
@@ -196,17 +172,27 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
       });
   }
 
+  private onTextInput:Subscription;
+
   ngOnInit():void {
     const stored = window.OpenProject.guardedLocalStorage(this.displayModeLocalStorageKey) as 'all'|'favorited'|undefined;
     this.displayMode = stored || 'all';
+    this.onTextInput = this.searchableProjectListService.queriedSearchText$.subscribe(() => this.loading$.next(true));
+  }
+
+  ngOnDestroy():void {
+    this.onTextInput.unsubscribe();
   }
 
   toggleDropModal():void {
     this.subscriptionComplete$.pipe(take(1)).subscribe(() => {
       this.dropModalOpen = !this.dropModalOpen;
       if (this.dropModalOpen) {
+        this.loading$.next(true);
+        this.searchableProjectListService.enableLoading();
         this.scrollToCurrent = true;
-        this.searchableProjectListService.loadAllProjects();
+      } else {
+        this.searchableProjectListService.disableLoading();
       }
     });
   }
@@ -221,8 +207,9 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
   }
 
   close():void {
-    this.searchableProjectListService.searchText = '';
     this.dropModalOpen = false;
+    this.searchableProjectListService.disableLoading();
+    this.searchableProjectListService.searchText = '';
   }
 
   currentProjectName():string {

--- a/frontend/src/app/shared/components/project-include/insert-in-list.ts
+++ b/frontend/src/app/shared/components/project-include/insert-in-list.ts
@@ -14,7 +14,11 @@ export const insertInList = (
   // In a set of projects, some ancestors may be undisclosed. The client then knows of its existence
   // but knows nothing more than that. Those projects receive an 'undisclosed' urn for their href. For building
   // the project hierarchy, they can be ignored.
-  const visibleAncestors = ancestors.filter((ancestor) => ancestor.href !== UNDISCLOSED_ANCESTOR);
+  // Additionally, if the list of projects is incomplete, an ancestor might also be effectively invisible and can also be ignored
+  const visibleAncestors = ancestors.filter((ancestor) => {
+    return ancestor.href !== UNDISCLOSED_ANCESTOR &&
+      projects.find((projectInList) => projectInList._links.self.href === ancestor.href);
+  });
 
   if (!visibleAncestors.length) {
     return [

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -30,9 +30,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   HostBinding,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
-import { BehaviorSubject, combineLatest } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -41,6 +42,7 @@ import {
   mergeMap,
   shareReplay,
   take,
+  tap,
 } from 'rxjs/operators';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -75,7 +77,7 @@ import { calculatePositions } from 'core-app/shared/components/project-include/c
   ],
   standalone: false,
 })
-export class OpProjectIncludeComponent extends UntilDestroyedMixin implements OnInit {
+export class OpProjectIncludeComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
   @HostBinding('class.op-project-include') className = true;
 
   public text = {
@@ -136,6 +138,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
   public set selectedProjects(val:string[]) {
     this._selectedProjects = val;
     this.selectedProjects$.next(val);
+    this.searchableProjectListService.preloadProjectIds = val.map((s) => s.split('/').pop()!);
   }
 
   public selectedProjects$ = new BehaviorSubject<string[]>([]);
@@ -165,17 +168,17 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
     this.searchableProjectListService.allProjects$,
     this.displayMode$.pipe(distinctUntilChanged()),
     this.includeSubprojects$.pipe(debounceTime(20)),
-    this.searchableProjectListService.searchText$.pipe(debounceTime(200)),
   ]).pipe(
-    mergeMap(([projects, displayMode, includeSubprojects, searchText]) => this.selectedProjects$.pipe(
+    mergeMap(([projects, displayMode, includeSubprojects]) => this.selectedProjects$.pipe(
       take(1),
-      map((selected) => [projects, displayMode, includeSubprojects, searchText, selected]),
+      map((selected) => [projects, displayMode, includeSubprojects, selected]),
     )),
     map(
-      ([projects, displayMode, includeSubprojects, searchText, selected]:[IProject[], string, boolean, string, string[]]) => [
+      ([projects, displayMode, includeSubprojects, selected]:[IProject[], string, boolean, string[]]) => [
         projects
           .filter(
             (project) => {
+              const searchText = this.searchableProjectListService.searchText;
               if (searchText.length) {
                 const matches = project.name.toLowerCase().includes(searchText.toLowerCase());
 
@@ -221,6 +224,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
         includeSubprojects,
       ],
     ),
+    tap(() => this.loading$.next(false)),
     mergeMap(([projects, includeSubprojects]) => this.selectedProjects$.pipe(
       map((selected) => [projects, includeSubprojects, selected]),
     )),
@@ -252,23 +256,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
     shareReplay(),
   );
 
-  /* This seems like a way too convoluted loading check, but there's a good reason we need it.
-   * The searchableProjectListService says fetching is "done" when the request returns.
-   * However, this causes flickering on the initial load, since `projects$` still needs
-   * to do the tree calculation. In the template, we show the project-list when `loading$ | async` is false,
-   * but if we would only make this depend on `fetchingProjects$` Angular would still wait with
-   * rendering the project-list until `projects$ | async` has also fired.
-   *
-   * To fix this, we first wait for fetchingProjects$ to be true once,
-   * then switch over to projects$, and after that has pinged once, it switches back to
-   * fetchingProjects$ as the decider for when fetching is done.
-   */
-  public loading$ = this.searchableProjectListService.fetchingProjects$.pipe(
-    filter((fetching) => fetching),
-    take(1),
-    mergeMap(() => this.projects$),
-    mergeMap(() => this.searchableProjectListService.fetchingProjects$),
-  );
+  public loading$ = new BehaviorSubject<boolean>(false);
 
   constructor(
     readonly I18n:I18nService,
@@ -291,6 +279,8 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       });
   }
 
+  private onTextInput:Subscription;
+
   public ngOnInit():void {
     this.query$
       .pipe(
@@ -300,6 +290,13 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       .subscribe((includeSubprojects) => {
         this.includeSubprojects = includeSubprojects;
       });
+
+    this.onTextInput = this.searchableProjectListService.queriedSearchText$.subscribe(() => this.loading$.next(true));
+  }
+
+  ngOnDestroy():void {
+    super.ngOnDestroy();
+    this.onTextInput.unsubscribe();
   }
 
   public toggleIncludeSubprojects():void {
@@ -310,14 +307,14 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
     this.opened = !this.opened;
 
     if (this.opened) {
-      this.searchableProjectListService.loadAllProjects();
+      this.loading$.next(true);
+      this.searchableProjectListService.enableLoading();
       this.projectsInFilter$
         .pipe(
           take(1),
         )
         .subscribe((selectedProjects) => {
           this.displayMode = 'all';
-          this.searchableProjectListService.searchText = '';
           this.selectedProjects = selectedProjects as string[];
         });
     }

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -4,20 +4,26 @@ import {
   ApiV3ListParameters,
   listParamsString,
 } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, forkJoin, of, Observable } from 'rxjs';
 import { IProject } from 'core-app/core/state/projects/project.model';
-import { getPaginatedResults } from 'core-app/core/apiv3/helpers/get-paginated-results';
 import { IHALCollection } from 'core-app/core/apiv3/types/hal-collection.type';
-import { finalize, take } from 'rxjs/operators';
+import { debounceTime, defaultIfEmpty, map, shareReplay, switchMap, take } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { ApiV3Filter } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { HttpClient } from '@angular/common/http';
 import { ID } from '@datorama/akita';
 import { IProjectData } from './project-data';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
+
+const UNDISCLOSED_ANCESTOR = 'urn:openproject-org:api:v3:undisclosed';
 
 @Injectable()
 export class SearchableProjectListService {
   private _searchText = '';
+  private searchText$ = new BehaviorSubject<string>('');
+  private loadingEnabled$ = new BehaviorSubject<boolean>(false);
+  public preloadProjectIds:string[] = [];
 
   get searchText():string {
     return this._searchText;
@@ -28,55 +34,129 @@ export class SearchableProjectListService {
     this.searchText$.next(val);
   }
 
+  private get maximumPageSize():number {
+    return this.configurationService.maximumApiV3PageSize;
+  }
+
+  private get preferredPageSize():number {
+    return Math.min(300, this.maximumPageSize);
+  }
+
   selectedItemID$ = new BehaviorSubject<ID|null>(null);
+  queriedSearchText$ = this.searchText$.pipe(debounceTime(400));
 
-  searchText$ = new BehaviorSubject<string>('');
+  public readonly favoriteIds$:Observable<string[]> = this
+    .apiV3Service
+    .projects
+    .signalled(
+      ApiV3Filter('favorited', '=', true),
+      [
+        'elements/id',
+      ],
+      { pageSize: this.maximumPageSize.toString() },
+    )
+    .pipe(
+      map((collection:IHALCollection<{ id:string|number }>) => collection._embedded.elements || []),
+      map((elements) => elements.map((item) => item.id.toString())),
+      defaultIfEmpty([]),
+      shareReplay(1),
+    );
 
-  allProjects$ = new BehaviorSubject<IProject[]>([]);
+  // Projects are fetched with a name filter on the search text, if one is provided. To provide good performance even on very
+  // large instances (> 10,000 visible projects per user), we are not retrieving all projects eagerly, but limit the result to
+  // a typical number of projects (preferredPageSize) and then ensure that certain projects are guaranteed to be present as well,
+  // such as ancestors of visible projects and the user's favorite projects.
+  // On small instances all projects are loaded in a single request, on large instances the typical ceiling is three requests,
+  // though some edge cases (like MANY favorites) might require more than that.
+  public readonly allProjects$ = combineLatest([
+    this.queriedSearchText$,
+    this.loadingEnabled$,
+  ]).pipe(
+    switchMap(([searchText, loadingEnabled]) => {
+      if(loadingEnabled) {
+        return this.favoriteIds$.pipe(map((favs) => [searchText, loadingEnabled as boolean, favs]));
+      } else {
+        return of([searchText, loadingEnabled as boolean, [] as string[]]);
+      }
+    }),
+    switchMap(([searchText, loadingEnabled, favoriteIds]:[string,boolean,string[]]) => {
+      if(!loadingEnabled) {
+        return of([[] as IProject[], searchText, loadingEnabled as boolean, favoriteIds]);
+      }
 
-  fetchingProjects$ = new BehaviorSubject(false);
+      const nameFilter:ApiV3ListFilter[] = [];
+      if (searchText.length > 0) {
+        nameFilter.push(['name', '~', [searchText]]);
+      }
+
+      return this.fetchProjects(nameFilter)
+                 .pipe(map((collection) => [collection._embedded.elements, searchText, loadingEnabled as boolean, favoriteIds]));
+    }),
+    switchMap(([projects, searchText, loadingEnabled, favoriteIds]:[IProject[],string,boolean,string[]]) => {
+      // Those extra fetches are intended to make sure that a limited, unfiltered fetch does not leave out relevant projects
+      // such as favorites or the preloaded projects (current project, selected projects)
+      // in a filtered view, it's legitimate for them to be missing, thus we skip extra fetching if a search text is present
+      if(!loadingEnabled || searchText.length > 0) {
+        return of([projects, false as boolean]);
+      }
+
+      return this.pipeConcatProjects(projects, this.preloadProjectIds.concat(favoriteIds))
+                 .pipe(map((p) => [p, true as boolean]));
+    }),
+    switchMap(([projects, enhancePreloadedProjects]:[IProject[],boolean]) => {
+      // These can be fetched in parallel to ancestors, since they share ancestors with preloadProjectIds entries and thus
+      // can't add new ancestors to the tree
+      const extraFetches:Observable<IHALCollection<IProject>>[] = [];
+      const allProjectsLoaded = projects.length < this.preferredPageSize;
+      if(enhancePreloadedProjects && !allProjectsLoaded) {
+        if(this.preloadProjectIds.length > 0) {
+          const fetchChildren = this.fetchProjects([['ancestor', '=', this.preloadProjectIds]]);
+          extraFetches.push(fetchChildren);
+        }
+        const parents = this.extractParents(projects, this.preloadProjectIds);
+        if(parents.length > 0) {
+          const fetchSiblings = this.fetchProjects([['parent_id', '=', parents]]);
+          extraFetches.push(fetchSiblings);
+        }
+      }
+      return this.pipeConcatProjects(projects, this.extractAncestors(projects), extraFetches);
+    })
+  );
 
   constructor(
     readonly http:HttpClient,
     readonly apiV3Service:ApiV3Service,
     readonly currentProjectService:CurrentProjectService,
+    readonly configurationService:ConfigurationService,
   ) { }
 
-  public loadAllProjects():void {
-    this.fetchingProjects$.next(true);
-
-    getPaginatedResults<IProject>(
-      (params) => {
-        const collectionURL = listParamsString({ ...this.params, ...params });
-        return this.http.get<IHALCollection<IProject>>(this.apiV3Service.projects.path + collectionURL);
-      },
-    )
-      .pipe(
-        finalize(() => this.fetchingProjects$.next(false)),
-      )
-      .subscribe((projects) => {
-        this.allProjects$.next(projects);
-      });
+  /** Causes fetching of a new project list and enables reloads of the project list, when the searchText changes. */
+  public enableLoading():void {
+    this.loadingEnabled$.next(true);
   }
 
-  public get params():ApiV3ListParameters {
+  /** Disables reloads of the project list, when the searchText changes, an empty result will be returned instead. */
+  public disableLoading():void {
+    this.loadingEnabled$.next(false);
+  }
+
+  private params(additionalFilters:ApiV3ListFilter[], pageSize?:number):ApiV3ListParameters {
     const filters:ApiV3ListFilter[] = [
+      ...additionalFilters,
       ['active', '=', ['t']],
     ];
 
     return {
       filters,
-      pageSize: -1,
+      pageSize: pageSize ?? this.preferredPageSize,
       select: [
         'elements/id',
         'elements/name',
         'elements/identifier',
         'elements/self',
-        'elements/ancestors',
-        'total',
-        'count',
-        'pageSize',
+        'elements/ancestors'
       ],
+      sortBy: [['lft', 'asc']],
     };
   }
 
@@ -222,5 +302,63 @@ export class SearchableProjectListService {
     const focused = document.activeElement;
     (listParent?.querySelector('.spot-list--item-action_active') as HTMLElement)?.click();
     (focused as HTMLElement)?.focus();
+  }
+
+  /**
+   * Fetches projects according to extraIds and appends them to projects. Fetching will only be performed for IDs that
+   * are not already present in projects.
+   * @param {IProject[]} projects - The initial projects that new fetches will be appended to
+   * @param {string[]} concatIds - A list of project IDs that identifies projects that shall be appended
+   */
+  private pipeConcatProjects(projects:IProject[], concatIds:string[], extraFetches:Observable<IHALCollection<IProject>>[] = []) {
+    const existingIds = this.extractIds(projects);
+    concatIds = concatIds.filter((id) => !existingIds.has(id));
+
+    for(let sliceStart = 0; sliceStart < concatIds.length; sliceStart += this.maximumPageSize) {
+      const extraFilter = [['id', '=', concatIds.slice(sliceStart, sliceStart + this.maximumPageSize)]] as ApiV3ListFilter[];
+      extraFetches.push(
+        this.fetchProjects(extraFilter, this.maximumPageSize)
+      );
+    }
+
+    if(extraFetches.length === 0) {
+      return of(projects);
+    }
+
+    return forkJoin(extraFetches).pipe(
+      map((collections) => collections.map((collection) => collection._embedded.elements)),
+      map((collections) => projects.concat(...collections)),
+      map((allProjects) => _.uniqBy(allProjects, (p) => p.id)),
+    );
+  }
+
+  private fetchProjects(filters:ApiV3ListFilter[] = [], pageSize?:number):Observable<IHALCollection<IProject>> {
+    const query = listParamsString(this.params(filters, pageSize));
+    return this.http.get<IHALCollection<IProject>>(this.apiV3Service.projects.path + query);
+  }
+
+  private extractIds(projects:IProject[]):Set<string> {
+    return new Set<string>(projects.map((p) => p.id.toString()));
+  }
+
+  private extractAncestors(projects:IProject[]):string[] {
+    const ancestors = new Set<string>();
+    projects.forEach((p) => p._links.ancestors.forEach((a) => ancestors.add(a.href)));
+
+    // FIXME: Once we target ECMA Script 2025, we can and should use ancestors.values().filter(...)
+    return [...ancestors.values()].filter((s) => s !== UNDISCLOSED_ANCESTOR).map((s) => s.split('/').pop()!);
+  }
+
+  private extractParents(projects:IProject[], childIds:string[]):string[] {
+    const parents = new Set<string>();
+    for(const p of projects.filter((p) => childIds.includes(p.id.toString()))) {
+      const parent = p._links.ancestors[p._links.ancestors.length - 1];
+      if(parent) {
+        parents.add(parent.href);
+      }
+    }
+
+    // FIXME: Once we target ECMA Script 2025, we can and should use parents.values().filter(...)
+    return [...parents.values()].filter((s) => s !== UNDISCLOSED_ANCESTOR).map((s) => s.split('/').pop()!);
   }
 }

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -58,6 +58,9 @@ module API
         property :maximum_attachment_file_size,
                  getter: ->(*) { attachment_max_size.to_i.kilobyte }
 
+        property :maximum_api_v3_page_size,
+                 getter: ->(*) { apiv3_max_page_size }
+
         property :per_page_options,
                  getter: ->(*) { per_page_options_array }
 


### PR DESCRIPTION
This is intended to improve performance for large installations of OpenProject, where a single user can see many projects. Instead of loading all visible projects eagerly, we only load about 300 projects, plus a few more to make sure that the user experience is not affected too badly (e.g. ancestors of all projects shown and the current project the user has opened). To still allow finding any project, the filtering according to the typed search term now also happens on the backend side, so typing will cause additional backend requests.
    
For small installations (< 300 projects) the difference in behaviour should be small: We only perform a single API request to load the project list. The main difference is, that typing causes further API requests, but they should be quick anyways. An increase in number of API requests is plausible though (due to requests after typing).
    
Large installations should see a significant drop in perceived loading times, because it's not necesarry to wait for pagination across all projects to finish, instead a constant number of requests - with a lower response time each - is sufficient. A decrease in number of requests is plausible here, because requests after typing might well be below a single full pagination. Also request concurrency should decrease.

# Ticket
https://community.openproject.org/wp/68612