### PR TITLE
New project template selector fixes

### DIFF
--- a/app/components/projects/index_sub_header_component.rb
+++ b/app/components/projects/index_sub_header_component.rb
@@ -88,9 +88,9 @@ module Projects
 
     def allowed_new_workspace_types
       allowed_types = []
-      allowed_types << Project.workspace_types[:project] if @current_user.allowed_globally?(:add_project)
       allowed_types << Project.workspace_types[:portfolio] if @current_user.allowed_globally?(:add_portfolios) && OpenProject::FeatureDecisions.portfolio_models_active?
       allowed_types << Project.workspace_types[:program] if @current_user.allowed_globally?(:add_programs) && OpenProject::FeatureDecisions.portfolio_models_active?
+      allowed_types << Project.workspace_types[:project] if @current_user.allowed_globally?(:add_project)
       allowed_types
     end
 

--- a/app/components/projects/index_sub_header_component.rb
+++ b/app/components/projects/index_sub_header_component.rb
@@ -72,14 +72,9 @@ module Projects
     end
 
     def new_workspace_path(type)
-      case type
-      when Project.workspace_types[:project]
-        new_project_path
-      when Project.workspace_types[:portfolio]
-        new_portfolio_path
-      when Project.workspace_types[:program]
-        new_program_path
-      end
+      return unless Project.workspace_types.key?(type)
+
+      url_for([:new, type.to_sym])
     end
 
     def new_workspace_label(type)
@@ -89,10 +84,10 @@ module Projects
     def allowed_new_workspace_types
       @allowed_new_workspace_types ||= [].tap do |types|
         if OpenProject::FeatureDecisions.portfolio_models_active?
-          types << Project.workspace_types[:portfolio] if @current_user.allowed_globally?(:add_portfolios)
-          types << Project.workspace_types[:program] if @current_user.allowed_globally?(:add_programs)
+          types << "portfolio" if @current_user.allowed_globally?(:add_portfolios)
+          types << "program" if @current_user.allowed_globally?(:add_programs)
         end
-        types << Project.workspace_types[:project] if @current_user.allowed_globally?(:add_project)
+        types << "project" if @current_user.allowed_globally?(:add_project)
       end
     end
 

--- a/app/components/projects/index_sub_header_component.rb
+++ b/app/components/projects/index_sub_header_component.rb
@@ -87,11 +87,13 @@ module Projects
     end
 
     def allowed_new_workspace_types
-      allowed_types = []
-      allowed_types << Project.workspace_types[:portfolio] if @current_user.allowed_globally?(:add_portfolios) && OpenProject::FeatureDecisions.portfolio_models_active?
-      allowed_types << Project.workspace_types[:program] if @current_user.allowed_globally?(:add_programs) && OpenProject::FeatureDecisions.portfolio_models_active?
-      allowed_types << Project.workspace_types[:project] if @current_user.allowed_globally?(:add_project)
-      allowed_types
+      @allowed_new_workspace_types ||= [].tap do |types|
+        if OpenProject::FeatureDecisions.portfolio_models_active?
+          types << Project.workspace_types[:portfolio] if @current_user.allowed_globally?(:add_portfolios)
+          types << Project.workspace_types[:program] if @current_user.allowed_globally?(:add_programs)
+        end
+        types << Project.workspace_types[:project] if @current_user.allowed_globally?(:add_project)
+      end
     end
 
     def for_a_single_new_allowed_type

--- a/app/components/projects/template_select_component.html.erb
+++ b/app/components/projects/template_select_component.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   component_wrapper do
     settings_primer_form_with(
-      url: new_project_path,
+      url: new_workspace_path,
       method: :get,
       data: {
         turbo_frame: Projects::NewComponent.wrapper_key,

--- a/app/components/projects/template_select_component.rb
+++ b/app/components/projects/template_select_component.rb
@@ -35,11 +35,22 @@ module Projects
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
+    option :project
     option :template
     option :parent, optional: true
     option :current_user, default: -> { User.current }
 
     private
+
+    def new_workspace_path
+      workspace_type = if Project.workspace_types.key?(project.workspace_type)
+                         project.workspace_type.to_sym
+                       else
+                         :project
+                       end
+
+      url_for([:new, workspace_type])
+    end
 
     def template_id = template&.id
     def parent_id = parent&.id

--- a/app/helpers/workspace_helper.rb
+++ b/app/helpers/workspace_helper.rb
@@ -29,24 +29,18 @@
 #++
 
 module WorkspaceHelper
+  WORKSPACE_ICON_MAPPING = Hash.new(:project)
+    .with_indifferent_access
+    .merge(
+      portfolio: :briefcase,
+      program: :"project-roadmap"
+    )
+
   def new_workspace_title(workspace)
-    if workspace.project?
-      I18n.t(:label_project_new)
-    elsif workspace.portfolio?
-      I18n.t(:label_portfolio_new)
-    elsif workspace.program?
-      I18n.t(:label_program_new)
-    end
+    return unless Project.workspace_types.key?(workspace.workspace_type)
+
+    I18n.t(:"label_#{workspace.workspace_type}_new")
   end
 
-  def workspace_icon(type)
-    case type
-    when Project.workspace_types[:portfolio]
-      :briefcase
-    when Project.workspace_types[:program]
-      :"project-roadmap"
-    else
-      :project
-    end
-  end
+  def workspace_icon(type) = WORKSPACE_ICON_MAPPING[type]
 end

--- a/app/helpers/workspace_helper.rb
+++ b/app/helpers/workspace_helper.rb
@@ -29,12 +29,11 @@
 #++
 
 module WorkspaceHelper
-  WORKSPACE_ICON_MAPPING = Hash.new(:project)
-    .with_indifferent_access
-    .merge(
-      portfolio: :briefcase,
-      program: :"project-roadmap"
-    )
+  WORKSPACE_ICON_MAPPING = {
+    project: :project,
+    portfolio: :briefcase,
+    program: :"project-roadmap"
+  }.with_indifferent_access.freeze
 
   def new_workspace_title(workspace)
     return unless Project.workspace_types.key?(workspace.workspace_type)

--- a/app/seeders/demo_data/project_seeder.rb
+++ b/app/seeders/demo_data/project_seeder.rb
@@ -164,7 +164,7 @@ module DemoData
         enabled_module_names: project_data.lookup("modules"),
         types: Type.all,
         parent: Project.find_by(identifier: project_data.lookup("parent")),
-        workspace_type: Project.workspace_types[:project]
+        workspace_type: "project"
       }
     end
   end

--- a/app/seeders/development_data/projects_seeder.rb
+++ b/app/seeders/development_data/projects_seeder.rb
@@ -113,7 +113,7 @@ module DevelopmentData
         identifier:,
         enabled_module_names: project_modules,
         types: Type.all,
-        workspace_type: Project.workspace_types[:project]
+        workspace_type: "project"
       }
     end
 

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -36,6 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render Projects::TemplateSelectComponent.new(
+    project: @new_project,
     template: @template,
     parent: @parent,
     current_user:

--- a/lib/api/v3/projects/create_form_api.rb
+++ b/lib/api/v3/projects/create_form_api.rb
@@ -39,8 +39,7 @@ module API
 
           post &::API::V3::Utilities::Endpoints::CreateForm.new(model: Project,
                                                                 params_modifier: ->(attributes) {
-                                                                  attributes[:workspace_type] = Project.workspace_types[:project]
-                                                                  attributes
+                                                                  attributes.merge!(workspace_type: "project")
                                                                 })
                                                            .mount
         end

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -42,8 +42,7 @@ module API
 
           post &::API::V3::Utilities::Endpoints::Create.new(model: Project,
                                                             params_modifier: ->(attributes) {
-                                                              attributes[:workspace_type] = Project.workspace_types[:project]
-                                                              attributes
+                                                              attributes.merge!(workspace_type: "project")
                                                             })
                                                        .mount
 

--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
             row.with_column do
               render(Primer::Beta::Text.new(color: :subtle)) do
                 concat render Primer::Beta::Octicon.new(
-                  icon: helpers.workspace_icon(child),
+                  icon: helpers.workspace_icon(child.workspace_type),
                   mr: 1,
                   color: :subtle,
                   "aria-label": child.workspace_label

--- a/spec/components/projects/template_select_component_spec.rb
+++ b/spec/components/projects/template_select_component_spec.rb
@@ -35,13 +35,68 @@ RSpec.describe Projects::TemplateSelectComponent, type: :component do
     render_inline(described_class.new(...))
   end
 
+  let(:project) { Project.new }
   let(:template) { build_stubbed(:template_project) }
   let(:current_user) { build_stubbed(:user) }
 
-  subject(:rendered_component) { render_component(template:, current_user:) }
+  subject(:rendered_component) { render_component(project:, template:, current_user:) }
 
   it "renders form" do
     expect(rendered_component).to have_element :form, method: "get"
+  end
+
+  describe "action" do
+    let(:project) { Project.new(workspace_type:) }
+
+    context "when workspace type is not set" do
+      let(:workspace_type) { nil }
+
+      it "sets action to create project" do
+        expect(rendered_component).to have_element :form, method: "get" do |form|
+          expect(form["action"]).to eq "/projects/new"
+        end
+      end
+    end
+
+    context "when workspace type set to unknown value" do
+      let(:workspace_type) { :unknown }
+
+      it "sets action to create project" do
+        expect(rendered_component).to have_element :form, method: "get" do |form|
+          expect(form["action"]).to eq "/projects/new"
+        end
+      end
+    end
+
+    context "when workspace type is set to project" do
+      let(:workspace_type) { :project }
+
+      it "sets action to create project" do
+        expect(rendered_component).to have_element :form, method: "get" do |form|
+          expect(form["action"]).to eq "/projects/new"
+        end
+      end
+    end
+
+    context "when workspace type is set to program" do
+      let(:workspace_type) { :program }
+
+      it "sets action to create project" do
+        expect(rendered_component).to have_element :form, method: "get" do |form|
+          expect(form["action"]).to eq "/programs/new"
+        end
+      end
+    end
+
+    context "when workspace type is set to portfolio" do
+      let(:workspace_type) { :portfolio }
+
+      it "sets action to create project" do
+        expect(rendered_component).to have_element :form, method: "get" do |form|
+          expect(form["action"]).to eq "/portfolios/new"
+        end
+      end
+    end
   end
 
   it "registers Stimulus controller" do


### PR DESCRIPTION
- reorder allowed types to put them in order portfolio > program > project
- remove unnecessary usage of `Project.workspace_types[:xxx]`
- keep workspace type url when selecting template