### PR TITLE
[#68719] Calculated Value: error messages discrepancies

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1470,7 +1470,7 @@ en:
             formula:
               blank: "Formula can't be blank."
               invalid: "Formula is invalid."
-              invalid_characters: "Only numeric values, project factors, calculated values and mathematical operators are allowed."
+              invalid_characters: "Only numeric values, mathematical operators and project attributes of type integer, float, calculated value and weighted list are allowed."
               not_allowed_custom_fields_referenced: "The attribute %{custom_fields} cannot be used because it leads to a circular reference; one attribute depends on the other."
               format: "%{message}"
         custom_fields_project:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,7 +371,7 @@ en:
       title: "Error with Calculated value"
     errors:
       unknown: "An unknown error occurred. Please review the formula for this Calculated value."
-      mathematical: "A mathematical error occurred during calculation."
+      mathematical: "The mathematical formula leads to an error. Please review the project calculation attribute and try again."
       missing_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is empty.
       disabled_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is disabled for the project.
 
@@ -1409,8 +1409,6 @@ en:
         inclusion: "is not set to one of the allowed values."
         inclusion_nested: "is not set to one of the allowed values at path '%{path}'."
         invalid: "is invalid."
-        invalid_characters: "contains invalid characters."
-        not_allowed_custom_fields_referenced: "contains custom fields that are not allowed: %{custom_fields}."
         invalid_url: "is not a valid URL."
         invalid_url_scheme: "is not a supported protocol (allowed: %{allowed_schemes})."
         less_than_or_equal_to: "must be less than or equal to %{count}."
@@ -1468,6 +1466,13 @@ en:
           referenced_in_other_fields_html:
             one: "%{name} is used in project attribute calculation %{links}."
             other: "%{name} is used in project attribute calculations: %{links}."
+          attributes:
+            formula:
+              blank: "Formula can't be blank."
+              invalid: "Formula is invalid."
+              invalid_characters: "Only numeric values, project factors, calculated values and mathematical operators are allowed."
+              not_allowed_custom_fields_referenced: "The attribute %{custom_fields} cannot be used because it leads to a circular reference; one attribute depends on the other."
+              format: "%{message}"
         custom_fields_project:
           attributes:
             project_ids:

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -621,14 +621,16 @@ RSpec.describe CustomField::CalculatedValue,
       let(:formula) { "abc + 2" }
 
       it_behaves_like "invalid formula",
-                      "Only numeric values, project factors, calculated values and mathematical operators are allowed."
+                      "Only numeric values, mathematical operators and project attributes of type integer, float, " \
+                      "calculated value and weighted list are allowed."
     end
 
     context "with a formula containing references to custom fields without pattern-mustaches" do
       let(:formula) { "100 * cf_3" }
 
       it_behaves_like "invalid formula",
-                      "Only numeric values, project factors, calculated values and mathematical operators are allowed."
+                      "Only numeric values, mathematical operators and project attributes of type integer, float, " \
+                      "calculated value and weighted list are allowed."
     end
 
     context "with a formula that is not a valid equation" do

--- a/spec/models/custom_field/calculated_value_spec.rb
+++ b/spec/models/custom_field/calculated_value_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe CustomField::CalculatedValue,
     let(:formula) { "" }
 
     context "with an empty formula" do
-      it_behaves_like "invalid formula", "can't be blank."
+      it_behaves_like "invalid formula", "Formula can't be blank."
     end
 
     context "with a formula containing only allowed characters" do
@@ -614,25 +614,27 @@ RSpec.describe CustomField::CalculatedValue,
     context "when omitting trailing decimals after a decimal point" do
       let(:formula) { "1.5 + 1. - 3.25" }
 
-      it_behaves_like "invalid formula", "is invalid."
+      it_behaves_like "invalid formula", "Formula is invalid."
     end
 
     context "with a formula containing forbidden characters" do
       let(:formula) { "abc + 2" }
 
-      it_behaves_like "invalid formula", "contains invalid characters."
+      it_behaves_like "invalid formula",
+                      "Only numeric values, project factors, calculated values and mathematical operators are allowed."
     end
 
     context "with a formula containing references to custom fields without pattern-mustaches" do
       let(:formula) { "100 * cf_3" }
 
-      it_behaves_like "invalid formula", "contains invalid characters."
+      it_behaves_like "invalid formula",
+                      "Only numeric values, project factors, calculated values and mathematical operators are allowed."
     end
 
     context "with a formula that is not a valid equation" do
       let(:formula) { "1 / + - 3" }
 
-      it_behaves_like "invalid formula", "is invalid."
+      it_behaves_like "invalid formula", "Formula is invalid."
     end
 
     context "with a formula that contains custom fields that are not visible to the user" do
@@ -654,7 +656,8 @@ RSpec.describe CustomField::CalculatedValue,
 
       current_user { user }
 
-      it_behaves_like "invalid formula", /contains custom fields that are not allowed: (int, float|float, int)./
+      it_behaves_like "invalid formula",
+                      /The attribute (int, float|float, int) cannot be used because it leads to a circular reference/
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68719

# What are you trying to accomplish?
Update error messages

# What approach did you choose and why?
Set the message format to `"%{message}"`, omitting the attribute name. Explicitly prepend the attribute name when it's required, such as for the `"Format can't be blank."` or `"Format is invalid"` messages.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
