### PR TITLE
[68850] Fix error 403 with news widget when news module is disabled

### DIFF
--- a/modules/grids/app/components/grids/widgets/news.html.erb
+++ b/modules/grids/app/components/grids/widgets/news.html.erb
@@ -29,10 +29,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper do |container|
-    if @newest.empty?
+    if no_news?
       render(Primer::Beta::Text.new(color: :subtle)) { t(".no_results") }
     else
-      @newest.each do |item|
+      newest.each do |item|
         container.with_row do
           render(
             Item.new(

--- a/modules/grids/app/components/grids/widgets/news.rb
+++ b/modules/grids/app/components/grids/widgets/news.rb
@@ -38,10 +38,16 @@ module Grids
 
       option :limit, default: -> { NEWS_LIMIT }
 
-      def initialize(...)
-        super
+      def no_news?
+        news_module_disabled? || newest.empty?
+      end
 
-        @news =
+      def newest
+        @newest ||= news.limit(limit).to_a
+      end
+
+      def news
+        @news ||=
           if project
             project.news.visible(current_user).newest_first
           else
@@ -50,16 +56,14 @@ module Grids
               .newest_first
               .includes(:project)
           end
-
-        @newest = @news.limit(limit).to_a
       end
 
       def title
         Project.human_attribute_name(:news)
       end
 
-      def render?
-        project.nil? || project.module_enabled?("news")
+      def news_module_disabled?
+        project.present? && !project.module_enabled?("news")
       end
     end
   end

--- a/modules/grids/app/controllers/grids/widgets/news_controller.rb
+++ b/modules/grids/app/controllers/grids/widgets/news_controller.rb
@@ -29,4 +29,9 @@
 #++
 
 class Grids::Widgets::NewsController < Grids::WidgetController
+  # skip authorization check as it would lead to a 403 if news module is
+  # disabled. When loaded through turbo, this causes the page to display a full
+  # 403 error page.
+  skip_before_action :load_and_authorize_in_optional_project
+  before_action :find_optional_project
 end

--- a/modules/grids/spec/components/grids/widgets/news_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/news_spec.rb
@@ -37,10 +37,14 @@ RSpec.describe Grids::Widgets::News, type: :component do
     render_inline(described_class.new(...))
   end
 
-  let(:project) { nil }
-  let(:user) { create(:admin) }
+  shared_let(:project_red) { create(:project, name: "Red", enabled_module_names: [:news]) }
+  shared_let(:project_blue) { create(:project, name: "Blue", enabled_module_names: [:news]) }
+  shared_let(:author) { create(:user) }
+  shared_let(:admin) { create(:admin) }
 
-  current_user { user }
+  let(:project) { nil }
+
+  current_user { admin }
 
   subject(:rendered_component) do
     render_component(project)
@@ -58,14 +62,14 @@ RSpec.describe Grids::Widgets::News, type: :component do
     end
 
     context "with news" do
-      let(:author) { create(:user) }
-      let!(:news) { create_list(:news, 2, author:) }
+      let!(:news_red) { create(:news, project: project_red, author:) }
+      let!(:news_blue) { create(:news, project: project_blue, author:) }
 
-      it "renders news items", :aggregate_failures do
+      it "renders news items from all projects", :aggregate_failures do
         expect(rendered_component).to have_list_item(count: 2)
         expect(rendered_component).to have_list_item(position: 2) do |item|
-          expect(item).to have_link href: news_path(news.first)
-          expect(item).to have_content /Added by .+ on \d{2}\/\d{2}\/\d{4} \d{2}:\d{2} [AP]M/
+          expect(item).to have_link href: news_path(news_red)
+          expect(item).to have_content(/Added by .+ on \d{2}\/\d{2}\/\d{4} \d{2}:\d{2} [AP]M/)
           expect(item).to have_link href: user_path(author)
         end
       end
@@ -73,7 +77,9 @@ RSpec.describe Grids::Widgets::News, type: :component do
   end
 
   context "with project" do
-    let(:project) { create(:project) }
+    let(:project) { project_red }
+    # these news from another project should not be visible
+    let!(:some_other_news) { create(:news, project: project_blue, author:) }
 
     context "with no news" do
       it "renders a message" do
@@ -82,14 +88,13 @@ RSpec.describe Grids::Widgets::News, type: :component do
     end
 
     context "with news" do
-      let(:author) { create(:user) }
-      let!(:news) { create_list(:news, 3, project:, author:) }
+      let!(:news) { create_list(:news, 3, project: project, author:) }
 
-      it "renders news items", :aggregate_failures do
+      it "renders news items of that project", :aggregate_failures do
         expect(rendered_component).to have_list_item(count: 3)
         expect(rendered_component).to have_list_item(position: 3) do |item|
           expect(item).to have_link href: news_path(news.first)
-          expect(item).to have_content /Added by .+ on \d{2}\/\d{2}\/\d{4} \d{2}:\d{2} [AP]M/
+          expect(item).to have_content(/Added by .+ on \d{2}\/\d{2}\/\d{4} \d{2}:\d{2} [AP]M/)
           expect(item).to have_link href: user_path(author)
         end
       end
@@ -97,11 +102,16 @@ RSpec.describe Grids::Widgets::News, type: :component do
   end
 
   context "with project without news module enabled" do
-    let(:project) { create(:project, enabled_module_names: [:wiki]) }
+    let(:project) { project_red }
+    let!(:news) { create(:news, project:, author:) }
 
-    it "does not render" do
-      expect(rendered_component).not_to have_primer_text "Nothing new to report.", color: "subtle"
+    before do
+      project.enabled_module_names -= %w[news]
+    end
+
+    it "renders 'nothing to report' message" do
       expect(rendered_component).not_to have_list "News"
+      expect(rendered_component).to have_primer_text "Nothing new to report.", color: "subtle"
     end
   end
 end

--- a/modules/grids/spec/controllers/grids/widgets/news_controller_spec.rb
+++ b/modules/grids/spec/controllers/grids/widgets/news_controller_spec.rb
@@ -57,5 +57,17 @@ RSpec.describe Grids::Widgets::NewsController do
         expect(response).to render_template "show"
       end
     end
+
+    context "with project and news module disabled" do
+      before do
+        project.enabled_module_names -= %w[news]
+        get :show, params: { project_id: project }
+      end
+
+      it "renders show template", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to render_template "show"
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68850

# What are you trying to accomplish?

When a project has the "News" module disabled and the news widget is on the dashboard, it would display an error instead of displaying something like "No news" like it did in 16.5

Because this happens on the dashboard page, this prevents some users from accessing their project. They have an error as soon as they select their project in the project picker.

## Screenshots

widget in 16.5 when "News" module is disabled:

<img width="1028" height="226" alt="image" src="https://github.com/user-attachments/assets/ac2d054f-cc99-4e71-8b1b-b587ed06b157" />

With the fix, when "news" module is disabled:

<img width="1321" height="234" alt="image" src="https://github.com/user-attachments/assets/70fbdf90-0a6f-4c2b-b3e9-e6733f5abc10" />

# What approach did you choose and why?

TLDR: no more permission check, always render the news widget, and it has additional logic to display "no news" when module is disabled.

The widget news controller was checking `:view_news` permission before rendering. For projects without the news module enabled, the permission check fails and renders a 403 error.

As the news widget from dashboard tab is rendered through Angular with `WidgetNewsComponent` using a turbo-frame, the 403 error was somehow rendering a full page error, preventing the page to be displayed properly. This prevented people from accessing the project page.

This fixes the issue by disabling the permission check for the news widget, and displaying a "Nothing new to report." message instead when the module is disabled.

I'm not too sure it's a good idea to disable the permission check like this, and tests in `modules/grids/spec/permissions/widgets/news_spec.rb` still pass, but actually the permission is not really checked.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
