### PR TITLE
[#69192] Adapt styles and info when user has no permission for work package

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -18168,9 +18168,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.11",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
-      "integrity": "sha512-sTj9yjbIdw5kzzdUI6Dm/8RfcS6+6yme1GVj+Sy8yXiAwa4ZKrcOfJf+nnr+HBHEeDpv8JOf/ACHKqWoMihakg==",
+      "version": "0.0.12",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
+      "integrity": "sha512-AKgE2ggOdbaxLd8G/Kcvg/McRMMjpxg+/AtligUWJIvSePfk3KbqwBo74RTF5XDq081aGaWEOgmXuOF7iO636A==",
       "dependencies": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
@@ -35799,8 +35799,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
-      "integrity": "sha512-sTj9yjbIdw5kzzdUI6Dm/8RfcS6+6yme1GVj+Sy8yXiAwa4ZKrcOfJf+nnr+HBHEeDpv8JOf/ACHKqWoMihakg==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
+      "integrity": "sha512-AKgE2ggOdbaxLd8G/Kcvg/McRMMjpxg+/AtligUWJIvSePfk3KbqwBo74RTF5XDq081aGaWEOgmXuOF7iO636A==",
       "requires": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.11/op-blocknote-extensions-0.0.11.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",


### PR DESCRIPTION
https://community.openproject.org/work_packages/69192

This updates the op-blocknote-extensions plugin to the version which includes the changes for this work package.

## Screenshots

## As User who is allowed to see the work package
<img width="387" height="152" alt="Screenshot from 2025-11-25 10-05-13" src="https://github.com/user-attachments/assets/cd0979a8-eb03-4a55-be60-0ab6563b3f8e" />

## As User who is **not** allowed to see the work package
<img width="471" height="141" alt="Screenshot from 2025-11-25 10-05-04" src="https://github.com/user-attachments/assets/213f3c97-350c-4116-bb5e-3a0a57a20ef4" />

## Loading state
<img width="140" height="96" alt="Screenshot from 2025-11-25 10-04-33" src="https://github.com/user-attachments/assets/558e6146-b741-4f06-89a8-855fef3388e4" />

## Error state
<img width="387" height="152" alt="image" src="https://github.com/user-attachments/assets/c7acc039-ae62-4f95-b4e2-14e5aa046545" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

