### PR TITLE
Make BlockNote editor read only when the user cannot edit a document

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -51,6 +51,7 @@ export interface OpBlockNoteContainerProps {
   inputField:HTMLInputElement;
   inputText?:string;
   activeUser:User;
+  readOnly:boolean;
   openProjectUrl:string;
   attachmentsUploadUrl:string;
   attachmentsCollectionKey:string;
@@ -68,6 +69,7 @@ const detectTheme = ():OpColorMode => { return window.OpenProject.theme.detectOp
 export default function OpBlockNoteContainer({ inputField,
                                                inputText,
                                                activeUser,
+                                               readOnly,
                                                openProjectUrl,
                                                attachmentsUploadUrl,
                                                attachmentsCollectionKey,
@@ -222,6 +224,7 @@ export default function OpBlockNoteContainer({ inputField,
           editor={editor}
           slashMenu={false}
           theme={theme}
+          editable={!readOnly}
           className={'block-note-editor-container'}
         >
           <SuggestionMenuController

--- a/frontend/src/stimulus/controllers/dynamic/block-note.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/block-note.controller.ts
@@ -48,6 +48,7 @@ export default class extends Controller {
   static values = {
     inputText: String,
     activeUser: Object,
+    readonly: Boolean,
     openProjectUrl: String,
     attachmentsUploadUrl: String,
     attachmentsCollectionKey: String,
@@ -57,6 +58,7 @@ export default class extends Controller {
 
   declare readonly inputTextValue:string;
   declare readonly activeUserValue:User;
+  declare readonly readonlyValue:boolean;
   declare readonly openProjectUrlValue:string;
   declare readonly attachmentsUploadUrlValue:string;
   declare readonly attachmentsCollectionKeyValue:string;
@@ -80,6 +82,7 @@ export default class extends Controller {
       inputField: this.blockNoteInputFieldTarget,
       inputText: this.inputTextValue,
       activeUser: this.activeUserValue,
+      readOnly: this.readonlyValue,
       openProjectUrl: this.openProjectUrlValue,
       attachmentsUploadUrl: this.attachmentsUploadUrlValue,
       attachmentsCollectionKey: this.attachmentsCollectionKeyValue,

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -37,6 +37,7 @@
       controller: "block-note",
       block_note_input_text_value: value,
       block_note_active_user_value: active_user,
+      block_note_readonly_value: readonly,
       block_note_attachments_upload_url_value: attachments_upload_url,
       block_note_attachments_collection_key_value: attachments_collection_key,
       block_note_collaboration_enabled_value: collaboration_enabled,

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -37,6 +37,7 @@ module Primer
 
         attr_reader :input,
                     :value,
+                    :readonly,
                     :active_user,
                     :attachments_upload_url,
                     :attachments_collection_key,
@@ -44,10 +45,11 @@ module Primer
 
         delegate :name, to: :@input
 
-        def initialize(input:, value:, attachments_upload_url: "", attachments_collection_key: "")
+        def initialize(input:, value:, readonly:, attachments_upload_url: "", attachments_collection_key: "")
           super()
           @input = input
           @value = value
+          @readonly = readonly
           @active_user = {
             id: User.current.id,
             username: User.current.name

--- a/lib/primer/open_project/forms/dsl/block_note_editor_input.rb
+++ b/lib/primer/open_project/forms/dsl/block_note_editor_input.rb
@@ -36,6 +36,7 @@ module Primer
           attr_reader :name,
                       :label,
                       :value,
+                      :readonly,
                       :classes,
                       :attachments_upload_url,
                       :attachments_collection_key
@@ -46,10 +47,12 @@ module Primer
           # @param value [String] The initial value of the input in base64 format.
           # @param attachments_upload_url [String] The URL to which attachments will be uploaded.
           # @param attachments_collection_key [String] The collection key for attachments.
-          def initialize(name:, label:, value:, attachments_upload_url: "", attachments_collection_key: "", **system_arguments)
+          def initialize(name:, label:, value:, readonly: false, attachments_upload_url: "", attachments_collection_key: "",
+                         **system_arguments)
             @name = name
             @label = label
             @value = value
+            @readonly = readonly
             @classes = system_arguments[:classes]
             @attachments_upload_url = attachments_upload_url
             @attachments_collection_key = attachments_collection_key
@@ -58,7 +61,7 @@ module Primer
           end
 
           def to_component
-            BlockNoteEditor.new(input: self, value:, attachments_upload_url:, attachments_collection_key:)
+            BlockNoteEditor.new(input: self, value:, readonly:, attachments_upload_url:, attachments_collection_key:)
           end
 
           def type

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -53,7 +53,7 @@
             method: :patch,
             data: { turbo: false }
           ) do |form|
-            render Documents::BlockNoteEditorForm.new(form, oauth_token:)
+            render Documents::BlockNoteEditorForm.new(form, oauth_token:, readonly:)
           end
         end
       end

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
@@ -36,7 +36,7 @@ module Documents
 
       alias_method :document, :model
 
-      options :project, :oauth_token, :state
+      options :project, :oauth_token, :state, :readonly
 
       private
 

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -62,6 +62,7 @@ class DocumentsController < ApplicationController
 
     if @document.collaborative? && Setting.real_time_text_collaboration_enabled?
       generate_encrypted_oauth_token
+      derive_readonly_from_permissions
       derive_show_edit_state_from_params
     end
   end
@@ -236,5 +237,10 @@ class DocumentsController < ApplicationController
 
   def derive_show_edit_state_from_params
     @state = params[:state] == "edit" ? :edit : :show
+  end
+
+  def derive_readonly_from_permissions
+    @readonly = current_user.allowed_in_project?(:view_documents, @project) &&
+      !current_user.allowed_in_project?(:manage_documents, @project)
   end
 end

--- a/modules/documents/app/forms/documents/block_note_editor_form.rb
+++ b/modules/documents/app/forms/documents/block_note_editor_form.rb
@@ -34,6 +34,7 @@ module Documents
       f.block_note_editor(
         name: :content_binary,
         label: I18n.t("label_document_description"),
+        readonly: readonly,
         visually_hide_label: true,
         classes: "document-form--long-description",
         value: model.content_binary,
@@ -42,11 +43,12 @@ module Documents
       )
     end
 
-    attr_reader :oauth_token
+    attr_reader :oauth_token, :readonly
 
-    def initialize(oauth_token: nil)
+    def initialize(oauth_token: nil, readonly: false)
       super()
       @oauth_token = oauth_token
+      @readonly = readonly
     end
 
     private

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -34,7 +34,7 @@
     <%=
       render(
         Documents::ShowEditView::BlockNoteEditorComponent.new(
-          @document, project: @project, oauth_token: @oauth_token, state: @state
+          @document, project: @project, oauth_token: @oauth_token, state: @state, readonly: @readonly
         )
       )
     %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/68699/activity
Also fixes https://community.openproject.org/wp/69072
And enables testing on https://community.openproject.org/wp/67651

Trickling down parameters~
