### PR TITLE
Fix uniq user index migration

### DIFF
--- a/db/migrate/20251105082400_add_unique_index_to_user_preferences_on_user_id.rb
+++ b/db/migrate/20251105082400_add_unique_index_to_user_preferences_on_user_id.rb
@@ -46,8 +46,16 @@ class AddUniqueIndexToUserPreferencesOnUserId < ActiveRecord::Migration[8.0]
       );
     SQL
 
-    say "Removing old non-unique index"
-    remove_index :user_preferences, name: "index_user_preferences_on_user_id", if_exists: true
+    old_index = ActiveRecord::Base
+      .connection
+      .indexes(:user_preferences)
+      .detect { |index| index.columns == ["user_id"] }
+      &.name
+
+    if old_index.present?
+      say "Removing old non-unique index"
+      remove_index :user_preferences, name: old_index
+    end
 
     say "Adding unique index on user_id"
     add_index :user_preferences, :user_id,

--- a/db/migrate/20251105082400_add_unique_index_to_user_preferences_on_user_id.rb
+++ b/db/migrate/20251105082400_add_unique_index_to_user_preferences_on_user_id.rb
@@ -47,7 +47,7 @@ class AddUniqueIndexToUserPreferencesOnUserId < ActiveRecord::Migration[8.0]
     SQL
 
     say "Removing old non-unique index"
-    remove_index :user_preferences, name: "index_user_preferences_on_user_id"
+    remove_index :user_preferences, name: "index_user_preferences_on_user_id", if_exists: true
 
     say "Adding unique index on user_id"
     add_index :user_preferences, :user_id,
@@ -57,7 +57,7 @@ class AddUniqueIndexToUserPreferencesOnUserId < ActiveRecord::Migration[8.0]
 
   def down
     say "Removing unique index"
-    remove_index :user_preferences, name: "index_user_preferences_on_user_id"
+    remove_index :user_preferences, name: "index_user_preferences_on_user_id", if_exists: true
 
     say "Re-adding non-unique index"
     add_index :user_preferences, :user_id,


### PR DESCRIPTION
# What are you trying to accomplish?
Only remove the index if it exists, otherwise it will thow an error:

`PG::UndefinedObject: ERROR: index "index_user_preferences_on_user_id" does not exist`

<img width="1037" height="467" alt="Bildschirmfoto 2025-11-13 um 13 23 21" src="https://github.com/user-attachments/assets/490f9880-d90f-4e0d-88cd-549b9c106141" />

