### PR TITLE
[#68700] Rename to weighted item list. Part 1. 

### DIFF
--- a/app/forms/custom_fields/hierarchy/item_form.rb
+++ b/app/forms/custom_fields/hierarchy/item_form.rb
@@ -99,7 +99,7 @@ module CustomFields
           label: I18n.t("custom_fields.admin.items.placeholder.score"),
           type: :number,
           step: :any,
-          value: @target_item.score,
+          value: @target_item.score, # TODO: use weight after the renaming.
           visually_hide_label: true,
           full_width: false,
           required: true,

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -56,7 +56,7 @@ module CustomFields
       def insert_item(contract_class:, parent:, label:, short: nil, score: nil, sort_order: nil)
         contract_class
           .new
-          .call({ parent:, label:, short:, score: })
+          .call({ parent:, label:, short:, score:, weight: score })
           .to_monad
           .bind { |validation| create_child_item(validation:, sort_order:) }
       end
@@ -72,7 +72,7 @@ module CustomFields
       def update_item(contract_class:, item:, label: nil, short: nil, score: nil)
         contract_class
           .new
-          .call({ item:, label:, short:, score: })
+          .call({ item:, label:, short:, score:, weight: score })
           .to_monad
           .bind { |attributes| update_item_attributes(item:, attributes:) }
       end
@@ -188,7 +188,8 @@ module CustomFields
       end
 
       def update_item_attributes(item:, attributes:)
-        if item.update(label: attributes[:label], short: attributes[:short], score: attributes[:score])
+        if item.update(label: attributes[:label], short: attributes[:short], score: attributes[:score],
+                       weight: attributes[:score])
           if item.score_previously_changed?
             # Only changes to item are of interest, so no need to pass descendant ids
             update_calculated_values_for_hierarchy(item_ids: item.id, custom_field: item.root&.custom_field)

--- a/db/migrate/20251030152928_add_list_item_weight.rb
+++ b/db/migrate/20251030152928_add_list_item_weight.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddListItemWeight < ActiveRecord::Migration[8.0]
+  def change
+    add_column :hierarchical_items, :weight, :decimal, default: nil, null: true
+  end
+end

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -376,6 +376,13 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
         expect(project_having_fields_enabled.custom_values).to be_empty
         expect(project_having_fields_enabled.custom_values).to be_empty
       end
+
+      it "updates both score and weight fields" do
+        expect(result).to be_success
+        one.reload
+        expect(one.score).to eq(42)
+        expect(one.weight).to eq(42)
+      end
     end
 
     describe "deleting an item" do


### PR DESCRIPTION
# Ticket
[[#68700] Rename to weighted item list](https://community.openproject.org/work_packages/68700)

# What are you trying to accomplish?
Introduces a new 'weight' column to the hierarchical_items table via migration. Update service logic to handle the new weight attribute alongside score, preparing for a future renaming. A minor form comment was added to indicate an upcoming change.

Part 1: new field and writing to both fields. 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
