### PR TITLE
Implementation/69415 limit portfolios to not allow subportfolios

### DIFF
--- a/app/components/projects/copy_form_component.html.erb
+++ b/app/components/projects/copy_form_component.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
           render(
             Primer::Forms::FormList.new(
               Projects::Settings::NameForm.new(f),
-              Projects::Settings::RelationsForm.new(f, visible: params[:parent_id].blank?),
+              Projects::Settings::RelationsForm.new(f, invisible: params[:parent_id].present?),
               Projects::Settings::CustomFieldsForm.new(f)
             )
           )

--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
             Primer::Forms::FormList.new(
               Projects::Settings::NameForm.new(f),
               Projects::Settings::DescriptionForm.new(f),
-              Projects::Settings::RelationsForm.new(f, visible: relation_form_visible?),
+              Projects::Settings::RelationsForm.new(f, invisible: params[:parent_id].present?),
               Projects::Settings::TypeForm.new(f)
             )
           )

--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
             Primer::Forms::FormList.new(
               Projects::Settings::NameForm.new(f),
               Projects::Settings::DescriptionForm.new(f),
-              Projects::Settings::RelationsForm.new(f, visible: params[:parent_id].blank?),
+              Projects::Settings::RelationsForm.new(f, visible: relation_form_visible?),
               Projects::Settings::TypeForm.new(f)
             )
           )

--- a/app/components/projects/new_component.rb
+++ b/app/components/projects/new_component.rb
@@ -53,9 +53,5 @@ module Projects
 
       url_for(workspace_type.pluralize.to_sym)
     end
-
-    def relation_form_visible?
-      project.parent_allowed? && params[:parent_id].blank?
-    end
   end
 end

--- a/app/components/projects/new_component.rb
+++ b/app/components/projects/new_component.rb
@@ -53,5 +53,9 @@ module Projects
 
       url_for(workspace_type.pluralize.to_sym)
     end
+
+    def relation_form_visible?
+      project.parent_allowed? && params[:parent_id].blank?
+    end
   end
 end

--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -67,21 +67,23 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    container.with_row(mb: 3) do
-      settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
-        concat(
-          render(Primer::Beta::Subhead.new) do |component|
-            component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_relations") }
-          end
-        )
-        concat(
-          render(
-            Primer::Forms::FormList.new(
-              Projects::Settings::RelationsForm.new(f),
-              Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_parent_project"))
+    if parent_allowed?
+      container.with_row(mb: 3) do
+        settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
+          concat(
+            render(Primer::Beta::Subhead.new) do |component|
+              component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_relations") }
+            end
+          )
+          concat(
+            render(
+              Primer::Forms::FormList.new(
+                Projects::Settings::RelationsForm.new(f),
+                Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_parent_project"))
+              )
             )
           )
-        )
+        end
       end
     end
   end

--- a/app/components/projects/settings/general/show_component.rb
+++ b/app/components/projects/settings/general/show_component.rb
@@ -38,6 +38,8 @@ module Projects
 
         attr_reader :project, :current_user
 
+        delegate :parent_allowed?, to: :project
+
         def initialize(project:, current_user:)
           super()
 

--- a/app/forms/projects/settings/relations_form.rb
+++ b/app/forms/projects/settings/relations_form.rb
@@ -33,7 +33,7 @@ module Projects
       delegate :parent, to: :model
 
       form do |f|
-        if @visible
+        if visible?
           f.project_autocompleter(
             name: :parent_id,
             label: attribute_name(:parent_id),
@@ -53,13 +53,19 @@ module Projects
         end
       end
 
-      def initialize(visible: true)
+      def initialize(invisible: false)
         super()
 
-        @visible = visible
+        @invisible = invisible
       end
 
       private
+
+      attr_reader :invisible
+
+      def visible?
+        model.parent_allowed? && !invisible
+      end
 
       def validation_message(attribute)
         model.errors.full_messages_for(attribute).to_sentence.presence

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,7 +58,7 @@ class Project < ApplicationRecord
   ALLOWED_PARENT_WORKSPACE_TYPES = {
     project: %i[portfolio program project],
     program: %i[portfolio],
-    portfolio: %i[portfolio]
+    portfolio: %i[]
   }.with_indifferent_access
 
   has_many :members, -> {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -279,8 +279,6 @@ class Project < ApplicationRecord
     name
   end
 
-  def allowed_parent_workspace_types = ALLOWED_PARENT_WORKSPACE_TYPES[workspace_type] || []
-
   def workspace_label
     case workspace_type
     when "program"

--- a/app/models/projects/hierarchy.rb
+++ b/app/models/projects/hierarchy.rb
@@ -171,5 +171,11 @@ module Projects::Hierarchy
       end
       stmt
     end
+
+    def allowed_parent_workspace_types = Project::ALLOWED_PARENT_WORKSPACE_TYPES[workspace_type] || []
+
+    def parent_allowed?
+      allowed_parent_workspace_types.any?
+    end
   end
 end

--- a/docs/api/apiv3/paths/projects_available_parent_projects.yml
+++ b/docs/api/apiv3/paths/projects_available_parent_projects.yml
@@ -20,6 +20,9 @@ get:
   - description: >-
       The workspace type of the new project the parent candidate is determined for.
       Ignored when `of` parameter is provided.
+
+      Note that while 'portfolio' is supported as a type (since it is a type of Workspace), the endpoint will currently
+      always return an empty resultset as portfolios cannot have parents.
     example: program
     in: query
     name: workspace_type

--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -37,15 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
                             scheme: :invisible,
                             aria: { label: I18n.t(:button_add_sub_item) } }
       ) do |menu|
-        if show_create_sub_work_space_buttons?
-          menu.with_item(
-            label: I18n.t(:label_portfolio),
-            tag: :a,
-            href: create_sub_portfolio_path
-          ) do |item|
-            item.with_leading_visual_icon(icon: :briefcase)
-          end
-
+        if can_create_sub_programs?
           menu.with_item(
             label: I18n.t(:label_program),
             tag: :a,

--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
     end
 
     if can_view_subprojects?
-      if !has_no_subitems?
+      if has_subitems?
         displayed_subitems.each do |child|
           container.with_row do
             flex_layout do |row|

--- a/modules/grids/app/components/grids/widgets/subitems.rb
+++ b/modules/grids/app/components/grids/widgets/subitems.rb
@@ -61,16 +61,12 @@ module Grids
         { full_width: true }
       end
 
-      def show_create_sub_work_space_buttons?
+      def can_create_sub_programs?
         project.portfolio? && can_create_sub_projects?
       end
 
       def can_create_sub_projects?
         @can_create_sub_projects ||= User.current.allowed_in_project?(:add_subprojects, @project)
-      end
-
-      def create_sub_portfolio_path
-        new_portfolio_path(parent_id: project.id)
       end
 
       def create_sub_program_path

--- a/modules/grids/app/components/grids/widgets/subitems.rb
+++ b/modules/grids/app/components/grids/widgets/subitems.rb
@@ -53,8 +53,8 @@ module Grids
         subitems_with_more.last
       end
 
-      def has_no_subitems?
-        displayed_subitems.empty?
+      def has_subitems?
+        displayed_subitems.any?
       end
 
       def wrapper_arguments

--- a/spec/features/portfolios/create_spec.rb
+++ b/spec/features/portfolios/create_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Portfolios",
 
     expect(page).to have_combo_box "Subproject of"
     parent_field.expect_no_option "Other portfolio"
-    parent_field.select_option "Root portfolio"
+    parent_field.expect_no_option "Root portfolio" # Since no a project cannot have a parent
 
     click_on "Complete"
 
@@ -79,7 +79,7 @@ RSpec.describe "Portfolios",
     portfolio = Project.last
     expect(portfolio.workspace_type).to eq "portfolio"
     expect(portfolio.identifier).to eq "foo-bar"
-    expect(portfolio.parent).to eq root_portfolio
+    expect(portfolio.parent).to be_nil
   end
 
   context "without the necessary permissions to create portfolios", with_flag: { portfolio_models: true } do

--- a/spec/features/portfolios/create_spec.rb
+++ b/spec/features/portfolios/create_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe "Portfolios",
     # Step 2: Fill in project details
     fill_in "Name", with: "Foo bar"
 
-    expect(page).to have_combo_box "Subproject of"
-    parent_field.expect_no_option "Other portfolio"
-    parent_field.expect_no_option "Root portfolio" # Since no a project cannot have a parent
+    # No parent field since portfolios are always root elements
+    expect(page)
+      .not_to have_combo_box "Subproject of"
 
     click_on "Complete"
 

--- a/spec/forms/projects/settings/relations_form_spec.rb
+++ b/spec/forms/projects/settings/relations_form_spec.rb
@@ -37,13 +37,21 @@ RSpec.describe Projects::Settings::RelationsForm, type: :forms do
   let(:parent) { nil }
   let(:workspace_type) { :project }
 
-  %i[portfolio program project].each do |workspace_type|
+  %i[program project].each do |workspace_type|
     context "for workspace type #{workspace_type}" do
       let(:workspace_type) { workspace_type }
 
       it "renders field" do
         expect(page).to have_element "opce-project-autocompleter", "data-input-name": "\"project[parent_id]\""
       end
+    end
+  end
+
+  context "for workspace type portfolio" do
+    let(:workspace_type) { "portfolio" }
+
+    it "does not render" do
+      expect(page).not_to have_element "opce-project-autocompleter", "data-input-name": "\"project[parent_id]\""
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -598,7 +598,7 @@ RSpec.describe Project do
     {
       project: %i[portfolio program project],
       program: %i[portfolio],
-      portfolio: %i[portfolio]
+      portfolio: %i[]
     }.each do |workspace_type, allowed_parent_workspace_types|
       context "for workspace type #{workspace_type}" do
         let(:project) { described_class.new(workspace_type:) }
@@ -615,6 +615,32 @@ RSpec.describe Project do
       subject { project.allowed_parent_workspace_types }
 
       it { is_expected.to eq [] }
+    end
+  end
+
+  describe "#parent_allowed?" do
+    context "for a project" do
+      let(:workspace) { build_stubbed(:project) }
+
+      it "is truthy" do
+        expect(workspace).to be_parent_allowed
+      end
+    end
+
+    context "for a program" do
+      let(:workspace) { build_stubbed(:program) }
+
+      it "is truthy" do
+        expect(workspace).to be_parent_allowed
+      end
+    end
+
+    context "for a portfolio" do
+      let(:workspace) { build_stubbed(:portfolio) }
+
+      it "is falsey" do
+        expect(workspace).not_to be_parent_allowed
+      end
     end
   end
 end

--- a/spec/models/projects/scopes/assignable_parents_spec.rb
+++ b/spec/models/projects/scopes/assignable_parents_spec.rb
@@ -78,12 +78,9 @@ RSpec.describe Projects::Scopes::AssignableParents do
   context "for a portfolio" do
     let(:workspace_type) { :portfolio }
 
-    it "returns portfolios the user has the add_subprojects permission in but without self or descendants" do
+    it "is empty since portfolios are always root elements" do
       expect(Project.assignable_parents(user, subject_workspace))
-        .to contain_exactly(
-          portfolio_with_permission,
-          parent_portfolio
-        )
+        .to be_empty
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69415

# What are you trying to accomplish?

Force portfolios to be root elements. To that end:

* The scope for selecting parent elements will not return any value in case the list of allowed projects is queried for a portfolio.
* The above leads the contract to prevent the creation of portfolios with a parent
* The parent selection is hidden on the portfolio create, update and copy form
* The "Subitem" widget no longer has "+ Portfolio" as part of its menu

<img width="1409" height="204" alt="image" src="https://github.com/user-attachments/assets/08b5baeb-15b5-47c8-98fa-079d81e713dc" />

# Merge checklist

- [x] Added/updated tests