### PR TITLE
Use `paste` icon for documents "Copy link to clipboard" action

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -70,7 +70,7 @@
           tag: :"clipboard-copy",
           content_arguments: { value: document_url(document) }
         ) do |item|
-          item.with_leading_visual_icon(icon: :copy)
+          item.with_leading_visual_icon(icon: :paste)
         end
       end
     end


### PR DESCRIPTION
https://community.openproject.org/wp/69081

ref: https://primer.style/octicons/icon/paste-16/

<img width="841" height="204" alt="Screenshot 2025-11-18 at 9 15 47 AM" src="https://github.com/user-attachments/assets/5eeec1fa-51ef-4955-bc05-5dc17c28bed4" />
