### PR TITLE
[#68679] Fix toggleability of Session expiry time

### DIFF
--- a/app/components/projects/phase_definitions/form_component.html.erb
+++ b/app/components/projects/phase_definitions/form_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= settings_primer_form_with(
       model: [:admin, :settings, model],
-      data: { controller: "show-when-checked" }
+      data: { controller: "show-when-checked", show_when_checked_visibility_class: "d-none" }
     ) do |f|
       flex_layout do |body|
         body.with_row do
@@ -44,8 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
           classes: model.start_gate.blank? ? "d-none" : "",
           data: {
             target_name: "start_gate",
-            "show-when-checked-target": "effect",
-            visibility_class: "d-none"
+            "show-when-checked-target": "effect"
           }
         ) do
           render Projects::PhaseDefinitions::StartGateNameForm.new(f)
@@ -59,8 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
           classes: model.finish_gate.blank? ? "d-none" : "",
           data: {
             target_name: "finish_gate",
-            "show-when-checked-target": "effect",
-            visibility_class: "d-none"
+            "show-when-checked-target": "effect"
           }
         ) do
           render Projects::PhaseDefinitions::FinishGateNameForm.new(f)

--- a/app/forms/settings/authentication_settings_form.rb
+++ b/app/forms/settings/authentication_settings_form.rb
@@ -32,15 +32,17 @@ module Settings
   class AuthenticationSettingsForm < ApplicationForm
     class SessionTtlForm < ApplicationForm
       settings_form do |f|
-        f.text_field(
-          name: :session_ttl,
-          type: :number,
-          size: 6,
-          min: 0,
-          caption: I18n.t("setting_session_ttl_hint"),
-          trailing_visual: { text: { text: I18n.t(:label_minute_plural) } },
-          input_width: :small
-        )
+        f.group(ml: -4) do |g|
+          g.text_field(
+            name: :session_ttl,
+            type: :number,
+            size: 6,
+            min: 0,
+            caption: I18n.t("setting_session_ttl_hint"),
+            trailing_visual: { text: { text: I18n.t(:label_minute_plural) } },
+            input_width: :small
+          )
+        end
       end
     end
 

--- a/app/forms/settings/authentication_settings_form.rb
+++ b/app/forms/settings/authentication_settings_form.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Settings
+  class AuthenticationSettingsForm < ApplicationForm
+    class SessionTtlForm < ApplicationForm
+      settings_form do |f|
+        f.text_field(
+          name: :session_ttl,
+          type: :number,
+          size: 6,
+          min: 0,
+          caption: I18n.t("setting_session_ttl_hint"),
+          trailing_visual: { text: { text: I18n.t(:label_minute_plural) } },
+          input_width: :small
+        )
+      end
+    end
+
+    settings_form do |f|
+      f.select_list(
+        name: :autologin,
+        input_width: :medium,
+        label: I18n.t(:setting_autologin)
+      ) do |select|
+        select.option(
+          value: 0,
+          label: I18n.t(:label_disabled),
+          selected: Setting.autologin == 0
+        )
+
+        Settings::Definition[:autologin].allowed.each do |days|
+          select.option(
+            value: days,
+            label: I18n.t("datetime.distance_in_words.x_days", count: days),
+            selected: Setting.autologin == days
+          )
+        end
+      end
+
+      f.check_box(
+        name: :session_ttl_enabled,
+        data: {
+          target_name: "session-ttl-enabled",
+          show_when_checked_target: "cause"
+        }
+      ) do |session_ttl_check_box|
+        session_ttl_check_box.nested_form(
+          classes: { "d-none" => !Setting.session_ttl_enabled? },
+          data: {
+            target_name: "session-ttl-enabled",
+            show_when_checked_target: "effect",
+            show_when: "checked",
+            visibility_class: "d-none"
+          }
+        ) do |builder|
+          SessionTtlForm.new(builder)
+        end
+      end
+
+      f.check_box(name: :log_requesting_user)
+
+      f.text_field(
+        name: :after_first_login_redirect_url,
+        caption: I18n.t(:setting_after_first_login_redirect_url_text_html).html_safe,
+        input_width: :large
+      )
+
+      f.text_field(
+        name: :after_login_default_redirect_url,
+        caption: I18n.t(:setting_after_login_default_redirect_url_text_html).html_safe,
+        input_width: :large
+      )
+
+      f.submit
+    end
+  end
+end

--- a/app/forms/settings/authentication_settings_form.rb
+++ b/app/forms/settings/authentication_settings_form.rb
@@ -73,12 +73,11 @@ module Settings
         }
       ) do |session_ttl_check_box|
         session_ttl_check_box.nested_form(
-          classes: { "d-none" => !Setting.session_ttl_enabled? },
+          classes: ["mt-2", { "d-none" => !Setting.session_ttl_enabled? }],
           data: {
             target_name: "session-ttl-enabled",
             show_when_checked_target: "effect",
-            show_when: "checked",
-            visibility_class: "d-none"
+            show_when: "checked"
           }
         ) do |builder|
           SessionTtlForm.new(builder)

--- a/app/forms/settings/authentication_settings_form.rb
+++ b/app/forms/settings/authentication_settings_form.rb
@@ -39,8 +39,9 @@ module Settings
             size: 6,
             min: 0,
             caption: I18n.t("setting_session_ttl_hint"),
-            trailing_visual: { text: { text: I18n.t(:label_minute_plural) } },
-            input_width: :small
+            trailing_visual: { text: { id: "settings_session_ttl_unit", text: I18n.t(:label_minute_plural) } },
+            input_width: :small,
+            aria: { describedby: "settings_session_ttl_unit" }
           )
         end
       end

--- a/app/forms/settings/form_decorator.rb
+++ b/app/forms/settings/form_decorator.rb
@@ -83,13 +83,13 @@ module Settings
     # @param name [Symbol] The name of the setting
     # @param options [Hash] Additional options for the check box
     # @return [Object] The check box input
-    def check_box(name:, **options)
+    def check_box(name:, **options, &)
       options.reverse_merge!(
         label: setting_label(name),
         checked: setting_value(name),
         disabled: setting_disabled?(name)
       )
-      form.check_box(name:, **options)
+      form.check_box(name:, **options, &)
     end
 
     # Creates a radio button group for a setting.

--- a/app/forms/settings/form_decorator.rb
+++ b/app/forms/settings/form_decorator.rb
@@ -174,6 +174,16 @@ module Settings
       end
     end
 
+    # Creates a group for a setting
+    #
+    # @param ** [Hash] Additional options for the group
+    # @see Primer::Forms::Dsl::FormObject#group
+    def group(**, &)
+      form.group(**) do |g|
+        yield Settings::FormDecorator.new(g)
+      end
+    end
+
     # Creates a save button to submit the form
     #
     # @return [Object] The submit button

--- a/app/forms/settings/form_object_decorator.rb
+++ b/app/forms/settings/form_object_decorator.rb
@@ -28,29 +28,41 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class ApplicationForm < Primer::Forms::Base
-  include AttributeHelpTexts::FormHelper
+# Decorates a form object to provide a more convenient interface for
+# rendering settings.
+#
+# It automatically sets the label, value, and disabled properties from the
+# setting name and its definition attributes.
+module Settings
+  class FormObjectDecorator
+    include ::ApplicationHelper
+    include InputMethods
 
-  def self.settings_form
-    form do |f|
-      yield Settings::FormObjectDecorator.new(f)
+    attr_reader :object
+
+    # Initializes a new Settings::FormObjectDecorator
+    #
+    # @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
+    def initialize(object)
+      @object = object
     end
-  end
 
-  def url_helpers
-    Rails.application.routes.url_helpers
-  end
+    def method_missing(method, ...)
+      object.send(method, ...)
+    end
 
-  # @return [ActiveRecord::Base] the model instance given to the form builder
-  def model
-    @builder.object
-  end
+    def respond_to_missing?(method, include_private = false)
+      object.respond_to?(method, include_private)
+    end
 
-  # Forwards all arguments to ActiveRecord's human_attribute_name.
-  #
-  # @param args [Array] Arguments to pass to human_attribute_name (e.g., attribute name, options)
-  # @return [String] The human-readable name of the specified attribute
-  def attribute_name(...)
-    model.class.human_attribute_name(...)
+    # Creates a group for a setting
+    #
+    # @param ** [Hash] Additional options for the group
+    # @see Primer::Forms::Dsl::FormObject#group
+    def group(**, &)
+      object.group(**) do |g|
+        yield Settings::FormObjectDecorator.new(g)
+      end
+    end
   end
 end

--- a/app/forms/settings/form_object_decorator.rb
+++ b/app/forms/settings/form_object_decorator.rb
@@ -34,26 +34,19 @@
 # It automatically sets the label, value, and disabled properties from the
 # setting name and its definition attributes.
 module Settings
-  class FormObjectDecorator
+  class FormObjectDecorator < SimpleDelegator
     include ::ApplicationHelper
     include InputMethods
 
-    attr_reader :object
+    # @!attribute [r] object
+    #   @return [Primer::Forms::Dsl::FormObject] the original form object
+    alias object __getobj__
 
-    # Initializes a new Settings::FormObjectDecorator
+    # @!method initialize(object)
+    #   Initializes a new {Settings::FormObjectDecorator}
     #
-    # @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    def initialize(object)
-      @object = object
-    end
-
-    def method_missing(method, ...)
-      object.send(method, ...)
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      object.respond_to?(method, include_private)
-    end
+    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
+    #   @return [FormObjectDecorator]
 
     # Creates a group for a setting
     #

--- a/app/forms/settings/input_group_decorator.rb
+++ b/app/forms/settings/input_group_decorator.rb
@@ -28,29 +28,31 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class ApplicationForm < Primer::Forms::Base
-  include AttributeHelpTexts::FormHelper
+# Decorates an input group to provide a more convenient interface for
+# rendering settings.
+#
+# It automatically sets the label, value, and disabled properties from the
+# setting name and its definition attributes.
+module Settings
+  class InputGroupDecorator
+    include ::ApplicationHelper
+    include InputMethods
 
-  def self.settings_form
-    form do |f|
-      yield Settings::FormObjectDecorator.new(f)
+    attr_reader :object
+
+    # Initializes a new Settings::InputGroupDecorator
+    #
+    # @param object [Primer::Forms::Dsl::InputGroup] The input group to be decorated
+    def initialize(object)
+      @object = object
     end
-  end
 
-  def url_helpers
-    Rails.application.routes.url_helpers
-  end
+    def method_missing(method, ...)
+      object.send(method, ...)
+    end
 
-  # @return [ActiveRecord::Base] the model instance given to the form builder
-  def model
-    @builder.object
-  end
-
-  # Forwards all arguments to ActiveRecord's human_attribute_name.
-  #
-  # @param args [Array] Arguments to pass to human_attribute_name (e.g., attribute name, options)
-  # @return [String] The human-readable name of the specified attribute
-  def attribute_name(...)
-    model.class.human_attribute_name(...)
+    def respond_to_missing?(method, include_private = false)
+      object.respond_to?(method, include_private)
+    end
   end
 end

--- a/app/forms/settings/input_group_decorator.rb
+++ b/app/forms/settings/input_group_decorator.rb
@@ -34,25 +34,18 @@
 # It automatically sets the label, value, and disabled properties from the
 # setting name and its definition attributes.
 module Settings
-  class InputGroupDecorator
+  class InputGroupDecorator < SimpleDelegator
     include ::ApplicationHelper
     include InputMethods
 
-    attr_reader :object
+    # @!attribute [r] object
+    #   @return [Primer::Forms::Dsl::InputGroup] the original input group
+    alias object __getobj__
 
-    # Initializes a new Settings::InputGroupDecorator
+    # @!method initialize(object)
+    #   Initializes a new {Settings::InputGroupDecorator}
     #
-    # @param object [Primer::Forms::Dsl::InputGroup] The input group to be decorated
-    def initialize(object)
-      @object = object
-    end
-
-    def method_missing(method, ...)
-      object.send(method, ...)
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      object.respond_to?(method, include_private)
-    end
+    #   @param object [Primer::Forms::Dsl::InputGroup] The input group to be decorated
+    #   @return [InputGroupDecorator]
   end
 end

--- a/app/forms/settings/input_methods.rb
+++ b/app/forms/settings/input_methods.rb
@@ -28,33 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
-#
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
 module Settings
-  class FormDecorator
+  module InputMethods
     include ::SettingsHelper
-    include ::ApplicationHelper
     include FormHelper
-
-    attr_reader :form
-
-    # Initializes a new Settings::FormDecorator
-    #
-    # @param form [Object] The form object to be decorated
-    def initialize(form)
-      @form = form
-    end
-
-    def method_missing(method, ...)
-      form.send(method, ...)
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      form.respond_to?(method, include_private)
-    end
 
     # Creates a text field input for a setting.
     #
@@ -71,7 +48,7 @@ module Settings
         value: setting_value(name),
         disabled: setting_disabled?(name)
       )
-      form.text_field(name:, **options)
+      object.text_field(name:, **options)
     end
 
     # Creates a check box input for a setting.
@@ -89,7 +66,7 @@ module Settings
         checked: setting_value(name),
         disabled: setting_disabled?(name)
       )
-      form.check_box(name:, **options, &)
+      object.check_box(name:, **options, &)
     end
 
     # Creates a radio button group for a setting.
@@ -119,7 +96,7 @@ module Settings
         label: setting_label(name),
         disabled: disabled || setting_disabled?(name)
       )
-      form.radio_button_group(
+      object.radio_button_group(
         name:,
         **radio_group_options
       ) do |radio_group|
@@ -151,7 +128,7 @@ module Settings
 
     def multi_language_text_select(name:, current_language: I18n.locale.to_s)
       # Add select list to switch
-      form.select_list(
+      object.select_list(
         name: :"#{name}_lang", # Should be excluded by settings params
         input_width: :small,
         id: "lang-for-#{name}",
@@ -169,18 +146,8 @@ module Settings
         end
       end
 
-      form.fields_for(name) do |builder|
+      object.fields_for(name) do |builder|
         MultiLangForm.new(builder, name:, current_language:)
-      end
-    end
-
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      form.group(**) do |g|
-        yield Settings::FormDecorator.new(g)
       end
     end
 
@@ -188,9 +155,9 @@ module Settings
     #
     # @return [Object] The submit button
     def submit
-      form.submit(name: "submit",
-                  label: I18n.t("button_save"),
-                  scheme: :primary)
+      object.submit(name: "submit",
+                    label: I18n.t("button_save"),
+                    scheme: :primary)
     end
   end
 end

--- a/app/views/admin/settings/authentication_settings/_login.html.erb
+++ b/app/views/admin/settings/authentication_settings/_login.html.erb
@@ -28,51 +28,12 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  settings_primer_form_with(scope: :settings,
-                            url: admin_settings_authentication_path(tab: params[:tab]),
-                            method: :patch) do |f|
-    render_inline_settings_form(f) do |form|
-      form.select_list(
-        name: :autologin,
-        input_width: :medium,
-        label: I18n.t(:setting_autologin),
-      ) do |select|
-        select.option(
-          value: 0,
-          label: I18n.t(:label_disabled),
-          selected: Setting.autologin == 0
-        )
-
-        Settings::Definition[:autologin].allowed.each do |days|
-          select.option(
-            value: days,
-            label: I18n.t("datetime.distance_in_words.x_days", count: days),
-            selected: Setting.autologin == days
-          )
-        end
-      end
-
-      form.check_box(name: :session_ttl_enabled)
-
-      form.text_field(name: :session_ttl,
-                      type: :number,
-                      size: 6,
-                      min: 0,
-                      caption: I18n.t("setting_session_ttl_hint"),
-                      trailing_visual: { text: { text: I18n.t(:label_minute_plural) } },
-                      input_width: :small)
-
-      form.check_box(name: :log_requesting_user)
-
-      form.text_field(name: :after_first_login_redirect_url,
-                      caption: I18n.t(:setting_after_first_login_redirect_url_text_html).html_safe,
-                      input_width: :large)
-
-      form.text_field(name: :after_login_default_redirect_url,
-                      caption: I18n.t(:setting_after_login_default_redirect_url_text_html).html_safe,
-                      input_width: :large)
-
-      form.submit
-    end
+  settings_primer_form_with(
+    scope: :settings,
+    url: admin_settings_authentication_path(tab: params[:tab]),
+    method: :patch,
+    data: { controller: "show-when-checked" }
+  ) do |f|
+    render(Settings::AuthenticationSettingsForm.new(f))
   end
 %>

--- a/app/views/admin/settings/authentication_settings/_login.html.erb
+++ b/app/views/admin/settings/authentication_settings/_login.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     scope: :settings,
     url: admin_settings_authentication_path(tab: params[:tab]),
     method: :patch,
-    data: { controller: "show-when-checked" }
+    data: { controller: "show-when-checked", show_when_checked_visibility_class: "d-none" }
   ) do |f|
     render(Settings::AuthenticationSettingsForm.new(f))
   end

--- a/frontend/src/app/core/setup/globals/global-listeners/settings.ts
+++ b/frontend/src/app/core/setup/globals/global-listeners/settings.ts
@@ -7,10 +7,6 @@ import invariant from 'tiny-invariant';
  * This should not be loaded globally and ideally refactored into components
  */
 export function listenToSettingChanges() {
-  jQuery('#settings_session_ttl_enabled').on('change', function () {
-    jQuery('#settings_session_ttl_container').toggle(jQuery(this).is(':checked'));
-  }).trigger('change');
-
   /** Sync SCM vendor select when enabled SCMs are changed */
   jQuery('[name="settings[enabled_scm][]"]').change(function (this:HTMLInputElement) {
     const wasDisabled = !this.checked;

--- a/frontend/src/app/shared/helpers/dom-helpers.spec.ts
+++ b/frontend/src/app/shared/helpers/dom-helpers.spec.ts
@@ -1,0 +1,187 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import {
+  toggleElement,
+  toggleElementByClass,
+  toggleElementByVisibility,
+} from './dom-helpers';
+
+describe('dom-helpers', () => {
+  describe('toggleElement', () => {
+    let element:HTMLElement;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('toggles the hidden property when no value is provided', () => {
+      expect(element.hidden).toBe(false);
+      toggleElement(element);
+
+      expect(element.hidden).toBe(true);
+      toggleElement(element);
+
+      expect(element.hidden).toBe(false);
+    });
+
+    it('shows the element when value is true', () => {
+      element.hidden = true;
+      toggleElement(element, true);
+
+      expect(element.hidden).toBe(false);
+    });
+
+    it('hides the element when value is false', () => {
+      element.hidden = false;
+      toggleElement(element, false);
+
+      expect(element.hidden).toBe(true);
+    });
+
+    it('keeps element visible when value is true and element is already visible', () => {
+      element.hidden = false;
+      toggleElement(element, true);
+
+      expect(element.hidden).toBe(false);
+    });
+
+    it('keeps element hidden when value is false and element is already hidden', () => {
+      element.hidden = true;
+      toggleElement(element, false);
+
+      expect(element.hidden).toBe(true);
+    });
+  });
+
+  describe('toggleElementByClass', () => {
+    let element:Element;
+    const className = 'hidden';
+
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('toggles the CSS class and sets aria-hidden when no value is provided', () => {
+      expect(element.classList.contains(className)).toBe(false);
+      expect(element.getAttribute('aria-hidden')).toBeNull();
+
+      toggleElementByClass(element, className);
+
+      expect(element.classList.contains(className)).toBe(true);
+      expect(element.getAttribute('aria-hidden')).toBe('true');
+
+      toggleElementByClass(element, className);
+
+      expect(element.classList.contains(className)).toBe(false);
+      expect(element.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('removes the CSS class and sets aria-hidden to false when value is true', () => {
+      element.classList.add(className);
+      toggleElementByClass(element, className, true);
+
+      expect(element.classList.contains(className)).toBe(false);
+      expect(element.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('adds the CSS class and sets aria-hidden to true when value is false', () => {
+      toggleElementByClass(element, className, false);
+
+      expect(element.classList.contains(className)).toBe(true);
+      expect(element.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('keeps element visible with aria-hidden false when value is true and element is already visible', () => {
+      element.classList.remove(className);
+      toggleElementByClass(element, className, true);
+
+      expect(element.classList.contains(className)).toBe(false);
+      expect(element.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('keeps element hidden with aria-hidden true when value is false and element is already hidden', () => {
+      element.classList.add(className);
+      toggleElementByClass(element, className, false);
+
+      expect(element.classList.contains(className)).toBe(true);
+      expect(element.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  describe('toggleElementByVisibility', () => {
+    let element:HTMLElement;
+
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('toggles visibility style property when no value is provided', () => {
+      // Initially, visibility is not set (defaults to visible in browsers)
+      expect(element.style.getPropertyValue('visibility')).toBe('');
+
+      // First call: empty string is not 'visible', so it sets to 'visible'
+      toggleElementByVisibility(element);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('visible');
+
+      // Second call: 'visible' toggles to 'hidden'
+      toggleElementByVisibility(element);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('hidden');
+    });
+
+    it('sets visibility to visible when value is true', () => {
+      element.style.setProperty('visibility', 'hidden');
+      toggleElementByVisibility(element, true);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('visible');
+    });
+
+    it('sets visibility to hidden when value is false', () => {
+      element.style.setProperty('visibility', 'visible');
+      toggleElementByVisibility(element, false);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('hidden');
+    });
+
+    it('keeps visibility visible when value is true and element is already visible', () => {
+      element.style.setProperty('visibility', 'visible');
+      toggleElementByVisibility(element, true);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('visible');
+    });
+
+    it('keeps visibility hidden when value is false and element is already hidden', () => {
+      element.style.setProperty('visibility', 'hidden');
+      toggleElementByVisibility(element, false);
+
+      expect(element.style.getPropertyValue('visibility')).toBe('hidden');
+    });
+  });
+});

--- a/frontend/src/app/shared/helpers/dom-helpers.ts
+++ b/frontend/src/app/shared/helpers/dom-helpers.ts
@@ -1,0 +1,71 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/**
+ * Toggles the visibility of an HTMLElement using `hidden` property.
+ *
+ * @note This is the recommended, modern approach. It is also accessible.
+ * @param element the element to be toggled.
+ * @param value force visibility (optional): `true` to show the element/`false` to hide the element.
+ */
+export function toggleElement(element:HTMLElement, value?:boolean) {
+  if (typeof value === 'undefined') {
+    element.hidden = !element.hidden;
+  } else {
+    element.hidden = !value;
+  }
+};
+
+/**
+ * Toggles the visibility of an Element using a CSS class.
+ * Also takes care of setting `aria-hidden` attribute for accessibility.
+ *
+ * @param element the element to be toggled.
+ * @param className the CSS class name to use.
+ * @param value force visibility (optional): `true` to show the element/`false` to hide the element.
+ */
+export function toggleElementByClass(element:Element, className:string, value?:boolean) {
+  let hiddenValue:boolean;
+  if (typeof value === 'undefined') {
+    hiddenValue = element.classList.toggle(className);
+  } else {
+    hiddenValue = element.classList.toggle(className, !value);
+  }
+  element.setAttribute('aria-hidden', hiddenValue.toString());
+};
+
+/**
+ * Toggles the visibility of an HTMLElement using `visibility` style property.
+ *
+ * @param element the element to be toggled.
+ * @param value force visibility (optional): `true` to show the element/`false` to hide the element.
+ */
+export function toggleElementByVisibility(element:HTMLElement, value?:boolean) {
+  value ??= element.style.getPropertyValue('visibility') !== 'visible';
+  element.style.setProperty('visibility', value ? 'visible' : 'hidden');
+};

--- a/frontend/src/stimulus/controllers/show-when-checked.controller.ts
+++ b/frontend/src/stimulus/controllers/show-when-checked.controller.ts
@@ -28,6 +28,7 @@
  * ++
  */
 
+import { toggleElement, toggleElementByClass, toggleElementByVisibility } from 'core-app/shared/helpers/dom-helpers';
 import { ApplicationController } from 'stimulus-use';
 
 // can show OR hide items by default (with "reversed" set to hide on checking)
@@ -77,11 +78,11 @@ export default class OpShowWhenCheckedController extends ApplicationController {
         }
 
         if (el.dataset.setVisibility === 'true') {
-          el.style.setProperty('visibility', shouldShow ? 'visible' : 'hidden');
-        } else if (el.dataset.visibilityClass) {
-          el.classList.toggle(el.dataset.visibilityClass, !shouldShow);
+          toggleElementByVisibility(el, shouldShow);
+        } else if ('visibilityClass' in el.dataset) {
+          toggleElementByClass(el, el.dataset.visibilityClass!, shouldShow);
         } else {
-          el.hidden = !shouldShow;
+          toggleElement(el, shouldShow);
         }
       });
   }

--- a/frontend/src/stimulus/controllers/show-when-checked.controller.ts
+++ b/frontend/src/stimulus/controllers/show-when-checked.controller.ts
@@ -40,9 +40,14 @@ export default class OpShowWhenCheckedController extends ApplicationController {
     reversed: Boolean,
   };
 
+  static classes = ['visibility'];
+
   declare reversedValue:boolean;
   declare readonly hasReversedValue:boolean;
   declare readonly effectTargets:HTMLElement[];
+
+  declare readonly visibilityClass:string;
+  declare readonly hasVisibilityClass:boolean;
 
   private boundListener = this.toggle.bind(this);
 
@@ -79,6 +84,8 @@ export default class OpShowWhenCheckedController extends ApplicationController {
 
         if (el.dataset.setVisibility === 'true') {
           toggleElementByVisibility(el, shouldShow);
+        } else if (this.hasVisibilityClass) {
+          toggleElementByClass(el, this.visibilityClass, shouldShow);
         } else if ('visibilityClass' in el.dataset) {
           toggleElementByClass(el, el.dataset.visibilityClass!, shouldShow);
         } else {

--- a/frontend/src/stimulus/controllers/show-when-value-selected.controller.ts
+++ b/frontend/src/stimulus/controllers/show-when-value-selected.controller.ts
@@ -1,3 +1,4 @@
+import { toggleElement, toggleElementByVisibility } from 'core-app/shared/helpers/dom-helpers';
 import { ApplicationController } from 'stimulus-use';
 
 export default class OpShowWhenValueSelectedController extends ApplicationController {
@@ -27,9 +28,9 @@ export default class OpShowWhenValueSelectedController extends ApplicationContro
         el.disabled = disabled;
 
         if (el.dataset.setVisibility === 'true') {
-          el.style.setProperty('visibility', disabled ? 'hidden' : 'visible');
+          toggleElementByVisibility(el, !disabled);
         } else {
-          el.hidden = disabled;
+          toggleElement(el, !disabled);
         }
     });
   }

--- a/lookbook/docs/patterns/02-forms.md.erb
+++ b/lookbook/docs/patterns/02-forms.md.erb
@@ -507,7 +507,7 @@ end
 
 It is easier to write and read.
 
-Under the hood, the form object is decorated with `Settings::FormDecorator`.
+Under the hood, the form object is decorated with `Settings::FormObjectDecorator`.
 That's where all the helper methods are defined. There aren't many for now, but
 this is intended to grow to support more advanced form features for
 administration pages.

--- a/spec/features/admin/settings/authentication_settings_spec.rb
+++ b/spec/features/admin/settings/authentication_settings_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Authentication Settings", :js do
       login_page.reload!
 
       expect(login_page).to have_checked_field "Session expires"
-      expect(login_page).to have_field "Session expiry time after inactivity", with: "30"
+      expect(login_page).to have_field "Session expiry time after inactivity", with: "30", described_by: "minutes"
 
       uncheck "Session expires"
 

--- a/spec/features/admin/settings/authentication_settings_spec.rb
+++ b/spec/features/admin/settings/authentication_settings_spec.rb
@@ -30,17 +30,113 @@
 
 require "spec_helper"
 
-RSpec.describe "Authentication Settings" do
+RSpec.describe "Authentication Settings", :js do
   shared_let(:admin) { create(:admin) }
-
-  let(:registration_page) { Pages::Admin::Authentication::Registration.new }
 
   before do
     login_as(admin)
   end
 
+  describe "login settings" do
+    let(:login_page) { Pages::Admin::Authentication::Login.new }
+
+    before do
+      login_page.visit!
+    end
+
+    it "allows changing autologin options" do
+      select "90 days", from: "Autologin"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_select "Autologin", selected: "90 days"
+
+      select "disabled", from: "Autologin"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_select "Autologin", selected: "disabled"
+    end
+
+    it "allows changing session expiration options" do
+      expect(login_page).to have_unchecked_field "Session expires"
+      expect(login_page).to have_no_field "Session expiry time after inactivity"
+
+      check "Session expires"
+      expect(login_page).to have_field "Session expiry time after inactivity"
+
+      fill_in "Session expiry time after inactivity", with: "30"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_checked_field "Session expires"
+      expect(login_page).to have_field "Session expiry time after inactivity", with: "30"
+
+      uncheck "Session expires"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_unchecked_field "Session expires"
+      expect(login_page).to have_no_field "Session expiry time after inactivity"
+    end
+
+    it "allows changing logging options" do
+      expect(login_page).to have_unchecked_field "Log user login, name, and mail address for all requests"
+
+      check "Log user login, name, and mail address for all requests"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_checked_field "Log user login, name, and mail address for all requests"
+
+      uncheck "Log user login, name, and mail address for all requests"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_unchecked_field "Log user login, name, and mail address for all requests"
+    end
+
+    it "allows changing login redirect options" do
+      expect(login_page).to have_field "First login redirect", with: ""
+      expect(login_page).to have_field "After login redirect", with: ""
+
+      fill_in "First login redirect", with: "/my/page"
+      fill_in "After login redirect", with: "/projects/awesome-project"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_field "First login redirect", with: "/my/page"
+      expect(login_page).to have_field "After login redirect", with: "/projects/awesome-project"
+
+      fill_in "First login redirect", with: "/projects/failing-project"
+
+      login_page.save
+      Setting.clear_cache
+      login_page.reload!
+
+      expect(login_page).to have_field "First login redirect", with: "/projects/failing-project"
+      expect(login_page).to have_field "After login redirect", with: "/projects/awesome-project"
+    end
+  end
+
   describe "self registration settings" do
-    it "allows changing self registration options", :js do
+    let(:registration_page) { Pages::Admin::Authentication::Registration.new }
+
+    it "allows changing self registration options" do
       registration_page.visit!
 
       choose I18n.t(:setting_self_registration_disabled)

--- a/spec/forms/settings/authentication_settings_form_spec.rb
+++ b/spec/forms/settings/authentication_settings_form_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe Settings::AuthenticationSettingsForm, type: :forms do
+  include ViewComponent::TestHelpers
+
+  def render_form
+    render_in_view_context(described_class) do |described_class|
+      primer_form_with(url: "/foo") do |f|
+        render(described_class.new(f))
+      end
+    end
+  end
+
+  before do
+    render_form
+  end
+
+  it "renders 'Autologin' select list" do
+    expect(page).to have_select "Autologin"
+  end
+
+  it "renders 'Session expires' checkbox" do
+    expect(page).to have_unchecked_field "Session expires"
+  end
+
+  it "renders 'Session expiry time after inactivity' number field" do
+    expect(page).to have_field "Session expiry time after inactivity", type: "number"
+  end
+
+  it "renders 'Log user login, name, and mail address for all requests' checkbox" do
+    expect(page).to have_unchecked_field "Log user login, name, and mail address for all requests"
+  end
+
+  it "renders 'First login redirect' text field" do
+    expect(page).to have_field "First login redirect"
+  end
+
+  it "renders 'After login redirect' text field" do
+    expect(page).to have_field "After login redirect"
+  end
+
+  it "renders Save button" do
+    expect(page).to have_button "Save", class: "Button--primary"
+  end
+end

--- a/spec/support/pages/admin/authentication/login.rb
+++ b/spec/support/pages/admin/authentication/login.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module Admin
+    module Authentication
+      class Login < ::Pages::Page
+        def path
+          admin_settings_authentication_path(tab: "login")
+        end
+
+        def save
+          click_button "Save"
+          # wait for the save to be processed
+          expect_and_dismiss_flash(message: "Successful update.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68679

# What are you trying to accomplish?

Fixes "toggleability" of "Session expiry time after inactivity" field on the _Administration > Authentication > Login and registration_ page.

- **Initial accessibility improvements**: Enhances the `show-when-checked` Stimulus controller with support for controller-level visibility classes and improved accessibility (`aria-hidden`). Does the same for `show-when-selected` controller for feature parity.
- **Refactoring**: Removed (broken) jQuery-based visibility toggling code for session TTL settings
- **Refactoring**: Extracted authentication settings form logic into a dedicated `Settings::AuthenticationSettingsForm`, also adding specs.
- **Robustness**: Adds feature specs.

The toggling may have been broken as part of #18734

## Screenshots

| Before | After 1 | After 2 |
|--------|--------|--------|
| <img width="938" height="725" alt="Screenshot 2025-10-29 at 20 05 36" src="https://github.com/user-attachments/assets/af27e7ee-a198-4fd9-9ba4-1436dddd5001" /> | <img width="921" height="569" alt="Screenshot 2025-10-29 at 20 04 57" src="https://github.com/user-attachments/assets/9f3766dc-8578-4091-a703-4d13df344e8c" /> | <img width="719" height="692" alt="image" src="https://github.com/user-attachments/assets/97b7a680-8972-4a59-8186-72885bb5cfc8" /> | 

# What approach did you choose and why?

I've tried to reuse (and improve) existing Stimulus controllers.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
