### PR TITLE
Exclude boolean fields from required, because they cannot really be validated as a required field.

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -54,7 +54,7 @@ class CustomField < ApplicationRecord
   has_many :calculated_value_errors, dependent: :delete_all, inverse_of: "custom_field"
 
   scope :hierarchy_root_and_children, -> { includes(hierarchy_root: { children: :children }) }
-  scope :required, -> { where(is_required: true).where.not(field_format: "calculated_value") }
+  scope :required, -> { where(is_required: true).where.not(field_format: ["calculated_value", "bool"]) }
 
   scope :field_format_calculated_value, -> { where(field_format: "calculated_value") }
 

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -631,4 +631,29 @@ RSpec.describe CustomField do
       end
     end
   end
+
+  describe ".required",
+           with_ee: %i[calculated_values],
+           with_flag: { calculated_value_project_attribute: true } do
+    let!(:required_text_field) { create(:text_project_custom_field, is_required: true) }
+    let!(:required_calculated_field) { create(:calculated_value_project_custom_field, is_required: true) }
+    let!(:required_bool_field) { create(:boolean_project_custom_field, is_required: true) }
+    let!(:optional_text_field) { create(:text_project_custom_field, is_required: false) }
+
+    it "includes required fields that are not calculated_value or bool" do
+      expect(described_class.required).to include(required_text_field)
+    end
+
+    it "excludes calculated_value fields even when required" do
+      expect(described_class.required).not_to include(required_calculated_field)
+    end
+
+    it "excludes bool fields even when required" do
+      expect(described_class.required).not_to include(required_bool_field)
+    end
+
+    it "excludes optional fields" do
+      expect(described_class.required).not_to include(optional_text_field)
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69762

# What are you trying to accomplish?
The project creation wizard falsely shows a 3rd step, when only a boolean project attributes is required.

## Screenshots
<details><summary>Before</summary>
<p>

<img width="972" height="773" alt="image" src="https://github.com/user-attachments/assets/c45df6e4-afbd-483c-958a-1397f52d4258" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="931" height="771" alt="image" src="https://github.com/user-attachments/assets/4ef094ce-bd6d-4993-906a-375e63c8aa1b" />


</p>
</details> 

# What approach did you choose and why?
Update the `CustomField.required` scope to exclude boolean fields too, because they cannot be required.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
