### PR TITLE
[#68875] force active built-in application

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -42,7 +42,8 @@ require_relative "../../lib_static/open_project/feature_decisions"
 #   end
 
 OpenProject::FeatureDecisions.add :built_in_oauth_applications,
-                                  description: "Allows the display and use of built-in OAuth applications."
+                                  description: "Allows the display and use of built-in OAuth applications.",
+                                  force_active: true
 
 OpenProject::FeatureDecisions.add :calculated_value_project_attribute,
                                   description: "Allows the use of calculated values as a project attribute.",


### PR DESCRIPTION
# Ticket
[#68875](https://community.openproject.org/wp/68875)

# What are you trying to accomplish?
- built in applications are available, so that mobile applications work for all 17.0 OP instances

# What approach did you choose and why?
- used for mobile applications