### PR TITLE
[#68459] when logging out display shortly defaults to light mode before detecting os display mode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -452,10 +452,10 @@ module ApplicationHelper
     end
   end
 
-  # To avoid the menu flickering, disable it
-  # by default unless we're in test mode
-  def initial_menu_styles(side_displayed)
-    Rails.env.test? || !side_displayed ? "" : "display:none"
+  # To avoid FOUC (menu flickering / dark mode on logout), hide page
+  # wrapper on load except in test environment.
+  def initial_menu_styles
+    Rails.env.test? || "display:none"
   end
 
   def initial_menu_classes(side_displayed, show_decoration)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -68,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>
 <% side_displayed = content_for?(:sidebar) || content_for?(:main_menu) || !main_menu.blank? %>
 <% initial_classes = initial_menu_classes(side_displayed, show_decoration) %>
-<div id="wrapper" style="<%= initial_menu_styles(side_displayed) %>" class="<%= initial_classes %>">
+<div id="wrapper" style="<%= initial_menu_styles %>" class="<%= initial_classes %>">
   <% if show_decoration %>
     <header class="op-app-header<%= " op-app-header_development" if OpenProject::Configuration.development_highlight_enabled? %>">
       <div class="op-app-header--start">


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68459

# What are you trying to accomplish?

Fixes flickering between light and dark mode on login page on user logout.

# What approach did you choose and why?

See #20709 for discussion on the implementation. This PR extracts the minimal necessary changes from that PR.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
