### PR TITLE
Feature/66308 limit hierarchy options based on workspace type

### DIFF
--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -95,7 +95,7 @@ module Projects
       if model.parent &&
          model.parent_id_changed? &&
          !assignable_parents.exists?(id: parent.id)
-        errors.add(:parent, :does_not_exist)
+        errors.add(:parent, :invalid)
       end
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -254,7 +254,7 @@ class ProjectsController < ApplicationController
 
   def set_wizard_step!(project)
     attributes_with_error = project.errors.attribute_names
-    second_step_attributes = %i[name description identifier]
+    second_step_attributes = %i[name description identifier parent]
     step_2_is_valid = !attributes_with_error.intersect?(second_step_attributes)
 
     params[:step] = step_2_is_valid ? 3 : 2

--- a/app/forms/projects/settings/relations_form.rb
+++ b/app/forms/projects/settings/relations_form.rb
@@ -49,10 +49,6 @@ module Projects
 
       private
 
-      def render?
-        model.project?
-      end
-
       def project_autocompleter_model
         return nil unless parent
         return { id: parent.id, name: I18n.t(:"api_v3.undisclosed.parent") } unless parent.visible? || User.current.admin?

--- a/app/forms/projects/settings/relations_form.rb
+++ b/app/forms/projects/settings/relations_form.rb
@@ -36,6 +36,8 @@ module Projects
         f.project_autocompleter(
           name: :parent_id,
           label: attribute_name(:parent_id),
+          invalid: model.errors.include?(:parent_id),
+          validation_message: validation_message(:parent),
           autocomplete_options: {
             model: project_autocompleter_model,
             focusDirectly: false,
@@ -48,6 +50,10 @@ module Projects
       end
 
       private
+
+      def validation_message(attribute)
+        model.errors.full_messages_for(attribute).to_sentence.presence
+      end
 
       def project_autocompleter_model
         return nil unless parent

--- a/app/forms/projects/settings/relations_form.rb
+++ b/app/forms/projects/settings/relations_form.rb
@@ -57,9 +57,13 @@ module Projects
       end
 
       def project_autocompleter_url
-        url_str = ::API::V3::Utilities::PathHelper::ApiV3Path.projects_available_parents
-        url_str << "?of=#{model.id}" unless model.new_record?
-        url_str
+        params = if model.new_record?
+                   { workspace_type: model.workspace_type }
+                 else
+                   { of: model.id }
+                 end
+
+        ::API::V3::Utilities::PathHelper::ApiV3Path.projects_available_parents(**params)
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,6 +55,12 @@ class Project < ApplicationRecord
     portfolio: "portfolio"
   }, validate: true
 
+  ALLOWED_PARENT_WORKSPACE_TYPES = {
+    project: %i[portfolio program project],
+    program: %i[portfolio],
+    portfolio: %i[portfolio]
+  }.with_indifferent_access
+
   has_many :members, -> {
     # TODO: check whether this should
     # remain to be limited to User only
@@ -268,6 +274,8 @@ class Project < ApplicationRecord
   def to_s
     name
   end
+
+  def allowed_parent_workspace_types = ALLOWED_PARENT_WORKSPACE_TYPES[workspace_type] || []
 
   def workspace_label
     case workspace_type

--- a/app/models/projects/scopes/assignable_parents.rb
+++ b/app/models/projects/scopes/assignable_parents.rb
@@ -34,12 +34,13 @@ module Projects::Scopes
 
     class_methods do
       def assignable_parents(user, project)
-        if project.portfolio? || project.program?
-          Project.none
-        else
+        if (allowed_parent_workspace_types = project.allowed_parent_workspace_types)
           Project
             .allowed_to(user, :add_subprojects)
             .where.not(id: project.self_and_descendants)
+            .where(workspace_type: allowed_parent_workspace_types)
+        else
+          Project.none
         end
       end
     end

--- a/docs/api/apiv3/paths/projects_available_parent_projects.yml
+++ b/docs/api/apiv3/paths/projects_available_parent_projects.yml
@@ -17,6 +17,16 @@ get:
     required: false
     schema:
       type: string
+  - description: >-
+      The workspace type of the new project the parent candidate is determined for.
+      Ignored when `of` parameter is provided.
+    example: program
+    in: query
+    name: workspace_type
+    required: false
+    schema:
+      type: string
+      enum: [project, program, portfolio]
   - description: |-
       JSON specifying sort criteria.
       Accepts the same format as returned by the [queries](https://www.openproject.org/docs/api/endpoints/queries/) endpoint and allows all the filters and sortBy supported by the project list endpoint.
@@ -137,7 +147,7 @@ get:
 
     To specify the project for which a parent is queried for, the `of` parameter can be provided. If no `of`
     parameter is provided, a new project is assumed. Then, the check for the hierarchy is omitted as a new project cannot be
-    part of a hierarchy yet.
+    part of a hierarchy yet, instead `workspace_type` parameter can be passed defining it for new project.
 
     Candidates can be filtered. Most commonly one will want to filter by name or identifier.
     You can do this through the `filters` parameter which works just like the work package index.

--- a/lib/api/v3/projects/available_parents_api.rb
+++ b/lib/api/v3/projects/available_parents_api.rb
@@ -39,25 +39,26 @@ module API
             end
           end
 
-          get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex.new(model: Project,
-                                                                       scope: -> do
-                                                                         project = if params[:of]
-                                                                                     Project.find(params[:of])
-                                                                                   else
-                                                                                     Project.new(workspace_type: "project")
-                                                                                   end
+          get &::API::V3::Utilities::Endpoints::SqlFallbackedIndex.new(
+            model: Project,
+            scope: -> do
+              project = if params[:of]
+                          Project.find(params[:of])
+                        else
+                          Project.new(workspace_type: params[:workspace_type] || "project")
+                        end
 
-                                                                         contract_class = if project.new_record?
-                                                                                            ::Projects::CreateContract
-                                                                                          else
-                                                                                            ::Projects::UpdateContract
-                                                                                          end
+              contract_class = if project.new_record?
+                                 ::Projects::CreateContract
+                               else
+                                 ::Projects::UpdateContract
+                               end
 
-                                                                         contract = contract_class.new(project, current_user)
+              contract = contract_class.new(project, current_user)
 
-                                                                         contract.assignable_parents.includes(:enabled_modules)
-                                                                       end)
-                                                                  .mount
+              contract.assignable_parents.includes(:enabled_modules)
+            end
+          ).mount
         end
       end
     end

--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -94,13 +94,13 @@ module API
                                        !current_user.allowed_globally?(:add_project)
                                    },
                                    href_callback: ->(*) {
-                                     query_props = if represented.model.new_record?
-                                                     ""
-                                                   else
-                                                     "?of=#{represented.model.id}"
-                                                   end
+                                     params = if represented.model.new_record?
+                                                { workspace_type: represented.model.workspace_type }
+                                              else
+                                                { of: represented.model.id }
+                                              end
 
-                                     api_v3_paths.projects_available_parents + query_props
+                                     api_v3_paths.projects_available_parents(**params)
                                    }
 
           schema :created_at,

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -359,8 +359,10 @@ module API
 
           show :project_status
 
-          def self.projects_available_parents
-            "#{projects}/available_parent_projects"
+          def self.projects_available_parents(of: nil, workspace_type: nil)
+            query = { of:, workspace_type: }.compact_blank.to_query
+
+            "#{projects}/available_parent_projects#{"?#{query}" unless query.empty?}"
           end
 
           def self.projects_schema

--- a/spec/contracts/projects/shared_contract_examples.rb
+++ b/spec/contracts/projects/shared_contract_examples.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples_for "project contract" do
   context "if the parent is not in the set of assignable_parents" do
     let(:assignable_parents) { [] }
 
-    it_behaves_like "contract is invalid", parent: %i(does_not_exist)
+    it_behaves_like "contract is invalid", parent: %i(invalid)
   end
 
   context "if active is nil" do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -361,6 +361,29 @@ RSpec.describe ProjectsController do
             end
           end
 
+          context "when the parent is invalid", with_flag: { portfolio_models: true } do
+            shared_let(:invalid_parent) { create(:project, workspace_type: :program) }
+            let(:project_params) { { name: "Valid Project", parent_id: invalid_parent.id, workspace_type: :portfolio } }
+
+            it "renders step 2 with errors", :aggregate_failures do
+              expect(controller.params[:step].to_i).to eq 2
+              expect(response).to render_template "new"
+              expect(response).to have_http_status :unprocessable_entity
+            end
+
+            it "shows an error on the parent", :aggregate_failures do
+              expect(assigns(:new_project).errors[:parent]).to be_present
+              expect(flash[:error]).to be_present
+            end
+
+            it "does not show custom field errors", :aggregate_failures do
+              expect(assigns(:new_project).errors[:"custom_field_#{custom_field.id}"]).to be_empty
+              assigns(:new_project).custom_values.each do |cv|
+                expect(cv.errors).to be_empty
+              end
+            end
+          end
+
           context "when it has no validation error on name" do
             let(:project_params) { { name: "Valid Project" } }
 

--- a/spec/features/portfolios/create_spec.rb
+++ b/spec/features/portfolios/create_spec.rb
@@ -39,8 +39,17 @@ RSpec.describe "Portfolios",
   end
   # Role granted to creator on portfolio creation to be able to access the portfolio.
   shared_let(:default_project_role) { create(:project_role) }
+  shared_let(:add_subproject_role) { create(:project_role, permissions: %i[add_subprojects]) }
+
+  let!(:root_portfolio) do
+    create(:portfolio, name: "Root portfolio", members: { user_with_permissions => add_subproject_role })
+  end
+  let!(:other_portfolio) do
+    create(:portfolio, name: "Other portfolio")
+  end
 
   let(:projects_page) { Pages::Projects::Index.new }
+  let(:parent_field) { FormFields::SelectFormField.new :parent }
 
   current_user { user_with_permissions }
 
@@ -54,19 +63,23 @@ RSpec.describe "Portfolios",
     click_on "Continue"
 
     # Step 2: Fill in project details
-    # This should be an
-    #   expect(page).to have_no_field "Subproject of"
-    # But this leads to a false negative. Even with the field being there, is the
-    # expectation passed.
-    expect(page).to have_no_content "Subproject of"
-
     fill_in "Name", with: "Foo bar"
+
+    expect(page).to have_combo_box "Subproject of"
+    parent_field.expect_no_option "Other portfolio"
+    parent_field.select_option "Root portfolio"
+
     click_on "Complete"
 
     expect_and_dismiss_flash type: :success, message: "Successful creation."
 
     expect(page).to have_current_path /\/projects\/foo-bar\/?/
     expect(page).to have_content "Foo bar"
+
+    portfolio = Project.last
+    expect(portfolio.workspace_type).to eq "portfolio"
+    expect(portfolio.identifier).to eq "foo-bar"
+    expect(portfolio.parent).to eq root_portfolio
   end
 
   context "without the necessary permissions to create portfolios", with_flag: { portfolio_models: true } do

--- a/spec/features/programs/create_spec.rb
+++ b/spec/features/programs/create_spec.rb
@@ -39,14 +39,22 @@ RSpec.describe "Programs",
   end
   # Role granted to creator on program creation to be able to access the program.
   shared_let(:default_project_role) { create(:project_role) }
+  shared_let(:add_subproject_role) { create(:project_role, permissions: %i[add_subprojects]) }
+
+  let!(:root_portfolio) do
+    create(:portfolio, name: "Root portfolio", members: { user_with_permissions => add_subproject_role })
+  end
+  let!(:other_portfolio) do
+    create(:portfolio, name: "Other portfolio")
+  end
 
   let(:projects_page) { Pages::Projects::Index.new }
+  let(:parent_field) { FormFields::SelectFormField.new :parent }
 
   current_user { user_with_permissions }
 
   it "can create a program", with_flag: { portfolio_models: true } do
     projects_page.visit!
-
     projects_page.create_new_workspace
 
     expect(page).to have_heading "New program"
@@ -55,19 +63,23 @@ RSpec.describe "Programs",
     click_on "Continue"
 
     # Step 2: Fill in project details
-    # This should be an
-    #   expect(page).to have_no_field "Subproject of"
-    # But this leads to a false negative. Even with the field being there, is the
-    # expectation passed.
-    expect(page).to have_no_content "Subproject of"
-
     fill_in "Name", with: "Foo bar"
+
+    expect(page).to have_combo_box "Subproject of"
+    parent_field.expect_no_option "Other portfolio"
+    parent_field.select_option "Root portfolio"
+
     click_on "Complete"
 
     expect_and_dismiss_flash type: :success, message: "Successful creation."
 
     expect(page).to have_current_path /\/projects\/foo-bar\/?/
     expect(page).to have_content "Foo bar"
+
+    program = Project.last
+    expect(program.workspace_type).to eq "program"
+    expect(program.identifier).to eq "foo-bar"
+    expect(program.parent).to eq root_portfolio
   end
 
   context "without the necessary permissions to create programs", with_flag: { portfolio_models: true } do

--- a/spec/forms/projects/settings/relations_form_spec.rb
+++ b/spec/forms/projects/settings/relations_form_spec.rb
@@ -92,4 +92,15 @@ RSpec.describe Projects::Settings::RelationsForm, type: :forms do
       end
     end
   end
+
+  context "with validation errors" do
+    before do
+      model.errors.add(:parent, :invalid)
+      render_form
+    end
+
+    it "renders error message" do
+      expect(page).to have_css ".FormControl-inlineValidation", text: "Subproject of is invalid"
+    end
+  end
 end

--- a/spec/forms/projects/settings/relations_form_spec.rb
+++ b/spec/forms/projects/settings/relations_form_spec.rb
@@ -33,11 +33,18 @@ require "spec_helper"
 RSpec.describe Projects::Settings::RelationsForm, type: :forms do
   include_context "with rendered form"
 
-  let(:model) { build_stubbed(:project, parent:) }
+  let(:model) { build_stubbed(:project, parent:, workspace_type:) }
   let(:parent) { nil }
+  let(:workspace_type) { :project }
 
-  it "renders field" do
-    expect(page).to have_element "opce-project-autocompleter", "data-input-name": "\"project[parent_id]\""
+  %i[portfolio program project].each do |workspace_type|
+    context "for workspace type #{workspace_type}" do
+      let(:workspace_type) { workspace_type }
+
+      it "renders field" do
+        expect(page).to have_element "opce-project-autocompleter", "data-input-name": "\"project[parent_id]\""
+      end
+    end
   end
 
   context "without parent" do

--- a/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
+++ b/spec/lib/api/v3/projects/schemas/project_schema_representer_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
   let(:embedded) { true }
   let(:new_record) { true }
   let(:model_id) { 1 }
+  let(:workspace_type) { "foobar" }
   let(:custom_field) do
     build_stubbed(:integer_project_custom_field)
   end
@@ -66,7 +67,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
       .to receive_messages(available_custom_fields: [custom_field, calculated_value_cf], model: model)
 
     allow(model)
-      .to receive_messages(new_record?: new_record, id: model_id)
+      .to receive_messages(new_record?: new_record, id: model_id, workspace_type:)
 
     contract
   end
@@ -330,7 +331,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
 
           it_behaves_like "links to allowed values via collection link" do
             let(:href) do
-              api_v3_paths.projects_available_parents
+              api_v3_paths.projects_available_parents(workspace_type: :foobar)
             end
           end
         end
@@ -372,7 +373,7 @@ RSpec.describe API::V3::Projects::Schemas::ProjectSchemaRepresenter do
 
           it_behaves_like "links to allowed values via collection link" do
             let(:href) do
-              api_v3_paths.projects_available_parents + "?of=#{model_id}"
+              api_v3_paths.projects_available_parents(of: model_id)
             end
           end
         end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -296,6 +296,18 @@ RSpec.describe API::V3::Utilities::PathHelper do
 
       it_behaves_like "api v3 path", "/projects/available_parent_projects"
     end
+
+    describe "#projects_available_parents with of parameter" do
+      subject { helper.projects_available_parents(of: 42) }
+
+      it_behaves_like "api v3 path", "/projects/available_parent_projects?of=42"
+    end
+
+    describe "#projects_available_parents with workspace_type parameter" do
+      subject { helper.projects_available_parents(workspace_type: :special) }
+
+      it_behaves_like "api v3 path", "/projects/available_parent_projects?workspace_type=special"
+    end
   end
 
   describe "project phase paths" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -593,4 +593,28 @@ RSpec.describe Project do
       end
     end
   end
+
+  describe "#allowed_parent_workspace_types" do
+    {
+      project: %i[portfolio program project],
+      program: %i[portfolio],
+      portfolio: %i[portfolio]
+    }.each do |workspace_type, allowed_parent_workspace_types|
+      context "for workspace type #{workspace_type}" do
+        let(:project) { described_class.new(workspace_type:) }
+
+        subject { project.allowed_parent_workspace_types }
+
+        it { is_expected.to match_array(allowed_parent_workspace_types) }
+      end
+    end
+
+    context "for unknown workspace type" do
+      let(:project) { described_class.new(workspace_type: :unknown) }
+
+      subject { project.allowed_parent_workspace_types }
+
+      it { is_expected.to eq [] }
+    end
+  end
 end

--- a/spec/models/projects/scopes/assignable_parents_spec.rb
+++ b/spec/models/projects/scopes/assignable_parents_spec.rb
@@ -33,40 +33,82 @@ require "spec_helper"
 RSpec.describe Projects::Scopes::AssignableParents do
   shared_let(:add_subprojects_role) { create(:project_role, permissions: %i[add_subprojects]) }
   shared_let(:view_role) { create(:project_role, permissions: %i[]) }
+
   shared_let(:user) { create(:user) }
+
+  shared_let(:portfolio_with_permission) { create(:portfolio, members: { user => add_subprojects_role }) }
+  shared_let(:program_with_permission) { create(:program, members: { user => add_subprojects_role }) }
   shared_let(:project_with_permission) { create(:project, members: { user => add_subprojects_role }) }
-  shared_let(:parent_project) { create(:project, members: { user => add_subprojects_role }) }
-  shared_let(:subject_project, reload: true) do
-    create(:project, parent: parent_project, members: { user => add_subprojects_role })
-  end
-  shared_let(:child_project) { create(:project, parent: subject_project, members: { user => add_subprojects_role }) }
+  shared_let(:portfolio_without_permission) { create(:portfolio, members: { user => view_role }) }
+  shared_let(:program_without_permission) { create(:program, members: { user => view_role }) }
   shared_let(:project_without_permission) { create(:project, members: { user => view_role }) }
 
+  # part of hierarchy used for test is not valid
+  shared_let(:parent_portfolio) { create(:portfolio, members: { user => add_subprojects_role }) }
+  shared_let(:parent_program) { create(:program, parent: parent_portfolio, members: { user => add_subprojects_role }) }
+  shared_let(:parent_project) { create(:project, parent: parent_program, members: { user => add_subprojects_role }) }
+  shared_let(:children) do
+    [
+      create(:portfolio, members: { user => add_subprojects_role }),
+      create(:program, members: { user => add_subprojects_role }),
+      create(:project, members: { user => add_subprojects_role })
+    ]
+  end
+
+  let!(:subject_workspace) do
+    create(:project, workspace_type:, parent: parent_project, children:, members: { user => add_subprojects_role })
+  end
+
   context "for a project" do
-    it "returns all projects the user has the add_subprojects permission in but without self or descendants" do
-      expect(Project.assignable_parents(user, subject_project))
-        .to contain_exactly(project_with_permission, parent_project)
+    let(:workspace_type) { :project }
+
+    it "returns all types of projects the user has the add_subprojects permission in but without self or descendants" do
+      expect(Project.assignable_parents(user, subject_workspace))
+        .to contain_exactly(
+          portfolio_with_permission,
+          program_with_permission,
+          project_with_permission,
+          parent_portfolio,
+          parent_program,
+          parent_project
+        )
     end
   end
 
   context "for a portfolio" do
-    before do
-      subject_project.portfolio!
-    end
+    let(:workspace_type) { :portfolio }
 
-    it "is empty" do
-      expect(Project.assignable_parents(user, subject_project))
-        .to be_empty
+    it "returns portfolios the user has the add_subprojects permission in but without self or descendants" do
+      expect(Project.assignable_parents(user, subject_workspace))
+        .to contain_exactly(
+          portfolio_with_permission,
+          parent_portfolio
+        )
     end
   end
 
   context "for a program" do
-    before do
-      subject_project.program!
+    let(:workspace_type) { :program }
+
+    it "returns portfolios the user has the add_subprojects permission in" do
+      expect(Project.assignable_parents(user, subject_workspace))
+      .to contain_exactly(
+        portfolio_with_permission,
+        parent_portfolio
+      )
+    end
+  end
+
+  context "for an unknown workspace type" do
+    let!(:subject_workspace) do
+      create(:project, :skip_validations, workspace_type: :unknown,
+                                          parent: parent_project,
+                                          children:,
+                                          members: { user => add_subprojects_role })
     end
 
-    it "is empty" do
-      expect(Project.assignable_parents(user, subject_project))
+    it do
+      expect(Project.assignable_parents(user, subject_workspace))
         .to be_empty
     end
   end

--- a/spec/requests/api/v3/projects/available_parents_resource_spec.rb
+++ b/spec/requests/api/v3/projects/available_parents_resource_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "API v3 Project available parents resource", content_type: :json 
     end
 
     context "with a project candidate" do
-      let(:path) { api_v3_paths.projects_available_parents + "?of=#{project.id}" }
+      let(:path) { api_v3_paths.projects_available_parents(of: project.id) }
 
       before do
         response

--- a/spec/requests/api/v3/projects/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/update_form_resource_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe API::V3::Projects::UpdateFormAPI, content_type: :json do
 
         it "links to the allowed parents in the schema" do
           expect(subject.body)
-            .to be_json_eql((api_v3_paths.projects_available_parents + "?of=#{project.id}").to_json)
+            .to be_json_eql(api_v3_paths.projects_available_parents(of: project.id).to_json)
             .at_path("_embedded/schema/parent/_links/allowedValues/href")
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/66308

# What are you trying to accomplish?
Allow only certain workspace type of project parents (anything for project, and only portfolio for portfolio and program)

# What approach did you choose and why?
Change `assignable_parents` and `available_parent_projects`  api endpoint that is using it and used for the list of projects in both create and update form.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
