### PR TITLE
Update op-blocknote-extensions to latest

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -104,7 +104,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.0.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.8/op-blocknote-extensions-0.0.8.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -18093,17 +18093,14 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.8",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.8/op-blocknote-extensions-0.0.8.tgz",
-      "integrity": "sha512-MJ5glkGiyWbobyNyrG0mmc+L6Hmxctbx5hX2lL8gs7DtE+9FJrh+lQBdFTfz9L/K+h+QQuuR/PpQUjusJke7fw==",
+      "version": "0.0.9",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
+      "integrity": "sha512-j57yMhEXYZmdmE0OVR1KkgblJ1nooa6Eq8ikAyvHRaT+qry8RALSeQpt+re2XZbkWfXg6rWeVQo9gxwn2nIc7g==",
       "dependencies": {
+        "@blocknote/core": "^0.41.1",
+        "@blocknote/mantine": "^0.41.1",
+        "@blocknote/react": "^0.41.1",
         "styled-components": "^6.1.19"
-      },
-      "peerDependencies": {
-        "@blocknote/core": "^0.41",
-        "@blocknote/react": "^0.41",
-        "react": "^19.x",
-        "react-dom": "^19.x"
       }
     },
     "node_modules/open": {
@@ -35697,9 +35694,12 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.8/op-blocknote-extensions-0.0.8.tgz",
-      "integrity": "sha512-MJ5glkGiyWbobyNyrG0mmc+L6Hmxctbx5hX2lL8gs7DtE+9FJrh+lQBdFTfz9L/K+h+QQuuR/PpQUjusJke7fw==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
+      "integrity": "sha512-j57yMhEXYZmdmE0OVR1KkgblJ1nooa6Eq8ikAyvHRaT+qry8RALSeQpt+re2XZbkWfXg6rWeVQo9gxwn2nIc7g==",
       "requires": {
+        "@blocknote/core": "^0.41.1",
+        "@blocknote/mantine": "^0.41.1",
+        "@blocknote/react": "^0.41.1",
         "styled-components": "^6.1.19"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -159,7 +159,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.0.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.8/op-blocknote-extensions-0.0.8.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -28,17 +28,17 @@
  * ++
  */
 
-import { BlockNoteEditorOptions, BlockNoteSchema, defaultBlockSpecs, filterSuggestionItems } from '@blocknote/core';
+import { BlockNoteEditorOptions, BlockNoteSchema, filterSuggestionItems } from '@blocknote/core';
 import { User } from '@blocknote/core/comments';
 import * as blockNoteLocales from '@blocknote/core/locales';
 import { BlockNoteView } from '@blocknote/mantine';
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { OpColorMode } from 'core-app/core/setup/globals/theme-utils';
-import { getDefaultOpenProjectSlashMenuItems, initOpenProjectApi, openProjectWorkPackageBlockSpec } from 'op-blocknote-extensions';
+import { IUploadFile } from 'core-app/core/upload/upload.service';
+import { initOpenProjectApi, openProjectWorkPackageBlockSpec, openProjectWorkPackageSlashMenu } from 'op-blocknote-extensions';
 import { useEffect, useState } from 'react';
 import * as Y from 'yjs';
-import { IUploadFile } from 'core-app/core/upload/upload.service';
 
 export interface OpBlockNoteContainerProps {
   inputField:HTMLInputElement;
@@ -52,9 +52,8 @@ export interface OpBlockNoteContainerProps {
   attachmentsUploadUrl:string;
 }
 
-const schema = BlockNoteSchema.create({
+const schema = BlockNoteSchema.create().extend({
   blockSpecs: {
-    ...defaultBlockSpecs,
     openProjectWorkPackage: openProjectWorkPackageBlockSpec(),
   },
 });
@@ -83,8 +82,7 @@ export default function OpBlockNoteContainer({ inputField,
   const collaborationEnabled = Boolean(hocuspocusUrl && documentName && oauthToken && activeUser);
   let hocuspocusProvider:HocuspocusProvider | null = null;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let editorParams:Partial<BlockNoteEditorOptions<any, any, any>>;
+  let editorParams:Partial<BlockNoteEditorOptions<typeof schema.blockSchema, typeof schema.inlineContentSchema, typeof schema.styleSchema>>;
   if(collaborationEnabled) {
     const url = new URL(hocuspocusUrl);
     url.searchParams.set('document_id', documentId);
@@ -163,11 +161,9 @@ export default function OpBlockNoteContainer({ inputField,
   }
 
   const getCustomSlashMenuItems = (editor:EditorType) => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return [
       ...getDefaultReactSlashMenuItems(editor),
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      ...getDefaultOpenProjectSlashMenuItems(editor),
+      openProjectWorkPackageSlashMenu(editor),
     ];
   };
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/68529/activity

This PR was created on the context of the ticket above, but it does not change any behaviour, it's just updating the op-blocknote-extensions version.

# What are you trying to accomplish?

- Update to the latest version of the op-blocknote-extensions
- minor typescript cleanup things on the OpBlockNoteContainer setup