### PR TITLE
[68724] Date picker shows unnecessary blank space on the right side

### DIFF
--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -7,6 +7,7 @@ $body-height: 460px
   .wp-datepicker-dialog
     &--content
       max-height: calc(var(--app-height) - 2rem)
+      width: 600px
       overflow: auto
 
     &--body

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -43,9 +43,3 @@ $body-height: 460px
   .wp-datepicker-dialog--content,
   #wp-datepicker-dialog--content
     height: inherit
-
-// Spot modal has 60rem width as the parent element,
-// So we should set the width to the spot modal itself
-@media #{$spot-mq-desktop}
-  .spot-modal:has(.wp-datepicker-dialog--content)
-    width: 600px

--- a/app/components/work_packages/date_picker/dialog_content_component.sass
+++ b/app/components/work_packages/date_picker/dialog_content_component.sass
@@ -7,7 +7,6 @@ $body-height: 460px
   .wp-datepicker-dialog
     &--content
       max-height: calc(var(--app-height) - 2rem)
-      width: 600px
       overflow: auto
 
     &--body
@@ -44,3 +43,9 @@ $body-height: 460px
   .wp-datepicker-dialog--content,
   #wp-datepicker-dialog--content
     height: inherit
+
+// Spot modal has 60rem width as the parent element,
+// So we should set the width to the spot modal itself
+@media #{$spot-mq-desktop}
+  .spot-modal:has(.wp-datepicker-dialog--content)
+    width: 600px

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.html
@@ -1,5 +1,5 @@
 <div
-  class="spot-modal spot-modal_full-screen-when-narrow loading-indicator--location"
+  class="spot-modal spot-modal_auto-size spot-modal_full-screen-when-narrow loading-indicator--location"
   data-indicator-name="modal"
   tabindex="0"
   >

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -17,7 +17,7 @@
   max-width: calc(100vw - 2rem)
   max-height: calc(#{var(--app-height)} - 2rem)
 
-  @media #{$spot-mq-mobile}
+  @media screen and (max-width: $breakpoint-sm)
     width: calc(100vw - 2rem)
     max-height: calc(#{var(--app-height)} - 5rem)
     overflow-y: auto
@@ -31,12 +31,12 @@
     min-height: 40vh
 
   &_auto-size
-    @media #{$spot-mq-desktop}
+    @media screen and (min-width: $breakpoint-sm)
       width: auto
       min-height: auto
 
   &_full-screen-when-narrow
-    @media #{$spot-mq-mobile}
+    @media screen and (max-width: $breakpoint-sm)
       width: 100dvw
       height: 100dvh
       max-height: unset

--- a/frontend/src/app/spot/styles/sass/components/modal.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal.sass
@@ -30,6 +30,11 @@
     width: 60rem
     min-height: 40vh
 
+  &_auto-size
+    @media #{$spot-mq-desktop}
+      width: auto
+      min-height: auto
+
   &_full-screen-when-narrow
     @media #{$spot-mq-mobile}
       width: 100dvw


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68724

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Set width on the spot modal, not on the dialog content

## Screenshots
Before:
<img width="793" height="686" alt="Screenshot 2025-10-31 at 13 12 18" src="https://github.com/user-attachments/assets/50764919-278c-4f57-9e8f-9502df19ea09" />


After:
<img width="842" height="677" alt="Screenshot 2025-10-31 at 13 11 29" src="https://github.com/user-attachments/assets/cded6269-04ad-4c2a-889e-cd88d38fae30" />

