### PR TITLE
[#68978] Style the rich-link workpackage macro (dark theme)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -18207,9 +18207,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.10",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
-      "integrity": "sha512-c0DINNJ7mEj5cS9dgQzmLssiZMrFvXRY4Hd3qBc/Uapne3+2LcWBqZJ41xz33MxGL+iWSrMQl/E60Huba2UGQg==",
+      "version": "0.0.11",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
+      "integrity": "sha512-sTj9yjbIdw5kzzdUI6Dm/8RfcS6+6yme1GVj+Sy8yXiAwa4ZKrcOfJf+nnr+HBHEeDpv8JOf/ACHKqWoMihakg==",
       "dependencies": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
@@ -35868,8 +35868,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
-      "integrity": "sha512-c0DINNJ7mEj5cS9dgQzmLssiZMrFvXRY4Hd3qBc/Uapne3+2LcWBqZJ41xz33MxGL+iWSrMQl/E60Huba2UGQg==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
+      "integrity": "sha512-sTj9yjbIdw5kzzdUI6Dm/8RfcS6+6yme1GVj+Sy8yXiAwa4ZKrcOfJf+nnr+HBHEeDpv8JOf/ACHKqWoMihakg==",
       "requires": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.10/op-blocknote-extensions-0.0.10.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",


### PR DESCRIPTION
This updates the op-blocknote-extensions package to the version which implemented the dark theme.

# Ticket
https://community.openproject.org/work_packages/68978

# What are you trying to accomplish?
Implement dark theme for link workpackge blocks inside the BlockNote editor

## Screenshots
<img width="599" height="773" alt="image" src="https://github.com/user-attachments/assets/e07d99e1-3e09-4d23-9652-fa6974eec225" />
