### PR TITLE
Don't allow global memberships on placeholder users

### DIFF
--- a/app/contracts/members/base_contract.rb
+++ b/app/contracts/members/base_contract.rb
@@ -32,6 +32,7 @@ module Members
   class BaseContract < ::ModelContract
     delegate :principal,
              :project,
+             :project_id,
              :new_record?,
              to: :model
 
@@ -41,6 +42,7 @@ module Members
     validate :roles_grantable
     validate :project_set
     validate :project_manageable
+    validate :validate_no_global_placeholder
 
     def assignable_projects
       Project
@@ -49,6 +51,12 @@ module Members
     end
 
     private
+
+    def validate_no_global_placeholder
+      return unless principal.is_a?(PlaceholderUser)
+
+      errors.add :principal, :invalid if project_id.nil?
+    end
 
     def user_allowed_to_manage
       errors.add :base, :error_unauthorized unless user_allowed_to_manage?

--- a/db/migrate/20250929070310_add_view_all_principals_permission_to_existing_roles.rb
+++ b/db/migrate/20250929070310_add_view_all_principals_permission_to_existing_roles.rb
@@ -80,8 +80,10 @@ class AddViewAllPrincipalsPermissionToExistingRoles < ActiveRecord::Migration[8.
     return [] if project_roles_with_manage_members.empty?
 
     # Find all users who have manage_members permission in any project
-    Member.joins(member_roles: :role)
+    # but avoid selecting PlaceholderUser
+    Member.joins(:principal, member_roles: :role)
           .where(member_roles: { roles: { id: project_roles_with_manage_members.pluck(:id) } })
+          .where.not("users.type": "PlaceholderUser")
           .pluck(:user_id)
           .uniq
   end

--- a/db/migrate/20251029134217_avoid_global_role_on_placeholder_user.rb
+++ b/db/migrate/20251029134217_avoid_global_role_on_placeholder_user.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AvoidGlobalRoleOnPlaceholderUser < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL.squish
+      DELETE FROM members
+      USING users
+      WHERE members.user_id = users.id
+        AND members.project_id IS NULL
+        AND users.type = 'PlaceholderUser'
+    SQL
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -126,9 +126,7 @@ module Pages::Meetings
     end
 
     def expect_modal(...)
-      expect(page).to have_modal(...)
-      modal = find(:modal, ...)
-      wait_for_size_animation_completion(modal)
+      Components::Common::Modal.new.expect_modal(...)
     end
 
     def expect_no_add_form

--- a/modules/meeting/spec/support/pages/recurring_meeting/show.rb
+++ b/modules/meeting/spec/support/pages/recurring_meeting/show.rb
@@ -127,7 +127,7 @@ module Pages::RecurringMeeting
     end
 
     def expect_modal(...)
-      expect(page).to have_modal(...)
+      Components::Common::Modal.new.expect_modal(...)
     end
 
     def expect_no_meeting(date:)

--- a/spec/contracts/members/create_contract_spec.rb
+++ b/spec/contracts/members/create_contract_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe Members::CreateContract do
 
         it_behaves_like "contract is invalid", principal: :unassignable
       end
+
+      context "if the principal is a placeholder user and the project is nil" do
+        let(:member_project) { nil }
+        let(:member_principal) { build(:placeholder_user) }
+
+        it_behaves_like "contract is invalid", principal: :invalid
+      end
     end
 
     describe "#assignable_projects" do

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -35,10 +35,12 @@ RSpec.describe "Enterprise token", :js do
 
   shared_let(:admin) { create(:admin) }
 
+  let(:enterprise_tokens_page) { Pages::Admin::EnterpriseTokens::Index.new }
+
   describe "EnterpriseToken management" do
     before do
       login_as admin
-      visit enterprise_tokens_path
+      enterprise_tokens_page.visit!
     end
 
     it "shows a teaser page and has a button to add a token with a dialog" do
@@ -53,14 +55,11 @@ RSpec.describe "Enterprise token", :js do
 
     context "with invalid input" do
       it "shows an error message" do
-        click_button "Add Enterprise token"
-        fill_in "Type support token text", with: "foobar"
-        click_button "Add"
+        enterprise_tokens_page.add_enterprise_token("foobar")
 
         # The dialog is still open with an error message on token field
-        expect(page).to have_dialog("Add Enterprise token")
         validation_error = "Enterprise support token can't be read. Are you sure it is a support token?"
-        expect(page).to have_field("Type support token text", validation_error:)
+        enterprise_tokens_page.expect_add_token_validation_error(validation_error)
       end
     end
 
@@ -74,19 +73,16 @@ RSpec.describe "Enterprise token", :js do
           token.domain = Setting.host_name
         end
       end
+      let(:modals) { Components::Common::Modal.new }
 
       before do
         allow(OpenProject::Token).to receive(:import).and_return(token_object)
       end
 
       it "allows token import flow" do
-        click_button "Add Enterprise token"
-        fill_in "Type support token text", with: "foobar"
-        click_button "Add"
+        enterprise_tokens_page.add_enterprise_token("foobar")
 
-        expect(page).to have_text("Quick feature overview")
-        expect(page).to have_css("#enterprise-trial-welcome-dialog video")
-        page.find('[data-close-dialog-id="enterprise-trial-welcome-dialog"]').click
+        enterprise_tokens_page.close_welcome_video_modal
 
         # Table headers
         [
@@ -117,7 +113,7 @@ RSpec.describe "Enterprise token", :js do
         wait_for_network_idle
 
         # Expect deletion modal
-        expect(page).to have_dialog("Delete enterprise token")
+        modals.expect_modal("Delete enterprise token")
         within_dialog("Delete enterprise token") do
           click_button "Delete"
         end
@@ -128,31 +124,22 @@ RSpec.describe "Enterprise token", :js do
       end
 
       it "cannot import same token twice" do
-        click_button "Add Enterprise token"
-        fill_in "Type support token text", with: "foobar"
-        click_button "Add"
+        enterprise_tokens_page.add_enterprise_token("foobar")
 
-        expect(page).to have_text("Quick feature overview")
-        expect(page).to have_css("#enterprise-trial-welcome-dialog video")
-        page.find('[data-close-dialog-id="enterprise-trial-welcome-dialog"]').click
+        enterprise_tokens_page.close_welcome_video_modal
 
-        click_button "Add Enterprise token"
-        fill_in "Type support token text", with: "foobar"
-        click_button "Add"
+        # Add the token a second time
+        enterprise_tokens_page.add_enterprise_token("foobar")
 
         # The dialog is still open with an error message on token field
-        expect(page).to have_dialog("Add Enterprise token")
-        validation_error = "This token has already been added."
-        expect(page).to have_field("Type support token text", validation_error:)
+        enterprise_tokens_page.expect_add_token_validation_error("This token has already been added.")
 
         # Try importing with blank spaces and newlines before and after
         fill_in "Type support token text", with: " \nfoobar \n"
         click_button "Add"
 
         # The dialog is still open with an error message on token field
-        expect(page).to have_dialog("Add Enterprise token")
-        validation_error = "This token has already been added."
-        expect(page).to have_field("Type support token text", validation_error:)
+        enterprise_tokens_page.expect_add_token_validation_error("This token has already been added.")
       end
     end
   end

--- a/spec/support/pages/admin/enterprise_tokens/index.rb
+++ b/spec/support/pages/admin/enterprise_tokens/index.rb
@@ -28,53 +28,39 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require_relative "../../flash/expectations"
+require "support/pages/page"
 
-module Components
-  module Common
-    class Modal
-      include Capybara::DSL
-      include Capybara::RSpecMatchers
-      include Flash::Expectations
-      include RSpec::Matchers
-      include WaitHelpers
-
-      def expect_modal(title, wait: Capybara.default_max_wait_time)
-        expect_title(title, wait:)
-        modal = find(:modal, title, wait:)
-        wait_for_size_animation_completion(modal)
-      end
-
-      def expect_title(text, wait: Capybara.default_max_wait_time)
-        expect(page).to have_modal(text, wait:)
-      end
-
-      def expect_open
-        expect(page).to have_modal(wait: 40)
-      end
-
-      def expect_closed
-        expect(page).not_to have_modal
-      end
-
-      def expect_text(text)
-        within_modal do
-          expect(page).to have_text(text)
+module Pages
+  module Admin
+    module EnterpriseTokens
+      class Index < ::Pages::Page
+        def path
+          enterprise_tokens_path
         end
-      end
 
-      def click_modal_button(text)
-        within_modal do
-          click_button text
+        def add_enterprise_token(token_text)
+          click_button "Add Enterprise token"
+          modals.expect_modal("Add Enterprise token")
+          fill_in "Type support token text", with: token_text
+          click_button "Add"
         end
-      end
 
-      def within_modal(name = nil, **, &)
-        super
-      end
+        def close_welcome_video_modal
+          modals.expect_modal("Quick feature overview")
+          expect(page).to have_css("#enterprise-trial-welcome-dialog video")
+          page.find('[data-close-dialog-id="enterprise-trial-welcome-dialog"]').click
+        end
 
-      def modal_element
-        find(:modal)
+        def expect_add_token_validation_error(message)
+          expect(page).to have_dialog("Add Enterprise token")
+          expect(page).to have_field("Type support token text", validation_error: message)
+        end
+
+        private
+
+        def modals
+          Components::Common::Modal.new
+        end
       end
     end
   end


### PR DESCRIPTION
The view_all_principals migration added global roles to all users with manage_members.

On QA, we had placeholder users with this permission. Placeholder users should never receive global roles, but there was no validation in place.

This commit adds a migration to remove those, and adds a validation to the contract.
https://community.openproject.org/work_packages/68655