### PR TITLE
[69412] Filter project attributes of type hierarchy by short name in creation wizard

### DIFF
--- a/app/forms/custom_fields/inputs/multi_select_list.rb
+++ b/app/forms/custom_fields/inputs/multi_select_list.rb
@@ -62,7 +62,7 @@ class CustomFields::Inputs::MultiSelectList < CustomFields::Inputs::Base::Autoco
     when "hierarchy", "weighted_item_list"
       hierarchical_list_items.map do |item|
         {
-          label: item.ancestry_path,
+          label: item.ancestry_path(include_shorts_and_weights: true),
           value: item.id,
           selected: custom_values.pluck(:value).map(&:to_i).include?(item.id)
         }

--- a/app/forms/custom_fields/inputs/single_select_list.rb
+++ b/app/forms/custom_fields/inputs/single_select_list.rb
@@ -57,7 +57,7 @@ class CustomFields::Inputs::SingleSelectList < CustomFields::Inputs::Base::Autoc
     when "hierarchy", "weighted_item_list"
       hierarchical_list_items.map do |item|
         {
-          label: item.ancestry_path,
+          label: item.ancestry_path(include_shorts_and_weights: true),
           value: item.id,
           selected: item.id == @custom_value.value&.to_i
         }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69412

# What are you trying to accomplish?
Include short names into the autocompleter options for hierarchy CF

## Screenshots
<img width="1213" height="345" alt="Bildschirmfoto 2025-11-26 um 13 01 52" src="https://github.com/user-attachments/assets/0ccfbf50-a786-4338-9107-c3fb21bf103b" />
<img width="872" height="115" alt="Bildschirmfoto 2025-11-26 um 13 01 42" src="https://github.com/user-attachments/assets/46b57c74-eb4e-4e05-8141-539b2a84bf4e" />

