### PR TITLE
Label hierarchy custom fields as "equals (OR)"

### DIFF
--- a/app/models/queries/filters/strategies/hierarchy.rb
+++ b/app/models/queries/filters/strategies/hierarchy.rb
@@ -37,6 +37,7 @@ module Queries
 
         def operator_map
           super.dup.tap do |super_value|
+            super_value["="] = ::Queries::Operators::EqualsOr
             super_value["eq_with_descendants"] = ::Queries::Operators::CustomFields::Hierarchies::EqualsWithDescendants
           end
         end

--- a/spec/features/work_packages/table/queries/hierarchy_cf_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/hierarchy_cf_filter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Work package filtering by hierarchy custom field", :js, with_ee:
 
         # Filtering by hierarchy (=)
 
-        filters.add_filter_by(hierarchy_cf.name, "is", [luke.label], hierarchy_cf.attribute_name(:camel_case))
+        filters.add_filter_by(hierarchy_cf.name, "is (OR)", [luke.label], hierarchy_cf.attribute_name(:camel_case))
 
         wp_table.ensure_work_package_not_listed!(wp_leia)
         wp_table.expect_work_package_listed(wp_luke)


### PR DESCRIPTION
This is done the same way for some other kinds of fields already and ensures that users understand, that a selection of many values means that either of the values needs to match.

# Ticket
https://community.openproject.org/wp/59752