### PR TITLE
Give attribute dialogs more space

### DIFF
--- a/modules/overviews/app/components/overviews/project_custom_fields/edit_dialog_component.html.erb
+++ b/modules/overviews/app/components/overviews/project_custom_fields/edit_dialog_component.html.erb
@@ -2,7 +2,8 @@
   render(
     Primer::Alpha::Dialog.new(
       title: t("label_edit_attribute"),
-      size: :medium_portrait,
+      classes: "Overlay--size-large-portrait",
+      size: :large,
       id: dialog_id
     )
   ) do |d|

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -42,7 +42,10 @@ module FormFields
       def open_options
         wait_for_autocompleter_options_to_be_loaded
         wait(timeout: 3).for do
-          field_container.find(".ng-select-container").click
+          # click the arrow to prevent clicking inside the input field and
+          # risking to remove some elements in a mult-select (clicking the "x")
+          # this may close the dropdown, but it will be clicked again if it's not open anyway.
+          field_container.find(".ng-select-container .ng-arrow-wrapper").click
           page
         end.to have_css(".ng-dropdown-panel-items", wait: 0.25)
       end

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -5,13 +5,13 @@ require_relative "form_field"
 module FormFields
   module Primerized
     class AutocompleteField < FormField
+      include RSpec::Wait
+
       ### actions
 
       def select_option(*values)
         values.each do |val|
-          wait_for_autocompleter_options_to_be_loaded
-
-          field_container.find(".ng-select-container").click
+          open_options
 
           expect(page).to have_css(".ng-option", text: val, visible: :all)
           page.find(".ng-option", text: val, visible: :all).click
@@ -21,9 +21,7 @@ module FormFields
 
       def deselect_option(*values)
         values.each do |val|
-          wait_for_autocompleter_options_to_be_loaded
-
-          field_container.find(".ng-select-container").click
+          open_options
           page.find(".ng-value", text: val, visible: :all).find(".ng-value-icon").click
           sleep 0.25 # still required?
         end
@@ -43,7 +41,10 @@ module FormFields
 
       def open_options
         wait_for_autocompleter_options_to_be_loaded
-        field_container.find(".ng-select-container").click
+        wait(timeout: 3).for do
+          field_container.find(".ng-select-container").click
+          page
+        end.to have_css(".ng-dropdown-panel-items", wait: 0.25)
       end
 
       def clear


### PR DESCRIPTION
Request to implement a quick win to give the hierachical attributes more space. Otherwise the tree view is rather squeezed