### PR TITLE
Remove "Experimental" type check for collaborative documents (editable via BlockNote)

### DIFF
--- a/modules/documents/app/forms/document_form.rb
+++ b/modules/documents/app/forms/document_form.rb
@@ -54,7 +54,7 @@ class DocumentForm < ApplicationForm
       required: true
     )
 
-    if OpenProject::FeatureDecisions.block_note_editor_active? && model.type&.name == "Experimental"
+    if OpenProject::FeatureDecisions.block_note_editor_active?
       f.block_note_editor(
         name: :content_binary,
         label: I18n.t("label_document_description"),

--- a/modules/documents/app/services/documents/set_attributes_service.rb
+++ b/modules/documents/app/services/documents/set_attributes_service.rb
@@ -33,13 +33,7 @@ module Documents
     include Attachments::SetReplacements
 
     def set_default_attributes(_params)
-      model.kind = experimental_block_note_editor_active? ? :collaborative : :classic
-    end
-
-    private
-
-    def experimental_block_note_editor_active?
-      model.type&.name == "Experimental" && OpenProject::FeatureDecisions.block_note_editor_active?
+      model.kind = OpenProject::FeatureDecisions.block_note_editor_active? ? :collaborative : :classic
     end
   end
 end

--- a/modules/documents/spec/services/documents/set_attributes_service_spec.rb
+++ b/modules/documents/spec/services/documents/set_attributes_service_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe Documents::SetAttributesService do
   shared_let(:user) { create(:admin) }
   shared_let(:project) { create(:project) }
-  shared_let(:experimental_type) { create(:document_type, :experimental) }
+  shared_let(:doc_type) { create(:document_type) }
 
   current_user { user }
 
@@ -42,23 +42,21 @@ RSpec.describe Documents::SetAttributesService do
       user:,
       model: Document.new,
       contract_class: Documents::BaseContract
-    ).call(type_id: experimental_type.id, title: "A Document", project:)
+    ).call(type_id: doc_type.id, title: "A Document", project:)
   end
 
   describe "#call" do
-    context "with 'Experimental' document type" do
-      context "and block note editor feature active", with_flag: { block_note_editor: true } do
-        it "sets the document kind to 'collaborative'" do
-          expect(set_attributes_service).to be_success
-          expect(set_attributes_service.result).to be_collaborative
-        end
+    context "with block note editor feature active", with_flag: { block_note_editor: true } do
+      it "sets the document kind to 'collaborative'" do
+        expect(set_attributes_service).to be_success
+        expect(set_attributes_service.result).to be_collaborative
       end
+    end
 
-      context "and block note editor feature inactive", with_flag: { block_note_editor: false } do
-        it "sets the document kind to 'classic'" do
-          expect(set_attributes_service).to be_success
-          expect(set_attributes_service.result).to be_classic
-        end
+    context "with block note editor feature inactive", with_flag: { block_note_editor: false } do
+      it "sets the document kind to 'classic'" do
+        expect(set_attributes_service).to be_success
+        expect(set_attributes_service.result).to be_classic
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/68788

Use the block note feature flag and the hocuspocus URL states to assess the possibility of collaboration.

Enables testing of collaboration features on pull preview https://github.com/opf/openproject/pull/20924