### PR TITLE
bug/66552 Prevent (possible) DOS in work package activity tab lazy page loading by limiting to 2 concurrent requests

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/index.controller.ts
@@ -30,6 +30,7 @@
 
 import { Controller } from '@hotwired/stimulus';
 import { ViewPortService } from './services/view-port-service';
+import { LazyLoadQueueService } from './services/lazy-load-queue.service';
 
 export default class IndexController extends Controller<HTMLElement> {
   static values = {
@@ -51,16 +52,29 @@ export default class IndexController extends Controller<HTMLElement> {
   declare readonly hasJournalsContainerTarget:boolean;
 
   viewPortService:ViewPortService;
+  lazyLoadQueueService:LazyLoadQueueService;
 
   connect() {
     this.viewPortService = new ViewPortService(this.notificationCenterPathNameValue);
+    this.lazyLoadQueueService = new LazyLoadQueueService();
 
     this.markAsConnected();
     this.setCssClasses();
   }
 
   disconnect() {
+    this.lazyLoadQueueService.clear();
     this.markAsDisconnected();
+  }
+
+  // Called by lazy-page controllers to enqueue their load request
+  enqueueLazyLoad(controller:unknown, loadFn:() => Promise<void>):void {
+    this.lazyLoadQueueService.enqueue(controller, loadFn);
+  }
+
+  // Called by lazy-page controllers when they're cancelled or unloaded
+  dequeueLazyLoad(controller:unknown):void {
+    this.lazyLoadQueueService.dequeue(controller);
   }
 
   setFilterToOnlyComments() { this.filterValue = 'only_comments'; }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
@@ -68,17 +68,26 @@ export default class LazyPageController extends BaseController {
 
     // Delay loading to allow rapid scrolling without triggering loads
     this.loadTimeout = window.setTimeout(() => {
-      void this.fetchPageStream()
-        .catch((error) => {
-          console.error('Error fetching next page:', error);
-        }).finally(() => {
-          this.isLoadedValue = true;
-        });
+      this.enqueueLoad();
     }, this.loadDelayMsValue);
   }
 
   disappear() {
     this.cancelPendingLoad(); // Cancel load if element leaves viewport before delay expires
+  }
+
+  private enqueueLoad():void {
+    this.indexOutlet.enqueueLazyLoad(this, () => this.performLoad());
+  }
+
+  private async performLoad():Promise<void> {
+    try {
+      await this.fetchPageStream();
+    } catch (error) {
+      console.error('Error fetching next page:', error);
+    } finally {
+      this.isLoadedValue = true;
+    }
   }
 
   private startObserving(root = this.scrollableContainer) {
@@ -116,5 +125,7 @@ export default class LazyPageController extends BaseController {
       window.clearTimeout(this.loadTimeout);
       this.loadTimeout = undefined;
     }
+
+    this.indexOutlet.dequeueLazyLoad(this);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/lazy-load-queue.service.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/lazy-load-queue.service.ts
@@ -1,0 +1,120 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+interface QueuedLoad {
+  controller:unknown;
+  load:() => Promise<void>;
+}
+
+/* eslint-disable no-unused-vars */
+export interface LazyLoadQueueServiceInterface {
+  enqueue(controller:unknown, loadFn:() => Promise<void>):void;
+  dequeue(controller:unknown):void;
+  clear():void;
+}
+/* eslint-enable no-unused-vars */
+
+/**
+ * Service to manage lazy loading of paginated content with request queuing
+ * to prevent simultaneous request storms.
+ *
+ * Features:
+ * - FIFO queue with configurable concurrency limit
+ * - Prevents duplicate requests from same controller
+ * - Automatic processing when capacity available
+ */
+export class LazyLoadQueueService implements LazyLoadQueueServiceInterface {
+  private queue:QueuedLoad[] = [];
+  private activeRequests = 0;
+  private maxConcurrentRequests:number;
+
+  constructor(
+    maxConcurrentRequests = 2,
+  ) {
+    this.maxConcurrentRequests = maxConcurrentRequests;
+  }
+
+  /**
+   * Add a load request to the queue
+   * @param controller - The controller instance requesting the load (used for deduplication)
+   * @param loadFn - The async function to execute when ready
+   */
+  enqueue(controller:unknown, loadFn:() => Promise<void>):void {
+    // Don't queue if already present (prevent duplicates)
+    if (this.queue.some((item) => item.controller === controller)) {
+      return;
+    }
+
+    this.queue.push({ controller, load: loadFn });
+    void this.processQueue();
+  }
+
+  /**
+   * Remove a load request from the queue
+   * @param controller - The controller instance to remove
+   */
+  dequeue(controller:unknown):void {
+    this.queue = this.queue.filter((item) => item.controller !== controller);
+  }
+
+  /**
+   * Clear all pending requests from the queue
+   */
+  clear():void {
+    this.queue = [];
+  }
+
+  private async processQueue():Promise<void> {
+    if (this.isAtCapacity || this.isQueueEmpty) return;
+
+    const item = this.queue.shift();
+    if (!item) return;
+
+    this.activeRequests += 1;
+
+    try {
+      await item.load();
+    } catch (error) {
+      console.error('Error processing lazy load:', error);
+    } finally {
+      this.activeRequests -= 1;
+      // Process next item in queue
+      void this.processQueue();
+    }
+  }
+
+  private get isAtCapacity():boolean {
+    return this.activeRequests >= this.maxConcurrentRequests;
+  }
+
+  private get isQueueEmpty():boolean {
+    return this.queue.length === 0;
+  }
+}


### PR DESCRIPTION
https://community.openproject.org/projects/communicator-stream/work_packages/66552/activity#comment-1507865

**Why?** On window resize events, as the AT is moved from the right-split pane to the bottom, all pages apparently become visible, causing a flood of requests- the 300ms delay is not sufficient in that instance. Although an unlikely edge case, we should still have some stopgap measure.

This PR introduces request queuing to mitigate such cases- this should also prevent similar unknown cases.

**How** Prevents DOS by coordinating lazy loading across multiple page controllers via a FIFO queue with max 2 concurrent requests, preventing request storms when many pages become visible simultaneously (e.g., during viewport resize).

Test WP: https://qa.openproject-edge.com/projects/test-project-cecile/work_packages/10423/activity

---

<details> <summary> 📸  Before: </summary>

<img width="2757" height="1625" alt="Screenshot 2025-11-11 at 1 56 55 PM" src="https://github.com/user-attachments/assets/b0dab4f1-50df-4bd6-beea-b5cd2fedff49" />

</details>

_Demo:_

https://github.com/user-attachments/assets/592aa898-b29c-4120-93aa-e896efe0856f


