### PR TITLE
Add persistent connection monitoring for BlockNote collaboration

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -28,6 +28,7 @@
  * ++
  */
 
+import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { BlockNoteEditorOptions, BlockNoteSchema, filterSuggestionItems } from '@blocknote/core';
 import { User } from '@blocknote/core/comments';
 import * as blockNoteLocales from '@blocknote/core/locales';
@@ -75,6 +76,7 @@ export default function OpBlockNoteContainer({ inputField,
                                                attachmentsCollectionKey,
                                                hocuspocusProvider }:OpBlockNoteContainerProps) {
   const [isLoading, setIsLoading] = useState(true);
+  const [connectionError, setConnectionError] = useState(false);
   const [theme, setTheme] = useState<OpColorMode>(detectTheme());
 
   initOpenProjectApi({ baseUrl: openProjectUrl });
@@ -177,10 +179,33 @@ export default function OpBlockNoteContainer({ inputField,
       inputField.value = b64;
     };
 
+    let connectionTimeout:ReturnType<typeof setTimeout> | null = null;
+
+    const editorReady = () => {
+      debugLog('[BlockNote Editor] synced with collaboration server');
+      setIsLoading(false);
+      setConnectionError(false);
+    };
+
+    const handleDisconnect = () => {
+      debugLog('[BlockNote Editor] Disconnected from collaboration server');
+      setConnectionError(true);
+    };
+
     if(hocuspocusProvider) {
-      if (hocuspocusProvider.synced) { setIsLoading(false); }
-      hocuspocusProvider.on('synced', () => setIsLoading(false));
-      hocuspocusProvider.on('disconnect', () => setIsLoading(true));
+      if (hocuspocusProvider.synced) {
+        editorReady();
+      } else {
+        // Set timeout to show connection error if not connected within 5 seconds
+        connectionTimeout = setTimeout(() => {
+          if (!hocuspocusProvider.synced) {
+            setConnectionError(true);
+          }
+        }, 5000);
+      }
+
+      hocuspocusProvider.on('synced', editorReady);
+      hocuspocusProvider.on('disconnect', handleDisconnect);
     } else {
       doc.on('update', updateInput);
       setIsLoading(false);
@@ -188,6 +213,10 @@ export default function OpBlockNoteContainer({ inputField,
 
     return () => {
       if (hocuspocusProvider) {
+        if (connectionTimeout) clearTimeout(connectionTimeout);
+
+        hocuspocusProvider.off('synced', editorReady);
+        hocuspocusProvider.off('disconnect', handleDisconnect);
         hocuspocusProvider.destroy();
       } else {
         // disable Yjs update listener. Opposite of doc.on('update', ...);
@@ -208,6 +237,15 @@ export default function OpBlockNoteContainer({ inputField,
       window.removeEventListener('op:theme-changed', handleThemeChange);
     };
   }, []);
+
+  if (connectionError) {
+    return (
+      <div
+        id="documents-show-edit-view-connection-error-notice-component"
+        data-controller="documents--connection-error-handler"
+      />
+    );
+  }
 
   return (
     <>

--- a/frontend/src/stimulus/controllers/dynamic/documents/connection-error-handler.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/connection-error-handler.controller.ts
@@ -1,0 +1,82 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import { renderStreamMessage } from '@hotwired/turbo';
+
+export default class extends Controller {
+  connect():void {
+    void this.fetchErrorTemplate();
+  }
+
+  disconnect():void {
+    void this.fetchRecoveryTemplate();
+  }
+
+  reloadPage():void {
+    window.location.reload();
+  }
+
+  private async fetchErrorTemplate() {
+    await this.fetchTemplate('error');
+  }
+
+  private async fetchRecoveryTemplate() {
+    await this.fetchTemplate('recovery');
+  }
+
+  private async fetchTemplate(name:string) {
+    const documentId = this.getDocumentIdFromUrl();
+    if (!documentId) {
+      console.error('Could not extract document ID from URL');
+      return;
+    }
+
+    const url = `/documents/${documentId}/render_connection_${name}`;
+
+    await fetch(url, {
+      method: 'GET',
+      headers: { Accept: 'text/vnd.turbo-stream.htm' },
+    })
+      .then((response:Response) => {
+        if (response.ok) {
+          return response.text();
+        }
+        return Promise.reject(new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`));
+      })
+      .then((html:string) => renderStreamMessage(html))
+      .catch((error:Error) => console.error('Error:', error));
+  }
+
+  private getDocumentIdFromUrl():string|null {
+    const match = /\/documents\/(\d+)/.exec(window.location.pathname);
+    return match ? match[1] : null;
+  }
+}

--- a/modules/documents/app/components/documents/show_edit_view/connection_error_notice_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/connection_error_notice_component.html.erb
@@ -1,0 +1,45 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  component_wrapper do
+    render(Primer::Alpha::Banner.new(icon: :stop, scheme: :danger)) do |banner|
+      banner.with_action_button(
+        data: {
+          turbo: false,
+          action: "click->documents--connection-error-handler#reloadPage"
+        },
+        size: :medium
+      ) { I18n.t("documents.show_edit_view.connection_error_notice.action") }
+      I18n.t("documents.show_edit_view.connection_error_notice.description")
+    end
+  end
+%>

--- a/modules/documents/app/components/documents/show_edit_view/connection_error_notice_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/connection_error_notice_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Documents
+  module ShowEditView
+    class ConnectionErrorNoticeComponent < ApplicationComponent
+      include OpTurbo::Streamable
+    end
+  end
+end

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -75,6 +75,20 @@ class DocumentsController < ApplicationController
     respond_with_turbo_streams
   end
 
+  def render_connection_error
+    update_via_turbo_stream(component: Documents::ShowEditView::ConnectionErrorNoticeComponent.new)
+
+    respond_with_turbo_streams
+  end
+
+  def render_connection_recovery
+    render_success_flash_message_via_turbo_stream(
+      message: I18n.t("documents.show_edit_view.connection_recovery_notice.description")
+    )
+
+    respond_with_turbo_streams
+  end
+
   def new
     @document = @project.documents.build
     @document.attributes = document_params

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -85,6 +85,15 @@ en:
         Unable to open document because real-time text collaboration is disabled.
         Please contact your administrator to enable real-time text collaboration if you want to access this document.
 
+    show_edit_view:
+      connection_error_notice:
+        description: |-
+          Unable to open document because the real-time text collaboration server is unreachable.
+          Please contact the administrator if the problem persists.
+        action: Try again
+      connection_recovery_notice:
+        description: "The connection to the real-time text collaboration server has been restored."
+
     index_page:
       name: "Name"
       type: "Type"

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
       put :update_type, defaults: { format: :turbo_stream }
       get :delete_dialog
       get :render_avatars, defaults: { format: :turbo_stream }
+      get :render_connection_error, defaults: { format: :turbo_stream }
+      get :render_connection_recovery, defaults: { format: :turbo_stream }
     end
   end
 

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -53,8 +53,12 @@ module OpenProject::Documents
 
       project_module :documents do |_map|
         permission :view_documents,
-                   { documents: %i[index search show download render_avatars],
-                     "documents/menus": %i[show] },
+                   {
+                     documents: %i[
+                       index search show download render_avatars render_connection_error render_connection_recovery
+                     ],
+                     "documents/menus": %i[show]
+                   },
                    permissible_on: :project
         permission :manage_documents,
                    {


### PR DESCRIPTION
https://community.openproject.org/wp/68801

Implement server-side error templates and continuous connection monitoring for the BlockNote editor when the Hocuspocus collaboration server becomes unreachable.

Flow:

-   Initial load, server down: Timeout 10s → Error notice
-   Server comes up: 'synced' event → Editor Recovery notice
-   Server goes down again: 'disconnect' event → Error notice

Ref: https://tiptap.dev/docs/hocuspocus/provider/events

https://github.com/user-attachments/assets/ddbaec70-90ba-42db-8c4c-4e798037a3d4


