### PR TITLE
[68793] Enforce feature flag for project overview to be true

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -70,7 +70,8 @@ OpenProject::FeatureDecisions.add :portfolio_models,
                                   description: "Enables the creation and management of portfolio and program work spaces."
 
 OpenProject::FeatureDecisions.add :new_project_overview,
-                                  description: "Enables the new project overview experience."
+                                  description: "Enables the new project overview experience.",
+                                  force_active: true
 
 OpenProject::FeatureDecisions.add :wp_activity_tab_lazy_pagination,
                                   description: "Enables lazy pagination for the activity tab."


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68793

# What are you trying to accomplish?
Force the feature flag for the overview page to true

