### PR TITLE
Feature/69034 change enforcement of project attributes on creation for templates

### DIFF
--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -54,7 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
               Projects::Settings::TypeForm.new(f),
               Projects::Settings::NameForm.new(f),
               Projects::Settings::RelationsForm.new(f),
-              Projects::Settings::CustomFieldsForm.new(f)
+              *(Projects::Settings::CustomFieldsForm.new(f) unless template)
             )
           )
         end

--- a/app/contracts/projects/create_contract.rb
+++ b/app/contracts/projects/create_contract.rb
@@ -33,6 +33,7 @@ module Projects
     # TODO: differentiate on allowed types based on permissions.
     # Permissions will need to be added: project, program, portfolio.
     attribute :workspace_type
+    attribute :template
 
     include AdminWritableTimestamps
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -226,10 +226,12 @@ class ProjectsController < ApplicationController
   def create_from_template # rubocop:disable Metrics/AbcSize
     @copy_options = Projects::CopyOptions.new(permitted_params.copy_project_options)
 
+    target_project_params = permitted_params.new_project.to_h.merge(template: @template)
+
     service_call = Projects::EnqueueCopyService
       .new(user: current_user, model: @template)
       .call(
-        target_project_params: permitted_params.new_project.to_h,
+        target_project_params:,
         only: @copy_options.dependencies,
         send_notifications: @copy_options.send_notifications
       )

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -233,6 +233,7 @@ class ProjectsController < ApplicationController
       .call(
         target_project_params:,
         only: @copy_options.dependencies,
+        skip_custom_field_validation: true,
         send_notifications: @copy_options.send_notifications
       )
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -104,6 +104,13 @@ class Project < ApplicationRecord
 
   has_many :recurring_meetings, dependent: :destroy
 
+  belongs_to :template, class_name: "Project", optional: true
+  has_many :templated_projects,
+           class_name: "Project",
+           foreign_key: "template_id",
+           inverse_of: :template,
+           dependent: nil
+
   accepts_nested_attributes_for :available_phases
   validates_associated :available_phases, on: :saving_phases
 

--- a/app/services/base_services/set_attributes.rb
+++ b/app/services/base_services/set_attributes.rb
@@ -67,6 +67,8 @@ module BaseServices
     end
 
     def set_custom_values_to_validate(params)
+      return model.deactivate_custom_field_validations! if contract_options[:skip_custom_field_validation]
+
       custom_field_ids = custom_field_ids_from(params)
 
       # Only update custom_values_to_validate when custom field params are provided.

--- a/app/services/projects/enqueue_copy_service.rb
+++ b/app/services/projects/enqueue_copy_service.rb
@@ -53,9 +53,9 @@ module Projects
     # Tests whether the copy can be performed
     def test_copy(params)
       test_params = params.merge(attributes_only: true)
-
+      contract_options = { skip_custom_field_validation: params[:skip_custom_field_validation] }
       Projects::CopyService
-        .new(user:, source:)
+        .new(user:, source:, contract_options:)
         .call(test_params)
     end
 
@@ -66,6 +66,7 @@ module Projects
       GoodJob::Batch.enqueue(on_finish: SendCopyProjectStatusEmailJob, user:, source_project: source) do
         job = CopyProjectJob.perform_later(target_project_params: params[:target_project_params],
                                            associations_to_copy: params[:only].to_a,
+                                           skip_custom_field_validation: params[:skip_custom_field_validation],
                                            send_mails: ActiveRecord::Type::Boolean.new.cast(params[:send_notifications]))
       end
       job

--- a/app/workers/copy_project_job.rb
+++ b/app/workers/copy_project_job.rb
@@ -35,12 +35,12 @@ class CopyProjectJob < ApplicationJob
   queue_with_priority :above_normal
 
   # Again error handling pushing the branch costs up
-  def perform(target_project_params:, associations_to_copy:, send_mails: false)
+  def perform(target_project_params:, associations_to_copy:, skip_custom_field_validation: false, send_mails: false) # rubocop:disable Metrics/AbcSize
     User.current = user
     target_project_params = target_project_params.with_indifferent_access
 
     target_project, errors = with_locale_for(user) do
-      create_project_copy(target_project_params, associations_to_copy, send_mails)
+      create_project_copy(target_project_params, associations_to_copy, skip_custom_field_validation, send_mails)
     end
 
     update_batch(target_project:, errors:, target_project_name: target_project_params[:name])
@@ -111,8 +111,13 @@ class CopyProjectJob < ApplicationJob
 
   # rubocop:disable Metrics/AbcSize
   # Most of the cost is from handling errors, we need to check what can be moved around / removed
-  def create_project_copy(target_project_params, associations_to_copy, send_mails)
-    service_result = copy_project(target_project_params, associations_to_copy, send_mails)
+  def create_project_copy(target_project_params, associations_to_copy, skip_custom_field_validation, send_mails)
+    service_result = copy_project(
+      target_project_params,
+      associations_to_copy,
+      skip_custom_field_validation,
+      send_mails
+    )
     target_project = service_result.result
     errors = service_result.errors.full_messages
 
@@ -138,8 +143,9 @@ class CopyProjectJob < ApplicationJob
   end
   # rubocop:enable Metrics/AbcSize
 
-  def copy_project(target_project_params, associations_to_copy, send_notifications)
-    copy_service = ::Projects::CopyService.new(source: source_project, user:)
+  def copy_project(target_project_params, associations_to_copy, skip_custom_field_validation, send_notifications)
+    contract_options = { skip_custom_field_validation: }
+    copy_service = ::Projects::CopyService.new(source: source_project, user:, contract_options:)
     result = copy_service.call({ target_project_params:, send_notifications:, only: Array(associations_to_copy) })
 
     enqueue_copy_project_folder_jobs(copy_service.state.copied_project_storages,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1272,6 +1272,7 @@ en:
         submission_status_when_submitted: "Status when submitted"
         submission_work_package_comment: "Work package comment"
         submission_work_package_type: "Work package type"
+        template: "Template"
         templated: "Template project"
         templated_value:
           true: "marked as template"

--- a/db/migrate/20251114174545_add_template_id_to_projects.rb
+++ b/db/migrate/20251114174545_add_template_id_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTemplateIdToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :projects, :template, foreign_key: { to_table: :projects }
+  end
+end

--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -224,11 +224,7 @@ module Redmine
         end
 
         def custom_values_to_validate
-          if persisted?
-            @custom_values_to_validate ||= []
-          else
-            custom_field_values
-          end
+          @custom_values_to_validate ||= persisted? ? [] : custom_field_values
         end
 
         def custom_values_to_validate=(custom_values)
@@ -245,6 +241,10 @@ module Redmine
 
         def activate_custom_field_validations!
           self.custom_values_to_validate = custom_field_values
+        end
+
+        def deactivate_custom_field_validations!
+          self.custom_values_to_validate = []
         end
 
         # Build the changes hash similar to ActiveRecord::Base#changes,

--- a/spec/components/projects/new_component_spec.rb
+++ b/spec/components/projects/new_component_spec.rb
@@ -32,13 +32,40 @@ require "rails_helper"
 
 RSpec.describe Projects::NewComponent, type: :component do
   let(:project) { build_stubbed(:project) }
+  let(:template) { nil }
+  let(:copy_options) { nil }
 
-  def render_component(**params)
-    render_inline(described_class.new(project:, **params))
+  def render_component
+    render_inline(described_class.new(project:, template:, copy_options:))
     page
   end
 
   it "renders a form" do
     expect(render_component).to have_css "form"
+  end
+
+  context "when creating from scratch" do
+    it "renders custom fields form" do
+      allow(Projects::Settings::CustomFieldsForm).to receive(:new).and_call_original
+      render_component
+      expect(Projects::Settings::CustomFieldsForm).to have_received(:new)
+    end
+  end
+
+  context "when creating from template" do
+    let(:template) { build_stubbed(:template_project) }
+    let(:copy_options) { Projects::CopyOptions.new }
+
+    it "does not render custom fields form" do
+      allow(Projects::Settings::CustomFieldsForm).to receive(:new)
+      render_component
+      expect(Projects::Settings::CustomFieldsForm).not_to have_received(:new)
+    end
+
+    it "renders template form" do
+      allow(Projects::TemplateForm).to receive(:new).and_call_original
+      render_component
+      expect(Projects::TemplateForm).to have_received(:new).with(anything, template:, copy_options:)
+    end
   end
 end

--- a/spec/contracts/projects/create_contract_spec.rb
+++ b/spec/contracts/projects/create_contract_spec.rb
@@ -144,6 +144,13 @@ RSpec.describe Projects::CreateContract do
         end
       end
 
+      describe "writing template attribute" do
+        it_behaves_like "can write" do
+          let(:attribute) { :template }
+          let(:value) { build_stubbed(:template_project) }
+        end
+      end
+
       describe "writing read-only attributes" do
         context "when enabled for admin", with_settings: { apiv3_write_readonly_attributes: true } do
           let(:current_user) { build_stubbed(:admin) }

--- a/spec/contracts/projects/update_contract_spec.rb
+++ b/spec/contracts/projects/update_contract_spec.rb
@@ -80,6 +80,14 @@ RSpec.describe Projects::UpdateContract do
       it_behaves_like "contract is invalid", workspace_type: :error_readonly
     end
 
+    context "if template is changed" do
+      before do
+        project.template_id = 1
+      end
+
+      it_behaves_like "contract is invalid", template_id: :error_readonly
+    end
+
     describe "permissions" do
       context "with edit_project_attributes" do
         let(:project_permissions) { %i(edit_project_attributes) }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe ProjectsController do
 
         allow(copy_service)
           .to receive(:call)
-              .with(target_project_params: { "name" => name }, only: [], send_notifications: false)
+              .with(target_project_params: { "name" => name, "template" => template }, only: [], send_notifications: false)
               .and_return(service_result)
 
         post :create, params: {

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -283,8 +283,12 @@ RSpec.describe ProjectsController do
 
         allow(copy_service)
           .to receive(:call)
-              .with(target_project_params: { "name" => name, "template" => template }, only: [], send_notifications: false)
-              .and_return(service_result)
+              .with(
+                target_project_params: { "name" => name, "template" => template },
+                only: [],
+                skip_custom_field_validation: true,
+                send_notifications: false
+              ).and_return(service_result)
 
         post :create, params: {
           template_id: template.id,

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -149,5 +149,40 @@ RSpec.describe "Project templates", :js, with_good_job_batches: [CopyProjectJob,
       expect(wiki_source.title).to eq(wiki_target.title)
       expect(wiki_source.text).to eq(wiki_target.text)
     end
+
+    it "skips custom field validation when creating from template" do
+      # Create a required custom field on the template
+      custom_field = create(:string_project_custom_field, is_required: true)
+      template.project_custom_field_ids = [custom_field.id]
+
+      visit new_project_path
+
+      # Should show required custom field when creating a blank project
+      expect(page).to have_field custom_field.name
+
+      choose "My template", fieldset: "Use template"
+
+      # Only when a template is selected, the options are displayed
+      expect(page).to have_selector :fieldset, "Copy from template"
+
+      fill_in "Name", with: "Project from template"
+
+      # Should not show custom field form when creating from template
+      expect(page).to have_no_field custom_field.name
+
+      click_on "Create"
+
+      expect(page).to have_dialog "Background job status"
+
+      GoodJob.perform_inline
+
+      expect(page).to have_current_path /\/projects\/project-from-template\/?/, wait: 20
+
+      # Project should be created successfully even though required custom field is empty
+      project = Project.find_by(identifier: "project-from-template")
+      expect(project).to be_present
+      expect(project.template).to eq(template)
+      expect(project.send(custom_field.attribute_getter)).to be_blank
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe Project do
     end
   end
 
+  describe "template associations" do
+    let(:template) { create(:template_project) }
+    let(:project_from_template) { create(:project, template:) }
+
+    it { is_expected.to belong_to(:template).class_name("Project").optional }
+    it { is_expected.to have_many(:templated_projects).class_name("Project").with_foreign_key("template_id") }
+
+    it "allows a project to reference its template" do
+      expect(project_from_template.template).to eq(template)
+    end
+
+    it "allows a template to access projects created from it" do
+      expect(template.templated_projects).to include(project_from_template)
+    end
+  end
+
   describe "#active?" do
     context "if active" do
       it "is true" do

--- a/spec/services/projects/enqueue_copy_service_spec.rb
+++ b/spec/services/projects/enqueue_copy_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::EnqueueCopyService, type: :model do
+  shared_let(:user) { create(:admin) }
+  shared_let(:source_project) { create(:project) }
+  shared_let(:instance) { described_class.new(user:, model: source_project) }
+  let(:target_project_params) { { name: "Target", identifier: "target" } }
+
+  describe "#call" do
+    let(:copy_service) { instance_double(Projects::CopyService) }
+    let(:test_result) { ServiceResult.success(result: build_stubbed(:project)) }
+    let(:mock_job) { instance_double(CopyProjectJob, job_id: "123") }
+
+    before do
+      allow(Projects::CopyService).to receive(:new).and_return(copy_service)
+      allow(copy_service).to receive(:call).and_return(test_result)
+      allow(CopyProjectJob).to receive(:perform_later).and_return(mock_job)
+      allow(GoodJob::Batch).to receive(:enqueue).and_yield
+    end
+
+    context "with skip_custom_field_validation parameter" do
+      let(:params) do
+        {
+          target_project_params:,
+          skip_custom_field_validation: true,
+          only: [],
+          send_notifications: false
+        }
+      end
+
+      it "passes skip_custom_field_validation to test copy" do
+        instance.call(params)
+
+        expect(Projects::CopyService).to have_received(:new).with(
+          hash_including(
+            user:,
+            source: source_project,
+            contract_options: { skip_custom_field_validation: true }
+          )
+        )
+      end
+
+      it "passes skip_custom_field_validation to job" do
+        instance.call(params)
+
+        expect(CopyProjectJob).to have_received(:perform_later).with(
+          hash_including(skip_custom_field_validation: true)
+        )
+      end
+    end
+
+    context "without skip_custom_field_validation parameter" do
+      let(:params) do
+        {
+          target_project_params:,
+          only: [],
+          send_notifications: false
+        }
+      end
+
+      it "does not pass skip_custom_field_validation to test copy" do
+        instance.call(params)
+
+        expect(Projects::CopyService).to have_received(:new).with(
+          hash_including(
+            user:,
+            source: source_project,
+            contract_options: { skip_custom_field_validation: nil }
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Projects::SetAttributesService, type: :model do
 
     allow(contract)
       .to receive(:new)
-      .with(project, user, options: {})
+      .with(project, user, options: contract_options)
       .and_return(contract_instance)
 
     contract
@@ -50,10 +50,12 @@ RSpec.describe Projects::SetAttributesService, type: :model do
     instance_double(ActiveModel::Errors)
   end
   let(:project_valid) { true }
+  let(:contract_options) { {} }
   let(:instance) do
     described_class.new(user:,
                         model: project,
-                        contract_class:)
+                        contract_class:,
+                        contract_options:)
   end
   let(:call_attributes) { {} }
   let(:project) do
@@ -309,6 +311,30 @@ RSpec.describe Projects::SetAttributesService, type: :model do
 
           include_examples "setting status attributes"
         end
+      end
+    end
+
+    context "when skip_custom_field_validation is true" do
+      let(:contract_options) { { skip_custom_field_validation: true } }
+      let(:project) { create(:project) }
+
+      it "deactivates custom field validations" do
+        allow(project).to receive(:deactivate_custom_field_validations!)
+        subject
+
+        expect(project).to have_received(:deactivate_custom_field_validations!)
+      end
+    end
+
+    context "when skip_custom_field_validation is false" do
+      let(:contract_options) { { skip_custom_field_validation: false } }
+      let(:project) { create(:project) }
+
+      it "does not deactivate custom field validations" do
+        allow(project).to receive(:deactivate_custom_field_validations!)
+        subject
+
+        expect(project).not_to have_received(:deactivate_custom_field_validations!)
       end
     end
   end

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -314,27 +314,44 @@ RSpec.describe Projects::SetAttributesService, type: :model do
       end
     end
 
-    context "when skip_custom_field_validation is true" do
-      let(:contract_options) { { skip_custom_field_validation: true } }
-      let(:project) { create(:project) }
+    context "with a required custom field" do
+      shared_let(:required_custom_field) { create(:text_project_custom_field, is_required: true) }
+      shared_let(:call_attributes) { { custom_field_values: { required_custom_field.id => "Provided value" } } }
 
-      it "deactivates custom field validations" do
-        allow(project).to receive(:deactivate_custom_field_validations!)
-        subject
+      context "when skip_custom_field_validation is true" do
+        let(:contract_options) { { skip_custom_field_validation: true } }
+        let(:project) { create(:project) }
 
-        expect(project).to have_received(:deactivate_custom_field_validations!)
+        it "deactivates custom field validations" do
+          allow(project).to receive(:deactivate_custom_field_validations!).and_call_original
+          subject
+
+          expect(project).to have_received(:deactivate_custom_field_validations!)
+        end
+
+        it "clears the custom values to validate" do
+          subject
+
+          expect(subject.result.custom_values_to_validate).to be_empty
+        end
       end
-    end
 
-    context "when skip_custom_field_validation is false" do
-      let(:contract_options) { { skip_custom_field_validation: false } }
-      let(:project) { create(:project) }
+      context "when skip_custom_field_validation is false" do
+        let(:contract_options) { { skip_custom_field_validation: false } }
+        let(:project) { create(:project) }
 
-      it "does not deactivate custom field validations" do
-        allow(project).to receive(:deactivate_custom_field_validations!)
-        subject
+        it "does not deactivate custom field validations" do
+          allow(project).to receive(:deactivate_custom_field_validations!).and_call_original
+          subject
 
-        expect(project).not_to have_received(:deactivate_custom_field_validations!)
+          expect(project).not_to have_received(:deactivate_custom_field_validations!)
+        end
+
+        it "keeps the custom values to validate" do
+          custom_field_ids = subject.result.custom_values_to_validate.map(&:custom_field_id).uniq
+
+          expect(custom_field_ids).to contain_exactly(required_custom_field.id)
+        end
       end
     end
   end

--- a/spec/support/shared/acts_as_customizable.rb
+++ b/spec/support/shared/acts_as_customizable.rb
@@ -174,12 +174,10 @@ RSpec.shared_examples_for "acts_as_customizable included" do
         )
       end
 
-      it "ignores the setter value and uses the custom_field_values" do
-        new_model_instance.custom_values_to_validate = []
+      it "returns and empty array" do
+        new_model_instance.deactivate_custom_field_validations!
 
-        expect(subject).to contain_exactly(
-          an_instance_of(CustomValue).and(having_attributes(custom_field_id: custom_field.id))
-        )
+        expect(subject).to be_empty
       end
 
       it "returns the values set via the setter" do
@@ -269,7 +267,7 @@ RSpec.shared_examples_for "acts_as_customizable included" do
             subject.custom_values_to_validate = []
           end
 
-          it_behaves_like "has a validation error on a required custom field"
+          it_behaves_like "is valid"
         end
       end
     end

--- a/spec/workers/copy_project_job_spec.rb
+++ b/spec/workers/copy_project_job_spec.rb
@@ -424,4 +424,27 @@ RSpec.describe CopyProjectJob, type: :model, with_good_job_batches: [CopyProject
       expect(members_create_service).to have_received(:call).with(hash_excluding(:send_notifications))
     end
   end
+
+  describe "skip_custom_field_validation parameter" do
+    let(:source_project) { create(:project) }
+    let(:job_args) do
+      {
+        target_project_params: { name: "Copy", identifier: "copy" },
+        associations_to_copy: [],
+        skip_custom_field_validation: true
+      }
+    end
+
+    it "passes skip_custom_field_validation to CopyService" do
+      allow(Projects::CopyService).to receive(:new).and_call_original
+      GoodJob::Batch.enqueue(user: admin, source_project:) do
+        described_class.perform_later(**job_args)
+      end
+      GoodJob.perform_inline
+
+      expect(Projects::CopyService).to have_received(:new).with(
+        hash_including(contract_options: { skip_custom_field_validation: true })
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69034

# What are you trying to accomplish?
- Store the template reference on projects that were created from a template.
- Do not show and validate project attributes when creating projects from templates.
- The PR should be merged only after the parent PR #20986 is reviewed/merged.

## Screenshots
<details><summary>Blank project does show the required project attributes</summary>
<p>

<img width="745" height="521" alt="image" src="https://github.com/user-attachments/assets/b244d1b0-325f-41f7-a489-d4fe01679acd" />


</p>
</details> 

<details><summary>Creating a project from templates does not show and require the project attributes</summary>
<p>

<img width="724" height="683" alt="image" src="https://github.com/user-attachments/assets/66f05093-2f8e-4260-acc1-f8312bbf5d9a" />


</p>
</details> 

# What approach did you choose and why?
- [x] Deactivate the custom field validation on the `SetAttributesContract` when a special contract option is passed `skip_custom_field_validation: true`.
- [x] Pass the flag from the projects controller down to the contract via the copy job and service.
- [x] Hide the custom fields on the project creation form when a template is chosen.
- [x] Store the `template_id` on the projects created from a template.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
