### PR TITLE
[68766] Custom logos with higher details than OpenProject might look small

### DIFF
--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -4,11 +4,12 @@
   margin: 0 0.5rem
 
   &--link
+    margin: 0.25rem 0
     width: 100%
     display: block
-    height: 100%
+    height: calc(100% - 8px)
     text-indent: -9999em
-    background: no-repeat center
+    background: no-repeat left center
     background-size: contain
 
   @media screen and (max-width: 850px)

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -4,10 +4,9 @@
   margin: 0 0.5rem
 
   &--link
-    margin-top: 16px
     width: 100%
     display: block
-    height: 24px
+    height: 100%
     text-indent: -9999em
     background: no-repeat center
     background-size: contain

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -1,13 +1,15 @@
+$op-logo-link-margin-y: 0.25rem
+
 .op-logo
   width: 130px
   height: var(--header-height)
   margin: 0 0.5rem
 
   &--link
-    margin: 0.25rem 0
+    margin: $op-logo-link-margin-y 0
     width: 100%
     display: block
-    height: calc(100% - 8px)
+    height: calc(100% - (#{$op-logo-link-margin-y} * 2))
     text-indent: -9999em
     background: no-repeat left center
     background-size: contain


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68766

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Make the logo fit the height of the header.

## Screenshots
<img width="194" height="57" alt="Screenshot 2025-11-14 at 14 16 07" src="https://github.com/user-attachments/assets/eec53c3b-a1b0-47b0-83b2-91db391d0467" />


