### PR TITLE
[#69420] Hide create from template permision behind a feature flag

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -70,6 +70,10 @@ OpenProject::FeatureDecisions.add :minutes_styling_meeting_pdf,
 OpenProject::FeatureDecisions.add :portfolio_models,
                                   description: "Enables the creation and management of portfolio and program work spaces."
 
+OpenProject::FeatureDecisions.add :create_from_template_permissions,
+                                  description: "Enables the currently unused " \
+                                               '"Create Project, Portfolio, Program from template" permission.'
+
 OpenProject::FeatureDecisions.add :new_project_overview,
                                   description: "Enables the new project overview experience.",
                                   force_active: true

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -58,19 +58,20 @@ Rails.application.reloader.to_prepare do
                      { projects: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
+                     visible: -> { OpenProject::FeatureDecisions.create_from_template_permissions_active? },
                      contract_actions: { projects: %i[create] }
 
       map.permission :add_portfolios_from_template,
                      { projects: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
-                     visible: -> { OpenProject::FeatureDecisions.portfolio_models_active? }
+                     visible: -> { OpenProject::FeatureDecisions.create_from_template_permissions_active? }
 
       map.permission :add_programs_from_template,
                      { projects: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
-                     visible: -> { OpenProject::FeatureDecisions.portfolio_models_active? }
+                     visible: -> { OpenProject::FeatureDecisions.create_from_template_permissions_active? }
 
       map.permission :archive_project,
                      {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69420

# What are you trying to accomplish?
Hide the `add_project_from_template`, `add_portfolios_from_template` and `add_programs_from_template` permissions from the permission settings, because they are not being used.

# What approach did you choose and why?
Introduce a feature flag called `create_from_template_permissions` and put the aforementioned permissions behind it.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
