### PR TITLE
Perform health check offline_access scope earlier

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/authentication_validator.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/authentication_validator.rb
@@ -77,17 +77,17 @@ module Storages
                 :non_provisioned_user,
                 :provisioned_user_provider,
                 :provider_capabilities,
+                :offline_access,
                 :token_negotiable,
-                :user_bound_request,
-                :offline_access
+                :user_bound_request
               )
 
               non_provisioned_user
               non_oidc_provisioned_user
               provider_capabilities
+              offline_access
               token_negotiable
               user_bound_request
-              offline_access
             end
 
             def non_provisioned_user


### PR DESCRIPTION
It now happens immediately after another check for the provider configuration and before we try to use the token of the current user to make a request. This allows to see potential warnings from this check, that might later ruin actual token requests.

# Ticket
https://community.openproject.org/wp/68615