### PR TITLE
Bug/69445 Truncate the name in the project list

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -154,19 +154,45 @@ module Projects
     end
 
     def name
-      content = [content_tag(:i, "", class: "projects-table--hierarchy-icon")]
+      content = [
+        hierarchy_icon,
+        name_link_section,
+        archived_label,
+        workspace_type_badge
+      ].compact_blank
 
-      content << helpers.link_to_project(project, {}, { data: { turbo: false } }, false)
+      safe_join(content)
+    end
 
-      if project.archived?
-        content << content_tag(:span, "(#{I18n.t('project.archive.archived')})", class: "archived-label")
+    def hierarchy_icon
+      content_tag(:i, "", class: "projects-table--hierarchy-icon")
+    end
+
+    def name_link_section
+      content_tag(:span, class: "projects-table--name-text") do
+        helpers.link_to_project(project, {}, { data: { turbo: false } }, false)
       end
+    end
 
-      if workspace_type_badge && OpenProject::FeatureDecisions.portfolio_models_active?
-        content << workspace_type_badge
+    def workspace_type_badge
+      return unless OpenProject::FeatureDecisions.portfolio_models_active?
+      # Only show icon and type for non-project workspaces
+      return unless project.workspace_type.in?(["portfolio", "program"])
+
+      render(Primer::Beta::Text.new(classes: "projects-table--name-description")) do
+        icon = render(Primer::Beta::Octicon.new(
+                        icon: helpers.workspace_icon(project.workspace_type),
+                        size: :xsmall
+                      ))
+
+        safe_join([icon, " ", I18n.t(:"label_#{project.workspace_type}")])
       end
+    end
 
-      safe_join(content, " ")
+    def archived_label
+      return unless project.archived?
+
+      content_tag(:span, "(#{I18n.t('project.archive.archived')})", class: "archived-label")
     end
 
     def project_status
@@ -428,19 +454,6 @@ module Projects
 
     def current_page
       table.model.current_page.to_s
-    end
-
-    def workspace_type_badge
-      # Only show icon and type for non-project workspaces
-      return unless project.workspace_type.in?(["portfolio", "program"])
-
-      render(Primer::Beta::Text.new(classes: "description")) do
-        icon = render(Primer::Beta::Octicon.new(
-                        icon: helpers.workspace_icon(project.workspace_type),
-                        size: :xsmall
-                      ))
-        safe_join([icon, " ", I18n.t(:"label_#{project.workspace_type}")])
-      end
     end
   end
 end

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -75,11 +75,11 @@ $content-padding: 10px
       color: var(--fgColor-muted)
 
   td.name
-    @include text-shortener
-    a
+    .projects-table--name-text
+      @include text-shortener
       white-space: nowrap
 
-    .description
+    .projects-table--name-description
       @extend %autocomplete-description
 
   td.project--hierarchy


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69445

# What are you trying to accomplish?

> - Projects list:
>   - The name of the projects should be truncated at the end of the modal preserving always visible, if present, the type label and icon.


## Screenshots
<details><summary>Project List</summary>
<p>

<img width="940" height="684" alt="image" src="https://github.com/user-attachments/assets/999e8f9b-c960-42b9-b263-592af8c2b3dd" />


</p>
</details> 

# What approach did you choose and why?
Use flexbox to keep the badge always displayed.

- [x] Projects list name shrinking
- [X] ~~Project dropdown name shrinking~~ Already addressed in #21448 .

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
