### PR TITLE
[#69430] Show empty status bar for portfolis without sub-items

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -191,8 +191,7 @@
           data: {
             hover_card_trigger_target: "card",
             test_selector: "op-portfolios--hover-card-#{portfolio.id}"
-          },
-          justify_content: :space_between
+          }
         ) do |popover|
           popover.with_column(mr: 3) do
             sub_item_count = sub_statuses_with_percentages.sum { |s| s[:count] }

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -45,7 +45,7 @@
                 }
               )
             ) do |bar|
-              sub_statuses_with_percentages.each do |status|
+              sub_status_bar_contents.each do |status|
                 status => { code:, percentage: }
 
                 status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -73,9 +73,7 @@ module Portfolios
     end
 
     def render_sub_status_bar?
-      # When none of the descendants have a status set, there's nothing to show and we
-      # will return false. Additionally, we won't show the bar for archived portfolios.
-      !archived? && sub_statuses.keys.any?(&:present?)
+      !archived?
     end
 
     def sub_statuses_with_percentages
@@ -89,6 +87,14 @@ module Portfolios
             { code:, count:, percentage: }
           end
         end
+    end
+
+    def sub_status_bar_contents
+      if sub_statuses_with_percentages.empty?
+        [{ code: "not_set", percentage: 100 }]
+      else
+        sub_statuses_with_percentages
+      end
     end
 
     def sub_status_hover_card_id

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -33,6 +33,7 @@ $status_not-set: var(--progressBar-track-bgColor) // invisible background color
     max-width: 550px
     flex-wrap: wrap
     row-gap: var(--base-size-16, 1rem)
+    justify-content: space-evenly
 
     .op-bubble
       margin: auto

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -148,8 +148,11 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
         let(:status_code_a) { nil }
         let(:status_code_b) { nil }
 
-        it "does not render a progress bar" do
-          expect(subject).not_to have_test_selector("op-portfolios--sub-status-bar")
+        it "renders an empty status bar" do
+          expect(subject).to have_test_selector("op-portfolios--sub-status-bar")
+          expect(subject).to have_test_selector("op-portfolios--status-not_set")
+          expect(subject).not_to have_test_selector("op-portfolios--status-#{status_code_a}")
+          expect(subject).not_to have_test_selector("op-portfolios--status-#{status_code_b}")
         end
       end
 

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -194,10 +194,8 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
           portfolios_page.expect_status_bar_percentage(portfolio_a, "at_risk", "33.3", find_row: false)
 
           # The status bar shows a hover card on hover:
-          hover_card_selector = "op-portfolios--hover-card-#{portfolio_a.id}"
-          expect(page).not_to have_test_selector(hover_card_selector)
           page.find_test_selector("op-portfolios--sub-status-bar").hover
-          expect(page).to have_test_selector(hover_card_selector)
+          portfolios_page.expect_hover_card(portfolio_a, text: /3\ssub-items\s2\sOn track\s1\sAt risk/)
         end
 
         # Portfolio B has a child portfolio of its own:
@@ -216,14 +214,19 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
         portfolios_page.expect_status_bar_percentage(portfolio_b, "not_set", "33.3")
       end
 
-      it "does not show a status summary if no sub-item has a status" do
+      it "does show an empty status bar if no sub-item has a status" do
         # Statusless sub-item:
         create(:project, parent: portfolio_favorited)
         portfolios_page.visit!
 
         portfolios_page.within_row(portfolio_favorited) do
           expect(page).to have_text("1 project")
-          expect(page).not_to have_test_selector("op-portfolios--sub-status-bar")
+          expect(page).to have_test_selector("op-portfolios--sub-status-bar")
+
+          portfolios_page.expect_status_bar_percentage(portfolio_favorited, "not_set", "100.0", find_row: false)
+
+          page.find_test_selector("op-portfolios--sub-status-bar").hover
+          portfolios_page.expect_hover_card(portfolio_favorited, text: /1\ssub-item\s1\sNot set/)
         end
       end
     end

--- a/spec/support/pages/portfolios/index.rb
+++ b/spec/support/pages/portfolios/index.rb
@@ -158,6 +158,10 @@ module Pages
         page.find('[data-test-selector="portfolio-new-button"]').click
       end
 
+      def expect_hover_card(portfolio, options = {})
+        expect(page).to have_test_selector("op-portfolios--hover-card-#{portfolio.id}", **options)
+      end
+
       def sidebar_menu_items
         page.find_by_id("menu-sidebar").all(".op-submenu--item-title").map(&:text)
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69430

# What are you trying to accomplish?
The status bar should always be shown for active portfolios, even if there is no sub-item.

Drive by fix: use a better spacing solution for the elements within the status bar hover card. Depending on the sub-item statuses, the hover card looked off. It looks much better now for some previously problematic content constellations.

## Screenshots
<img width="923" height="406" alt="image" src="https://github.com/user-attachments/assets/cc7170a6-00aa-4367-9a92-d1b01b44e575" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
