### PR TITLE
allow elevating user to admin within block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -544,6 +544,27 @@ class User < Principal
     User.current = previous_user
   end
 
+  # Temporarily elevates a user's permissions to admin for the duration
+  # of the given block.
+  #
+  # This method ensures that any changes to the user's admin status are
+  # safely reverted after the block is executed, regardless of whether
+  # an exception is raised within the block.
+  #
+  # Saving of the user is not prevented within the block which would be a
+  # dangerous operation to perform granting the user permanent admin privileges.
+  #
+  # @param user [User] The user that requires temporary admin elevation.
+  def self.execute_as_admin(user)
+    previous_user_admin_state = user.admin
+    user.admin = true
+    user.reset_permission_caches
+    yield
+  ensure
+    user.admin = previous_user_admin_state
+    user.reset_permission_caches
+  end
+
   ##
   # Returns true if no authentication method has been chosen for this user yet.
   # There are three possible methods currently:

--- a/app/models/users/permission_checks.rb
+++ b/app/models/users/permission_checks.rb
@@ -68,9 +68,7 @@ module Users::PermissionChecks
   end
 
   def reload(*args)
-    @user_permissible_service = nil
-    @user_allowed_service = nil
-    @project_role_cache = nil
+    reset_permission_caches
 
     super
   end
@@ -158,6 +156,12 @@ module Users::PermissionChecks
         false
       end
     end
+  end
+
+  def reset_permission_caches
+    @user_permissible_service = nil
+    @user_allowed_service = nil
+    @project_role_cache = nil
   end
 
   private

--- a/spec/models/users/execute_as_admin_spec.rb
+++ b/spec/models/users/execute_as_admin_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe User, ".execute_as_admin" do # rubocop:disable RSpec/SpecFilePathFormat
+  shared_let(:user, reload: true) { create(:user) }
+  shared_let(:project, reload: true) { create(:project) }
+
+  context "for a project permission" do
+    shared_examples "no permissions granted" do
+      it "still disallows the action in the project", :aggregate_failures do
+        expect(user)
+          .not_to be_allowed_in_project(:view_work_packages, project)
+
+        described_class.execute_as_admin(user) do
+          expect(user)
+            .not_to be_allowed_in_project(:view_work_packages, project)
+        end
+
+        expect(user)
+          .not_to be_allowed_in_project(:view_work_packages, project)
+      end
+
+      it "does not return projects in the .allowed_to scope", :aggregate_failures do
+        expect(Project.allowed_to(user, :view_work_packages))
+          .to be_empty
+
+        described_class.execute_as_admin(user) do
+          expect(Project.allowed_to(user, :view_work_packages))
+            .to be_empty
+        end
+
+        expect(Project.allowed_to(user, :view_work_packages))
+          .to be_empty
+      end
+    end
+
+    context "with the permission's module being enabled" do
+      it "allows actions within the project the user normally doesn't have", :aggregate_failures do
+        expect(user)
+          .not_to be_allowed_in_project(:view_work_packages, project)
+
+        described_class.execute_as_admin(user) do
+          expect(user)
+            .to be_allowed_in_project(:view_work_packages, project)
+        end
+
+        expect(user)
+          .not_to be_allowed_in_project(:view_work_packages, project)
+      end
+
+      it "returns projects for which the user normally doesn't have permissions when using the .allowed_to scope",
+         :aggregate_failures do
+        expect(Project.allowed_to(user, :view_work_packages))
+          .to be_empty
+
+        described_class.execute_as_admin(user) do
+          expect(Project.allowed_to(user, :view_work_packages))
+            .to match [project]
+        end
+
+        expect(Project.allowed_to(user, :view_work_packages))
+          .to be_empty
+      end
+    end
+
+    context "with the permission's module being disabled" do
+      before do
+        project.enabled_module_names = []
+        project.save
+      end
+
+      it_behaves_like "no permissions granted"
+    end
+
+    context "with the project being archived" do
+      before do
+        project.active = false
+        project.save
+      end
+
+      it_behaves_like "no permissions granted"
+    end
+
+    context "with the user being inactive" do
+      before do
+        user.locked!
+      end
+
+      it_behaves_like "no permissions granted"
+    end
+  end
+
+  context "for a global permission" do
+    it "allows actions globally the user normally doesn't have", :aggregate_failures do
+      expect(user)
+        .not_to be_allowed_globally(:add_project)
+
+      described_class.execute_as_admin(user) do
+        expect(user)
+          .to be_allowed_globally(:add_project)
+      end
+
+      expect(user)
+        .not_to be_allowed_globally(:add_project)
+    end
+
+    context "with the user being inactive" do
+      before do
+        user.locked!
+      end
+
+      it "still disallows the action globally", :aggregate_failures do
+        expect(user)
+          .not_to be_allowed_globally(:add_project)
+
+        described_class.execute_as_admin(user) do
+          expect(user)
+            .not_to be_allowed_globally(:add_project)
+        end
+
+        expect(user)
+          .not_to be_allowed_globally(:add_project)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69167

# What are you trying to accomplish?

Based on the decision in [WP 69070](https://community.openproject.org/work_packages/69070) we need to safely allow users to perform an action with the certainty that it will not be blocked by lacking permissions. We cannot completely guarantee this as the user might be locked or the project might not grant the permission. But we can grant the user admin permissions for the duration of the block.

# Merge checklist

- [x] Added/updated tests