### PR TITLE
[#69014] fix hierarchy display in project attributes filter

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -104,8 +104,12 @@ module Filter
     end
 
     def custom_field_hierarchy_autocomplete_options(filter)
-      options = { items: filter.allowed_values.map { |name, id| { name:, id: } } }
-      autocomplete_options.merge(options).merge(model: filter.values)
+      items = filter.allowed_values.map do |name, id|
+        path = name.split(" / ")
+        { name: path.last, id:, depth: path.length - 1 }
+      end
+
+      autocomplete_options.merge({ items: }).merge(model: filter.values)
     end
 
     def list_autocomplete_options(filter)

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -39,7 +39,7 @@ class CustomField::Hierarchy::Item < ApplicationRecord
   def to_s = suffix.empty? ? label : "#{label} #{suffix}"
 
   def ancestry_path(include_shorts_and_weights: false)
-    path = self_and_ancestors.filter_map(&:to_s).reverse.join(" / ")
+    path = self_and_ancestors.filter_map(&:label).reverse.join(" / ")
 
     return path unless include_shorts_and_weights
 

--- a/app/models/exports/formatters/hierarchy_formatter.rb
+++ b/app/models/exports/formatters/hierarchy_formatter.rb
@@ -40,7 +40,7 @@ module Exports
         item = ::CustomField::Hierarchy::Item.find_by(id: item_value.to_s)
         return "#{item_value} #{I18n.t(:label_not_found)}" unless item
 
-        item.ancestry_path
+        item.ancestry_path(include_shorts_and_weights: true)
       end
     end
   end

--- a/spec/models/exports/formatters/custom_field_hierarchy_spec.rb
+++ b/spec/models/exports/formatters/custom_field_hierarchy_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Exports::Formatters::CustomField, with_ee: [:custom_field_hierarc
         [CustomValue.new(custom_field:, value: bart.id)]
       end
 
-      it "returns the label and short" do
+      it "returns the ancestors, label and short" do
         expect(subject.format_for_export(work_package, custom_field)).to eq("Homer / Bart (BS)")
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe Exports::Formatters::CustomField, with_ee: [:custom_field_hierarc
         [CustomValue.new(custom_field:, value: lisa.id)]
       end
 
-      it "returns the label and short" do
+      it "returns the ancestors and label" do
         expect(subject.format_for_export(work_package, custom_field)).to eq("Homer / Lisa")
       end
     end

--- a/spec/models/exports/formatters/custom_field_hierarchy_spec.rb
+++ b/spec/models/exports/formatters/custom_field_hierarchy_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Exports::Formatters::CustomField, with_ee: [:custom_field_hierarc
       end
 
       it "returns the label and short" do
-        expect(subject.format_for_export(work_package, custom_field)).to eq("Homer (HS) / Bart (BS)")
+        expect(subject.format_for_export(work_package, custom_field)).to eq("Homer / Bart (BS)")
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Exports::Formatters::CustomField, with_ee: [:custom_field_hierarc
       end
 
       it "returns the label and short" do
-        expect(subject.format_for_export(work_package, custom_field)).to eq("Homer (HS) / Lisa")
+        expect(subject.format_for_export(work_package, custom_field)).to eq("Homer / Lisa")
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe Exports::Formatters::CustomField, with_ee: [:custom_field_hierarc
 
       it "returns multiple comma-separated values" do
         expect(subject.format_for_export(work_package, custom_field))
-          .to eq("Homer (HS), Homer (HS) / Bart (BS), Homer (HS) / Lisa, Homer (HS) / Lisa / Zia")
+          .to eq("Homer (HS), Homer / Bart (BS), Homer / Lisa, Homer / Lisa / Zia")
       end
     end
   end


### PR DESCRIPTION
# Ticket
[#69014](https://community.openproject.org/work_packages/69014)

# What are you trying to accomplish?
- show tree like view in project attributes filter

# What approach did you choose and why?
- return custom field filter items with depth and label without path
