### PR TITLE
prevent saving of the user within the execute_as_admin block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -551,18 +551,21 @@ class User < Principal
   # safely reverted after the block is executed, regardless of whether
   # an exception is raised within the block.
   #
-  # Saving of the user is not prevented within the block which would be a
-  # dangerous operation to perform granting the user permanent admin privileges.
+  # Saving of the user is attempted to be prevented but this might not be foolproof.
+  # Saving the user within the block should be avoided to prevent undesired side effects.
   #
   # @param user [User] The user that requires temporary admin elevation.
   def self.execute_as_admin(user)
     previous_user_admin_state = user.admin
+    previous_user_readonly_state = user.readonly?
     user.admin = true
     user.reset_permission_caches
+    user.readonly!
     yield
   ensure
     user.admin = previous_user_admin_state
     user.reset_permission_caches
+    user.instance_variable_set(:@readonly, previous_user_readonly_state)
   end
 
   ##

--- a/spec/models/users/execute_as_admin_spec.rb
+++ b/spec/models/users/execute_as_admin_spec.rb
@@ -152,4 +152,15 @@ RSpec.describe User, ".execute_as_admin" do # rubocop:disable RSpec/SpecFilePath
       end
     end
   end
+
+  it "throws an error if the user is attempted to be saved", :aggregate_failures do
+    described_class.execute_as_admin(user) do
+      expect { user.save }.to raise_error ActiveRecord::ReadOnlyRecord
+      expect { user.save(validate: false) }.to raise_error ActiveRecord::ReadOnlyRecord
+      expect { user.update_attribute(:firstname, "Obi") }.to raise_error ActiveRecord::ReadOnlyRecord
+    end
+
+    expect(user)
+      .not_to be_readonly
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69167

# What are you trying to accomplish?

Follow up to #21088 that prevents saving the user within the block

# Merge checklist

- [x] Added/updated tests