### PR TITLE
[#68877] Render a ProgressBar with subitem status for Portfolios

### DIFF
--- a/app/components/_index.sass
+++ b/app/components/_index.sass
@@ -7,6 +7,7 @@
 @import "open_project/common/attribute_label_component"
 @import "open_project/common/submenu_component"
 @import "open_project/common/main_menu_toggle_component"
+@import "portfolios/details_component"
 @import "projects/row_component"
 @import "projects/phases/hover_card_component"
 @import "projects/wizard/page_component"

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -88,6 +88,19 @@
           )
         end
 
+        if render_subportfolios?
+          footer.with_column(mr: 3) do
+            render(
+              Primer::Beta::Octicon.new(
+                icon: workspace_icon("portfolio"),
+                align_self: :center,
+                "aria-label": t("portfolio.count", count: all_subportfolios.count),
+                mr: 1
+              )
+            ) + content_tag(:span, t("portfolio.count", count: all_subportfolios.count))
+          end
+        end
+
         footer.with_column(mr: 3) do
           render(
             Primer::Beta::Octicon.new(

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -14,7 +14,7 @@
           end
         end
 
-        header.with_column do
+        header.with_column(mr: 2) do
           render(
             Projects::StatusButtonComponent.new(
               user: @current_user,
@@ -25,7 +25,22 @@
           )
         end
 
-        # TODO: WP-68877 render progress bar
+        header.with_column(classes: "op-portfolios--progress") do
+          render(Primer::Beta::ProgressBar.new(size: :large)) do |bar|
+            sub_statuses_with_percentages.each do |status|
+              status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
+
+              bar.with_item(
+                percentage: status[:percentage],
+                bg: nil, # unset default color so that we can inject our own via CSS class
+                classes: "op-portfolios--sub-status #{helpers.project_status_css_class(status[:code])}",
+                aria: {
+                  label: status_label
+                }
+              )
+            end
+          end
+        end
       end
     end
 

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -47,7 +47,10 @@
                   aria: {
                     label: status_label
                   },
-                  test_selector: "op-portfolios--status-#{status[:code] || 'not_set'}"
+                  test_selector: "op-portfolios--status-#{status[:code] || 'not_set'}",
+                  data: {
+                    percentage: status[:percentage]
+                  }
                 )
               end
             end

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -2,7 +2,7 @@
   flex_layout do |flex|
     flex.with_row(mb: 2) do
       flex_layout(align_items: :center) do |header|
-        header.with_column(mr: 2) do
+        header.with_column do
           render(
             Primer::Beta::Link.new(
               classes: "portfolio-name",
@@ -14,7 +14,7 @@
           end
         end
 
-        header.with_column(mr: 2) do
+        header.with_column(ml: 2, mr: 2) do
           render(
             Projects::StatusButtonComponent.new(
               user: @current_user,
@@ -33,23 +33,25 @@
                 data: {
                   hover_card_trigger_target: "trigger",
                   hover_card_popover_id: sub_status_hover_card_id,
-                  test_selector: "op-portfolios--sub-status"
+                  test_selector: "op-portfolios--sub-status-bar"
                 }
               )
             ) do |bar|
               sub_statuses_with_percentages.each do |status|
-                status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
+                status => { code:, percentage: }
+
+                status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")
 
                 bar.with_item(
-                  percentage: status[:percentage],
+                  percentage:,
                   bg: nil, # unset default color so that we can inject our own via CSS class
-                  classes: "op-portfolios--sub-status #{helpers.project_status_css_class(status[:code])}",
+                  classes: "op-portfolios--sub-status #{helpers.project_status_css_class(code)}",
                   aria: {
                     label: status_label
                   },
-                  test_selector: "op-portfolios--status-#{status[:code] || 'not_set'}",
+                  test_selector: "op-portfolios--status-#{code || 'not_set'}",
                   data: {
-                    percentage: status[:percentage]
+                    percentage:
                   }
                 )
               end
@@ -164,32 +166,26 @@
           popover.with_column(mr: 3) do
             sub_item_count = sub_statuses_with_percentages.sum { |s| s[:count] }
 
-            concat(
-              render(Primer::Beta::Text.new(color: :muted, font_weight: :bold)) do
-                "#{sub_item_count} "
-              end
-            )
-
-            concat(
-              render(Primer::Beta::Text.new(color: :muted)) do
-                t("portfolios.index.sub_items", count: sub_item_count)
-              end
-            )
+            render(Primer::Beta::Text.new(color: :muted)) do
+              t("portfolios.index.sub_items_html", count: sub_item_count)
+            end
           end
 
           sub_statuses_with_percentages.each do |status|
-            status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
+            status => { code:, count: }
+
+            status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")
 
             popover.with_column(mr: 3, display: :flex) do
-              concat(content_tag(:span, class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(status[:code])}") { "" })
+              concat(content_tag(:span, class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(code)}") { "" })
               concat(
                 render(Primer::Beta::Text.new(ml: 2, font_weight: :bold)) do
-                  status[:count].to_s
+                  count.to_s
                 end
               )
               concat(
                 render(Primer::Beta::Text.new(ml: 1)) do
-                  status_label
+                  " #{status_label}"
                 end
               )
             end

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -25,7 +25,7 @@
           )
         end
 
-        if sub_statuses_with_percentages.any?
+        if render_sub_status_bar?
           header.with_column(classes: "op-portfolios--progress") do
             render(
               Primer::Beta::ProgressBar.new(
@@ -133,7 +133,7 @@
     end
 
     # Card that appears when hovering over the progress bar
-    if sub_statuses_with_percentages.any?
+    if render_sub_status_bar?
       flex.with_row(classes: "op-portfolios--popover-container") do
         flex_layout(
           classes: "op-portfolios--popover op-hover-card",

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -25,19 +25,29 @@
           )
         end
 
-        header.with_column(classes: "op-portfolios--progress") do
-          render(Primer::Beta::ProgressBar.new(size: :large)) do |bar|
-            sub_statuses_with_percentages.each do |status|
-              status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
-
-              bar.with_item(
-                percentage: status[:percentage],
-                bg: nil, # unset default color so that we can inject our own via CSS class
-                classes: "op-portfolios--sub-status #{helpers.project_status_css_class(status[:code])}",
-                aria: {
-                  label: status_label
+        if sub_statuses_with_percentages.any?
+          header.with_column(classes: "op-portfolios--progress") do
+            render(
+              Primer::Beta::ProgressBar.new(
+                size: :large,
+                data: {
+                  hover_card_trigger_target: "trigger",
+                  hover_card_popover_id: sub_status_hover_card_id
                 }
               )
+            ) do |bar|
+              sub_statuses_with_percentages.each do |status|
+                status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
+
+                bar.with_item(
+                  percentage: status[:percentage],
+                  bg: nil, # unset default color so that we can inject our own via CSS class
+                  classes: "op-portfolios--sub-status #{helpers.project_status_css_class(status[:code])}",
+                  aria: {
+                    label: status_label
+                  }
+                )
+              end
             end
           end
         end
@@ -115,6 +125,55 @@
             )
           ) do
             t(:label_updated_time, value: distance_of_time_in_words(Time.current, portfolio.updated_at))
+          end
+        end
+      end
+    end
+
+    # Card that appears when hovering over the progress bar
+    if sub_statuses_with_percentages.any?
+      flex.with_row(classes: "op-portfolios--popover-container") do
+        flex_layout(
+          classes: "op-portfolios--popover op-hover-card",
+          id: sub_status_hover_card_id,
+          popover: :auto,
+          data: {
+            hover_card_trigger_target: "card"
+          },
+          justify_content: :space_between
+        ) do |popover|
+          popover.with_column(mr: 3) do
+            sub_item_count = sub_statuses_with_percentages.sum { |s| s[:count] }
+
+            concat(
+              render(Primer::Beta::Text.new(color: :muted, font_weight: :bold)) do
+                "#{sub_item_count} "
+              end
+            )
+
+            concat(
+              render(Primer::Beta::Text.new(color: :muted)) do
+                t("portfolios.index.sub_items", count: sub_item_count)
+              end
+            )
+          end
+
+          sub_statuses_with_percentages.each do |status|
+            status_label = t("js.grid.widgets.project_status.#{status[:code] || 'not_set'}")
+
+            popover.with_column(mr: 3, display: :flex) do
+              concat(content_tag(:span, class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(status[:code])}") { "" })
+              concat(
+                render(Primer::Beta::Text.new(ml: 2, font_weight: :bold)) do
+                  status[:count].to_s
+                end
+              )
+              concat(
+                render(Primer::Beta::Text.new(ml: 1)) do
+                  status_label
+                end
+              )
+            end
           end
         end
       end

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -90,7 +90,7 @@
           )
         end
 
-        if render_subportfolios?
+        if has_subportfolios?
           footer.with_column(mr: 3) do
             render(
               Primer::Beta::Octicon.new(
@@ -177,7 +177,7 @@
             status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")
 
             popover.with_column(mr: 3, display: :flex) do
-              concat(content_tag(:span, class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(code)}") { "" })
+              concat(content_tag(:span, "", class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(code)}"))
               concat(
                 render(Primer::Beta::Text.new(ml: 2, font_weight: :bold)) do
                   count.to_s

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -32,7 +32,8 @@
                 size: :large,
                 data: {
                   hover_card_trigger_target: "trigger",
-                  hover_card_popover_id: sub_status_hover_card_id
+                  hover_card_popover_id: sub_status_hover_card_id,
+                  test_selector: "op-portfolios--sub-status"
                 }
               )
             ) do |bar|
@@ -45,7 +46,8 @@
                   classes: "op-portfolios--sub-status #{helpers.project_status_css_class(status[:code])}",
                   aria: {
                     label: status_label
-                  }
+                  },
+                  test_selector: "op-portfolios--status-#{status[:code] || 'not_set'}"
                 )
               end
             end
@@ -138,7 +140,8 @@
           id: sub_status_hover_card_id,
           popover: :auto,
           data: {
-            hover_card_trigger_target: "card"
+            hover_card_trigger_target: "card",
+            test_selector: "op-portfolios--hover-card-#{portfolio.id}"
           },
           justify_content: :space_between
         ) do |popover|

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -54,10 +54,29 @@ module Portfolios
       all_descendants.project
     end
 
+    def sub_statuses_with_percentages
+      return @status_percentage if @status_percentage
+
+      statuses = sub_statuses
+      total = statuses.values.sum
+
+      @status_percentage = statuses.map do |code, count|
+        percentage = ((count.to_f / total) * 100).round
+
+        { code:, count:, percentage: }
+      end
+    end
+
     private
 
     def all_descendants
       @all_descendants ||= portfolio.descendants.visible
+    end
+
+    def sub_statuses
+      @sub_statuses ||= all_descendants.where("workspace_type = ? OR workspace_type = ?", "project", "program")
+                                       .pluck(:status_code)
+                                       .tally
     end
   end
 end

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -46,6 +46,14 @@ module Portfolios
       @currently_favorited ||= portfolio.favorited?
     end
 
+    def render_subportfolios?
+      all_subportfolios.any?
+    end
+
+    def all_subportfolios
+      all_descendants.portfolio
+    end
+
     def all_subprograms
       all_descendants.program
     end

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -69,16 +69,16 @@ module Portfolios
     end
 
     def sub_statuses_with_percentages
-      return @status_percentage if @status_percentage.present?
+      @sub_statuses_with_percentages ||=
+        begin
+          total = sub_statuses.values.sum
 
-      statuses = sub_statuses
-      total = statuses.values.sum
+          sub_statuses.map do |code, count|
+            percentage = (count.fdiv(total) * 100).round
 
-      @status_percentage = statuses.map do |code, count|
-        percentage = ((count.to_f / total) * 100).round
-
-        { code:, count:, percentage: }
-      end
+            { code:, count:, percentage: }
+          end
+        end
     end
 
     def sub_status_hover_card_id
@@ -92,7 +92,8 @@ module Portfolios
     end
 
     def sub_statuses
-      @sub_statuses ||= all_descendants.reorder(:status_code)
+      @sub_statuses ||= all_descendants
+                          .reorder(:status_code)
                           .pluck(:status_code)
                           .tally
     end

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -46,8 +46,8 @@ module Portfolios
       @currently_favorited ||= portfolio.favorited?
     end
 
-    def render_subportfolios?
-      all_subportfolios.any?
+    def has_subportfolios?
+      all_subportfolios.present?
     end
 
     def all_subportfolios
@@ -74,7 +74,7 @@ module Portfolios
           total = sub_statuses.values.sum
 
           sub_statuses.map do |code, count|
-            percentage = (count.fdiv(total) * 100).round
+            percentage = (count.fdiv(total) * 100).round(1)
 
             { code:, count:, percentage: }
           end

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -54,6 +54,12 @@ module Portfolios
       all_descendants.project
     end
 
+    def render_sub_status_bar?
+      # When none of the descendants have a status set, there's nothing to show and we
+      # will return false.
+      sub_statuses.keys.any?(&:present?)
+    end
+
     def sub_statuses_with_percentages
       return @status_percentage if @status_percentage
 

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -67,6 +67,10 @@ module Portfolios
       end
     end
 
+    def sub_status_hover_card_id
+      "portfolio-progress-hover-card-#{portfolio.id}"
+    end
+
     private
 
     def all_descendants

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -61,7 +61,7 @@ module Portfolios
     end
 
     def sub_statuses_with_percentages
-      return @status_percentage if @status_percentage
+      return @status_percentage if @status_percentage.present?
 
       statuses = sub_statuses
       total = statuses.values.sum
@@ -84,8 +84,9 @@ module Portfolios
     end
 
     def sub_statuses
-      @sub_statuses ||= all_descendants.pluck(:status_code)
-                                       .tally
+      @sub_statuses ||= all_descendants.reorder(:status_code)
+                          .pluck(:status_code)
+                          .tally
     end
   end
 end

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -84,8 +84,7 @@ module Portfolios
     end
 
     def sub_statuses
-      @sub_statuses ||= all_descendants.where("workspace_type = ? OR workspace_type = ?", "project", "program")
-                                       .pluck(:status_code)
+      @sub_statuses ||= all_descendants.pluck(:status_code)
                                        .tally
     end
   end

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -1,12 +1,10 @@
-// Color variables copied from _project_status.sass
-// We should properly import them instead.
-$project-status_not-set: var(--fgColor-subtle, var(--color-subtle-fg))
-$project-status_off-track: var(--fgColor-danger, var(--color-danger-fg))
-$project-status_at-risk: var(--fgColor-severe, var(--color-severe-fg))
-$project-status_on-track: var(--fgColor-success, var(--color-success-fg))
-$project-status_discontinued: var(--fgColor-attention, var(--color-attention-fg))
-$project-status_not-started: var(--fgColor-accent, var(--fgColor-accent))
-$project-status_finished: var(--fgColor-done, var(--color-done-fg))
+$status_not-set: var(--progressBar-track-bgColor) // invisible background color
+$status_off-track: var(--fgColor-danger)
+$status_at-risk: var(--fgColor-severe)
+$status_on-track: var(--fgColor-success)
+$status_discontinued: var(--fgColor-attention)
+$status_not-started: var(--fgColor-accent)
+$status_finished: var(--fgColor-done)
 
 .op-portfolios
 
@@ -17,16 +15,37 @@ $project-status_finished: var(--fgColor-done, var(--color-done-fg))
 
   &--sub-status
     &.-not-set
-      background-color: $project-status_not-set
+      background-color: $status_not-set
     &.-off-track
-      background-color: $project-status_off-track
+      background-color: $status_off-track
     &.-at-risk
-      background-color: $project-status_at-risk
+      background-color: $status_at-risk
     &.-on-track
-      background-color: $project-status_on_track
+      background-color: $status_on_track
     &.-not-started
-      background-color: $project-status_not_started
+      background-color: $status_not_started
     &.-finished
-      background-color: $project-status_finished
+      background-color: $status_finished
     &.-discontinued
-      background-color: $project-status_discontinued
+      background-color: $status_discontinued
+
+  &--popover
+    width: fit-content
+
+    .op-bubble
+      margin: auto
+
+      &.-not-set
+        background-color: $status_not-set
+      &.-off-track
+        background-color: $status_off-track
+      &.-at-risk
+        background-color: $status_at-risk
+      &.-on-track
+        background-color: $status_on_track
+      &.-not-started
+        background-color: $status_not_started
+      &.-finished
+        background-color: $status_finished
+      &.-discontinued
+        background-color: $status_discontinued

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -3,14 +3,14 @@ $status_not-set: var(--progressBar-track-bgColor) // invisible background color
 @mixin portfolio-sub-item-status-background-color
   &.-not-set
     background-color: $status_not-set
-  &.-off-track
-    background-color: $project-status_off-track
+  &.-on-track
+    background-color: $project-status_on-track
   &.-at-risk
     background-color: $project-status_at-risk
-  &.-on-track
-    background-color: $project-status_on_track
+  &.-off-track
+    background-color: $project-status_off-track
   &.-not-started
-    background-color: $project-status_not_started
+    background-color: $project-status_not-started
   &.-finished
     background-color: $project-status_finished
   &.-discontinued

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -1,0 +1,32 @@
+// Color variables copied from _project_status.sass
+// We should properly import them instead.
+$project-status_not-set: var(--fgColor-subtle, var(--color-subtle-fg))
+$project-status_off-track: var(--fgColor-danger, var(--color-danger-fg))
+$project-status_at-risk: var(--fgColor-severe, var(--color-severe-fg))
+$project-status_on-track: var(--fgColor-success, var(--color-success-fg))
+$project-status_discontinued: var(--fgColor-attention, var(--color-attention-fg))
+$project-status_not-started: var(--fgColor-accent, var(--fgColor-accent))
+$project-status_finished: var(--fgColor-done, var(--color-done-fg))
+
+.op-portfolios
+
+  &--progress
+    flex-basis: 25%
+    max-width: 300px
+    margin-left: auto
+
+  &--sub-status
+    &.-not-set
+      background-color: $project-status_not-set
+    &.-off-track
+      background-color: $project-status_off-track
+    &.-at-risk
+      background-color: $project-status_at-risk
+    &.-on-track
+      background-color: $project-status_on_track
+    &.-not-started
+      background-color: $project-status_not_started
+    &.-finished
+      background-color: $project-status_finished
+    &.-discontinued
+      background-color: $project-status_discontinued

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -1,51 +1,39 @@
 $status_not-set: var(--progressBar-track-bgColor) // invisible background color
-$status_off-track: var(--fgColor-danger)
-$status_at-risk: var(--fgColor-severe)
-$status_on-track: var(--fgColor-success)
-$status_discontinued: var(--fgColor-attention)
-$status_not-started: var(--fgColor-accent)
-$status_finished: var(--fgColor-done)
+
+@mixin portfolio-sub-item-status-background-color
+  &.-not-set
+    background-color: $status_not-set
+  &.-off-track
+    background-color: $project-status_off-track
+  &.-at-risk
+    background-color: $project-status_at-risk
+  &.-on-track
+    background-color: $project-status_on_track
+  &.-not-started
+    background-color: $project-status_not_started
+  &.-finished
+    background-color: $project-status_finished
+  &.-discontinued
+    background-color: $project-status_discontinued
 
 .op-portfolios
-
   &--progress
     flex-basis: 25%
     max-width: 300px
     margin-left: auto
 
+    @media screen and (max-width: $breakpoint-sm)
+      display: none
+
   &--sub-status
-    &.-not-set
-      background-color: $status_not-set
-    &.-off-track
-      background-color: $status_off-track
-    &.-at-risk
-      background-color: $status_at-risk
-    &.-on-track
-      background-color: $status_on_track
-    &.-not-started
-      background-color: $status_not_started
-    &.-finished
-      background-color: $status_finished
-    &.-discontinued
-      background-color: $status_discontinued
+    @include portfolio-sub-item-status-background-color
 
   &--popover
     width: fit-content
+    max-width: 550px
+    flex-wrap: wrap
+    row-gap: var(--base-size-16, 1rem)
 
     .op-bubble
       margin: auto
-
-      &.-not-set
-        background-color: $status_not-set
-      &.-off-track
-        background-color: $status_off-track
-      &.-at-risk
-        background-color: $status_at-risk
-      &.-on-track
-        background-color: $status_on_track
-      &.-not-started
-        background-color: $status_not_started
-      &.-finished
-        background-color: $status_finished
-      &.-discontinued
-        background-color: $status_discontinued
+      @include portfolio-sub-item-status-background-color

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -497,9 +497,9 @@ en:
       search:
         label: Portfolio name filter
         placeholder: Search portfolios
-      sub_items:
-        one: "sub-item"
-        other: "sub-items"
+      sub_items_html:
+        one: "<strong>1</strong> sub-item"
+        other: "<strong>%{count}</strong> sub-items"
     lists:
       active: "Active portfolios"
       my: "My portfolios"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4191,6 +4191,12 @@ en:
   placeholders:
     default: "-"
 
+  portfolio:
+    count:
+      zero: "0 portfolios"
+      one: "1 portfolio"
+      other: "%{count} portfolios"
+
   program:
     count:
       zero: "0 programs"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -497,6 +497,9 @@ en:
       search:
         label: Portfolio name filter
         placeholder: Search portfolios
+      sub_items:
+        one: "sub-item"
+        other: "sub-items"
     lists:
       active: "Active portfolios"
       my: "My portfolios"

--- a/frontend/src/global_styles/common/bubble/bubble.sass
+++ b/frontend/src/global_styles/common/bubble/bubble.sass
@@ -4,6 +4,9 @@
   &_alt_highlighting
     background: #878787
 
+  &_squared
+    padding: 0
+
   &_mini
     width: 12px
     height: 12px

--- a/frontend/src/global_styles/content/_hover_cards.sass
+++ b/frontend/src/global_styles/content/_hover_cards.sass
@@ -49,6 +49,8 @@
   padding: var(--overlay-paddingBlock-normal)
   border-radius: var(--overlay-borderRadius)
   opacity: 0
+  visibility: hidden
 
   &:popover-open
     opacity: 1
+    visibility: visible

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -38,7 +38,7 @@ import { computePosition, flip, limitShift, shift } from '@floating-ui/dom';
  * You can define a trigger element by adding the `data-hover-card-trigger-target="trigger"` to it.
  * To have hover cards available everywhere, add this controller to the body tag.
  *
- * TODO: insert instructions of how to use hover cards without a turbo frame. Also update lookbook.
+ * Please see our guide in the lookbook for more information on how to use hover cards.
  */
 export default class HoverCardTriggerController extends ApplicationController {
   static targets = ['trigger', 'card'];

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -128,7 +128,6 @@ export default class HoverCardTriggerController extends ApplicationController {
     if (!this.triggerTargets.some((trigger) => trigger === el)) {
       // If the element is not a trigger itself, one of its parents must be. Find the correct one.
       const trigger = el.closest('[data-hover-card-trigger-target="trigger"]')!;
-      if (!trigger) { return; }
 
       el = trigger as HTMLElement;
     }

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -37,6 +37,8 @@ import { computePosition, flip, limitShift, shift } from '@floating-ui/dom';
  *
  * You can define a trigger element by adding the `data-hover-card-trigger-target="trigger"` to it.
  * To have hover cards available everywhere, add this controller to the body tag.
+ *
+ * TODO: insert instructions of how to use hover cards without a turbo frame. Also update lookbook.
  */
 export default class HoverCardTriggerController extends ApplicationController {
   static targets = ['trigger', 'card'];
@@ -48,6 +50,8 @@ export default class HoverCardTriggerController extends ApplicationController {
   private hoverTimeout:number|null = null;
   private closeTimeout:number|null = null;
   private previousTarget:HTMLElement|null = null;
+
+  private staticPopover:HTMLElement|null = null;
 
   // Track whether we currently show a hover card or not. It is important not to open multiple hover cards at
   // the same time, and refrain from closing the wrong kind of modal overlay.
@@ -123,10 +127,10 @@ export default class HoverCardTriggerController extends ApplicationController {
     // the original trigger as this makes event and state handling easier. Find the correct target element:
     if (!this.triggerTargets.some((trigger) => trigger === el)) {
       // If the element is not a trigger itself, one of its parents must be. Find the correct one.
-      const trigger = el.closest('[data-hover-card-trigger-target="trigger"]') as HTMLElement;
+      const trigger = el.closest('[data-hover-card-trigger-target="trigger"]')!;
       if (!trigger) { return; }
 
-      el = trigger;
+      el = trigger as HTMLElement;
     }
 
     this.mouseIsHoveringOverTrigger = true;
@@ -142,7 +146,8 @@ export default class HoverCardTriggerController extends ApplicationController {
     this.close(true);
 
     const turboFrameUrl = this.parseHoverCardUrl(el);
-    if (!turboFrameUrl) { return; }
+    const popoverEl = this.getPopoverFromId(el);
+    if (!turboFrameUrl && !popoverEl) { return; }
 
     // Reset close timer for when hovering over multiple triggers in quick succession.
     // A timer from a previous hover card might still be running. We do not want it to
@@ -151,22 +156,26 @@ export default class HoverCardTriggerController extends ApplicationController {
 
     // Set a delay before showing the hover card
     this.hoverTimeout = window.setTimeout(() => {
-      this.showHoverCard(el, turboFrameUrl);
+      this.showHoverCard(el, turboFrameUrl, popoverEl);
     }, this.OPEN_DELAY_IN_MS);
   }
 
-  private showHoverCard(el:HTMLElement, turboFrameUrl:string) {
-    // Abort if the element is no longer present in the DOM. This can happen when this method is called after a delay.
+  private showHoverCard(el:HTMLElement, turboFrameUrl:string, popoverElement:HTMLElement|null) {
+    // Abort if the trigger element is no longer present in the DOM. This can happen when this method is called after a delay.
     if (!this.element.contains(el)) { return; }
     // Do not try to show two hover cards at the same time.
     if (this.isShowingHoverCard) { return; }
     // The mouse might have left the trigger while we were waiting for the hover delay.
     if (!this.mouseIsHoveringOverTrigger) { return; }
 
-    this.loadAndShowHoverCard(el, turboFrameUrl);
+    if (popoverElement) {
+      this.showExistingPopover(el, popoverElement);
+    } else {
+      this.loadAndShowHoverCardViaTurboFrame(el, turboFrameUrl);
+    }
   }
 
-  private loadAndShowHoverCard(targetEl:HTMLElement, turboFrameUrl:string) {
+  private loadAndShowHoverCardViaTurboFrame(targetEl:HTMLElement, turboFrameUrl:string) {
     const overlay = this.getAndResetOverlay();
     if (!overlay) { return; }
 
@@ -183,6 +192,17 @@ export default class HoverCardTriggerController extends ApplicationController {
       // Content has been loaded, card has been positioned. Show it!
       popover.showPopover();
     });
+  }
+
+  private showExistingPopover(targetEl:HTMLElement, popover:HTMLElement) {
+    this.getAndResetOverlay();
+
+    this.staticPopover = popover;
+    this.isShowingHoverCard = true;
+    this.previousTarget = targetEl;
+
+    void this.reposition(popover, targetEl);
+    popover.showPopover();
   }
 
   // Should be called when the mouse leaves the hover-zone so that we no longer attempt to display the hover card.
@@ -213,6 +233,9 @@ export default class HoverCardTriggerController extends ApplicationController {
 
     if (this.isShowingHoverCard && !this.mouseInModal) {
       this.getAndResetOverlay();
+
+      this.staticPopover?.hidePopover();
+      this.staticPopover = null;
 
       this.isShowingHoverCard = false;
       // Allow opening this target once more, since it has been orderly closed
@@ -246,6 +269,13 @@ export default class HoverCardTriggerController extends ApplicationController {
     // `sanitizeUrl` will return 'about:blank' for invalid URLs. We will return an empty-string instead since
     // there's no reason to show an empty hover card.
     return url === 'about:blank' ? '' : url;
+  }
+
+  private getPopoverFromId(el:HTMLElement):HTMLElement|null {
+    const id = el.getAttribute('data-hover-card-popover-id');
+    if (!id) { return null; }
+
+    return document.getElementById(id);
   }
 
   private async reposition(element:HTMLElement, target:HTMLElement) {

--- a/lookbook/docs/components/hover-cards.md.erb
+++ b/lookbook/docs/components/hover-cards.md.erb
@@ -1,4 +1,14 @@
-The HoverCard is a pattern related to the `Primer::Beta::Popover` and is used to show additional contextual information on certain kinds of resources like work packages and users. The hover card is opened by hovering over a certain trigger. When hovering outside of the card or its trigger, the popover is closed again.
+The HoverCard is a pattern related to the `Primer::Beta::Popover` and is used to show additional contextual information
+on certain kinds of resources like work packages and users. The hover card is opened by hovering over a certain trigger.
+
+When leaving the card or trigger, the popover is closed again. There is a grace period after leaving where the user
+may return to the card to keep it open. Users may also click outside the card or press the escape key to close it.
+
+It is possible to interact with the contents of a hover card. Placing links and buttons in there is possible,
+but keep in mind that hover cards are not ideal for complex interactions.
+
+Some devices do not support hovering detection, so hover cards will never work on all devices.
+Therefore, hover cards should only contain non-essential information.
 
 ## Overview
 
@@ -11,7 +21,8 @@ The HoverCard is a pattern related to the `Primer::Beta::Popover` and is used to
 The HoverCard always consists of two basic parts:
 
 1. A trigger: That can be anything that is hoverable, like a link or a chip
-2. The actual card: A small popover that is opened directly next to the trigger. The actual content of the card depends on the type of resource it is calling.
+2. The actual card: A small popover that is opened directly next to the trigger. The actual content of the card
+   can be defined as either a turbo frame provided by a controller - or an existing DOM element that is shown/hidden.
 
 ## Best practices
 
@@ -25,26 +36,44 @@ The HoverCard always consists of two basic parts:
 - WorkPackage preview when linking via `#ID`
 - User preview on usernames and avatars
 - Phase gate details on the phase gate icon
+- A legend for the contents of the portfolio module sub-item status chart
 
-## Technical notes
+## HoverCardTriggerController
 
-In the past, we could not easily use the `Primer::Beta::Popover` component. With recent changes, this is now possible.
-But it would require us to adjust the DOM of the hover card contents and the styling of the popover, so that it maintains its looks.
+This Stimulus controller does all the heavy-lifting for hover cards. It takes care of listening to hover events on
+trigger elements, fetching the content for the hover card (if necessary) and rendering it relative to the trigger.
+It also ensures that only one hover card is open at a time. It takes measures to make hover cards work on top of
+top-level dialogs.
+
+The controller is intended to be used globally and should thus be added to the body tag or another high-level element.
+
+To detect hover card opportunities, the controller looks for elements with the attribute
+`data-hover-card-trigger-target="trigger"`. When hovering over such an element, the controller will open a hover
+card for it. See the next section to see how to define the contents of a hover card.
+
+## Defining hover card contents
+
+A hover card is the popover that is shown when hovering over a trigger element.
+
+The content of a hover card can be defined in two ways:
+
+1. Via a turbo frame that is fetched from a URL. This is the preferred way if you want to lazily load the contents
+   of the hover card when needed.
+2. Via an existing DOM element that is present (but hidden) in the document on page load. This is useful when the
+   content is already present and no additional fetching is necessary.
 
 Essentially the `HoverCard` is just a div which renders inside a `turboFrame`.
 
-We have a `HoverCardTriggerController` that listens for hover events on elements with the attribute `data-hover-card-trigger-target="trigger"`
-and renders a hover card for that element when the mouse enters the trigger.
-Additionally, the trigger element needs to pass the URL for the `turboFrame` as a data attribute called `data-hover-card-url`.
+### Asynchronous hover cards via turbo frame
 
-When the hovering event is received, the `HoverCardTriggerController` will retrieve the data for the turbo frame from
-the URL and sanitize it. Then it will construct a div, create a turbo frame with the sanitized URL within it and
-append it to either the body or an existing dialog element. The final placement depends on the position of the trigger
-in the DOM.
+The element that defines the trigger (via `data-hover-card-trigger-target="trigger"`) must provide an attribute
+pointing to a URL that will return a turbo frame: `data-hover-card-url`
 
-The hover card will close automatically when the mouse leaves the trigger or the card itself.
+Usually, the URL will point to a Rails controller action that renders a turbo frame containing a component
+with the hover card contents.
 
-### Code structure
+The `HoverCardTriggerController` will take that turbo frame and construct a hover card for it, placing it next to the
+trigger element into the DOM.
 
 **Trigger**:
 ```html
@@ -68,7 +97,8 @@ The hover card will close automatically when the mouse leaves the trigger or the
   </body>
 ```
 
-Note that the user example is simplified. For actual use in the application, it is recommended to use the `AvatarComponent`, which offers an option for hover cards.
+Note that the user example is simplified. For actual use in the application, it is recommended to use the
+`AvatarComponent`, which offers an option for hover cards.
 
 **Actually rendered card content**:
 ```html
@@ -81,4 +111,44 @@ Note that the user example is simplified. For actual use in the application, it 
   <turbo-frame id="op-hover-card-body">
     &lt;%= render Users::HoverCardComponent.new(id: 14) %&gt;
   </turbo-frame>
+```
+
+### Static hover cards via existing DOM elements
+
+If the content of a hover card is already present in the DOM, it is possible to define hover cards contents by
+pointing to the ID of an existing element. To do so, you must provide the attribute `data-hover-card-popover-id` on the
+trigger element.
+
+**Trigger**:
+```html
+  <!-- important: make sure the controller is attached somewhere, preferably the body tag -->
+  <body data-controller="hover-card-trigger">
+
+    <!-- A hover card will be shown when hovering over this link: -->
+    <a href="work_packages/14/activity"
+       data-hover-card-popover-id="work-package-hover-card-14"
+       data-hover-card-trigger-target="trigger">
+      #14
+    </a>
+  </body>
+```
+The hover card content can be placed at a convenient place in the DOM. The following attributes must be set on the
+element to ensure it will be displayed correctly:
+
+1. `op-hover-card` class.
+2. A `popover` attribute set to `auto`.
+3. The ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
+
+On page load, the hover card will be hidden automatically. When hovering over the trigger, the hover card will be
+shown next to it.
+
+**Card content**:
+```html
+  <!-- Somewhere else in the DOM -->
+  <div class="op-hover-card"
+       id="work-package-hover-card-14"
+       popover="auto">
+
+    <p>Description text of work package 14!</p>
+  </div>
 ```

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
     portfolio.reload
 
-    portfolio.define_singleton_method(:favorited?) { false }
+    def portfolio.favorited?; false; end
   end
 
   describe "portfolio" do
@@ -102,8 +102,8 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
     context "when there are child portfolios" do
       before do
-        create(:portfolio, parent: portfolio, status_code: status_code_b).tap do |child_portfolio|
-          create(:program, parent: child_portfolio, status_code: status_code_b)
+        create(:portfolio, parent: portfolio).tap do |child_portfolio|
+          create(:program, parent: child_portfolio)
         end
 
         portfolio.reload
@@ -145,6 +145,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
           expect(subject).not_to have_test_selector("op-portfolios--status-#{status_code_b}")
+          expect(subject).to have_test_selector("op-portfolios--status-not_set")
         end
       end
 
@@ -154,6 +155,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_b}")
+          expect(subject).not_to have_test_selector("op-portfolios--status-not_set")
         end
       end
     end

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   let(:status_code_a) { "on_track" }
   let(:status_code_b) { "at_risk" }
   let!(:portfolio) { create(:portfolio, description: "portfolio description") }
-  let(:add_sub_items_to_portfolio) { true }
 
   current_user { user }
 
@@ -51,22 +50,20 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   end
 
   before do
-    if add_sub_items_to_portfolio
-      create(:program, parent: portfolio, status_code: status_code_a).tap do |program_a|
-        create(:project, parent: program_a, status_code: status_code_a).tap do |project_a|
-          create(:project, parent: project_a, status_code: status_code_b)
-        end
+    create(:program, parent: portfolio, status_code: status_code_a).tap do |program_a|
+      create(:project, parent: program_a, status_code: status_code_a).tap do |project_a|
+        create(:project, parent: project_a, status_code: status_code_b)
       end
-
-      create(:program, parent: portfolio, status_code: status_code_b).tap do |program_b|
-        create(:project, parent: program_b, status_code: status_code_b)
-        create(:project, parent: program_b, status_code: status_code_a)
-      end
-
-      create(:project, parent: portfolio, status_code: status_code_a)
-
-      portfolio.reload
     end
+
+    create(:program, parent: portfolio, status_code: status_code_b).tap do |program_b|
+      create(:project, parent: program_b, status_code: status_code_b)
+      create(:project, parent: program_b, status_code: status_code_a)
+    end
+
+    create(:project, parent: portfolio, status_code: status_code_a)
+
+    portfolio.reload
 
     portfolio.define_singleton_method(:favorited?) { false }
   end
@@ -110,19 +107,32 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
     end
 
     describe "sub-item status" do
-      context "when there are no sub-items" do
-        let(:add_sub_items_to_portfolio) { false }
-        let(:portfolio) { create(:portfolio) }
+      context "when none of the sub-items has a status" do
+        let(:status_code_a) { nil }
+        let(:status_code_b) { nil }
 
         it "does not render a progress bar" do
-          expect(portfolio.descendants.count).to eq(0)
           expect(subject).not_to have_test_selector("op-portfolios--sub-status")
         end
       end
 
       context "when some of the sub-items have a status set" do
+        let(:status_code_b) { nil }
+
         it "renders a progress bar detailing the status of child programs and projects" do
           expect(subject).to have_test_selector("op-portfolios--sub-status")
+
+          expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
+          expect(subject).not_to have_test_selector("op-portfolios--status-#{status_code_b}")
+        end
+      end
+
+      context "when all of the sub-items have a status set" do
+        it "renders a progress bar detailing the status of child programs and projects" do
+          expect(subject).to have_test_selector("op-portfolios--sub-status")
+
+          expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
+          expect(subject).to have_test_selector("op-portfolios--status-#{status_code_b}")
         end
       end
     end

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -39,26 +39,10 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   end
 
   let(:user) { create(:admin) }
-
-  shared_let(:portfolio) do
-    create(:portfolio,
-           description: "portfolio description") do |portfolio|
-      create(:project, parent: portfolio)
-    end
-  end
-  shared_let(:program_a) do
-    create(:program, parent: portfolio) do |program_a|
-      create(:project, parent: program_a) do |project_a|
-        create(:project, parent: project_a)
-      end
-    end
-  end
-  shared_let(:program_b) do
-    create(:program, parent: portfolio) do |program_b|
-      create(:project, parent: program_b)
-      create(:project, parent: program_b)
-    end
-  end
+  let(:status_code_a) { "on_track" }
+  let(:status_code_b) { "at_risk" }
+  let!(:portfolio) { create(:portfolio, description: "portfolio description") }
+  let(:add_sub_items_to_portfolio) { true }
 
   current_user { user }
 
@@ -67,6 +51,23 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   end
 
   before do
+    if add_sub_items_to_portfolio
+      create(:program, parent: portfolio, status_code: status_code_a).tap do |program_a|
+        create(:project, parent: program_a, status_code: status_code_a).tap do |project_a|
+          create(:project, parent: project_a, status_code: status_code_b)
+        end
+      end
+
+      create(:program, parent: portfolio, status_code: status_code_b).tap do |program_b|
+        create(:project, parent: program_b, status_code: status_code_b)
+        create(:project, parent: program_b, status_code: status_code_a)
+      end
+
+      create(:project, parent: portfolio, status_code: status_code_a)
+
+      portfolio.reload
+    end
+
     portfolio.define_singleton_method(:favorited?) { false }
   end
 
@@ -105,6 +106,24 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
       it "shows when the portfolio was last updated" do
         expect(subject).to have_test_selector("op-portfolios--updated-at", text: "Updated about 1 month ago")
+      end
+    end
+
+    describe "sub-item status" do
+      context "when there are no sub-items" do
+        let(:add_sub_items_to_portfolio) { false }
+        let(:portfolio) { create(:portfolio) }
+
+        it "does not render a progress bar" do
+          expect(portfolio.descendants.count).to eq(0)
+          expect(subject).not_to have_test_selector("op-portfolios--sub-status")
+        end
+      end
+
+      context "when some of the sub-items have a status set" do
+        it "renders a progress bar detailing the status of child programs and projects" do
+          expect(subject).to have_test_selector("op-portfolios--sub-status")
+        end
       end
     end
   end

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
         let(:status_code_b) { nil }
 
         it "does not render a progress bar" do
-          expect(subject).not_to have_test_selector("op-portfolios--sub-status")
+          expect(subject).not_to have_test_selector("op-portfolios--sub-status-bar")
         end
       end
 
@@ -120,7 +120,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
         let(:status_code_b) { nil }
 
         it "renders a progress bar detailing the status of child programs and projects" do
-          expect(subject).to have_test_selector("op-portfolios--sub-status")
+          expect(subject).to have_test_selector("op-portfolios--sub-status-bar")
 
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
           expect(subject).not_to have_test_selector("op-portfolios--status-#{status_code_b}")
@@ -129,7 +129,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
       context "when all of the sub-items have a status set" do
         it "renders a progress bar detailing the status of child programs and projects" do
-          expect(subject).to have_test_selector("op-portfolios--sub-status")
+          expect(subject).to have_test_selector("op-portfolios--sub-status-bar")
 
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_a}")
           expect(subject).to have_test_selector("op-portfolios--status-#{status_code_b}")

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -91,9 +91,30 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
       end
     end
 
-    describe "displays the number of child programs and projects" do
-      it { expect(subject).to have_text("2 programs") }
-      it { expect(subject).to have_text("5 projects") }
+    context "when there are no child portfolios" do
+      describe "displays the number of child programs and projects" do
+        it { expect(subject).to have_text("2 programs") }
+        it { expect(subject).to have_text("5 projects") }
+
+        it { expect(subject).to have_no_text("0 portfolios") }
+      end
+    end
+
+    context "when there are child portfolios" do
+      before do
+        create(:portfolio, parent: portfolio, status_code: status_code_b).tap do |child_portfolio|
+          create(:program, parent: child_portfolio, status_code: status_code_b)
+        end
+
+        portfolio.reload
+      end
+
+      describe "displays the number of child programs and projects, including portfolios" do
+        it { expect(subject).to have_text("3 programs") }
+        it { expect(subject).to have_text("5 projects") }
+
+        it { expect(subject).to have_text("1 portfolio") }
+      end
     end
 
     describe "#updated_at" do

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Portfolios", "index", :js do
   let!(:portfolio_a) { create(:portfolio, name: "Portfolio A") }
+  let!(:portfolio_b) { create(:portfolio, name: "Portfolio B") }
   let!(:portfolio_favorited) { create(:portfolio, name: "Favorited") }
   let!(:inactive_portfolio) { create(:portfolio, name: "Inactive", active: false) }
 
@@ -54,6 +55,11 @@ RSpec.describe "Portfolios", "index", :js do
       create(:project, parent: program_a, status_code: "on_track")
     end
 
+    create(:portfolio, parent: portfolio_b, status_code: "discontinued").tap do |portfolio_b_child|
+      create(:project, parent: portfolio_b_child, status_code: "not_started")
+      create(:project, parent: portfolio_b_child)
+    end
+
     portfolios_page.visit!
   end
 
@@ -62,7 +68,7 @@ RSpec.describe "Portfolios", "index", :js do
       expect(page).to have_title("Portfolios")
       portfolios_page.expect_title("Active portfolios")
 
-      portfolios_page.expect_portfolios_listed(portfolio_a, portfolio_favorited)
+      portfolios_page.expect_portfolios_listed(portfolio_a, portfolio_b, portfolio_favorited)
       portfolios_page.expect_portfolios_not_listed(inactive_portfolio)
 
       portfolios_page.within_row(portfolio_a) do
@@ -71,6 +77,7 @@ RSpec.describe "Portfolios", "index", :js do
 
         expect(page).to have_text("2 projects")
         expect(page).to have_text("1 program")
+        expect(page).to have_no_text("0 portfolios")
       end
     end
 
@@ -96,7 +103,7 @@ RSpec.describe "Portfolios", "index", :js do
       end
 
       it "only lists visible portfolios" do
-        portfolios_page.expect_portfolios_not_listed(inactive_portfolio, portfolio_favorited)
+        portfolios_page.expect_portfolios_not_listed(inactive_portfolio, portfolio_b, portfolio_favorited)
       end
     end
 
@@ -117,17 +124,17 @@ RSpec.describe "Portfolios", "index", :js do
       click_on "Favorite portfolios"
       portfolios_page.expect_title("Favorite portfolios")
       portfolios_page.expect_portfolios_listed(portfolio_favorited)
-      portfolios_page.expect_portfolios_not_listed(portfolio_a, inactive_portfolio)
+      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, inactive_portfolio)
 
       click_on "My portfolios"
       portfolios_page.expect_title("My portfolios")
       portfolios_page.expect_portfolios_listed(portfolio_a)
-      portfolios_page.expect_portfolios_not_listed(portfolio_favorited, inactive_portfolio)
+      portfolios_page.expect_portfolios_not_listed(portfolio_favorited, portfolio_b, inactive_portfolio)
 
       click_on "Archived portfolios"
       portfolios_page.expect_title("Archived portfolios")
       portfolios_page.expect_portfolios_listed(inactive_portfolio)
-      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_favorited)
+      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, portfolio_favorited)
     end
 
     it "allows you to favorite and unfavorite portfolios" do
@@ -149,13 +156,13 @@ RSpec.describe "Portfolios", "index", :js do
     it "lets you apply filters" do
       portfolios_page.filter_by_name_and_identifier("Favorited")
       portfolios_page.expect_portfolios_listed(portfolio_favorited)
-      portfolios_page.expect_portfolios_not_listed(portfolio_a, inactive_portfolio)
+      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, inactive_portfolio)
       page.find_by_id("portfolio-filters-form-clear-button").click
 
       portfolios_page.toggle_filters_section
       portfolios_page.filter_by_active("no")
       portfolios_page.expect_portfolios_listed(inactive_portfolio)
-      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_favorited)
+      portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, portfolio_favorited)
     end
 
     it "allows seeing and changing the portfolio status" do
@@ -187,6 +194,25 @@ RSpec.describe "Portfolios", "index", :js do
           expect(page).not_to have_test_selector(hover_card_selector)
           page.find_test_selector("op-portfolios--sub-status-bar").hover
           expect(page).to have_test_selector(hover_card_selector)
+        end
+
+        # Portfolio B has a child portfolio of its own:
+        portfolios_page.within_row(portfolio_b) do
+          expect(page).to have_text("1 portfolio")
+          expect(page).to have_text("0 programs")
+          expect(page).to have_text("2 projects")
+
+          expect(page).to have_test_selector("op-portfolios--sub-status-bar")
+
+          # Status of the child portfolio
+          discontinued = page.find_test_selector("op-portfolios--status-discontinued")
+          discontinued_percentage = discontinued["data-percentage"]
+          expect(discontinued_percentage).to eq("33")
+
+          # Status of a child project
+          not_started = page.find_test_selector("op-portfolios--status-not_started")
+          not_started_percentage = not_started["data-percentage"]
+          expect(not_started_percentage).to eq("33")
         end
       end
 

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "Portfolios", "index", :js do
     describe "status of sub-items" do
       it "shows the status summary of sub-items" do
         portfolios_page.within_row(portfolio_a) do
-          expect(page).to have_test_selector("op-portfolios--sub-status")
+          expect(page).to have_test_selector("op-portfolios--sub-status-bar")
 
           # It renders the correct percentages per status:
           on_track = page.find_test_selector("op-portfolios--status-on_track")
@@ -185,14 +185,14 @@ RSpec.describe "Portfolios", "index", :js do
           # The status bar shows a hover card on hover:
           hover_card_selector = "op-portfolios--hover-card-#{portfolio_a.id}"
           expect(page).not_to have_test_selector(hover_card_selector)
-          page.find_test_selector("op-portfolios--sub-status").hover
+          page.find_test_selector("op-portfolios--sub-status-bar").hover
           expect(page).to have_test_selector(hover_card_selector)
         end
       end
 
       it "does not show a status summary if no sub-item has a status" do
         portfolios_page.within_row(portfolio_favorited) do
-          expect(page).not_to have_test_selector("op-portfolios--sub-status")
+          expect(page).not_to have_test_selector("op-portfolios--sub-status-bar")
         end
       end
     end

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -183,11 +183,11 @@ RSpec.describe "Portfolios", "index", :js do
           # It renders the correct percentages per status:
           on_track = page.find_test_selector("op-portfolios--status-on_track")
           on_track_percentage = on_track["data-percentage"]
-          expect(on_track_percentage).to eq("67")
+          expect(on_track_percentage).to eq("66.7")
 
           at_risk = page.find_test_selector("op-portfolios--status-at_risk")
           at_risk_percentage = at_risk["data-percentage"]
-          expect(at_risk_percentage).to eq("33")
+          expect(at_risk_percentage).to eq("33.3")
 
           # The status bar shows a hover card on hover:
           hover_card_selector = "op-portfolios--hover-card-#{portfolio_a.id}"
@@ -203,21 +203,22 @@ RSpec.describe "Portfolios", "index", :js do
           expect(page).to have_text("2 projects")
 
           expect(page).to have_test_selector("op-portfolios--sub-status-bar")
-
-          # Status of the child portfolio
-          discontinued = page.find_test_selector("op-portfolios--status-discontinued")
-          discontinued_percentage = discontinued["data-percentage"]
-          expect(discontinued_percentage).to eq("33")
-
-          # Status of a child project
-          not_started = page.find_test_selector("op-portfolios--status-not_started")
-          not_started_percentage = not_started["data-percentage"]
-          expect(not_started_percentage).to eq("33")
         end
+
+        # Status of the child portfolio
+        portfolios_page.expect_status_bar_percentage(portfolio_b, "discontinued", "33.3")
+        # Status of a child project
+        portfolios_page.expect_status_bar_percentage(portfolio_b, "not_started", "33.3")
+        portfolios_page.expect_status_bar_percentage(portfolio_b, "not_set", "33.3")
       end
 
       it "does not show a status summary if no sub-item has a status" do
+        # Statusless sub-item:
+        create(:project, parent: portfolio_favorited)
+        portfolios_page.visit!
+
         portfolios_page.within_row(portfolio_favorited) do
+          expect(page).to have_text("1 project")
           expect(page).not_to have_test_selector("op-portfolios--sub-status-bar")
         end
       end

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe "Portfolios", "index", :js do
 
   before do
     create(:favorite, user: current_user, favorited: portfolio_favorited)
-    create(:project, parent: portfolio_a)
-    create(:program, parent: portfolio_a).tap do |program_a|
-      create(:project, parent: program_a)
+    create(:project, parent: portfolio_a, status_code: "on_track")
+    create(:program, parent: portfolio_a, status_code: "at_risk").tap do |program_a|
+      create(:project, parent: program_a, status_code: "on_track")
     end
 
     portfolios_page.visit!
@@ -158,7 +158,7 @@ RSpec.describe "Portfolios", "index", :js do
       portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_favorited)
     end
 
-    it "allows seeing and changing the status" do
+    it "allows seeing and changing the portfolio status" do
       portfolios_page.expect_status_of(portfolio_a, "Not set")
       portfolios_page.expect_status_of(portfolio_favorited, "Not set")
 
@@ -166,6 +166,35 @@ RSpec.describe "Portfolios", "index", :js do
 
       portfolios_page.expect_status_of(portfolio_favorited, "At risk")
       portfolios_page.expect_status_of(portfolio_a, "Not set")
+    end
+
+    describe "status of sub-items" do
+      it "shows the status summary of sub-items" do
+        portfolios_page.within_row(portfolio_a) do
+          expect(page).to have_test_selector("op-portfolios--sub-status")
+
+          # It renders the correct percentages per status:
+          on_track = page.find_test_selector("op-portfolios--status-on_track")
+          on_track_percentage = on_track["data-percentage"]
+          expect(on_track_percentage).to eq("67")
+
+          at_risk = page.find_test_selector("op-portfolios--status-at_risk")
+          at_risk_percentage = at_risk["data-percentage"]
+          expect(at_risk_percentage).to eq("33")
+
+          # The status bar shows a hover card on hover:
+          hover_card_selector = "op-portfolios--hover-card-#{portfolio_a.id}"
+          expect(page).not_to have_test_selector(hover_card_selector)
+          page.find_test_selector("op-portfolios--sub-status").hover
+          expect(page).to have_test_selector(hover_card_selector)
+        end
+      end
+
+      it "does not show a status summary if no sub-item has a status" do
+        portfolios_page.within_row(portfolio_favorited) do
+          expect(page).not_to have_test_selector("op-portfolios--sub-status")
+        end
+      end
     end
 
     context "when using the more menu" do

--- a/spec/support/pages/portfolios/index.rb
+++ b/spec/support/pages/portfolios/index.rb
@@ -81,6 +81,14 @@ module Pages
         expect(page).to have_css('[data-test-selector="portfolio-query-name"]', text: name)
       end
 
+      def expect_status_bar_percentage(portfolio, status_text, percentage)
+        within_row(portfolio) do
+          status = page.find_test_selector("op-portfolios--status-#{status_text}")
+          status_percentage = status["data-percentage"]
+          expect(status_percentage).to eq(percentage.to_s)
+        end
+      end
+
       def expect_status_of(portfolio, status_text)
         expect(page).to have_css("#projects-status-button-component-#{portfolio.id} .Button-label", text: status_text)
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68877

# What are you trying to accomplish?
Show a progress bar with the status of all sub-items of the portfolio. When you hover over it, it will show a card with a legend.

## Video

https://github.com/user-attachments/assets/7102ae86-dab5-43e2-a13c-16a16deccc7e


# What approach did you choose and why?

* Since hovering is not possible on mobile, the legend will never be visible. Without the legend, the progress bar is not very useful -> hide the entire progress bar on mobile.
* The progress bar will only be shown when at least one descendant has a status set. Showing empty progress bars all over the view did not look nice.
* The hover card required some engineering. It is displayed by making an existing DOM element visible. This feature was added to the `HoverCardController`. The hover card will try to fit the content, but has a max width set. For portfolios with a lot of different sub-item statuses, it might wrap its contents.
* I have used the standard primer ProgressBar component. It does not deal with edge cases (and states so in the documentation). E.g., when you have 400 sub-items, but only four of these have a status set. That means each status will have a total of under 1 %. The progress bar will not round that number up, so these entries will have a width of 0%, leading to an empty progress bar. I would not fix issues like these for now as I don't expect Portfolios to grow that much in size.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
