### PR TITLE
Implementation/69146 add document types admin page

### DIFF
--- a/modules/documents/app/components/_index.sass
+++ b/modules/documents/app/components/_index.sass
@@ -1,2 +1,3 @@
+@import "documents/admin/document_types/index_component"
 @import "documents/list_component"
 @import "documents/show_edit_view/block_note_editor_component"

--- a/modules/documents/app/components/documents/admin/document_types/cannot_delete_last_dialog_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/cannot_delete_last_dialog_component.html.erb
@@ -1,0 +1,41 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= render(
+      Primer::OpenProject::FeedbackDialog.new(
+        title: t("documents.delete_document_type_dialog.at_least_one_type_required.title")
+      )
+    ) do |dialog| %>
+  <% dialog.with_feedback_message(icon_arguments: { icon: :"circle-slash", color: :danger }) do |message|
+       message.with_heading(tag: :h2) { t("documents.delete_document_type_dialog.at_least_one_type_required.heading") }
+       message.with_description { t("documents.delete_document_type_dialog.at_least_one_type_required.message") }
+     end %>
+<% end %>

--- a/modules/documents/app/components/documents/admin/document_types/cannot_delete_last_dialog_component.rb
+++ b/modules/documents/app/components/documents/admin/document_types/cannot_delete_last_dialog_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2010-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,31 +26,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
 module Documents
   module Admin
     module DocumentTypes
-      class ItemComponent < ::Admin::Enumerations::ItemComponent
-        alias_method :document_type, :enumeration
-
-        def deletion_enumeration(menu)
-          menu.with_item(
-            label: I18n.t(:button_delete),
-            scheme: :danger,
-            tag: :a,
-            content_arguments: {
-              data: { controller: "async-dialog" }
-            },
-            href: delete_dialog_admin_settings_document_type_path(document_type)
-          ) do |item|
-            item.with_leading_visual_icon(icon: :trash)
-          end
-        end
-
-        def colored?
-          false
-        end
+      class CannotDeleteLastDialogComponent < ApplicationComponent
+        include OpTurbo::Streamable
       end
     end
   end

--- a/modules/documents/app/components/documents/admin/document_types/delete_dialog_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/delete_dialog_component.html.erb
@@ -1,0 +1,65 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<% if document_type.in_use? %>
+  <%= primer_form_with(
+        model: document_type,
+        scope: :enumeration,
+        url: admin_settings_document_type_path(document_type),
+        method: :delete,
+        data: { turbo: true }
+      ) do |form_builder| %>
+    <%= render(
+          danger_dialog(
+            form_arguments: { builder: form_builder },
+            size: :large
+          )
+        ) do |dialog| %>
+      <% with_confirmation_message(dialog) %>
+
+      <% dialog.with_additional_details do %>
+        <%= render(Primer::Box.new(flex: 1, border: true, border_radius: 2, p: 3)) do %>
+          <%= render(Documents::Admin::DocumentTypes::SelectReassignToForm.new(form_builder, other_document_types:)) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(
+        danger_dialog(
+          form_arguments: {
+            action: admin_settings_document_type_path(document_type),
+            method: :delete,
+            data: { turbo: true }
+          }
+        )
+      ) { with_confirmation_message(it) } %>
+<% end %>

--- a/modules/documents/app/components/documents/admin/document_types/delete_dialog_component.rb
+++ b/modules/documents/app/components/documents/admin/document_types/delete_dialog_component.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Documents
+  module Admin
+    module DocumentTypes
+      class DeleteDialogComponent < ApplicationComponent
+        include OpTurbo::Streamable
+
+        alias_method :document_type, :model
+
+        def danger_dialog(**system_args, &)
+          Primer::OpenProject::DangerDialog.new(
+            id: "delete-document-type-dialog",
+            title: I18n.t("documents.delete_document_type_dialog.title"),
+            confirm_button_text: I18n.t(:button_delete_permanently),
+            **system_args,
+            &
+          )
+        end
+
+        def with_confirmation_message(dialog)
+          dialog.with_confirmation_message do |message|
+            message.with_heading(tag: :h2) { I18n.t("documents.delete_document_type_dialog.heading") }
+            message.with_description_content(confirmation_message)
+          end
+        end
+
+        def confirmation_message
+          if document_type.in_use?
+            count = document_type.documents.count
+            I18n.t(
+              "documents.delete_document_type_dialog.reassign_message",
+              type_name: document_type.name,
+              document_count: count,
+              count:
+            )
+          else
+            I18n.t(
+              "documents.delete_document_type_dialog.confirmation_message",
+              type_name: document_type.name
+            )
+          end
+        end
+
+        def other_document_types
+          DocumentType.where.not(id: document_type.id).order(:position)
+        end
+      end
+    end
+  end
+end

--- a/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
@@ -33,7 +33,7 @@
   component_wrapper do
     flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
-        render(Primer::OpenProject::SubHeader.new) do |subheader|
+        render(Primer::OpenProject::SubHeader.new(test_selector: "admin-document-types-subheader")) do |subheader|
           subheader.with_action_button(
             scheme: :primary,
             leading_icon: :plus,

--- a/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
@@ -1,0 +1,79 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    flex_layout(data: wrapper_data_attributes) do |flex|
+      flex.with_row do
+        render(Primer::OpenProject::SubHeader.new) do |subheader|
+          subheader.with_action_button(
+            scheme: :primary,
+            leading_icon: :plus,
+            label: t(:button_add),
+            tag: :a,
+            href: helpers.url_for(action: :new),
+            test_selector: "add-document-type-button"
+          ) do
+            I18n.t(:button_add)
+          end
+        end
+      end
+
+      flex.with_row do
+        render(border_box_container(data: drop_target_config)) do |component|
+          component.with_header(font_weight: :bold) do
+            grid_layout("op-documents-types-list--header", tag: :div, align_items: :center) do |grid|
+              grid.with_area(:name, tag: :div, mr: 3) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { I18n.t("documents.index_page.type") }
+              end
+
+              grid.with_area(:"documents-count", tag: :div, hide: :sm) do
+                render(Primer::Beta::Text.new(font_weight: :semibold)) { I18n.t("label_documents") }
+              end
+            end
+          end
+
+          if document_types.empty?
+            component.with_row do
+              render(Primer::Beta::Text.new(color: :subtle)) { t(:no_results_title_text) }
+            end
+          else
+            document_types.each do |document_type|
+              component.with_row(test_selector: "document-type-row-#{document_type.id}", data: draggable_item_config(document_type)) do
+                render(item_component_class.new(enumeration: document_type, max_position: max_position))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/modules/documents/app/components/documents/admin/document_types/index_component.rb
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,46 +26,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-Rails.application.routes.draw do
-  resources :projects, only: [] do
-    resources :documents, only: %i[create new index] do
-      collection do
-        get :menu, to: "documents/menus#show"
-        get :search
-      end
-    end
-  end
+module Documents
+  module Admin
+    module DocumentTypes
+      class IndexComponent < ::Admin::Enumerations::IndexComponent
+        alias_method :document_types, :enumerations
 
-  resources :documents, except: %i[create new index] do
-    member do
-      get :edit_title, defaults: { format: :turbo_stream }
-      put :update_title, defaults: { format: :turbo_stream }
-      get :cancel_title_edit, defaults: { format: :turbo_stream }
-      put :update_type, defaults: { format: :turbo_stream }
-      get :delete_dialog
-    end
-  end
-
-  scope module: :documents do
-    namespace :admin do
-      namespace :settings do
-        resources :document_types, except: [:show] do
-          member do
-            put :move
-          end
-        end
-      end
-    end
-  end
-
-  namespace :admin do
-    namespace :settings do
-      resources :document_categories, except: [:show] do
-        member do
-          put :move
-          get :reassign
+        def item_component_class
+          ::Documents::Admin::DocumentTypes::ItemComponent
         end
       end
     end

--- a/modules/documents/app/components/documents/admin/document_types/index_component.sass
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.sass
@@ -1,0 +1,15 @@
+.op-documents-types-list--header,
+.op-documents-types-list--item
+  display: grid
+  grid-template-columns: 20px 2fr 1fr 1fr
+  grid-template-areas: "drag-handle name documents-count actions"
+
+  &--actions
+    justify-self: end
+
+@media screen and (max-width: $breakpoint-sm)
+  .op-documents-types-list--header,
+  .op-documents-types-list--item
+    grid-template-columns: 20px 1fr 1fr
+    grid-template-areas: "drag-handle name actions"
+    column-gap: 5px

--- a/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
@@ -1,0 +1,87 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    grid_layout("op-documents-types-list--item", tag: :div, align_items: :center) do |grid|
+      grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
+        render(Primer::OpenProject::DragHandle.new(draggable: true))
+      end
+
+      grid.with_area(:name, tag: :div, classes: "ellipsis") do
+        flex_layout do |flex|
+          flex.with_column do
+            render(
+              Primer::Beta::Link.new(
+                href: helpers.url_for(action: :edit, id: document_type),
+                underline: false
+              )
+            ) do
+              render(Primer::Beta::Text.new(font_weight: :bold)) { document_type.name }
+            end
+          end
+
+          unless document_type.active?
+            flex.with_column(ml: 2) do
+              render(Primer::Beta::Label.new(scheme: :default, test_selector: "label-inactive")) do
+                I18n.t(:label_inactive)
+              end
+            end
+          end
+
+          if document_type.is_default?
+            flex.with_column(ml: 2) do
+              render(Primer::Beta::Label.new(scheme: :primary, test_selector: "label-is-default")) do
+                I18n.t(:label_default)
+              end
+            end
+          end
+        end
+      end
+
+      grid.with_area(:"documents-count", tag: :div, hide: :sm) do
+        render(Primer::Beta::Text.new(color: :subtle)) { document_type.documents_count.to_s }
+      end
+
+      grid.with_area(:actions, tag: :div, classes: "hide-when-print") do
+        render(Primer::Alpha::ActionMenu.new(test_selector: "op-document-types--action-menu")) do |menu|
+          menu.with_show_button(
+            icon: "kebab-horizontal",
+            scheme: :invisible,
+            "aria-label": I18n.t("documents.document_type_actions")
+          )
+
+          build_enumeration_menu(menu)
+        end
+      end
+    end
+  end
+%>

--- a/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
@@ -29,59 +29,59 @@
   ++#
 %>
 
-<%=
-  component_wrapper do
-    grid_layout("op-documents-types-list--item", tag: :div, align_items: :center) do |grid|
-      grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
-        render(Primer::OpenProject::DragHandle.new(draggable: true))
-      end
+<%= component_wrapper do
+      grid_layout("op-documents-types-list--item", tag: :div, align_items: :center) do |grid|
+        grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
+          render(Primer::OpenProject::DragHandle.new(draggable: true))
+        end
 
-      grid.with_area(:name, tag: :div, classes: "ellipsis") do
-        flex_layout do |flex|
-          flex.with_column do
-            render(
-              Primer::Beta::Link.new(
-                href: helpers.url_for(action: :edit, id: document_type),
-                underline: false
-              )
-            ) do
-              render(Primer::Beta::Text.new(font_weight: :bold)) { document_type.name }
-            end
-          end
-
-          unless document_type.active?
-            flex.with_column(ml: 2) do
-              render(Primer::Beta::Label.new(scheme: :default, test_selector: "label-inactive")) do
-                I18n.t(:label_inactive)
+        grid.with_area(:name, tag: :div, classes: "ellipsis") do
+          flex_layout do |flex|
+            flex.with_column do
+              render(
+                Primer::Beta::Link.new(
+                  href: helpers.url_for(action: :edit, id: document_type),
+                  underline: false
+                )
+              ) do
+                render(Primer::Beta::Text.new(font_weight: :bold)) { document_type.name }
               end
             end
-          end
 
-          if document_type.is_default?
-            flex.with_column(ml: 2) do
-              render(Primer::Beta::Label.new(scheme: :primary, test_selector: "label-is-default")) do
-                I18n.t(:label_default)
+            unless document_type.active?
+              flex.with_column(ml: 2) do
+                render(Primer::Beta::Label.new(scheme: :default, test_selector: "label-inactive")) do
+                  I18n.t(:label_inactive)
+                end
+              end
+            end
+
+            if document_type.is_default?
+              flex.with_column(ml: 2) do
+                render(Primer::Beta::Label.new(scheme: :primary, test_selector: "label-is-default")) do
+                  I18n.t(:label_default)
+                end
               end
             end
           end
         end
-      end
 
-      grid.with_area(:"documents-count", tag: :div, hide: :sm) do
-        render(Primer::Beta::Text.new(color: :subtle)) { document_type.documents_count.to_s }
-      end
+        grid.with_area(:"documents-count", tag: :div, hide: :sm) do
+          render(Primer::Beta::Text.new(color: :subtle, test_selector: "documents-count")) do
+            document_type.documents_count.to_s
+          end
+        end
 
-      grid.with_area(:actions, tag: :div, classes: "hide-when-print") do
-        render(Primer::Alpha::ActionMenu.new(test_selector: "op-document-types--action-menu")) do |menu|
-          menu.with_show_button(
-            icon: "kebab-horizontal",
-            scheme: :invisible,
-            "aria-label": I18n.t("documents.document_type_actions")
-          )
+        grid.with_area(:actions, tag: :div, classes: "hide-when-print") do
+          render(Primer::Alpha::ActionMenu.new(test_selector: "op-document-types--action-menu")) do |menu|
+            menu.with_show_button(
+              icon: "kebab-horizontal",
+              scheme: :invisible,
+              "aria-label": I18n.t("documents.document_type_actions")
+            )
 
-          build_enumeration_menu(menu)
+            build_enumeration_menu(menu)
+          end
         end
       end
-    end
-  end
-%>
+    end %>

--- a/modules/documents/app/components/documents/admin/document_types/item_component.rb
+++ b/modules/documents/app/components/documents/admin/document_types/item_component.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) the OpenProject GmbH
+# Copyright (C) 2010-2024 the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,46 +26,16 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-Rails.application.routes.draw do
-  resources :projects, only: [] do
-    resources :documents, only: %i[create new index] do
-      collection do
-        get :menu, to: "documents/menus#show"
-        get :search
-      end
-    end
-  end
+module Documents
+  module Admin
+    module DocumentTypes
+      class ItemComponent < ::Admin::Enumerations::ItemComponent
+        alias_method :document_type, :enumeration
 
-  resources :documents, except: %i[create new index] do
-    member do
-      get :edit_title, defaults: { format: :turbo_stream }
-      put :update_title, defaults: { format: :turbo_stream }
-      get :cancel_title_edit, defaults: { format: :turbo_stream }
-      put :update_type, defaults: { format: :turbo_stream }
-      get :delete_dialog
-    end
-  end
-
-  scope module: :documents do
-    namespace :admin do
-      namespace :settings do
-        resources :document_types, except: [:show] do
-          member do
-            put :move
-          end
-        end
-      end
-    end
-  end
-
-  namespace :admin do
-    namespace :settings do
-      resources :document_categories, except: [:show] do
-        member do
-          put :move
-          get :reassign
+        def colored?
+          false
         end
       end
     end

--- a/modules/documents/app/controllers/documents/admin/settings/document_types_controller.rb
+++ b/modules/documents/app/controllers/documents/admin/settings/document_types_controller.rb
@@ -28,44 +28,20 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-Rails.application.routes.draw do
-  resources :projects, only: [] do
-    resources :documents, only: %i[create new index] do
-      collection do
-        get :menu, to: "documents/menus#show"
-        get :search
-      end
-    end
-  end
+module Documents
+  module Admin
+    module Settings
+      class DocumentTypesController < ::Admin::Settings::EnumerationsControllerBase
+        menu_item :document_types
 
-  resources :documents, except: %i[create new index] do
-    member do
-      get :edit_title, defaults: { format: :turbo_stream }
-      put :update_title, defaults: { format: :turbo_stream }
-      get :cancel_title_edit, defaults: { format: :turbo_stream }
-      put :update_type, defaults: { format: :turbo_stream }
-      get :delete_dialog
-    end
-  end
+        private
 
-  scope module: :documents do
-    namespace :admin do
-      namespace :settings do
-        resources :document_types, except: [:show] do
-          member do
-            put :move
-          end
+        def enumeration_class
+          DocumentType
         end
-      end
-    end
-  end
 
-  namespace :admin do
-    namespace :settings do
-      resources :document_categories, except: [:show] do
-        member do
-          put :move
-          get :reassign
+        def index_component_class
+          ::Documents::Admin::DocumentTypes::IndexComponent
         end
       end
     end

--- a/modules/documents/app/controllers/documents/admin/settings/document_types_controller.rb
+++ b/modules/documents/app/controllers/documents/admin/settings/document_types_controller.rb
@@ -34,6 +34,17 @@ module Documents
       class DocumentTypesController < ::Admin::Settings::EnumerationsControllerBase
         menu_item :document_types
 
+        def delete_dialog
+          find_enumeration
+          respond_with_dialog(
+            if @enumeration.only_remaining_record?
+              Documents::Admin::DocumentTypes::CannotDeleteLastDialogComponent.new
+            else
+              Documents::Admin::DocumentTypes::DeleteDialogComponent.new(@enumeration)
+            end
+          )
+        end
+
         private
 
         def enumeration_class

--- a/modules/documents/app/forms/documents/admin/document_types/select_reassign_to_form.rb
+++ b/modules/documents/app/forms/documents/admin/document_types/select_reassign_to_form.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
-# Copyright (C) 2010-2024 the OpenProject GmbH
+# Copyright (C) the OpenProject GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License version 3.
@@ -26,30 +26,31 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
 module Documents
   module Admin
     module DocumentTypes
-      class ItemComponent < ::Admin::Enumerations::ItemComponent
-        alias_method :document_type, :enumeration
+      class SelectReassignToForm < ApplicationForm
+        attr_reader :other_document_types
 
-        def deletion_enumeration(menu)
-          menu.with_item(
-            label: I18n.t(:button_delete),
-            scheme: :danger,
-            tag: :a,
-            content_arguments: {
-              data: { controller: "async-dialog" }
-            },
-            href: delete_dialog_admin_settings_document_type_path(document_type)
-          ) do |item|
-            item.with_leading_visual_icon(icon: :trash)
-          end
+        def initialize(other_document_types:)
+          super()
+
+          @other_document_types = other_document_types
         end
 
-        def colored?
-          false
+        form do |form|
+          form.select_list(
+            name: :reassign_to_id,
+            label: I18n.t(:"documents.delete_document_type_dialog.select_reassign_to_label"),
+            required: true,
+            input_width: :large
+          ) do |select|
+            other_document_types.each do |document_type|
+              select.option(value: document_type.id, label: document_type.name)
+            end
+          end
         end
       end
     end

--- a/modules/documents/app/models/concerns/documents/enumeration_model.rb
+++ b/modules/documents/app/models/concerns/documents/enumeration_model.rb
@@ -28,21 +28,42 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DocumentType < ApplicationRecord
-  include ::Documents::EnumerationModel
+module Documents
+  # Concern to be included in enumeration-like models within the documents module.
+  module EnumerationModel
+    extend ActiveSupport::Concern
 
-  default_scope { order(:position) }
-  acts_as_list
+    included do
+      before_save :unmark_old_default_values, if: :became_default_value?
+      before_save :ensure_activated, if: -> { self.class.can_have_default_value? && is_default? }
+    end
 
-  has_many :documents, foreign_key: :type_id,
-                       dependent: :nullify,
-                       inverse_of: :type
+    class_methods do
+      def can_have_default_value?
+        true
+      end
+    end
 
-  normalizes :name, with: ->(name) { name.strip.capitalize }
+    def colored?
+      false
+    end
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+    def became_default_value?
+      is_default? && is_default_changed?
+    end
 
-  def self.default
-    where(is_default: true).first || first
+    def unmark_old_default_values
+      self.class.update_all(is_default: false)
+    end
+
+    def in_use?
+      Document.exists?(type_id: id)
+    end
+
+    private
+
+    def ensure_activated
+      self.active = true
+    end
   end
 end

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -36,7 +36,7 @@ class Document < ApplicationRecord
 
   belongs_to :category, class_name: "DocumentCategory", optional: true
   belongs_to :project
-  belongs_to :type, class_name: "DocumentType", optional: true
+  belongs_to :type, class_name: "DocumentType", optional: true, counter_cache: :documents_count
 
   acts_as_attachable delete_permission: :manage_documents,
                      add_permission: :manage_documents

--- a/modules/documents/app/models/document_type.rb
+++ b/modules/documents/app/models/document_type.rb
@@ -42,7 +42,36 @@ class DocumentType < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 
+  before_destroy :prevent_deletion_of_last_type
+
   def self.default
     where(is_default: true).first || first
+  end
+
+  def only_remaining_record?
+    self.class.where.not(id: id).none?
+  end
+
+  alias :destroy_without_reassign :destroy
+
+  def destroy(reassign_to = nil)
+    if reassign_to.is_a?(DocumentType)
+      transfer_relations(reassign_to)
+    end
+    destroy_without_reassign
+  end
+
+  private
+
+  def prevent_deletion_of_last_type
+    if only_remaining_record?
+      errors.add(:base, :one_or_more_required)
+      throw(:abort)
+    end
+  end
+
+  def transfer_relations(to)
+    documents.update_all(type_id: to.id)
+    to.update_column(:documents_count, to.documents.count)
   end
 end

--- a/modules/documents/app/views/documents/admin/settings/document_types/edit.html.erb
+++ b/modules/documents/app/views/documents/admin/settings/document_types/edit.html.erb
@@ -1,0 +1,49 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.v
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<% html_title t(:label_administration), t("documents.menu.types") %>
+
+<%= render(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { @enumeration.name }
+      header.with_breadcrumbs(
+        [
+          { href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_document_types_path, text: t("project_module_documents") },
+          { href: url_for(action: :index), text: t("documents.menu.types") },
+          @enumeration.name
+        ]
+      )
+    end %>
+
+<% content_controller "admin--enumerations" %>
+
+<%= settings_primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :update, id: @enumeration)) do |f| %>
+  <%= render(Admin::Enumerations::ItemForm.new(f)) %>
+<% end %>

--- a/modules/documents/app/views/documents/admin/settings/document_types/index.html.erb
+++ b/modules/documents/app/views/documents/admin/settings/document_types/index.html.erb
@@ -1,0 +1,45 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<% html_title t(:label_administration), t("documents.menu.types") %>
+
+<%= render(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { t("documents.menu.types") }
+      header.with_breadcrumbs(
+        [
+          { href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_document_types_path, text: t("project_module_documents") },
+          t("documents.menu.types")
+        ]
+      )
+    end %>
+
+<%= render(index_component_class.new(enumerations: @enumerations)) %>

--- a/modules/documents/app/views/documents/admin/settings/document_types/new.html.erb
+++ b/modules/documents/app/views/documents/admin/settings/document_types/new.html.erb
@@ -1,0 +1,48 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.v
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<% html_title t(:label_administration), t("documents.new_type") %>
+
+<%= render(Primer::OpenProject::PageHeader.new) do |header|
+      header.with_title { I18n.t("documents.new_type") }
+      header.with_breadcrumbs(
+        [
+          { href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_document_types_path, text: t("project_module_documents") },
+          t("documents.new_type")
+        ]
+      )
+    end %>
+
+<% content_controller "admin--enumerations" %>
+
+<%= primer_form_with(model: @enumeration, scope: :enumeration, url: url_for(action: :create)) do |f| %>
+  <%= render(Admin::Enumerations::ItemForm.new(f)) %>
+<% end %>

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -64,6 +64,8 @@ en:
       heading: "There are no documents yet"
       description: "There are no documents in this view. You can click the button below to add one."
 
+    document_type_actions: "Document type actions"
+
     index_page:
       name: "Name"
       type: "Type"
@@ -79,6 +81,7 @@ en:
     label_attachment_author: "Attachment author"
     label_categories: "Categories"
     new_category: "New category"
+    new_type: "New type"
 
     delete_dialog:
       title: "Delete document"

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -32,12 +32,18 @@ en:
     description: "An OpenProject plugin to allow creation of documents in projects."
 
   activerecord:
+    errors:
+      models:
+        document_type:
+          one_or_more_required: "Cannot delete the last document type"
     models:
       document: "Document"
+      documents: "Documents"
     attributes:
       document:
         content_binary: "Content binary"
         title: "Title"
+
 
   activity:
     filter:
@@ -87,6 +93,20 @@ en:
       title: "Delete document"
       heading: "Delete this document?"
       confirmation_message_html: "This will permanently delete this document and all file attachments. Are you sure you want to do this?"
+
+    delete_document_type_dialog:
+      title: Delete document type
+      heading: Delete this document type?
+      confirmation_message: |-
+        The type "%{type_name}" is currently unused. Deleting this type will have no effect on existing documents.
+      select_reassign_to_label: Reassign documents to
+      reassign_message:
+        one: The type "%{type_name}" is currently being used in %{document_count} document. Please select which type to reassign them to.
+        other: The type "%{type_name}" is currently being used in %{document_count} documents. Please select which type to reassign them to.
+      at_least_one_type_required:
+        title: Cannot delete document type
+        heading: Cannot delete the last document type
+        message: There must always be at least one document type configured. Create another one first if you want to delete this one.
 
   label_document_added: "Document added"
   label_document_new: "New document"

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
         resources :document_types, except: [:show] do
           member do
             put :move
+            get :delete_dialog, defaults: { format: :turbo_stream }
           end
         end
       end

--- a/modules/documents/db/migrate/20251119095014_add_active_and_document_count_to_document_types.rb
+++ b/modules/documents/db/migrate/20251119095014_add_active_and_document_count_to_document_types.rb
@@ -28,21 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DocumentType < ApplicationRecord
-  include ::Documents::EnumerationModel
+class AddActiveAndDocumentCountToDocumentTypes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :document_types, :active, :boolean, default: true, null: false
+    add_column :document_types, :documents_count, :integer, default: 0, null: false
 
-  default_scope { order(:position) }
-  acts_as_list
-
-  has_many :documents, foreign_key: :type_id,
-                       dependent: :nullify,
-                       inverse_of: :type
-
-  normalizes :name, with: ->(name) { name.strip.capitalize }
-
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
-
-  def self.default
-    where(is_default: true).first || first
+    reversible do |dir|
+      dir.up do
+        say_with_time "update documents counter cache for document_types" do
+          execute <<-SQL.squish
+            UPDATE document_types
+            SET documents_count = (
+              SELECT COUNT(*)
+              FROM documents
+              WHERE documents.type_id = document_types.id
+            )
+          SQL
+        end
+      end
+    end
   end
 end

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -67,6 +67,21 @@ module OpenProject::Documents
       end
 
       menu :admin_menu,
+           :documents,
+           { controller: "/documents/admin/settings/document_types", action: :index },
+           if: ->(_) { User.current.admin? },
+           caption: :label_document_plural,
+           before: :files,
+           icon: "note"
+
+      menu :admin_menu,
+           :document_types,
+           { controller: "/documents/admin/settings/document_types", action: :index },
+           if: ->(_) { User.current.admin? },
+           caption: :"documents.menu.types",
+           parent: :documents
+
+      menu :admin_menu,
            :document_categories,
            { controller: "/admin/settings/document_categories", action: :index },
            if: ->(_) { User.current.admin? },

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Document types admin", :js do
+  include Flash::Expectations
+
+  current_user { create(:admin) }
+  let!(:default_document_type) { create(:document_type, is_default: true, name: "Note") }
+
+  def within_enumeration_item(type, &)
+    page.within("#documents-admin-document-types-item-component-#{type.id}", &)
+  end
+
+  it "can be managed (created, updated, deleted)" do
+    visit admin_settings_document_types_path
+
+    within_enumeration_item(default_document_type) do
+      expect(page).to have_content("Note")
+      expect(page).to have_content("Default")
+    end
+
+    within_test_selector("admin-document-types-subheader") do
+      click_on "Add"
+    end
+
+    fill_in "Name", with: "Documentation"
+    check "Default"
+    click_on("Save")
+
+    expect_and_dismiss_flash(message: "Successful update.")
+
+    # we are redirected back to the index page
+    expect(page).to have_current_path(admin_settings_document_types_path)
+
+    new_document_type = DocumentType.last
+
+    # The new document type is shown in the list as the default document type
+    within_enumeration_item(new_document_type) do
+      expect(page).to have_content("Documentation")
+      expect(page).to have_content("Default")
+    end
+
+    # Since the new document type is now the default, the former default looses that flag
+    within_enumeration_item(default_document_type) do
+      expect(page).to have_content("Note")
+      expect(page).to have_no_content("Default")
+    end
+
+    click_link "Documentation"
+
+    fill_in "Name", with: "Report"
+    click_on("Save")
+
+    expect_and_dismiss_flash(message: "Successful update.")
+
+    within_enumeration_item(new_document_type) do
+      expect(page).to have_content("Report")
+      expect(page).to have_content("Default")
+    end
+
+    expect(DocumentType).to exist(name: "Report")
+    expect(DocumentType).not_to exist(name: "Documentation")
+
+    # It allows deleting document types
+    within_enumeration_item(new_document_type) do
+      click_on accessible_name: "Document type actions"
+      click_button("Delete")
+    end
+
+    expect_and_dismiss_flash(message: "Successful deletion.")
+
+    expect(page).to have_no_content("Report")
+
+    # Since the old default is deleted another is now the default.
+    within_enumeration_item(default_document_type) do
+      expect(page).to have_content("Note")
+      expect(page).to have_no_content("Default")
+    end
+  end
+end

--- a/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_types_spec.rb
@@ -34,76 +34,153 @@ RSpec.describe "Document types admin", :js do
   include Flash::Expectations
 
   current_user { create(:admin) }
-  let!(:default_document_type) { create(:document_type, is_default: true, name: "Note") }
 
   def within_enumeration_item(type, &)
     page.within("#documents-admin-document-types-item-component-#{type.id}", &)
   end
 
-  it "can be managed (created, updated, deleted)" do
-    visit admin_settings_document_types_path
+  context "when managing document types" do
+    let!(:default_document_type) { create(:document_type, is_default: true, name: "Note") }
 
-    within_enumeration_item(default_document_type) do
-      expect(page).to have_content("Note")
-      expect(page).to have_content("Default")
+    it "can be managed (created, updated, deleted)" do
+      visit admin_settings_document_types_path
+
+      within_enumeration_item(default_document_type) do
+        expect(page).to have_content("Note")
+        expect(page).to have_content("Default")
+      end
+
+      within_test_selector("admin-document-types-subheader") do
+        click_on "Add"
+      end
+
+      fill_in "Name", with: "Documentation"
+      check "Default"
+      click_on("Save")
+
+      expect_and_dismiss_flash(message: "Successful update.")
+
+      # we are redirected back to the index page
+      expect(page).to have_current_path(admin_settings_document_types_path)
+
+      new_document_type = DocumentType.last
+
+      # The new document type is shown in the list as the default document type
+      within_enumeration_item(new_document_type) do
+        expect(page).to have_content("Documentation")
+        expect(page).to have_content("Default")
+      end
+
+      # Since the new document type is now the default, the former default looses that flag
+      within_enumeration_item(default_document_type) do
+        expect(page).to have_content("Note")
+        expect(page).to have_no_content("Default")
+      end
+
+      click_link "Documentation"
+
+      fill_in "Name", with: "Report"
+      click_on("Save")
+
+      expect_and_dismiss_flash(message: "Successful update.")
+
+      within_enumeration_item(new_document_type) do
+        expect(page).to have_content("Report")
+        expect(page).to have_content("Default")
+      end
+
+      expect(DocumentType).to exist(name: "Report")
+      expect(DocumentType).not_to exist(name: "Documentation")
+
+      # It allows deleting document types
+      within_enumeration_item(new_document_type) do
+        click_on accessible_name: "Document type actions"
+        click_on("Delete")
+      end
+
+      within_dialog("Delete document type") do
+        expect(page).to have_heading "Delete this document type?"
+        expect(page).to have_content 'The type "Report" is currently unused. ' \
+                                     "Deleting this type will have no effect on existing documents."
+
+        click_on "Delete permanently"
+      end
+
+      expect_and_dismiss_flash(message: "Successful deletion.")
+
+      expect(page).to have_no_content("Report")
+
+      # Since the old default is deleted another is now the default.
+      within_enumeration_item(default_document_type) do
+        expect(page).to have_content("Note")
+        expect(page).to have_no_content("Default")
+      end
     end
+  end
 
-    within_test_selector("admin-document-types-subheader") do
-      click_on "Add"
-    end
+  context "with multiple types having documents" do
+    let!(:type_with_documents) { create(:document_type, name: "Type with documents") }
+    let!(:another_type) { create(:document_type, name: "Another type") }
+    let!(:unused_type) { create(:document_type, name: "Unused type") }
+    let!(:document) { create(:document, type: type_with_documents) }
 
-    fill_in "Name", with: "Documentation"
-    check "Default"
-    click_on("Save")
+    it "reassigns documents when deleting a document type" do
+      visit admin_settings_document_types_path
 
-    expect_and_dismiss_flash(message: "Successful update.")
+      within_enumeration_item(type_with_documents) do
+        click_on accessible_name: "Document type actions"
+        click_on("Delete")
+      end
 
-    # we are redirected back to the index page
-    expect(page).to have_current_path(admin_settings_document_types_path)
+      within_dialog("Delete document type") do
+        expect(page).to have_heading "Delete this document type?"
+        expect(page).to have_content 'The type "Type with documents" is currently being used in 1 document. ' \
+                                     "Please select which type to reassign them to."
 
-    new_document_type = DocumentType.last
+        select another_type.name, from: "Reassign documents to"
+        click_on "Delete permanently"
+      end
 
-    # The new document type is shown in the list as the default document type
-    within_enumeration_item(new_document_type) do
-      expect(page).to have_content("Documentation")
-      expect(page).to have_content("Default")
-    end
+      expect_and_dismiss_flash(message: "Successful deletion.")
 
-    # Since the new document type is now the default, the former default looses that flag
-    within_enumeration_item(default_document_type) do
-      expect(page).to have_content("Note")
-      expect(page).to have_no_content("Default")
-    end
+      expect(DocumentType).not_to exist(name: "Type with documents")
+      expect(document.reload.type).to eq another_type
 
-    click_link "Documentation"
+      within_enumeration_item(another_type) do
+        expect(page).to have_test_selector("documents-count", text: "1")
+      end
 
-    fill_in "Name", with: "Report"
-    click_on("Save")
+      # It allows deleting unused document types
+      within_enumeration_item(unused_type) do
+        click_on accessible_name: "Document type actions"
+        click_on("Delete")
+      end
 
-    expect_and_dismiss_flash(message: "Successful update.")
+      within_dialog("Delete document type") do
+        expect(page).to have_heading "Delete this document type?"
+        expect(page).to have_content 'The type "Unused type" is currently unused. ' \
+                                     "Deleting this type will have no effect on existing documents."
 
-    within_enumeration_item(new_document_type) do
-      expect(page).to have_content("Report")
-      expect(page).to have_content("Default")
-    end
+        click_on "Delete permanently"
+      end
 
-    expect(DocumentType).to exist(name: "Report")
-    expect(DocumentType).not_to exist(name: "Documentation")
+      expect_and_dismiss_flash(message: "Successful deletion.")
 
-    # It allows deleting document types
-    within_enumeration_item(new_document_type) do
-      click_on accessible_name: "Document type actions"
-      click_button("Delete")
-    end
+      expect(DocumentType).not_to exist(name: "Unused type")
 
-    expect_and_dismiss_flash(message: "Successful deletion.")
+      # Last remaining type cannot be deleted
+      within_enumeration_item(another_type) do
+        click_on accessible_name: "Document type actions"
+        click_on("Delete")
+      end
 
-    expect(page).to have_no_content("Report")
+      within_dialog("Cannot delete document type") do
+        expect(page).to have_heading "Cannot delete the last document type"
+        expect(page).to have_content "There must always be at least one document type configured. " \
+                                     "Create another one first if you want to delete this one."
 
-    # Since the old default is deleted another is now the default.
-    within_enumeration_item(default_document_type) do
-      expect(page).to have_content("Note")
-      expect(page).to have_no_content("Default")
+        click_on "Close"
+      end
     end
   end
 end

--- a/modules/documents/spec/models/concerns/documents/enumeration_model_spec.rb
+++ b/modules/documents/spec/models/concerns/documents/enumeration_model_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+RSpec.describe Documents::EnumerationModel do
+  subject { build(:document_type) }
+
+  it { is_expected.not_to be_colored }
+
+  describe "#became_default_value?" do
+    it "returns true if is_default changed to true" do
+      subject.is_default = false
+      subject.save!(validate: false)
+
+      subject.is_default = true
+
+      expect(subject).to be_became_default_value
+    end
+
+    it "returns false if is_default did not change" do
+      subject.is_default = true
+      subject.save!(validate: false)
+
+      subject.is_default = true
+
+      expect(subject).not_to be_became_default_value
+    end
+
+    it "returns false if is_default changed to false" do
+      subject.is_default = true
+      subject.save!(validate: false)
+
+      subject.is_default = false
+
+      expect(subject).not_to be_became_default_value
+    end
+  end
+
+  describe "#unmark_old_default_values" do
+    it "unmarks all other default values" do
+      other_type = create(:document_type, is_default: true)
+      subject.is_default = true
+
+      subject.unmark_old_default_values
+
+      expect(other_type.reload.is_default).to be(false)
+    end
+  end
+
+  describe "#ensure_activated" do
+    it "ensures that the enumeration is activated when marked as default" do
+      subject.is_default = true
+      subject.active = false
+
+      subject.save
+
+      expect(subject).to be_active & be_is_default
+    end
+  end
+
+  describe "#in_use?" do
+    subject { create(:document_type) }
+
+    context "with documents associated" do
+      before do
+        create(:document, type: subject)
+      end
+
+      it "returns true" do
+        expect(subject).to be_in_use
+      end
+    end
+
+    context "without documents associated" do
+      it "returns false" do
+        expect(subject).not_to be_in_use
+      end
+    end
+  end
+end

--- a/modules/documents/spec/models/document_type_spec.rb
+++ b/modules/documents/spec/models/document_type_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe DocumentType do
         .dependent(:nullify)
         .with_foreign_key(:type_id)
     end
+
+    context "for documents" do
+      let(:document_type) { create(:document_type) }
+
+      it "maintains documents counter cache" do
+        expect { create(:document, type: document_type) }
+          .to change { document_type.reload.documents_count }.by(1)
+      end
+    end
   end
 
   describe "Normalizations" do

--- a/modules/documents/spec/models/document_type_spec.rb
+++ b/modules/documents/spec/models/document_type_spec.rb
@@ -77,4 +77,28 @@ RSpec.describe DocumentType do
       expect(described_class.default).to eq first_type
     end
   end
+
+  describe "#destroy(reassign_to)" do
+    let!(:document_type) { create(:document_type) }
+    let!(:other_type) { create(:document_type) }
+    let!(:document) { create(:document, type: document_type) }
+
+    it "reassigns documents to the given document type before destroying" do
+      expect do
+        document_type.destroy(other_type)
+      end.to change { document.reload.type }.from(document_type).to(other_type)
+        .and(change { other_type.reload.documents_count }.by(1))
+        .and(change(described_class, :count).by(-1))
+    end
+  end
+
+  describe "#prevent_deletion_of_last_type" do
+    let!(:only_type) { create(:document_type) }
+
+    it "prevents destroying the last remaining document type" do
+      expect(only_type.destroy).to be_falsey
+      expect(only_type.errors[:base]).to include("Cannot delete the last document type")
+      expect(described_class.count).to eq 1
+    end
+  end
 end

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe "Admin menu items",
   context "without having any menu items hidden in configuration" do
     it "must display all menu items" do
       expect(page).to have_test_selector("menu-blocks--container")
-      expect(page).to have_test_selector("menu-block", count: 20)
-      expect(page).to have_test_selector("op-menu--item-action", count: 21) # All plus 'overview'
+      expect(page).to have_test_selector("menu-block", count: 21)
+      expect(page).to have_test_selector("op-menu--item-action", count: 22) # All plus 'overview'
     end
   end
 
@@ -57,10 +57,10 @@ RSpec.describe "Admin menu items",
           } do
     it "must not display the hidden menu items and blocks" do
       expect(page).to have_test_selector("menu-blocks--container")
-      expect(page).to have_test_selector("menu-block", count: 19)
+      expect(page).to have_test_selector("menu-block", count: 20)
       expect(page).not_to have_test_selector("menu-block", text: I18n.t(:label_color_plural))
 
-      expect(page).to have_test_selector("op-menu--item-action", count: 20) # All plus 'overview'
+      expect(page).to have_test_selector("op-menu--item-action", count: 21) # All plus 'overview'
       expect(page).not_to have_test_selector("op-menu--item-action", text: I18n.t(:label_color_plural))
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/69146

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Add document types admin page

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="2695" height="784" alt="Screenshot 2025-11-20 at 8 54 28 PM" src="https://github.com/user-attachments/assets/5575dfae-1d13-423b-bc53-024fef672842" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

> [!IMPORTANT]
> The implementation extends enumerations functionality as it's (currently) generally similar. At a later point, it possible we can decouple from enumerations view logic.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
