### PR TITLE
[#69175] Impossible to open first meeting occurence from draft if user edits the meeting details  

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -174,6 +174,9 @@ module RecurringMeetings
       # Delete all scheduled jobs for this meeting
       GoodJob::Job.where(finished_at: nil, concurrency_key:).delete_all
 
+      # Don't init the next meeting in draft mode
+      return if recurring_meeting.template.draft?
+
       # Ensure we init the next meeting directly
       InitNextOccurrenceJob.perform_now(recurring_meeting, recurring_meeting.next_occurrence)
     end

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
         expect(series.upcoming_instantiated_meetings.count).to eq 1
       end
     end
+
+    context "when the template is in draft mode",
+            with_good_job: RecurringMeetings::InitNextOccurrenceJob do
+      let(:params) do
+        { start_time: Time.zone.today + 2.days + 11.hours }
+      end
+
+      before do
+        series.template.update_column(:state, :draft)
+      end
+
+      it "reschedules, but does not init an occurrence (Bug #69175)" do
+        expect(service_result).to be_success
+
+        expect(series.upcoming_instantiated_meetings).to be_empty
+
+        series.reload
+        expect(series.start_time).to eq Time.zone.today + 2.days + 11.hours
+      end
+    end
   end
 
   describe "rescheduling mails" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
 https://community.openproject.org/work_packages/69175

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Prevent editing the details of a series from automatically opening an occurrence and locking a user in draft mode (because clicking the button first checks for open meetings, and so if there is one already you're stuck)

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Prevent the init job from running when the series is in draft mode, thereby resulting in no instantiated meetings after editing the details

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
