### PR TITLE
Reintroduce the hocuspocus SECRET in settings

### DIFF
--- a/app/views/admin/settings/general_settings/show.html.erb
+++ b/app/views/admin/settings/general_settings/show.html.erb
@@ -65,6 +65,9 @@ See COPYRIGHT and LICENSE files for more details.
         <%= t(:label_example) %>: wss://websocket.server/path
       </span>
     </div>
+    <div class="form--field">
+      <%= setting_text_field :collaborative_editing_hocuspocus_secret, size: 60, container_class: "-wide" %>
+    </div>
     <div class="form--field"><%= setting_check_box :cache_formatted_text %></div>
     <div class="form--field">
       <%= setting_text_area :allowed_link_protocols, rows: 5, container_class: "-wide" %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -581,6 +581,14 @@ module Settings
           development: "wss://hocuspocus.local"
         }
       },
+      collaborative_editing_hocuspocus_secret: {
+        format: :string,
+        default: nil,
+        default_by_env: {
+          development: "secret12345"
+        },
+        description: "The secret used for generating access tokens to access documents on hocuspocus server."
+      },
       hours_per_day: {
         description: "This will define what is considered a “day” when displaying duration in a more natural way " \
                      "(for example, if a day is 8 hours, 32 hours would be 4 days).",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69116

# What are you trying to accomplish?
Related to https://github.com/opf/openproject/pull/20363/files
I'm re-adding some setting I though wasn't going to be necessary

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
