### PR TITLE
[68341] Improve styling for hierarchy CF macros

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-item-display-field.module.ts
@@ -52,7 +52,7 @@ export class HierarchyItemDisplayField extends ResourceDisplayField {
     });
   }
 
-  private branch(item:HalResource):Observable<HTMLDivElement> {
+  private branch(item:HalResource):Observable<HTMLSpanElement> {
     const itemLink = item.$link as HalLink;
 
     return from(itemLink.$fetch())

--- a/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/multiple-lines-hierarchy-item-display-field.module.ts
@@ -57,13 +57,13 @@ export class MultipleLinesHierarchyItemDisplayField extends ResourcesDisplayFiel
     return this.stringValue.join(', ');
   }
 
-  private branches(items:HalResource[]):Observable<HTMLDivElement[]> {
+  private branches(items:HalResource[]):Observable<HTMLSpanElement[]> {
     return combineLatest(items.map((value:HalResource) => {
       const itemLink = value.$link as HalLink;
 
       return from(itemLink.$fetch())
         .pipe(
-          switchMap((resource:HalResource) => renderHierarchyItem(resource)),
+          switchMap((resource:HalResource) => renderHierarchyItem(resource, true)),
         );
     }));
   }

--- a/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
@@ -32,16 +32,19 @@ import { map } from 'rxjs/operators';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 
-export function renderHierarchyItem(item:HalResource):Observable<HTMLDivElement> {
+export function renderHierarchyItem(item:HalResource, multiple = false):Observable<HTMLSpanElement> {
   const customFieldItemLinks = item.$links as { branch:() => HalResource[] };
   return from(customFieldItemLinks.branch())
     .pipe(
       map((ancestors:CollectionResource) => spansFromAncestors(ancestors)),
       map((spans) => {
-        const div = document.createElement('div');
-        div.className = 'path';
-        spans.forEach((span) => div.appendChild(span));
-        return div;
+        const span = document.createElement('span');
+        span.classList.add('path');
+        if (multiple) {
+          span.classList.add('-multiline');
+        }
+        spans.forEach((s) => span.appendChild(s));
+        return span;
       }),
     );
 }

--- a/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
+++ b/frontend/src/global_styles/content/work_packages/inplace_editing/_display_fields.sass
@@ -116,18 +116,22 @@ display-field
   &.spentTime .time-logging--value
     padding: 0 2px
 
-  &.hierarchy-items
-    .path
-      & > span
-        margin-right: 0.25rem
-
-      & > span:last-child
-        margin-right: 0
-
   &.combinedDate, &.date
     .display-field--scheduling-icon
       position: relative
       top: 1px
+
+display-field .hierarchy-items,
+.inline-edit--display-field.hierarchy-items,
+  .path
+    & > span
+      margin-right: 0.25rem
+
+    & > span:last-child
+      margin-right: 0
+
+    &.-multiline
+      display: block
 
 .wp-table--cell-container
   .inline-edit--display-field.-placeholder,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/68341/activity#comment-1478556

# What are you trying to accomplish?
Style hierachy fields in macros correctly

## Screenshots
<img width="484" height="271" alt="Bildschirmfoto 2025-10-29 um 10 10 36" src="https://github.com/user-attachments/assets/648823bb-f8ca-4207-a66a-b04e8021e372" />
