### PR TITLE
[#68740] Rework Repo Revision form using Stimulus

### DIFF
--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
         </colgroup>
         <caption class="sr-only">
           <span>
-            <%= t(:text_table_difference_description, entries: t(:label_changeset) + " " + t(:label_version_plural)) %>
+            <%= t(:text_table_difference_description, entries: "#{t(:label_changeset)} #{t(:label_version_plural)}") %>
           </span>
         </caption>
         <thead>
@@ -68,7 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
               <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
-                    <%= t(:description_compare_from) + " " + t(:label_changeset) %>
+                    <%= "#{t(:description_compare_from)} #{t(:label_changeset)}" %>
                   </span>
                 </div>
               </div>
@@ -77,7 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
               <div class="generic-table--empty-header">
                 <div class="generic-table--header">
                   <span>
-                    <%= t(:description_compare_to) + " " + t(:label_changeset) %>
+                    <%= "#{t(:description_compare_to)} #{t(:label_changeset)}" %>
                   </span>
                 </div>
               </div>
@@ -120,7 +120,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= link_to_revision(changeset, project) %>
               </td>
               <td class="checkbox">
-                <%= label_tag "cb-#{line_num}", t(:description_compare_from) + " " + t(:label_changeset), class: "sr-only" %>
+                <%= label_tag "cb-#{line_num}", "#{t(:description_compare_from)} #{t(:label_changeset)}", class: "sr-only" %>
                 <% if show_diff && (line_num < revisions.size) %>
                 <%= radio_button_tag "rev",
                                      changeset.identifier,
@@ -130,7 +130,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <% end %>
               </td>
               <td class="checkbox">
-                <%= label_tag "cbto-#{line_num}", t(:description_compare_to) + " " + t(:label_changeset), class: "sr-only" %>
+                <%= label_tag "cbto-#{line_num}", "#{t(:description_compare_to)} #{t(:label_changeset)}", class: "sr-only" %>
                 <% if show_diff && (line_num > 1) %>
                 <%= radio_button_tag "rev_to",
                                      changeset.identifier,

--- a/app/views/repositories/_revisions.html.erb
+++ b/app/views/repositories/_revisions.html.erb
@@ -27,7 +27,13 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= form_tag({ controller: "/repositories", action: "diff", project_id: @project, repo_path: to_path_param(path) }, method: :get) do %>
+<%=
+  form_tag(
+    { controller: "/repositories", action: "diff", project_id: @project, repo_path: to_path_param(path) },
+    method: :get,
+    data: { controller: "repositories--revisions-form" }
+  ) do
+%>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
       <table class="generic-table changesets">
@@ -119,12 +125,8 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= radio_button_tag "rev",
                                      changeset.identifier,
                                      (line_num == 1),
-                                     id: "cb-#{line_num}" %>
-                <% csp_onclick(
-                     "document.getElementById('cbto-#{line_num + 1}').checked = true;",
-                     "#cb-#{line_num}",
-                     prevent_default: false
-                   ) %>
+                                     id: "cb-#{line_num}",
+                                     data: { repositories__revisions_form_target: "rev" } %>
                 <% end %>
               </td>
               <td class="checkbox">
@@ -133,12 +135,8 @@ See COPYRIGHT and LICENSE files for more details.
                 <%= radio_button_tag "rev_to",
                                      changeset.identifier,
                                      (line_num == 2),
-                                     id: "cbto-#{line_num}" %>
-                  <% csp_onclick(
-                       "if (document.getElementById('cb-#{line_num}')?.checked) {document.getElementById('cb-#{line_num - 1}').checked = true;}",
-                       "#cbto-#{line_num}",
-                       prevent_default: false
-                     ) %>
+                                     id: "cbto-#{line_num}",
+                                     data: { repositories__revisions_form_target: "revTo" } %>
                 <% end %>
               </td>
               <td class="committed_on">

--- a/frontend/src/stimulus/controllers/dynamic/repositories/revisions-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/repositories/revisions-form.controller.ts
@@ -1,0 +1,87 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class RevisionsFormController extends Controller<HTMLFormElement> {
+  static targets = ['rev', 'revTo'];
+
+  declare readonly revTargets:HTMLInputElement[];
+  declare readonly revToTargets:HTMLInputElement[];
+
+  private onRevChange = this.updateRevToTargets.bind(this);
+  private onRevToChange = this.updateRevTargets.bind(this);
+
+  revTargetConnected(target:HTMLInputElement) {
+    target.addEventListener('change', this.onRevChange);
+  }
+
+  revTargetDisconnected(target:HTMLInputElement) {
+    target.removeEventListener('change', this.onRevChange);
+  }
+
+  revToTargetConnected(target:HTMLInputElement) {
+    target.addEventListener('change', this.onRevToChange);
+  }
+
+  revToTargetDisconnected(target:HTMLInputElement) {
+    target.removeEventListener('change', this.onRevToChange);
+  }
+
+  private updateRevTargets() {
+    const revIndex = this.revTargetCheckedIndex;
+    const revToIndex = this.revToTargetCheckedIndex;
+    if (revIndex === -1 || revToIndex === -1) {
+      // Do not update if either index is invalid
+      return;
+    }
+    const newIndex = Math.min(revIndex, revToIndex);
+    this.revTargets.at(newIndex)!.checked = true;
+  }
+
+  private updateRevToTargets() {
+    const revIndex = this.revTargetCheckedIndex;
+    const revToIndex = this.revToTargetCheckedIndex;
+    if (revIndex === -1 || revToIndex === -1) {
+      // Do not update if either index is invalid
+      return;
+    }
+    const newIndex = Math.max(revIndex, revToIndex);
+    this.revToTargets.at(newIndex)!.checked = true;
+  }
+
+  private get revTargetCheckedIndex() {
+    return this.revTargets.findIndex((t) => t.checked);
+  }
+
+  private get revToTargetCheckedIndex() {
+    return this.revToTargets.findIndex((t) => t.checked);
+  }
+}


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68740 (follow up)

# What are you trying to accomplish?

Follow up to 9c0e223a. Replaces inline code with custom form controller.

Also fixes "rev to" behavior: the "rev" radio will only be adjusted if it is the same (or later) revision.

## Screenshots


https://github.com/user-attachments/assets/b873deb0-33b8-40c8-b809-9b7b19dc5d82



# What approach did you choose and why?

Migrates more inline scripts (`csp_onclick`) to Stimulus controllers - #20884

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
