### PR TITLE
Bug Pass template to the project creation footer.

### DIFF
--- a/app/components/projects/project_creation_footer_component.rb
+++ b/app/components/projects/project_creation_footer_component.rb
@@ -32,9 +32,10 @@ module Projects
   class ProjectCreationFooterComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    def initialize(form_identifier:, project:, current_step:)
+    def initialize(form_identifier:, project:, template:, current_step:)
       @form_identifier = form_identifier
       @project = project
+      @template = template
       @current_step = current_step
 
       super
@@ -51,7 +52,7 @@ module Projects
       end
     end
 
-    attr_reader :form_identifier, :project, :current_step
+    attr_reader :form_identifier, :project, :template, :current_step
 
     private
 
@@ -75,7 +76,7 @@ module Projects
     end
 
     def total_steps
-      project.template_id.nil? && project.available_custom_fields.required.any? ? 3 : 2
+      template.nil? && project.available_custom_fields.required.any? ? 3 : 2
     end
   end
 end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -75,6 +75,7 @@ See COPYRIGHT and LICENSE files for more details.
       render Projects::ProjectCreationFooterComponent.new(
         form_identifier: "project-create-form",
         project: @new_project,
+        template: @template,
         current_step: params.fetch(:step, 1).to_i
       )
     end

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "Projects", "creation",
     click_on "Continue"
 
     # Step 2: Fill in project details
+    expect(page).to have_text("2 of 2")
     fill_in "Name", with: "Foo bar"
     click_on "Complete"
 
@@ -100,10 +101,13 @@ RSpec.describe "Projects", "creation",
     # Step 1: Select workspace type (blank project)
     click_on "Continue"
 
+    # Step 2: Try to complete without name
+    expect(page).to have_text("2 of 2")
     click_on "Complete"
 
     expect_and_dismiss_flash type: :error, message: /^Creation failed/
 
+    expect(page).to have_text("2 of 2")
     expect(page).to have_field "Name", validation_error: "can't be blank."
   end
 
@@ -131,10 +135,12 @@ RSpec.describe "Projects", "creation",
       click_on "Continue"
 
       # Step 2: Fill in project details
+      expect(page).to have_text("2 of 3")
       fill_in "Name", with: "Foo bar"
       click_on "Continue"
 
       # Step 3: Fill in custom fields
+      expect(page).to have_text("3 of 3")
       expect(page).to have_combo_box "List CF *"
       list_field.select_option "A", "B"
 
@@ -191,10 +197,12 @@ RSpec.describe "Projects", "creation",
       click_on "Continue"
 
       # Step 2: Fill in project details
+      expect(page).to have_text("2 of 3")
       fill_in "Name", with: "Foo bar"
       click_on "Continue"
 
       # Step 3: Fill in custom fields
+      expect(page).to have_text("3 of 3")
       expect(page).to have_combo_box "Version CF *"
 
       # expect the versions are grouped by the project name
@@ -259,10 +267,12 @@ RSpec.describe "Projects", "creation",
         click_on "Continue"
 
         # Step 2: Project details - skip to step 3
+        expect(page).to have_text("2 of 3")
         fill_in "Name", with: "Test Project"
         click_on "Continue"
 
         # Step 3: Custom fields
+        expect(page).to have_text("3 of 3")
         expect(page).to have_field "Required Foo *"
         expect(page).to have_field "Required User *"
         expect(page).to have_no_field "Optional Foo"
@@ -281,14 +291,17 @@ RSpec.describe "Projects", "creation",
         click_on "Continue"
 
         # Step 2: Fill in name
+        expect(page).to have_text("2 of 3")
         fill_in "Name", with: "Test Project"
         click_on "Continue"
 
         # Step 3: Try to complete without required custom field
+        expect(page).to have_text("3 of 3")
         click_on "Complete"
 
         expect_and_dismiss_flash type: :error, message: /^Creation failed/
 
+        expect(page).to have_text("3 of 3")
         expect(page).to have_field "Required Foo *", validation_error: "can't be blank."
       end
     end

--- a/spec/features/projects/template_spec.rb
+++ b/spec/features/projects/template_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "Project templates", :js, with_good_job_batches: [CopyProjectJob,
       click_on "Continue"
 
       # Step 2: Project details
+      expect(page).to have_text("2 of 2")
       fill_in "Name", with: "Foo bar"
 
       click_on "Complete"
@@ -152,9 +153,10 @@ RSpec.describe "Project templates", :js, with_good_job_batches: [CopyProjectJob,
       click_on "Continue"
 
       # Step 2: Project details
+      expect(page).to have_text("2 of 2")
       fill_in "Name", with: "Project from template"
 
-      click_on "Continue"
+      click_on "Complete"
 
       # Step 3: Custom fields - should not show custom field form when creating from template
       expect(page).to have_no_field custom_field.name


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69348

# What are you trying to accomplish?
The wizard progress footer shows 3 steps when creating a project from template, which is incorrect because there are 2 steps only.


# What approach did you choose and why?
Do not rely on the `project.template_id` because it is not always present in the `projects#new` action. Rely on the `@template` instead.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
