### PR TITLE
[69145] Unnecessary 'end' showing at the bottom of attribute help text modals if they contain an image

### DIFF
--- a/app/components/attribute_help_texts/show_component.html.erb
+++ b/app/components/attribute_help_texts/show_component.html.erb
@@ -12,5 +12,4 @@
       inputs: { allowUploading: false, allowRemoval: false }
     )
   %>
-  end
 <% end %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69145
