### PR TITLE
[#69404] Correct height of the grey footer in the creation wizard  

### DIFF
--- a/app/components/step_wizard/footer_component.sass
+++ b/app/components/step_wizard/footer_component.sass
@@ -31,7 +31,7 @@
   background: var(--display-gray-bgColor-muted)
   border: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
   border-radius: var(--borderRadius-medium)
-  padding: var(--base-size-8, 0.5rem) var(--base-size-24, 1.5rem)
+  padding: var(--base-size-8, 0.5rem) var(--base-size-16, 1rem)
   display: grid
   grid-template-columns: 1fr 2fr 1fr
   gap: var(--base-size-16, 1rem)

--- a/app/components/step_wizard/footer_component.sass
+++ b/app/components/step_wizard/footer_component.sass
@@ -27,11 +27,11 @@
 // ++
 
 .op-step-wizard-footer
-  height: 70px
+  height: 56px
   background: var(--display-gray-bgColor-muted)
   border: var(--borderWidth-thin, 1px) solid var(--borderColor-default)
   border-radius: var(--borderRadius-medium)
-  padding: var(--base-size-16, 1rem) var(--base-size-24, 1.5rem)
+  padding: var(--base-size-8, 0.5rem) var(--base-size-24, 1.5rem)
   display: grid
   grid-template-columns: 1fr 2fr 1fr
   gap: var(--base-size-16, 1rem)

--- a/app/components/step_wizard/page_layout_component.sass
+++ b/app/components/step_wizard/page_layout_component.sass
@@ -43,7 +43,7 @@
   height: 100%
   min-height: 0
   grid-template-areas: "content" "footer"
-  grid-template-rows: 1fr 70px
+  grid-template-rows: 1fr 56px
   gap: var(--base-size-16, 1rem)
   overflow: hidden
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/69404

## Before
<img width="1246" height="175" alt="image" src="https://github.com/user-attachments/assets/abd26451-7da2-47ce-8c5e-94919a1470c8" />

## After
<img width="1258" height="135" alt="image" src="https://github.com/user-attachments/assets/ee0b9433-444d-4a72-ab65-63cc744193fd" />
