### PR TITLE
[#68648] Custom field admin page: text for "Required" is still old

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -349,8 +349,8 @@ en:
     placeholder_version_select: "Work package or project selection is required first"
     calculated_field_not_editable: "Non-editable attribute. This value is calculated automatically."
     instructions:
-      is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources."
-      is_required_for_project: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects."
+      is_required: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new or updating existing resources. Existing resources will not require a value when being updated."
+      is_required_for_project: "Check to enable this attribute and make it required in all projects. It cannot be deactived for individual projects. Existing projects will not require a value when being updated."
       is_for_all: "Mark the custom field as available in all existing and new projects."
       multi_select: "Allows the user to assign multiple values to this custom field."
       searchable: "Include the field values when using the global search functionality."


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68648

# What are you trying to accomplish?
Update custom field required flag description, including the project attributes too.

## Screenshots

<details><summary>Custom field</summary>
<p>

<img width="703" height="505" alt="image" src="https://github.com/user-attachments/assets/abe6dff7-d4a2-422d-9d62-0ea4a18b63cd" />

</p>
</details> 

<details><summary>Project Attributes</summary>
<p>

<img width="1046" height="650" alt="image" src="https://github.com/user-attachments/assets/81ae9b8b-0645-46d1-b8c5-b96720aa05f7" />


</p>
</details> 

# What approach did you choose and why?
Update translations.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
