### PR TITLE
[69359] Subitems overview widget can be navigated until blankslate + does not update URL

### DIFF
--- a/modules/grids/app/components/grids/widget_box_component.rb
+++ b/modules/grids/app/components/grids/widget_box_component.rb
@@ -73,7 +73,7 @@ module Grids
       @system_arguments[:id] ||= "#{key}-box"
 
       @turbo_enabled = turbo_enabled
-      @turbo_frame_arguments = { tag: :"turbo-frame", id: key }
+      @turbo_frame_arguments = { tag: :"turbo-frame", id: key, target: "_top" }
       @turbo_frame_arguments[:style] = "display:contents"
 
       @list_arguments = { tag: :ul }

--- a/modules/grids/spec/components/grids/widget_box_component_spec.rb
+++ b/modules/grids/spec/components/grids/widget_box_component_spec.rb
@@ -43,6 +43,6 @@ RSpec.describe Grids::WidgetBoxComponent, type: :component do
   end
 
   it "renders turbo-frame around content" do
-    expect(rendered_component).to have_element :"turbo-frame", id: "cool_widget"
+    expect(rendered_component).to have_element :"turbo-frame", id: "cool_widget", target: "_top"
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69359

# What are you trying to accomplish?
Fix frame target to allow actual navigation


