### PR TITLE
[69421] Inconsistent translation strings

### DIFF
--- a/app/components/projects/settings/creation_wizard/page_header_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/page_header_component.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [{ href: project_overview_path(@project.id), text: @project.name },
        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },
-       I18n.t("label_project_initiation_request")]
+       I18n.t("settings.project_initiation_request.name.options.project_initiation_request")]
     )
 
     enabled = @project.project_creation_wizard_enabled

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -727,7 +727,7 @@ Redmine::MenuManager.map :project_menu do |menu|
     },
     project_custom_fields: { caption: :label_project_attributes_plural },
     creation_wizard: {
-      caption: :label_project_initiation_request,
+      caption: :"settings.project_initiation_request.name.options.project_initiation_request",
       if: ->(_) { OpenProject::FeatureDecisions.project_initiation_active? }
     },
     modules: { caption: :label_module_plural },


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/69421

# What are you trying to accomplish?
Change module name from "new project initiation request" to "project initiation request". Actually, I think the label for `label_project_initiation_request` is wrong, but given that it is already translated, I did not want to destroy that before the freeze.

## Screenshots
<img width="787" height="342" alt="Bildschirmfoto 2025-11-26 um 16 40 55" src="https://github.com/user-attachments/assets/52e3fb15-4293-44ba-a6bd-e7703ea52837" />
