### PR TITLE
[#69114] Disable archived portfolios in view

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -2,7 +2,7 @@
   flex_layout(**archived_style) do |flex|
     flex.with_row(mb: 2) do
       flex_layout(align_items: :center) do |header|
-        header.with_column do
+        header.with_column(mr: 2) do
           if archived?
             render(Primer::Beta::Text.new(classes: "portfolio-name")) do
               name_caption
@@ -21,7 +21,7 @@
         end
 
         unless archived?
-          header.with_column(ml: 2) do
+          header.with_column(mr: 2) do
             render(
               Projects::StatusButtonComponent.new(
                 user: @current_user,
@@ -101,6 +101,26 @@
           end
         end
 
+        if has_subportfolios?
+          footer.with_column(mr: 3) do
+            concat(
+              render(
+                Primer::Beta::Octicon.new(
+                  icon: workspace_icon("portfolio"),
+                  align_self: :center,
+                  "aria-label": t("portfolio.count", count: all_subportfolios.count),
+                  mr: 1
+                )
+              )
+            )
+            concat(
+              render(Primer::Beta::Text.new) do
+                t("portfolio.count", count: all_subportfolios.count)
+              end
+            )
+          end
+        end
+
         footer.with_column(mr: 3) do
           concat(
             render(
@@ -117,19 +137,6 @@
               t("program.count", count: all_subprograms.count)
             end
           )
-        end
-
-        if has_subportfolios?
-          footer.with_column(mr: 3) do
-            render(
-              Primer::Beta::Octicon.new(
-                icon: workspace_icon("portfolio"),
-                align_self: :center,
-                "aria-label": t("portfolio.count", count: all_subportfolios.count),
-                mr: 1
-              )
-            ) + content_tag(:span, t("portfolio.count", count: all_subportfolios.count))
-          end
         end
 
         footer.with_column(mr: 3) do

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -98,75 +98,75 @@
               )
             )
           end
-        end
 
-        if has_subportfolios?
+          if has_subportfolios?
+            footer.with_column(mr: 3) do
+              concat(
+                render(
+                  Primer::Beta::Octicon.new(
+                    icon: workspace_icon("portfolio"),
+                    align_self: :center,
+                    "aria-label": t("portfolio.count", count: all_subportfolios.count),
+                    mr: 1
+                  )
+                )
+              )
+              concat(
+                render(Primer::Beta::Text.new) do
+                  t("portfolio.count", count: all_subportfolios.count)
+                end
+              )
+            end
+          end
+
           footer.with_column(mr: 3) do
             concat(
               render(
                 Primer::Beta::Octicon.new(
-                  icon: workspace_icon("portfolio"),
+                  icon: workspace_icon("program"),
                   align_self: :center,
-                  "aria-label": t("portfolio.count", count: all_subportfolios.count),
+                  "aria-label": t("program.count", count: all_subprograms.count),
                   mr: 1
                 )
               )
             )
             concat(
               render(Primer::Beta::Text.new) do
-                t("portfolio.count", count: all_subportfolios.count)
+                t("program.count", count: all_subprograms.count)
               end
             )
           end
-        end
 
-        footer.with_column(mr: 3) do
-          concat(
-            render(
-              Primer::Beta::Octicon.new(
-                icon: workspace_icon("program"),
-                align_self: :center,
-                "aria-label": t("program.count", count: all_subprograms.count),
-                mr: 1
+          footer.with_column(mr: 3) do
+            concat(
+              render(
+                Primer::Beta::Octicon.new(
+                  icon: workspace_icon("project"),
+                  align_self: :center,
+                  "aria-label": t("project.count", count: all_subprojects.count),
+                  mr: 1
+                )
               )
             )
-          )
-          concat(
-            render(Primer::Beta::Text.new) do
-              t("program.count", count: all_subprograms.count)
-            end
-          )
-        end
-
-        footer.with_column(mr: 3) do
-          concat(
-            render(
-              Primer::Beta::Octicon.new(
-                icon: workspace_icon("project"),
-                align_self: :center,
-                "aria-label": t("project.count", count: all_subprojects.count),
-                mr: 1
-              )
+            concat(
+              render(Primer::Beta::Text.new) do
+                t("project.count", count: all_subprojects.count)
+              end
             )
-          )
-          concat(
-            render(Primer::Beta::Text.new) do
-              t("project.count", count: all_subprojects.count)
-            end
-          )
-        end
+          end
 
-        # TODO: WP-68872 render budget
-        # footer.with_column(mr: 3) do
-        #   render(
-        #     Primer::Beta::Octicon.new(
-        #       icon: "op-budget",
-        #       align_self: :center,
-        #       "aria-label": "TODO",
-        #       mr: 1
-        #     )
-        #   ) + content_tag(:span, "34,000 EUR budget - 12,000 EUR spent")
-        # end
+          # TODO: WP-68872 render budget
+          # footer.with_column(mr: 3) do
+          #   render(
+          #     Primer::Beta::Octicon.new(
+          #       icon: "op-budget",
+          #       align_self: :center,
+          #       "aria-label": "TODO",
+          #       mr: 1
+          #     )
+          #   ) + content_tag(:span, "34,000 EUR budget - 12,000 EUR spent")
+          # end
+        end
 
         footer.with_column do
           render(

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -21,7 +21,7 @@
         end
 
         unless archived?
-          header.with_column(mr: 2) do
+          header.with_column(mr: 2, test_selector: "op-portfolios--status") do
             render(
               Projects::StatusButtonComponent.new(
                 user: @current_user,
@@ -33,7 +33,6 @@
           end
         end
 
-        # TODO: hide when archived
         if render_sub_status_bar?
           header.with_column(classes: "op-portfolios--progress") do
             render(
@@ -183,7 +182,6 @@
     end
 
     # Card that appears when hovering over the progress bar
-    # TODO: hide when archived
     if render_sub_status_bar?
       flex.with_row(classes: "op-portfolios--popover-container") do
         flex_layout(

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -1,30 +1,39 @@
 <%=
-  flex_layout do |flex|
+  flex_layout(**archived_style) do |flex|
     flex.with_row(mb: 2) do
       flex_layout(align_items: :center) do |header|
         header.with_column do
-          render(
-            Primer::Beta::Link.new(
-              classes: "portfolio-name",
-              href: project_overview_path(@portfolio),
-              font_weight: :bold
-            )
-          ) do
-            @portfolio.name
+          if archived?
+            render(Primer::Beta::Text.new(classes: "portfolio-name")) do
+              name_caption
+            end
+          else
+            render(
+              Primer::Beta::Link.new(
+                classes: "portfolio-name",
+                href: project_overview_path(@portfolio),
+                font_weight: :bold
+              )
+            ) do
+              name_caption
+            end
           end
         end
 
-        header.with_column(ml: 2, mr: 2) do
-          render(
-            Projects::StatusButtonComponent.new(
-              user: @current_user,
-              project: @portfolio,
-              hide_help_text: true,
-              size: :small
+        unless archived?
+          header.with_column(ml: 2) do
+            render(
+              Projects::StatusButtonComponent.new(
+                user: @current_user,
+                project: @portfolio,
+                hide_help_text: true,
+                size: :small
+              )
             )
-          )
+          end
         end
 
+        # TODO: hide when archived
         if render_sub_status_bar?
           header.with_column(classes: "op-portfolios--progress") do
             render(
@@ -71,22 +80,42 @@
 
     flex.with_row do
       flex_layout(align_items: :center) do |footer|
-        footer.with_column(mr: 3) do
-          render(
-            Primer::Beta::IconButton.new(
-              icon: currently_favorited? ? "star-fill" : "star",
-              scheme: :invisible,
-              mobile_icon: currently_favorited? ? "star-fill" : "star",
-              size: :medium,
-              tag: :a,
-              tooltip_direction: :e,
-              href: helpers.build_favorite_path(@portfolio, format: :html),
-              data: { turbo_method: currently_favorited? ? :delete : :post },
-              classes: currently_favorited? ? "op-primer--star-icon " : "",
-              label: currently_favorited? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite),
-              aria: { label: currently_favorited? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite) },
-              test_selector: "op-portfolios--favorite-button"
+        unless archived?
+          footer.with_column(mr: 3) do
+            render(
+              Primer::Beta::IconButton.new(
+                icon: currently_favorited? ? "star-fill" : "star",
+                scheme: :invisible,
+                mobile_icon: currently_favorited? ? "star-fill" : "star",
+                size: :medium,
+                tag: :a,
+                tooltip_direction: :e,
+                href: helpers.build_favorite_path(@portfolio, format: :html),
+                data: { turbo_method: currently_favorited? ? :delete : :post },
+                classes: currently_favorited? ? "op-primer--star-icon " : "",
+                label: currently_favorited? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite),
+                aria: { label: currently_favorited? ? I18n.t(:button_unfavorite) : I18n.t(:button_favorite) },
+                test_selector: "op-portfolios--favorite-button"
+              )
             )
+          end
+        end
+
+        footer.with_column(mr: 3) do
+          concat(
+            render(
+              Primer::Beta::Octicon.new(
+                icon: workspace_icon("program"),
+                align_self: :center,
+                "aria-label": t("program.count", count: all_subprograms.count),
+                mr: 1
+              )
+            )
+          )
+          concat(
+            render(Primer::Beta::Text.new) do
+              t("program.count", count: all_subprograms.count)
+            end
           )
         end
 
@@ -104,25 +133,21 @@
         end
 
         footer.with_column(mr: 3) do
-          render(
-            Primer::Beta::Octicon.new(
-              icon: workspace_icon("program"),
-              align_self: :center,
-              "aria-label": t("program.count", count: all_subprograms.count),
-              mr: 1
+          concat(
+            render(
+              Primer::Beta::Octicon.new(
+                icon: workspace_icon("project"),
+                align_self: :center,
+                "aria-label": t("project.count", count: all_subprojects.count),
+                mr: 1
+              )
             )
-          ) + content_tag(:span, t("program.count", count: all_subprograms.count))
-        end
-
-        footer.with_column(mr: 3) do
-          render(
-            Primer::Beta::Octicon.new(
-              icon: workspace_icon("project"),
-              align_self: :center,
-              "aria-label": t("project.count", count: all_subprojects.count),
-              mr: 1
-            )
-          ) + content_tag(:span, t("project.count", count: all_subprojects.count))
+          )
+          concat(
+            render(Primer::Beta::Text.new) do
+              t("project.count", count: all_subprojects.count)
+            end
+          )
         end
 
         # TODO: WP-68872 render budget
@@ -151,6 +176,7 @@
     end
 
     # Card that appears when hovering over the progress bar
+    # TODO: hide when archived
     if render_sub_status_bar?
       flex.with_row(classes: "op-portfolios--popover-container") do
         flex_layout(

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -74,8 +74,8 @@ module Portfolios
 
     def render_sub_status_bar?
       # When none of the descendants have a status set, there's nothing to show and we
-      # will return false.
-      sub_statuses.keys.any?(&:present?)
+      # will return false. Additionally, we won't show the bar for archived portfolios.
+      !archived? && sub_statuses.keys.any?(&:present?)
     end
 
     def sub_statuses_with_percentages

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -36,10 +36,20 @@ module Portfolios
 
     attr_reader :current_user, :portfolio
 
+    delegate :archived?, to: :portfolio
+
     def initialize(portfolio:, current_user:)
       super
       @portfolio = portfolio
       @current_user = current_user
+    end
+
+    def name_caption
+      if archived?
+        "#{@portfolio.name} (#{t('project.archive.archived')})"
+      else
+        @portfolio.name
+      end
     end
 
     def currently_favorited?
@@ -96,6 +106,15 @@ module Portfolios
                           .reorder(:status_code)
                           .pluck(:status_code)
                           .tally
+    end
+
+    # Will return a hash with Primer style options if the portfolio is archived.
+    # Will return an empty hash if the portfolio is active.
+    #
+    # Intended to be injected into a Primer component's `**options` parameter that relies on the archived
+    # state of a portfolio to decide the display style.
+    def archived_style
+      archived? ? { color: :muted } : {}
     end
   end
 end

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -49,7 +49,9 @@ module Projects
       ""
     end
 
-    def favorited
+    def favorited # rubocop:disable Metrics/AbcSize
+      return nil if project.archived?
+
       render(Primer::Beta::IconButton.new(
                icon: currently_favorited? ? "star-fill" : "star",
                scheme: :invisible,
@@ -154,11 +156,11 @@ module Projects
     def name
       content = [content_tag(:i, "", class: "projects-table--hierarchy-icon")]
 
-      if project.archived?
-        content << content_tag(:span, I18n.t("project.archive.archived"), class: "archived-label")
-      end
-
       content << helpers.link_to_project(project, {}, { data: { turbo: false } }, false)
+
+      if project.archived?
+        content << content_tag(:span, "(#{I18n.t('project.archive.archived')})", class: "archived-label")
+      end
 
       if workspace_type_badge && OpenProject::FeatureDecisions.portfolio_models_active?
         content << workspace_type_badge
@@ -295,7 +297,7 @@ module Projects
     end
 
     def more_menu_favorite_item
-      return if currently_favorited?
+      return if currently_favorited? || project.archived?
 
       {
         scheme: :default,
@@ -308,7 +310,7 @@ module Projects
     end
 
     def more_menu_unfavorite_item
-      return unless currently_favorited?
+      return if !currently_favorited? || project.archived?
 
       {
         scheme: :default,

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -73,8 +73,6 @@ $content-padding: 10px
 
     .archived
       color: var(--fgColor-muted)
-      span.archived-label
-        text-transform: uppercase
 
   td.name
     @include text-shortener

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   let(:user) { create(:admin) }
   let(:status_code_a) { "on_track" }
   let(:status_code_b) { "at_risk" }
-  let!(:portfolio) { create(:portfolio, description: "portfolio description") }
+  let(:active) { true }
+  let!(:portfolio) { create(:portfolio, description: "portfolio description", active:) }
 
   current_user { user }
 
@@ -68,13 +69,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
     def portfolio.favorited?; false; end
   end
 
-  describe "portfolio" do
-    it "renders the title as a link" do
-      expect(subject).to have_element("a", text: portfolio.name) do |link|
-        expect(link[:href]).to eq(project_overview_path(portfolio))
-      end
-    end
-
+  shared_examples "having a description, updated info and sub-item counts" do
     it { expect(subject).to have_text(portfolio.description) }
 
     context "when the portfolio has no description" do
@@ -85,9 +80,13 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
       it { expect(subject).to have_text("No description provided") }
     end
 
-    it "offers a button to favor the portfolio" do
-      expect(subject).to have_test_selector("op-portfolios--favorite-button") do |link|
-        expect(link[:href]).to eq(build_favorite_path(portfolio, format: :html))
+    describe "#updated_at" do
+      before do
+        allow(portfolio).to receive(:updated_at).and_return(1.month.ago)
+      end
+
+      it "shows when the portfolio was last updated" do
+        expect(subject).to have_test_selector("op-portfolios--updated-at", text: "Updated about 1 month ago")
       end
     end
 
@@ -116,14 +115,31 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
         it { expect(subject).to have_text("1 portfolio") }
       end
     end
+  end
 
-    describe "#updated_at" do
-      before do
-        allow(portfolio).to receive(:updated_at).and_return(1.month.ago)
+  describe "portfolio" do
+    it_behaves_like "having a description, updated info and sub-item counts"
+
+    it "renders the title as a link" do
+      expect(subject).to have_css(".portfolio-name", text: portfolio.name) do |link|
+        expect(link[:href]).to eq(project_overview_path(portfolio))
+      end
+    end
+
+    it "offers a button to favor the portfolio" do
+      expect(subject).to have_test_selector("op-portfolios--favorite-button") do |link|
+        expect(link[:href]).to eq(build_favorite_path(portfolio, format: :html))
+      end
+    end
+
+    describe "portfolio status" do
+      it "shows the status button if the status is not set" do
+        expect(subject).to have_css("#projects-status-button-component-#{portfolio.id}", text: "Not set")
       end
 
-      it "shows when the portfolio was last updated" do
-        expect(subject).to have_test_selector("op-portfolios--updated-at", text: "Updated about 1 month ago")
+      it "shows the status button if the status is set" do
+        portfolio.status_code = "on_track"
+        expect(subject).to have_css("#projects-status-button-component-#{portfolio.id}", text: "On track")
       end
     end
 
@@ -158,6 +174,29 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
           expect(subject).not_to have_test_selector("op-portfolios--status-not_set")
         end
       end
+    end
+  end
+
+  describe "archived portfolio" do
+    let(:active) { false }
+
+    it_behaves_like "having a description, updated info and sub-item counts"
+
+    it "renders the title as text" do
+      expect(subject).to have_no_css(".portfolio-name.Link")
+      expect(subject).to have_css(".portfolio-name", text: "#{portfolio.name} (Archived)")
+    end
+
+    it "has to button to favor the portfolio" do
+      expect(subject).not_to have_test_selector("op-portfolios--favorite-button")
+    end
+
+    it "has no status button" do
+      expect(subject).to have_no_css("#projects-status-button-component-#{portfolio.id}")
+    end
+
+    it "has no sub-item status" do
+      expect(subject).not_to have_test_selector("op-portfolios--sub-status-bar")
     end
   end
 end

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
     def portfolio.favorited?; false; end
   end
 
-  shared_examples "having a description, updated info and sub-item counts" do
+  shared_examples "having a description and last update time" do
     it { expect(subject).to have_text(portfolio.description) }
 
     context "when the portfolio has no description" do
@@ -87,6 +87,22 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
       it "shows when the portfolio was last updated" do
         expect(subject).to have_test_selector("op-portfolios--updated-at", text: "Updated about 1 month ago")
+      end
+    end
+  end
+
+  describe "portfolio" do
+    it_behaves_like "having a description and last update time"
+
+    it "renders the title as a link" do
+      expect(subject).to have_css(".portfolio-name", text: portfolio.name) do |link|
+        expect(link[:href]).to eq(project_overview_path(portfolio))
+      end
+    end
+
+    it "offers a button to favor the portfolio" do
+      expect(subject).to have_test_selector("op-portfolios--favorite-button") do |link|
+        expect(link[:href]).to eq(build_favorite_path(portfolio, format: :html))
       end
     end
 
@@ -113,22 +129,6 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
         it { expect(subject).to have_text("5 projects") }
 
         it { expect(subject).to have_text("1 portfolio") }
-      end
-    end
-  end
-
-  describe "portfolio" do
-    it_behaves_like "having a description, updated info and sub-item counts"
-
-    it "renders the title as a link" do
-      expect(subject).to have_css(".portfolio-name", text: portfolio.name) do |link|
-        expect(link[:href]).to eq(project_overview_path(portfolio))
-      end
-    end
-
-    it "offers a button to favor the portfolio" do
-      expect(subject).to have_test_selector("op-portfolios--favorite-button") do |link|
-        expect(link[:href]).to eq(build_favorite_path(portfolio, format: :html))
       end
     end
 
@@ -180,7 +180,11 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   describe "archived portfolio" do
     let(:active) { false }
 
-    it_behaves_like "having a description, updated info and sub-item counts"
+    it_behaves_like "having a description and last update time"
+
+    it { expect(subject).to have_no_text("2 programs") }
+    it { expect(subject).to have_no_text("5 projects") }
+    it { expect(subject).to have_no_text("0 portfolios") }
 
     it "renders the title as text" do
       expect(subject).to have_no_css(".portfolio-name.Link")

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -135,6 +135,13 @@ RSpec.describe "Portfolios", "index", :js do
       portfolios_page.expect_title("Archived portfolios")
       portfolios_page.expect_portfolios_listed(inactive_portfolio)
       portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, portfolio_favorited)
+
+      # For archived portfolios, no status bar or favorite button is shown:
+      portfolios_page.within_row(inactive_portfolio) do
+        expect(page).to have_no_test_selector("op-portfolios--favorite-button")
+        expect(page).to have_no_test_selector("op-portfolios--sub-status-bar")
+        expect(page).to have_no_test_selector("op-portfolios--status")
+      end
     end
 
     it "allows you to favorite and unfavorite portfolios" do
@@ -180,14 +187,8 @@ RSpec.describe "Portfolios", "index", :js do
         portfolios_page.within_row(portfolio_a) do
           expect(page).to have_test_selector("op-portfolios--sub-status-bar")
 
-          # It renders the correct percentages per status:
-          on_track = page.find_test_selector("op-portfolios--status-on_track")
-          on_track_percentage = on_track["data-percentage"]
-          expect(on_track_percentage).to eq("66.7")
-
-          at_risk = page.find_test_selector("op-portfolios--status-at_risk")
-          at_risk_percentage = at_risk["data-percentage"]
-          expect(at_risk_percentage).to eq("33.3")
+          portfolios_page.expect_status_bar_percentage(portfolio_a, "on_track", "66.7", find_row: false)
+          portfolios_page.expect_status_bar_percentage(portfolio_a, "at_risk", "33.3", find_row: false)
 
           # The status bar shows a hover card on hover:
           hover_card_selector = "op-portfolios--hover-card-#{portfolio_a.id}"

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -136,11 +136,14 @@ RSpec.describe "Portfolios", "index", :js do
       portfolios_page.expect_portfolios_listed(inactive_portfolio)
       portfolios_page.expect_portfolios_not_listed(portfolio_a, portfolio_b, portfolio_favorited)
 
-      # For archived portfolios, no status bar or favorite button is shown:
+      # For archived portfolios, no status bar, favorite button or project count is shown:
       portfolios_page.within_row(inactive_portfolio) do
         expect(page).to have_no_test_selector("op-portfolios--favorite-button")
         expect(page).to have_no_test_selector("op-portfolios--sub-status-bar")
         expect(page).to have_no_test_selector("op-portfolios--status")
+        expect(page).to have_no_text("0 portfolios")
+        expect(page).to have_no_text("0 projects")
+        expect(page).to have_no_text("0 programs")
       end
     end
 

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -175,9 +175,9 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
 
       # Test visibility of 'more' menu list items
       projects_page.activate_menu_of(parent_project) do |menu|
-        expect(menu).to have_text("Add to favorites")
         expect(menu).to have_text("Unarchive")
         expect(menu).to have_text("Delete")
+        expect(menu).to have_no_text("Add to favorites")
         expect(menu).to have_no_text("Archive")
         expect(menu).to have_no_text("Copy")
         expect(menu).to have_no_text("Settings")

--- a/spec/features/projects/lists/table_spec.rb
+++ b/spec/features/projects/lists/table_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Projects lists table display and actions", :js, with_settings: {
     end
   end
   shared_let(:development_project) { create(:project, name: "Development project", identifier: "development-project") }
+  shared_let(:archived_project) { create(:project, name: "Archived project", identifier: "archived-project", active: false) }
 
   let(:news) { create(:news, project:) }
   let(:projects_page) { Pages::Projects::Index.new }
@@ -222,6 +223,23 @@ RSpec.describe "Projects lists table display and actions", :js, with_settings: {
             .to have_css("th", text: "LATEST ACTIVITY AT")
           expect(page)
             .to have_css("td", text: news.created_at.strftime("%m/%d/%Y"))
+        end
+      end
+
+      specify "archived projects offer no option to be marked as favorite" do
+        login_as(admin)
+        visit projects_path
+        load_and_open_filters admin
+        projects_page.filter_by_active("no")
+        wait_for_reload
+
+        projects_page.within_row(archived_project) do
+          expect(page).to have_text(archived_project.name)
+          expect(page).not_to have_test_selector("project-list-favorite-button")
+        end
+
+        projects_page.activate_menu_of(archived_project) do |menu|
+          expect(menu).to have_no_text("Add to favorites")
         end
       end
 

--- a/spec/support/pages/portfolios/index.rb
+++ b/spec/support/pages/portfolios/index.rb
@@ -81,11 +81,17 @@ module Pages
         expect(page).to have_css('[data-test-selector="portfolio-query-name"]', text: name)
       end
 
-      def expect_status_bar_percentage(portfolio, status_text, percentage)
-        within_row(portfolio) do
+      def expect_status_bar_percentage(portfolio, status_text, percentage, find_row: true)
+        blk = Proc.new do
           status = page.find_test_selector("op-portfolios--status-#{status_text}")
           status_percentage = status["data-percentage"]
           expect(status_percentage).to eq(percentage.to_s)
+        end
+
+        if find_row
+          within_row(portfolio, &blk)
+        else
+          blk.call
         end
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -44,7 +44,7 @@ module Pages
         within_table do
           projects.each do |project|
             displayed_name = if archived
-                               "ARCHIVED #{project.name}"
+                               "#{project.name} (Archived)"
                              else
                                project.name
                              end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69114


# What are you trying to accomplish?
Render archived portoflios in a disabled state. Some components are hidden, text is greyed out.

* Append a suffix of `(Archived)` to the name, remove link
* Mute (apply grey coloring) the entire portfolio row -> all text and icons are muted
* Hide status
* Hide the sub-item status "progress bar"
* Hide the favorite-button
* Hide the sub-item counts (n portfolios, n programs, n projects)

Similarly, to stay consistent, we apply similar measures in the project list. It already did some of the above. The following changes were made:

* Append a suffix of `(Archived)` to the name instead of prefixing "ARCHIVED"
* Hide the favorite-button from the favorited-column
* Hide the favorite/unfavorite button from the rows "More..." menu

## Screenshots

Portfolios
<img width="1459" height="881" alt="image" src="https://github.com/user-attachments/assets/0c1b50db-bd03-4ba8-ad9d-cf906d410d9c" />

Project list
<img width="1459" height="881" alt="image" src="https://github.com/user-attachments/assets/2b1c88ce-9380-4a07-996a-5e80a74edfcf" />


# What approach did you choose and why?


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
