### PR TITLE
hack to resolve base tag conflicting with openapi explorer by not inserting the tag for that page

### DIFF
--- a/app/controllers/api_docs_controller.rb
+++ b/app/controllers/api_docs_controller.rb
@@ -36,5 +36,7 @@ class APIDocsController < ApplicationController
 
   def index
     render_404 unless Setting.apiv3_docs_enabled?
+
+    render locals: { skip_base_tag: true }
   end
 end

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -6,7 +6,9 @@
 <% relative_url_root = OpenProject::Configuration["rails_relative_url_root"] || "" %>
 <meta name="app_title" content="<%= page_title(*html_title_parts) %>">
 <meta name="app_base_path" content="<%= relative_url_root %>">
-<base href="<%= relative_url_root %>/">
+<% unless local_assigns[:skip_base_tag] %>
+  <base href="<%= relative_url_root %>/">
+<% end %>
 <% if @project %>
   <meta name="current_project"
         data-project-name="<%= h @project.name %>"

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
       xml:lang="<%= I18n.locale.to_s %>"
       class="<%= "in_modal" unless show_decoration %>">
 <head>
-  <%= render partial: "layouts/common_head" %>
+  <%= render partial: "layouts/common_head", locals: local_assigns %>
   <!-- project specific tags -->
   <%= call_hook :view_layouts_base_html_head %>
   <!-- page specific tags -->


### PR DESCRIPTION
openapi explorer uses replaceState (pushState in later versions) with anchor only, but this doesn't work with base tag, as anchor is added to the base url instead of current url. So don't insert the tag on exploror page

Alternative to #21061
See also https://community.openproject.org/wp/69113