### PR TITLE
Rename changed attribute interpolation in attribute help text

### DIFF
--- a/app/views/attribute_help_texts/edit.html.erb
+++ b/app/views/attribute_help_texts/edit.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <% html_title t(:label_administration),
-              t(:"attribute_help_texts.edit", attribute_field_name: @attribute_help_text.attribute_field_name) %>
+              t(:"attribute_help_texts.edit_field_name", attribute_field_name: @attribute_help_text.attribute_field_name) %>
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,7 +210,7 @@ en:
     text_overview: "In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute."
     show_preview: "Preview text"
     add_new: "Add help text"
-    edit: "Edit help text for %{attribute_field_name}"
+    edit_field_name: "Edit help text for %{attribute_field_name}"
 
   background_jobs:
     status:


### PR DESCRIPTION
Fixes inconsistent interpolation error:

````
Inconsistent interpolations (54) | i18n-tasks v1.1.1
+--------+---------------------------+-----------------------------------------------------------+
| Locale | Key                       | Value                                                     |
+--------+---------------------------+-----------------------------------------------------------+
|   af   | attribute_help_texts.edit | Edit help text for %{attribute_caption}                   |
|   ar   | attribute_help_texts.edit | Edit help text for %{attribute_caption}                   |