### PR TITLE
Allow activating good job dashboard through basic auth

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -556,6 +556,11 @@ module Settings
         writable: false,
         default: 7.days
       },
+      good_job_engine_basic_auth: {
+        description: "Allow basic authentication for GoodJob web interface by setting a password",
+        format: :string,
+        default: nil
+      },
       host_name: {
         format: :string,
         default: -> { "#{ENV.fetch('HOST', 'localhost')}:#{ENV.fetch('PORT', 3000)}" },

--- a/config/initializers/good_job_dashboard.rb
+++ b/config/initializers/good_job_dashboard.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# On development, the GoodJob dashboard is fully accessible.
+if OpenProject::Configuration.good_job_engine_basic_auth.present?
+  GoodJob::Engine.middleware.use(Rack::Auth::Basic) do |_, password|
+    ActiveSupport::SecurityUtils.secure_compare(OpenProject::Configuration.good_job_engine_basic_auth, password)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1035,6 +1035,9 @@ Rails.application.routes.draw do
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
+  if Rails.env.development? || OpenProject::Configuration.good_job_engine_basic_auth.present?
     mount GoodJob::Engine => "good_job"
   end
 end


### PR DESCRIPTION
Allow activating the GoodJob engine / dashboard on production using a separate opt-in credential