### PR TITLE
Remove name part of reply_to address

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -68,6 +68,16 @@ class ApplicationMailer < ActionMailer::Base
       end
     end
 
+    ##
+    # Return the email address of reply to
+    #
+    # @return [String] the default from address
+    def reply_to_address
+      address = reply_to
+      # Extract email from "Name <email>" format if present
+      address[/<(.+)>/, 1] || address
+    end
+
     def host
       if OpenProject::Configuration.rails_relative_url_root.blank?
         Setting.host_name
@@ -76,9 +86,7 @@ class ApplicationMailer < ActionMailer::Base
       end
     end
 
-    def protocol
-      Setting.protocol
-    end
+    delegate :protocol, to: :Setting
 
     def default_url_options
       options = super.merge(host:, protocol:)

--- a/app/services/incoming_emails/dispatch_service.rb
+++ b/app/services/incoming_emails/dispatch_service.rb
@@ -219,7 +219,7 @@ module IncomingEmails
     def system_mail_addresses
       [
         ApplicationMailer.mail_from,
-        ApplicationMailer.reply_to
+        ApplicationMailer.reply_to_address
       ]
         .map { |mail| mail.to_s.strip.downcase }
     end

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -275,7 +275,7 @@ module Meetings
     end
 
     def ical_organizer
-      Icalendar::Values::CalAddress.new("mailto:#{ApplicationMailer.reply_to}", cn: Setting.app_title)
+      Icalendar::Values::CalAddress.new("mailto:#{ApplicationMailer.reply_to_address}", cn: Setting.app_title)
     end
 
     def url_helpers

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(watcher1.mail)
-      expect(mail.from).to eq([ApplicationMailer.reply_to])
+      expect(mail.from).to eq([ApplicationMailer.reply_to_address])
     end
 
     it "renders the text body" do
@@ -164,7 +164,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(watcher1.mail)
-      expect(mail.from).to eq([ApplicationMailer.reply_to])
+      expect(mail.from).to eq([ApplicationMailer.reply_to_address])
     end
 
     describe "text body" do
@@ -214,7 +214,7 @@ RSpec.describe MeetingMailer do
       expect(mail.subject).to include(meeting.project.name)
       expect(mail.subject).to include(meeting.title)
       expect(mail.to).to contain_exactly(author.mail)
-      expect(mail.from).to eq([ApplicationMailer.reply_to])
+      expect(mail.from).to eq([ApplicationMailer.reply_to_address])
     end
 
     describe "text body" do

--- a/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_series_mailer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe MeetingSeriesMailer do
       expect(mail.subject).to include(series.project.name)
       expect(mail.subject).to include(series.title)
       expect(mail.to).to contain_exactly(recipient.mail)
-      expect(mail.from).to eq([ApplicationMailer.reply_to])
+      expect(mail.from).to eq([ApplicationMailer.reply_to_address])
     end
 
     it "renders the text body" do
@@ -97,7 +97,7 @@ RSpec.describe MeetingSeriesMailer do
       expect(mail.subject).to include(series.project.name)
       expect(mail.subject).to include(series.title)
       expect(mail.to).to contain_exactly(recipient.mail)
-      expect(mail.from).to eq([ApplicationMailer.reply_to])
+      expect(mail.from).to eq([ApplicationMailer.reply_to_address])
     end
 
     it "renders the text body" do

--- a/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
         entry = ical.events.first
 
         expect(entry.uid).to eq(meeting.uid)
-        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to_address}")
         expect(entry.attendee.map(&:to_s)).to match_array([user, user2].map { |u| "mailto:#{u.mail}" })
         expect(entry.dtstart.utc).to eq meeting.start_time
         expect(entry.dtend.utc).to eq meeting.start_time + 1.hour
@@ -186,7 +186,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
         entry = ical.events.first
 
         expect(entry.uid).to eq(recurring_meeting.uid)
-        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to_address}")
         expect(entry.attendee.map(&:to_s)).to match_array([user, user2].map { |u| "mailto:#{u.mail}" })
         expect(entry.summary).to eq "Recurring meeting"
         expect(entry.description).to eq "Link to meeting series: http://#{Setting.host_name}/recurring_meetings/#{recurring_meeting.id}"
@@ -228,7 +228,7 @@ RSpec.describe AllMeetings::ICalService, type: :model do # rubocop:disable RSpec
 
         expect(entry.uid).to eq(recurring_meeting.uid)
         expect(entry.recurrence_id).to eq(meeting.scheduled_meeting.start_time)
-        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to}")
+        expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to_address}")
         expect(entry.attendee).to be_empty
         expect(entry.summary).to eq "Recurring meeting"
         description = <<~STR.strip

--- a/modules/meeting/spec/services/meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/meetings/ical_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Meetings::ICalService, type: :model do # rubocop:disable RSpec/Sp
     it "renders the ICS file", :aggregate_failures do
       expect(result).to be_a String
 
-      expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to}")
+      expect(entry.organizer.to_s).to eq("mailto:#{ApplicationMailer.reply_to_address}")
       expect(entry.attendee.map(&:to_s)).to contain_exactly("mailto:foo@example.com", "mailto:bob@example.com")
       expect(entry.dtstart.utc).to eq meeting.start_time
       expect(entry.dtend.utc).to eq meeting.start_time + 1.hour


### PR DESCRIPTION
https://community.openproject.org/work_packages/68659

saas provides a reply to with a mailbox (name <mail>) which otherwise would break ics output if it's not removed