### PR TITLE
[68561] UI broken when user with whom a wp has been shared opens the project (subitems widget breaking)

### DIFF
--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -51,7 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
             end
 
             row.with_column(ml: 2) do
-              render(Primer::Beta::Link.new(href: project_path(child))) { child.name }
+              render(Primer::Beta::Link.new(href: project_path(child), target: "_top")) { child.name }
             end
 
             row.with_column(ml: 2) do

--- a/modules/grids/app/controllers/grids/widgets/subitems_controller.rb
+++ b/modules/grids/app/controllers/grids/widgets/subitems_controller.rb
@@ -29,4 +29,12 @@
 #++
 
 class Grids::Widgets::SubitemsController < Grids::WidgetController
+  skip_before_action :load_and_authorize_in_optional_project
+  before_action :load_project, only: :show
+
+  private
+
+  def load_project
+    @project = Project.find(params[:project_id]) if params[:project_id].present?
+  end
 end

--- a/modules/grids/lib/grids/engine.rb
+++ b/modules/grids/lib/grids/engine.rb
@@ -16,7 +16,6 @@ module Grids
           .controller_actions
           .push(
             "grids/widgets/project_statuses/show",
-            "grids/widgets/subitems/show"
           )
 
         OpenProject::AccessControl.permission(:edit_project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68561

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Remove the view_project permission check for the current user in subitems widget, because [here](https://github.com/opf/openproject/blob/dev/modules/grids/app/components/grids/widgets/subitems.rb#L66), we return the subitems that the current user has access to.
