### PR TITLE
use different ids for login form inputs in pulldown

### DIFF
--- a/app/forms/login_form.rb
+++ b/app/forms/login_form.rb
@@ -37,6 +37,7 @@ class LoginForm < ApplicationForm
 
     f.text_field(
       name: :username,
+      id: "username#{@id_suffix}",
       value: @username,
       autofocus: @username.blank?,
       label: User.human_attribute_name(:login),
@@ -46,6 +47,7 @@ class LoginForm < ApplicationForm
 
     f.text_field(
       name: :password,
+      id: "password#{@id_suffix}",
       type: :password,
       autofocus: @username.present?,
       label: User.human_attribute_name(:password),
@@ -55,6 +57,7 @@ class LoginForm < ApplicationForm
 
     if Setting::Autologin.enabled?
       f.check_box name: "autologin",
+                  id: "autologin#{@id_suffix}",
                   checked: false,
                   value: 1,
                   label: I18n.t("users.autologins.prompt",
@@ -85,9 +88,10 @@ class LoginForm < ApplicationForm
     end
   end
 
-  def initialize(back_url: nil, username: nil)
+  def initialize(back_url: nil, username: nil, id_suffix: nil)
     super()
     @back_url = back_url
     @username = username
+    @id_suffix = id_suffix
   end
 end

--- a/app/views/account/_login.html.erb
+++ b/app/views/account/_login.html.erb
@@ -33,7 +33,14 @@ See COPYRIGHT and LICENSE files for more details.
       url: { controller: "/account", action: "login" },
       method: :post
     ) do |form_builder|
-      render(LoginForm.new(form_builder, back_url: back_url_to_current_page, username: params[:username]))
+      render(
+        LoginForm.new(
+          form_builder,
+          back_url: back_url_to_current_page,
+          username: params[:username],
+          id_suffix: "-pulldown"
+        )
+      )
     end
   %>
 


### PR DESCRIPTION
Partial primerization of login form #20838 introduced a problem when login form is rendered multiple times on the page, like on /login page. The form uses same ids "username" and "password" for inputs in every render, which is not valid according to html spec, and leads to a problem using labels, as clicking them will focus wrong input. Also broke my userscript for simplifying login on dev, but that is the way I discovered the issue.

I added `-pulldown` suffix to inputs in pulldown form which was used before #20838