### PR TITLE
Fix SAML single logout

### DIFF
--- a/modules/auth_saml/app/models/saml/provider/hash_builder.rb
+++ b/modules/auth_saml/app/models/saml/provider/hash_builder.rb
@@ -71,6 +71,7 @@ module Saml
         sp_entity_id:,
         idp_sso_service_url:,
         idp_slo_service_url:,
+        idp_slo_target_url: idp_slo_service_url, # for compatibility with 1.10 version of the omniauth-saml gem
         name_identifier_format:,
         certificate:,
         private_key:,

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -114,7 +114,7 @@ en:
       idp_sso_service_url: >
         The URL of the identity provider login endpoint.
       idp_slo_service_url: >
-        The URL of the identity provider login endpoint.
+        The URL of the identity provider logout endpoint.
       idp_cert: >
         Enter the X509 PEM-formatted public certificate of the identity provider.
         You can enter multiple certificates by separating them with a newline.

--- a/modules/auth_saml/lib/open_project/auth_saml/engine.rb
+++ b/modules/auth_saml/lib/open_project/auth_saml/engine.rb
@@ -44,10 +44,11 @@ module OpenProject
             h[:retain_from_session] = %w[saml_uid saml_session_index saml_transaction_id]
 
             # remember the origin in RelayState
-            h[:idp_sso_target_url_runtime_params] = { origin: :RelayState }
+            h[:idp_sso_service_url_runtime_params] = { origin: :RelayState } # omniauth-saml 2.x
+            h[:idp_sso_target_url_runtime_params] = { origin: :RelayState } # omniauth-saml 1.10
 
             h[:single_sign_out_callback] = Proc.new do |prev_session, _prev_user|
-              next unless h[:idp_slo_target_url]
+              next unless h[:idp_slo_service_url]
               next unless prev_session[:saml_uid] && prev_session[:saml_session_index]
 
               # Set the uid and index for the logout in this session again


### PR DESCRIPTION
Single logout via SAML wasn't working at all. It was effectively blocked by two things:

1. We were checking for the wrong value in a hash we built ourselves and thus early returned from the logout callback
2. With that early return out of the way, SLO was disabled by the `omniauth-saml` gem, because we used an option name for the wrong version of the gem to configure SLO

# Ticket
https://community.openproject.org/wp/69234