### PR TITLE
Sync blocknote color theme when OP core changes themes automatically without a page refresh

### DIFF
--- a/frontend/src/app/core/setup/globals/theme-utils.ts
+++ b/frontend/src/app/core/setup/globals/theme-utils.ts
@@ -56,5 +56,10 @@ export class ThemeUtils {
     body.setAttribute('data-color-mode', colorMode);
     body.setAttribute(`data-${colorMode}-theme`, increaseContrast ? `${colorMode}_high_contrast` : colorMode);
     body.removeAttribute(`data-${otherColorMode}-theme`);
+
+    // Dispatch custom event for components that need to react to theme changes
+    window.dispatchEvent(new CustomEvent('op:theme-changed', {
+      detail: { colorMode, increaseContrast },
+    }));
   }
 }

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -72,6 +72,7 @@ export default function OpBlockNoteContainer({ inputField,
                                                attachmentsUploadUrl,
                                                attachmentsCollectionKey }:OpBlockNoteContainerProps) {
   const [isLoading, setIsLoading] = useState(true);
+  const [theme, setTheme] = useState<OpColorMode>(detectTheme());
 
   initOpenProjectApi({ baseUrl: openProjectUrl });
 
@@ -202,6 +203,19 @@ export default function OpBlockNoteContainer({ inputField,
     };
   }, []);
 
+  useEffect(() => {
+    const handleThemeChange = () => {
+      const newTheme = detectTheme();
+      setTheme(newTheme);
+    };
+
+    window.addEventListener('op:theme-changed', handleThemeChange);
+
+    return () => {
+      window.removeEventListener('op:theme-changed', handleThemeChange);
+    };
+  }, []);
+
   return (
     <>
       {isLoading ? <div>Loading...</div>
@@ -209,7 +223,7 @@ export default function OpBlockNoteContainer({ inputField,
         <BlockNoteView
           editor={editor}
           slashMenu={false}
-          theme={detectTheme()}
+          theme={theme}
           className={'block-note-editor-container'}
         >
           <SuggestionMenuController


### PR DESCRIPTION
https://community.openproject.org/work_packages/68976

Theme changes can occur from the following:
 * Sync with OS - Auto-switching based on OS preference
 * Manual theme selection - User picks light/dark mode manually

Sync up the blocknote view with the op color mode by listening and reacting to `op:theme-changed` event

Previous discussions: https://github.com/opf/openproject/pull/19627#discussion_r2218429777

_Before_


https://github.com/user-attachments/assets/ca160722-e7b4-4931-9ddf-122fa3b97a70



_After_


https://github.com/user-attachments/assets/29d990b3-352d-4825-aed2-0930337a185f