### PR TITLE
Fix Meetings Outcome CRUD feature spec

### DIFF
--- a/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
@@ -101,10 +101,8 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
           field.set_value "It means no worries"
         end
 
-        dismiss_confirm do
-          page.within("#meeting-agenda-items-outcomes-base-component-#{item.id}") do
-            click_link_or_button "Outcome"
-          end
+        page.within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+          click_link_or_button "Outcome"
         end
 
         show_page.in_outcome_component(wp_item) do


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Fix multiple outcomes scenario and get CI back to green.

# What approach did you choose and why?

N.B. there is still a modal dialog warning:

```
$ bundle exec rspec ./modules/meeting/spec/features/meeting_outcomes_crud_spec.rb

Randomized with seed 28840

Meeting Outcomes CRUD
  when a user has the necessary 'manage_outcomes' permission
    when the meeting is 'open'
      can only view existing outcomes
    when the meeting is 'closed'
      can only view existing outcomes
    when the meeting is 'in progress'
      can add multiple outcomes
/Users/alexbcoles/.gem/ruby/3.4.7/gems/cuprite-0.17/lib/capybara/cuprite/page.rb:164:in 'block in Capybara::Cuprite::Page#prepare_page': Modal window with text `Are you sure?` has been opened, but you didn't wrap your code into (`accept_prompt` | `dismiss_prompt` | `accept_confirm` | `dismiss_confirm` | `accept_alert`), accepting by default (StructuredWarnings::StandardWarning)
```


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
