### PR TITLE
[68734] Low color contrast on Buy now button on enterprise banners

### DIFF
--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -54,7 +54,7 @@ $op-enterprise-banner-fixed-height-large: 320px
   grid-template-areas: "visual content dismiss"
   grid-template-columns: min-content 1fr min-content
   grid-template-rows: min-content
-  border: var(--borderWidth-thin) solid var(--borderColor-severe-muted)
+  border: var(--borderWidth-thin) solid var(--enterprise-upsell-color)
   border-radius: var(--borderRadius-medium)
   background: var(--body-background)
   padding: var(--base-size-8)

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -92,6 +92,7 @@
       --ck-color-labeled-field-label-background: var(--overlay-bgColor);
       --ck-color-input-disabled-background: var(--bgColor-disabled);
       --ck-color-link-default: var(--accent-color);
+      --enterprise-upsell-text-color: #D55400;
   }
 
   [data-dark-theme=dark_high_contrast] {

--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -92,7 +92,6 @@
       --ck-color-labeled-field-label-background: var(--overlay-bgColor);
       --ck-color-input-disabled-background: var(--bgColor-disabled);
       --ck-color-link-default: var(--accent-color);
-      --enterprise-upsell-text-color: var(--enterprise-upsell-color);
   }
 
   [data-dark-theme=dark_high_contrast] {

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -17,7 +17,7 @@
   .widget-box.upsell
     padding: 0
     flex-basis: 100%
-    border: var(--borderWidth-thin) solid var(--borderColor-severe-muted)
+    border: var(--borderWidth-thin) solid var(--enterprise-upsell-color)
     border-radius: var(--borderRadius-medium)
     background: var(--body-background)
     container-name: upsellContainer
@@ -25,7 +25,7 @@
 
 .widget-box--upsell-block
   margin-bottom: 1rem
-  border: var(--borderWidth-thin) solid var(--borderColor-severe-muted)
+  border: var(--borderWidth-thin) solid var(--enterprise-upsell-color)
   border-radius: var(--borderRadius-medium)
   background: var(--body-background)
   // Ensure the image does not overflow the container on the borders

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -41,12 +41,12 @@
   color: var(--enterprise-upsell-color) !important
 
 .upsell-colored-text
-  color: var(--enterprise-upsell-highlight-color) !important
+  color: var(--enterprise-upsell-color) !important
 
 .upsell-colored-background
-  background: var(--enterprise-upsell-highlight-color) !important
+  background: var(--enterprise-upsell-color) !important
   color: white !important
-  border-color: var(--enterprise-upsell-border-color) !important
+  border-color: var(--enterprise-upsell-color) !important
 
 .widget-box--blocks--upsell-title
   font-weight: 400

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -41,7 +41,7 @@
   color: var(--enterprise-upsell-color) !important
 
 .upsell-colored-text
-  color: var(--enterprise-upsell-color) !important
+  color: var(--enterprise-upsell-text-color) !important
 
 .upsell-colored-background
   background: var(--enterprise-upsell-color) !important

--- a/frontend/src/global_styles/content/_enterprise.sass
+++ b/frontend/src/global_styles/content/_enterprise.sass
@@ -41,10 +41,10 @@
   color: var(--enterprise-upsell-color) !important
 
 .upsell-colored-text
-  color: var(--enterprise-upsell-text-color) !important
+  color: var(--enterprise-upsell-highlight-color) !important
 
 .upsell-colored-background
-  background: var(--enterprise-upsell-color) !important
+  background: var(--enterprise-upsell-highlight-color) !important
   color: white !important
   border-color: var(--enterprise-upsell-border-color) !important
 

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -133,4 +133,5 @@
   --full-view-split-right-width: 550px;
   --gantt-split-width: 50%;
   --enterprise-upsell-color: #CE4C00;
+  --enterprise-upsell-text-color: #CE4C00;
 }

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -133,6 +133,6 @@
   --full-view-split-right-width: 550px;
   --gantt-split-width: 50%;
   --enterprise-upsell-color: #FB8F44;
-  --enterprise-upsell-text-color: #CE4C00;
+  --enterprise-upsell-highlight-color: #CE4C00;
   --enterprise-upsell-border-color: #fb8f4466;
 }

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -132,7 +132,5 @@
   --split-screen-width: 550px;
   --full-view-split-right-width: 550px;
   --gantt-split-width: 50%;
-  --enterprise-upsell-color: #FB8F44;
-  --enterprise-upsell-highlight-color: #CE4C00;
-  --enterprise-upsell-border-color: #fb8f4466;
+  --enterprise-upsell-color: #CE4C00;
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67834

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Use the darker orange HEX currently used for the text which pass accessibility test in light and dark modes

## Screenshots

<img width="462" height="172" alt="Screenshot 2025-11-28 at 10 42 05" src="https://github.com/user-attachments/assets/62da8966-0407-4443-b9e7-5248d621a528" />
<img width="451" height="170" alt="Screenshot 2025-11-28 at 10 41 45" src="https://github.com/user-attachments/assets/106229da-d5ba-4251-a0b1-eb6c2dfaac47" />
