### PR TITLE
[#68040] Switching a multi select list cf to a single select cf breaks

### DIFF
--- a/app/forms/custom_fields/inputs/base/input.rb
+++ b/app/forms/custom_fields/inputs/base/input.rb
@@ -54,7 +54,7 @@ class CustomFields::Inputs::Base::Input < ApplicationForm
   end
 
   def custom_value
-    @custom_value ||= model.custom_value_for(@custom_field.id)
+    @custom_value ||= model.custom_value_for(@custom_field)
   end
 
   def invalid?

--- a/app/models/exports/pdf/components/wp_table.rb
+++ b/app/models/exports/pdf/components/wp_table.rb
@@ -118,8 +118,6 @@ module Exports::PDF::Components::WpTable
     list = key.map { |v| v&.value }
     if list.empty?
       nil
-    elsif list.length == 1
-      list.first
     else
       list
     end

--- a/app/models/projects/exports/pdf_export/report.rb
+++ b/app/models/projects/exports/pdf_export/report.rb
@@ -195,7 +195,7 @@ module Projects::Exports::PDFExport
     end
 
     def write_formattable_custom_field(project, custom_field)
-      custom_field_value = project.custom_value_for(custom_field.id)
+      custom_field_value = project.custom_value_for(custom_field)
       write_project_markdown custom_field_value.value, custom_field.name
     end
 

--- a/app/models/queries/work_packages/selects/custom_field_select.rb
+++ b/app/models/queries/work_packages/selects/custom_field_select.rb
@@ -54,7 +54,7 @@ class Queries::WorkPackages::Selects::CustomFieldSelect < Queries::WorkPackages:
   end
 
   def value(work_package)
-    work_package.formatted_custom_value_for(@cf.id)
+    work_package.formatted_custom_value_for(@cf)
   end
 
   def self.instances(context = nil)

--- a/app/views/customizable/_form.html.erb
+++ b/app/views/customizable/_form.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
      .each do |custom_field| %>
   <%
     form_options = {
-      custom_value: form.object.custom_value_for(custom_field.id),
+      custom_value: form.object.custom_value_for(custom_field),
       custom_field: custom_field
     }
   %>

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -162,19 +162,20 @@ module Redmine
           custom_field_values.reject(&:admin_only?)
         end
 
-        def custom_value_for(c)
-          field_id = (c.is_a?(CustomField) ? c.id : c.to_i)
-          values = custom_field_values.select { |v| v.custom_field_id == field_id }
+        def custom_value_for(custom_field)
+          raise ArgumentError, "Expected a CustomField, got #{custom_field.class}" unless custom_field.is_a?(CustomField)
 
-          if values.size > 1
+          values = custom_field_values.select { |v| v.custom_field_id == custom_field.id }
+
+          if values.size > 1 && custom_field.multi_value?
             values.sort_by { |v| v.id.to_i } # need to cope with nil
           else
             values.first
           end
         end
 
-        def typed_custom_value_for(c)
-          cvs = custom_value_for(c)
+        def typed_custom_value_for(custom_field)
+          cvs = custom_value_for(custom_field)
 
           case cvs
           when Array
@@ -186,8 +187,8 @@ module Redmine
           end
         end
 
-        def formatted_custom_value_for(c)
-          cvs = custom_value_for(c)
+        def formatted_custom_value_for(custom_field)
+          cvs = custom_value_for(custom_field)
 
           case cvs
           when Array

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -167,7 +167,7 @@ module Redmine
 
           values = custom_field_values.select { |v| v.custom_field_id == custom_field.id }
 
-          if values.size > 1 && custom_field.multi_value?
+          if custom_field.multi_value?
             values.sort_by { |v| v.id.to_i } # need to cope with nil
           else
             values.first

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Custom field filter in boards",
 
     # Expect custom field to be unchanged
     work_package.reload
-    cv = work_package.custom_value_for(custom_field).typed_value
-    expect(cv).to eq "B"
+    cv = work_package.custom_value_for(custom_field).map(&:typed_value)
+    expect(cv).to eq ["B"]
   end
 end

--- a/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/item_component.rb
@@ -40,7 +40,7 @@ module Overviews
         super
 
         @project_custom_field = project_custom_field
-        @project_custom_field_values = project_custom_field_values
+        @project_custom_field_values = Array(project_custom_field_values)
         @project = project
       end
 
@@ -157,32 +157,28 @@ module Overviews
         when "user"
           render_user
         else
-          render(Primer::Beta::Text.new) do
-            @project_custom_field_values&.map do |cf_value|
-              format_value(cf_value.value, @project_custom_field)
-            end&.join(", ")
-          end
+          render_custom_field_values
         end
       end
 
       def render_long_text
         render OpenProject::Common::AttributeComponent.new("dialog-cf-#{@project_custom_field.id}",
                                                            @project_custom_field.name,
-                                                           @project_custom_field_values&.first&.value,
+                                                           @project_custom_field_values.first&.value,
                                                            lines: 3)
       end
 
       def render_user
         if @project_custom_field.multi_value?
           flex_layout do |avatar_container|
-            @project_custom_field_values&.each do |cf_value|
+            @project_custom_field_values.each do |cf_value|
               avatar_container.with_row do
                 render_avatar(cf_value.typed_value)
               end
             end
           end
         else
-          render_avatar(@project_custom_field_values&.first&.typed_value)
+          render_avatar(@project_custom_field_values.first&.typed_value)
         end
       end
 
@@ -191,7 +187,7 @@ module Overviews
       end
 
       def render_link
-        href = @project_custom_field_values&.first&.value
+        href = @project_custom_field_values.first&.value
         link = Addressable::URI.parse(href)
         return href unless link
 
@@ -201,12 +197,21 @@ module Overviews
         end
       end
 
+      def render_custom_field_values
+        render(Primer::Beta::Text.new) { custom_field_values }
+      end
+
       def accessible_value_text
         return I18n.t("placeholders.default") if not_set?
+        custom_field_values
+      end
 
-        @project_custom_field_values.map do |cf_value|
-          format_value(cf_value.value, @project_custom_field)
-        end.join(", ")
+      def custom_field_values
+        return @custom_field_values if defined?(@custom_field_values)
+
+        values = @project_custom_field_values.map { |v| format_value(v.value, @project_custom_field) }
+
+        @custom_field_values = @project_custom_field.multi_value? ? values.join(", ") : values.first
       end
     end
   end

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
 
           subject do
             WorkPackage.where(id: work_package_ids)
-              .map { |w| w.custom_value_for(custom_field1.id).value }
+              .map { |w| w.custom_value_for(custom_field1).value }
               .uniq
           end
 
@@ -438,7 +438,7 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
           end
 
           subject do
-            work_packages.map { |w| w.custom_value_for(custom_field1.id).value }
+            work_packages.map { |w| w.custom_value_for(custom_field1).value }
                          .uniq
           end
 

--- a/spec/features/custom_fields/multi_version_custom_field_spec.rb
+++ b/spec/features/custom_fields/multi_version_custom_field_spec.rb
@@ -77,12 +77,11 @@ RSpec.describe "multi version custom field", :js do
 
     work_package.reload
 
-    # only one value, so no array
     cvs = work_package
             .custom_value_for(custom_field)
-            .typed_value
+            .map(&:typed_value)
 
-    expect(cvs).to eq version_old
+    expect(cvs).to eq [version_old]
   end
 
   context "with existing version values" do

--- a/spec/features/custom_fields/non_open_version_custom_field_spec.rb
+++ b/spec/features/custom_fields/non_open_version_custom_field_spec.rb
@@ -133,12 +133,11 @@ RSpec.describe "support for non-open version values in version custom field", :j
 
       work_package.reload
 
-      # only one value, so no array
       cvs = work_package
               .custom_value_for(custom_field)
-              .typed_value
+              .map(&:typed_value)
 
-      expect(cvs).to eq version_closed
+      expect(cvs).to eq [version_closed]
     end
   end
 

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/update_spec.rb
@@ -428,6 +428,34 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
             expect(page).to have_no_text first_option
           end
         end
+
+        it "renders correctly when switching a multi select field to a single select" do
+          # Simulate a multi select field being switched to single select
+          # by having multiple custom values chosen.
+          create(:custom_value, customized: project, custom_field:, value: unused_selection)
+
+          overview_page.visit_page
+
+          # Do not show the second unused option as selected.
+          overview_page.within_custom_field_container(custom_field) do
+            expect(page).to have_text first_option
+            expect(page).to have_no_text unused_option
+          end
+
+          overview_page.open_edit_dialog_for_custom_field(custom_field)
+
+          # Choose the unused option as the new selection
+          field.select_option(unused_option)
+
+          dialog.submit
+          dialog.expect_closed
+
+          # Display the new selection in the sidebar
+          overview_page.within_custom_field_container(custom_field) do
+            expect(page).to have_text unused_option
+            expect(page).to have_no_text first_option
+          end
+        end
       end
 
       describe "with list CF" do
@@ -435,6 +463,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:field) { FormFields::Primerized::AutocompleteField.new(custom_field) }
 
         let(:first_option) { custom_field.custom_options.first.value }
+        let(:unused_option) { custom_field.custom_options.second.value }
+        let(:unused_selection) { custom_field.custom_options.second }
 
         it_behaves_like "a select field"
       end
@@ -444,6 +474,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:field) { FormFields::Primerized::AutocompleteField.new(custom_field) }
 
         let(:first_option) { first_version.name }
+        let(:unused_option) { second_version.name }
+        let(:unused_selection) { second_version }
 
         it_behaves_like "a select field"
       end
@@ -453,6 +485,8 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
         let(:field) { FormFields::Primerized::AutocompleteField.new(custom_field) }
 
         let(:first_option) { member_in_project.name }
+        let(:unused_option) { another_member_in_project.name }
+        let(:unused_selection) { another_member_in_project }
 
         it_behaves_like "a select field"
 

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe "custom field inplace editor", :js do
         field.expect_state_text "10,000.55"
 
         work_package.reload
-        expect(work_package.custom_value_for(custom_field.id).typed_value).to eq 10000.55
+        expect(work_package.custom_value_for(custom_field).typed_value).to eq 10000.55
       end
     end
 
@@ -234,7 +234,7 @@ RSpec.describe "custom field inplace editor", :js do
         field.expect_state_text "10.000,55"
 
         work_package.reload
-        expect(work_package.custom_value_for(custom_field.id).typed_value).to eq 10000.55
+        expect(work_package.custom_value_for(custom_field).typed_value).to eq 10000.55
       end
     end
   end

--- a/spec/features/work_packages/details/date_editor_spec.rb
+++ b/spec/features/work_packages/details/date_editor_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe "date inplace editor", :js, :selenium, with_settings: { date_form
       create_page.expect_and_dismiss_toaster message: "Successful creation"
 
       wp = WorkPackage.last
-      expect(wp.custom_value_for(date_cf.id).value).to eq Time.zone.today.iso8601
+      expect(wp.custom_value_for(date_cf).value).to eq Time.zone.today.iso8601
     end
 
     it "can set the date via the in-place editing" do

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "Switching types in work package table", :js do
       new_wp = WorkPackage.last
       expect(new_wp.subject).to eq("My subject")
       expect(new_wp.type_id).to eq(type_with_cf.id)
-      expect(new_wp.custom_value_for(custom_field.id).map(&:typed_value)).to match_array(%w(pineapple mushrooms))
+      expect(new_wp.custom_value_for(custom_field).map(&:typed_value)).to match_array(%w(pineapple mushrooms))
     end
   end
 end

--- a/spec/models/projects/customizable_spec.rb
+++ b/spec/models/projects/customizable_spec.rb
@@ -118,6 +118,11 @@ RSpec.describe Project, "customizable" do
     end
 
     describe "#custom_field_values and #custom_value_for" do
+      it "raises an ArgumentError when a non custom field argument is provided" do
+        expect { project.custom_value_for("invalid") }
+          .to raise_error(ArgumentError, /Expected a CustomField, got String/)
+      end
+
       context "when no custom fields are mapped to this project" do
         it "#custom_value_for returns nil" do
           expect(project.custom_value_for(text_custom_field))

--- a/spec/models/queries/work_packages/selects/custom_field_select_spec.rb
+++ b/spec/models/queries/work_packages/selects/custom_field_select_spec.rb
@@ -123,8 +123,9 @@ RSpec.describe Queries::WorkPackages::Selects::CustomFieldSelect do
     let(:mock) { instance_double(WorkPackage) }
 
     it "delegates to formatted_custom_value_for" do
-      expect(mock).to receive(:formatted_custom_value_for).with(custom_field.id)
+      allow(mock).to receive(:formatted_custom_value_for).with(custom_field)
       instance.value(mock)
+      expect(mock).to have_received(:formatted_custom_value_for).with(custom_field)
     end
   end
 end

--- a/spec/models/work_package/work_package_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_custom_fields_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe WorkPackage do
         end
 
         context "save" do
-          subject { work_package.typed_custom_value_for(custom_field.id) }
+          subject { work_package.typed_custom_value_for(custom_field) }
 
           it { is_expected.to eq("PostgreSQL") }
         end
@@ -242,7 +242,7 @@ RSpec.describe WorkPackage do
           work_package.reload
         end
 
-        subject { work_package.typed_custom_value_for(custom_field.id) }
+        subject { work_package.typed_custom_value_for(custom_field) }
 
         it { is_expected.to eql("PostgreSQL") }
       end
@@ -317,7 +317,7 @@ RSpec.describe WorkPackage do
           end
           wp.attributes = attribute_hash
 
-          wp.custom_value_for(custom_field_2.id).value
+          wp.custom_value_for(custom_field_2).value
         end
 
         it { is_expected.to eql(OpenProject::Database::DB_VALUE_TRUE) }

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe WorkPackage do
   end
 
   let(:values) { work_package.custom_value_for(custom_field) }
-  let(:typed_values) { work_package.typed_custom_value_for(custom_field.id) }
+  let(:typed_values) { work_package.typed_custom_value_for(custom_field) }
 
   it "returns the properly typed values" do
     expect(values.map(&:value)).to eq(custom_values)

--- a/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
+++ b/spec/models/work_package/work_package_multi_value_custom_fields_spec.rb
@@ -75,10 +75,8 @@ RSpec.describe WorkPackage do
     let(:work_package) { create(:work_package, project:, type:) }
 
     it "returns nil properly" do
-      # I suspect this should rather be
-      # expect(values.map(&:value)).to eq([nil])
-      expect(values.value).to be_nil
-      expect(typed_values).to be_nil
+      expect(values.map(&:value)).to eq([nil])
+      expect(typed_values).to eq([nil])
     end
   end
 

--- a/spec/services/work_packages/copy_service_integration_spec.rb
+++ b/spec/services/work_packages/copy_service_integration_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe WorkPackages::CopyService, "integration", type: :model do
           custom_value
         end
 
-        subject { copy.custom_value_for(custom_field.id) }
+        subject { copy.custom_value_for(custom_field) }
 
         it { is_expected.to be_nil }
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68040

# What are you trying to accomplish?
Fix the list project attribute dialog in a special case when the attribute is switched from being a multi select to a single select.

# What approach did you choose and why?
- [X] Change the custom_value_for method to return multiple values only when the custom field is multi select.
- [X] Change the custom_value_for method signature to always use a custom field.
- [X] Display a single selected value in the overview page for single select project attribute field.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
