### PR TITLE
[#69307] Portfolio details align vertically on mobile

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   flex_layout(**archived_style) do |flex|
     flex.with_row(mb: 2) do
-      flex_layout(align_items: :center) do |header|
+      flex_layout(classes: "op-portfolios--details-header") do |header|
         header.with_column(mr: 2) do
           if archived?
             render(Primer::Beta::Text.new(classes: "portfolio-name")) do
@@ -69,7 +69,7 @@
       end
     end
 
-    flex.with_row(mb: 2) do
+    flex.with_row(classes: "op-portfolios--description", mb: 2) do
       if @portfolio.description.blank?
         render(Primer::Beta::Text.new(color: :muted)) { t("create_project.blank_description") }
       else
@@ -78,7 +78,7 @@
     end
 
     flex.with_row do
-      flex_layout(align_items: :center) do |footer|
+      flex_layout(classes: "op-portfolios--details-footer") do |footer|
         unless archived?
           footer.with_column(mr: 3) do
             render(

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -37,3 +37,16 @@ $status_not-set: var(--progressBar-track-bgColor) // invisible background color
     .op-bubble
       margin: auto
       @include portfolio-sub-item-status-background-color
+
+  &--details-footer, &--details-header
+    align-items: center
+
+    @media screen and (max-width: $breakpoint-sm)
+      flex-direction: column !important
+      align-items: flex-start
+      row-gap: var(--base-size-16, 1rem)
+
+  &--description
+    @media screen and (max-width: $breakpoint-sm)
+      margin-top: var(--base-size-16, 1rem)
+      margin-bottom: var(--base-size-16, 1rem) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69307

Tried to vertically align the contents of the portfolio details view on mobile, so that there's enough space to accommodate all of our components.

This approach is not great, but it's better than the original, crammed style. Since we have no mobile design for this page, this makeshift solution could be good enough for now.

Compare old and new styles on mobile:

## Old
https://github.com/user-attachments/assets/608fd3eb-cf6e-4ab4-83dd-48fc16976f62


## New
https://github.com/user-attachments/assets/75894183-5624-475a-9978-520f05ebab63

