### PR TITLE
Fix flaky specs

### DIFF
--- a/modules/bim/spec/support/pages/ifc_models/index.rb
+++ b/modules/bim/spec/support/pages/ifc_models/index.rb
@@ -91,9 +91,9 @@ module Pages
       end
 
       def delete_model(model_name)
-        click_table_icon model_name, ".icon-delete"
-
-        page.driver.browser.switch_to.alert.accept
+        accept_alert do
+          click_table_icon model_name, ".icon-delete"
+        end
 
         model_listed false, model_name
         expect(page).to have_current_path bcf_project_ifc_models_path(project), ignore_query: true

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -401,9 +401,9 @@ RSpec.describe "Open the Meetings tab",
             1
           )
 
-          meetings_tab.expect_upcoming_counter_to_be(1)
-
           wait_for_network_idle
+
+          meetings_tab.expect_upcoming_counter_to_be(1)
 
           page.within_test_selector("op-meeting-container-#{ongoing_meeting.id}") do
             expect(page).to have_content("Some notes to be added")

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -403,6 +403,8 @@ RSpec.describe "Open the Meetings tab",
 
           meetings_tab.expect_upcoming_counter_to_be(1)
 
+          wait_for_network_idle
+
           page.within_test_selector("op-meeting-container-#{ongoing_meeting.id}") do
             expect(page).to have_content("Some notes to be added")
           end

--- a/spec/features/admin/oauth/oauth_applications_management_spec.rb
+++ b/spec/features/admin/oauth/oauth_applications_management_spec.rb
@@ -79,8 +79,12 @@ RSpec.describe "OAuth applications management", :js do
     fill_in "application_redirect_uri", with: "urn:ietf:wg:oauth:2.0:oob"
     click_on "Save"
 
+    wait_for_network_idle
+
     # Show application
     click_on "My API application"
+
+    wait_for_network_idle
 
     expect(page).to have_no_css(".attributes-key-value--key", text: "Client secret")
     expect(page).to have_no_css(".attributes-key-value--value code")


### PR DESCRIPTION
## 1

Failing spec: ./spec/features/admin/oauth/oauth_applications_management_spec.rb:40
Failing run: https://github.com/opf/openproject/actions/runs/19169871346/job/54802405024?pr=20674

It needed more waits.

## 2

Failing spec: ./modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb:392
Failing run: https://github.com/opf/openproject/actions/runs/19172257098/job/54807699326?pr=20971

Sometimes the component hasn't been loaded yet. wait_for_network_idle appears to fix the timing issue.

## 3

Failing spec: ./modules/bim/spec/features/model_management_spec.rb:64
Failing run: https://github.com/opf/openproject/actions/runs/19172257098/job/54807699326?pr=20971

Using accept_alert which waits by default appears to fix the timing related flakiness.