### PR TITLE
Encrypt the oauth token used to connect to Hocuspocus

### DIFF
--- a/docker/dev/hocuspocus/docker-compose.yml
+++ b/docker/dev/hocuspocus/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - ALLOWED_DOMAINS=openproject.local,localhost
       - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - SECRET=secret12345
 networks:
   gateway:
     external: true

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -61,7 +61,7 @@ class DocumentsController < ApplicationController
     @attachments = @document.attachments.order(Arel.sql("created_at DESC"))
 
     if @document.collaborative?
-      generate_oauth_token
+      generate_encrypted_oauth_token
       derive_show_edit_state_from_params
     end
   end
@@ -200,8 +200,8 @@ class DocumentsController < ApplicationController
     redirect_to document_path(call.result, state: :edit)
   end
 
-  def generate_oauth_token
-    # do not generate a token if the user is not allowed to manage documents
+  # rubocop:disable Metrics/AbcSize
+  def generate_encrypted_oauth_token
     if !current_user.allowed_in_project?(:view_documents, @project)
       return
     end
@@ -210,12 +210,23 @@ class DocumentsController < ApplicationController
       .new(user: current_user)
       .call
 
-    if result.success?
-      @oauth_token = result.result.plaintext_token
-    else
+    if result.failure?
       Rails.logger.error("Failed to generate OAuth token for document #{@document.id}: #{result.errors}")
+      return
     end
+
+    result = Documents::OAuth::EncryptTokenService
+      .new(token: result.result.plaintext_token)
+      .call
+
+    if result.failure?
+      Rails.logger.error("Failed to encrypt OAuth token for document #{@document.id}: #{result.errors}")
+      return
+    end
+
+    @oauth_token = result.result
   end
+  # rubocop:enable Metrics/AbcSize
 
   def update_header_component_via_turbo_stream(state: :show)
     update_via_turbo_stream(

--- a/modules/documents/app/services/documents/oauth/encrypt_token_service.rb
+++ b/modules/documents/app/services/documents/oauth/encrypt_token_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Documents
+  module OAuth
+    class EncryptTokenService < BaseServices::BaseCallable
+      ALGORITHM = "aes-256-gcm"
+
+      def initialize(token:)
+        super()
+
+        @token = token
+      end
+
+      def perform
+        encryptor = ActiveSupport::MessageEncryptor.new(
+          key,
+          cipher: ALGORITHM,
+          serializer: ActiveSupport::MessageEncryptor::NullSerializer
+        )
+        encrypted = encryptor.encrypt_and_sign(token)
+
+        ServiceResult.success(result: encrypted)
+      rescue StandardError => e
+        ServiceResult.failure(errors: e.message)
+      end
+
+      private
+
+      attr_reader :token
+
+      def key
+        @key ||= begin
+          secret = Setting.collaborative_editing_hocuspocus_secret
+          raise "Collaborative editing secret is not set. Cannot encrypt token." if secret.blank?
+
+          Digest::SHA256.digest(secret)
+        end
+      end
+    end
+  end
+end

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -186,7 +186,8 @@ RSpec.describe DocumentsController do
     end
   end
 
-  describe "generate_oauth_token" do
+  describe "generate_oauth_token",
+           with_config: { collaborative_editing_hocuspocus_secret: "secret1234" } do
     let(:manage_role) { create(:project_role, permissions: %i[view_documents manage_documents]) }
     let(:view_only_role) { create(:project_role, permissions: [:view_documents]) }
     let(:user_with_manage) { create(:user) }

--- a/modules/documents/spec/services/documents/oauth/encrypt_token_service_spec.rb
+++ b/modules/documents/spec/services/documents/oauth/encrypt_token_service_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Documents::OAuth::EncryptTokenService do
+  subject(:service_call) { described_class.new(token:).call }
+
+  before do
+    allow(Setting)
+      .to receive(:collaborative_editing_hocuspocus_secret)
+      .and_return(secret)
+  end
+
+  describe "#call" do
+    context "when the secret is not defined" do
+      let(:secret) { nil }
+      let(:token) { "anything" }
+
+      it "return an failure" do
+        result = service_call
+        expect(result).to be_failure
+      end
+    end
+
+    context "when the secret is short" do
+      let(:secret) { "short_secret" }
+      let(:token) { "sensitive_token_value" }
+
+      it "returns a successful result with the encrypted token" do
+        result = service_call
+        expect(result).to be_success
+
+        encrypted_token = result.result
+
+        expect(encrypted_token).not_to eq(token)
+        expect(encrypted_token).to be_a(String)
+        expect(encrypted_token.length).to be > token.length
+      end
+    end
+
+    context "when the secret is long" do
+      let(:secret) { "this_is_a_very_long_and_secure_secret_for_encryption_purposes_123456" }
+      let(:token) { "sensitive_token_value" }
+
+      it "returns a success result with the encrypted token" do
+        result = service_call
+        expect(result).to be_success
+
+        encrypted_token = result.result
+
+        expect(encrypted_token).not_to eq(token)
+        expect(encrypted_token).to be_a(String)
+        expect(encrypted_token.length).to be > token.length
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/69116/activity

# What are you trying to accomplish?
The goal is to set a shared secret between OpenProject and the collaboration server so that tokens generated for communication between the two services are not exposed on the frontend unnecessarily.

This PR is a counterpart of https://github.com/opf/op-blocknote-hocuspocus/pull/12

# What approach did you choose and why?
We encrypt tokens with rails's [ActiveSupport::MessageEncryptor.new](https://api.rubyonrails.org/classes/ActiveSupport/MessageEncryptor.html).

The frontend maintains the same implementation, establishing a [connection to the HocuspocusProvider](https://github.com/opf/openproject/blob/dev/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts#L55-L61), but now using the encrypted token instead of plaintext.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
