### PR TITLE
[#67471] Style the rich-link workpackage macro (light theme)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -6779,6 +6779,18 @@
       "integrity": "sha512-DIp04IeZvZ+gwCUcBchIvRwJA2PikP/6hnFhcLKgwttcg5OYjBH9t0cZjLnv10Aq1jN0rAFFG+WPMd3bw4hXcA==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.1"
+      }
+    },
+    "node_modules/@primer/octicons-react": {
+      "version": "19.21.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.21.0.tgz",
+      "integrity": "sha512-KMWYYEIDKNIY0N3fMmNGPWJGHgoJF5NHkJllpOM3upDXuLtAe26Riogp1cfYdhp+sVjGZMt32DxcUhTX7ZhLOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
       }
     },
     "node_modules/@primer/primitives": {
@@ -18165,13 +18177,14 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.9",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
-      "integrity": "sha512-j57yMhEXYZmdmE0OVR1KkgblJ1nooa6Eq8ikAyvHRaT+qry8RALSeQpt+re2XZbkWfXg6rWeVQo9gxwn2nIc7g==",
+      "version": "0.0.10",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
+      "integrity": "sha512-c0DINNJ7mEj5cS9dgQzmLssiZMrFvXRY4Hd3qBc/Uapne3+2LcWBqZJ41xz33MxGL+iWSrMQl/E60Huba2UGQg==",
       "dependencies": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
         "@blocknote/react": "^0.41.1",
+        "@primer/octicons-react": "^19.20.0",
         "styled-components": "^6.1.19"
       }
     },
@@ -27861,6 +27874,11 @@
         "@lit-labs/ssr-dom-shim": "^1.2.1"
       }
     },
+    "@primer/octicons-react": {
+      "version": "19.21.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.21.0.tgz",
+      "integrity": "sha512-KMWYYEIDKNIY0N3fMmNGPWJGHgoJF5NHkJllpOM3upDXuLtAe26Riogp1cfYdhp+sVjGZMt32DxcUhTX7ZhLOQ=="
+    },
     "@primer/primitives": {
       "version": "11.2.1",
       "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.2.1.tgz",
@@ -35795,12 +35813,13 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
-      "integrity": "sha512-j57yMhEXYZmdmE0OVR1KkgblJ1nooa6Eq8ikAyvHRaT+qry8RALSeQpt+re2XZbkWfXg6rWeVQo9gxwn2nIc7g==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
+      "integrity": "sha512-c0DINNJ7mEj5cS9dgQzmLssiZMrFvXRY4Hd3qBc/Uapne3+2LcWBqZJ41xz33MxGL+iWSrMQl/E60Huba2UGQg==",
       "requires": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
         "@blocknote/react": "^0.41.1",
+        "@primer/octicons-react": "^19.20.0",
         "styled-components": "^6.1.19"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.9/op-blocknote-extensions-0.0.9.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -67,6 +67,6 @@ RSpec.describe "BlockNote editor rendering", :js, with_flag: { block_note_editor
 
     expect(page).to have_test_selector("blocknote-document-description")
     editor.fill_in_with_content("/openproject")
-    expect(page).to have_content("Search and link an existing Work Package")
+    expect(page).to have_content("Link to existing work package")
   end
 end


### PR DESCRIPTION
https://community.openproject.org/work_packages/67471

This updates the op-blocknote-extensions dependency to include the version which has the new light theme implemented.