### PR TITLE
Reset prepared statement cache after db migration spec to prevent contaminating subsequent tests

### DIFF
--- a/modules/documents/spec/migrations/add_collaboration_to_documents_spec.rb
+++ b/modules/documents/spec/migrations/add_collaboration_to_documents_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe AddCollaborationToDocuments, type: :model do
         end
       end
 
+      after do
+        # Ensure cache is cleared after migration spec to prevent contaminating subsequent tests
+        ActiveRecord::Base.connection.clear_cache!
+      end
+
       it "sets existing documents to 'classic' kind" do
         ActiveRecord::Migration.suppress_messages { described_class.new.migrate(:up) }
 


### PR DESCRIPTION
Should address flaky tests:

* https://github.com/opf/openproject/actions/runs/19572515078/job/56049249008
* https://github.com/opf/openproject/actions/runs/19570681534/job/56045526176
* https://github.com/opf/openproject/actions/runs/19354970291/job/55374413489?pr=21032

Modifying the db structure during test runs conflicts with prepared (cached) query plans, causing `ActiveRecord::PreparedStatementCacheExpired: ERROR: cached plan must not change result type` - hence we need to reset the cache after db migration tests so that they don't interfere with subsequent tests.

_📖 [Read more on this error.](https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf)_ 

