### PR TITLE
Update the document representer to show the update link when permitted

### DIFF
--- a/modules/documents/lib/api/v3/documents/document_representer.rb
+++ b/modules/documents/lib/api/v3/documents/document_representer.rb
@@ -43,6 +43,14 @@ module API
 
         self_link title_getter: ->(*) { represented.title }
 
+        link :update,
+             cache_if: -> { current_user.allowed_in_project?(:manage_documents, represented.project) } do
+          {
+            href: api_v3_paths.document(represented.id),
+            method: :patch
+          }
+        end
+
         property :id
 
         property :title

--- a/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/modules/documents/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -75,6 +75,19 @@ RSpec.describe API::V3::Documents::DocumentRepresenter, "rendering" do
       let(:method) { :post }
       let(:permission) { :manage_documents }
     end
+
+    it_behaves_like "has an untitled action link" do
+      let(:link) { :update }
+      let(:href) { api_v3_paths.document document.id }
+      let(:method) { :patch }
+      let(:permission) { :manage_documents }
+    end
+
+    context "when user is not allowed to edit documents" do
+      it_behaves_like "has no link" do
+        let(:link) { :update }
+      end
+    end
   end
 
   describe "properties" do


### PR DESCRIPTION
# Ticket
Part of https://community.openproject.org/projects/communicator-stream/work_packages/68699/activity

# What are you trying to accomplish?
Include the link to update the document when the user has permissions to do so

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
