### PR TITLE
[#69444] In autocompleters: Program icons wrong, text not muted

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -24,6 +24,7 @@
       >{{ item.name }}</div>
       @if (shouldShowWorkspaceTypeBadge(item)) {
         <div
+          class="color-fg-muted"
           [innerHTML]="workspaceTypeIconWithLabel(item)"
           style="flex-shrink: 0;"
         ></div>

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
@@ -38,7 +38,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
 import {
   toDOMString,
-  projectRoadmapIconData,
+  versionsIconData,
   briefcaseIconData,
   SVGData,
 } from '@openproject/octicons-angular';
@@ -80,7 +80,7 @@ export class ProjectAutocompleterTemplateComponent implements IAutocompleterTemp
   private workspaceTypeSVGData(workspaceType:string):SVGData|undefined {
     switch (workspaceType) {
       case 'Program': {
-        return projectRoadmapIconData;
+        return versionsIconData;
       }
       case 'Portfolio': {
         return briefcaseIconData;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69444

# What are you trying to accomplish?
Use the correct icon and mute text for the badge in autocompleters.

## Screenshots
<img width="805" height="263" alt="image" src="https://github.com/user-attachments/assets/cd74c9eb-9c7c-4410-ab8a-dfce0022f46a" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
