### PR TITLE
Fix show-when-checked `target-name` data attribute

### DIFF
--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -149,7 +149,7 @@
           modal_body.with_row(
             mt: 3,
             data: {
-              "show-when-checked-target-name": "notification-banner",
+              "target-name": "notification-banner",
               "show-when-checked-target": "effect",
               "show-when": "checked",
               visibility_class: "d-none"
@@ -162,7 +162,7 @@
             mt: 3,
             classes: "d-none",
             data: {
-              "show-when-checked-target-name": "notification-banner",
+              "target-name": "notification-banner",
               "show-when-checked-target": "effect",
               "show-when": "unchecked",
               visibility_class: "d-none"

--- a/modules/meeting/app/forms/meeting/send_email_updates.rb
+++ b/modules/meeting/app/forms/meeting/send_email_updates.rb
@@ -36,7 +36,7 @@ class Meeting::SendEmailUpdates < ApplicationForm
       checked: true,
       data: {
         "show-when-checked-target": "cause",
-        "show-when-checked-target-name": "notification-banner"
+        "target-name": "notification-banner"
       }
     )
   end


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

**Found while working on another PR: #20846**

Fixes the `target-name` data attribute used with `show-when-checked` controller in meeting module. Although the usage is incorrect, it doesn't appear to have caused any user-facing issues.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
