### PR TITLE
Bug/66552: Add handling for multi-value custom fields in the AT journal changes filter (for the lazy loading of the activities tab’s `:only_changes` filtration)

### DIFF
--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -73,23 +73,27 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
     def attachment_changes_condition_sql
       association_changes_condition_sql(
         table: Journal::AttachableJournal.table_name,
-        id_column: "attachment_id",
+        join_columns: ["attachment_id"],
         value_columns: ["filename"]
       )
     end
 
+    # Custom fields require special handling because of multi-value fields.
+    # For multi-value CFs (e.g., multi-select), we must join on BOTH custom_field_id AND value
+    # to prevent Cartesian products. This matches the behavior of:
+    # Acts::Journalized::Differ::Association with multiple_values: :joined
     def custom_field_changes_condition_sql
       association_changes_condition_sql(
         table: Journal::CustomizableJournal.table_name,
-        id_column: "custom_field_id",
-        value_columns: ["value"]
+        join_columns: %w[custom_field_id value],
+        value_columns: [] # Changes detected via join_columns, not value comparison
       )
     end
 
     def file_link_changes_condition_sql
       association_changes_condition_sql(
         table: Journal::StorableJournal.table_name,
-        id_column: "file_link_id",
+        join_columns: ["file_link_id"],
         value_columns: %w[link_name storage_name]
       )
     end
@@ -115,20 +119,37 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
     end
 
     # Detect changes in association journals by checking for additions or removals.
-    def association_changes_condition_sql(table:, id_column:, value_columns:)
-      "#{association_items_added_sql(table:, id_column:, value_columns:)} " \
+    # join_columns: Array of column names to match predecessor and current records (e.g., ["attachment_id"])
+    #               For multi-value fields, use multiple columns (e.g., ["custom_field_id", "value"])
+    # value_columns: Array of column names to compare for modifications (e.g., ["filename"])
+    def association_changes_condition_sql(table:, join_columns:, value_columns:)
+      "#{association_items_added_sql(table:, join_columns:, value_columns:)} " \
         "UNION ALL " \
-        "#{association_items_removed_sql(table:, id_column:)}"
+        "#{association_items_removed_sql(table:, join_columns:)}"
     end
 
     # Detect added or modified association items by comparing with predecessor journal.
     # Returns SQL that finds items that either:
     # - Exist in current journal but not in predecessor (additions)
     # - Exist in both but have different values (modifications)
-    def association_items_added_sql(table:, id_column:, value_columns:)
-      value_changes = value_columns.map do |col|
-        "pred.#{col} IS DISTINCT FROM curr.#{col}"
-      end.join(" OR ")
+    def association_items_added_sql(table:, join_columns:, value_columns:)
+      join_conditions = join_columns.map do |col|
+        "pred.#{col} = curr.#{col}"
+      end.join(" AND ")
+
+      # No value columns means join_columns fully define identity
+      # (e.g., custom fields where custom_field_id + value is the composite key)
+      value_changes = if value_columns.any?
+                        value_columns.map do |col|
+                          "pred.#{col} IS DISTINCT FROM curr.#{col}"
+                        end.join(" OR ")
+                      end
+
+      where_clause = if value_changes
+                       "pred.id IS NULL OR (#{value_changes})"
+                     else
+                       "pred.id IS NULL"
+                     end
 
       <<~SQL.squish
         SELECT 1
@@ -139,15 +160,19 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
             AND predecessor.version = (#{max_predecessor_version_sql})
           LEFT JOIN #{table} pred
             ON pred.journal_id = predecessor.id
-            AND pred.#{id_column} = curr.#{id_column}
+            AND #{join_conditions}
           WHERE curr.journal_id = journals.id
-            AND (pred.id IS NULL OR (#{value_changes}))
+            AND (#{where_clause})
       SQL
     end
 
     # Detect removed association items by comparing with predecessor journal.
     # Returns SQL that finds items that existed in predecessor but not in current journal.
-    def association_items_removed_sql(table:, id_column:)
+    def association_items_removed_sql(table:, join_columns:)
+      join_conditions = join_columns.map do |col|
+        "curr.#{col} = pred.#{col}"
+      end.join(" AND ")
+
       <<~SQL.squish
         SELECT 1
           FROM journals predecessor
@@ -155,7 +180,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
             ON pred.journal_id = predecessor.id
           LEFT JOIN #{table} curr
             ON curr.journal_id = journals.id
-            AND curr.#{id_column} = pred.#{id_column}
+            AND #{join_conditions}
           WHERE predecessor.journable_id = journals.journable_id
             AND predecessor.journable_type = journals.journable_type
             AND predecessor.version = (#{max_predecessor_version_sql})

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -468,6 +468,125 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         end
       end
 
+      context "with multi-value custom field" do
+        let!(:multi_select_cf) do
+          create(:work_package_custom_field,
+                 field_format: "list",
+                 multi_value: true,
+                 possible_values: ["Option 1", "Option 2", "Option 3"])
+        end
+        let!(:option1) { multi_select_cf.custom_options.find_by(value: "Option 1") }
+        let!(:option2) { multi_select_cf.custom_options.find_by(value: "Option 2") }
+        let!(:option3) { multi_select_cf.custom_options.find_by(value: "Option 3") }
+
+        let!(:other_cf) { create(:work_package_custom_field, field_format: "string") }
+
+        let!(:journal_with_multi_cf_set) do
+          project.work_package_custom_fields << multi_select_cf
+          project.work_package_custom_fields << other_cf
+          work_package.type.custom_fields << multi_select_cf
+          work_package.type.custom_fields << other_cf
+          work_package.custom_field_values = { multi_select_cf.id => [option1.id, option2.id] }
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        let!(:journal_with_multi_cf_snapshot) do
+          work_package.add_journal(notes: "Just a comment")
+          work_package.save!
+          work_package.journals.order(:version).last
+        end
+
+        it "includes journal where multi-value custom field was set" do
+          _pagy, records = paginator.call
+          expect(records.map(&:id)).to include(journal_with_multi_cf_set.id)
+
+          changes = journal_with_multi_cf_set.reload.get_changes
+          expect(changes).to have_key("custom_fields_#{multi_select_cf.id}")
+        end
+
+        it "excludes journal with only notes and multi-value CF snapshot" do
+          _pagy, records = paginator.call
+
+          expect(journal_with_multi_cf_snapshot.reload.customizable_journals.count).to eq(2)
+
+          changes = journal_with_multi_cf_snapshot.reload.get_changes
+          expect(changes).not_to have_key("custom_fields_#{multi_select_cf.id}")
+          expect(changes).not_to have_key("custom_fields_#{other_cf.id}")
+
+          expect(records.map(&:id)).not_to include(journal_with_multi_cf_snapshot.id)
+        end
+
+        context "when adding an option to existing selection" do
+          let!(:journal_adding_option) do
+            journal_with_multi_cf_snapshot
+
+            work_package.reload.custom_field_values = { multi_select_cf.id => [option1.id, option2.id, option3.id] }
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it "detects the addition as a change" do
+            _pagy, records = paginator.call
+
+            expect(records.map(&:id)).to include(journal_adding_option.id)
+
+            changes = journal_adding_option.reload.get_changes
+            expect(changes).to have_key("custom_fields_#{multi_select_cf.id}")
+
+            change = changes["custom_fields_#{multi_select_cf.id}"]
+            new_value, old_value = change
+            expect(new_value).not_to eq(old_value)
+          end
+        end
+
+        context "when removing an option from existing selection" do
+          let!(:journal_removing_option) do
+            journal_with_multi_cf_snapshot
+
+            work_package.reload.custom_field_values = { multi_select_cf.id => [option1.id] }
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it "detects the removal as a change" do
+            _pagy, records = paginator.call
+
+            expect(records.map(&:id)).to include(journal_removing_option.id)
+
+            changes = journal_removing_option.reload.get_changes
+            expect(changes).to have_key("custom_fields_#{multi_select_cf.id}")
+
+            change = changes["custom_fields_#{multi_select_cf.id}"]
+            new_value, old_value = change
+            expect(new_value).not_to eq(old_value)
+          end
+        end
+
+        context "when changing options (adding and removing simultaneously)" do
+          let!(:journal_changing_options) do
+            journal_with_multi_cf_snapshot
+
+            work_package.reload.custom_field_values = { multi_select_cf.id => [option2.id, option3.id] }
+            work_package.save!
+            work_package.journals.order(:version).last
+          end
+
+          it "detects both additions and removals as changes" do
+            _pagy, records = paginator.call
+
+            expect(records.map(&:id)).to include(journal_changing_options.id)
+
+            changes = journal_changing_options.reload.get_changes
+            expect(changes).to have_key("custom_fields_#{multi_select_cf.id}")
+
+            change = changes["custom_fields_#{multi_select_cf.id}"]
+            new_value, old_value = change
+            expect(new_value).not_to eq(old_value)
+          end
+        end
+      end
+
       context "with file link changes" do
         let(:storage) { create(:nextcloud_storage) }
 


### PR DESCRIPTION
https://community.openproject.org/wp/66552

**_Hotfix:_** https://github.com/opf/openproject/pull/20896 For multi-value CFs, JOIN on BOTH `custom_field_id` AND `value` to prevent otherwise false positives.

> [!NOTE]
>  In the previous tests, we didn't have (multi-value) custom fields test data which is why we missed this case. Thanks to @cbliard for the assist in debugging and identifying the root cause! 🤩 


---

Test WP: https://qa.openproject-stage.com/projects/cecile-demo-project/work_packages/3647/activity

<details> <summary><em>Before/after screenshots for posterity</em></summary>

<img width="1342" height="1356" alt="Screenshot 2025-11-07 at 12 36 09 PM" src="https://github.com/user-attachments/assets/8645271d-ef48-4ad5-a50a-68c340dd7f90" />
<img width="1354" height="1369" alt="Screenshot 2025-11-07 at 12 33 56 PM" src="https://github.com/user-attachments/assets/695f23b9-b133-4d89-9478-203af785d100" />

</details>

_Co-authored with AI ✨_ 