### PR TITLE
[#69224][#68811] Update op-blocknote-extensions for high contrast and translation support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -13823,6 +13823,24 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-parse-stringify/node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -14085,6 +14103,46 @@
         "bignumber.js": "*",
         "lodash": "*",
         "make-plural": "*"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.6.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.6.3.tgz",
+      "integrity": "sha512-AEQvoPDljhp67a1+NsnG/Wb1Nh6YoSvtrmeEd24sfGn3uujCtXCF3cXpr7ulhMywKNFF7p3TX1u2j7y+caLOJg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next/node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -18167,14 +18225,16 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.12",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
-      "integrity": "sha512-AKgE2ggOdbaxLd8G/Kcvg/McRMMjpxg+/AtligUWJIvSePfk3KbqwBo74RTF5XDq081aGaWEOgmXuOF7iO636A==",
+      "version": "0.0.13",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
+      "integrity": "sha512-fX87C1FRiQoKpIG0jmKgKLRM1ecuq68tnp5xtlSBq2GCbzZ1Llq3wEguvX3tYsMGmjtWO+eaHDlAtVYbSDougA==",
       "dependencies": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
         "@blocknote/react": "^0.41.1",
         "@primer/octicons-react": "^19.20.0",
+        "i18next": "^25.6.3",
+        "react-i18next": "^16.3.5",
         "styled-components": "^6.1.19"
       }
     },
@@ -19335,6 +19395,33 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "16.3.5",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.3.5.tgz",
+      "integrity": "sha512-F7Kglc+T0aE6W2rO5eCAFBEuWRpNb5IFmXOYEgztjZEuiuSLTe/xBIEG6Q3S0fbl8GXMNo+Q7gF8bpokFNWJww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-icons": {
@@ -32849,6 +32936,21 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      },
+      "dependencies": {
+        "void-elements": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+          "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
+        }
+      }
+    },
     "html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -33037,6 +33139,21 @@
         "bignumber.js": "*",
         "lodash": "*",
         "make-plural": "*"
+      }
+    },
+    "i18next": {
+      "version": "25.6.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.6.3.tgz",
+      "integrity": "sha512-AEQvoPDljhp67a1+NsnG/Wb1Nh6YoSvtrmeEd24sfGn3uujCtXCF3cXpr7ulhMywKNFF7p3TX1u2j7y+caLOJg==",
+      "requires": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.28.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+          "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="
+        }
       }
     },
     "iconv-lite": {
@@ -35798,13 +35915,15 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
-      "integrity": "sha512-AKgE2ggOdbaxLd8G/Kcvg/McRMMjpxg+/AtligUWJIvSePfk3KbqwBo74RTF5XDq081aGaWEOgmXuOF7iO636A==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
+      "integrity": "sha512-fX87C1FRiQoKpIG0jmKgKLRM1ecuq68tnp5xtlSBq2GCbzZ1Llq3wEguvX3tYsMGmjtWO+eaHDlAtVYbSDougA==",
       "requires": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
         "@blocknote/react": "^0.41.1",
         "@primer/octicons-react": "^19.20.0",
+        "i18next": "^25.6.3",
+        "react-i18next": "^16.3.5",
         "styled-components": "^6.1.19"
       }
     },
@@ -36611,6 +36730,16 @@
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "requires": {
         "scheduler": "^0.27.0"
+      }
+    },
+    "react-i18next": {
+      "version": "16.3.5",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.3.5.tgz",
+      "integrity": "sha512-F7Kglc+T0aE6W2rO5eCAFBEuWRpNb5IFmXOYEgztjZEuiuSLTe/xBIEG6Q3S0fbl8GXMNo+Q7gF8bpokFNWJww==",
+      "requires": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
       }
     },
     "react-icons": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.14/op-blocknote-extensions-0.0.14.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -18225,9 +18225,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.13",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
-      "integrity": "sha512-fX87C1FRiQoKpIG0jmKgKLRM1ecuq68tnp5xtlSBq2GCbzZ1Llq3wEguvX3tYsMGmjtWO+eaHDlAtVYbSDougA==",
+      "version": "0.0.14",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.14/op-blocknote-extensions-0.0.14.tgz",
+      "integrity": "sha512-duqLTRcUZbCM6aP87lwtgKr45sOTpkr0OcMqFBDm2PdlEnvdePzN8+TZM1D/TouWchRGLlbCKVWxJVAXXTy3QA==",
       "dependencies": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",
@@ -35915,8 +35915,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
-      "integrity": "sha512-fX87C1FRiQoKpIG0jmKgKLRM1ecuq68tnp5xtlSBq2GCbzZ1Llq3wEguvX3tYsMGmjtWO+eaHDlAtVYbSDougA==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.14/op-blocknote-extensions-0.0.14.tgz",
+      "integrity": "sha512-duqLTRcUZbCM6aP87lwtgKr45sOTpkr0OcMqFBDm2PdlEnvdePzN8+TZM1D/TouWchRGLlbCKVWxJVAXXTy3QA==",
       "requires": {
         "@blocknote/core": "^0.41.1",
         "@blocknote/mantine": "^0.41.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.12/op-blocknote-extensions-0.0.12.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.13/op-blocknote-extensions-0.0.13.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.14/op-blocknote-extensions-0.0.14.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -38,7 +38,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import { OpColorMode } from 'core-app/core/setup/globals/theme-utils';
 import { IUploadFile } from 'core-app/core/upload/upload.service';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
-import { initOpenProjectApi, openProjectWorkPackageBlockSpec, openProjectWorkPackageSlashMenu } from 'op-blocknote-extensions';
+import { initializeOpBlockNoteExtensions, openProjectWorkPackageBlockSpec, openProjectWorkPackageSlashMenu } from 'op-blocknote-extensions';
 import { useEffect, useState } from 'react';
 import { firstValueFrom } from 'rxjs';
 import * as Y from 'yjs';
@@ -79,11 +79,11 @@ export default function OpBlockNoteContainer({ inputField,
   const [connectionError, setConnectionError] = useState(false);
   const [theme, setTheme] = useState<OpColorMode>(detectTheme());
 
-  initOpenProjectApi({ baseUrl: openProjectUrl });
-
   const userLocale = window.I18n.locale;
   const blockNoteLocaleString = Object.keys(blockNoteLocales).includes(userLocale) ? userLocale : 'en';
   const blockNoteLocale = blockNoteLocales[blockNoteLocaleString as keyof typeof blockNoteLocales];
+
+  initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: blockNoteLocaleString});
 
   let doc = LiveCollaborationManager.ydoc;
 


### PR DESCRIPTION
This updates the op-blocknote-extensions plugin to the version which includes the changes for the high contrast color variants.

# Ticket
https://community.openproject.org/work_packages/69224
