### PR TITLE
[#68860] Send out notification on creation of a project  

### DIFF
--- a/app/components/admin/settings/new_project_settings/page_header_component.html.erb
+++ b/app/components/admin/settings/new_project_settings/page_header_component.html.erb
@@ -26,13 +26,30 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<% html_title t(:label_administration), t(:label_project_new) %>
 
-<%= render Admin::Settings::NewProjectSettings::PageHeaderComponent.new %>
+<%=
+  render Primer::OpenProject::PageHeader.new do |header|
+    header.with_title { t(:label_project_new) }
+    header.with_breadcrumbs(
+      [{ href: admin_index_path, text: t(:label_administration) },
+       { href: admin_settings_project_custom_fields_path, text: t(:label_project_plural) },
+       t(:label_project_new)]
+    )
 
-<% case params[:tab] %>
-<% when "settings" %>
-  <%= render partial: "settings" %>
-<% when "notifications" %>
-  <%= render partial: "notifications" %>
-<% end %>
+    header.with_tab_nav(label: nil) do |tab_nav|
+      tab_nav.with_tab(
+        selected: params[:tab] == "settings" || params[:tab].blank?,
+        href: helpers.admin_settings_new_project_path(tab: :settings)
+      ) do |t|
+        t.with_text { t(:label_setting_plural) }
+      end
+
+      tab_nav.with_tab(
+        selected: params[:tab] == "notifications",
+        href: helpers.admin_settings_new_project_path(tab: :notifications)
+      ) do |t|
+        t.with_text { I18n.t(:label_notification_center_plural) }
+      end
+    end
+  end
+%>

--- a/app/components/admin/settings/new_project_settings/page_header_component.rb
+++ b/app/components/admin/settings/new_project_settings/page_header_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class Admin::Settings::NewProjectSettings::PageHeaderComponent < ApplicationComponent
+  include OpPrimer::ComponentHelpers
+end

--- a/app/controllers/admin/settings/new_project_settings_controller.rb
+++ b/app/controllers/admin/settings/new_project_settings_controller.rb
@@ -38,6 +38,7 @@ module Admin::Settings
 
     # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     def validate_enabled_modules
+      return if params[:tab] == "notifications"
       return if settings_params[:default_projects_modules].blank?
 
       enabled_modules = settings_params[:default_projects_modules].map(&:to_sym)
@@ -60,7 +61,7 @@ module Admin::Settings
       if module_missing_deps.any?
         flash[:error] = helpers.list_of_messages(module_missing_deps)
 
-        redirect_to action: :show
+        redirect_to action: :show, tab: params[:tab]
       end
     end
 

--- a/app/forms/settings/input_methods.rb
+++ b/app/forms/settings/input_methods.rb
@@ -51,6 +51,24 @@ module Settings
       object.text_field(name:, **options)
     end
 
+    # Creates a rich text area input for a setting.
+    #
+    # The rich text area label is set from translating the key "setting_<name>".
+    #
+    # Any options passed to this method will override the default options.
+    #
+    # @param name [Symbol] The name of the setting
+    # @param options [Hash] Additional options for the rich text area
+    # @return [Object] The rich text area input
+    def rich_text_area(name:, **options)
+      options.reverse_merge!(
+        label: setting_label(name),
+        value: setting_value(name),
+        disabled: setting_disabled?(name)
+      )
+      object.rich_text_area(name:, **options)
+    end
+
     # Creates a check box input for a setting.
     #
     # The check box label is set from translating the key "setting_<name>".

--- a/app/forms/settings/new_project_notifications_form.rb
+++ b/app/forms/settings/new_project_notifications_form.rb
@@ -42,6 +42,8 @@ module Settings
 
       f.rich_text_area(
         name: :new_project_notification_text,
+        value: Setting.new_project_notification_text.presence ||
+               I18n.t("admin.settings.new_project.notification_text_default"),
         required: true,
         rich_text_options: {
           showAttachments: false,

--- a/app/forms/settings/new_project_notifications_form.rb
+++ b/app/forms/settings/new_project_notifications_form.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Settings
+  class NewProjectNotificationsForm < ApplicationForm
+    settings_form do |f|
+      f.check_box(
+        name: :new_project_send_confirmation_email,
+        label: I18n.t(:setting_new_project_send_confirmation_email),
+        data: {
+          "show-when-checked-target": "cause",
+          target_name: "send_confirmation_email"
+        }
+      )
+
+      f.rich_text_area(
+        name: :new_project_notification_text,
+        required: true,
+        rich_text_options: {
+          showAttachments: false,
+          editorType: "constrained"
+        },
+        wrapper_classes: Setting.new_project_send_confirmation_email ? "" : "d-none",
+        wrapper_data_attributes: {
+          "show-when-checked-target": "effect",
+          target_name: "send_confirmation_email",
+          "visibility-class": "d-none"
+        }
+      )
+
+      f.submit
+    end
+  end
+end

--- a/app/forms/settings/new_project_settings_form.rb
+++ b/app/forms/settings/new_project_settings_form.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Settings
+  class NewProjectSettingsForm < ApplicationForm
+    settings_form do |f|
+      f.check_box(
+        name: :default_projects_public
+      )
+
+      f.check_box_group(
+        name: :default_projects_modules,
+        label: I18n.t(:setting_default_projects_modules)
+      ) do |check_box_group|
+        OpenProject::AccessControl.available_project_modules(sorted: true).each do |m|
+          check_box_group.check_box(
+            value: m.to_s,
+            label: I18n.t("project_module_#{m}", default: m.to_s.humanize),
+            checked: Setting.default_projects_modules.include?(m.to_s)
+          )
+        end
+      end
+
+      f.select_list(
+        name: :new_project_user_role_id,
+        label: I18n.t(:setting_new_project_user_role_id),
+        input_width: :medium,
+        include_blank: I18n.t(:actionview_instancetag_blank_option)
+      ) do |select|
+        ProjectRole.givable.each do |role|
+          select.option(
+            value: role.id.to_s,
+            label: role.name,
+            selected: Setting.new_project_user_role_id == role.id
+          )
+        end
+      end
+
+      f.submit
+    end
+  end
+end

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -29,6 +29,8 @@
 #++
 
 class ProjectMailer < ApplicationMailer
+  include Exports::PDF::Common::Macro
+
   def delete_project_completed(project, user:, dependent_projects: [])
     open_project_headers Project: project.identifier,
                          Author: user.login
@@ -92,7 +94,9 @@ class ProjectMailer < ApplicationMailer
     message_id project, user
     @project = project
     @user = user
-    @notification_text = Setting.new_project_notification_text
+    notification_text = Setting.new_project_notification_text.presence ||
+                        I18n.t("admin.settings.new_project.notification_text_default")
+    @notification_text = apply_markdown_field_macros(notification_text, { project:, user: })
 
     send_localized_mail(user) do
       I18n.t("projects.create.notification_email_subject", project_name: project.name)

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -84,4 +84,18 @@ class ProjectMailer < ApplicationMailer
       I18n.t("copy_project.succeeded", target_project_name: target_project.name)
     end
   end
+
+  def project_created(project, user:)
+    open_project_headers Project: project.identifier,
+                         Author: user.login
+
+    message_id project, user
+    @project = project
+    @user = user
+    @notification_text = Setting.new_project_notification_text
+
+    send_localized_mail(user) do
+      I18n.t("projects.create.notification_email_subject", project_name: project.name)
+    end
+  end
 end

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -43,7 +43,7 @@ module Projects::Concerns
 
       set_default_role(new_project) unless user.admin?
       disable_custom_fields_with_empty_values(new_project)
-      notify_project_created(new_project)
+      notify_project_created(new_project) if new_project.persisted?
 
       super
     end

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -76,6 +76,12 @@ module Projects::Concerns
         OpenProject::Events::PROJECT_CREATED,
         project: new_project
       )
+
+      send_project_creation_email(new_project) if Setting.new_project_send_confirmation_email?
+    end
+
+    def send_project_creation_email(new_project)
+      ProjectMailer.project_created(new_project, user:).deliver_later
     end
 
     def disable_custom_fields_with_empty_values(new_project)

--- a/app/views/admin/settings/new_project_settings/_notifications.html.erb
+++ b/app/views/admin/settings/new_project_settings/_notifications.html.erb
@@ -26,13 +26,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<% html_title t(:label_administration), t(:label_project_new) %>
 
-<%= render Admin::Settings::NewProjectSettings::PageHeaderComponent.new %>
-
-<% case params[:tab] %>
-<% when "settings" %>
-  <%= render partial: "settings" %>
-<% when "notifications" %>
-  <%= render partial: "notifications" %>
-<% end %>
+<%=
+  settings_primer_form_with(
+    scope: :settings,
+    url: admin_settings_new_project_path(tab: "notifications"),
+    method: :patch,
+    data: { controller: "show-when-checked" }
+  ) do |f|
+    render(Settings::NewProjectNotificationsForm.new(f))
+  end
+%>

--- a/app/views/admin/settings/new_project_settings/_settings.html.erb
+++ b/app/views/admin/settings/new_project_settings/_settings.html.erb
@@ -26,13 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-<% html_title t(:label_administration), t(:label_project_new) %>
 
-<%= render Admin::Settings::NewProjectSettings::PageHeaderComponent.new %>
-
-<% case params[:tab] %>
-<% when "settings" %>
-  <%= render partial: "settings" %>
-<% when "notifications" %>
-  <%= render partial: "notifications" %>
-<% end %>
+<%=
+  settings_primer_form_with(
+    scope: :settings,
+    url: admin_settings_new_project_path(tab: "settings"),
+    method: :patch
+  ) do |f|
+    render(Settings::NewProjectSettingsForm.new(f))
+  end
+%>

--- a/app/views/admin/settings/new_project_settings/show.html.erb
+++ b/app/views/admin/settings/new_project_settings/show.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render Admin::Settings::NewProjectSettings::PageHeaderComponent.new %>
 
-<% case params[:tab] %>
+<% case params.fetch(:tab, "settings") %>
 <% when "settings" %>
   <%= render partial: "settings" %>
 <% when "notifications" %>

--- a/app/views/project_mailer/project_created.html.erb
+++ b/app/views/project_mailer/project_created.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
           I18n.t(
             "projects.create.complete_wizard_link",
             artefact_name: I18n.t(
-              "settings.project_initiation_request.name.options.#{@project.name_artefact_name}"
+              "settings.project_initiation_request.name.options.#{@project.project_creation_wizard_artifact_name}"
             )
           ),
           project_creation_wizard_url(@project),

--- a/app/views/project_mailer/project_created.html.erb
+++ b/app/views/project_mailer/project_created.html.erb
@@ -27,34 +27,22 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render layout: "mailer/spacer_table" do %>
-  <%= render partial: "mailer/mailer_header",
-             locals: {
-               user: @user,
-               summary: I18n.t("projects.create.notification_email_subject", project_name: @project.name),
-               bottom_spacing: false
-             } %>
+<h1><%= link_to @project.name, project_url(@project) %></h1>
 
-  <%= render layout: "mailer/border_table" do %>
-    <tr>
-      <%= placeholder_cell("24px", vertical: true) %>
-      <td>
-        <%= @notification_text %>
-      </td>
-    </tr>
-  <% end %>
+<%= format_text(@notification_text, project: @project) %>
 
-  <table>
-    <tr>
-      <%= placeholder_cell("20px", vertical: false) %>
-    </tr>
-  </table>
-
-  <%= action_button do %>
-    <%= link_to I18n.t("projects.create.open_project_link"),
-                project_url(@project),
-                target: "_blank",
-                rel: "noopener",
-                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;" %>
-  <% end %>
+<% if @project.project_creation_wizard_enabled? %>
+  <p>
+    <%= link_to(
+          I18n.t(
+            "projects.create.complete_wizard_link",
+            artefact_name: I18n.t(
+              "settings.project_initiation_request.name.options.#{@project.name_artefact_name}"
+            )
+          ),
+          project_creation_wizard_url(@project),
+          target: "_blank",
+          rel: "noopener"
+        ) %>
+  </p>
 <% end %>

--- a/app/views/project_mailer/project_created.html.erb
+++ b/app/views/project_mailer/project_created.html.erb
@@ -1,0 +1,60 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render layout: "mailer/spacer_table" do %>
+  <%= render partial: "mailer/mailer_header",
+             locals: {
+               user: @user,
+               summary: I18n.t("projects.create.notification_email_subject", project_name: @project.name),
+               bottom_spacing: false
+             } %>
+
+  <%= render layout: "mailer/border_table" do %>
+    <tr>
+      <%= placeholder_cell("24px", vertical: true) %>
+      <td>
+        <%= @notification_text %>
+      </td>
+    </tr>
+  <% end %>
+
+  <table>
+    <tr>
+      <%= placeholder_cell("20px", vertical: false) %>
+    </tr>
+  </table>
+
+  <%= action_button do %>
+    <%= link_to I18n.t("projects.create.open_project_link"),
+                project_url(@project),
+                target: "_blank",
+                rel: "noopener",
+                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;" %>
+  <% end %>
+<% end %>

--- a/app/views/project_mailer/project_created.text.erb
+++ b/app/views/project_mailer/project_created.text.erb
@@ -35,6 +35,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= I18n.t(
       "projects.create.complete_wizard_link",
-      artefact_name: I18n.t("settings.project_initiation_request.name.options.#{@project.name_artefact_name}")
+      artefact_name: I18n.t("settings.project_initiation_request.name.options.#{@project.project_creation_wizard_artifact_name}")
     ) %>: <%= project_creation_wizard_url(@project) %>
 <% end %>

--- a/app/views/project_mailer/project_created.text.erb
+++ b/app/views/project_mailer/project_created.text.erb
@@ -27,6 +27,14 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= I18n.t("projects.create.notification_email_subject", project_name: @project.name) %> (<%= project_url(@project) %>)
+<%= @project.name %>
+<%= project_url(@project) %>
 
 <%= strip_tags(@notification_text) %>
+<% if @project.project_creation_wizard_enabled? %>
+
+<%= I18n.t(
+      "projects.create.complete_wizard_link",
+      artefact_name: I18n.t("settings.project_initiation_request.name.options.#{@project.name_artefact_name}")
+    ) %>: <%= project_creation_wizard_url(@project) %>
+<% end %>

--- a/app/views/project_mailer/project_created.text.erb
+++ b/app/views/project_mailer/project_created.text.erb
@@ -1,0 +1,32 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= I18n.t("projects.create.notification_email_subject", project_name: @project.name) %> (<%= project_url(@project) %>)
+
+<%= strip_tags(@notification_text) %>

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -742,11 +742,11 @@ module Settings
       },
       new_project_send_confirmation_email: {
         format: :boolean,
-        default: true
+        default: false
       },
       new_project_notification_text: {
         format: :string,
-        default: nil
+        default: ""
       },
       notifications_hidden: {
         default: false

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -740,6 +740,14 @@ module Settings
         default: nil,
         allowed: -> { Role.pluck(:id) }
       },
+      new_project_send_confirmation_email: {
+        format: :boolean,
+        default: true
+      },
+      new_project_notification_text: {
+        format: :string,
+        default: nil
+      },
       notifications_hidden: {
         default: false
       },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4497,7 +4497,7 @@ en:
   setting_mail_handler_body_delimiter_regex: "Truncate emails matching this regex"
   setting_mail_handler_ignore_filenames: "Ignored mail attachments"
   setting_new_project_user_role_id: "Role given to a non-admin user who creates a project"
-  setting_new_project_send_confirmation_email: "Send confirmation email to the user that created the project"
+  setting_new_project_send_confirmation_email: "Send notification to author when creating a new project"
   setting_new_project_notification_text: "Notification text"
   setting_password_active_rules: "Active character classes"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,6 +174,10 @@ en:
     settings:
       new_project:
         project_creation: "Project creation"
+        notification_text_default: >
+          <p>Hello,</p>
+          <p>A new project has been created: projectValue:name</p>
+          <p>Thank you</p>
     workflows:
       tabs:
         default_transitions: "Default transitions"
@@ -512,7 +516,7 @@ en:
       work_package_shares: "Work packages: shares"
     create:
       notification_email_subject: "Your project '%{project_name}' has been created"
-      open_project_link: "Open project"
+      complete_wizard_link: "Complete the %{artefact_name}"
     delete:
       scheduled: "Deletion has been scheduled and is performed in the background. You will be notified of the result."
       schedule_failed: "Project cannot be deleted: %{errors}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,9 @@ en:
         expired: "Expired on %{date}"
         revoked: "Revoked on %{date}"
         title: "Access token table"
+    settings:
+      new_project:
+        project_creation: "Project creation"
     workflows:
       tabs:
         default_transitions: "Default transitions"
@@ -4487,6 +4490,8 @@ en:
   setting_mail_handler_body_delimiter_regex: "Truncate emails matching this regex"
   setting_mail_handler_ignore_filenames: "Ignored mail attachments"
   setting_new_project_user_role_id: "Role given to a non-admin user who creates a project"
+  setting_new_project_send_confirmation_email: "Send confirmation email to the user that created the project"
+  setting_new_project_notification_text: "Notification text"
   setting_password_active_rules: "Active character classes"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"
   setting_password_days_valid: "Number of days, after which to enforce a password change"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,12 +510,15 @@ en:
       work_package_categories: "Work packages: categories"
       work_package_file_links: "Work packages: file links"
       work_package_shares: "Work packages: shares"
+    create:
+      notification_email_subject: "Your project '%{project_name}' has been created"
+      open_project_link: "Open project"
     delete:
       scheduled: "Deletion has been scheduled and is performed in the background. You will be notified of the result."
       schedule_failed: "Project cannot be deleted: %{errors}"
-      failed: "Deletion of project %{name} has failed"
-      failed_text: "The request to delete project %{name} has failed. The project was left archived."
-      completed: "Deletion of project %{name} completed"
+      failed: "Deletion of project '%{name}' has failed"
+      failed_text: "The request to delete project '%{name}' has failed. The project was left archived."
+      completed: "Deletion of project '%{name}' completed"
       completed_text: "The request to delete project '%{name}' has been completed."
       completed_text_children: "Additionally, the following subprojects have been deleted:"
     index:

--- a/spec/controllers/admin/settings/new_project_settings_controller_spec.rb
+++ b/spec/controllers/admin/settings/new_project_settings_controller_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe Admin::Settings::NewProjectSettingsController do
     render_views
 
     describe "default project modules" do
-      it "contains a check box for the activity module on the projects tab" do
-        get "show", params: { tab: "projects" }
+      it "contains a check box for the activity module on the settings tab" do
+        get "show", params: { tab: "settings" }
 
         expect(response).to be_successful
         expect(response).to render_template "admin/settings/new_project_settings/show"
@@ -56,7 +56,7 @@ RSpec.describe Admin::Settings::NewProjectSettingsController do
         end
 
         it "contains an unchecked checkbox for activity" do
-          get "show", params: { tab: "projects" }
+          get "show", params: { tab: "settings" }
 
           expect(response).to be_successful
           expect(response).to render_template "admin/settings/new_project_settings/show"
@@ -72,13 +72,23 @@ RSpec.describe Admin::Settings::NewProjectSettingsController do
         end
 
         it "contains a checked checkbox for activity" do
-          get "show", params: { tab: "projects" }
+          get "show", params: { tab: "settings" }
 
           expect(response).to be_successful
           expect(response).to render_template "admin/settings/new_project_settings/show"
           expect(response.body)
             .to have_css "input[@name='settings[default_projects_modules][]'][@value='activity'][@checked='checked']"
         end
+      end
+    end
+
+    describe "project creation notifications" do
+      it "contains a checkbox for sending confirmation emails in the notifications tab" do
+        get "show", params: { tab: "notifications" }
+
+        expect(response).to be_successful
+        expect(response).to render_template "admin/settings/new_project_settings/show"
+        expect(response.body).to have_css "input[@name='settings[new_project_send_confirmation_email]']"
       end
     end
   end
@@ -90,14 +100,14 @@ RSpec.describe Admin::Settings::NewProjectSettingsController do
       it "does not store the activity in the default_projects_modules if unchecked" do
         patch "update",
               params: {
-                tab: "projects",
+                tab: "settings",
                 settings: {
                   default_projects_modules: ["wiki"]
                 }
               }
 
         expect(response).to be_redirect
-        expect(response).to redirect_to action: "show", tab: "projects"
+        expect(response).to redirect_to action: "show", tab: "settings"
 
         expect(Setting.default_projects_modules).to eq(["wiki"])
       end
@@ -105,16 +115,49 @@ RSpec.describe Admin::Settings::NewProjectSettingsController do
       it "stores the activity in the default_projects_modules if checked" do
         patch "update",
               params: {
-                tab: "projects",
+                tab: "settings",
                 settings: {
                   default_projects_modules: ["activity", "wiki"]
                 }
               }
 
         expect(response).to be_redirect
-        expect(response).to redirect_to action: "show", tab: "projects"
+        expect(response).to redirect_to action: "show", tab: "settings"
 
         expect(Setting.default_projects_modules).to eq(["activity", "wiki"])
+      end
+    end
+
+    describe "project creation notifications" do
+      it "enables confirmation emails when checked" do
+        expect(Setting.new_project_send_confirmation_email).to be false
+
+        patch "update",
+              params: {
+                tab: "notifications",
+                settings: {
+                  new_project_send_confirmation_email: "1"
+                }
+              }
+
+        expect(response).to be_redirect
+        expect(response).to redirect_to action: "show", tab: "notifications"
+
+        expect(Setting.new_project_send_confirmation_email).to be true
+      end
+
+      it "stores the notification text" do
+        patch "update",
+              params: {
+                tab: "notifications",
+                settings: {
+                  new_project_send_confirmation_email: "1",
+                  new_project_notification_text: "Custom notification message"
+                }
+              }
+
+        expect(response).to be_redirect
+        expect(Setting.new_project_notification_text).to eq("Custom notification message")
       end
     end
 

--- a/spec/mailers/project_mailer_spec.rb
+++ b/spec/mailers/project_mailer_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "../spec_helper"
+
+RSpec.describe ProjectMailer do
+  let(:project) { build_stubbed(:project) }
+  let(:user) { build_stubbed(:user) }
+
+  describe "#project_created" do
+    subject(:mail) { described_class.project_created(project, user:) }
+
+    it "has a subject with the project name" do
+      expect(mail.subject)
+        .to eq I18n.t("projects.create.notification_email_subject", project_name: project.name)
+    end
+
+    it "is sent to the user" do
+      expect(mail.to)
+        .to contain_exactly(user.mail)
+    end
+
+    it "sets the project header" do
+      expect(mail["X-OpenProject-Project"].value)
+        .to eq project.identifier
+    end
+
+    it "sets the author header" do
+      expect(mail["X-OpenProject-Author"].value)
+        .to eq user.login
+    end
+
+    it "contains the project name in the body by default" do
+      expect(mail.html_part.body.encoded)
+        .to include(project.name)
+    end
+
+    context "with custom notification text" do
+      before do
+        allow(Setting).to receive(:new_project_notification_text).and_return("Some custom text")
+      end
+
+      it "includes the custom text" do
+        expect(mail.html_part.body.encoded)
+          .to include("Some custom text")
+      end
+    end
+
+    context "with the creation wizard enabled" do
+      before do
+        allow(project).to receive_messages(
+          project_creation_wizard_enabled?: true,
+          project_creation_wizard_artifact_name: "project_initiation_request"
+        )
+      end
+
+      it "includes a link to the wizard" do
+        expect(mail.html_part.body.encoded)
+          .to include("/projects/#{project.identifier}/creation_wizard")
+      end
+    end
+
+    context "with project creation wizard disabled" do
+      before do
+        allow(project).to receive_messages(
+          project_creation_wizard_enabled?: false,
+          project_creation_wizard_artifact_name: "project_initiation_request"
+        )
+      end
+
+      it "does not include the wizard link" do
+        expect(mail.html_part.body.encoded)
+          .not_to include("/projects/#{project.identifier}/creation_wizard")
+      end
+    end
+  end
+end

--- a/spec/services/projects/create_service_spec.rb
+++ b/spec/services/projects/create_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Projects::CreateService, type: :model do
               roles: [new_project_role])
     end
 
-    context "current user is admin" do
+    context "when current user is admin" do
       it "does not add the user to the project" do
         allow(user)
           .to(receive(:admin?))
@@ -70,6 +70,31 @@ RSpec.describe Projects::CreateService, type: :model do
 
         expect(create_member_instance)
           .not_to(have_received(:call))
+      end
+    end
+
+    describe "project creation email" do
+      context "when enabled", with_settings: { new_project_send_confirmation_email: true } do
+        it "sends the email to the user" do
+          allow(ProjectMailer)
+            .to receive(:project_created)
+            .with(model_instance, user:)
+            .and_call_original
+
+          subject
+
+          expect(ProjectMailer).to have_received(:project_created)
+        end
+      end
+
+      context "when disabled", with_settings: { new_project_send_confirmation_email: false } do
+        it "does not send the email" do
+          allow(ProjectMailer).to receive(:project_created)
+
+          subject
+
+          expect(ProjectMailer).not_to have_received(:project_created)
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/68860

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Update administration for new projects
   - Add tab layout
   - Primerize old settings and move them to the first tab
   - Add new settings to the second tab
- Add checkbox "Send notification to author when creating a new project"
- Add text box for the content of the email
   - With a default body that can be overwritten
- In the email, if the project has a PIR, add a link to that wizard in the email

# Merge checklist

- [x] Added/updated tests