### PR TITLE
Add I18n for BlockNote

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -145,8 +145,10 @@ export default function OpBlockNoteContainer({ inputField,
       const result = await service.addAttachments('documents', attachmentsUploadUrl, [iUploadFile]).toPromise();
 
       return result?.[0]._links.downloadLocation.href ?? '';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch(error:any) {
       const toastService = pluginContext.services.notifications;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       toastService.addError(error);
 
       return '';

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -30,6 +30,7 @@
 
 import { BlockNoteEditorOptions, BlockNoteSchema, defaultBlockSpecs, filterSuggestionItems } from '@blocknote/core';
 import { User } from '@blocknote/core/comments';
+import * as blockNoteLocales from '@blocknote/core/locales';
 import { BlockNoteView } from '@blocknote/mantine';
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
@@ -73,6 +74,10 @@ export default function OpBlockNoteContainer({ inputField,
 
   initOpenProjectApi({ baseUrl: openProjectUrl });
 
+  const userLocale = window.I18n.locale;
+  const blockNoteLocaleString = Object.keys(blockNoteLocales).includes(userLocale) ? userLocale : 'en';
+  const blockNoteLocale = blockNoteLocales[blockNoteLocaleString as keyof typeof blockNoteLocales];
+
   let doc = new Y.Doc();
 
   const collaborationEnabled = Boolean(hocuspocusUrl && documentName && oauthToken && activeUser);
@@ -103,6 +108,7 @@ export default function OpBlockNoteContainer({ inputField,
         },
         showCursorLabels: 'activity'
       },
+      dictionary: blockNoteLocale,
       uploadFile,
     };
   } else { // collaboration disabled
@@ -126,6 +132,7 @@ export default function OpBlockNoteContainer({ inputField,
           color: '#333333',
         },
       },
+      dictionary: blockNoteLocale,
       uploadFile,
     };
   }

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -30,17 +30,18 @@
 
 require "rails_helper"
 
-RSpec.describe "BlockNote editor rendering", :js do
+RSpec.describe "BlockNote editor rendering", :js, with_flag: { block_note_editor: true } do
   let(:admin) { create(:admin) }
   let(:project) { create(:project) }
   let(:category) { create(:document_category, name: "Experimental", project:) }
   let(:document) { create(:document, category:) }
+  let(:editor) { FormFields::Primerized::BlockNoteEditorInput.new }
 
   before do
     login_as(admin)
   end
 
-  it "renders the blocknote editor when editting a document", with_flag: { block_note_editor: true } do
+  it "renders the BlockNote editor when editting a document" do
     visit edit_document_path(document)
 
     expect(page).to have_field("Category", required: true)
@@ -58,5 +59,27 @@ RSpec.describe "BlockNote editor rendering", :js do
     visit edit_document_path(document)
 
     expect(page).to have_test_selector("blocknote-document-description", text: "Additional text")
+  end
+
+  it "renders the BlockNote editor in the users locale" do
+    admin.update!(language: "de")
+    visit edit_document_path(document)
+
+    expect(page).to have_test_selector("blocknote-document-description")
+    expect(page).to have_no_content("Überschrift")
+
+    editor.open_command_dialog
+    expect(page).to have_content("Überschrift")
+  end
+
+  it "renders the blocknote editor in english if the users locale is not available for BlockNote" do
+    admin.update!(language: "af")
+    visit edit_document_path(document)
+
+    expect(page).to have_test_selector("blocknote-document-description")
+    expect(page).to have_no_content("Heading")
+
+    editor.open_command_dialog
+    expect(page).to have_content("Heading")
   end
 end

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -10,6 +10,11 @@ module FormFields
         editor.send_keys("/image")
         editor.send_keys(:enter)
       end
+
+      def open_command_dialog
+        editor = page.find("div[role='textbox']")
+        editor.send_keys("/")
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68606

# What are you trying to accomplish?
Load Blocknote translations in the user's locale, fallback to english if it is not available.

## Screenshots
<img width="1130" height="770" alt="image" src="https://github.com/user-attachments/assets/52d3c0c3-20dd-4ce5-888e-ad57d490e8e9" />

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
