### PR TITLE
[#69406] no implicit conversion of nil into Hash while exporting to PDF

### DIFF
--- a/app/models/exports/pdf/common/markdown.rb
+++ b/app/models/exports/pdf/common/markdown.rb
@@ -159,7 +159,7 @@ module Exports::PDF::Common::Markdown
 
     def handle_unknown_html_tag(tag, node, opts)
       if tag.name == "mention"
-        handle_mention_html_tag(tag, node, opts)
+        [handle_mention_html_tag(tag, node, opts), opts]
       else
         # unknown/unsupported html tags eg. <foo>hi</foo> are ignored
         # but scanned for supported or text children [true, ...]


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/openproject/work_packages/69406/activity

# What approach did you choose and why?
handle_unknown_html_tag method returns no opts when mention tag encountered. So markdown engine tries to merge nil as hash into opts. 
Wrap method return data into array and return current render options instead of nil as it made for unknown HTML tags.

Do we need a spec exmaple here?