### PR TITLE
Remove unnecessary check from generating oauth tokens

### DIFF
--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -59,6 +59,10 @@ class DocumentsController < ApplicationController
 
   def show
     @attachments = @document.attachments.order(Arel.sql("created_at DESC"))
+    # we will need to generate tokens for both view only and writer users
+    # so when we build the show page it is necessary to include the following line
+    #
+    # generate_oauth_token
   end
 
   def new
@@ -124,11 +128,6 @@ class DocumentsController < ApplicationController
   end
 
   def generate_oauth_token
-    # do not generate a token if the user is not allowed to manage documents
-    if !current_user.allowed_in_project?(:manage_documents, @project)
-      return
-    end
-
     result = Documents::OAuth::GenerateTokenService
       .new(user: current_user)
       .call


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/68699/activity

# What are you trying to accomplish?
Allow readonly users to also get tokens to connect to the hocuspocus server. This will enable users with readonly access to view live updates, so when a readonly user connects to a document being edited by somebody else, they get to see the text transforming live.

To test this approach include the following snippet into the `documents/show.html.erb` view

```ruby
<%=
  settings_primer_form_with(
    model: @document,
    url: document_path(@document),
    method: :patch,
    data: { turbo: false }
  ) do |f|
    render DocumentForm.new(f, oauth_token: @oauth_token)
  end
%>
```

and make sure to uncomment the line `generate_oauth_token` from the `documents/.../documents_controller.rb`

...

This solution will only be properly testable once we have the show view in place.

