### PR TITLE
[#69437] Fix Projects formatting in Webhooks table

### DIFF
--- a/app/components/op_primer/warning_text.html.erb
+++ b/app/components/op_primer/warning_text.html.erb
@@ -1,0 +1,7 @@
+<%= render(Primer::Beta::Text.new(**@system_arguments)) do %>
+  <%= render(Primer::Beta::Octicon.new(icon: :"alert-fill", size: :xsmall, mr: 2, aria: { hidden: true })) %>
+  <span>
+    <%= render(Primer::Beta::Text.new(tag: :strong).with_content("#{I18n.t(:warning)}:")) if show_warning_label? %>
+    <%= content %>
+  </span>
+<% end %>

--- a/app/components/op_primer/warning_text.rb
+++ b/app/components/op_primer/warning_text.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  # A simple component to render warning text.
+  #
+  # The warning text is rendered in the "attention" Primer color and
+  # uses a leading alert Octicon for additional emphasis. This component
+  # is designed to be used "inline", e.g. table cells, and in places
+  # where a Banner component might be overkill.
+  class WarningText < Primer::Component # rubocop:disable OpenProject/AddPreviewForViewComponent
+    # @param show_warning_label [Boolean] whether to show a leading "Warning:" label
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(show_warning_label: true, **system_arguments)
+      super()
+
+      @show_warning_label = show_warning_label
+      @system_arguments = system_arguments
+      @system_arguments[:display] = :inline_flex
+      @system_arguments[:align_items] = :center
+      @system_arguments[:color] = :attention
+    end
+
+    def show_warning_label?
+      !!@show_warning_label
+    end
+
+    def render?
+      content.present?
+    end
+  end
+end

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
@@ -4,6 +4,8 @@ module ::Webhooks
       class RowComponent < ::RowComponent
         property :description
 
+        delegate :event_names, to: :webhook
+
         def webhook
           model
         end
@@ -20,40 +22,18 @@ module ::Webhooks
         end
 
         def events
-          selected_events =
-            webhook
-              .events
-              .pluck(:name)
-              .map(&method(:lookup_event_name))
-              .compact
-              .uniq
+          return t(:"webhooks.outgoing.label_x_event_resources", count: 0) if event_names.empty?
 
-          count = selected_events.count
-          if count <= 3
-            selected_events.join(", ")
-          else
-            content_tag("span", count, class: "badge")
-          end
-        end
-
-        def lookup_event_name(name)
-          OpenProject::Webhooks::EventResources.lookup_resource_name(name)
+          event_names
+            .filter_map { OpenProject::Webhooks::EventResources.lookup_resource_name(it) }
+            .uniq
+            .join(", ")
         end
 
         def selected_projects
-          if webhook.all_projects?
-            return "(#{I18n.t(:label_all)})"
-          end
+          return t(:"webhooks.outgoing.form.project_ids.all") if webhook.all_projects?
 
-          selected = webhook.projects.map(&:name)
-
-          if selected.empty?
-            "(#{I18n.t(:label_all)})"
-          elsif selected.size <= 3
-            webhook.projects.pluck(:name).join(", ")
-          else
-            content_tag("span", selected, class: "badge")
-          end
+          t(:label_x_projects, count: webhook.projects.size)
         end
 
         def row_css_class

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
@@ -27,7 +27,7 @@ module ::Webhooks
           event_names
             .filter_map { OpenProject::Webhooks::EventResources.lookup_resource_name(it) }
             .uniq
-            .join(", ")
+            .join(t(:"support.array.words_connector", default: ", "))
         end
 
         def selected_projects

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
@@ -2,6 +2,8 @@ module ::Webhooks
   module Outgoing
     module Webhooks
       class RowComponent < ::RowComponent
+        include OpPrimer::ComponentHelpers
+
         property :description
 
         delegate :event_names, to: :webhook
@@ -22,16 +24,18 @@ module ::Webhooks
         end
 
         def events
-          return t(:"webhooks.outgoing.label_x_event_resources", count: 0) if event_names.empty?
+          return render_warning(t(:"webhooks.outgoing.label_x_event_resources", count: 0).capitalize) if event_names.empty?
 
           event_names
-            .filter_map { OpenProject::Webhooks::EventResources.lookup_resource_name(it) }
-            .uniq
-            .join(t(:"support.array.words_connector", default: ", "))
+            .map { OpenProject::Webhooks::EventResources.lookup_resource_name(it) }
+            .group_by(&:first)
+            .transform_values { |pairs| pairs.map(&:last).sort }
+            .then { render_events_list(it) }
         end
 
         def selected_projects
           return t(:"webhooks.outgoing.form.project_ids.all") if webhook.all_projects?
+          return render_warning(t(:label_x_projects, count: 0).capitalize) if webhook.projects.empty?
 
           t(:label_x_projects, count: webhook.projects.size)
         end
@@ -64,6 +68,27 @@ module ::Webhooks
             data: { turbo_method: :delete, turbo_confirm: I18n.t(:text_are_you_sure) },
             title: t(:button_delete)
           )
+        end
+
+        private
+
+        def render_warning(text)
+          render OpPrimer::WarningText.new(show_warning_label: false).with_content(text)
+        end
+
+        def render_events_list(items)
+          render(OpPrimer::ListComponent.new(ml: 0)) do |list|
+            items.each do |resource, events|
+              list.with_item do
+                component_collection do |list_item_parts|
+                  list_item_parts.with_component(Primer::Beta::Text.new.with_content(resource))
+                  list_item_parts.with_component(Primer::Beta::Text.new(font_size: :small, color: :muted)) do
+                    events.join(t(:"support.array.words_connector", default: ", ")).then { "(#{it})" }
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/row_component.rb
@@ -24,7 +24,7 @@ module ::Webhooks
         end
 
         def events
-          return render_warning(t(:"webhooks.outgoing.label_x_event_resources", count: 0).capitalize) if event_names.empty?
+          return render_warning(t(:"webhooks.outgoing.label_x_events", count: 0).capitalize) if event_names.empty?
 
           event_names
             .map { OpenProject::Webhooks::EventResources.lookup_resource_name(it) }

--- a/modules/webhooks/app/components/webhooks/outgoing/webhooks/table_component.rb
+++ b/modules/webhooks/app/components/webhooks/outgoing/webhooks/table_component.rb
@@ -32,8 +32,8 @@ module ::Webhooks
           [
             ["name", { caption: I18n.t("attributes.name") }],
             ["enabled", { caption: I18n.t(:label_active) }],
-            ["selected_projects", { caption: ::Webhooks::Webhook.human_attribute_name("projects") }],
-            ["events", { caption: I18n.t("webhooks.outgoing.label_event_resources") }],
+            ["selected_projects", { caption: ::Webhooks::Webhook.human_attribute_name(:projects) }],
+            ["events", { caption: ::Webhooks::Webhook.human_attribute_name(:events) }],
             ["description", { caption: I18n.t("attributes.description") }]
           ]
         end

--- a/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
+++ b/modules/webhooks/app/views/webhooks/outgoing/admin/index.html.erb
@@ -8,6 +8,13 @@
        { href: admin_settings_api_path, text: t("menus.admin.api_and_webhooks") },
        t("webhooks.plural")]
     )
+
+    header.with_description do
+      t(
+        "webhooks.outgoing.explanation.text",
+        link: link_to(t(:"webhooks.outgoing.explanation.link"), admin_settings_aggregation_path, target: "_blank", rel: "noopener")
+      ).html_safe
+    end
   end
 %>
 
@@ -24,12 +31,5 @@
     end
   end
 %>
-
-<p>
-  <%= t(
-        "webhooks.outgoing.explanation.text",
-        link: link_to(t(:"webhooks.outgoing.explanation.link"), admin_settings_aggregation_path, target: "_blank")
-      ).html_safe %>
-</p>
 
 <%= render ::Webhooks::Outgoing::Webhooks::TableComponent.new(rows: @webhooks) %>

--- a/modules/webhooks/config/locales/en.yml
+++ b/modules/webhooks/config/locales/en.yml
@@ -28,11 +28,10 @@ en:
       no_results_table: No webhooks have been defined yet.
       label_add_new: Add new webhook
       label_edit: Edit webhook
-      label_event_resources: Event resources
-      label_x_event_resources:
-        one: "1 event resource"
-        other: "%{count} event resources"
-        zero: "No event resources"
+      label_x_events:
+        one: "1 events"
+        other: "%{count} events"
+        zero: "No events"
       events:
         created: "Created"
         updated: "Updated"

--- a/modules/webhooks/config/locales/en.yml
+++ b/modules/webhooks/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
       label_add_new: Add new webhook
       label_edit: Edit webhook
       label_x_events:
-        one: "1 events"
+        one: "1 event"
         other: "%{count} events"
         zero: "No events"
       events:

--- a/modules/webhooks/config/locales/en.yml
+++ b/modules/webhooks/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
       label_add_new: Add new webhook
       label_edit: Edit webhook
       label_event_resources: Event resources
+      label_x_event_resources:
+        one: "1 event resource"
+        other: "%{count} event resources"
+        zero: "No event resources"
       events:
         created: "Created"
         updated: "Updated"

--- a/modules/webhooks/lib/open_project/webhooks/event_resources.rb
+++ b/modules/webhooks/lib/open_project/webhooks/event_resources.rb
@@ -1,17 +1,17 @@
+# frozen_string_literal: true
+
 module OpenProject::Webhooks
   module EventResources
     class << self
       def subscribe!
-        resource_modules.each do |handler|
-          handler.subscribe!
-        end
+        resource_modules.each(&:subscribe!)
       end
 
       ##
       # Return a complete mapping of all resource modules
       # in the form { label => { event1: label , event2: label } }
       def available_events_map
-        resource_modules.map { |m| [m.resource_name, m.available_events_map] }.to_h
+        resource_modules.to_h { |m| [m.resource_name, m.available_events_map] }
       end
 
       ##

--- a/modules/webhooks/lib/open_project/webhooks/event_resources.rb
+++ b/modules/webhooks/lib/open_project/webhooks/event_resources.rb
@@ -17,8 +17,10 @@ module OpenProject::Webhooks
       ##
       # Find a module based on the event name
       def lookup_resource_name(event_name)
-        resource = resource_modules.detect { |m| m.available_events_map.key?(event_name) }
-        resource.try(:resource_name)
+        resource, events = available_events_map.detect { |_, events_map| events_map.key?(event_name) }
+        event = events[event_name] if resource
+
+        [resource, event]
       end
 
       def resource_modules

--- a/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
+++ b/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Outgoing::Webhooks::RowComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  subject(:rendered_component) do
+    table = instance_double(Webhooks::Outgoing::Webhooks::TableComponent,
+                            columns: [column],
+                            target_controller: "webhooks/outgoing/admin")
+    render_inline(described_class.new(row: webhook, table:))
+  end
+
+  describe "Name" do
+    let(:webhook) { build_stubbed(:webhook, name: "Hook me up") }
+    let(:column) { :name }
+
+    it "renders name" do
+      expect(rendered_component).to have_content "Hook me up"
+    end
+  end
+
+  describe "Enabled Projects" do
+    let(:column) { :selected_projects }
+
+    context "when all projects enabled" do
+      let(:webhook) { build_stubbed(:webhook, all_projects: true) }
+
+      it "renders 'All projects'" do
+        expect(rendered_component).to have_content "All projects"
+      end
+    end
+
+    context "when some projects are enabled" do
+      let(:webhook) { create(:webhook, all_projects: false, projects: create_list(:project, 2)) }
+
+      it "renders 'X projects'" do
+        expect(rendered_component).to have_content "2 projects"
+      end
+    end
+
+    context "when no projects are enabled" do
+      let(:webhook) { build_stubbed(:webhook, all_projects: false) }
+
+      it "renders 'no projects'" do
+        expect(rendered_component).to have_content "no projects"
+      end
+    end
+  end
+
+  describe "Event Resources" do
+    let(:column) { :events }
+    let(:webhook) { create(:webhook, event_names:) }
+
+    context "when no events are enabled" do
+      let(:event_names) { [] }
+
+      it "renders 'no event resources'" do
+        expect(rendered_component).to have_content "No event resources"
+      end
+    end
+
+    context "when some events are enabled" do
+      let(:event_names) { ["project:created", "work_package_comment:comment"] }
+
+      it "renders resource list" do
+        expect(rendered_component).to have_content "Projects, Work package comments"
+      end
+    end
+  end
+end

--- a/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
+++ b/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
@@ -80,23 +80,23 @@ RSpec.describe Webhooks::Outgoing::Webhooks::RowComponent, type: :component do
     end
   end
 
-  describe "Event Resources" do
+  describe "Events" do
     let(:column) { :events }
     let(:webhook) { create(:webhook, event_names:) }
 
     context "when no events are enabled" do
       let(:event_names) { [] }
 
-      it "renders 'No event resources'" do
+      it "renders 'No events'" do
         expect(rendered_component).to have_octicon :"alert-fill"
-        expect(rendered_component).to have_primer_text "No event resources", color: "attention"
+        expect(rendered_component).to have_primer_text "No events", color: "attention"
       end
     end
 
     context "when some events are enabled" do
       let(:event_names) { ["project:created", "work_package_comment:comment"] }
 
-      it "renders resource list", :aggregate_failures do
+      it "renders events list grouped by Resource", :aggregate_failures do
         expect(rendered_component).to have_list do |list|
           expect(list).to have_list_item count: 2
           expect(list).to have_list_item "Projects (created)"

--- a/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
+++ b/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
@@ -31,10 +31,6 @@
 require "rails_helper"
 
 RSpec.describe Webhooks::Outgoing::Webhooks::RowComponent, type: :component do
-  def render_component(...)
-    render_inline(described_class.new(...))
-  end
-
   subject(:rendered_component) do
     table = instance_double(Webhooks::Outgoing::Webhooks::TableComponent,
                             columns: [column],

--- a/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
+++ b/modules/webhooks/spec/components/webhooks/outgoing/webhooks/row_component_spec.rb
@@ -73,8 +73,9 @@ RSpec.describe Webhooks::Outgoing::Webhooks::RowComponent, type: :component do
     context "when no projects are enabled" do
       let(:webhook) { build_stubbed(:webhook, all_projects: false) }
 
-      it "renders 'no projects'" do
-        expect(rendered_component).to have_content "no projects"
+      it "renders 'No projects'" do
+        expect(rendered_component).to have_octicon :"alert-fill"
+        expect(rendered_component).to have_primer_text "No projects", color: "attention"
       end
     end
   end
@@ -86,16 +87,21 @@ RSpec.describe Webhooks::Outgoing::Webhooks::RowComponent, type: :component do
     context "when no events are enabled" do
       let(:event_names) { [] }
 
-      it "renders 'no event resources'" do
-        expect(rendered_component).to have_content "No event resources"
+      it "renders 'No event resources'" do
+        expect(rendered_component).to have_octicon :"alert-fill"
+        expect(rendered_component).to have_primer_text "No event resources", color: "attention"
       end
     end
 
     context "when some events are enabled" do
       let(:event_names) { ["project:created", "work_package_comment:comment"] }
 
-      it "renders resource list" do
-        expect(rendered_component).to have_content "Projects, Work package comments"
+      it "renders resource list", :aggregate_failures do
+        expect(rendered_component).to have_list do |list|
+          expect(list).to have_list_item count: 2
+          expect(list).to have_list_item "Projects (created)"
+          expect(list).to have_list_item "Work package comments (comment)"
+        end
       end
     end
   end

--- a/modules/webhooks/spec/components/webhooks/outgoing/webhooks/table_component_spec.rb
+++ b/modules/webhooks/spec/components/webhooks/outgoing/webhooks/table_component_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Outgoing::Webhooks::TableComponent, type: :component do
+  def render_component(...)
+    render_inline(described_class.new(...))
+  end
+
+  subject(:rendered_component) do
+    render_component(rows: webhooks)
+  end
+
+  context "with no webhooks" do
+    let(:webhooks) { create_list(:webhook, 0) }
+
+    it_behaves_like "rendering generic table", expected_headers_count: 6, expected_rows_count: 1
+
+    it "renders 'no webhooks' message" do
+      expect(rendered_component).to have_selector(:row, text: "No webhooks have been defined yet.")
+    end
+  end
+
+  context "with webhooks" do
+    let(:webhooks) { create_list(:webhook, 2) }
+
+    it_behaves_like "rendering generic table", expected_headers_count: 6, expected_rows_count: 2
+  end
+end

--- a/modules/webhooks/spec/features/manage_webhooks_spec.rb
+++ b/modules/webhooks/spec/features/manage_webhooks_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Manage webhooks through UI", :js, :selenium do
       expect(webhook.all_projects).to be_truthy
 
       expect(page).to have_css(".webhooks--outgoing-webhook-row .enabled .icon-yes")
-      expect(page).to have_css(".webhooks--outgoing-webhook-row .selected_projects", text: "(all)")
+      expect(page).to have_css(".webhooks--outgoing-webhook-row .selected_projects", text: "All projects")
       expect(page).to have_css(".webhooks--outgoing-webhook-row .events", text: "Work packages")
       expect(page).to have_css(".webhooks--outgoing-webhook-row .description", text: webhook.description)
 

--- a/spec/components/op_primer/warning_text_spec.rb
+++ b/spec/components/op_primer/warning_text_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+require "rails_helper"
+
+RSpec.describe OpPrimer::WarningText, type: :component do
+  def render_component(**, &)
+    render_inline(described_class.new(**), &)
+  end
+
+  subject(:rendered_component) do
+    render_component(show_warning_label:) { "Important Message" }
+  end
+
+  shared_examples "rendering container and icon" do
+    it "renders container" do
+      expect(rendered_component).to have_css "span:first-child"
+    end
+
+    it "applies inline flex styling" do
+      expect(rendered_component).to have_css ".d-inline-flex.flex-items-center"
+    end
+
+    it "renders an icon" do
+      expect(rendered_component).to have_octicon :"alert-fill", size: :xsmall, aria: { hidden: true }
+    end
+  end
+
+  context "with default args" do
+    let(:show_warning_label) { true }
+
+    include_examples "rendering container and icon"
+
+    it "renders text, including 'Warning:' prefix" do
+      expect(rendered_component).to have_primer_text "Warning: Important Message", color: :attention do |text|
+        expect(text).to have_css "strong", exact_text: "Warning:"
+      end
+    end
+  end
+
+  context "with show_warning_label: false" do
+    let(:show_warning_label) { false }
+
+    include_examples "rendering container and icon"
+
+    it "renders just the text" do
+      expect(rendered_component).to have_primer_text "Important Message", color: :attention
+    end
+  end
+
+  context "with blank content" do
+    subject(:rendered_component) do
+      render_component { " " }
+    end
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_empty
+    end
+  end
+end

--- a/spec/support/capybara/primer_component_selectors.rb
+++ b/spec/support/capybara/primer_component_selectors.rb
@@ -118,9 +118,7 @@ Capybara.add_selector :octicon, locator_type: [String, Symbol] do
 
   describe_expression_filters do |size: nil, **|
     desc = +""
-    if size.present?
-      desc << size.is_a?(Numeric) ? " with size #{size}px" : " with #{size} size"
-    end
+    desc << (size.is_a?(Numeric) ? " with size #{size}px" : " with #{size.inspect} size") if size.present?
     desc
   end
 end

--- a/spec/support/capybara/primer_component_selectors.rb
+++ b/spec/support/capybara/primer_component_selectors.rb
@@ -64,6 +64,8 @@ Capybara.add_selector :primer_label, locator_type: [String, Symbol] do
   describe_expression_filters do |scheme: nil, **|
     " with scheme #{scheme.inspect}" if scheme
   end
+
+  filter_set(:capybara_accessible_selectors, %i[aria described_by])
 end
 
 Capybara.add_selector :primer_text, locator_type: [String] do
@@ -100,6 +102,8 @@ Capybara.add_selector :primer_text, locator_type: [String] do
   describe_expression_filters do |color: nil, **|
     " with color #{color.inspect}" if color
   end
+
+  filter_set(:capybara_accessible_selectors, %i[aria described_by])
 end
 
 Capybara.add_selector :octicon, locator_type: [String, Symbol] do
@@ -121,6 +125,8 @@ Capybara.add_selector :octicon, locator_type: [String, Symbol] do
     desc << (size.is_a?(Numeric) ? " with size #{size}px" : " with #{size.inspect} size") if size.present?
     desc
   end
+
+  filter_set(:capybara_accessible_selectors, %i[aria described_by])
 end
 
 module Capybara

--- a/spec/support/shared/components/table_component.rb
+++ b/spec/support/shared/components/table_component.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_examples_for "rendering generic table" do |expected_headers_count: nil, expected_rows_count: nil|
+  with = []
+  with << "#{expected_headers_count} headers" if expected_headers_count
+  with << "#{expected_rows_count} rows" if expected_rows_count
+  with = with.any? ? " with #{with.to_sentence}" : ""
+
+  it "renders generic table#{with}" do
+    expect(rendered_component).to have_selector :table
+    if expected_headers_count
+      expect(rendered_component).to have_css("colgroup > col", count: expected_headers_count)
+                               .and have_css("thead th", count: expected_headers_count)
+    end
+    if expected_rows_count
+      expect(rendered_component).to have_css "tbody tr", count: expected_rows_count
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69437

# What are you trying to accomplish?

Fixes display of Enabled Projects in Admin > Webhooks table.

After discussion with @HDinger, we agreed that we should:

- always show either a project count or "all projects" in the Enabled Projects column.
- always show the full list of resources in the Event Resources column.
- use default formatting rather than a badge (Primer Label/Counter) for counts, etc.

## Screenshots

### Before

<img width="993" height="462" alt="Screenshot 2025-12-17 at 12 32 33" src="https://github.com/user-attachments/assets/a1cea093-67a4-402a-9cf6-327ab75ddab7" />

### After

<img width="990" height="458" alt="Screenshot 2025-12-17 at 12 32 07" src="https://github.com/user-attachments/assets/41cabba7-9df9-4e58-a3b3-f4c262ba910c" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
