### PR TITLE
Mark user's name property as read-only in API

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5234,6 +5234,8 @@ en:
       multiple_errors: "Multiple field constraints have been violated."
       unable_to_create_attachment: "The attachment could not be created"
       unable_to_create_attachment_permissions: "The attachment could not be saved due to lacking file system permissions"
+      user:
+        name_readonly: "The name attribute is read-only. Changes can be written through the attributes firstname and lastname."
       render:
         context_not_parsable: "The context provided is not a link to a resource."
         unsupported_context: "The resource given is not supported as context."

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -121,6 +121,10 @@ module API
                  setter: ->(fragment:, represented:, **) { represented.admin = fragment },
                  cache_if: -> { current_user_is_admin? }
 
+        property :name,
+                 render_nil: true,
+                 setter: ->(*) { raise API::Errors::UnwritableProperty.new(:name, I18n.t("api_v3.errors.user.name_readonly")) }
+
         property :firstname,
                  as: :firstName,
                  exec_context: :decorator,

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe API::V3::Users::UsersAPI do
       end
     end
 
+    describe "updating name attribute" do
+      let(:parameters) { { name: "Bobnelda Bobbit" } }
+
+      it "responds with an error" do
+        send_request
+
+        expect(last_response).to have_http_status(:unprocessable_entity)
+
+        expect(last_response.body)
+          .to be_json_eql("name".to_json)
+                .at_path("_embedded/details/attribute")
+
+        expect(last_response.body)
+          .to be_json_eql("urn:openproject-org:api:v3:errors:PropertyIsReadOnly".to_json)
+                .at_path("errorIdentifier")
+      end
+    end
+
     describe "custom fields" do
       let!(:required_custom_field) do
         create(:user_custom_field,


### PR DESCRIPTION
This property was inherited from the PrincipalRepresenter where it's writable. For users this would lead to a server error, since there is no name attribute on the user model.

We could've just marked the property as `writable: false`, though then changes to it would just be ignored without any API feedback, but marking it as read-only through the contract is not possible, since the contract can only validate attributes that really do exist.

To be able to provide API feedback, I overwrote the setter to raise a proper validation error.

# Ticket
https://community.openproject.org/wp/68501