### PR TITLE
Format subject dates according to instance setting

### DIFF
--- a/app/models/work_package_types/patterns/token_property_mapper.rb
+++ b/app/models/work_package_types/patterns/token_property_mapper.rb
@@ -33,7 +33,7 @@ module WorkPackageTypes
     class TokenPropertyMapper
       STRING_OR_NIL = ->(v) { v&.to_s }
       ARRAY = ->(v) { v.compact.presence&.join(", ") }
-      DATE = ->(v) { v&.strftime("%Y-%m-%d") }
+      DATE = ->(v) { v&.strftime(Setting.date_format || "%Y-%m-%d") }
       DURATION = ->(v) { DurationConverter.output(v) }
 
       class << self
@@ -120,11 +120,13 @@ module WorkPackageTypes
       end
 
       def tokenize(custom_field_scope, prefix = nil)
-        custom_field_scope.pluck(:name, :id, :multi_value).map do |name, id, multiple|
+        custom_field_scope.pluck(:name, :id, :field_format, :multi_value).map do |name, id, format, multiple|
           formatter = if multiple
                         ARRAY
+                      elsif format == "date"
+                        DATE
                       else
-                        ->(v) { v.is_a?(Symbol) ? v : v&.to_s }
+                        ->(v) { v.is_a?(Symbol) ? v : STRING_OR_NIL.call(v) }
                       end
           AttributeToken.new(
             :"#{prefix}custom_field_#{id}",

--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -63,7 +63,7 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
 
     it "allows to manage hierarchy" do
       # Add parent
-      relations.add_parent(parent.id, parent)
+      relations.add_parent(parent)
       wp_page.expect_and_dismiss_toaster(message: "Successful update.")
       relations.expect_parent(parent)
       tabs.expect_counter(relations_tab, 1)
@@ -150,7 +150,7 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
 
         it "is able to link parent and children" do
           # Add parent
-          relations.add_parent(parent.id, parent)
+          relations.add_parent(parent)
           wp_page.expect_and_dismiss_toaster(message: "Successful update.")
           relations.expect_parent(parent)
           tabs.expect_counter(relations_tab, 3)

--- a/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
+++ b/spec/models/work_package_types/patterns/token_property_mapper_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       expect(token.call(work_package)).to eq("false")
     end
 
-    it "formats date custom fields correctly" do
+    it "formats date custom fields with a default format" do
       enabled, = subject
       token = enabled.detect do |t|
         t.key == :"custom_field_#{date_custom_field.id}"
@@ -174,6 +174,17 @@ RSpec.describe WorkPackageTypes::Patterns::TokenPropertyMapper do
       enabled, disabled = subject
       expect(detect(enabled, :"custom_field_#{cf.id}")).to be_nil
       expect(detect(disabled, :"custom_field_#{cf.id}")&.label).to eq(cf.name)
+    end
+
+    context "when defining an instance date format", with_settings: { date_format: "%d.%m.%Y" } do
+      it "formats date custom fields according to the instance date format" do
+        enabled, = subject
+        token = enabled.detect do |t|
+          t.key == :"custom_field_#{date_custom_field.id}"
+        end
+
+        expect(token.call(work_package)).to eq("03.10.2025")
+      end
     end
   end
 

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -307,7 +307,7 @@ module Components
         expect(page).to have_test_selector("no-relations-blankslate", text: "This work package does not have any relations yet.")
       end
 
-      def add_parent(query, work_package)
+      def add_parent(work_package)
         # Open the parent edit
         SeleniumHubWaiter.wait
         find(".wp-relation--parent-change").click
@@ -316,9 +316,8 @@ module Components
         SeleniumHubWaiter.wait
         autocomplete = page.find_test_selector("wp-relations-autocomplete")
         select_autocomplete autocomplete,
-                            query:,
-                            results_selector: ".ng-dropdown-panel-items",
-                            select_text: work_package.id
+                            query: work_package.subject,
+                            results_selector: ".ng-dropdown-panel-items"
       end
 
       def expect_parent(work_package)


### PR DESCRIPTION
We default to the ISO8601 format, if the instance
set no preference, but otherwise we use the instance's preference.

# Ticket
https://community.openproject.org/wp/63481