### PR TITLE
[68666] Fix various Browser console warnings

### DIFF
--- a/frontend/src/app/core/state/effects/effect-handler.decorator.ts
+++ b/frontend/src/app/core/state/effects/effect-handler.decorator.ts
@@ -4,8 +4,8 @@ import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { ActionCreator } from 'ts-action/action';
 import { Action } from 'ts-action';
 import { takeWhile } from 'rxjs/operators';
-import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { Observable } from 'rxjs';
+import { Injectable, OnDestroy } from '@angular/core';
 
 /**
  * This interface specifies a constraint on the classes that can
@@ -71,7 +71,8 @@ export function registerEffectCallbacks(instance:EffectClass, untilDestroyed:(so
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function EffectHandler<T extends new(...args:any[]) => EffectClass>(constructor:T):any {
-  return class extends constructor {
+  @Injectable()
+  class EffectHandlerWithInjectable extends constructor implements OnDestroy {
     private serviceDestroyed = false;
 
     /* The class decorator requires any[] args to it to function */
@@ -89,6 +90,8 @@ export function EffectHandler<T extends new(...args:any[]) => EffectClass>(const
       }
     }
   };
+
+  return EffectHandlerWithInjectable;
 }
 
 /**

--- a/frontend/src/app/core/state/effects/effect-handler.decorator.ts
+++ b/frontend/src/app/core/state/effects/effect-handler.decorator.ts
@@ -4,8 +4,8 @@ import { ActionsService } from 'core-app/core/state/actions/actions.service';
 import { ActionCreator } from 'ts-action/action';
 import { Action } from 'ts-action';
 import { takeWhile } from 'rxjs/operators';
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { Observable } from 'rxjs';
-import { Injectable, OnDestroy } from '@angular/core';
 
 /**
  * This interface specifies a constraint on the classes that can
@@ -71,8 +71,7 @@ export function registerEffectCallbacks(instance:EffectClass, untilDestroyed:(so
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export function EffectHandler<T extends new(...args:any[]) => EffectClass>(constructor:T):any {
-  @Injectable()
-  class EffectHandlerWithInjectable extends constructor implements OnDestroy {
+  return class extends constructor {
     private serviceDestroyed = false;
 
     /* The class decorator requires any[] args to it to function */
@@ -90,8 +89,6 @@ export function EffectHandler<T extends new(...args:any[]) => EffectClass>(const
       }
     }
   };
-
-  return EffectHandlerWithInjectable;
 }
 
 /**

--- a/frontend/src/app/shared/components/grids/widgets/documents/documents.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/documents/documents.component.ts
@@ -18,6 +18,7 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DocumentResource } from '../../../../../../../../modules/documents/frontend/module/hal/resources/document-resource';
 
 @Component({
+  selector: 'op-documents-widget',
   templateUrl: './documents.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
-  Component, Injector,
+  Component,
+  Injector,
 } from '@angular/core';
 import { AbstractTurboWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-turbo-widget.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -8,9 +9,10 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 
 @Component({
+  selector: 'op-members-widget',
   templateUrl: './members.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: false,
+  standalone: false
 })
 export class WidgetMembersComponent extends AbstractTurboWidgetComponent {
   text = {

--- a/frontend/src/app/shared/components/grids/widgets/news/news.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/news/news.component.ts
@@ -30,6 +30,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { AbstractTurboWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-turbo-widget.component';
 
 @Component({
+  selector: 'op-news-widget',
   templateUrl: './news.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/app/shared/components/grids/widgets/project-status-beta/project-status-beta.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/project-status-beta/project-status-beta.component.ts
@@ -30,6 +30,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { AbstractTurboWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-turbo-widget.component';
 
 @Component({
+  selector: 'op-project-status-beta-widget',
   templateUrl: './project-status-beta.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/subprojects/subprojects.component.ts
@@ -5,6 +5,7 @@ import {
 import { AbstractTurboWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-turbo-widget.component';
 
 @Component({
+  selector: 'op-subitems-widget',
   templateUrl: './subprojects.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
@@ -10,6 +10,7 @@ import { DisplayedDays } from 'core-app/features/calendar/te-calendar/te-calenda
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 @Component({
+  selector: 'op-time-entries-current-user-widget',
   templateUrl: './time-entries-current-user.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/app/shared/components/grids/widgets/wp-overview/wp-overview.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-overview/wp-overview.component.ts
@@ -30,6 +30,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 
 @Component({
+  selector: 'op-wp-overview-widget',
   templateUrl: './wp-overview.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,7 +3,6 @@ import { enableProdMode } from '@angular/core';
 
 import 'core-app/core/setup/init-jquery';
 
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { initializeLocale } from 'core-app/core/setup/init-locale';
 import { environment } from './environments/environment';
 import { configureErrorReporter } from 'core-app/core/errors/configure-reporter';
@@ -14,6 +13,7 @@ import 'core-app/core/setup/init-vendors';
 import 'core-app/core/setup/init-globals';
 import './stimulus/setup';
 import './turbo/setup';
+import { platformBrowser } from '@angular/platform-browser';
 
 // Ensure we set the correct dynamic frontend path
 // based on the RAILS_RELATIVE_URL_ROOT setting
@@ -43,5 +43,6 @@ void initializeLocale()
   .then(() => {
     initializeGlobalListeners();
 
-    void platformBrowserDynamic().bootstrapModule(OpenProjectModule);
+    // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'
+    void platformBrowser().bootstrapModule(OpenProjectModule);
   });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,8 +2,6 @@ import { OpenProjectModule } from 'core-app/app.module';
 import { enableProdMode } from '@angular/core';
 
 import 'core-app/core/setup/init-jquery';
-
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { initializeLocale } from 'core-app/core/setup/init-locale';
 import { environment } from './environments/environment';
 import { configureErrorReporter } from 'core-app/core/errors/configure-reporter';
@@ -14,6 +12,7 @@ import 'core-app/core/setup/init-vendors';
 import 'core-app/core/setup/init-globals';
 import './stimulus/setup';
 import './turbo/setup';
+import { platformBrowser } from '@angular/platform-browser';
 
 // Ensure we set the correct dynamic frontend path
 // based on the RAILS_RELATIVE_URL_ROOT setting
@@ -43,5 +42,6 @@ void initializeLocale()
   .then(() => {
     initializeGlobalListeners();
 
-    void platformBrowserDynamic().bootstrapModule(OpenProjectModule);
+    // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'
+    void platformBrowser().bootstrapModule(OpenProjectModule);
   });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,8 @@ import { OpenProjectModule } from 'core-app/app.module';
 import { enableProdMode } from '@angular/core';
 
 import 'core-app/core/setup/init-jquery';
+
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { initializeLocale } from 'core-app/core/setup/init-locale';
 import { environment } from './environments/environment';
 import { configureErrorReporter } from 'core-app/core/errors/configure-reporter';
@@ -12,7 +14,6 @@ import 'core-app/core/setup/init-vendors';
 import 'core-app/core/setup/init-globals';
 import './stimulus/setup';
 import './turbo/setup';
-import { platformBrowser } from '@angular/platform-browser';
 
 // Ensure we set the correct dynamic frontend path
 // based on the RAILS_RELATIVE_URL_ROOT setting
@@ -42,6 +43,5 @@ void initializeLocale()
   .then(() => {
     initializeGlobalListeners();
 
-    // Due to the behaviour of the Edge browser we need to wait for 'DOM ready'
-    void platformBrowser().bootstrapModule(OpenProjectModule);
+    void platformBrowserDynamic().bootstrapModule(OpenProjectModule);
   });


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68666

# What are you trying to accomplish?
* fix two browser console warnings
  * `NG0912: Component ID generation collision detected. Components '_WidgetNewsComponent' and '_WidgetSubprojectsComponent' with selector 'ng-component' generated the same component ID. To fix this, you can change the selector of one of those components or add an extra host attribute to force a different ID. Find more at https://v20.angular.dev/errors/NG0912`
  * `DEPRECATED: DI is instantiating a token "" that inherits its @Injectable decorator but does not provide one itself.
This will become an error in a future version of Angular. Please add @Injectable() to the "" class.`

