### PR TITLE
fix access tokens link in the Subscribe to calendar dialog

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -336,7 +336,7 @@ en:
       warning: "Please don't share this URL with other users. Anyone with this link will be able to view work package details without an account or password."
       token_name_label: "Where will you be using this?"
       token_name_placeholder: 'Type a name, e.g. "Phone"'
-      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="my/access_token", target="_blank">access tokens</a> list.'
+      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="%{myAccessTokensUrl}" target="_blank">access tokens</a> list.'
       copy_url_label: "Copy URL"
       ical_generation_error_text: "An error occured while generating the calendar URL."
       success_message: 'The URL "%{name}" was successfully copied to your clipboard. Paste it in your calendar client to complete the subscription.'

--- a/frontend/src/app/core/path-helper/path-helper.service.ts
+++ b/frontend/src/app/core/path-helper/path-helper.service.ts
@@ -126,6 +126,10 @@ export class PathHelperService {
     return `${this.staticBase}/my/page`;
   }
 
+  public myAccessTokensPath() {
+    return `${this.staticBase}/my/access_tokens`;
+  }
+
   public myNotificationsSettingsPath() {
     return `${this.staticBase}/my/notifications`;
   }

--- a/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
+++ b/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
@@ -34,7 +34,7 @@ import { OpModalComponent } from 'core-app/shared/components/modal/modal.compone
 import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit,
+  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, inject,
 } from '@angular/core';
 import {
   UntypedFormGroup,
@@ -59,6 +59,19 @@ interface TokenNameFormValue {
   standalone: false,
 })
 export class QueryGetIcalUrlModalComponent extends OpModalComponent implements OnInit {
+  public readonly elementRef = inject(ElementRef);
+  public locals:OpModalLocalsMap = inject(OpModalLocalsToken);
+  public readonly I18n = inject(I18nService);
+  public readonly states = inject(States);
+  public readonly querySpace = inject(IsolatedQuerySpace);
+  public readonly cdRef = inject(ChangeDetectorRef);
+  public readonly wpListService = inject(WorkPackagesListService);
+  public readonly halNotification = inject(HalResourceNotificationService);
+  public readonly toastService = inject(ToastService);
+  public readonly pathService = inject(PathHelperService);
+  protected apiV3Service = inject(ApiV3Service);
+  protected copyToClipboardService = inject(CopyToClipboardService);
+
   public tokenName = '';
 
   public query:QueryResource;
@@ -90,21 +103,13 @@ export class QueryGetIcalUrlModalComponent extends OpModalComponent implements O
     return this.tokenNameForm.get('name');
   }
 
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly cdRef:ChangeDetectorRef,
-    readonly wpListService:WorkPackagesListService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly toastService:ToastService,
-    readonly pathService:PathHelperService,
-    protected apiV3Service:ApiV3Service,
-    protected copyToClipboardService:CopyToClipboardService,
-  ) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    // Pass required deps to the base class using inject()
+    super(
+      inject(OpModalLocalsToken),
+      inject(ChangeDetectorRef),
+      inject(ElementRef),
+    );
   }
 
   ngOnInit():void {
@@ -127,7 +132,6 @@ export class QueryGetIcalUrlModalComponent extends OpModalComponent implements O
     if (this.isBusy) {
       return;
     }
-
 
     const tokenName = (this.tokenNameForm.value as TokenNameFormValue)?.name;
 

--- a/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
+++ b/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
@@ -47,6 +47,7 @@ import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/q
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { CopyToClipboardService } from 'core-app/shared/components/copy-to-clipboard/copy-to-clipboard.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 interface TokenNameFormValue {
   name:string;
@@ -70,7 +71,10 @@ export class QueryGetIcalUrlModalComponent extends OpModalComponent implements O
     ical_sharing_warning: this.I18n.t('js.ical_sharing_modal.warning'),
     token_name: this.I18n.t('js.ical_sharing_modal.token_name_label'),
     token_name_placeholder: this.I18n.t('js.ical_sharing_modal.token_name_placeholder'),
-    token_name_description_text: this.I18n.t('js.ical_sharing_modal.token_name_description_text'),
+    token_name_description_text: this.I18n.t(
+      'js.ical_sharing_modal.token_name_description_text',
+      { myAccessTokensUrl: this.pathService.myAccessTokensPath() }
+    ),
     token_name_already_in_use_error_text: this.I18n.t('js.ical_sharing_modal.token_name_already_in_use_error_text'),
     button_copy: this.I18n.t('js.ical_sharing_modal.copy_url_label'),
     button_cancel: this.I18n.t('js.button_cancel'),
@@ -96,6 +100,7 @@ export class QueryGetIcalUrlModalComponent extends OpModalComponent implements O
     readonly wpListService:WorkPackagesListService,
     readonly halNotification:HalResourceNotificationService,
     readonly toastService:ToastService,
+    readonly pathService:PathHelperService,
     protected apiV3Service:ApiV3Service,
     protected copyToClipboardService:CopyToClipboardService,
   ) {


### PR DESCRIPTION
Noticed that `my/access_token` is used instead of `my/access_tokens`