### PR TITLE
[#66307] Visualize "Portfolio", "Program" and "Project" differently for autocompleters

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocomplete-item.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocomplete-item.ts
@@ -5,6 +5,7 @@ export interface IProjectAutocompleteItem {
   id:ID;
   href:string;
   name:string;
+  _type?:string;
   disabled:boolean;
   disabledReason?:string;
   ancestors:IHalResourceLink[];

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -4,15 +4,7 @@
   let-clear="clear"
   >
   <span class="ng-value-icon left" (click)="clear(item)">×</span>
-  <span class="ng-value-label" style="display: flex; gap: 0.5rem;">
-    <span class="ellipsis">{{ item.name }}</span>
-    @if (shouldShowWorkspaceTypeBadge(item)) {
-      <span
-        [innerHTML]="workspaceTypeIconWithLabel(item)"
-        style="flex-shrink: 0;"
-      ></span>
-    }
-  </span>
+  <span class="ng-value-label">{{ item.name }}</span>
 </ng-template>
 
 <ng-template

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -13,11 +13,23 @@
   let-search="search"
   >
   <div
-    [title]="item.name"
-    class="ng-option-label ellipsis"
+    class="ng-option-label"
     [ngStyle]="{ 'padding-left.px': item.numberOfAncestors * 16 }"
-    [opSearchHighlight]="search"
-  >{{ item.name }}</div>
+  >
+    <div style="display: flex; gap: 0.5rem;">
+      <div
+        [title]="item.name"
+        class="ellipsis"
+        [opSearchHighlight]="search"
+      >{{ item.name }}</div>
+      @if (shouldShowWorkspaceTypeBadge(item)) {
+        <div
+          [innerHTML]="workspaceTypeIconWithLabel(item)"
+          style="flex-shrink: 0;"
+        ></div>
+      }
+    </div>
+  </div>
   @if (item.disabled && item.disabledReason) {
     <div
       [title]="item.disabledReason"

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -4,7 +4,15 @@
   let-clear="clear"
   >
   <span class="ng-value-icon left" (click)="clear(item)">×</span>
-  <span class="ng-value-label">{{ item.name }}</span>
+  <span class="ng-value-label" style="display: flex; gap: 0.5rem;">
+    <span class="ellipsis">{{ item.name }}</span>
+    @if (shouldShowWorkspaceTypeBadge(item)) {
+      <span
+        [innerHTML]="workspaceTypeIconWithLabel(item)"
+        style="flex-shrink: 0;"
+      ></span>
+    }
+  </span>
 </ng-template>
 
 <ng-template

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
@@ -31,8 +31,18 @@ import {
   Component,
   TemplateRef,
   ViewChild,
+  inject,
 } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
+import {
+  toDOMString,
+  projectRoadmapIconData,
+  briefcaseIconData,
+  SVGData,
+} from '@openproject/octicons-angular';
+import { IProjectAutocompleteItem } from './project-autocomplete-item';
 
 @Component({
   templateUrl: './project-autocompleter-template.component.html',
@@ -42,4 +52,42 @@ import { IAutocompleterTemplateComponent } from 'core-app/shared/components/auto
 export class ProjectAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {
   @ViewChild('optionTemplate') optionTemplate:TemplateRef<Element>;
   @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
+
+  readonly I18n = inject(I18nService);
+  readonly sanitizer = inject(DomSanitizer);
+
+  shouldShowWorkspaceTypeBadge(project:IProjectAutocompleteItem):boolean {
+    return !!project._type && project._type !== 'Project';
+  }
+
+  workspaceTypeIconWithLabel(project:IProjectAutocompleteItem):SafeHtml {
+    const workspaceType = project._type;
+    if (!workspaceType) {
+      return '';
+    }
+
+    const iconData = this.workspaceTypeSVGData(workspaceType);
+    if (!iconData) {
+      return '';
+    }
+
+    const htmlString = toDOMString(iconData, 'small', { 'aria-hidden': 'true', class: 'octicon' });
+    const translatedTypeName = this.I18n.t(`js.include_workspaces.types.${workspaceType.toLowerCase()}`);
+    const iconWithText = htmlString + ' ' + translatedTypeName;
+    return this.sanitizer.bypassSecurityTrustHtml(iconWithText);
+  }
+
+  private workspaceTypeSVGData(workspaceType:string):SVGData|undefined {
+    switch (workspaceType) {
+      case 'Program': {
+        return projectRoadmapIconData;
+      }
+      case 'Portfolio': {
+        return briefcaseIconData;
+      }
+      default: {
+        return undefined;
+      }
+    }
+  }
 }

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter.component.ts
@@ -142,7 +142,7 @@ export class ProjectAutocompleterComponent extends OpAutocompleterComponent<IPro
       return projects;
     }
 
-    const normalizedValue = (value || []);
+    const normalizedValue = (value ?? []);
     const arrayedValue = (Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue]).map((p) => p.href || p.id);
     return projects.map((project) => {
       const isSelected = !!arrayedValue.find((selected) => selected === this.projectTracker(project));
@@ -177,7 +177,7 @@ export class ProjectAutocompleterComponent extends OpAutocompleterComponent<IPro
 
         filteredURL.searchParams.set('pageSize', params.pageSize?.toString() || '-1');
         filteredURL.searchParams.set('offset', params.offset?.toString() || '1');
-        filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/identifier,elements/self,elements/ancestors,total,count,pageSize');
+        filteredURL.searchParams.set('select', 'elements/id,elements/name,elements/identifier,elements/self,elements/ancestors,elements/_type,total,count,pageSize');
 
         return this
           .http
@@ -193,6 +193,7 @@ export class ProjectAutocompleterComponent extends OpAutocompleterComponent<IPro
             id: project.id,
             href: project._links.self.href,
             name: project.name,
+            _type: project._type,
             disabled,
             disabledReason: (typeof this.disabledProjects[id] === 'string') ? this.disabledProjects[id] : '',
             ancestors: project._links.ancestors,

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -445,4 +445,59 @@ RSpec.describe "Projects", "creation",
       end
     end
   end
+
+  context "with workspace type badges in parent field", with_flag: { portfolio_models: true } do
+    include_context "ng-select-autocomplete helpers"
+
+    shared_let(:portfolio) { create(:portfolio, name: "Parent Portfolio") }
+    shared_let(:program) { create(:program, name: "Parent Program") }
+
+    it "displays workspace type badges for portfolios and programs in the parent field" do
+      visit new_project_path
+
+      # Step 1: Select workspace type (blank project)
+      click_on "Continue"
+
+      # Step 2: Fill in project details
+      fill_in "Name", with: "Test Subproject"
+
+      # Open parent field autocompleter
+      expect(page).to have_combo_box "Subproject of"
+      parent_autocompleter = page.find("opce-project-autocompleter")
+
+      # Search for portfolio
+      dropdown = search_autocomplete(parent_autocompleter,
+                                     query: "Portfolio",
+                                     results_selector: ".ng-dropdown-panel-items")
+
+      within(dropdown) do
+        expect(page).to have_text("Portfolio")
+        expect(page).to have_css("svg.octicon")
+      end
+
+      # Clear and search for program
+      parent_autocompleter.find("input").set("")
+
+      dropdown = search_autocomplete(parent_autocompleter,
+                                     query: "Program",
+                                     results_selector: ".ng-dropdown-panel-items")
+
+      within(dropdown) do
+        expect(page).to have_text("Program")
+        expect(page).to have_css("svg.octicon")
+      end
+
+      # Clear and search for regular project - should not have workspace type badge
+      parent_autocompleter.find("input").set("")
+
+      dropdown = search_autocomplete(parent_autocompleter,
+                                     query: "Foo project",
+                                     results_selector: ".ng-dropdown-panel-items")
+
+      within(dropdown) do
+        expect(page).to have_text("Foo project")
+        expect(page).to have_no_css("svg.octicon")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/66307

# What are you trying to accomplish?
Add the workspace badges to the project autocompleters.

## Screenshots

<details><summary>Project parent selector on the project creation page</summary>
<p>

<img width="982" height="772" alt="image" src="https://github.com/user-attachments/assets/083bc616-2f09-4be5-a510-ea3fb9fbb911" />


</p>
</details> 


<details><summary>Work package project selector</summary>
<p>

<img width="831" height="529" alt="image" src="https://github.com/user-attachments/assets/2a1ee258-59f5-4fae-926e-a1370dd26fd3" />


</p>
</details> 

# What approach did you choose and why?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
