### PR TITLE
Move meetings and watchers tab

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -791,6 +791,7 @@ Redmine::MenuManager.map :work_package_split_view do |menu|
   menu.push :watchers,
             { tab: :watchers },
             skip_permissions_check: true,
+            last: true,
             badge: ->(work_package:, **) {
               work_package.watchers.count
             },

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -85,6 +85,25 @@ export class WorkPackageTabsService {
     ];
   }
 
+  registerBefore(id:string, tab:WpTabDefinition):void {
+    const index = this.registeredTabs.findIndex((t) => t.id === id);
+    if (index !== -1) {
+      this.registeredTabs.splice(index, 0, tab);
+    } else {
+      throw new Error(`Tab with id "${id}" not found. Appending tab to the end.`);
+    }
+  }
+
+  registerAfter(id:string, tab:WpTabDefinition):void {
+    const index = this.registeredTabs.findIndex((t) => t.id === id);
+    if (index !== -1) {
+      this.registeredTabs.splice(index + 1, 0, tab);
+    } else {
+      throw new Error(`Tab with id "${id}" not found. Appending tab to the end.`);
+    }
+  }
+
+
   patchTabCondition(id:string, displayable:(workPackage:WorkPackageResource, $state:StateService) => boolean):void {
     const tabDefinition = this.registeredTabs.find((tab) => tab.id === id);
     if (tabDefinition) {

--- a/modules/github_integration/frontend/module/main.ts
+++ b/modules/github_integration/frontend/module/main.ts
@@ -24,11 +24,11 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { Injector, NgModule, } from '@angular/core';
+import { Injector, NgModule } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import {
-  WorkPackageTabsService
+  WorkPackageTabsService,
 } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
 import { GitHubTabComponent } from './github-tab/github-tab.component';
 import { TabHeaderComponent } from './tab-header/tab-header.component';
@@ -40,7 +40,7 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GithubPullRequestResourceService } from './state/github-pull-request.service';
-import { PullRequestMacroComponent, } from './pull-request/pull-request-macro.component';
+import { PullRequestMacroComponent } from './pull-request/pull-request-macro.component';
 import { PullRequestStateComponent } from './pull-request/pull-request-state.component';
 import { registerCustomElement } from 'core-app/shared/helpers/angular/custom-elements.helper';
 
@@ -58,13 +58,16 @@ export function workPackageGithubPrsCount(
 
 export function initializeGithubIntegrationPlugin(injector:Injector) {
   const wpTabService = injector.get(WorkPackageTabsService);
-  wpTabService.register({
-    component: GitHubTabComponent,
-    name: I18n.t('js.github_integration.work_packages.tab_name'),
-    id: 'github',
-    displayable: (workPackage) => !!workPackage.github,
-    count: workPackageGithubPrsCount,
-  });
+  wpTabService.registerBefore(
+    'watchers',
+    {
+      component: GitHubTabComponent,
+      name: I18n.t('js.github_integration.work_packages.tab_name'),
+      id: 'github',
+      displayable: (workPackage) => !!workPackage.github,
+      count: workPackageGithubPrsCount,
+    },
+  );
 }
 
 @NgModule({

--- a/modules/github_integration/lib/open_project/github_integration/engine.rb
+++ b/modules/github_integration/lib/open_project/github_integration/engine.rb
@@ -85,6 +85,7 @@ module OpenProject::GithubIntegration
            badge: ->(work_package:, **) {
              work_package.github_pull_requests.count
            },
+           before: :watchers,
            caption: :project_module_github
     end
 

--- a/modules/gitlab_integration/frontend/module/main.ts
+++ b/modules/gitlab_integration/frontend/module/main.ts
@@ -30,7 +30,9 @@
 import { Injector, NgModule } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
-import { WorkPackageTabsService } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
+import {
+  WorkPackageTabsService,
+} from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
 
 
 import { GitlabTabComponent } from './gitlab-tab/gitlab-tab.component';
@@ -70,13 +72,16 @@ export function workPackageGitlabCount(
 
 export function initializeGitlabIntegrationPlugin(injector:Injector) {
   const wpTabService = injector.get(WorkPackageTabsService);
-  wpTabService.register({
-    component: GitlabTabComponent,
-    name: I18n.t('js.gitlab_integration.work_packages.tab_name'),
-    id: 'gitlab',
-    displayable: (workPackage) => !!workPackage.gitlab,
-    count: workPackageGitlabCount,
-  });
+  wpTabService.registerBefore(
+    'watchers',
+    {
+      component: GitlabTabComponent,
+      name: I18n.t('js.gitlab_integration.work_packages.tab_name'),
+      id: 'gitlab',
+      displayable: (workPackage) => !!workPackage.gitlab,
+      count: workPackageGitlabCount,
+    },
+  );
 }
 
 

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/engine.rb
@@ -60,6 +60,7 @@ module OpenProject::GitlabIntegration
              work_package.gitlab_merge_requests.count +
                work_package.gitlab_issues.count
            },
+           before: :watchers,
            caption: :project_module_github
     end
 

--- a/modules/meeting/frontend/module/main.ts
+++ b/modules/meeting/frontend/module/main.ts
@@ -78,13 +78,16 @@ export function workPackageMeetingsCount(
 export function initializeMeetingPlugin(injector:Injector) {
   const wpTabService = injector.get(WorkPackageTabsService);
   const I18n = injector.get(I18nService);
-  wpTabService.register({
-    component: MeetingsTabComponent,
-    name: I18n.t('js.label_meetings'),
-    id: 'meetings',
-    displayable: (workPackage) => !!workPackage.meetings,
-    count: workPackageMeetingsCount,
-  });
+  wpTabService.registerAfter(
+    'relations',
+    {
+      component: MeetingsTabComponent,
+      name: I18n.t('js.label_meetings'),
+      id: 'meetings',
+      displayable: (workPackage) => !!workPackage.meetings,
+      count: workPackageMeetingsCount,
+    },
+  );
 }
 
 @NgModule({

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -126,6 +126,7 @@ module OpenProject::Meeting
            :meetings,
            { tab: :meetings },
            skip_permissions_check: true,
+           after: :relations,
            if: ->(_project) {
              User.current.allowed_in_any_project?(:view_meetings)
            },


### PR DESCRIPTION
Meetings should come after relations, then gitlab/github (if enabled), then watchers last.
https://community.openproject.org/work_packages/69118