### PR TITLE
implementation/69016 Add loading skeleton for blocknote view

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -204,7 +204,14 @@ export default function OpBlockNoteContainer({ inputField,
 
   return (
     <>
-      {isLoading ? <div>Loading...</div>
+      {isLoading ? <div>
+        <div className={'mb-3'}>
+          <div style={{width: '25%', height: '40px'}} className={'SkeletonBox'}/>
+        </div>
+        <div className={'mb-3'}>
+          <div style={{width: '100%', height: '150px'}} className={'SkeletonBox'}/>
+        </div>
+      </div>
         :
         <BlockNoteView
           editor={editor}


### PR DESCRIPTION
https://community.openproject.org/work_packages/69016

![docs-loading-indicator](https://github.com/user-attachments/assets/2200c7c3-2850-4092-9928-bc2d284205ef)
