### PR TITLE
Implementation/68876 render the portfolio status badge in the portfolio view

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -1,8 +1,8 @@
 <%=
   flex_layout do |flex|
     flex.with_row(mb: 2) do
-      flex_layout do |header|
-        header.with_column do
+      flex_layout(align_items: :center) do |header|
+        header.with_column(mr: 2) do
           render(
             Primer::Beta::Link.new(
               classes: "portfolio-name",
@@ -14,7 +14,16 @@
           end
         end
 
-        # TODO: WP-68876 render status_code
+        header.with_column do
+          render(
+            Projects::StatusButtonComponent.new(
+              user: @current_user,
+              project: @portfolio,
+              hide_help_text: true,
+              size: :small
+            )
+          )
+        end
 
         # TODO: WP-68877 render progress bar
       end

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -48,6 +48,10 @@ class Projects::StatusButtonComponent < ApplicationComponent
     @status = find_status(project.status_code)
   end
 
+  def wrapper_uniq_by
+    project
+  end
+
   private
 
   def edit_enabled?

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -74,7 +74,7 @@ class Projects::StatusButtonComponent < ApplicationComponent
       icon: status.icon,
       item_id: status.id,
       tag: :a,
-      href: project_status_path(project, status_code: status.value),
+      href: project_status_path(project, status_code: status.value, status_size: @size),
       content_arguments: {
         data: { turbo_method: status.value ? :put : :delete },
         aria: { current: (true if status == @status) }

--- a/app/controllers/projects/status_controller.rb
+++ b/app/controllers/projects/status_controller.rb
@@ -63,7 +63,17 @@ class Projects::StatusController < ApplicationController
 
   def respond_with_update_status_button
     message = t(:notice_successful_update)
-    update_via_turbo_stream(component: Projects::StatusButtonComponent.new(project: @project, user: current_user))
+
+    # Some views send a size parameter to adjust the status button size, keep that in
+    # mind when refreshing the component via turbo stream:
+    size = params[:status_size]&.to_sym
+    component_options = {
+      project: @project,
+      user: current_user,
+      size:
+    }.compact
+
+    update_via_turbo_stream(component: Projects::StatusButtonComponent.new(**component_options))
     render_success_flash_message_via_turbo_stream(message:)
     respond_with_turbo_streams do |format|
       fallback_responses_for(format, flash: { notice: message })

--- a/modules/grids/spec/components/grids/widgets/project_status_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/project_status_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Grids::Widgets::ProjectStatus, type: :component do
   end
 
   it "renders Projects Status Button component" do
-    expect(rendered_component).to have_element id: "projects-status-button-component"
+    expect(rendered_component).to have_element id: "projects-status-button-component-#{project.id}"
   end
 
   context "when user is not allowed to edit" do

--- a/spec/components/projects/status_button_component_spec.rb
+++ b/spec/components/projects/status_button_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe Projects::StatusButtonComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   let(:project) { build_stubbed(:project, status_code:) }
   let(:status_code) { nil }
 
@@ -43,13 +45,10 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
     page
   end
 
-  shared_examples "component wrapper" do |id|
-    it "renders component wrapper" do
-      expect(subject).to have_xpath "//*[@id='#{id}']", count: 1
-    end
+  it "renders component wrapper" do
+    id = "projects-status-button-component-#{project.id}"
+    expect(subject).to have_xpath "//*[@id='#{id}']", count: 1
   end
-
-  it_behaves_like "component wrapper", "projects-status-button-component"
 
   context "when the user has no project edit permissions" do
     context "when status code is not set" do
@@ -103,15 +102,30 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
 
         expect(page).to have_menu do
           expect(page).to have_selector :menuitem, count: 7
-          expect(page).to (have_selector :menuitem, text: "Not set", aria: { current: true } do |link|
+          expect(page).to have_selector(:menuitem, text: "Not set", aria: { current: true }) do |link|
             expect(link[:"data-turbo-method"]).to eq "delete"
-          end)
+          end
           expect(page).to have_selector :menuitem, text: "On track"
           expect(page).to have_selector :menuitem, text: "At risk"
           expect(page).to have_selector :menuitem, text: "Not started"
           expect(page).to have_selector :menuitem, text: "Finished"
           expect(page).to have_selector :menuitem, text: "Discontinued"
           expect(page).to have_selector :menuitem, text: "Off track"
+        end
+      end
+
+      it "includes the component size in the status change links" do
+        # Necessary for turbo stream to preserve the size on update
+        subject
+
+        expect(page).to have_menu do
+          expect(page).to have_selector(:menuitem, text: "Not set", aria: { current: true }) do |link|
+            expect(link[:"data-turbo-method"]).to eq "delete"
+            expect(link[:href]).to eq(project_status_path(project, status_code: nil, status_size: :medium))
+          end
+          expect(page).to have_selector(:menuitem, text: "On track") do |link|
+            expect(link[:href]).to eq(project_status_path(project, status_code: "on_track", status_size: :medium))
+          end
         end
       end
     end
@@ -134,9 +148,9 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
         expect(page).to have_menu do
           expect(page).to have_selector :menuitem, count: 7
           expect(page).to have_selector :menuitem, text: "Not set"
-          expect(page).to (have_selector :menuitem, text: "On track", aria: { current: true } do |link|
+          expect(page).to have_selector(:menuitem, text: "On track", aria: { current: true }) do |link|
             expect(link[:"data-turbo-method"]).to eq "put"
-          end)
+          end
           expect(page).to have_selector :menuitem, text: "At risk"
           expect(page).to have_selector :menuitem, text: "Not started"
           expect(page).to have_selector :menuitem, text: "Finished"

--- a/spec/controllers/projects/status_controller_spec.rb
+++ b/spec/controllers/projects/status_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Projects::StatusController do
       it "renders turbo streams updating Projects::StatusButtonComponent and flash action", :aggregate_failures do
         expect(response).to be_successful
         expect(assigns(:project)).to eq project
-        expect(response).to have_turbo_stream action: "update", target: "projects-status-button-component"
+        expect(response).to have_turbo_stream action: "update", target: "projects-status-button-component-#{project.id}"
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
       end
     end
@@ -109,6 +109,24 @@ RSpec.describe Projects::StatusController do
         let(:service_result) { ServiceResult.success(result: project) }
 
         it_behaves_like "successful update"
+
+        context "when updating a status via turbo stream" do
+          let(:format) { :turbo_stream }
+
+          it "includes the default size of medium in the response by default" do
+            parsed_response = Nokogiri::HTML.fragment(response.body)
+            expect(parsed_response.css(".op-status-button .Button--medium")).to be_present
+          end
+
+          context "when a size parameter is given" do
+            let(:params) { { status_code: :foo, status_size: "small" } }
+
+            it "keeps the given size for the turbo stream update" do
+              parsed_response = Nokogiri::HTML.fragment(response.body)
+              expect(parsed_response.css(".op-status-button .Button--small")).to be_present
+            end
+          end
+        end
       end
 
       context "when service call fails" do

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -158,6 +158,16 @@ RSpec.describe "Portfolios", "index", :js do
       portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_favorited)
     end
 
+    it "allows seeing and changing the status" do
+      portfolios_page.expect_status_of(portfolio_a, "Not set")
+      portfolios_page.expect_status_of(portfolio_favorited, "Not set")
+
+      portfolios_page.select_status_from_dropdown(portfolio_favorited, "At risk")
+
+      portfolios_page.expect_status_of(portfolio_favorited, "At risk")
+      portfolios_page.expect_status_of(portfolio_a, "Not set")
+    end
+
     context "when using the more menu" do
       it "offers the zen mode" do
         portfolios_page.expect_more_menu_item("Zen mode")

--- a/spec/support/pages/portfolios/index.rb
+++ b/spec/support/pages/portfolios/index.rb
@@ -81,6 +81,31 @@ module Pages
         expect(page).to have_css('[data-test-selector="portfolio-query-name"]', text: name)
       end
 
+      def expect_status_of(portfolio, status_text)
+        expect(page).to have_css("#projects-status-button-component-#{portfolio.id} .Button-label", text: status_text)
+      end
+
+      def click_status_button(portfolio)
+        page.find("#projects-status-button-component-#{portfolio.id} .op-status-button").click
+      end
+
+      def select_status_from_dropdown(portfolio, status_text)
+        click_status_button portfolio
+        page.find("#projects-status-button-component-#{portfolio.id} .op-status-button .ActionListItem",
+                  text: status_text,
+                  exact_text: true).click
+
+        wait_for_reload
+      end
+
+      def expect_filter_available(filter_name)
+        expect(page).to have_select("add_filter_select", with_options: [filter_name])
+      end
+
+      def expect_filter_not_available(filter_name)
+        expect(page).to have_no_select("add_filter_select", with_options: [filter_name])
+      end
+
       def filter_by_active(value)
         set_filter("active", "Active", "is", [value])
         wait_for_reload


### PR DESCRIPTION
~Note: review #20979 first, as this branch is based upon it.~

# Ticket
https://community.openproject.org/wp/68876

# What are you trying to accomplish?
Use the ProjectStatusButtonComponent to show (and edit) a portfolios status.

## Screenshots
![2025-11-14 16 52 44](https://github.com/user-attachments/assets/90aab7ad-d283-4a4b-86d2-5681738e4509)

# What approach did you choose and why?
In order to make this work, the component had to be patched in two ways:

* It was not ready to be used in multiple instances on the same page. Since it had no unique ID, rendering multiple of these lead to only the first one being replaced by a turbo stream when you edited the status of any portfolio on the page. Fixed by providing a unique ID.
* In a similar fashion, turbo stream updates did not preserve the configured component size. It would always be reset to the default of `:medium` after editing the status. Fixed by sending the configured size as a get parameter and including it in the turbo stream response.

## Known issue

* It should not be possible to edit the status of an archived/inactive portfolio. But right now, you can. This will be fixed in [another work package](https://community.openproject.org/wp/69114) soon and is out of scope for this PR.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
