### PR TITLE
Bug/66552 Fix the activities tab’s `:only_changes` filtration for lazy loading

### DIFF
--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -228,36 +228,42 @@ class WorkPackages::ActivitiesTab::Paginator
     Journal::WorkPackageJournal.column_names - ["id", "project_phase_definition_id"]
   end
 
-  # Detect attachment changes by comparing with predecessor journal.
   def attachment_changes_condition_sql
     association_changes_condition_sql(
-      table: "attachable_journals",
+      table: Journal::AttachableJournal.table_name,
       id_column: "attachment_id",
       value_columns: ["filename"]
     )
   end
 
-  # Detect custom field changes by comparing with predecessor journal.
   def custom_field_changes_condition_sql
     association_changes_condition_sql(
-      table: "customizable_journals",
+      table: Journal::CustomizableJournal.table_name,
       id_column: "custom_field_id",
       value_columns: ["value"]
     )
   end
 
-  # Detect file link changes by comparing with predecessor journal.
   def file_link_changes_condition_sql
     association_changes_condition_sql(
-      table: "storages_file_links_journals",
+      table: Journal::StorableJournal.table_name,
       id_column: "file_link_id",
       value_columns: %w[link_name storage_name]
     )
   end
 
-  # Generic SQL to detect changes in association journals by comparing with predecessor.
-  # Detects added items, removed items, and changed values.
+  # Detect changes in association journals by checking for additions and removals.
   def association_changes_condition_sql(table:, id_column:, value_columns:)
+    "#{association_items_added_sql(table:, id_column:, value_columns:)} " \
+      "UNION " \
+      "#{association_items_removed_sql(table:, id_column:)}"
+  end
+
+  # Detect added or modified association items by comparing with predecessor journal.
+  # Returns SQL that finds items that either:
+  # - Exist in current journal but not in predecessor (additions)
+  # - Exist in both but have different values (modifications)
+  def association_items_added_sql(table:, id_column:, value_columns:)
     value_changes = value_columns.map do |col|
       "pred.#{col} IS DISTINCT FROM curr.#{col}"
     end.join(" OR ")
@@ -274,7 +280,13 @@ class WorkPackages::ActivitiesTab::Paginator
           AND pred.#{id_column} = curr.#{id_column}
         WHERE curr.journal_id = journals.id
           AND (pred.id IS NULL OR (#{value_changes}))
-      UNION
+    SQL
+  end
+
+  # Detect removed association items by comparing with predecessor journal.
+  # Returns SQL that finds items that existed in predecessor but not in current journal.
+  def association_items_removed_sql(table:, id_column:)
+    <<~SQL.squish
       SELECT 1
         FROM journals predecessor
         INNER JOIN #{table} pred

--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -171,22 +171,22 @@ class WorkPackages::ActivitiesTab::Paginator
   #
   # Includes journals that have:
   #   * Initial journal (version = 1) - always included
-  #   * Attachment changes (attachable_journals association)
-  #   * Custom field changes (customizable_journals association)
-  #   * File link changes (storages_file_links_journals association)
+  #   * Attachment changes (compares attachable_journals with predecessor)
+  #   * Custom field changes (compares customizable_journals with predecessor)
+  #   * File link changes (compares storages_file_links_journals with predecessor)
   #   * Cause metadata (system-triggered changes)
   #   * Attribute/data changes (compares work_package_journals columns with immediate predecessor)
   #
-  # Note: This heuristic may include false positives (journals without actual changes)
-  # for performance reasons, as it uses EXISTS subqueries and cannot guarantee perfect accuracy.
+  # This heuristic compares association records with the predecessor journal to detect actual changes,
+  # not just the presence of snapshot records.
   def apply_only_changes_filter_heuristic(journals)
     sql = <<~SQL.squish
       version = 1
-      OR EXISTS (SELECT 1 FROM attachable_journals WHERE attachable_journals.journal_id = journals.id)
-      OR EXISTS (SELECT 1 FROM customizable_journals WHERE customizable_journals.journal_id = journals.id)
-      OR EXISTS (SELECT 1 FROM storages_file_links_journals WHERE storages_file_links_journals.journal_id = journals.id)
       OR (cause IS NOT NULL AND cause != '{}')
       OR EXISTS (#{attribute_data_changes_condition_sql})
+      OR EXISTS (#{attachment_changes_condition_sql})
+      OR EXISTS (#{custom_field_changes_condition_sql})
+      OR EXISTS (#{file_link_changes_condition_sql})
     SQL
 
     journals.where(OpenProject::SqlSanitization.sanitize(sql))
@@ -226,5 +226,66 @@ class WorkPackages::ActivitiesTab::Paginator
 
   def data_change_columns
     Journal::WorkPackageJournal.column_names - ["id", "project_phase_definition_id"]
+  end
+
+  # Detect attachment changes by comparing with predecessor journal.
+  def attachment_changes_condition_sql
+    association_changes_condition_sql(
+      table: "attachable_journals",
+      id_column: "attachment_id",
+      value_columns: ["filename"]
+    )
+  end
+
+  # Detect custom field changes by comparing with predecessor journal.
+  def custom_field_changes_condition_sql
+    association_changes_condition_sql(
+      table: "customizable_journals",
+      id_column: "custom_field_id",
+      value_columns: ["value"]
+    )
+  end
+
+  # Detect file link changes by comparing with predecessor journal.
+  def file_link_changes_condition_sql
+    association_changes_condition_sql(
+      table: "storages_file_links_journals",
+      id_column: "file_link_id",
+      value_columns: %w[link_name storage_name]
+    )
+  end
+
+  # Generic SQL to detect changes in association journals by comparing with predecessor.
+  # Detects added items, removed items, and changed values.
+  def association_changes_condition_sql(table:, id_column:, value_columns:)
+    value_changes = value_columns.map do |col|
+      "pred.#{col} IS DISTINCT FROM curr.#{col}"
+    end.join(" OR ")
+
+    <<~SQL.squish
+      SELECT 1
+        FROM #{table} curr
+        LEFT JOIN journals predecessor
+          ON predecessor.journable_id = journals.journable_id
+          AND predecessor.journable_type = journals.journable_type
+          AND predecessor.version = (#{max_predecessor_version_sql})
+        LEFT JOIN #{table} pred
+          ON pred.journal_id = predecessor.id
+          AND pred.#{id_column} = curr.#{id_column}
+        WHERE curr.journal_id = journals.id
+          AND (pred.id IS NULL OR (#{value_changes}))
+      UNION
+      SELECT 1
+        FROM journals predecessor
+        INNER JOIN #{table} pred
+          ON pred.journal_id = predecessor.id
+        LEFT JOIN #{table} curr
+          ON curr.journal_id = journals.id
+          AND curr.#{id_column} = pred.#{id_column}
+        WHERE predecessor.journable_id = journals.journable_id
+          AND predecessor.journable_type = journals.journable_type
+          AND predecessor.version = (#{max_predecessor_version_sql})
+          AND curr.id IS NULL
+    SQL
   end
 end

--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -140,10 +140,12 @@ class WorkPackages::ActivitiesTab::Paginator
       .reorder(version: :desc) # Always fetch newest first for pagination
       .with_sequence_version
 
-    journals = journals.where.not(notes: [nil, ""]) if filter == :only_comments
-    journals = apply_only_changes_filter_heuristic(journals) if filter == :only_changes
-
-    journals
+    case filter
+    when :only_comments then apply_comments_only_filter(journals)
+    when :only_changes then apply_changes_only_filter(journals)
+    else
+      journals
+    end
   end
 
   def fetch_revisions
@@ -167,137 +169,11 @@ class WorkPackages::ActivitiesTab::Paginator
     end
   end
 
-  # SQL-based heuristic to filter journals with changes.
-  #
-  # Includes journals that have:
-  #   * Initial journal (version = 1) - always included
-  #   * Attachment changes (compares attachable_journals with predecessor)
-  #   * Custom field changes (compares customizable_journals with predecessor)
-  #   * File link changes (compares storages_file_links_journals with predecessor)
-  #   * Cause metadata (system-triggered changes)
-  #   * Attribute/data changes (compares work_package_journals columns with immediate predecessor)
-  #
-  # This heuristic compares association records with the predecessor journal to detect actual changes,
-  # not just the presence of snapshot records.
-  def apply_only_changes_filter_heuristic(journals)
-    sql = <<~SQL.squish
-      version = 1
-      OR (cause IS NOT NULL AND cause != '{}')
-      OR EXISTS (#{attribute_data_changes_condition_sql})
-      OR EXISTS (#{attachment_changes_condition_sql})
-      OR EXISTS (#{custom_field_changes_condition_sql})
-      OR EXISTS (#{file_link_changes_condition_sql})
-    SQL
-
-    journals.where(OpenProject::SqlSanitization.sanitize(sql))
+  def apply_comments_only_filter(scope)
+    scope.where.not(notes: [nil, ""])
   end
 
-  def attribute_data_changes_condition_sql
-    <<~SQL.squish
-      SELECT 1
-        FROM journals predecessor
-        INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
-        INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
-        WHERE predecessor.journable_id = journals.journable_id
-          AND predecessor.journable_type = journals.journable_type
-          AND predecessor.version = (#{max_predecessor_version_sql})
-          AND (#{data_changes_condition_sql})
-    SQL
-  end
-
-  # Identify the immediate predecessor journal for comparison.
-  # NB: Journal versions are incremental but not guaranteed to be sequential.
-  def max_predecessor_version_sql
-    <<~SQL.squish
-      SELECT MAX(version)
-      FROM journals p2
-      WHERE p2.journable_id = journals.journable_id
-        AND p2.journable_type = journals.journable_type
-        AND p2.version < journals.version
-    SQL
-  end
-
-  # Detect changes in work_package_journals columns.
-  def data_changes_condition_sql
-    data_change_columns.map do |column_name|
-      "pred_data.#{column_name} IS DISTINCT FROM curr_data.#{column_name}"
-    end.join(" OR ")
-  end
-
-  def data_change_columns
-    Journal::WorkPackageJournal.column_names - ["id", "project_phase_definition_id"]
-  end
-
-  def attachment_changes_condition_sql
-    association_changes_condition_sql(
-      table: Journal::AttachableJournal.table_name,
-      id_column: "attachment_id",
-      value_columns: ["filename"]
-    )
-  end
-
-  def custom_field_changes_condition_sql
-    association_changes_condition_sql(
-      table: Journal::CustomizableJournal.table_name,
-      id_column: "custom_field_id",
-      value_columns: ["value"]
-    )
-  end
-
-  def file_link_changes_condition_sql
-    association_changes_condition_sql(
-      table: Journal::StorableJournal.table_name,
-      id_column: "file_link_id",
-      value_columns: %w[link_name storage_name]
-    )
-  end
-
-  # Detect changes in association journals by checking for additions and removals.
-  def association_changes_condition_sql(table:, id_column:, value_columns:)
-    "#{association_items_added_sql(table:, id_column:, value_columns:)} " \
-      "UNION " \
-      "#{association_items_removed_sql(table:, id_column:)}"
-  end
-
-  # Detect added or modified association items by comparing with predecessor journal.
-  # Returns SQL that finds items that either:
-  # - Exist in current journal but not in predecessor (additions)
-  # - Exist in both but have different values (modifications)
-  def association_items_added_sql(table:, id_column:, value_columns:)
-    value_changes = value_columns.map do |col|
-      "pred.#{col} IS DISTINCT FROM curr.#{col}"
-    end.join(" OR ")
-
-    <<~SQL.squish
-      SELECT 1
-        FROM #{table} curr
-        LEFT JOIN journals predecessor
-          ON predecessor.journable_id = journals.journable_id
-          AND predecessor.journable_type = journals.journable_type
-          AND predecessor.version = (#{max_predecessor_version_sql})
-        LEFT JOIN #{table} pred
-          ON pred.journal_id = predecessor.id
-          AND pred.#{id_column} = curr.#{id_column}
-        WHERE curr.journal_id = journals.id
-          AND (pred.id IS NULL OR (#{value_changes}))
-    SQL
-  end
-
-  # Detect removed association items by comparing with predecessor journal.
-  # Returns SQL that finds items that existed in predecessor but not in current journal.
-  def association_items_removed_sql(table:, id_column:)
-    <<~SQL.squish
-      SELECT 1
-        FROM journals predecessor
-        INNER JOIN #{table} pred
-          ON pred.journal_id = predecessor.id
-        LEFT JOIN #{table} curr
-          ON curr.journal_id = journals.id
-          AND curr.#{id_column} = pred.#{id_column}
-        WHERE predecessor.journable_id = journals.journable_id
-          AND predecessor.journable_type = journals.journable_type
-          AND predecessor.version = (#{max_predecessor_version_sql})
-          AND curr.id IS NULL
-    SQL
+  def apply_changes_only_filter(scope)
+    JournalChangesFilter.apply(scope)
   end
 end

--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -114,10 +114,10 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
       end.join(" OR ")
     end
 
-    # Detect changes in association journals by checking for additions and removals.
+    # Detect changes in association journals by checking for additions or removals.
     def association_changes_condition_sql(table:, id_column:, value_columns:)
       "#{association_items_added_sql(table:, id_column:, value_columns:)} " \
-        "UNION " \
+        "UNION ALL " \
         "#{association_items_removed_sql(table:, id_column:)}"
     end
 

--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# SQL-based heuristic to filter journals with changes.
+#
+# Includes journals that have:
+#   * Initial journal (version = 1) - always included
+#   * Attachment changes (compares attachable_journals with predecessor)
+#   * Custom field changes (compares customizable_journals with predecessor)
+#   * File link changes (compares storages_file_links_journals with predecessor)
+#   * Cause metadata (system-triggered changes)
+#   * Attribute/data changes (compares work_package_journals columns with immediate predecessor)
+#
+# This heuristic compares association records with the predecessor journal to detect actual changes,
+# not just the presence of snapshot records.
+class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
+  class << self
+    def apply(scope)
+      sql = <<~SQL.squish
+        version = 1
+        OR (cause IS NOT NULL AND cause != '{}')
+        OR EXISTS (#{attribute_data_changes_condition_sql})
+        OR EXISTS (#{attachment_changes_condition_sql})
+        OR EXISTS (#{custom_field_changes_condition_sql})
+        OR EXISTS (#{file_link_changes_condition_sql})
+      SQL
+
+      scope.where(OpenProject::SqlSanitization.sanitize(sql))
+    end
+
+    private
+
+    def attribute_data_changes_condition_sql
+      <<~SQL.squish
+        SELECT 1
+          FROM journals predecessor
+          INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
+          INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
+          WHERE predecessor.journable_id = journals.journable_id
+            AND predecessor.journable_type = journals.journable_type
+            AND predecessor.version = (#{max_predecessor_version_sql})
+            AND (#{data_changes_condition_sql})
+      SQL
+    end
+
+    def attachment_changes_condition_sql
+      association_changes_condition_sql(
+        table: Journal::AttachableJournal.table_name,
+        id_column: "attachment_id",
+        value_columns: ["filename"]
+      )
+    end
+
+    def custom_field_changes_condition_sql
+      association_changes_condition_sql(
+        table: Journal::CustomizableJournal.table_name,
+        id_column: "custom_field_id",
+        value_columns: ["value"]
+      )
+    end
+
+    def file_link_changes_condition_sql
+      association_changes_condition_sql(
+        table: Journal::StorableJournal.table_name,
+        id_column: "file_link_id",
+        value_columns: %w[link_name storage_name]
+      )
+    end
+
+    # Identify the immediate predecessor journal for comparison.
+    # NB: Journal versions are incremental but not guaranteed to be sequential.
+    def max_predecessor_version_sql
+      <<~SQL.squish
+        SELECT MAX(version)
+        FROM journals p2
+        WHERE p2.journable_id = journals.journable_id
+          AND p2.journable_type = journals.journable_type
+          AND p2.version < journals.version
+      SQL
+    end
+
+    def data_changes_condition_sql
+      data_change_columns = Journal::WorkPackageJournal.column_names - ["id"]
+
+      data_change_columns.map do |column_name|
+        "pred_data.#{column_name} IS DISTINCT FROM curr_data.#{column_name}"
+      end.join(" OR ")
+    end
+
+    # Detect changes in association journals by checking for additions and removals.
+    def association_changes_condition_sql(table:, id_column:, value_columns:)
+      "#{association_items_added_sql(table:, id_column:, value_columns:)} " \
+        "UNION " \
+        "#{association_items_removed_sql(table:, id_column:)}"
+    end
+
+    # Detect added or modified association items by comparing with predecessor journal.
+    # Returns SQL that finds items that either:
+    # - Exist in current journal but not in predecessor (additions)
+    # - Exist in both but have different values (modifications)
+    def association_items_added_sql(table:, id_column:, value_columns:)
+      value_changes = value_columns.map do |col|
+        "pred.#{col} IS DISTINCT FROM curr.#{col}"
+      end.join(" OR ")
+
+      <<~SQL.squish
+        SELECT 1
+          FROM #{table} curr
+          LEFT JOIN journals predecessor
+            ON predecessor.journable_id = journals.journable_id
+            AND predecessor.journable_type = journals.journable_type
+            AND predecessor.version = (#{max_predecessor_version_sql})
+          LEFT JOIN #{table} pred
+            ON pred.journal_id = predecessor.id
+            AND pred.#{id_column} = curr.#{id_column}
+          WHERE curr.journal_id = journals.id
+            AND (pred.id IS NULL OR (#{value_changes}))
+      SQL
+    end
+
+    # Detect removed association items by comparing with predecessor journal.
+    # Returns SQL that finds items that existed in predecessor but not in current journal.
+    def association_items_removed_sql(table:, id_column:)
+      <<~SQL.squish
+        SELECT 1
+          FROM journals predecessor
+          INNER JOIN #{table} pred
+            ON pred.journal_id = predecessor.id
+          LEFT JOIN #{table} curr
+            ON curr.journal_id = journals.id
+            AND curr.#{id_column} = pred.#{id_column}
+          WHERE predecessor.journable_id = journals.journable_id
+            AND predecessor.journable_type = journals.journable_type
+            AND predecessor.version = (#{max_predecessor_version_sql})
+            AND curr.id IS NULL
+      SQL
+    end
+  end
+end

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe WorkPackages::ActivitiesTab::Paginator do
+RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_aggregation_time_minutes: 0 } do
   shared_let(:user) { create(:admin) }
   shared_let(:project) { create(:project) }
   shared_let(:work_package) { create(:work_package, :created_in_past, project:, author: user, created_at: 4.days.ago) }
@@ -348,45 +348,33 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator do
       end
 
       context "with attribute changes" do
-        before do
-          # Create journal with attribute change
+        let!(:journal_with_attribute_change) do
           work_package.subject = "Updated subject"
           work_package.save!
+          work_package.journals.order(:version).last
         end
 
         it "includes journals with attribute changes" do
           _pagy, records = paginator.call
 
-          changed_journal = work_package.journals.order(:version).last
-          expect(records.map(&:id)).to include(changed_journal.id)
+          expect(records.map(&:id)).to include(journal_with_attribute_change.id)
         end
       end
 
-      context "with only notes (no attribute changes)" do
+      context "with only notes added (no attribute/association changes)" do
         let!(:notes_only_journal) do
           journal = work_package.journals.last
           journal.update_column(:notes, "Just a comment")
-          journal
-        end
 
-        it "may include journals with only notes (acceptable false positive)" do
-          _pagy, records = paginator.call
-
-          expect(records).not_to be_empty
-        end
-      end
-
-      context "with attachment changes" do
-        before do
-          work_package.attachments << create(:attachment)
+          work_package.add_journal(notes: "Comment only")
           work_package.save!
+          work_package.journals.order(:version).last
         end
 
-        it "includes journals with attachment changes" do
+        it "excludes journals with only notes (no actual changes to track)" do
           _pagy, records = paginator.call
 
-          attachment_journal = work_package.journals.order(:version).last
-          expect(records.map(&:id)).to include(attachment_journal.id)
+          expect(records.map(&:id)).not_to include(notes_only_journal.id)
         end
       end
 
@@ -399,45 +387,179 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator do
           journal
         end
 
-        it "includes journals with cause" do
+        it "includes journals with cause metadata" do
           _pagy, records = paginator.call
 
           expect(records.map(&:id)).to include(journal_with_cause.id)
         end
       end
 
-      context "with custom field changes" do
-        let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
-
-        before do
-          project.work_package_custom_fields << custom_field
-          work_package.type.custom_fields << custom_field
-          work_package.custom_field_values = { custom_field.id => "Custom value" }
+      context "with attachment added" do
+        let!(:journal_with_attachment_added) do
+          work_package.attachments << create(:attachment)
           work_package.save!
+          work_package.journals.order(:version).last
         end
 
-        it "includes journals with custom field changes" do
+        it "includes journals where attachments were added" do
           _pagy, records = paginator.call
 
-          cf_journal = work_package.journals.order(:version).last
-          expect(records.map(&:id)).to include(cf_journal.id)
+          expect(records.map(&:id)).to include(journal_with_attachment_added.id)
         end
       end
 
-      context "with file link changes" do
-        let(:storage) { create(:nextcloud_storage) }
-        let(:file_link) { create(:file_link, container: work_package, storage:) }
+      context "with custom field value changed" do
+        let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
 
-        before do
-          create(:project_storage, project:, storage:)
-          file_link # Trigger file link creation which creates a journal
+        let!(:journal_with_cf_set) do
+          project.work_package_custom_fields << custom_field
+          work_package.type.custom_fields << custom_field
+          work_package.custom_field_values = { custom_field.id => "Initial value" }
+          work_package.save!
+          work_package.journals.order(:version).last
         end
 
-        it "includes journals with file link changes" do
+        let!(:journal_with_cf_changed) do
+          work_package.custom_field_values = { custom_field.id => "Changed value" }
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journals where custom field value was initially set" do
           _pagy, records = paginator.call
 
-          file_link_journal = work_package.journals.order(:version).last
-          expect(records.map(&:id)).to include(file_link_journal.id)
+          expect(records.map(&:id)).to include(journal_with_cf_set.id)
+        end
+
+        it "includes journals where custom field value was changed" do
+          _pagy, records = paginator.call
+
+          expect(records.map(&:id)).to include(journal_with_cf_changed.id)
+        end
+      end
+
+      context "with file link added" do
+        let(:storage) { create(:nextcloud_storage) }
+
+        let!(:journal_with_file_link_added) do
+          create(:project_storage, project:, storage:)
+          create(:file_link, container: work_package, storage:)
+          work_package.reload
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journals where file links were added" do
+          _pagy, records = paginator.call
+
+          expect(records.map(&:id)).to include(journal_with_file_link_added.id)
+        end
+      end
+
+      context "with attachable_journals record but no attachment change" do
+        let!(:journal_with_attachment_added) do
+          attachment = create(:attachment, container: nil, author: user)
+          work_package.attachments << attachment
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let(:attachment) { journal_with_attachment_added.attachable_journals.first&.attachment }
+
+        let!(:journal_with_attachment_snapshot) do
+          work_package.add_journal(notes: "Unrelated to Attachments change")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where attachment was added" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_attachment_added.id)
+
+          changes = journal_with_attachment_added.reload.get_changes
+          expect(changes).to have_key("attachments_#{attachment.id}")
+        end
+
+        it "excludes journal with only attachment snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_attachment_snapshot.reload.attachable_journals.count).to eq(1)
+          changes = journal_with_attachment_snapshot.reload.get_changes
+          expect(changes).to eq({}) # no changes
+
+          expect(records.map(&:id)).not_to include(journal_with_attachment_snapshot.id)
+        end
+      end
+
+      context "with customizable_journals record but no custom field value change" do
+        let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
+
+        let!(:journal_with_cf_set) do
+          project.work_package_custom_fields << custom_field
+          work_package.type.custom_fields << custom_field
+          work_package.custom_field_values = { custom_field.id => "Value" }
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_cf_snapshot) do
+          work_package.add_journal(notes: "Unrelated to CF change")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where custom field was set" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_cf_set.id)
+
+          changes = journal_with_cf_set.reload.get_changes
+          expect(changes).to have_key("custom_fields_#{custom_field.id}")
+        end
+
+        it "excludes journal with only custom field snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_cf_snapshot.reload.customizable_journals.count).to eq(1)
+          changes = journal_with_cf_snapshot.reload.get_changes
+          expect(changes).to eq({}) # no changes
+
+          expect(records.map(&:id)).not_to include(journal_with_cf_snapshot.id)
+        end
+      end
+
+      context "with storable_journals record but no file link change" do
+        let(:storage) { create(:nextcloud_storage) }
+
+        let!(:journal_with_file_link_added) do
+          create(:project_storage, project:, storage:)
+          create(:file_link, container: work_package, storage:)
+          work_package.add_journal(notes: "Here be file links")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_file_link_snapshot) do
+          work_package.add_journal(notes: "Unrelated change")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where file link was added" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_file_link_added.id)
+
+          file_link = journal_with_file_link_added.reload.storable_journals.first&.file_link
+          changes = journal_with_file_link_added.reload.get_changes
+          expect(changes).to have_key("file_links_#{file_link.id}")
+        end
+
+        it "excludes journal with only file link snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_file_link_snapshot.reload.storable_journals.count).to eq(1)
+          changes = journal_with_file_link_snapshot.reload.get_changes
+          expect(changes).to eq({}) # no changes
+
+          expect(records.map(&:id)).not_to include(journal_with_file_link_snapshot.id)
         end
       end
     end

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -357,15 +357,14 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         it "includes journals with attribute changes" do
           _pagy, records = paginator.call
 
+          changes = journal_with_attribute_change.reload.get_changes
+          expect(changes).to have_key("subject")
           expect(records.map(&:id)).to include(journal_with_attribute_change.id)
         end
       end
 
       context "with only notes added (no attribute/association changes)" do
         let!(:notes_only_journal) do
-          journal = work_package.journals.last
-          journal.update_column(:notes, "Just a comment")
-
           work_package.add_journal(notes: "Comment only")
           work_package.save!
           work_package.journals.order(:version).last
@@ -374,11 +373,13 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         it "excludes journals with only notes (no actual changes to track)" do
           _pagy, records = paginator.call
 
+          changes = notes_only_journal.reload.get_changes
+          expect(changes).to eq({}) # no changes
           expect(records.map(&:id)).not_to include(notes_only_journal.id)
         end
       end
 
-      context "with cause attribute" do
+      context "with cause change" do
         let!(:journal_with_cause) do
           work_package.subject = "Changed by system"
           work_package.save!
@@ -390,72 +391,13 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         it "includes journals with cause metadata" do
           _pagy, records = paginator.call
 
+          changes = journal_with_cause.reload.get_changes
+          expect(changes.keys).to contain_exactly("subject", "cause")
           expect(records.map(&:id)).to include(journal_with_cause.id)
         end
       end
 
-      context "with attachment added" do
-        let!(:journal_with_attachment_added) do
-          work_package.attachments << create(:attachment)
-          work_package.save!
-          work_package.journals.order(:version).last
-        end
-
-        it "includes journals where attachments were added" do
-          _pagy, records = paginator.call
-
-          expect(records.map(&:id)).to include(journal_with_attachment_added.id)
-        end
-      end
-
-      context "with custom field value changed" do
-        let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
-
-        let!(:journal_with_cf_set) do
-          project.work_package_custom_fields << custom_field
-          work_package.type.custom_fields << custom_field
-          work_package.custom_field_values = { custom_field.id => "Initial value" }
-          work_package.save!
-          work_package.journals.order(:version).last
-        end
-
-        let!(:journal_with_cf_changed) do
-          work_package.custom_field_values = { custom_field.id => "Changed value" }
-          work_package.save!
-          work_package.journals.order(:version).last
-        end
-
-        it "includes journals where custom field value was initially set" do
-          _pagy, records = paginator.call
-
-          expect(records.map(&:id)).to include(journal_with_cf_set.id)
-        end
-
-        it "includes journals where custom field value was changed" do
-          _pagy, records = paginator.call
-
-          expect(records.map(&:id)).to include(journal_with_cf_changed.id)
-        end
-      end
-
-      context "with file link added" do
-        let(:storage) { create(:nextcloud_storage) }
-
-        let!(:journal_with_file_link_added) do
-          create(:project_storage, project:, storage:)
-          create(:file_link, container: work_package, storage:)
-          work_package.reload
-          work_package.journals.order(:version).last
-        end
-
-        it "includes journals where file links were added" do
-          _pagy, records = paginator.call
-
-          expect(records.map(&:id)).to include(journal_with_file_link_added.id)
-        end
-      end
-
-      context "with attachable_journals record but no attachment change" do
+      context "with attachment changes" do
         let!(:journal_with_attachment_added) do
           attachment = create(:attachment, container: nil, author: user)
           work_package.attachments << attachment
@@ -490,7 +432,7 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         end
       end
 
-      context "with customizable_journals record but no custom field value change" do
+      context "with custom field value changes" do
         let!(:custom_field) { create(:work_package_custom_field, field_format: "string") }
 
         let!(:journal_with_cf_set) do
@@ -526,7 +468,7 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         end
       end
 
-      context "with storable_journals record but no file link change" do
+      context "with file link changes" do
         let(:storage) { create(:nextcloud_storage) }
 
         let!(:journal_with_file_link_added) do


### PR DESCRIPTION
Follows #20733

https://community.openproject.org/wp/66552

Correct the `:only_changes` filter added in #20733 such that it checks for at least one journal change and **_NOT_** presence as it did before. The latter would evaluate to false positives that further materialized the original bug.

Test WP:
 * https://qa.openproject-stage.com/projects/cecile-demo-project/work_packages/3647/activity
 * https://qa.openproject-edge.com/projects/test-project-cecile/work_packages/10423/activity

<details> <summary> <em>The red borders demarcate page nodes. (Click to see highlight code change)</em> </summary>

```ruby
diff --git a/app/components/work_packages/activities_tab/journals/page_component.html.erb b/app/components/work_packages/activities_tab/journals/page_component.html.erb
index cc02170f5fc..621bc2eca2f 100644
--- a/app/components/work_packages/activities_tab/journals/page_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/page_component.html.erb
@@ -1,6 +1,6 @@
 <%=
   component_wrapper do
-    flex_layout do |flex_container|
+    flex_layout(style: "border: 2px dashed red;") do |flex_container|
       journals.each do |record|
         flex_container.with_row do
           if record.is_a?(Changeset)
```

</details>

**_Before:_**

<img width="1737" height="1524" alt="Screenshot 2025-11-03 at 4 31 07 PM" src="https://github.com/user-attachments/assets/95046682-6f60-4ef5-8344-78612f6f9e15" />

**_After:_**

<img width="1731" height="1420" alt="Screenshot 2025-11-03 at 4 29 54 PM" src="https://github.com/user-attachments/assets/11d55669-69fb-4f4c-b821-092852e8dbf1" />

----

<details> <summary> Sample resulting query </summary>

```sql
SELECT *
FROM "journals"
JOIN LATERAL
  (SELECT journals_rank.id,
          ROW_NUMBER() OVER (
                             ORDER BY VERSION ASC) sequence_version
   FROM journals journals_rank
   WHERE journals_rank.journable_id = journals.journable_id
     AND journals_rank.journable_type = journals.journable_type) ranked ON ranked.id = journals.id
WHERE "journals"."journable_id" = 40
  AND "journals"."journable_type" = 'WorkPackage'
  AND "journals"."restricted" = FALSE
  AND (VERSION = 1
       OR (cause IS NOT NULL
           AND cause != '{}')
       OR EXISTS
         (SELECT 1
          FROM journals predecessor
          INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
          INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
          WHERE predecessor.journable_id = journals.journable_id
            AND predecessor.journable_type = journals.journable_type
            AND predecessor.version =
              (SELECT MAX(VERSION)
               FROM journals p2
               WHERE p2.journable_id = journals.journable_id
                 AND p2.journable_type = journals.journable_type
                 AND p2.version < journals.version)
            AND (pred_data.type_id IS DISTINCT
                 FROM curr_data.type_id
                 OR pred_data.project_id IS DISTINCT
                 FROM curr_data.project_id
                 OR pred_data.subject IS DISTINCT
                 FROM curr_data.subject
                 OR pred_data.description IS DISTINCT
                 FROM curr_data.description
                 OR pred_data.due_date IS DISTINCT
                 FROM curr_data.due_date
                 OR pred_data.category_id IS DISTINCT
                 FROM curr_data.category_id
                 OR pred_data.status_id IS DISTINCT
                 FROM curr_data.status_id
                 OR pred_data.assigned_to_id IS DISTINCT
                 FROM curr_data.assigned_to_id
                 OR pred_data.priority_id IS DISTINCT
                 FROM curr_data.priority_id
                 OR pred_data.version_id IS DISTINCT
                 FROM curr_data.version_id
                 OR pred_data.author_id IS DISTINCT
                 FROM curr_data.author_id
                 OR pred_data.done_ratio IS DISTINCT
                 FROM curr_data.done_ratio
                 OR pred_data.estimated_hours IS DISTINCT
                 FROM curr_data.estimated_hours
                 OR pred_data.start_date IS DISTINCT
                 FROM curr_data.start_date
                 OR pred_data.parent_id IS DISTINCT
                 FROM curr_data.parent_id
                 OR pred_data.responsible_id IS DISTINCT
                 FROM curr_data.responsible_id
                 OR pred_data.derived_estimated_hours IS DISTINCT
                 FROM curr_data.derived_estimated_hours
                 OR pred_data.schedule_manually IS DISTINCT
                 FROM curr_data.schedule_manually
                 OR pred_data.duration IS DISTINCT
                 FROM curr_data.duration
                 OR pred_data.ignore_non_working_days IS DISTINCT
                 FROM curr_data.ignore_non_working_days
                 OR pred_data.derived_remaining_hours IS DISTINCT
                 FROM curr_data.derived_remaining_hours
                 OR pred_data.derived_done_ratio IS DISTINCT
                 FROM curr_data.derived_done_ratio
                 OR pred_data.story_points IS DISTINCT
                 FROM curr_data.story_points
                 OR pred_data.remaining_hours IS DISTINCT
                 FROM curr_data.remaining_hours
                 OR pred_data.budget_id IS DISTINCT
                 FROM curr_data.budget_id
                 OR pred_data.project_phase_definition_id IS DISTINCT
                 FROM curr_data.project_phase_definition_id))
       OR EXISTS
         (SELECT 1
          FROM attachable_journals curr
          LEFT JOIN journals predecessor ON predecessor.journable_id = journals.journable_id
          AND predecessor.journable_type = journals.journable_type
          AND predecessor.version =
            (SELECT MAX(VERSION)
             FROM journals p2
             WHERE p2.journable_id = journals.journable_id
               AND p2.journable_type = journals.journable_type
               AND p2.version < journals.version)
          LEFT JOIN attachable_journals pred ON pred.journal_id = predecessor.id
          AND pred.attachment_id = curr.attachment_id
          WHERE curr.journal_id = journals.id
            AND (pred.id IS NULL
                 OR (pred.filename IS DISTINCT
                     FROM curr.filename))
          UNION ALL SELECT 1
          FROM journals predecessor
          INNER JOIN attachable_journals pred ON pred.journal_id = predecessor.id
          LEFT JOIN attachable_journals curr ON curr.journal_id = journals.id
          AND curr.attachment_id = pred.attachment_id
          WHERE predecessor.journable_id = journals.journable_id
            AND predecessor.journable_type = journals.journable_type
            AND predecessor.version =
              (SELECT MAX(VERSION)
               FROM journals p2
               WHERE p2.journable_id = journals.journable_id
                 AND p2.journable_type = journals.journable_type
                 AND p2.version < journals.version)
            AND curr.id IS NULL)
       OR EXISTS
         (SELECT 1
          FROM customizable_journals curr
          LEFT JOIN journals predecessor ON predecessor.journable_id = journals.journable_id
          AND predecessor.journable_type = journals.journable_type
          AND predecessor.version =
            (SELECT MAX(VERSION)
             FROM journals p2
             WHERE p2.journable_id = journals.journable_id
               AND p2.journable_type = journals.journable_type
               AND p2.version < journals.version)
          LEFT JOIN customizable_journals pred ON pred.journal_id = predecessor.id
          AND pred.custom_field_id = curr.custom_field_id
          WHERE curr.journal_id = journals.id
            AND (pred.id IS NULL
                 OR (pred.value IS DISTINCT
                     FROM curr.value))
          UNION ALL SELECT 1
          FROM journals predecessor
          INNER JOIN customizable_journals pred ON pred.journal_id = predecessor.id
          LEFT JOIN customizable_journals curr ON curr.journal_id = journals.id
          AND curr.custom_field_id = pred.custom_field_id
          WHERE predecessor.journable_id = journals.journable_id
            AND predecessor.journable_type = journals.journable_type
            AND predecessor.version =
              (SELECT MAX(VERSION)
               FROM journals p2
               WHERE p2.journable_id = journals.journable_id
                 AND p2.journable_type = journals.journable_type
                 AND p2.version < journals.version)
            AND curr.id IS NULL)
       OR EXISTS
         (SELECT 1
          FROM storages_file_links_journals curr
          LEFT JOIN journals predecessor ON predecessor.journable_id = journals.journable_id
          AND predecessor.journable_type = journals.journable_type
          AND predecessor.version =
            (SELECT MAX(VERSION)
             FROM journals p2
             WHERE p2.journable_id = journals.journable_id
               AND p2.journable_type = journals.journable_type
               AND p2.version < journals.version)
          LEFT JOIN storages_file_links_journals pred ON pred.journal_id = predecessor.id
          AND pred.file_link_id = curr.file_link_id
          WHERE curr.journal_id = journals.id
            AND (pred.id IS NULL
                 OR (pred.link_name IS DISTINCT
                     FROM curr.link_name
                     OR pred.storage_name IS DISTINCT
                     FROM curr.storage_name))
          UNION ALL SELECT 1
          FROM journals predecessor
          INNER JOIN storages_file_links_journals pred ON pred.journal_id = predecessor.id
          LEFT JOIN storages_file_links_journals curr ON curr.journal_id = journals.id
          AND curr.file_link_id = pred.file_link_id
          WHERE predecessor.journable_id = journals.journable_id
            AND predecessor.journable_type = journals.journable_type
            AND predecessor.version =
              (SELECT MAX(VERSION)
               FROM journals p2
               WHERE p2.journable_id = journals.journable_id
                 AND p2.journable_type = journals.journable_type
                 AND p2.version < journals.version)
            AND curr.id IS NULL))
ORDER BY "journals"."version" DESC
```

</details>

 Performance Analysis Report ✨ _(AI Assisted)_

  Benchmark Results Summary (Work Package `#10423`, 684 journals)

  | Scenario              | Average Time | Min      | Max      | Notes                         |
  |-----------------------|--------------|----------|----------|-------------------------------|
  | filter=:all           | 335.68ms     | 237.65ms | 471.76ms | Baseline - loads all journals |
  | filter=:only_comments | 247.12ms     | 233.16ms | 255.78ms | 26% faster than :all          |
  | filter=:only_changes  | 19.48ms      | 17.14ms  | 24.38ms  | 94% faster than :all! ✅       |
  | Anchor navigation     | 256.53ms     | 232.08ms | 312.85ms | Similar to :only_comments     |

<details> <summary>Benchmark script</summary>

```ruby
# frozen_string_literal: true

# Benchmark script for WorkPackages::ActivitiesTab::Paginator
# Run with: bundle exec rails runner tmp/paginator_benchmark.rb

require 'benchmark'

wp_id = 10423
work_package = WorkPackage.find(wp_id)

puts "=" * 80
puts "Paginator Performance Benchmark"
puts "=" * 80
puts "Work Package: ##{work_package.id}"
puts "Journals count: #{work_package.journals.count}"
puts "=" * 80
puts

# Helper to run and report
def benchmark_scenario(name, &block)
  puts "\n#{name}"
  puts "-" * 80

  result = nil
  times = []

  # Warm up
  block.call

  # Run 5 times
  5.times do
    time = Benchmark.realtime { result = block.call }
    times << time
  end

  avg_time = times.sum / times.size
  min_time = times.min
  max_time = times.max

  puts "Average: #{(avg_time * 1000).round(2)}ms"
  puts "Min:     #{(min_time * 1000).round(2)}ms"
  puts "Max:     #{(max_time * 1000).round(2)}ms"

  if result.is_a?(Array) && result[1].is_a?(Array)
    puts "Results: #{result[1].size} records"
  end

  result
end

# Scenario 1: Filter :all (baseline)
benchmark_scenario("Scenario 1: filter=:all (baseline)") do
  WorkPackages::ActivitiesTab::Paginator.paginate(work_package, filter: :all, page: 1)
end

# Scenario 2: Filter :only_comments
benchmark_scenario("Scenario 2: filter=:only_comments") do
  WorkPackages::ActivitiesTab::Paginator.paginate(work_package, filter: :only_comments, page: 1)
end

# Scenario 3: Filter :only_changes (with new heuristic)
benchmark_scenario("Scenario 3: filter=:only_changes (with change detection)") do
  WorkPackages::ActivitiesTab::Paginator.paginate(work_package, filter: :only_changes, page: 1)
end

# Scenario 4: Anchor navigation (find_index performance)
benchmark_scenario("Scenario 4: Anchor navigation to middle journal") do
  middle_journal = work_package.journals.order(:version).offset(work_package.journals.count / 2).first
  WorkPackages::ActivitiesTab::Paginator.paginate(work_package, anchor: "comment-#{middle_journal.id}", page: 1)
end

# Deep dive: SQL query analysis
puts "\n" + "=" * 80
puts "SQL Query Analysis (with EXPLAIN)"
puts "=" * 80

ActiveRecord::Base.logger = Logger.new($stdout)
ActiveRecord::Base.logger.level = Logger::DEBUG

puts "\nQuery for :only_changes filter:"
puts "-" * 80
WorkPackages::ActivitiesTab::Paginator.paginate(work_package, filter: :only_changes, page: 1)

ActiveRecord::Base.logger = nil

puts "\n" + "=" * 80
puts "Benchmark Complete"
puts "=" * 80
```

</details>