### PR TITLE
Skip creating another artifact work package if one already exists

### DIFF
--- a/app/services/projects/create_artifact_work_package_service.rb
+++ b/app/services/projects/create_artifact_work_package_service.rb
@@ -38,6 +38,7 @@ module Projects
     def initialize(user:, model:, contract_class: Projects::CreateArtifactWorkPackageContract)
       super(user:, contract_class:)
       self.model = model
+      @skip_creation = false
     end
 
     def project = model
@@ -46,7 +47,26 @@ module Projects
 
     attr_accessor :artifact_work_package
 
+    def skip_creation? = @skip_creation
+    def skip_creation! = @skip_creation = true
+
+    def before_perform(service_call)
+      if WorkPackage.exists?(project.project_creation_wizard_artifact_work_package_id)
+        skip_creation!
+      end
+
+      service_call
+    end
+
+    def validate_contract(service_call)
+      return service_call if skip_creation?
+
+      super
+    end
+
     def persist(service_call)
+      return service_call if skip_creation?
+
       creation_call = create_artifact_work_package
 
       creation_call.on_success do
@@ -63,7 +83,7 @@ module Projects
     end
 
     def after_perform(service_call)
-      return service_call if store_attachment_locally?
+      return service_call if store_attachment_locally? || skip_creation?
 
       if project_storage.nil?
         service_call.errors.add(:base, I18n.t("projects.wizard.create_artifact_storage_error"))

--- a/spec/services/projects/create_artifact_work_package_service_spec.rb
+++ b/spec/services/projects/create_artifact_work_package_service_spec.rb
@@ -232,5 +232,88 @@ RSpec.describe Projects::CreateArtifactWorkPackageService do
         end
       end
     end
+
+    context "when an artifact work package already exists" do
+      shared_let(:already_existing_artifact_work_package) do
+        create(:work_package, project:, subject: "Fake project initiation request")
+      end
+
+      before do
+        project.update(project_creation_wizard_artifact_work_package_id: already_existing_artifact_work_package.id)
+      end
+
+      it "does not create a new artifact work package" do
+        result = instance.call
+        expect(result).to be_success
+        expect(result.errors.full_messages).to be_empty
+
+        project = result.result
+        expect(project.project_creation_wizard_artifact_work_package_id)
+          .to eq(already_existing_artifact_work_package.id)
+        expect(project.work_packages.count).to eq(1)
+      end
+
+      it "does not try to validate the contract" do
+        instance.call
+        expect(mocked_contract).not_to have_received(:validate)
+      end
+
+      context "when artifact storage is project storage" do
+        before do
+          # setup storage to ensure it's not called
+          storage = create(:nextcloud_storage_with_local_connection)
+          project_storage = create(:project_storage, project:, storage:, project_folder_id: "/project_folder")
+          project.update(
+            project_creation_wizard_artifact_export_type: "file_link",
+            project_creation_wizard_artifact_export_storage: project_storage.id
+          )
+
+          allow(Storages::UploadFileService)
+            .to receive(:call)
+            .and_return(ServiceResult.success)
+        end
+
+        it "does not try to create another artifact pdf and upload it" do
+          result = instance.call
+          expect(result).to be_success
+          expect(result.errors.full_messages).to be_empty
+          expect(Storages::UploadFileService).not_to have_received(:call)
+        end
+      end
+
+      context "when the already existing artifact work package gets deleted " \
+              "(dangling artifact work package id in project settings)" do
+        before do
+          already_existing_artifact_work_package.destroy
+        end
+
+        it "creates a new artifact work package" do
+          result = instance.call
+          expect(result).to be_success
+          expect(result.errors.full_messages).to be_empty
+          expect(project.project_creation_wizard_artifact_work_package_id).not_to eq(already_existing_artifact_work_package.id)
+        end
+      end
+    end
+  end
+
+  context "when contract is invalid" do
+    before do
+      allow(mocked_contract).to receive_messages(
+        validate: false,
+        errors: ActiveModel::Errors.new(project).tap do |errors|
+          errors.add(:base, :error_unauthorized)
+        end
+      )
+    end
+
+    it "does not create any work packages" do
+      result = instance.call
+
+      expect(result.errors.full_messages).not_to be_empty
+      project = result.result
+      expect(project.project_creation_wizard_artifact_work_package_id).to be_nil
+      expect(project.work_packages.count).to be_zero
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68862

This PR is based on #21168.

# What are you trying to accomplish?

When the wizard is completed, a work package is created to host the project initiation request.
When the wizard is completed a second time, and the work package still exist, it should not create it again. If it does not exist anymore, it is recreated.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
