### PR TITLE
[45921] Primerize login form (partially)

### DIFF
--- a/app/forms/login_form.rb
+++ b/app/forms/login_form.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class LoginForm < ApplicationForm
+  include ApplicationHelper
+  include OpPrimer::ComponentHelpers
+
+  form do |f|
+    f.hidden(name: "back_url", value: @back_url) if @back_url.present?
+
+    f.text_field(
+      name: :username,
+      value: @username,
+      autofocus: @username.blank?,
+      label: User.human_attribute_name(:login),
+      required: true,
+      autocomplete: "username"
+    )
+
+    f.text_field(
+      name: :password,
+      type: :password,
+      autofocus: @username.present?,
+      label: User.human_attribute_name(:password),
+      required: true,
+      autocomplete: "current-password"
+    )
+
+    if Setting::Autologin.enabled?
+      f.check_box name: "autologin",
+                  checked: false,
+                  value: 1,
+                  label: I18n.t("users.autologins.prompt",
+                                num_days: I18n.t("datetime.distance_in_words.x_days", count: Setting.autologin))
+    end
+
+    f.html_content do
+      flex_layout(justify_content: :space_between, align_items: :center) do |flex|
+        flex.with_column do
+          render(Primer::Beta::Button.new(type: :submit, scheme: :primary)) { I18n.t(:button_login) }
+        end
+
+        flex.with_column do
+          flex_layout do |links|
+            if Setting::SelfRegistration.enabled?
+              links.with_row do
+                render(Primer::Beta::Link.new(href: url_helpers.account_register_path)) { I18n.t(:label_register) }
+              end
+            end
+            if Setting.lost_password?
+              links.with_row do
+                render(Primer::Beta::Link.new(href: url_helpers.account_lost_password_path)) { I18n.t(:label_password_lost) }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def initialize(back_url: nil, username: nil)
+    super()
+    @back_url = back_url
+    @username = username
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -361,15 +361,15 @@ module ApplicationHelper
     hidden_field_tag("back_url", CGI.escape(back_url), id: nil) if back_url.present?
   end
 
-  def back_url_to_current_page_hidden_field_tag
-    back_url = params[:back_url]
+  def back_url_to_current_page
+    back_url = params[:back_url] if params.present?
     if back_url.present?
       back_url = back_url.to_s
-    elsif request.get? and params.present?
+    elsif request.get? && params.present?
       back_url = request.url
     end
 
-    hidden_field_tag("back_url", back_url) if back_url.present?
+    back_url
   end
 
   def check_all_links(form_name)

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -28,60 +28,14 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <div id="nav-login-content">
-  <%= styled_form_tag(
-        { controller: "/account", action: "login" },
-        autocomplete: "off", class: "-vertical"
-      ) do %>
-    <%= back_url_to_current_page_hidden_field_tag %>
+  <%=
+    primer_form_with(
+      url: { controller: "/account", action: "login" },
+      method: :post
+    ) do |form_builder|
+      render(LoginForm.new(form_builder, back_url: back_url_to_current_page, username: params[:username]))
+    end
+  %>
 
-    <div class="grid-block">
-      <div class="form--field -required">
-        <%= styled_label_tag "username-pulldown", User.human_attribute_name(:login) %>
-        <div class="form--field-container">
-          <%= styled_text_field_tag "username", nil, id: "username-pulldown", autocapitalize: "none" %>
-        </div>
-        <div class="form--field-extra-actions">
-          <% if Setting::Autologin.enabled? %>
-            <label class="form--label-with-check-box -no-ellipsis">
-              <%= styled_check_box_tag "autologin", 1, false, id: "autologin-pulldown" %>
-              <%= t("users.autologins.prompt", num_days: I18n.t("datetime.distance_in_words.x_days", count: Setting.autologin)) %>
-            </label>
-          <% elsif Setting::SelfRegistration.enabled? %>
-            <%# show here if autologin is disabled, otherwise below lost_password link %>
-              <%= link_to t(:label_register),
-                          account_register_path,
-                          title: t(:label_register) %>
-          <% end %>
-        </div>
-      </div>
-      <div class="form--field -required">
-        <%= styled_label_tag "password-pulldown", User.human_attribute_name(:password) %>
-        <div class="form--field-container">
-          <%= styled_password_field_tag "password", nil, id: "password-pulldown" %>
-        </div>
-        <div class="form--field-extra-actions">
-          <% if Setting.lost_password? %>
-            <%= link_to t(:label_password_lost), { controller: "/account", action: "lost_password" } %>
-          <% end %>
-          <% if Setting::Autologin.enabled? && Setting::SelfRegistration.enabled? %>
-            <%# show here if autologin is enabled, otherwise below login field %>
-            <%= "<br>".html_safe if Setting.lost_password? %>
-            <%= link_to t(:label_register),
-                        account_register_path,
-                        title: t(:label_register) %>
-          <% end %>
-        </div>
-      </div>
-    </div>
-    <div class="grid-block">
-      <div class="form--field">
-        <label class="form--label" for="login-pulldown">
-          &nbsp;
-        </label>
-        <input type="submit" name="login" id="login-pulldown"
-               value="<%= t(:button_login) %>" class="button -primary button_no-margin" tabindex="1">
-      </div>
-    </div>
-    <%= render partial: "account/auth_providers" %>
-  <% end %>
+  <%= render partial: "account/auth_providers" %>
 </div>

--- a/app/views/account/_password_login_form.html.erb
+++ b/app/views/account/_password_login_form.html.erb
@@ -26,71 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-
-<%= styled_form_tag(
-      { action: "login" },
-      autocomplete: "off",
-      class: "-wide-labels user-login--form",
-      data: { turbo: false } # allow redirects without turbo
-    ) do %>
-  <%= back_url_hidden_field_tag %>
-
-  <div class="form--field -required">
-    <%= styled_label_tag "username", User.human_attribute_name(:login) %>
-    <div class="form--field-container">
-      <%= styled_text_field_tag "username", params[:username], autofocus: params[:username].blank?, autocapitalize: "none" %>
-    </div>
-  </div>
-
-  <div class="form--field -required">
-    <%= styled_label_tag "password", User.human_attribute_name(:password) %>
-    <div class="form--field-container">
-      <%= styled_password_field_tag "password", nil, autofocus: params[:username].present? %>
-    </div>
-  </div>
-
-  <% if Setting::Autologin.enabled? %>
-    <div class="form--field -no-label">
-      <div class="form--field-container">
-        <label class="form--label-with-check-box">
-          <%= styled_check_box_tag "autologin", 1, false %>
-          <%= t("users.autologins.prompt", num_days: I18n.t("datetime.distance_in_words.x_days", count: Setting.autologin)) %>
-        </label>
-      </div>
-    </div>
-  <% end %>
-
-  <div class="login-form--footer">
-    <%= submit_tag t(:button_login),
-                   name: :login,
-                   class: "button -primary button_no-margin",
-                   data: {
-                     controller: "disable-when-clicked",
-                     "disable-when-clicked-text-value": t(:label_loading)
-                   } %>
-
-    <div class="login-options-container">
-      <div class="login-links">
-        <% if Setting.lost_password? %>
-          <%= link_to t(:label_password_lost),
-                      { controller: "/account", action: "lost_password" },
-                      class: "login-form--footer-link" %>
-          <br>
-        <% end %>
-        <% if Setting::SelfRegistration.enabled? %>
-          <%= link_to t(:label_register),
-                      "",
-                      title: t(:label_register),
-                      class: "login-form--footer-link registration-modal--activation-link" %>
-        <% end %>
-      </div>
-    </div>
-  </div>
-<% end %>
-
-<section data-augmented-model-wrapper
-         data-activation-selector=".registration-modal--activation-link"
-         data-modal-class-name="registration-modal -primary">
-  <% @user ||= User.new %>
-  <%= render partial: "/account/register" %>
-</section>
+<%= primer_form_with(
+      url: { controller: "/account", action: "login" },
+      method: :post,
+      data: {
+        turbo: false, # allow redirects without turbo
+        test_selector: "user-login--form"
+      }
+    ) do |form_builder|
+      render(LoginForm.new(form_builder, back_url: back_url_to_current_page, username: params[:username]))
+    end %>

--- a/spec/features/auth/auth_stages_spec.rb
+++ b/spec/features/auth/auth_stages_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Authentication Stages", :skip_2fa_stage do
     end
 
     it "redirects to authentication stage after automatic registration and before login" do
-      visit signin_path
+      visit account_register_path
 
       within("#new_user") do
         fill_in "user_login", with: "h.wurst"

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -58,7 +58,7 @@ module AuthenticationHelpers
   def login_with(login, password, autologin: false, visit_signin_path: true)
     visit signin_path if visit_signin_path
 
-    within(".user-login--form") do
+    within_test_selector("user-login--form") do
       fill_in "username", with: login
       fill_in "password", with: password
       if autologin


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/45921

# What are you trying to accomplish?
"Stay logged in" in German (and Spanish) was truncated on login screen. To fix that, the inner part of the form was harmonized and primerized. The authProvider list remains untouched for now. That will be part of https://community.openproject.org/wp/63849


## Screenshots
<img width="555" height="554" alt="Bildschirmfoto 2025-10-29 um 13 47 38" src="https://github.com/user-attachments/assets/1caaf599-10e0-47d3-99e6-16c85fa6d78c" />

<img width="485" height="443" alt="Bildschirmfoto 2025-10-29 um 13 53 00" src="https://github.com/user-attachments/assets/aabda58d-caf1-461b-b119-d740a9a7895e" />

