### PR TITLE
Harden nc error handling

### DIFF
--- a/lib/open_project.rb
+++ b/lib/open_project.rb
@@ -63,6 +63,7 @@ module OpenProject
                 .plugin(:persistent)
                 .plugin(:basic_auth)
                 .plugin(:webdav)
+                .with(headers: { "User-Agent" => "OpenProject #{OpenProject::VERSION.to_semver} HTTPX Client" })
                 .with(
                   timeout: {
                     connect_timeout: OpenProject::Configuration.httpx_connect_timeout,

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/base.rb
@@ -78,6 +78,17 @@ module Storages
               Failure(error.with(payload: "No origin user ID or user token found. Cannot execute query without user context."))
             end
           end
+
+          # Validates the OCS Meta Statuscode for fatal errors (i.e. unexpected server-side errors). Client-side errors,
+          # such as a 404 File Not Found do not cause an error.
+          # @return [Dry::Result]
+          def fail_on_ocs_error(json, error)
+            if json.dig(:ocs, :meta, :statuscode) < 500
+              Success(json)
+            else
+              Failure(error.with(code: :error))
+            end
+          end
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/file_info_query.rb
@@ -55,7 +55,7 @@ module Storages
 
               case response
               in { status: 200..299 }
-                Success(response.json(symbolize_keys: true))
+                fail_on_ocs_error(response.json(symbolize_keys: true), error)
               in { status: 404 }
                 Failure(error.with(code: :not_found))
               in { status: 401 }

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_info_query.rb
@@ -57,19 +57,11 @@ module Storages
 
               case response
               in { status: 200..299 }
-                verify_successful_response(response.json(symbolize_keys: true), error)
+                fail_on_ocs_error(response.json(symbolize_keys: true), error)
               in { status: 404 }
                 Failure(error.with(code: :not_found))
               in { status: 401 }
                 Failure(error.with(code: :unauthorized))
-              else
-                Failure(error.with(code: :error))
-              end
-            end
-
-            def verify_successful_response(json, error)
-              if json.dig(:ocs, :meta, :status) == "ok"
-                Success(json)
               else
                 Failure(error.with(code: :error))
               end

--- a/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_user_token_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_user_token_spec.rb
@@ -118,7 +118,7 @@ module Storages
                   "Accept" => "*/*",
                   "Accept-Encoding" => "gzip, deflate",
                   "Authorization" => "Bearer #{token.access_token}",
-                  "User-Agent" => /httpx\.rb\/\d+\.\d+\.\d+/
+                  "User-Agent" => /OpenProject \d+\.\d+\.\d+ HTTPX Client/
                 }
               )
               .to_return(status: 401, body: <<~XML, headers: {})
@@ -140,7 +140,7 @@ module Storages
                   "Accept" => "*/*",
                   "Accept-Encoding" => "gzip, deflate",
                   "Authorization" => "Bearer NEW_ACCESS_TOKEN",
-                  "User-Agent" => /httpx\.rb\/\d+\.\d+\.\d+/
+                  "User-Agent" => /OpenProject \d+\.\d+\.\d+ HTTPX Client/
                 }
               )
               .to_return(status: 200, body: <<~JSON, headers: { "Content-Type" => "application/json; charset=utf-8" })
@@ -157,7 +157,7 @@ module Storages
                   "Accept" => "*/*",
                   "Accept-Encoding" => "gzip, deflate",
                   "Content-Type" => "application/x-www-form-urlencoded",
-                  "User-Agent" => /httpx\.rb\/\d+\.\d+\.\d+/
+                  "User-Agent" => /OpenProject \d+\.\d+\.\d+ HTTPX Client/
                 }
               )
               .to_return(status: 200, body: <<~JSON, headers: { "Content-Type" => "application/json; charset=utf-8" })

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/create_folder_command_spec.rb
@@ -68,7 +68,7 @@ module Storages
               let(:parent_location) { "/DeathStar3" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: parent not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "when folder already exists", vcr: "nextcloud/create_folder_already_exists" do
@@ -76,7 +76,7 @@ module Storages
               let(:parent_location) { "/" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: folder already exists"
+              it_behaves_like "storage adapter: error response", :conflict
             end
 
             # For the VCR tests in this block it's necessary to

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/rename_file_command_spec.rb
@@ -66,7 +66,7 @@ module Storages
               let(:name) { "this_will_not_happen.txt" }
               let(:error_source) { Queries::FileInfoQuery }
 
-              it_behaves_like "adapter rename_file_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/set_permissions_command_spec.rb
@@ -52,7 +52,7 @@ module Storages
               let(:error_source) { Queries::FileInfoQuery }
               let(:input_data) { permission_input_data("1337", []) }
 
-              it_behaves_like "adapter set_permissions_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "if no permissions exist", vcr: "nextcloud/set_permissions_new" do

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/upload_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/upload_file_command_spec.rb
@@ -62,8 +62,9 @@ module Storages
 
             context "when uploading a file to a non-existing folder", vcr: "nextcloud/upload_file_missing_folder" do
               let(:parent_location) { "/non-existing-folder/" }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter upload_file_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "when uploading a file that has a filename with non-ASCII characters", vcr: "nextcloud/upload_file_unicode" do

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
@@ -46,23 +46,23 @@ module Storages
             it_behaves_like "storage adapter: query call signature", "file_info"
 
             context "with a file id requested", vcr: "nextcloud/file_info_query_success_file" do
-              let(:file_id) { "267" }
+              let(:file_id) { "56" }
               let(:file_info) do
                 Results::StorageFileInfo.new(
                   id: file_id,
                   status: "ok",
                   status_code: 200,
-                  name: "android-studio-linux.tar.gz",
-                  size: 982713473,
-                  mime_type: "application/gzip",
-                  created_at: Time.parse("1970-01-01T00:00:00Z"),
-                  last_modified_at: Time.parse("2022-12-01T07:43:36Z"),
+                  name: "Reasons to use Nextcloud.pdf",
+                  size: 976625,
+                  mime_type: "application/pdf",
+                  created_at: Time.at(0).utc,
+                  last_modified_at: Time.parse("2025-09-08T11:32:11Z"),
                   owner_name: "admin",
                   owner_id: "admin",
-                  last_modified_by_name: nil,
-                  last_modified_by_id: nil,
+                  last_modified_by_name: "admin",
+                  last_modified_by_id: "admin",
                   permissions: "RGDNVW",
-                  location: "/My%20files/android-studio-linux.tar.gz"
+                  location: "/Reasons%20to%20use%20Nextcloud.pdf"
                 )
               end
 
@@ -124,6 +124,13 @@ module Storages
               let(:error_source) { described_class }
 
               it_behaves_like "adapter file_info_query: not found"
+            end
+
+            context "with integration app disabled", vcr: "nextcloud/file_info_query_app_disabled" do
+              let(:file_id) { "56" }
+              let(:error_source) { described_class }
+
+              it_behaves_like "adapter file_info_query: error"
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
@@ -123,14 +123,14 @@ module Storages
               let(:file_id) { "not_existent" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter file_info_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "with integration app disabled", vcr: "nextcloud/file_info_query_app_disabled" do
               let(:file_id) { "56" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter file_info_query: error"
+              it_behaves_like "storage adapter: error response", :error
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_path_to_id_map_query_spec.rb
@@ -119,7 +119,7 @@ module Storages
               let(:folder) { "/I/just/made/that/up" }
               let(:error_source) { PropfindQuery }
 
-              it_behaves_like "adapter file_path_to_id_map_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
@@ -116,6 +116,13 @@ module Storages
 
               it_behaves_like "adapter files_info_query: successful list response"
             end
+
+            context "with the integration app being disabled", vcr: "nextcloud/files_info_query_app_disabled" do
+              let(:file_ids) { %w[50 53] }
+              let(:error_source) { described_class }
+
+              it_behaves_like "adapter files_info_query: error"
+            end
           end
         end
       end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
@@ -121,7 +121,7 @@ module Storages
               let(:file_ids) { %w[50 53] }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter files_info_query: error"
+              it_behaves_like "storage adapter: error response", :error
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
@@ -234,7 +234,7 @@ module Storages
               let(:folder) { "/I/just/made/that/up" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter files_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/upload_link_query_spec.rb
@@ -64,7 +64,7 @@ module Storages
 
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter upload_link_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/create_folder_command_spec.rb
@@ -62,15 +62,17 @@ module Storages
             context "when creating a folder in a non-existing parent folder", vcr: "one_drive/create_folder_parent_not_found" do
               let(:folder_name) { "Földer CreatedBy Çommand" }
               let(:parent_location) { "01AZJL5PKU2WV3U3RKKFF4A7ZCWVBXRTEU" }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: parent not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "when folder already exists", vcr: "one_drive/create_folder_already_exists" do
               let(:folder_name) { "Folder" }
               let(:parent_location) { "/" }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: folder already exists"
+              it_behaves_like "storage adapter: error response", :conflict
             end
 
             private

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/rename_file_command_spec.rb
@@ -62,7 +62,7 @@ module Storages
               let(:name) { "this_will_not_happen.png" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter rename_file_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/set_permissions_command_spec.rb
@@ -58,7 +58,7 @@ module Storages
               let(:error_source) { described_class }
               let(:input_data) { permission_input_data("THIS_IS_NOT_THE_FOLDER_YOURE_LOOKING_FOR", []) }
 
-              it_behaves_like "adapter set_permissions_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "if a write roles is already set" do

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_info_query_spec.rb
@@ -124,7 +124,7 @@ module Storages
               let(:file_id) { "not_existent" }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter file_info_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_path_to_id_map_query_spec.rb
@@ -121,7 +121,7 @@ module Storages
               let(:folder) { "/I/just/made/that/up" }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter file_path_to_id_map_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
@@ -186,7 +186,7 @@ module Storages
               let(:folder) { "/I/just/made/that/up" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter files_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_file_link_query_spec.rb
@@ -70,7 +70,7 @@ module Storages
               let(:input_data) { Input::OpenFileLink.build(file_id:).value! }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter open_file_link_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/upload_link_query_spec.rb
@@ -76,8 +76,9 @@ module Storages
                 Input::UploadLink
                   .build(folder_id: "04AZJL5PN6Y2GOVW7725BZO354PWSELRRZ", file_name: "DeathStart_blueprints.tiff").value!
               end
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter upload_link_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_folder_command_spec.rb
@@ -63,15 +63,17 @@ module Storages
             context "when creating a folder in a non-existing parent folder", vcr: "sharepoint/create_folder_parent_not_found" do
               let(:folder_name) { "Földer CreatedBy Çommand" }
               let(:parent_location) { composite_identifier("01AZJL5PKU2WV3U3RKKFF4A7ZCWVBXRTEU") }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: parent not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "when folder already exists", vcr: "sharepoint/create_folder_already_exists" do
               let(:folder_name) { "data" }
               let(:parent_location) { composite_identifier(nil) }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter create_folder_command: folder already exists"
+              it_behaves_like "storage adapter: error response", :conflict
             end
 
             context "when trying to create a folder under the root of the site",

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/rename_file_command_spec.rb
@@ -63,7 +63,7 @@ module Storages
               let(:name) { "this_will_not_happen.png" }
               let(:error_source) { described_class }
 
-              it_behaves_like "adapter rename_file_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/set_permissions_command_spec.rb
@@ -59,7 +59,7 @@ module Storages
               let(:error_source) { Queries::Internal::DriveItemQuery }
               let(:input_data) { permission_input_data("#{base_drive}:THIS_IS_NOT_THE_FOLDER_YOURE_LOOKING_FOR", []) }
 
-              it_behaves_like "adapter set_permissions_command: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "if a write roles is already set" do

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_info_query_spec.rb
@@ -124,7 +124,7 @@ module Storages
               let(:file_id) { "#{drive_id}:not_existent" }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter file_info_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query_spec.rb
@@ -138,7 +138,7 @@ module Storages
               let(:folder) { "#{base_drive}:01ANJ53WZVLARJSRFKOFF3HLYZPMPUK6HI " }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter file_path_to_id_map_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_query_spec.rb
@@ -314,14 +314,16 @@ module Storages
 
             context "when requesting an unknown file", vcr: "sharepoint/files_query_file_not_found" do
               let(:folder) { "/Marcello VCR/POTATO" }
+              let(:error_source) { Internal::ChildrenQuery }
 
-              it_behaves_like "adapter files_query: not found", Internal::ChildrenQuery
+              it_behaves_like "storage adapter: error response", :not_found
             end
 
             context "when requestion an unknown drive", vcr: "sharepoint/files_query_drive_not_found" do
               let(:folder) { "/That is no moon" }
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter files_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/open_file_link_query_spec.rb
@@ -75,7 +75,7 @@ module Storages
               let(:input_data) { Input::OpenFileLink.build(file_id:).value! }
               let(:error_source) { Internal::DriveItemQuery }
 
-              it_behaves_like "adapter open_file_link_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/upload_link_query_spec.rb
@@ -101,8 +101,9 @@ module Storages
                   file_name: "DeathStart_blueprints.tiff"
                 ).value!
               end
+              let(:error_source) { described_class }
 
-              it_behaves_like "adapter upload_link_query: not found"
+              it_behaves_like "storage adapter: error response", :not_found
             end
           end
         end

--- a/modules/storages/spec/services/storages/storage_file_service_spec.rb
+++ b/modules/storages/spec/services/storages/storage_file_service_spec.rb
@@ -59,7 +59,7 @@ module Storages
       end
 
       context "when the file exists", vcr: "nextcloud/file_info_query_success_file" do
-        let(:file_id) { "267" }
+        let(:file_id) { "56" }
 
         it_behaves_like "storage file service: successful response"
       end

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/file_info_query_app_disabled.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/file_info_query_app_disabled.yml
@@ -24,14 +24,12 @@ http_interactions:
     headers:
       Cache-Control:
       - no-cache, no-store, must-revalidate
-      Content-Encoding:
-      - gzip
       Content-Security-Policy:
       - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 20 Nov 2025 14:26:16 GMT
+      - Thu, 20 Nov 2025 14:33:15 GMT
       Feature-Policy:
       - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
         'none';payment 'none'
@@ -40,13 +38,13 @@ http_interactions:
       Server:
       - Apache/2.4.65 (Debian)
       Set-Cookie:
-      - ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7; path=/; secure; HttpOnly; SameSite=Lax,
-        oc_sessionPassphrase=y0AhPf0PsM2ugxn0wPl3%2BgM%2BcAoQkFmVhRsXwjZ9WQJt5bVboBv%2Bv%2FSf3fzgCUNQKD%2F%2BX8bGP16Vkz6ljB%2FYi3PMKDBMmTIiSxxCBC%2B14iG%2Fl0I%2FKFTNXZUTUPsTq7TY;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+      - ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=Opf6zYxw7%2Fy3%2FifIQb%2BIrXL13pHiT2JE3CtYPVGJLJIm%2F8tyaP%2Bq44dMlz5gWWUFpgXhDDH6H3qUzit76MY4UbQQ1eQdYTPKZqmT0szLBm7EkPkLS%2BGBL6F3VMPoehVr;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
         path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
         path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
         __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
-        31-Dec-2100 23:59:59 GMT; SameSite=strict, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
         path=/; secure; HttpOnly; SameSite=Lax, nc_username=deleted; expires=Thu,
         01 Jan 1970 00:00:01 GMT; Max-Age=0; secure; HttpOnly, nc_token=deleted; expires=Thu,
         01 Jan 1970 00:00:01 GMT; Max-Age=0; secure; HttpOnly, nc_session_id=deleted;
@@ -54,12 +52,12 @@ http_interactions:
         expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; secure; HttpOnly,
         nc_token=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/;
         secure; HttpOnly, nc_session_id=deleted; expires=Thu, 01 Jan 1970 00:00:01
-        GMT; Max-Age=0; path=/; secure; HttpOnly, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+        GMT; Max-Age=0; path=/; secure; HttpOnly, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=6972e6984effb3a7c5f1fa3d40a38b37;
         path=/; secure; HttpOnly; SameSite=Lax
       X-Content-Type-Options:
       - nosniff
@@ -70,17 +68,16 @@ http_interactions:
       X-Powered-By:
       - PHP/8.3.27
       X-Request-Id:
-      - WlZrpzCh5VsO1qezwkdj
+      - L1lM1NPFTDtpoOL7Iovc
       X-Robots-Tag:
       - noindex, nofollow
       X-User-Id:
       - admin
       Content-Length:
-      - '253'
+      - '134'
     body:
       encoding: UTF-8
-      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":56,"name":"Reasons
-        to use Nextcloud.pdf","mtime":1757331131,"ctime":0,"mimetype":"application\/pdf","size":976625,"owner_name":"admin","owner_id":"admin","modifier_name":"admin","modifier_id":"admin","dav_permissions":"RGDNVW","path":"files\/Reasons
-        to use Nextcloud.pdf"}}}'
-  recorded_at: Thu, 20 Nov 2025 14:26:16 GMT
+      string: '{"ocs":{"meta":{"status":"failure","statuscode":996,"message":"Internal
+        Server Error\n","totalitems":"","itemsperpage":""},"data":[]}}'
+  recorded_at: Thu, 20 Nov 2025 14:33:15 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_info_query_app_disabled.yml
+++ b/modules/storages/spec/support/fixtures/vcr_cassettes/nextcloud/files_info_query_app_disabled.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/fileinfo/56
+    method: post
+    uri: https://nextcloud.local/ocs/v1.php/apps/integration_openproject/filesinfo
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"fileIds":["50","53"]}'
     headers:
       User-Agent:
       - OpenProject 17.0.0 HTTPX Client
@@ -17,6 +17,10 @@ http_interactions:
       - 'true'
       Authorization:
       - Bearer <BEARER TOKEN>
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '23'
   response:
     status:
       code: 200
@@ -24,14 +28,12 @@ http_interactions:
     headers:
       Cache-Control:
       - no-cache, no-store, must-revalidate
-      Content-Encoding:
-      - gzip
       Content-Security-Policy:
       - default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 20 Nov 2025 14:26:16 GMT
+      - Thu, 20 Nov 2025 14:43:17 GMT
       Feature-Policy:
       - autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone
         'none';payment 'none'
@@ -40,13 +42,13 @@ http_interactions:
       Server:
       - Apache/2.4.65 (Debian)
       Set-Cookie:
-      - ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7; path=/; secure; HttpOnly; SameSite=Lax,
-        oc_sessionPassphrase=y0AhPf0PsM2ugxn0wPl3%2BgM%2BcAoQkFmVhRsXwjZ9WQJt5bVboBv%2Bv%2FSf3fzgCUNQKD%2F%2BX8bGP16Vkz6ljB%2FYi3PMKDBMmTIiSxxCBC%2B14iG%2Fl0I%2FKFTNXZUTUPsTq7TY;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+      - ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0; path=/; secure; HttpOnly; SameSite=Lax,
+        oc_sessionPassphrase=YjMxwdW635xx1%2B24ionHxlLjF75mcSV%2FUbAm8Okh5%2F3h9w1xi5OQjs%2BN2kZO9I4DNyUEZi9mdEr%2BWJ89vHaey69wurib5lhiTRSXOiga9kcGH7ZGhyNl%2FqymVhLUXpr2;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
         path=/; secure; HttpOnly; SameSite=Lax, __Host-nc_sameSiteCookielax=true;
         path=/; httponly;secure; expires=Fri, 31-Dec-2100 23:59:59 GMT; SameSite=lax,
         __Host-nc_sameSiteCookiestrict=true; path=/; httponly;secure; expires=Fri,
-        31-Dec-2100 23:59:59 GMT; SameSite=strict, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+        31-Dec-2100 23:59:59 GMT; SameSite=strict, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
         path=/; secure; HttpOnly; SameSite=Lax, nc_username=deleted; expires=Thu,
         01 Jan 1970 00:00:01 GMT; Max-Age=0; secure; HttpOnly, nc_token=deleted; expires=Thu,
         01 Jan 1970 00:00:01 GMT; Max-Age=0; secure; HttpOnly, nc_session_id=deleted;
@@ -54,12 +56,12 @@ http_interactions:
         expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/; secure; HttpOnly,
         nc_token=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT; Max-Age=0; path=/;
         secure; HttpOnly, nc_session_id=deleted; expires=Thu, 01 Jan 1970 00:00:01
-        GMT; Max-Age=0; path=/; secure; HttpOnly, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
-        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5ad0d1bb8b45c52211b5bfed6d2529c7;
+        GMT; Max-Age=0; path=/; secure; HttpOnly, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
+        path=/; secure; HttpOnly; SameSite=Lax, ocup2vbftjhb=5cdff16f83d24e97c54c6d8bff1a6fd0;
         path=/; secure; HttpOnly; SameSite=Lax
       X-Content-Type-Options:
       - nosniff
@@ -70,17 +72,16 @@ http_interactions:
       X-Powered-By:
       - PHP/8.3.27
       X-Request-Id:
-      - WlZrpzCh5VsO1qezwkdj
+      - rMqwQ3IV0HSR3ZOAuHfe
       X-Robots-Tag:
       - noindex, nofollow
       X-User-Id:
       - admin
       Content-Length:
-      - '253'
+      - '134'
     body:
       encoding: UTF-8
-      string: '{"ocs":{"meta":{"status":"ok","statuscode":100,"message":"OK","totalitems":"","itemsperpage":""},"data":{"status":"OK","statuscode":200,"id":56,"name":"Reasons
-        to use Nextcloud.pdf","mtime":1757331131,"ctime":0,"mimetype":"application\/pdf","size":976625,"owner_name":"admin","owner_id":"admin","modifier_name":"admin","modifier_id":"admin","dav_permissions":"RGDNVW","path":"files\/Reasons
-        to use Nextcloud.pdf"}}}'
-  recorded_at: Thu, 20 Nov 2025 14:26:16 GMT
+      string: '{"ocs":{"meta":{"status":"failure","statuscode":996,"message":"Internal
+        Server Error\n","totalitems":"","itemsperpage":""},"data":[]}}'
+  recorded_at: Thu, 20 Nov 2025 14:43:17 GMT
 recorded_with: VCR 6.3.1

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/create_folder_command_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/create_folder_command_examples.rb
@@ -43,27 +43,3 @@ RSpec.shared_examples_for "adapter create_folder_command: successful folder crea
     delete_created_folder(response)
   end
 end
-
-RSpec.shared_examples_for "adapter create_folder_command: parent not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(described_class)
-  end
-end
-
-RSpec.shared_examples_for "adapter create_folder_command: folder already exists" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:conflict)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/error_response_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/error_response_examples.rb
@@ -23,20 +23,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-RSpec.shared_examples_for "adapter files_info_query: successful list response" do
-  it "returns an array of file info objects" do
+RSpec.shared_examples_for "storage adapter: error response" do |error_type|
+  it "returns a failure: #{error_type}" do
     result = described_class.call(storage:, auth_strategy:, input_data:)
 
-    expect(result).to be_success
+    expect(result).to be_failure
 
-    response = result.value!
-    expect(response).to be_an(Array)
-    expect(response).to all(be_a(Storages::Adapters::Results::StorageFileInfo))
-    expect(response).to eq(expected_file_infos)
+    error = result.failure
+    expect(error.code).to eq(error_type)
+    expect(error.source).to eq(error_source)
   end
 end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/file_info_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/file_info_query_examples.rb
@@ -60,6 +60,6 @@ RSpec.shared_examples_for "adapter file_info_query: error" do
 
     error = result.failure
     expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
+    expect(error.source).to eq(error_source)
   end
 end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/file_info_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/file_info_query_examples.rb
@@ -39,27 +39,3 @@ RSpec.shared_examples_for "adapter file_info_query: successful file/folder respo
     expect(response).to eq(file_info)
   end
 end
-
-RSpec.shared_examples_for "adapter file_info_query: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source)
-  end
-end
-
-RSpec.shared_examples_for "adapter file_info_query: error" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(error_source)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/file_path_to_id_map_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/file_path_to_id_map_query_examples.rb
@@ -37,15 +37,3 @@ RSpec.shared_examples_for "adapter file_path_to_id_map_query: successful query" 
     expect(response.transform_values(&:id)).to eq(expected_ids)
   end
 end
-
-RSpec.shared_examples_for "adapter file_path_to_id_map_query: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/files_info_query_examples.rb
@@ -40,3 +40,15 @@ RSpec.shared_examples_for "adapter files_info_query: successful list response" d
     expect(response).to eq(expected_file_infos)
   end
 end
+
+RSpec.shared_examples_for "adapter files_info_query: error" do
+  it "returns a failure" do
+    result = described_class.call(storage:, auth_strategy:, input_data:)
+
+    expect(result).to be_failure
+
+    error = result.failure
+    expect(error.code).to eq(:error)
+    expect(error.source).to eq(error_source)
+  end
+end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/files_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/files_query_examples.rb
@@ -39,27 +39,3 @@ RSpec.shared_examples_for "adapter files_query: successful files response" do
     expect(response).to eq(files_result)
   end
 end
-
-RSpec.shared_examples_for "adapter files_query: not found" do |error_source = described_class|
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source)
-  end
-end
-
-RSpec.shared_examples_for "adapter files_query: error" do |error_source = described_class|
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(error_source)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/open_file_link_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/open_file_link_query_examples.rb
@@ -38,27 +38,3 @@ RSpec.shared_examples_for "adapter open_file_link_query: successful link respons
     expect(response).to eq(open_file_link)
   end
 end
-
-RSpec.shared_examples_for "adapter open_file_link_query: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source)
-  end
-end
-
-RSpec.shared_examples_for "adapter open_file_link_query: error" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/rename_file_command_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/rename_file_command_examples.rb
@@ -40,27 +40,3 @@ RSpec.shared_examples_for "adapter rename_file_command: successful file renaming
     expect(response.name).to eq(name)
   end
 end
-
-RSpec.shared_examples_for "adapter rename_file_command: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source || described_class)
-  end
-end
-
-RSpec.shared_examples_for "adapter rename_file_command: error" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/set_permissions_command_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/set_permissions_command_examples.rb
@@ -78,26 +78,3 @@ RSpec.shared_examples_for "adapter set_permissions_command: unknown remote ident
     clean_up file_id
   end
 end
-
-RSpec.shared_examples_for "adapter set_permissions_command: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(error_source)
-  end
-end
-
-RSpec.shared_examples_for "adapter set_permissions_command: error" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/upload_file_command_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/upload_file_command_examples.rb
@@ -41,15 +41,3 @@ RSpec.shared_examples_for "adapter upload_file_command: successful file upload" 
     expect(response.mime_type).to eq("text/plain")
   end
 end
-
-RSpec.shared_examples_for "adapter upload_file_command: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/modules/storages/spec/support/shared_examples_for_storage_providers/upload_link_query_examples.rb
+++ b/modules/storages/spec/support/shared_examples_for_storage_providers/upload_link_query_examples.rb
@@ -41,27 +41,3 @@ RSpec.shared_examples_for "adapter upload_link_query: successful upload link res
     expect(response.method).to eq(upload_method)
   end
 end
-
-RSpec.shared_examples_for "adapter upload_link_query: not found" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:not_found)
-    expect(error.source).to eq(described_class)
-  end
-end
-
-RSpec.shared_examples_for "adapter upload_link_query: error" do
-  it "returns a failure" do
-    result = described_class.call(storage:, auth_strategy:, input_data:)
-
-    expect(result).to be_failure
-
-    error = result.failure
-    expect(error.code).to eq(:error)
-    expect(error.source).to eq(described_class)
-  end
-end

--- a/spec/support/storage_server_helpers.rb
+++ b/spec/support/storage_server_helpers.rb
@@ -141,6 +141,7 @@ module StorageServerHelpers
     folder1_xml_response = build(:webdav_data_folder)
     folder1_fileinfo_response = {
       ocs: {
+        meta: { statuscode: 100 },
         data: {
           status: "OK",
           statuscode: 200,


### PR DESCRIPTION
Improves error handling of responses received from Nextcloud, so that we error out in the desired way if the integration app was disabled after initial setup.

# Ticket
https://community.openproject.org/wp/68026