### PR TITLE
[#68994] Custom slash menu items on BlockNote disappear after a few chars

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -208,6 +208,7 @@ export default function OpBlockNoteContainer({ inputField,
         :
         <BlockNoteView
           editor={editor}
+          slashMenu={false}
           theme={detectTheme()}
           className={'block-note-editor-container'}
         >

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "BlockNote editor rendering", :js, with_flag: { block_note_editor
     expect(page).to have_content("Überschrift")
   end
 
-  it "renders the blocknote editor in english if the users locale is not available for BlockNote" do
+  it "renders the BlockNote editor in english if the users locale is not available for BlockNote" do
     admin.update!(language: "af")
     visit edit_document_path(document)
 
@@ -80,5 +80,13 @@ RSpec.describe "BlockNote editor rendering", :js, with_flag: { block_note_editor
 
     editor.open_command_dialog
     expect(page).to have_content("Heading")
+  end
+
+  it "renders the BlockNote editor with custom menu entries for work package linking" do
+    visit edit_document_path(document)
+
+    expect(page).to have_test_selector("blocknote-document-description")
+    editor.send_keys("/openproject")
+    expect(page).to have_content("Search and link an existing Work Package")
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68994

# What are you trying to accomplish?
Fix disappearing menu entries

## Screenshots

### before
[Screencast from 2025-11-10 15-51-28.webm](https://github.com/user-attachments/assets/8a29055c-2a69-4061-822c-aaea8a010c1e)

### after
[Screencast from 2025-11-12 12-58-31.webm](https://github.com/user-attachments/assets/c17acb4d-c48c-4699-9993-282841dd8da8)


# Merge checklist

- [x] Added/updated tests