### PR TITLE
[#69101] create UI for artifact export in project initiation request

### DIFF
--- a/app/components/projects/settings/creation_wizard/export_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/export_component.html.erb
@@ -21,10 +21,17 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render Projects::Settings::CreationWizard::ExportComponent.new(project: @project) %>
+<%=
+  settings_primer_form_with(
+    model: @project,
+    id: "project_creation_wizard_export_artifact_form",
+    url: "https://todo.update-route.controller",
+    method: :put
+  ) { |form| render Projects::Settings::CreationWizard::ExportForm.new(form) }
+%>

--- a/app/components/projects/settings/creation_wizard/export_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/export_component.html.erb
@@ -31,7 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   settings_primer_form_with(
     model: @project,
     id: "project_creation_wizard_export_artifact_form",
-    url: "https://todo.update-route.controller",
-    method: :put
+    url: "/todo/update/correct/controller/action/path",
+    method: :put,
+    data: { controller: "projects--settings--initiation-request--export-artifact" }
   ) { |form| render Projects::Settings::CreationWizard::ExportForm.new(form) }
 %>

--- a/app/components/projects/settings/creation_wizard/export_component.rb
+++ b/app/components/projects/settings/creation_wizard/export_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -23,24 +23,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module Projects::CreationWizard
-  extend ActiveSupport::Concern
+module Projects
+  module Settings
+    module CreationWizard
+      class ExportComponent < ApplicationComponent
+        include OpPrimer::FormHelpers
 
-  included do
-    store_attribute :settings, :project_creation_wizard_enabled, :boolean
+        def initialize(project:)
+          super
 
-    store_attribute :settings, :submission_work_package_type_id, :integer
-    store_attribute :settings, :submission_status_when_submitted_id, :integer
-    store_attribute :settings, :submission_send_confirmation_email, :boolean
-    store_attribute :settings, :submission_assignee_custom_field_id, :integer
-    store_attribute :settings, :submission_notification_text, :string
-    store_attribute :settings, :submission_work_package_comment, :string
-    store_attribute :settings, :project_creation_wizard_pdf_export, :string, default: "attachment"
-    store_attribute :settings, :project_creation_wizard_pdf_export_storage, :string
+          @project = project
+        end
+      end
+    end
   end
 end

--- a/app/components/projects/settings/creation_wizard/page_header_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/page_header_component.html.erb
@@ -81,7 +81,7 @@ See COPYRIGHT and LICENSE files for more details.
           selected: params[:tab] == "export",
           href: helpers.project_settings_creation_wizard_path(@project, tab: :export)
         ) do |t|
-          t.with_text { I18n.t(:label_artefact_export) }
+          t.with_text { I18n.t("projects.settings.creation_wizard.export.label_artifact_export") }
         end
       end
     end

--- a/app/forms/projects/settings/creation_wizard/export_form.rb
+++ b/app/forms/projects/settings/creation_wizard/export_form.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module Projects
+  module Settings
+    module CreationWizard
+      class ExportForm < ApplicationForm
+        form do |f|
+          f.radio_button_group(
+            name: :project_creation_wizard_pdf_export,
+            label: I18n.t("projects.settings.creation_wizard.export.pdf_file_storage")
+          ) do |group|
+            group.radio_button(
+              value: :attachment,
+              checked: checked?(:attachment),
+              label: I18n.t("projects.settings.creation_wizard.export.label_attachment_export"),
+              caption: I18n.t("projects.settings.creation_wizard.export.description_attachment_export")
+            )
+            group.radio_button(
+              value: :file_link,
+              checked: checked?(:file_link),
+              label: file_link_label,
+              caption: I18n.t("projects.settings.creation_wizard.export.description_file_link_export"),
+              disabled: file_storages.empty?
+            )
+          end
+
+          if file_storages.any?
+            f.select_list(
+              name: :project_creation_wizard_pdf_export_storage,
+              label: I18n.t("projects.settings.creation_wizard.export.external_file_storage"),
+              caption: I18n.t("projects.settings.creation_wizard.export.description_file_storage_selection")
+            ) do |list|
+              file_storages.each do |project_storage|
+                list.option(label: project_storage.storage.typed_label, value: project_storage.id)
+              end
+            end
+          end
+
+          f.submit(name: :submit, label: I18n.t(:button_save), scheme: :primary)
+        end
+
+        private
+
+        def file_link_export_enabled?
+          file_storages.any?
+        end
+
+        def checked?(value)
+          value == (model.project_creation_wizard_pdf_export&.to_sym || :attachment)
+        end
+
+        def file_link_label
+          label = I18n.t("projects.settings.creation_wizard.export.label_file_link_export")
+          if file_storages.any?
+            label
+          else
+            "#{label} (#{I18n.t('projects.settings.creation_wizard.export.unavailable')})"
+          end
+        end
+
+        def file_storages
+          @file_storages ||= model.project_storages
+                                  .includes(:storage)
+                                  .filter(&:project_folder_automatic?)
+                                  .filter { |project_storages| project_storages.storage.provider_type_nextcloud? }
+        end
+      end
+    end
+  end
+end

--- a/app/forms/projects/settings/creation_wizard/export_form.rb
+++ b/app/forms/projects/settings/creation_wizard/export_form.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -33,32 +33,39 @@ module Projects
       class ExportForm < ApplicationForm
         form do |f|
           f.radio_button_group(
-            name: :project_creation_wizard_pdf_export,
+            name: :project_creation_wizard_pdf_export_type,
             label: I18n.t("projects.settings.creation_wizard.export.pdf_file_storage")
           ) do |group|
             group.radio_button(
               value: :attachment,
               checked: checked?(:attachment),
               label: I18n.t("projects.settings.creation_wizard.export.label_attachment_export"),
-              caption: I18n.t("projects.settings.creation_wizard.export.description_attachment_export")
+              caption: I18n.t("projects.settings.creation_wizard.export.description_attachment_export"),
+              data: { action: "projects--settings--initiation-request--export-artifact#updateForm" }
             )
             group.radio_button(
               value: :file_link,
               checked: checked?(:file_link),
               label: file_link_label,
               caption: I18n.t("projects.settings.creation_wizard.export.description_file_link_export"),
-              disabled: file_storages.empty?
+              disabled: file_storages.empty?,
+              data: { action: "projects--settings--initiation-request--export-artifact#updateForm" }
             )
           end
 
           if file_storages.any?
-            f.select_list(
-              name: :project_creation_wizard_pdf_export_storage,
-              label: I18n.t("projects.settings.creation_wizard.export.external_file_storage"),
-              caption: I18n.t("projects.settings.creation_wizard.export.description_file_storage_selection")
-            ) do |list|
-              file_storages.each do |project_storage|
-                list.option(label: project_storage.storage.typed_label, value: project_storage.id)
+            f.group(display: :none,
+                    data: {
+                      "projects--settings--initiation-request--export-artifact-target": "projectStoragesSelectList"
+                    }) do |storage_select|
+              storage_select.select_list(
+                name: :project_creation_wizard_pdf_export_storage,
+                label: I18n.t("projects.settings.creation_wizard.export.external_file_storage"),
+                caption: I18n.t("projects.settings.creation_wizard.export.description_file_storage_selection")
+              ) do |list|
+                file_storages.each do |project_storage|
+                  list.option(label: project_storage.storage.typed_label, value: project_storage.id)
+                end
               end
             end
           end
@@ -73,7 +80,7 @@ module Projects
         end
 
         def checked?(value)
-          value == (model.project_creation_wizard_pdf_export&.to_sym || :attachment)
+          value == (model.project_creation_wizard_pdf_export_type&.to_sym || :attachment)
         end
 
         def file_link_label
@@ -87,8 +94,8 @@ module Projects
 
         def file_storages
           @file_storages ||= model.project_storages
+                                  .automatic
                                   .includes(:storage)
-                                  .filter(&:project_folder_automatic?)
                                   .filter { |project_storages| project_storages.storage.provider_type_nextcloud? }
         end
       end

--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -40,7 +40,7 @@ module Projects::CreationWizard
     store_attribute :settings, :submission_assignee_custom_field_id, :integer
     store_attribute :settings, :submission_notification_text, :string
     store_attribute :settings, :submission_work_package_comment, :string
-    store_attribute :settings, :project_creation_wizard_pdf_export, :string, default: "attachment"
+    store_attribute :settings, :project_creation_wizard_pdf_export_type, :string, default: "attachment"
     store_attribute :settings, :project_creation_wizard_pdf_export_storage, :string
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,11 +590,20 @@ en:
       work_package_priorities:
         new_label: "New priority"
       creation_wizard:
+        export:
+          description_attachment_export: "The generated artifact will be saved as a PDF attachment to the artifact work package."
+          description_file_link_export: "The artifact work package will have a file link to a PDF stored in an external file storage. Requires a working file storage with automatically-managed project folders. At the moment only Nextcloud file storages are supported."
+          description_file_storage_selection: "Select which of the configured external file storages should be used."
+          external_file_storage: "External file storage"
+          label_artifact_export: "Artifact export"
+          label_attachment_export: "Save as work package file attachment"
+          label_file_link_export: "Upload file to external file storage and add file link to work package"
+          pdf_file_storage: "PDF file storage"
+          unavailable: "unavailable"
+        label_request_submission: "Request submission"
         project_attributes_description: >
           Select which project attributes should be included in the project initiation request. 
           This list only includes [project attributes](project_attributes_url) enabled for for this project.
-        label_request_submission: "Request submission"
-        label_artefact_export: "Artifact export"
     status:
       button_edit: Edit project status
     wizard:
@@ -3046,7 +3055,6 @@ en:
   label_add_column: "Add column"
   label_applied_status: "Applied status"
   label_archive_project: "Archive project"
-  label_artefact_export: "Artefact export"
   label_ascending: "Ascending"
   label_assigned_to_me_work_packages: "Work packages assigned to me"
   label_associated_revisions: "Associated revisions"

--- a/frontend/src/stimulus/controllers/dynamic/projects/settings/initiation-request/export-artifact.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/settings/initiation-request/export-artifact.controller.ts
@@ -1,0 +1,73 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class ExportArtifactController extends Controller {
+
+  static targets = [
+    'projectStoragesSelectList',
+  ];
+
+  declare readonly projectStoragesSelectListTarget:HTMLSelectElement;
+
+  connect():void {
+    this.hideProjectStoragesSelectList();
+  }
+
+  protected updateForm(evt:InputEvent):void {
+    if (!this.isInputElement(evt.target)) {
+      return;
+    }
+
+    switch (evt.target.value) {
+      case 'file_link':
+        this.showProjectStoragesSelectList();
+        break;
+      case 'attachment':
+        this.hideProjectStoragesSelectList();
+        break;
+      default:
+        throw new Error(`invalid event target: ${evt.target.value}`);
+    }
+  }
+
+  private showProjectStoragesSelectList():void {
+    this.projectStoragesSelectListTarget.classList.remove('d-none');
+  }
+
+  private hideProjectStoragesSelectList():void {
+    this.projectStoragesSelectListTarget.classList.add('d-none');
+  }
+
+  private isInputElement(target:EventTarget|null):target is HTMLInputElement {
+    return target !== null && target instanceof HTMLInputElement;
+  }
+}

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -90,6 +90,7 @@ module Storages
       def short_provider_name = raise Errors::SubclassResponsibility
 
       def allowed_by_enterprise_token? = true
+
       def disallowed_by_enterprise_token? = !allowed_by_enterprise_token?
 
       # TODO: Compatibility Method To be Removed once all references are removed - 2025-07-14 @mereghost
@@ -212,6 +213,11 @@ module Storages
     def extract_origin_user_id(token)
       auth_strategy = Adapters::Input::Strategy.build(key: :bearer_token, token: token.access_token)
       Adapters::Registry.resolve("#{self}.queries.user").call(auth_strategy:, storage: self).fmap { it[:id] }
+    end
+
+    def typed_label
+      type = I18n.t("storages.provider_types.#{short_provider_name}.name")
+      "#{name} (#{type})"
     end
   end
 end

--- a/modules/storages/app/views/storages/project_settings/_storage_select_form.html.erb
+++ b/modules/storages/app/views/storages/project_settings/_storage_select_form.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div class="form--field -required">
   <%= f.select :storage_id,
-               @available_storages.map { |storage| ["#{storage.name} (#{storage})", storage.id] },
+               @available_storages.map { |storage| [storage.typed_label, storage.id] },
                class: "-bold",
                selected: @available_storages.first.id.to_s,
                container_class: "-slim" %>

--- a/modules/storages/spec/features/manage_project_storage_spec.rb
+++ b/modules/storages/spec/features/manage_project_storage_spec.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -105,8 +105,7 @@ RSpec.describe("Activation of storages in projects",
     page.first(:link, "New storage").click
     expect(page).to have_current_path new_project_settings_project_storage_path(project_id: project)
     expect(page).to have_text("Add a file storage")
-    expect(page).to have_select("storages_project_storage_storage_id",
-                                options: ["#{storage.name} (#{storage})"])
+    expect(page).to have_select("storages_project_storage_storage_id", options: [storage.typed_label])
     page.click_on("Continue")
 
     # by default automatic have to be chosen if storage has automatic management enabled
@@ -270,10 +269,9 @@ RSpec.describe("Activation of storages in projects",
       page.first(:link, "New storage").click
 
       aggregate_failures "select field options" do
-        expect(page).to have_select("storages_project_storage_storage_id",
-                                    options: ["#{configured_storage.name} (#{configured_storage.short_provider_type})"])
+        expect(page).to have_select("storages_project_storage_storage_id", options: [configured_storage.typed_label])
         expect(page).to have_no_select("storages_project_storage_storage_id",
-                                       options: ["#{unconfigured_storage.name} (#{unconfigured_storage.short_provider_type})"])
+                                       options: [unconfigured_storage.typed_label])
       end
     end
   end

--- a/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
+++ b/modules/storages/spec/features/storages/project_settings/oauth_access_grant_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "OAuth Access Grant Nudge upon adding a storage to a project",
 
     click_on("Storage")
 
-    expect(page).to have_select("Storage", options: ["#{storage.name} (nextcloud)"])
+    expect(page).to have_select("Storage", options: [storage.typed_label])
     click_on("Continue")
 
     expect(page).to have_checked_field("New folder with automatically managed permissions")


### PR DESCRIPTION
# Ticket
[#69101](https://community.openproject.org/work_packages/69101)

# What are you trying to accomplish?
- show UI for artifact export configuration
- no project settings update - yet
- no form initialization with project settings - yet

# What approach did you choose and why?
- Add form and view components
- add logic to list correct file storages
- add settings for the configurable attributes

# Hint

- As Mir is currently working on the creation wizard controller, I didn't want to implement the update in parallel. Instead I forwarded some feedback and expectations. 