### PR TITLE
Use usernames instead of IDs to identify users on external password change

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -182,14 +182,14 @@ class AccountController < ApplicationController
   # to change the password.
   # When making changes here, also check MyController.change_password
   def change_password
-    # Retrieve user_id from session
-    @user = User.find(params[:password_change_user_id])
+    # Retrieve user login name from session
+    @user = User.find_by!(login: params[:password_change_user])
 
     change_password_flow(user: @user, params:, show_user_name: true) do
       password_authentication(@user.login, params[:new_password])
     end
   rescue ActiveRecord::RecordNotFound
-    Rails.logger.error "Failed to find user for change_password request: #{flash[:_password_change_user_id]}"
+    Rails.logger.error "Failed to find user for change_password request: #{flash[:_password_change_user]}"
     render_404
   end
 

--- a/app/views/my/password.html.erb
+++ b/app/views/my/password.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
       { autocomplete: "off", class: "form -wide-labels" }
     ) do %>
   <%= back_url_hidden_field_tag %>
-  <%= hidden_field_tag :password_change_user_id, @user.id %>
+  <%= hidden_field_tag :password_change_user, @user.login %>
   <section class="form--section">
     <%= render partial: "my/password_form_fields",
                locals: { show_user_name: !!(defined? show_user_name) ? show_user_name : nil,

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
       before do
         post "change_password",
              flash: {
-               _password_change_user_id: nil
+               _password_change_user: nil
              },
              params: {
                username: admin.login,
@@ -481,8 +481,7 @@ RSpec.describe AccountController, :skip_2fa_stage do
       before do
         post "change_password",
              params: {
-               password_change_user_id: admin.id,
-               username: admin.login,
+               password_change_user: admin.login,
                password: "adminADMIN!",
                new_password: "adminADMIN!New",
                new_password_confirmation: "adminADMIN!New"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69214

# What are you trying to accomplish?
- Use the user's login instead of the ID to identify users on the external password change page

# Merge checklist
- [x] Added/updated tests
