### PR TITLE
[#69358] improve insert item interface

### DIFF
--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -61,24 +61,19 @@ module Admin
 
         def create
           item_service
-            .insert_item(contract_class: create_contract, **item_input)
+            .insert_item(contract_class: create_contract, **insert_item_input)
             .either(
               lambda { |item| redirect_to action: :new, position: item.sort_order + 1 },
               lambda do |validation_result|
-                add_errors_to_form(validation_result)
+                add_errors_to_new_form(validation_result)
                 render :new
               end
             )
         end
 
         def update
-          input = item_input
           item_service
-            .update_item(contract_class: update_contract,
-                         item: @active_item,
-                         label: input[:label],
-                         short: input[:short],
-                         weight: input[:weight])
+            .update_item(contract_class: update_contract, **update_item_input)
             .either(
               ->(*) { redirect_to action: :show, id: @active_item.parent, status: :see_other },
               lambda do |validation_result|
@@ -141,13 +136,23 @@ module Admin
           ::CustomFields::Hierarchy::HierarchicalItemService.new
         end
 
-        def item_input # rubocop:disable Metrics/AbcSize
-          input = { parent: @active_item, label: params[:label] }
-          input[:short] = params[:short] if params[:short].present?
-          input[:weight] = params[:weight] if params[:weight].present?
-          input[:sort_order] = params[:sort_order].to_i if params[:sort_order].present?
+        def insert_item_input
+          {
+            parent: @active_item,
+            label: params[:label],
+            short: params[:short],
+            weight: params[:weight],
+            before: params[:sort_order]
+          }
+        end
 
-          input
+        def update_item_input
+          {
+            item: @active_item,
+            label: params[:label],
+            short: params[:short],
+            weight: params[:weight]
+          }
         end
 
         def new_parent_params
@@ -176,8 +181,11 @@ module Admin
           end
         end
 
-        def add_errors_to_form(validation_result)
-          @new_item = ::CustomField::Hierarchy::Item.new(**item_input)
+        def add_errors_to_new_form(validation_result)
+          attributes = insert_item_input
+          attributes[:sort_order] = attributes.delete(:before)
+
+          @new_item = ::CustomField::Hierarchy::Item.new(**attributes)
           validation_result.errors(full: true).to_h.each do |attribute, errors|
             @new_item.errors.add(attribute, errors.join(", "))
           end

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -51,14 +51,15 @@ module CustomFields
       # @param label [String] the node label/name that must be unique at the same tree level
       # @param short [String] an alias for the node
       # @param weight [Decimal] a numeric value for the node
-      # @param sort_order [Integer] the position into which insert the item.
+      # @param before [Integer] the position where to prepend the item. If not set or the position does not exist,
+      #   the item is inserted at the end.
       # @return [Success(CustomField::Hierarchy::Item), Failure(Dry::Validation::Result), Failure(ActiveModel::Errors)]
-      def insert_item(contract_class:, parent:, label:, short: nil, weight: nil, sort_order: nil)
+      def insert_item(contract_class:, parent:, label:, short: nil, weight: nil, before: nil)
         contract_class
           .new
           .call({ parent:, label:, short:, weight: })
           .to_monad
-          .bind { |validation| create_child_item(validation:, sort_order:) }
+          .bind { |validation| create_child_item(validation:, before:) }
       end
 
       # Updates an item/node
@@ -176,11 +177,17 @@ module CustomFields
         Success(item)
       end
 
-      def create_child_item(validation:, sort_order: nil)
-        attributes = validation.to_h
-        attributes[:sort_order] = sort_order - 1 if sort_order
+      def create_child_item(validation:, before:)
+        item = CustomField::Hierarchy::Item.new(**validation.to_h.except(:parent))
+        parent = validation[:parent]
+        relative_sibling = parent.children.find_by(sort_order: before)
 
-        item = validation[:parent].children.create(**attributes)
+        if relative_sibling.present?
+          relative_sibling.prepend_sibling(item)
+        else
+          parent.add_child(item)
+        end
+
         return Failure(item.errors) if item.new_record?
 
         update_position_cache(item.root)
@@ -204,13 +211,13 @@ module CustomFields
         return unless custom_field&.field_format_weighted_item_list?
 
         custom_field.class.customized_class
-          .where(custom_values: custom_field.custom_values.where(value: item_ids))
-          .find_each do |customized|
-            affected_cfs = customized.available_custom_fields.affected_calculated_fields([custom_field.id])
+                    .where(custom_values: custom_field.custom_values.where(value: item_ids))
+                    .find_each do |customized|
+          affected_cfs = customized.available_custom_fields.affected_calculated_fields([custom_field.id])
 
-            customized.calculate_custom_fields(affected_cfs)
-            customized.save if customized.changed_for_autosave?
-          end
+          customized.calculate_custom_fields(affected_cfs)
+          customized.save if customized.changed_for_autosave?
+        end
       end
 
       def update_item_order(item:, new_sort_order:)

--- a/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
+++ b/spec/services/custom_fields/hierarchy/hierarchical_item_service_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
           expect(result).to be_success
         end
 
-        it "insert an item into a specific sort_order" do
+        it "insert an item at a specific position" do
           leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
           expect(root.reload.children).to contain_exactly(luke, leia)
 
-          bob = service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
+          bob = service.insert_item(contract_class:, parent: root, label: "Bob", before: 1).value!
           expect(root.reload.children).to contain_exactly(luke, bob, leia)
         end
 
@@ -96,15 +96,15 @@ RSpec.describe CustomFields::Hierarchy::HierarchicalItemService, with_ee: [:cust
           leia = service.insert_item(contract_class:, parent: root, label: "leia").value!
           expect(root.reload.position_cache).to eq(64)
 
-          service.insert_item(contract_class:, parent: root, label: "Bob", sort_order: 1).value!
+          service.insert_item(contract_class:, parent: root, label: "Bob", before: 1).value!
           expect(leia.reload.position_cache).to eq(200)
         end
       end
 
       context "with invalid item" do
         it "fails to insert an item" do
-          child = instance_double(CustomField::Hierarchy::Item, new_record?: true, errors: "some errors")
-          allow(root.children).to receive(:create).and_return(child)
+          # child item won't be persisted if `add_child` is mocked
+          allow(root).to receive(:add_child)
 
           result = service.insert_item(contract_class:, parent: root, label:, short:)
           expect(result).to be_failure


### PR DESCRIPTION
# Ticket
[#69358](https://community.openproject.org/work_packages/69358)

# What are you trying to accomplish?
- (hopefully) avoid inconsistent behaviour when adding new hierarchy items at certain positions


# What approach did you choose and why?
- use before instead of sort_order to emphasize behaviour of the method
- use closure tree methods - prepend_sibling - to ensure consistency in the tree
