### PR TITLE
[#68802] add shorts and weights to tree selector for project attributes

### DIFF
--- a/app/helpers/custom_field_hierarchy_tree_view_helper.rb
+++ b/app/helpers/custom_field_hierarchy_tree_view_helper.rb
@@ -57,9 +57,9 @@ module CustomFieldHierarchyTreeViewHelper
     end
   end
 
-  def item_attributes(item, options) # rubocop:disable Metrics/PerceivedComplexity
+  def item_attributes(item, options) # rubocop:disable Metrics/PerceivedComplexity,Metrics/AbcSize
     {
-      label: item.label,
+      label: options[:label_fn]&.call(item) || item.label,
       value: item.id,
       select_variant: options[:select_variant] || :none,
       checked: options[:checked_fn]&.call(item) || false,

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -36,19 +36,25 @@ class CustomField::Hierarchy::Item < ApplicationRecord
 
   scope :including_children, -> { includes(children: :children) }
 
-  def to_s = short.nil? ? label : "#{label} (#{short})"
+  def to_s = suffix.empty? ? label : "#{label} #{suffix}"
 
   def ancestry_path(include_shorts_and_weights: false)
     path = self_and_ancestors.filter_map(&:to_s).reverse.join(" / ")
 
     return path unless include_shorts_and_weights
 
+    suffix.empty? ? path : "#{path} #{suffix}"
+  end
+
+  private
+
+  def suffix
     if short.present?
-      "#{path} (#{short})"
+      "(#{short})"
     elsif weight.present?
-      "#{path} #{weight}"
+      weight.to_s
     else
-      path
+      ""
     end
   end
 end

--- a/modules/overviews/app/components/overviews/project_custom_fields/edit_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/edit_component.html.erb
@@ -29,6 +29,7 @@
 
             item_options = {
               expanded_fn: ->(*) { true },
+              label_fn: ->(item) { item.to_s },
               checked_fn:,
               select_variant: @project_custom_field.multi_value? ? :multiple : :single
             }

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1257,7 +1257,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           it_behaves_like "has a titled link" do
             let(:link) { "customField#{custom_field.id}" }
             let(:href) { "/api/v3/custom_field_items/#{weighted_item.id}" }
-            let(:title) { "TIE Fighter" }
+            let(:title) { "TIE Fighter 16.7" }
           end
         end
 

--- a/spec/models/custom_value/weighted_item_list_strategy_spec.rb
+++ b/spec/models/custom_value/weighted_item_list_strategy_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CustomValue::WeightedItemListStrategy do
       end
 
       it "is the hierarchy item label" do
-        expect(subject).to eql "Foo Bar Baz"
+        expect(subject).to eql "Foo Bar Baz 42.0"
       end
 
       context "when item has short value" do


### PR DESCRIPTION
# Ticket
[#68802](https://community.openproject.org/work_packages/68802)

# What are you trying to accomplish?
- selecting items in tree view gives more context about weights and shorts

# What approach did you choose and why?
- `item.to_s` now returns weights as a suffix, not only shorts
- tree helper now accepts label callbacks, to accept labels that are not only `item.label`