### PR TITLE
Unsubscribe events when unloading JobStatus class in dev mode

### DIFF
--- a/modules/job_status/lib/open_project/job_status/engine.rb
+++ b/modules/job_status/lib/open_project/job_status/engine.rb
@@ -61,5 +61,13 @@ module OpenProject::JobStatus
       # That way, the result of a background job is available even after the original job is gone.
       EventListener.register!
     end
+
+    config.after_initialize do
+      if Rails.application.config.reloading_enabled?
+        Rails.autoloaders.main.on_unload(EventListener.name) do |klass, _abspath|
+          klass.unsubscribe_all_to_prevent_duplicates_on_reload!
+        end
+      end
+    end
   end
 end

--- a/modules/job_status/lib/open_project/job_status/event_listener.rb
+++ b/modules/job_status/lib/open_project/job_status/event_listener.rb
@@ -30,32 +30,25 @@ module OpenProject
   module JobStatus
     class EventListener
       class << self
-        def register!
+        def register! # rubocop:disable Metrics/AbcSize
           # Listen to enqueues
-          ActiveSupport::Notifications.subscribe(/enqueue(_at)?\.active_job/) do |_name, _started, _call, _id, payload|
-            job = payload[:job]
-            next unless job
-
+          subscribe(/enqueue(_at)?\.active_job/) do |job, _payload|
             Rails.logger.debug { "Enqueuing background job #{job.inspect}" }
             for_statused_jobs(job) { create_job_status(job) }
           end
 
           # Start of process
-          ActiveSupport::Notifications.subscribe("perform_start.active_job") do |_name, _started, _call, _id, payload|
-            job = payload[:job]
-            next unless job
-
+          subscribe("perform_start.active_job") do |job, _payload|
             Rails.logger.debug { "Background job #{job.inspect} is being started" }
             for_statused_jobs(job) { on_start(job) }
           end
 
           # Complete, or failure
-          ActiveSupport::Notifications.subscribe("perform.active_job") do |_name, _started, _call, _id, payload|
-            job = payload[:job]
+          subscribe("perform.active_job") do |job, payload|
             exception_object = payload[:exception_object]
 
             Rails.logger.debug do
-              successful = exception_object ? "with error #{exception_object}" : "successful"
+              successful = exception_object ? "with error #{exception_object}" : "successfully"
               "Background job #{job.inspect} was performed #{successful}."
             end
 
@@ -63,8 +56,7 @@ module OpenProject
           end
 
           # Retry stopped -> failure
-          ActiveSupport::Notifications.subscribe("retry_stopped.active_job") do |_name, _started, _call, _id, payload|
-            job = payload[:job]
+          subscribe("retry_stopped.active_job") do |job, payload|
             error = payload[:error]
 
             Rails.logger.debug { "Background job #{job.inspect} no longer retrying due to: #{error}" }
@@ -72,8 +64,7 @@ module OpenProject
           end
 
           # Retry enqueued
-          ActiveSupport::Notifications.subscribe("enqueue_retry.active_job") do |_name, _started, _call, _id, payload|
-            job = payload[:job]
+          subscribe("enqueue_retry.active_job") do |job, payload|
             error = payload[:error]
 
             Rails.logger.debug { "Background job #{job.inspect} is being retried after error: #{error}" }
@@ -81,8 +72,7 @@ module OpenProject
           end
 
           # Discarded job
-          ActiveSupport::Notifications.subscribe("discard.active_job") do |_name, _started, _call, _id, payload|
-            job = payload[:job]
+          subscribe("discard.active_job") do |job, payload|
             error = payload[:error]
 
             Rails.logger.debug { "Background job #{job.inspect} is being discarded after error: #{error}" }
@@ -90,7 +80,26 @@ module OpenProject
           end
         end
 
+        # Unsubscribe all existing subscribers to prevent duplicate
+        # subscriptions on reload in development env.
+        def unsubscribe_all_to_prevent_duplicates_on_reload!
+          return unless @subscribers
+
+          @subscribers.each { |subscriber| ActiveSupport::Notifications.unsubscribe(subscriber) }
+          @subscribers.clear
+        end
+
         private
+
+        def subscribe(pattern, &)
+          @subscribers ||= []
+          @subscribers << ActiveSupport::Notifications.subscribe(pattern) do |_name, _started, _call, _id, payload|
+            job = payload[:job]
+            next unless job
+
+            yield job, payload
+          end
+        end
 
         ##
         # Yiels the block if the job


### PR DESCRIPTION
`OpenProject::JobStatus::EventListener.register!` is called in  a `config.to_prepare` block, meaning it's called after each reload in development mode and events are subscribed to multiple times.

This is for instance visible in logs with the same job-related message being logged multiple times:

```
I, [2025-11-21T10:02:13.993101 #51789]  INFO -- : [ActiveJob] Enqueued Journals::CompletedJob (Job ID: 85e5a6cf-e394-4d44-87c7-177aa4535a65) to GoodJob(default) at 2025-11-21 09:07:13 UTC
I, [2025-11-21T10:02:13.993971 #51789]  INFO -- : [ActiveJob] ↳ app/workers/journals/completed_job.rb:39:in 'Journals::CompletedJob.schedule'
D, [2025-11-21T10:02:13.994114 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994153 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994178 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994203 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994229 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994254 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
D, [2025-11-21T10:02:13.994278 #51789] DEBUG -- : [ActiveJob] Enqueuing background job #<Journals::CompletedJob:0x00000003d59def80 @arguments=[81, 2025-11-21 09:00:52.603688000 UTC +00:00, true], @job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @queue_name="default", @scheduled_at=2025-11-21 09:07:13.984857000 UTC +00:00, @priority=5, @executions=0, @exception_executions={}, @timezone="Etc/UTC", @successfully_enqueued=true, @provider_job_id="85e5a6cf-e394-4d44-87c7-177aa4535a65", @_halted_callback_hook_called=nil>
...
```

Fix it by unsubscribing them all when the class is unloaded.
