### PR TITLE
Include a docker-compose.override example for Hocuspocus

### DIFF
--- a/docker/dev/hocuspocus/docker-compose.override.example.yml
+++ b/docker/dev/hocuspocus/docker-compose.override.example.yml
@@ -1,0 +1,12 @@
+# The service defined here overrides the hocuspocus service to use local code for development
+# Make sure to adjust the volume path to where your hocuspocus source code is
+
+services:
+  hocuspocus:
+    # In case of MacOS you need to specify the platform in your `docker/dev/hocuspocus/docker-compose.override.yml`:
+    # platform: linux/amd64
+    image: node:22-alpine
+    working_dir: /app
+    command: sh -c "npm run dev"
+    volumes:
+      - ../../../../op-blocknote-hocuspocus:/app


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/68663/activity

also related to https://github.com/opf/op-blocknote-hocuspocus/pull/4

# What are you trying to accomplish?
Allow for easier local development setup
