### PR TITLE
change default of Setting.large_instance_wp_allowed_to_sql

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -636,7 +636,7 @@ module Settings
       large_instance_wp_allowed_to_sql: {
         description: "When querying for allowed work packages, use SQL better suited for instances " \
                      "with a larger set of work packages, projects, members and users",
-        default: false
+        default: true
       },
       ldap_force_no_page: {
         description: "Force LDAP to respond as a single page, in case paged responses do not work with your server.",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68674

# What are you trying to accomplish?

Tests in production indicate that the performance is improved with the altered SQL statement for larger instances while not worsening the response time for smaller instances. The changed SQL can therefore become the default.

The setting will be removed in a subsequent release.
