### PR TITLE
Fix assignable check in create artifact work package contract

### DIFF
--- a/app/contracts/projects/create_artifact_work_package_contract.rb
+++ b/app/contracts/projects/create_artifact_work_package_contract.rb
@@ -91,12 +91,15 @@ module Projects
     end
 
     def missing_assignee_custom_field_value?
-      project.custom_value_for(assignee_custom_field).value.blank?
+      assignee_id.blank?
     end
 
     def assignee_not_allowed_be_assigned_to_work_package?
-      assignee = project.typed_custom_value_for(assignee_custom_field)
-      !assignee.allowed_in_project?(:work_package_assigned, project)
+      !Principal.possible_assignee(project).exists?(id: assignee_id)
+    end
+
+    def assignee_id
+      project.custom_value_for(assignee_custom_field).value
     end
 
     def assignee_custom_field

--- a/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
+++ b/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
 
   context "with all project initiation request information filled correctly" do
     it_behaves_like "contract is valid"
+
+    context "when the assignee is an admin" do
+      before do
+        user_assignee.update(admin: true)
+      end
+
+      it_behaves_like "contract is valid"
+    end
   end
 
   context "with project initiation request disabled" do


### PR DESCRIPTION
The `:work_package_assigned` permission has `granted_to_admin: false` so `#allowed_in_project?(:work_package_assigned, project)` will always return `false` for admins. Not sure why it's designed like this.

This bug prevented the completion of the project initiation request when the project reviewer was an admin.

The check has been reworked to use the same logic as in `WorkPackages::BaseContract#assignable_assignees` to prevent any other potential issues.