### PR TITLE
Overview refinements

### DIFF
--- a/app/components/open_project/common/divider_component.rb
+++ b/app/components/open_project/common/divider_component.rb
@@ -35,6 +35,9 @@ module OpenProject
         system_arguments[:tag] = :hr
         system_arguments[:mt] = system_arguments.fetch(:mt, 3)
         system_arguments[:mb] = system_arguments.fetch(:mb, 3)
+        system_arguments[:role] = system_arguments.fetch(:role, :presentation)
+        system_arguments[:aria] = system_arguments.fetch(:aria, { hidden: true })
+
         super(**system_arguments) # rubocop:disable Style/SuperArguments
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4637,7 +4637,7 @@ en:
         checkbox_message: "I understand that this action is not reversible"
     project_phase_definitions:
       heading: "Project life cycle"
-      heading_description: "Project life cycle define the project phases that can be used for your project planning and will appear in the overview page of each project. These attributes can be enabled or disabled but not re-ordered at a project level."
+      heading_description: "Project life cycle defines the project phases that can be used for your project planning and will appear in the overview page of each project. These attributes can be enabled or disabled but not re-ordered at a project level."
       label_add: "Add"
       label_add_description: "Add project phase definition"
       filter:

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -50,9 +50,6 @@ $widget-box--enumeration-width: 20px
     .widget-box--feature-list
       flex-grow: 2
 
-    &.-align-boxes-start
-      align-items: start
-
   .icon-context:before
     padding-right: 5px
 

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -159,7 +159,7 @@ $widget-box--enumeration-width: 20px
 
 .op-widget-box--header
   font-weight: var(--base-text-weight-bold)
-  font-size: var(--body-font-size)
+  font-size: var(--h4-size, 16px)
   color: var(--fgColor-default)
   display: flex
   align-items: center
@@ -180,7 +180,7 @@ $widget-box--enumeration-width: 20px
   .editable-toolbar-title--fixed,
   .toolbar--editable-toolbar,
   .editable-toolbar-title--input
-    font-size: var(--body-font-size)
+    font-size: var(--h4-size, 16px)
     font-weight: var(--base-text-weight-bold)
     color: var(--fgColor-default) !important
     padding: 0 !important

--- a/modules/grids/app/components/grids/widget_grid_component.rb
+++ b/modules/grids/app/components/grids/widget_grid_component.rb
@@ -34,7 +34,7 @@ module Grids
       build_widget(widget_class, *widget_args, **system_arguments)
     }
 
-    def initialize(align_boxes_start: false, **system_arguments)
+    def initialize(**system_arguments)
       super()
 
       @system_arguments = system_arguments
@@ -42,8 +42,7 @@ module Grids
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
         "widget-boxes",
-        "-flex",
-        "-align-boxes-start" => align_boxes_start
+        "-flex"
       )
     end
 

--- a/modules/overviews/app/components/overviews/show_component.html.erb
+++ b/modules/overviews/app/components/overviews/show_component.html.erb
@@ -44,6 +44,10 @@ See COPYRIGHT and LICENSE files for more details.
         )
       end
 
+      if life_cycle_sidebar_enabled? && custom_fields_sidebar_enabled?
+        concat(render(OpenProject::Common::DividerComponent.new))
+      end
+
       if custom_fields_sidebar_enabled?
         concat(
           render_sidebar_turbo_frame(

--- a/modules/overviews/app/components/overviews/show_component.rb
+++ b/modules/overviews/app/components/overviews/show_component.rb
@@ -60,7 +60,10 @@ module Overviews
     def custom_fields_sidebar_enabled?
       @custom_fields_sidebar_enabled ||=
         current_user.allowed_in_project?(:view_project_attributes, project) &&
-        project.project_custom_fields.visible.any?
+          project.project_custom_fields
+                 .visible
+                 .group_by(&:project_custom_field_section)
+                 .any? { |section, _| section.shown_in_overview_sidebar? }
     end
 
     def render_sidebar_turbo_frame(*ids, src: nil, target: nil, **attributes)

--- a/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
@@ -34,6 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
     grid.with_widget(Grids::Widgets::Subitems, @portfolio)
     grid.with_widget(Grids::Widgets::Members, @portfolio)
 
-    grid.with_widget(Grids::ProjectAttributeWidgets, @project)
+    grid.with_widget(Grids::ProjectAttributeWidgets, @portfolio)
   end
 %>

--- a/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/portfolio_overview_grid_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+  render(Grids::WidgetGridComponent.new) do |grid|
     grid.with_widget(Grids::Widgets::Description, @portfolio)
     grid.with_widget(Grids::Widgets::ProjectStatus, @portfolio)
     grid.with_widget(Grids::Widgets::Subitems, @portfolio)

--- a/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+  render(Grids::WidgetGridComponent.new) do |grid|
     grid.with_widget(Grids::Widgets::Description, @program)
     grid.with_widget(Grids::Widgets::ProjectStatus, @program)
     grid.with_widget(Grids::Widgets::Subitems, @program)

--- a/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/program_overview_grid_component.html.erb
@@ -34,6 +34,6 @@ See COPYRIGHT and LICENSE files for more details.
     grid.with_widget(Grids::Widgets::Subitems, @program)
     grid.with_widget(Grids::Widgets::Members, @program)
 
-    grid.with_widget(Grids::ProjectAttributeWidgets, @project)
+    grid.with_widget(Grids::ProjectAttributeWidgets, @program)
   end
 %>

--- a/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
+++ b/modules/overviews/app/components/overviews/workspaces/project_overview_grid_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Grids::WidgetGridComponent.new(align_boxes_start: true)) do |grid|
+  render(Grids::WidgetGridComponent.new) do |grid|
     grid.with_widget(Grids::Widgets::Description, @project)
     grid.with_widget(Grids::Widgets::ProjectStatus, @project)
     grid.with_widget(Grids::Widgets::Subitems, @project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69170
https://community.openproject.org/wp/68966
https://community.openproject.org/wp/69169
https://community.openproject.org/wp/69134


# What are you trying to accomplish?
* Overview page for Portfolios and Programs is working again
* Fix typo in project life cycle description
* Increase wisget title font size
* Let widgets grow on the overview page
* Hide the sidebar when there are no objects to show there
* Add a separator between the life cycle and the attributes
