### PR TITLE
Properly format times in automatically generated subjects

### DIFF
--- a/app/models/work_package_types/pattern_resolver.rb
+++ b/app/models/work_package_types/pattern_resolver.rb
@@ -57,32 +57,34 @@ module WorkPackageTypes
       return ATTRIBUTE_PLACEHOLDER if attribute_token.nil?
 
       I18n.with_locale(Setting.default_language) do
-        stringify(attribute_token.call(context), nil_replacement(attribute_token))
+        stringify(attribute_token.key, attribute_token.call(context), nil_replacement(attribute_token))
       end
     end
 
-    def nil_replacement(attribute_resolver)
-      if attribute_resolver.context == :work_package
-        "[#{attribute_resolver.label}]"
+    def nil_replacement(attribute_token)
+      if attribute_token.context == :work_package
+        "[#{attribute_token.label}]"
       else
-        "[#{attribute_resolver.label_with_context}]"
+        "[#{attribute_token.label_with_context}]"
       end
     end
 
-    def stringify(value, nil_fallback)
+    def stringify(key, value, nil_fallback)
       case value
       when Date, Time, DateTime
-        value.strftime("%Y-%m-%d")
+        return value.strftime("%Y-%m-%d")
       when Array
         compact = value.compact
-        compact.empty? ? nil_fallback : compact.join(", ")
+        return compact.empty? ? nil_fallback : compact.join(", ")
       when NilClass
-        nil_fallback
+        return nil_fallback
       when :attribute_not_available
-        ATTRIBUTE_PLACEHOLDER
-      else
-        value.to_s
+        return ATTRIBUTE_PLACEHOLDER
       end
+
+      return DurationConverter.output(value) if key.to_s.ends_with?("_time")
+
+      value.to_s
     end
   end
 end

--- a/app/models/work_package_types/pattern_resolver.rb
+++ b/app/models/work_package_types/pattern_resolver.rb
@@ -57,7 +57,7 @@ module WorkPackageTypes
       return ATTRIBUTE_PLACEHOLDER if attribute_token.nil?
 
       I18n.with_locale(Setting.default_language) do
-        stringify(attribute_token.key, attribute_token.call(context), nil_replacement(attribute_token))
+        stringify(attribute_token.call(context), nil_replacement(attribute_token))
       end
     end
 
@@ -69,22 +69,15 @@ module WorkPackageTypes
       end
     end
 
-    def stringify(key, value, nil_fallback)
+    def stringify(value, nil_fallback)
       case value
-      when Date, Time, DateTime
-        return value.strftime("%Y-%m-%d")
-      when Array
-        compact = value.compact
-        return compact.empty? ? nil_fallback : compact.join(", ")
       when NilClass
-        return nil_fallback
+        nil_fallback
       when :attribute_not_available
-        return ATTRIBUTE_PLACEHOLDER
+        ATTRIBUTE_PLACEHOLDER
+      else
+        value
       end
-
-      return DurationConverter.output(value) if key.to_s.ends_with?("_time")
-
-      value.to_s
     end
   end
 end

--- a/app/models/work_package_types/patterns/attribute_token.rb
+++ b/app/models/work_package_types/patterns/attribute_token.rb
@@ -30,7 +30,7 @@
 
 module WorkPackageTypes
   module Patterns
-    AttributeToken = Data.define(:key, :label_fn, :resolve_fn) do
+    AttributeToken = Data.define(:key, :label_fn, :resolve_fn, :formatter) do
       def label_with_context
         attribute_context = I18n.t("types.edit.subject_configuration.token.context.#{context}")
         I18n.t("types.edit.subject_configuration.token.label_with_context", attribute_context:, attribute_label: label)
@@ -41,7 +41,8 @@ module WorkPackageTypes
       end
 
       def call(*)
-        resolve_fn.call(*)
+        value = resolve_fn.call(*)
+        formatter.call(value)
       end
 
       def context

--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -31,41 +31,51 @@
 module WorkPackageTypes
   module Patterns
     class TokenPropertyMapper
+      STRING_OR_NIL = ->(v) { v&.to_s }
+      ARRAY = ->(v) { v.compact.presence&.join(", ") }
+      DATE = ->(v) { v&.strftime("%Y-%m-%d") }
+      DURATION = ->(v) { DurationConverter.output(v) }
+
+      class << self
+        def attribute(key, label_fn, value_fn, formatter = STRING_OR_NIL)
+          AttributeToken.new(key, label_fn, value_fn, formatter)
+        end
+      end
       # rubocop:disable Layout/LineLength
       BASE_ATTRIBUTE_TOKENS = [
-        AttributeToken.new(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id }),
-        AttributeToken.new(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible&.name }),
-        AttributeToken.new(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to&.name }),
-        AttributeToken.new(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author&.name }),
-        AttributeToken.new(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category&.name }),
-        AttributeToken.new(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }),
-        AttributeToken.new(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }),
-        AttributeToken.new(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }),
-        AttributeToken.new(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }),
-        AttributeToken.new(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id }),
-        AttributeToken.new(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to&.name }),
-        AttributeToken.new(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author&.name }),
-        AttributeToken.new(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category&.name }),
-        AttributeToken.new(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }),
-        AttributeToken.new(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }),
-        AttributeToken.new(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }),
-        AttributeToken.new(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }),
-        AttributeToken.new(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority }),
-        AttributeToken.new(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
-        AttributeToken.new(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status&.name }),
-        AttributeToken.new(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type&.name }),
-        AttributeToken.new(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.version&.name }),
-        AttributeToken.new(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
-        AttributeToken.new(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
-        AttributeToken.new(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
-        AttributeToken.new(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project.name }),
-        AttributeToken.new(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
-        AttributeToken.new(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
-        AttributeToken.new(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
-        AttributeToken.new(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }),
-        AttributeToken.new(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status&.name }),
-        AttributeToken.new(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type&.name }),
-        AttributeToken.new(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.version&.name })
+        attribute(:id, -> { WorkPackage.human_attribute_name(:id) }, ->(wp) { wp.id }),
+        attribute(:accountable, -> { WorkPackage.human_attribute_name(:responsible) }, ->(wp) { wp.responsible }),
+        attribute(:assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(wp) { wp.assigned_to }),
+        attribute(:author, -> { WorkPackage.human_attribute_name(:author) }, ->(wp) { wp.author }),
+        attribute(:category, -> { WorkPackage.human_attribute_name(:category) }, ->(wp) { wp.category }),
+        attribute(:creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(wp) { wp.created_at }, DATE),
+        attribute(:estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(wp) { wp.estimated_hours }, DURATION),
+        attribute(:remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(wp) { wp.remaining_hours }, DURATION),
+        attribute(:finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(wp) { wp.due_date }, DATE),
+        attribute(:parent_id, -> { WorkPackage.human_attribute_name(:id) }, ->(parent) { parent.id }),
+        attribute(:parent_assignee, -> { WorkPackage.human_attribute_name(:assigned_to) }, ->(parent) { parent.assigned_to }),
+        attribute(:parent_author, -> { WorkPackage.human_attribute_name(:author) }, ->(parent) { parent.author }),
+        attribute(:parent_category, -> { WorkPackage.human_attribute_name(:category) }, ->(parent) { parent.category }),
+        attribute(:parent_creation_date, -> { WorkPackage.human_attribute_name(:created_at) }, ->(parent) { parent.created_at }, DATE),
+        attribute(:parent_estimated_time, -> { WorkPackage.human_attribute_name(:estimated_hours) }, ->(parent) { parent.estimated_hours }, DURATION),
+        attribute(:parent_remaining_time, -> { WorkPackage.human_attribute_name(:remaining_hours) }, ->(parent) { parent.remaining_hours }, DURATION),
+        attribute(:parent_finish_date, -> { WorkPackage.human_attribute_name(:due_date) }, ->(parent) { parent.due_date }, DATE),
+        attribute(:parent_priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(parent) { parent.priority }),
+        attribute(:parent_subject, -> { WorkPackage.human_attribute_name(:subject) }, ->(parent) { parent.subject }),
+        attribute(:parent_status, -> { WorkPackage.human_attribute_name(:status) }, ->(parent) { parent.status }),
+        attribute(:parent_type, -> { WorkPackage.human_attribute_name(:type) }, ->(parent) { parent.type }),
+        attribute(:parent_version, -> { WorkPackage.human_attribute_name(:version) }, ->(parent) { parent.version }),
+        attribute(:priority, -> { WorkPackage.human_attribute_name(:priority) }, ->(wp) { wp.priority }),
+        attribute(:project_id, -> { Project.human_attribute_name(:id) }, ->(project) { project.id }),
+        attribute(:project_active, -> { Project.human_attribute_name(:active) }, ->(project) { project.active? }),
+        attribute(:project_name, -> { Project.human_attribute_name(:name) }, ->(project) { project }),
+        attribute(:project_status, -> { Project.human_attribute_name(:status_code) }, ->(project) { project.status_code && I18n.t("activerecord.attributes.project.status_codes.#{project.status_code}") }),
+        attribute(:project_parent, -> { Project.human_attribute_name(:parent) }, ->(project) { project.parent_id }),
+        attribute(:project_public, -> { Project.human_attribute_name(:public) }, ->(project) { project.public? }),
+        attribute(:start_date, -> { WorkPackage.human_attribute_name(:start_date) }, ->(wp) { wp.start_date }, DATE),
+        attribute(:status, -> { WorkPackage.human_attribute_name(:status) }, ->(wp) { wp.status }),
+        attribute(:type, -> { WorkPackage.human_attribute_name(:type) }, ->(wp) { wp.type }),
+        attribute(:version, -> { WorkPackage.human_attribute_name(:version) }, ->(wp) { wp.version })
       ].freeze
       # rubocop:enable Layout/LineLength
 
@@ -110,7 +120,12 @@ module WorkPackageTypes
       end
 
       def tokenize(custom_field_scope, prefix = nil)
-        custom_field_scope.pluck(:name, :id).map do |name, id|
+        custom_field_scope.pluck(:name, :id, :multi_value).map do |name, id, multiple|
+          formatter = if multiple
+                        ARRAY
+                      else
+                        ->(v) { v.is_a?(Symbol) ? v : v&.to_s }
+                      end
           AttributeToken.new(
             :"#{prefix}custom_field_#{id}",
             -> { name },
@@ -119,7 +134,8 @@ module WorkPackageTypes
               return :attribute_not_available unless context.respond_to?(key)
 
               context.public_send(key)
-            end
+            end,
+            formatter
           )
         end
       end

--- a/spec/models/work_package_types/pattern_resolver_spec.rb
+++ b/spec/models/work_package_types/pattern_resolver_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe WorkPackageTypes::PatternResolver do
   let(:subject_pattern) { "ID Please: {{id}}" }
 
-  shared_let(:work_package) { create(:work_package) }
+  shared_let(:work_package) { create(:work_package, remaining_hours: 2) }
 
   subject(:resolver) { described_class.new(subject_pattern) }
 
@@ -64,6 +64,14 @@ RSpec.describe WorkPackageTypes::PatternResolver do
 
     it "resolves the pattern" do
       expect(subject.resolve(work_package)).to eq("N/A | empty: [Assignee] | without parent: N/A")
+    end
+  end
+
+  context "when the pattern has time attributes" do
+    let(:subject_pattern) { "Time left: {{remaining_time}}" }
+
+    it "resolves the pattern" do
+      expect(subject.resolve(work_package)).to eq("Time left: 2h")
     end
   end
 

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -66,18 +66,28 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       project.work_package_custom_fields << custom_field
       work_package.type.custom_fields << custom_field
 
-      work_package.send(:"custom_field_#{custom_field.id}=", true)
-      work_package.save
+      work_package.send(:"custom_field_#{custom_field.id}=", false)
+      work_package.save!
+    end
+  end
+
+  shared_let(:date_custom_field) do
+    create(:date_wp_custom_field).tap do |custom_field|
+      project.work_package_custom_fields << custom_field
+      work_package.type.custom_fields << custom_field
+
+      work_package.send(:"custom_field_#{custom_field.id}=", "2025-10-03T13:37:00Z")
+      work_package.save!
     end
   end
 
   shared_let(:mult_list_custom_field) do
-    create(:multi_list_wp_custom_field).tap do
-      project.work_package_custom_fields << it
-      work_package.type.custom_fields << it
+    create(:multi_list_wp_custom_field).tap do |custom_field|
+      project.work_package_custom_fields << custom_field
+      work_package.type.custom_fields << custom_field
 
-      work_package.send(:"custom_field_#{it.id}=", it.possible_values.take(2))
-      work_package.save
+      work_package.send(:"custom_field_#{custom_field.id}=", custom_field.possible_values.take(2))
+      work_package.save!
     end
   end
 
@@ -111,7 +121,7 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       token = enabled.detect do |t|
         t.key == :"custom_field_#{mult_list_custom_field.id}"
       end
-      expect(token.call(work_package)).to eq(%w[A B])
+      expect(token.call(work_package)).to eq("A, B")
     end
 
     it "supports boolean custom fields" do
@@ -120,7 +130,16 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
         t.key == :"custom_field_#{boolean_custom_field.id}"
       end
 
-      expect(token.call(work_package)).to be(true)
+      expect(token.call(work_package)).to eq("false")
+    end
+
+    it "formats date custom fields correctly" do
+      enabled, = subject
+      token = enabled.detect do |t|
+        t.key == :"custom_field_#{date_custom_field.id}"
+      end
+
+      expect(token.call(work_package)).to eq("2025-10-03")
     end
 
     it "must return :attribute_not_available if custom field is not activated in project" do


### PR DESCRIPTION
Using default formatting rules for times, so depending on the instance setting, they will be formatted as "18h" or "2d 2h".

# Ticket
https://community.openproject.org/wp/63477