### PR TITLE
Feature/66313 limit template options based on workspace type

### DIFF
--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
     },
     target: "_top"
   ) do
-    settings_primer_form_with(model: project) do |f|
+    settings_primer_form_with(model: project, url: workspaces_path) do |f|
       flex_layout do |container|
         if template
           container.with_row(mb: 3) do

--- a/app/components/projects/new_component.rb
+++ b/app/components/projects/new_component.rb
@@ -35,5 +35,15 @@ module Projects
     include OpTurbo::Streamable
 
     options :project, :template, :copy_options
+
+    def workspaces_path
+      workspace_type = if Project.workspace_types.key?(project.workspace_type)
+                         project.workspace_type
+                       else
+                         "project"
+                       end
+
+      url_for(workspace_type.pluralize.to_sym)
+    end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,7 +43,7 @@ class ProjectsController < ApplicationController
   before_action :not_authorized_on_feature_flag_inactive,
                 only: %i[new create],
                 if: -> {
-                  params[:workspace_type].in?(Project.workspace_types.values_at(:program, :portfolio))
+                  params[:workspace_type].in?(%w[portfolio program])
                 }
   before_action :find_optional_template, only: %i[new create]
   before_action :find_optional_parent, only: :new
@@ -248,7 +248,13 @@ class ProjectsController < ApplicationController
   end
 
   def find_optional_template
-    @template = Project.templated.visible(current_user).find(params[:template_id]) if params[:template_id].present?
+    return if params[:workspace_type].blank? || params[:template_id].blank?
+
+    @template = Project
+      .templated
+      .workspace_type(params[:workspace_type])
+      .visible(current_user)
+      .find_by(id: params[:template_id])
   end
 
   def find_optional_parent

--- a/app/forms/projects/template_select_form.rb
+++ b/app/forms/projects/template_select_form.rb
@@ -81,6 +81,7 @@ module Projects
         .visible(current_user)
         .active
         .templated
+        .workspace_type(workspace_type)
         .order(name: :asc)
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -222,6 +222,7 @@ class Project < ApplicationRecord
   scope :archived, -> { where(active: false) }
   scope :with_member, ->(user = User.current) { where(id: user.memberships.select(:project_id)) }
   scope :without_member, ->(user = User.current) { where.not(id: user.memberships.select(:project_id)) }
+  scope :workspace_type, ->(workspace_type) { workspace_types.key?(workspace_type) ? where(workspace_type:) : none }
   scope :templated, -> { where(templated: true) }
 
   scopes :activated_time_activity,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -500,20 +500,20 @@ Rails.application.routes.draw do
     end
   end
 
+  # Portfolio and program creation is handled by the projects controller
+  %w[portfolio program].each do |workspace_type|
+    resources workspace_type.pluralize,
+              only: %i[new],
+              defaults: { workspace_type: },
+              controller: "projects"
+  end
+
   resources :portfolios,
             only: %i[index]
-
-  # Portfolio creation is handled by the project controller:
-  get "portfolios/new", to: "projects#new", defaults: { workspace_type: "portfolio" }, as: :new_portfolio
 
   namespace :portfolios do
     resource :menu, only: %i[show]
   end
-
-  resources :programs,
-            only: %i[new],
-            defaults: { workspace_type: "program" },
-            controller: "projects"
 
   resources :project_phases, only: [] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,10 +270,10 @@ Rails.application.routes.draw do
   # Extracted from the resources definition right below so that the
   # default parameters can be defined.
   resources :projects,
-            only: %i[new],
+            only: %i[new create],
             defaults: { workspace_type: "project" }
 
-  resources :projects, except: %i[new show edit update] do
+  resources :projects, except: %i[new create show edit update] do
     scope module: "projects" do
       namespace "settings" do
         resource :general, only: %i[show update], controller: "general" do
@@ -503,7 +503,7 @@ Rails.application.routes.draw do
   # Portfolio and program creation is handled by the projects controller
   %w[portfolio program].each do |workspace_type|
     resources workspace_type.pluralize,
-              only: %i[new],
+              only: %i[new create],
               defaults: { workspace_type: },
               controller: "projects"
   end

--- a/spec/components/projects/new_component_spec.rb
+++ b/spec/components/projects/new_component_spec.rb
@@ -32,39 +32,58 @@ require "rails_helper"
 
 RSpec.describe Projects::NewComponent, type: :component do
   let(:project) { build_stubbed(:project) }
-  let(:template) { nil }
-  let(:copy_options) { nil }
+  let(:params) { {} }
 
-  def render_component
-    render_inline(described_class.new(project:, template:, copy_options:))
-    page
-  end
+  subject(:rendered_component) { render_inline(described_class.new(project:, **params)) }
 
   it "renders a form" do
-    expect(render_component).to have_css "form"
+    expect(rendered_component).to have_css "form"
+  end
+
+  describe "action" do
+    let(:project) { Project.new(workspace_type:) }
+
+    [
+      ["not set",               nil,        "/projects"],
+      ["set to unknown value",  :unknown,   "/projects"],
+      ["set to project",        :project,   "/projects"],
+      ["set to program",        :program,   "/programs"],
+      ["set to portfolio",      :portfolio, "/portfolios"]
+    ].each do |condition, value, expected_path|
+      context "when workspace type is #{condition}" do
+        let(:workspace_type) { value }
+
+        it "sets action to create project" do
+          expect(rendered_component).to have_element :form do |form|
+            expect(form["action"]).to eq expected_path
+          end
+        end
+      end
+    end
   end
 
   context "when creating from scratch" do
     it "renders custom fields form" do
       allow(Projects::Settings::CustomFieldsForm).to receive(:new).and_call_original
-      render_component
+      rendered_component
       expect(Projects::Settings::CustomFieldsForm).to have_received(:new)
     end
   end
 
   context "when creating from template" do
+    let(:params) { { template:, copy_options: } }
     let(:template) { build_stubbed(:template_project) }
     let(:copy_options) { Projects::CopyOptions.new }
 
     it "does not render custom fields form" do
       allow(Projects::Settings::CustomFieldsForm).to receive(:new)
-      render_component
+      rendered_component
       expect(Projects::Settings::CustomFieldsForm).not_to have_received(:new)
     end
 
     it "renders template form" do
       allow(Projects::TemplateForm).to receive(:new).and_call_original
-      render_component
+      rendered_component
       expect(Projects::TemplateForm).to have_received(:new).with(anything, template:, copy_options:)
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -86,8 +86,10 @@ RSpec.describe ProjectsController do
       end
     end
 
+    let(:workspace_type) { "project" }
+
     before do
-      get :new, params: { parent_id: parent&.id, template_id: template&.id }
+      get :new, params: { parent_id: parent&.id, template_id: template&.id, workspace_type: }
     end
 
     context "as an admin" do
@@ -134,20 +136,94 @@ RSpec.describe ProjectsController do
       end
     end
 
-    context "as a non-admin with global add_portfolios permission", with_flag: { portfolio_models: true } do
-      let(:parent) { nil }
-      let(:user) { create(:user, global_permissions: [:add_portfolios]) }
+    context "for portfolio" do
       let(:template) { nil }
+      let(:workspace_type) { "portfolio" }
+      let(:parent) { nil }
 
-      it_behaves_like "successful request"
+      context "as an admin" do
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it_behaves_like "successful request"
+        end
+
+        context "with flag disabled", with_flag: { portfolio_models: false } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+
+      context "as a non-admin with global add_portfolios permission" do
+        let(:user) { create(:user, global_permissions: [:add_portfolios]) }
+
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it_behaves_like "successful request"
+        end
+
+        context "with flag disabled", with_flag: { portfolio_models: false } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+
+      context "as a non-admin without add_portfolios permission" do
+        let(:user) { create(:user) }
+
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
     end
 
-    context "as a non-admin with global add_programs permission", with_flag: { portfolio_models: true } do
-      let(:parent) { nil }
-      let(:user) { create(:user, global_permissions: [:add_programs]) }
+    context "for program" do
       let(:template) { nil }
+      let(:workspace_type) { "program" }
+      let(:parent) { nil }
 
-      it_behaves_like "successful request"
+      context "as an admin" do
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it_behaves_like "successful request"
+        end
+
+        context "with flag disabled", with_flag: { portfolio_models: false } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+
+      context "as a non-admin with global add_programs permission" do
+        let(:user) { create(:user, global_permissions: [:add_programs]) }
+
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it_behaves_like "successful request"
+        end
+
+        context "with flag disabled", with_flag: { portfolio_models: false } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+
+      context "as a non-admin without add_programs permission" do
+        let(:user) { create(:user) }
+
+        context "with flag enabled", with_flag: { portfolio_models: true } do
+          it "returns 403 Not Authorized" do
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
     end
   end
 
@@ -271,7 +347,7 @@ RSpec.describe ProjectsController do
     end
 
     context "with a template" do
-      let(:template) { create(:template_project) }
+      let(:template) { create(:template_project, workspace_type:) }
 
       before do
         copy_service = instance_double(Projects::EnqueueCopyService)
@@ -292,12 +368,14 @@ RSpec.describe ProjectsController do
 
         post :create, params: {
           template_id: template.id,
+          workspace_type:,
           project: { name: },
           copy_options: { dependencies: [""], send_notifications: false } # emulating empty dependencies array
         }
       end
 
       context "when service call succeeds" do
+        let(:workspace_type) { "project" }
         let(:name) { "Copied project" }
         let(:job) { CopyProjectJob.new }
         let(:service_result) { ServiceResult.success(result: job) }
@@ -307,20 +385,26 @@ RSpec.describe ProjectsController do
         end
       end
 
-      context "when service call fails" do
+      context "when service call fails", with_flag: { portfolio_models: true } do
         let(:name) { "" }
         let(:project) { Project.new }
         let(:service_result) { ServiceResult.failure(result: project, message: "") }
 
-        it "renders new template with errors", :aggregate_failures do
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :unprocessable_entity
-          expect(assigns(:new_project)).to be_a_new(Project)
-          expect(assigns(:new_project)).not_to be_valid
-          expect(assigns(:template)).not_to be_nil
-          expect(assigns(:copy_options)).not_to be_nil
-          expect(flash[:error]).to start_with I18n.t(:notice_unsuccessful_create_with_reason, reason: "")
-          expect(response).to render_template "new"
+        %w[portfolio program project].each do |workspace_type|
+          context "for workspace type #{workspace_type}" do
+            let(:workspace_type) { workspace_type }
+
+            it "renders new template with errors", :aggregate_failures do
+              expect(response).not_to be_successful
+              expect(response).to have_http_status :unprocessable_entity
+              expect(assigns(:new_project)).to be_a_new(Project)
+              expect(assigns(:new_project)).not_to be_valid
+              expect(assigns(:template)).not_to be_nil
+              expect(assigns(:copy_options)).not_to be_nil
+              expect(flash[:error]).to start_with I18n.t(:notice_unsuccessful_create_with_reason, reason: "")
+              expect(response).to render_template "new"
+            end
+          end
         end
       end
     end

--- a/spec/forms/projects/template_select_form_spec.rb
+++ b/spec/forms/projects/template_select_form_spec.rb
@@ -61,28 +61,72 @@ RSpec.describe Projects::TemplateSelectForm, type: :forms do
   end
 
   context "with templates" do
-    let!(:templates) do
+    shared_let(:templates) do
       [
         create(:template_project, name: "Agile", description: "**Great for beginners.**"),
         create(:template_project, name: "SAF€", description: nil),
-        create(:template_project, name: "PRINCE", description: "## His Majesty's Choice.")
+        create(:template_project, name: "PRINCE", description: "## His Majesty's Choice."),
+        create(:template_project, name: "The Portfolio", description: "Collect them all", workspace_type: "portfolio"),
+        create(:template_project, name: "The Program", description: "Collect some of them", workspace_type: "program")
       ]
     end
 
-    it "renders radio buttons for each template in addition to Blank Project", :aggregate_failures do
-      expect(rendered_form).to have_field type: :radio, count: 4, fieldset: "Use template"
-      expect(rendered_form).to have_field "Blank project",
-                                          type: :radio,
-                                          accessible_description: /^Start from scratch.*project/
-      expect(rendered_form).to have_field "Agile",
-                                          type: :radio,
-                                          accessible_description: /^Great for beginners\.$/
-      expect(rendered_form).to have_field "SAF€",
-                                          type: :radio,
-                                          accessible_description: /^No description provided\.$/
-      expect(rendered_form).to have_field "PRINCE",
-                                          type: :radio,
-                                          accessible_description: /^His Majesty's Choice\.$/
+    context "when workspace_type is project", :aggregate_failures do
+      let(:model) { create(:project, workspace_type: "project") }
+
+      it "renders radio buttons for each project template in addition to Blank Project, but not other templates" do
+        expect(rendered_form).to have_field type: :radio, count: 4, fieldset: "Use template"
+        expect(rendered_form).to have_field "Blank project",
+                                            type: :radio,
+                                            accessible_description: /^Start from scratch.*project/
+        expect(rendered_form).to have_field "Agile",
+                                            type: :radio,
+                                            accessible_description: /^Great for beginners\.$/
+        expect(rendered_form).to have_field "SAF€",
+                                            type: :radio,
+                                            accessible_description: /^No description provided\.$/
+        expect(rendered_form).to have_field "PRINCE",
+                                            type: :radio,
+                                            accessible_description: /^His Majesty's Choice\.$/
+        expect(rendered_form).to have_no_field "The Portfolio"
+        expect(rendered_form).to have_no_field "The Program"
+      end
+    end
+
+    context "when workspace_type is portfolio", :aggregate_failures do
+      let(:model) { create(:project, workspace_type: "portfolio") }
+
+      it "renders radio buttons for each portfolio template in addition to Blank Project, but not other templates" do
+        expect(rendered_form).to have_field type: :radio, count: 2, fieldset: "Use template"
+        expect(rendered_form).to have_field "Blank portfolio",
+                                            type: :radio,
+                                            accessible_description: /^Start from scratch.*portfolio/
+        expect(rendered_form).to have_no_field "Agile"
+        expect(rendered_form).to have_no_field "SAF€"
+        expect(rendered_form).to have_no_field "PRINCE"
+        expect(rendered_form).to have_field "The Portfolio",
+                                            type: :radio,
+                                            accessible_description: "Collect them all"
+        expect(rendered_form).to have_no_field "The Program"
+      end
+    end
+
+    context "when workspace_type is program", :aggregate_failures do
+      let(:model) { create(:project, workspace_type: "program") }
+
+      it "renders radio buttons for each program template in addition to Blank Project, but not other templates" do
+        expect(rendered_form).to have_field type: :radio, count: 2, fieldset: "Use template"
+        expect(rendered_form).to have_field "Blank program",
+                                            type: :radio,
+                                            accessible_description: /^Start from scratch.*program/
+        expect(rendered_form).to have_no_field "Agile"
+        expect(rendered_form).to have_no_field "SAF€"
+        expect(rendered_form).to have_no_field "PRINCE"
+        expect(rendered_form).to have_no_field "The Portfolio"
+        expect(rendered_form).to have_field "The Program",
+                                            type: :radio,
+                                            accessible_description: "Collect some of them"
+      end
     end
 
     context "when template_id is nil" do
@@ -92,7 +136,7 @@ RSpec.describe Projects::TemplateSelectForm, type: :forms do
     end
 
     context "when template_id is not nil" do
-      let(:template_id) { templates.last.id }
+      let(:template_id) { templates.find { it.name == "PRINCE" }.id }
 
       it "renders checked radio button for given template" do
         expect(rendered_form).to have_checked_field "PRINCE", type: :radio

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -74,7 +74,19 @@ RSpec.describe ProjectsController do
   describe "create" do
     it do
       expect(post("/projects")).to route_to(
-        controller: "projects", action: "create"
+        controller: "projects", action: "create", workspace_type: "project"
+      )
+    end
+
+    it do
+      expect(post("/portfolios")).to route_to(
+        controller: "projects", action: "create", workspace_type: "portfolio"
+      )
+    end
+
+    it do
+      expect(post("/programs")).to route_to(
+        controller: "projects", action: "create", workspace_type: "program"
       )
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66313

# What are you trying to accomplish?
Show only templates with matching workspace type

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
