### PR TITLE
[68647] Sidebar icon overlaps diff header

### DIFF
--- a/app/views/journals/diff.html.erb
+++ b/app/views/journals/diff.html.erb
@@ -29,7 +29,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title @journable.to_s %>
 
-<p><%= authoring @journal.created_at, @journal.user, label: :label_updated_time_by %></p>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_view_diff) }
+    header.with_breadcrumbs( [{ href: project_overview_path(@project.id), text: @project.name },
+                              { href: project_work_packages_path(@project), text: t(:label_work_package_plural) },
+                              { href: project_work_package_path(@project, @journable.id), text: @journable.to_s },
+                              t(:label_view_diff) ])
+    header.with_description { authoring @journal.created_at, @journal.user, label: :label_updated_time_by }
+  end
+%>
 
 <%= render partial: "diff",
            locals: { diff: @diff } %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68647

# What are you trying to accomplish?
Introduce missing PageHeader on journal diff view

## Screenshots

<img width="1300" height="337" alt="Bildschirmfoto 2025-10-29 um 10 33 18" src="https://github.com/user-attachments/assets/b54a5820-ca25-4f56-995a-d1e0155d9b62" />
