### PR TITLE
DRY up attribute list handling with `attributeTokenList`

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -58,7 +58,7 @@ import { fromEvent, Subscription } from 'rxjs';
 import { AttachmentCollectionResource } from 'core-app/features/hal/resources/attachment-collection-resource';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { navigator } from '@hotwired/turbo';
-import { uniqueId } from 'lodash';
+import { attributeTokenList, ensureId } from 'core-app/shared/helpers/dom-helpers';
 
 @Component({
   templateUrl: './ckeditor-augmented-textarea.html',
@@ -334,16 +334,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
     const ckContent = this.element.querySelector<HTMLElement>('.ck-content')!;
 
-    let labelId;
-    if (label.hasAttribute('id')) {
-      labelId = label.getAttribute('id')!;
-    } else {
-      labelId = uniqueId('label-');
-      label.setAttribute('id', labelId);
-    }
-
     ckContent.removeAttribute('aria-label');
-    ckContent.setAttribute('aria-labelledby', labelId);
+    attributeTokenList(ckContent, 'aria-labelledby').add(ensureId(label, 'label'));
 
     if (!this.labelClickSubscription) {
       this.labelClickSubscription = fromEvent(label, 'click')

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -26,6 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { attributeTokenList } from 'core-app/shared/helpers/dom-helpers';
 import { ApplicationController } from 'stimulus-use';
 import { useMutation } from 'stimulus-use';
 
@@ -117,23 +118,11 @@ export default class ExternalLinksController extends ApplicationController {
 
 function updateBlankLink(link:HTMLAnchorElement) {
   // Ensure accessibility description
-  const describedBy = link.getAttribute('aria-describedby');
-  if (!describedBy) {
-    link.setAttribute('aria-describedby', BLANK_LINK_DESCRIPTION_ID);
-  } else if (!describedBy.split(/\s+/).includes(BLANK_LINK_DESCRIPTION_ID)) {
-    link.setAttribute('aria-describedby', `${describedBy} ${BLANK_LINK_DESCRIPTION_ID}`);
-  }
+  attributeTokenList(link, 'aria-describedby').add(BLANK_LINK_DESCRIPTION_ID);
 }
 
 function updateExternalLink(link:HTMLAnchorElement) {
   // Ensure external link behavior
   link.target = '_blank';
-
-  // Merge rel attributes safely
-  const relValues = new Set([
-    ...(link.getAttribute('rel')?.split(/\s+/) ?? []),
-    'noopener',
-    'noreferrer',
-  ]);
-  link.setAttribute('rel', Array.from(relValues).join(' '));
+  attributeTokenList(link, 'rel').add('noopener', 'noreferrer');
 }


### PR DESCRIPTION
⚠️ **This PR is based off #21134.** Please review/merge that first.

# Ticket

No ticket - just some small improvements that didn't really belong in #21134.

# What are you trying to accomplish?

Uses recently introduced `attributeTokenList` to DRY up implementation of various Stimulus controllers/Angular components.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
