### PR TITLE
Portfolio view should not display sub-portfolios

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -99,26 +99,6 @@
             )
           end
 
-          if has_subportfolios?
-            footer.with_column(mr: 3) do
-              concat(
-                render(
-                  Primer::Beta::Octicon.new(
-                    icon: workspace_icon("portfolio"),
-                    align_self: :center,
-                    "aria-label": t("portfolio.count", count: all_subportfolios.count),
-                    mr: 1
-                  )
-                )
-              )
-              concat(
-                render(Primer::Beta::Text.new) do
-                  t("portfolio.count", count: all_subportfolios.count)
-                end
-              )
-            end
-          end
-
           footer.with_column(mr: 3) do
             concat(
               render(

--- a/app/components/portfolios/details_component.rb
+++ b/app/components/portfolios/details_component.rb
@@ -56,14 +56,6 @@ module Portfolios
       @currently_favorited ||= portfolio.favorited?
     end
 
-    def has_subportfolios?
-      all_subportfolios.present?
-    end
-
-    def all_subportfolios
-      all_descendants.portfolio
-    end
-
     def all_subprograms
       all_descendants.program
     end
@@ -104,7 +96,10 @@ module Portfolios
     private
 
     def all_descendants
-      @all_descendants ||= portfolio.descendants.visible
+      @all_descendants ||= portfolio
+                             .descendants
+                             .where(workspace_type: %w[project program])
+                             .visible
     end
 
     def sub_statuses

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -106,30 +106,9 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
       end
     end
 
-    context "when there are no child portfolios" do
-      describe "displays the number of child programs and projects" do
-        it { expect(subject).to have_text("2 programs") }
-        it { expect(subject).to have_text("5 projects") }
-
-        it { expect(subject).to have_no_text("0 portfolios") }
-      end
-    end
-
-    context "when there are child portfolios" do
-      before do
-        create(:portfolio, parent: portfolio).tap do |child_portfolio|
-          create(:program, parent: child_portfolio)
-        end
-
-        portfolio.reload
-      end
-
-      describe "displays the number of child programs and projects, including portfolios" do
-        it { expect(subject).to have_text("3 programs") }
-        it { expect(subject).to have_text("5 projects") }
-
-        it { expect(subject).to have_text("1 portfolio") }
-      end
+    describe "displays the number of child programs and projects" do
+      it { expect(subject).to have_text("2 programs") }
+      it { expect(subject).to have_text("5 projects") }
     end
 
     describe "portfolio status" do
@@ -187,14 +166,13 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
     it { expect(subject).to have_no_text("2 programs") }
     it { expect(subject).to have_no_text("5 projects") }
-    it { expect(subject).to have_no_text("0 portfolios") }
 
     it "renders the title as text" do
       expect(subject).to have_no_css(".portfolio-name.Link")
       expect(subject).to have_css(".portfolio-name", text: "#{portfolio.name} (Archived)")
     end
 
-    it "has to button to favor the portfolio" do
+    it "has a button to favor the portfolio" do
       expect(subject).not_to have_test_selector("op-portfolios--favorite-button")
     end
 

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -55,11 +55,6 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
       create(:project, parent: program_a, status_code: "on_track")
     end
 
-    create(:portfolio, parent: portfolio_b, status_code: "discontinued").tap do |portfolio_b_child|
-      create(:project, parent: portfolio_b_child, status_code: "not_started")
-      create(:project, parent: portfolio_b_child)
-    end
-
     portfolios_page.visit!
   end
 
@@ -77,7 +72,6 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
 
         expect(page).to have_text("2 projects")
         expect(page).to have_text("1 program")
-        expect(page).to have_no_text("0 portfolios")
       end
     end
 
@@ -141,7 +135,6 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
         expect(page).to have_no_test_selector("op-portfolios--favorite-button")
         expect(page).to have_no_test_selector("op-portfolios--sub-status-bar")
         expect(page).to have_no_test_selector("op-portfolios--status")
-        expect(page).to have_no_text("0 portfolios")
         expect(page).to have_no_text("0 projects")
         expect(page).to have_no_text("0 programs")
       end
@@ -197,21 +190,6 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
           page.find_test_selector("op-portfolios--sub-status-bar").hover
           portfolios_page.expect_hover_card(portfolio_a, text: /3\ssub-items\s2\sOn track\s1\sAt risk/)
         end
-
-        # Portfolio B has a child portfolio of its own:
-        portfolios_page.within_row(portfolio_b) do
-          expect(page).to have_text("1 portfolio")
-          expect(page).to have_text("0 programs")
-          expect(page).to have_text("2 projects")
-
-          expect(page).to have_test_selector("op-portfolios--sub-status-bar")
-        end
-
-        # Status of the child portfolio
-        portfolios_page.expect_status_bar_percentage(portfolio_b, "discontinued", "33.3")
-        # Status of a child project
-        portfolios_page.expect_status_bar_percentage(portfolio_b, "not_started", "33.3")
-        portfolios_page.expect_status_bar_percentage(portfolio_b, "not_set", "33.3")
       end
 
       it "does show an empty status bar if no sub-item has a status" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69468

# What are you trying to accomplish?
It is not possible for a portfolio to have a portfolio as a parent. Remove options to show such a state in the view.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
