### PR TITLE
Limit metrics to memory in CI workflow

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: runs-on/action@v2
       with:
-        metrics: cpu,memory,disk,io,network
+        metrics: memory
     - uses: actions/checkout@v5
     - name: Cache DOCKER
       id: cache_docker


### PR DESCRIPTION
Reduces some of the Cloudwatch costs linked to metric ingestion.