### PR TITLE
Use resource id instead of document name for Hocuspocus

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -35,26 +35,18 @@ import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaborati
 export default class extends Controller {
   static values = {
     hocuspocusUrl: String,
-    openProjectUrl: String,
     oauthToken: String,
     documentName: String,
-    documentId: String,
   };
 
   declare readonly hocuspocusUrlValue:string;
-  declare readonly openProjectUrlValue:string;
   declare readonly oauthTokenValue:string;
   declare readonly documentNameValue:string;
-  declare readonly documentIdValue:string;
 
   connect():void {
-    const url = new URL(this.hocuspocusUrlValue);
-    url.searchParams.set('document_id', this.documentIdValue);
-    url.searchParams.set('openproject_base_path', this.openProjectUrlValue);
-
     LiveCollaborationManager.initializeYjsProvider(
       new HocuspocusProvider({
-        url: url.toString(),
+        url: this.hocuspocusUrlValue,
         name: this.documentNameValue,
         token: this.oauthTokenValue,
         document: LiveCollaborationManager.ydoc,

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -33,10 +33,8 @@
   helpers.content_controller(
     "documents--init-yjs-provider",
     "documents--init-yjs-provider-hocuspocus-url-value": Setting.collaborative_editing_hocuspocus_url,
-    "documents--init-yjs-provider-open-project-url-value": root_url,
     "documents--init-yjs-provider-oauth-token-value": oauth_token,
-    "documents--init-yjs-provider-document-name-value": document.title,
-    "documents--init-yjs-provider-document-id-value": document.id
+    "documents--init-yjs-provider-document-name-value": resource_url
   )
 %>
 

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
@@ -37,6 +37,15 @@ module Documents
       alias_method :document, :model
 
       options :project, :oauth_token, :state
+
+      private
+
+      def resource_url
+        URI.join(
+          root_url,
+          API::V3::Utilities::PathHelper::ApiV3Path.document(document.id)
+        ).to_s
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/69240/activity

counterpart of https://github.com/opf/op-blocknote-hocuspocus/pull/14

# What are you trying to accomplish?
Use a better key for communicating between OpenProject and Hocuspocus. Also fix issues where changing the document name, or having multiple documents with the same name would cause misalignment with Hocuspocus.

Additionally this simplifies the Hocuspocus setup, we don't need as many parameters, just a resource link.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
