### PR TITLE
Use ApplicationMailer.mail_from in more places

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -45,6 +45,16 @@ class ApplicationMailer < ActionMailer::Base
   default from: Proc.new { Setting.mail_from }
 
   class << self
+
+    ##
+    # Provide an easy way to get the default from address
+    # which is overridden for SaaS for tenant specific from addresses
+    #
+    # @return [String] the default from address
+    def mail_from
+      default[:from].call
+    end
+
     def host
       if OpenProject::Configuration.rails_relative_url_root.blank?
         Setting.host_name
@@ -178,7 +188,7 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def header_host_value
-    host = Setting.mail_from.to_s.gsub(%r{\A.*@}, "")
+    host = ApplicationMailer.mail_from.to_s.gsub(%r{\A.*@}, "")
     host = "#{::Socket.gethostname}.openproject" if host.empty?
     host
   end

--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -47,7 +47,7 @@ class DigestMailer < ApplicationMailer
   class << self
     def generate_message_id(_, user)
       hash = "openproject.digest-#{user.id}-#{Time.current.strftime('%Y%m%d%H%M%S')}"
-      host = Setting.mail_from.to_s.gsub(%r{\A.*@}, "")
+      host = ApplicationMailer.mail_from.to_s.gsub(%r{\A.*@}, "")
       host = "#{::Socket.gethostname}.openproject" if host.empty?
       "#{hash}@#{host}"
     end

--- a/app/services/incoming_emails/dispatch_service.rb
+++ b/app/services/incoming_emails/dispatch_service.rb
@@ -207,13 +207,21 @@ module IncomingEmails
 
     def mail_from_system?
       # Ignore emails received from the application emission address to avoid hell cycles
-      if sender_email.downcase == Setting.mail_from.to_s.strip.downcase
+      if system_mail_addresses.include?(sender_email.downcase)
         log "ignoring email from emission address [#{sender_email}]", report: false
         # don't report back errors to ourselves
         return true
       end
 
       false
+    end
+
+    def system_mail_addresses
+      [
+        Setting.mail_from,
+        ApplicationMailer.mail_from
+      ]
+        .map { |mail| mail.to_s.strip.downcase }
     end
 
     def ignored_by_header?

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -275,7 +275,7 @@ module Meetings
     end
 
     def ical_organizer
-      Icalendar::Values::CalAddress.new("mailto:#{Setting.mail_from}", cn: Setting.app_title)
+      Icalendar::Values::CalAddress.new("mailto:#{ApplicationMailer.mail_from}", cn: Setting.app_title)
     end
 
     def url_helpers

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(watcher1.mail)
-      expect(mail.from).to eq([Setting.mail_from])
+      expect(mail.from).to eq([ApplicationMailer.mail_from])
     end
 
     it "renders the text body" do
@@ -164,7 +164,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(watcher1.mail)
-      expect(mail.from).to eq([Setting.mail_from])
+      expect(mail.from).to eq([ApplicationMailer.mail_from])
     end
 
     describe "text body" do
@@ -214,7 +214,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(author.mail)
-      expect(mail.from).to eq([Setting.mail_from])
+      expect(mail.from).to eq([ApplicationMailer.mail_from])
     end
 
     describe "text body" do

--- a/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe MeetingSeriesMailer do
       expect(mail.subject).to include(series.project.name)
       expect(mail.subject).to include(series.title)
       expect(mail.to).to contain_exactly(recipient.mail)
-      expect(mail.from).to eq([Setting.mail_from])
+      expect(mail.from).to eq([ApplicationMailer.mail_from])
     end
 
     it "renders the text body" do
@@ -97,7 +97,7 @@ RSpec.describe MeetingSeriesMailer do
       expect(mail.subject).to include(series.project.name)
       expect(mail.subject).to include(series.title)
       expect(mail.to).to contain_exactly(recipient.mail)
-      expect(mail.from).to eq([Setting.mail_from])
+      expect(mail.from).to eq([ApplicationMailer.mail_from])
     end
 
     it "renders the text body" do

--- a/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
         entry = ical.events.first
 
         expect(entry.uid).to eq(meeting.uid)
-        expect(entry.organizer.to_s).to eq("mailto:#{Setting.mail_from}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.mail_from}")
         expect(entry.attendee.map(&:to_s)).to match_array([user, user2].map { |u| "mailto:#{u.mail}" })
         expect(entry.dtstart.utc).to eq meeting.start_time
         expect(entry.dtend.utc).to eq meeting.start_time + 1.hour
@@ -186,7 +186,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
         entry = ical.events.first
 
         expect(entry.uid).to eq(recurring_meeting.uid)
-        expect(entry.organizer.to_s).to eq("mailto:#{Setting.mail_from}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.mail_from}")
         expect(entry.attendee.map(&:to_s)).to match_array([user, user2].map { |u| "mailto:#{u.mail}" })
         expect(entry.summary).to eq "Recurring meeting"
         expect(entry.description).to eq "Link to meeting series: http://#{Setting.host_name}/recurring_meetings/#{recurring_meeting.id}"
@@ -228,7 +228,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
 
         expect(entry.uid).to eq(recurring_meeting.uid)
         expect(entry.recurrence_id).to eq(meeting.scheduled_meeting.start_time)
-        expect(entry.organizer.to_s).to eq("mailto:#{Setting.mail_from}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.mail_from}")
         expect(entry.attendee).to be_empty
         expect(entry.summary).to eq "Recurring meeting"
         description = <<~STR.strip

--- a/modules/meeting/spec/services/meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/ical_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Meetings::ICalService, type: :model do # rubocop:disable RSpec/Sp
     it "renders the ICS file", :aggregate_failures do
       expect(result).to be_a String
 
-      expect(entry.organizer.to_s).to eq("mailto:#{Setting.mail_from}")
+      expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.mail_from}")
       expect(entry.attendee.map(&:to_s)).to contain_exactly("mailto:foo@example.com", "mailto:bob@example.com")
       expect(entry.dtstart.utc).to eq meeting.start_time
       expect(entry.dtend.utc).to eq meeting.start_time + 1.hour

--- a/spec/mailers/shared_examples.rb
+++ b/spec/mailers/shared_examples.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples_for "mail is sent" do
   end
 
   it "is sent from the configured address" do
-    expect(deliveries.first.from).to contain_exactly(Setting.mail_from)
+    expect(deliveries.first.from).to contain_exactly(ApplicationMailer.mail_from)
   end
 end
 


### PR DESCRIPTION
It is defined by SaaS to use the reply_token, which fails otherwise

https://community.openproject.org/projects/openproject/work_packages/68659/activity