### PR TITLE
Associate artifact file link to artifact work package, not project

### DIFF
--- a/app/controllers/projects/creation_wizard_controller.rb
+++ b/app/controllers/projects/creation_wizard_controller.rb
@@ -56,15 +56,17 @@ class Projects::CreationWizardController < ApplicationController
     if service_call.success?
       if last_page?
         creation_call = Projects::CreateArtifactWorkPackageService.new(user: current_user, model: @project).call
+
+        # even when successful, there can be errors related to the artifact
+        # upload to Nextcloud that needs to be shown to the user
+        flash[:error] = creation_call.errors.full_messages # rubocop:disable Rails/ActionControllerFlashBeforeRender
         if creation_call.success?
           redirect_to project_work_packages_path(@project, @project.project_creation_wizard_artifact_work_package_id),
                       notice: I18n.t("projects.wizard.success")
         else
-          flash[:error] = creation_call.errors.full_messages
           render :show,
                  locals: { menu_name: :none },
                  status: :unprocessable_entity
-
         end
       else
         redirect_to project_creation_wizard_path(@project, section: params[:next_section])

--- a/app/services/projects/create_artifact_work_package_service.rb
+++ b/app/services/projects/create_artifact_work_package_service.rb
@@ -42,11 +42,13 @@ module Projects
 
     private
 
+    attr_accessor :artifact_work_package
+
     def persist(service_call)
       creation_call = create_artifact_work_package
 
       creation_call.on_success do
-        artifact_work_package = creation_call.result
+        self.artifact_work_package = creation_call.result
         project.project_creation_wizard_artifact_work_package_id = artifact_work_package.id
         project.save
       end
@@ -74,7 +76,7 @@ module Projects
 
       storage_call = Storages::UploadFileService
         .call(
-          container: service_call.result,
+          container: artifact_work_package,
           project_storage:,
           file_path: project.project_creation_wizard_artifact_name,
           file_data: StringIO.new(export.content),

--- a/spec/services/projects/create_artifact_work_package_service_spec.rb
+++ b/spec/services/projects/create_artifact_work_package_service_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageService do
         date = Date.current.iso8601
         expect(Storages::UploadFileService)
           .to have_received(:call)
-          .with(container: project,
+          .with(container: artifact_work_package,
                 project_storage:,
                 file_path: "project_mandate",
                 filename: /Important_Project_Project_mandate_#{date}_\d+-\d+.pdf/,


### PR DESCRIPTION
The file link was errorneously added to the project instead of the workpackage.

This fix was developed during a live session where we debugged the issue. Probably more tests and a cleaner solution are required longterm.

# Ticket
https://community.openproject.org/work_packages/68864