### PR TITLE
[#68837] No longer possible to drag and drop Form Configuration after saving

### DIFF
--- a/frontend/src/app/features/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/features/admin/types/type-form-configuration.component.ts
@@ -35,6 +35,7 @@ export const emptyTypeGroup = '__empty';
   templateUrl: './type-form-configuration.html',
   providers: [
     TypeBannerService,
+    DragulaService
   ],
   standalone: false,
 })

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -34,6 +34,9 @@ export interface DraggableOption {
   templateUrl: './draggable-autocomplete.component.html',
   styleUrls: ['./draggable-autocomplete.component.sass'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    DragulaService
+  ],
   standalone: false,
 })
 export class DraggableAutocompleteComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68837

# What are you trying to accomplish?

Fix an  issue where drag and drop would no longer work after submitting the Form Configuration form.

# What approach did you choose and why?

`DragulaService` should be registered in `providers` (and will be scoped to the individual component). It is not registered globally by ng2-dragula. We could also register in `AppModule` ([as the README suggests](https://github.com/valor-software/ng2-dragula/blob/master/README.md#2-add-dragulamoduleforroot-to-your-application-module)), but since Angular is moving away form `@NgModule`, I decided not to go that route.

```ts
import { DragulaModule } from 'ng2-dragula';
@NgModule({
  imports: [
    ...,
    DragulaModule.forRoot()
  ],
})
export class AppModule { }
```

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
