### PR TITLE
[60535] CKEditor logo z-index bug

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -93,7 +93,7 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
   .document-editor__toolbar
     position: sticky
     top: 0
-    z-index: 2
+    z-index: var(--ck-z-panel)
 
     // Reset these styles explicitly when the editor is opened inside a Dialog, as position: sticky opens a separate stacking context.
     // In case the dialog has multiple editors below each other, these different context interfere and the paragraph dropdown of an editor will be behind the editor below it.
@@ -128,9 +128,6 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
 .ck-icon_inherit-color
   path
     fill: var(--body-font-color) !important
-
-.ck.ck-balloon-panel.ck-powered-by-balloon
-  z-index: var(--ck-z-default) !important
 
 @media (max-width: $breakpoint-sm)
   .ck-balloon-panel.ck-balloon-panel_visible

--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -129,6 +129,9 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
   path
     fill: var(--body-font-color) !important
 
+.ck.ck-balloon-panel.ck-powered-by-balloon
+  z-index: var(--ck-z-default) !important
+
 @media (max-width: $breakpoint-sm)
   .ck-balloon-panel.ck-balloon-panel_visible
     left: 5vw !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/60535

## Screenshots
Before:
<img width="252" height="249" alt="Screenshot 2025-11-14 at 16 02 37" src="https://github.com/user-attachments/assets/45c51ce0-f5b3-4c9a-be4d-aa9ac5265e0d" />

After:
<img width="308" height="301" alt="Screenshot 2025-11-14 at 16 01 13" src="https://github.com/user-attachments/assets/2ec76c9b-6880-430c-889a-999d37ef66ae" />
