### PR TITLE
[68766] Custom logos with higher details than OpenProject might look small

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4793,9 +4793,9 @@ en:
       <li><b>Add custom fields for projects to your Project list to create a project portfolio view</b></li>
     </ul>
   text_custom_logo_instructions: >
-    A white logo on transparent background is recommended.
-    For best results on both, conventional and retina displays,
-    make sure your image's dimensions are 460px by 60px.
+    The logo automatically scales to fit the header.
+    For best results, upload a white logo on a transparent 130×47px image.
+    You can add as much spacing inside that image as you like.
   text_custom_export_logo_instructions: >
     This is the logo that appears in your PDF exports.
     It needs to be a PNG or JPEG image file.

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -1,4 +1,5 @@
 $op-logo-link-margin-y: 0.25rem
+$op-logo-icon-margin-y: 11px
 
 .op-logo
   width: 130px
@@ -23,5 +24,7 @@ $op-logo-link-margin-y: 0.25rem
     background-position: left center
     background-size: contain
     @media screen and (max-width: 850px)
+      margin: $op-logo-icon-margin-y 0 $op-logo-icon-margin-y 0.5rem
       display: block
-      width: 24px
+      width: 130px
+      height: calc(100% - (#{$op-logo-icon-margin-y} * 2))

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -1,5 +1,5 @@
 $op-logo-link-margin-y: 0.25rem
-$op-logo-icon-margin-y: 11px
+$op-logo-icon-margin-y: 11px // Ensures the mobile logo has the same vertical spacing as the right-side create action button
 
 .op-logo
   width: 130px

--- a/frontend/src/global_styles/common/header/logo.sass
+++ b/frontend/src/global_styles/common/header/logo.sass
@@ -24,5 +24,4 @@ $op-logo-link-margin-y: 0.25rem
     background-size: contain
     @media screen and (max-width: 850px)
       display: block
-      height: 24px
       width: 24px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68766

# What are you trying to accomplish?

1. The mobile logo’s width should match the desktop logo’s width; the width is intentionally large, so non-square or wide logos still look good on mobile.
2. The top and bottom spacing of the mobile logo matches the vertical space around the green create button in the header.
3. Update the desktop logo instruction:The logo automatically scales to fit the header. For best results, upload a white logo on a transparent 130×47px image. You can add as much spacing inside that image as you like.

130px is width and 47px is:  55px (header-height) - 8px (margin)