### PR TITLE
bug/66552 Prevent lazy page load storms on viewport resize in the work package activity tab

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/lazy-page.controller.ts
@@ -81,9 +81,9 @@ export default class LazyPageController extends BaseController {
     this.cancelPendingLoad(); // Cancel load if element leaves viewport before delay expires
   }
 
-  private startObserving(root = this.scrollableContainer) {
+  private startObserving() {
     const [_observe, unobserve] = useIntersection(this, {
-      root,
+      root: null, // Use document viewport as root to prevent false - positive intersections during responsive layout shifts
       threshold: 0.05,
       dispatchEvent: false
     });


### PR DESCRIPTION
https://community.openproject.org/wp/66552

Use document viewport as intersection observer root instead of scrollable container. The scrollable container changes position/dimensions during responsive layout shifts (split-view to single-column), causing the Intersection Observer to re-evaluate all lazy pages and trigger simultaneous loads. Using the stable viewport as root prevents false-positive intersections during resize.

This is an extension of https://github.com/opf/openproject/pull/20660

_See [stimulus-use-intersection](https://stimulus-use.github.io/stimulus-use/#/use-intersection)_

> [!NOTE]
> `16.6.2` Patch as lazy loading is behind feature flag.

_Before_

<img width="2757" height="1625" alt="Screenshot 2025-11-11 at 1 56 55 PM" src="https://github.com/user-attachments/assets/b0dab4f1-50df-4bd6-beea-b5cd2fedff49" />

_After_

https://github.com/user-attachments/assets/fbb35af8-34e6-48d1-bf96-8e76928be3ba


