### PR TITLE
[#69115] Render portfolio description with formatting

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -30,7 +30,11 @@
     end
 
     flex.with_row(mb: 2) do
-      @portfolio.description
+      if @portfolio.description.blank?
+        render(Primer::Beta::Text.new(color: :muted)) { t("create_project.blank_description") }
+      else
+        render(Primer::Beta::Text.new(classes: "line-clamp-5 lh-default")) { format_text(@portfolio.description) }
+      end
     end
 
     flex.with_row do

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
     it { expect(subject).to have_text(portfolio.description) }
 
+    context "when the portfolio has no description" do
+      before do
+        allow(portfolio).to receive(:description).and_return(nil)
+      end
+
+      it { expect(subject).to have_text("No description provided") }
+    end
+
     it "offers a button to favor the portfolio" do
       expect(subject).to have_test_selector("op-portfolios--favorite-button") do |link|
         expect(link[:href]).to eq(build_favorite_path(portfolio, format: :html))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69115

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

* Render portfolio description with formatting
* Restricts the line amount to around 5, to keep it brief
* Also deals with the case that the description is blank

As you can see in the screenshot, this looks fine unless the description begins with a big table or macro. I think for a start, this is rather good.

## Screenshots

<img width="1112" height="863" alt="image" src="https://github.com/user-attachments/assets/5e1c35b3-76fc-4820-8109-a7161c1115d8" />

The caveat with a big table:
<img width="1112" height="711" alt="image" src="https://github.com/user-attachments/assets/92f06cf1-c386-4bbc-b77c-0e2039923d83" />


# Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation in Lookbook (patterns, previews, etc)~
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
