### PR TITLE
[#69174] Meeting presentation mode: upcoming/previous item name wraps instead of being truncated  

### DIFF
--- a/modules/meeting/app/components/meetings/presentation_mode/show_component.sass
+++ b/modules/meeting/app/components/meetings/presentation_mode/show_component.sass
@@ -63,19 +63,11 @@
   &--footer-right
     align-self: flex-start
     min-width: 0
-    display: flex
-    flex-direction: column
-
-  &--footer-left
-    align-items: flex-start
 
   &--footer-right
     text-align: right
-    align-items: flex-end
 
   &--footer-agenda-item
-    min-width: 0
-    max-width: 100%
     overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis

--- a/modules/meeting/app/components/meetings/presentation_mode/show_component.sass
+++ b/modules/meeting/app/components/meetings/presentation_mode/show_component.sass
@@ -57,15 +57,28 @@
     display: grid
     grid-template-columns: 1fr auto 1fr
     align-items: center
-    gap: var(--base-size-8)
+    gap: var(--base-size-24)
 
   &--footer-left,
   &--footer-right
     align-self: flex-start
+    min-width: 0
+    display: flex
+    flex-direction: column
 
+  &--footer-left
+    align-items: flex-start
 
   &--footer-right
     text-align: right
+    align-items: flex-end
+
+  &--footer-agenda-item
+    min-width: 0
+    max-width: 100%
+    overflow: hidden
+    white-space: nowrap
+    text-overflow: ellipsis
 
   &--progress
     text-align: center


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/69174

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Before
<img width="970" height="139" alt="image" src="https://github.com/user-attachments/assets/b67605a9-0a17-4e00-a646-37c0cea54fa9" />

### After
<img width="936" height="95" alt="image" src="https://github.com/user-attachments/assets/9c3733b5-7da1-414d-b8d3-851c7891b265" />