### PR TITLE
Temporarily ditch ics attachments

### DIFF
--- a/app/services/incoming_emails/dispatch_service.rb
+++ b/app/services/incoming_emails/dispatch_service.rb
@@ -147,7 +147,7 @@ module IncomingEmails
     # If the user is not found, we will handle using the given unkown_user option
     def determine_actor
       if sender_email.present?
-        @user = User.find_by_mail(sender_email) # rubocop:disable Rails/DynamicFindBy
+        @user = User.find_by_mail(sender_email)
       end
 
       # If the user is still not set, we have to deal with an unkonwn user
@@ -202,7 +202,7 @@ module IncomingEmails
     end
 
     def ignore_mail?
-      mail_from_system? || ignored_by_header? || ignored_user?
+      mail_from_system? || ignored_by_header? || ignored_user? || mail_with_ics_attachment?
     end
 
     def mail_from_system?
@@ -247,6 +247,16 @@ module IncomingEmails
       unless @user.active?
         log "ignoring email from non-active user [#{@user.login}]"
         true
+      end
+    end
+
+    def mail_with_ics_attachment?
+      if email.attachments.any? { |a| a.content_type.start_with?("text/calendar") } ||
+          (email.multipart? && email.parts.any? { |part| part.content_type.start_with?("text/calendar") })
+        log "ignoring email with calendar attachment from [#{sender_email}]"
+        true
+      else
+        false
       end
     end
 

--- a/spec/services/incoming_emails/dispatch_service_spec.rb
+++ b/spec/services/incoming_emails/dispatch_service_spec.rb
@@ -114,7 +114,12 @@ RSpec.describe IncomingEmails::DispatchService do
 
   describe "#ignore_mail?" do
     it "returns false by default" do
-      allow(service).to receive_messages(mail_from_system?: false, ignored_by_header?: false, ignored_user?: false)
+      allow(service).to receive_messages(
+        mail_from_system?: false,
+        ignored_by_header?: false,
+        ignored_user?: false,
+        mail_with_ics_attachment?: false
+      )
 
       expect(service.send(:ignore_mail?)).to be_falsey
     end
@@ -174,6 +179,46 @@ RSpec.describe IncomingEmails::DispatchService do
 
       it "returns false" do
         expect(service.send(:ignored_by_header?)).to be_falsey
+      end
+    end
+  end
+
+  describe "#mail_with_ics_attachment?" do
+    context "when the mail has no attachments and no part" do
+      it "returns false" do
+        allow(email).to receive(:attachments).and_return([])
+        allow(email).to receive(:multipart?).and_return(false)
+
+        expect(service.send(:mail_with_ics_attachment?)).to be_falsey
+      end
+    end
+
+    context "when the mail has a text/calendar attachment" do
+      let(:email) do
+        Mail.new do
+          from "somebody@example.com"
+          add_file filename: "reponse.ics", content: "BEGIN:VCALENDAR..."
+        end
+      end
+
+      it "logs a message and returns true" do
+        expect(service).to receive(:log).with(/ignoring email with calendar attachment from .*/)
+        expect(service.send(:mail_with_ics_attachment?)).to be_truthy
+      end
+    end
+
+    context "when the mail has a text/calendar part" do
+      let(:email) do
+        Mail.new do
+          from "somebody@example.com"
+          part content_type: "text/plain", body: "This is the body"
+          part content_type: "text/calendar", body: "BEGIN:VCALENDAR...", method: "REPLY"
+        end
+      end
+
+      it "logs a message and returns true" do
+        expect(service).to receive(:log).with(/ignoring email with calendar attachment from .*/)
+        expect(service.send(:mail_with_ics_attachment?)).to be_truthy
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/69361

# What are you trying to accomplish?
- When we get an incoming mail that is a meeting reply, we respond with an email that we cannot determine the project from the mail.
- Until we implement [Ticket #68453](https://community.openproject.org/projects/meetings-stream/work_packages/68453), we want to drop all emails with an ICS response

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
