### PR TITLE
Email address can only be edited by global admins

### DIFF
--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -38,7 +38,8 @@ module Users
               }
     attribute :firstname
     attribute :lastname
-    attribute :mail
+    attribute :mail,
+              writable: ->(*) { model.new_record? || model.id == user.id || user.admin? }
     attribute :admin,
               writable: ->(*) { user.admin? && model.id != user.id }
     attribute :language

--- a/app/views/users/form/_basic_attributes.html.erb
+++ b/app/views/users/form/_basic_attributes.html.erb
@@ -22,6 +22,7 @@
 <div class="form--field -required">
   <%= f.text_field :mail,
                    required: true,
+                   disabled: !(@user.new_record? || User.current.admin?),
                    container_class: "-middle" %>
 </div>
 

--- a/spec/contracts/users/update_contract_spec.rb
+++ b/spec/contracts/users/update_contract_spec.rb
@@ -82,7 +82,28 @@ RSpec.describe Users::UpdateContract do
       end
     end
 
-    context "when global user" do
+    context "when user is an admin" do
+      let(:current_user) { create(:admin) }
+
+      describe "can update the email" do
+        before do
+          user.mail = "a.new@email.address"
+        end
+
+        it_behaves_like "contract is valid"
+      end
+
+      describe "can update the password" do
+        before do
+          user.password = "newpassword"
+          user.password_confirmation = "newpassword"
+        end
+
+        it_behaves_like "contract is valid"
+      end
+    end
+
+    context "when user with global manage_user permission" do
       let(:current_user) { create(:user, global_permissions: :manage_user) }
 
       describe "can lock the user" do
@@ -98,6 +119,14 @@ RSpec.describe Users::UpdateContract do
 
         it_behaves_like "contract is invalid"
       end
+
+      describe "cannot update the email" do
+        before do
+          user.mail = "a.new@email.address"
+        end
+
+        it_behaves_like "contract is invalid", mail: :error_readonly
+      end
     end
 
     context "when updated user is current user" do
@@ -112,6 +141,14 @@ RSpec.describe Users::UpdateContract do
         end
 
         it_behaves_like "contract is invalid", status: :error_readonly
+      end
+
+      describe "can update the email" do
+        before do
+          user.mail = "a.new@email.address"
+        end
+
+        it_behaves_like "contract is valid"
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -770,7 +770,7 @@ RSpec.describe UsersController do
                      value: "another_email@example.com",
                      edited_user: :some_admin,
                      current_user: :admin
-    include_examples "it can update field",
+    include_examples "it cannot update field",
                      field: :mail,
                      value: "another_email@example.com",
                      edited_user: :some_user,

--- a/spec/requests/api/v3/user/update_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_form_resource_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
-          .to be_json_eql(user.mail.to_json)
-                .at_path("_embedded/payload/email")
+          .to be_json_eql(user.login.to_json)
+                .at_path("_embedded/payload/login")
 
         expect(body)
           .to be_json_eql(user.firstname.to_json)
@@ -127,8 +127,8 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         expect(response.body).to be_json_eql("Form".to_json).at_path("_type")
 
         expect(body)
-          .to be_json_eql(user.mail.to_json)
-                .at_path("_embedded/payload/email")
+          .to be_json_eql(user.login.to_json)
+                .at_path("_embedded/payload/login")
 
         expect(body)
           .not_to have_json_path("_embedded/payload/firstName")
@@ -174,7 +174,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         context "when no custom field value is provided" do
           let(:payload) do
             {
-              email: "updated@example.org"
+              login: "new.login"
             }
           end
 
@@ -182,8 +182,8 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
             expect(response).to have_http_status(:ok)
             expect(body).to have_json_size(0).at_path("_embedded/validationErrors")
             expect(body)
-              .to be_json_eql("updated@example.org".to_json)
-              .at_path("_embedded/payload/email")
+              .to be_json_eql("new.login".to_json)
+              .at_path("_embedded/payload/login")
             expect(body)
               .to be_json_eql(api_v3_paths.user(user.id).to_json)
               .at_path("_links/commit/href")
@@ -193,7 +193,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         context "when the custom field is provided but empty" do
           let(:payload) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               required_custom_field.attribute_name(:camel_case) => {
                 raw: ""
               }
@@ -213,7 +213,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         context "when the custom field value is provided and valid" do
           let(:payload) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               required_custom_field.attribute_name(:camel_case) => {
                 raw: "Engineering"
               }
@@ -240,7 +240,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
 
         let(:payload) do
           {
-            email: "updated@example.org",
+            login: "new.login",
             visible_custom_field.attribute_name(:camel_case) => {
               raw: "CF text"
             }
@@ -269,7 +269,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
           let(:current_user) { create(:admin) }
           let(:payload) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               admin_only_custom_field.attribute_name(:camel_case) => {
                 raw: "CF text"
               }
@@ -291,7 +291,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
         context "with non-admin permissions" do
           let(:payload) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               admin_only_custom_field.attribute_name(:camel_case) => {
                 raw: "CF text"
               }
@@ -312,7 +312,7 @@ RSpec.describe API::V3::Users::UpdateFormAPI, content_type: :json do
             let(:is_required) { true }
             let(:payload) do
               {
-                email: "updated@example.org"
+                login: "new.login"
               }
             end
 

--- a/spec/requests/api/v3/user/update_user_resource_spec.rb
+++ b/spec/requests/api/v3/user/update_user_resource_spec.rb
@@ -69,14 +69,14 @@ RSpec.describe API::V3::Users::UsersAPI do
     end
 
     describe "attribute change" do
-      let(:parameters) { { email: "foo@example.org", language: "de" } }
+      let(:parameters) { { login: "new.login", language: "de" } }
 
-      it_behaves_like "successful update", mail: "foo@example.org", language: "de"
+      it_behaves_like "successful update", login: "new.login", language: "de"
     end
 
     describe "attribute collision" do
-      let(:parameters) { { email: "foo@example.org" } }
-      let(:collision) { create(:user, mail: "foo@example.org") }
+      let(:parameters) { { login: "new.login" } }
+      let(:collision) { create(:user, login: "new.login") }
 
       before do
         collision
@@ -88,7 +88,7 @@ RSpec.describe API::V3::Users::UsersAPI do
         expect(last_response).to have_http_status(:unprocessable_entity)
 
         expect(last_response.body)
-          .to be_json_eql("email".to_json)
+          .to be_json_eql("login".to_json)
                 .at_path("_embedded/details/attribute")
 
         expect(last_response.body)
@@ -127,11 +127,11 @@ RSpec.describe API::V3::Users::UsersAPI do
         context "when no custom field value is provided" do
           let(:parameters) do
             {
-              email: "updated@example.org"
+              login: "new.login"
             }
           end
 
-          it_behaves_like "successful update", mail: "updated@example.org"
+          it_behaves_like "successful update", login: "new.login"
 
           it "keeps the custom field value empty" do
             send_request
@@ -143,7 +143,7 @@ RSpec.describe API::V3::Users::UsersAPI do
         context "when the custom field is provided but empty" do
           let(:parameters) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               required_custom_field.attribute_name(:camel_case) => {
                 raw: ""
               }
@@ -165,14 +165,14 @@ RSpec.describe API::V3::Users::UsersAPI do
         context "when the custom field value is provided and valid" do
           let(:parameters) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               required_custom_field.attribute_name(:camel_case) => {
                 raw: "Engineering"
               }
             }
           end
 
-          it_behaves_like "successful update", mail: "updated@example.org"
+          it_behaves_like "successful update", login: "new.login"
 
           it "updates the user with the custom field value" do
             send_request
@@ -189,14 +189,14 @@ RSpec.describe API::V3::Users::UsersAPI do
 
         let(:parameters) do
           {
-            email: "updated@example.org",
+            login: "new.login",
             custom_field.attribute_name(:camel_case) => {
               raw: "CF text"
             }
           }
         end
 
-        it_behaves_like "successful update", mail: "updated@example.org"
+        it_behaves_like "successful update", login: "new.login"
 
         it "sets the cf value" do
           send_request
@@ -215,14 +215,14 @@ RSpec.describe API::V3::Users::UsersAPI do
           let(:current_user) { create(:admin) }
           let(:parameters) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               admin_only_custom_field.attribute_name(:camel_case) => {
                 raw: "CF text"
               }
             }
           end
 
-          it_behaves_like "successful update", mail: "updated@example.org"
+          it_behaves_like "successful update", login: "new.login"
 
           it "sets the cf value" do
             send_request
@@ -235,14 +235,14 @@ RSpec.describe API::V3::Users::UsersAPI do
           let(:current_user) { create(:user, global_permissions: [:manage_user]) }
           let(:parameters) do
             {
-              email: "updated@example.org",
+              login: "new.login",
               admin_only_custom_field.attribute_name(:camel_case) => {
                 raw: "CF text"
               }
             }
           end
 
-          it_behaves_like "successful update", mail: "updated@example.org"
+          it_behaves_like "successful update", login: "new.login"
 
           it "does not set the cf value" do
             send_request
@@ -254,11 +254,11 @@ RSpec.describe API::V3::Users::UsersAPI do
             let(:is_required) { true }
             let(:parameters) do
               {
-                email: "updated@example.org"
+                login: "new.login"
               }
             end
 
-            it_behaves_like "successful update", mail: "updated@example.org"
+            it_behaves_like "successful update", login: "new.login"
 
             it "does not set the cf value" do
               send_request
@@ -290,8 +290,21 @@ RSpec.describe API::V3::Users::UsersAPI do
       end
     end
 
+    describe "email update" do
+      let(:email) { "this.is.a.new@email.address" }
+      let(:parameters) { { email:  email } }
+
+      it "updates the users email correctly" do
+        send_request
+        expect(last_response).to have_http_status(:ok)
+
+        updated_user = User.find(user.id)
+        expect(updated_user.mail).to eq(email)
+      end
+    end
+
     describe "unknown user" do
-      let(:parameters) { { email: "foo@example.org" } }
+      let(:parameters) { { login: "new.login" } }
       let(:path) { api_v3_paths.user(666) }
 
       it "responds with 404" do
@@ -317,6 +330,24 @@ RSpec.describe API::V3::Users::UsersAPI do
 
         expect(last_response.body)
           .to be_json_eql("password".to_json)
+                .at_path("_embedded/details/attribute")
+
+        expect(last_response.body)
+          .to be_json_eql("urn:openproject-org:api:v3:errors:PropertyIsReadOnly".to_json)
+                .at_path("errorIdentifier")
+      end
+    end
+
+    describe "email update" do
+      let(:email) { "this.is.a.new@email.address" }
+      let(:parameters) { { email: email } }
+
+      it "rejects the users email update" do
+        send_request
+        expect(last_response).to have_http_status(:unprocessable_entity)
+
+        expect(last_response.body)
+          .to be_json_eql("email".to_json)
                 .at_path("_embedded/details/attribute")
 
         expect(last_response.body)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69211

# What are you trying to accomplish?
- Restrict editing of a user's email address to global administrators

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
