### PR TITLE
[#68654] Confirmation dialog is shown even when no changes are made to the text  

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/meeting-agenda-item-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meeting-agenda-item-form.controller.ts
@@ -51,6 +51,13 @@ export default class extends Controller {
     useMeta(this, { suffix: false });
     this.focusInput();
     this.addNotes();
+    this.storeInitialValues();
+  }
+
+  storeInitialValues():void {
+    this.element.querySelectorAll('input[type="text"], input[type="number"]').forEach((input) => {
+      (input as HTMLInputElement).dataset.initialValue = (input as HTMLInputElement).value;
+    });
   }
 
   focusInput():void {

--- a/frontend/src/stimulus/helpers/meetings-helpers.ts
+++ b/frontend/src/stimulus/helpers/meetings-helpers.ts
@@ -41,8 +41,20 @@ export function appendCollapsedState(
 }
 
 export function hasUnsavedChanges():boolean {
-  const textInputs = Array.from(document.querySelectorAll('input[type="text"], input[type="number"]'));
-  const allTextSaved = textInputs.every((input) => (input as HTMLInputElement).value.trim().length === 0);
+  let hasTextChanges = false;
 
-  return !allTextSaved || window.OpenProject.pageWasEdited;
+  document.querySelectorAll('input[type="text"], input[type="number"]').forEach((input) => {
+    const currentValue = (input as HTMLInputElement).value;
+    const initialValue = (input as HTMLInputElement).dataset.initialValue;
+
+    if (initialValue === undefined) {
+      if (currentValue.trim().length > 0) {
+        hasTextChanges = true;
+      }
+    } else if (currentValue !== initialValue) {
+      hasTextChanges = true;
+    }
+  });
+
+  return hasTextChanges || window.OpenProject.pageWasEdited;
 }

--- a/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
+++ b/modules/meeting/spec/features/meetings_edit_agenda_spec.rb
@@ -87,4 +87,42 @@ RSpec.describe "Meetings edit agenda", :js do
       expect(show_page).to have_selector :rich_text, "Notes", text: "More notes..."
     end
   end
+
+  it "correctly tracks unsaved changes in agenda item forms (Bug #68654)" do
+    show_page.add_agenda_item do
+      fill_in "Title", with: "First Item"
+    end
+    show_page.add_agenda_item do
+      fill_in "Title", with: "Second Item"
+    end
+
+    show_page.expect_agenda_item title: "First Item"
+    show_page.expect_agenda_item title: "Second Item"
+    show_page.assert_agenda_order! "First Item", "Second Item"
+
+    first_item = MeetingAgendaItem.find_by(title: "First Item")
+    second_item = MeetingAgendaItem.find_by(title: "Second Item")
+
+    show_page.select_action(second_item, "Edit")
+
+    # No confirmation when title isn't changed
+    expect do
+      accept_confirm do
+        show_page.select_action(first_item, I18n.t(:label_sort_lowest))
+      end
+    end.to raise_error(Capybara::ModalNotFound)
+
+    show_page.assert_agenda_order! "Second Item", "First Item"
+
+    second_item.reload
+
+    show_page.edit_agenda_item(second_item, save: false) do
+      fill_in "Title", with: "Modified Second Item"
+    end
+
+    # Confirmation when title is changed
+    dismiss_confirm do
+      show_page.select_action(first_item, I18n.t(:label_sort_highest))
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/68654

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Only show the confirmation dialog when the agenda item title/duration has been changed on edit

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Compare against the original values instead of only checking for emptiness

# Merge checklist

- [x] Added/updated tests