### PR TITLE
remove Setting.large_instance_wp_allowed_to_sql

### DIFF
--- a/app/models/work_packages/scopes/allowed_to.rb
+++ b/app/models/work_packages/scopes/allowed_to.rb
@@ -46,10 +46,8 @@ module WorkPackages::Scopes
           admin_allowed_to(permissions)
         elsif user.anonymous?
           anonymous_allowed_to(user, permissions)
-        elsif Setting.large_instance_wp_allowed_to_sql?
-          logged_in_non_admin_allowed_to_large_instances(user, permissions)
         else
-          logged_in_non_admin_allowed_to_small_instances(user, permissions)
+          logged_in_non_admin_allowed_to(user, permissions)
         end
       end
 
@@ -63,15 +61,7 @@ module WorkPackages::Scopes
         where(project_id: Project.allowed_to(user, permissions))
       end
 
-      def logged_in_non_admin_allowed_to_small_instances(user, permissions)
-        allowed_via_wp_membership = allowed_to_member_relation(user, permissions)
-        allowed_via_project_membership = Project.unscoped.allowed_to(user, permissions)
-
-        where(project_id: allowed_via_project_membership.select(:id))
-          .or(where(id: allowed_via_wp_membership.select(arel_table[:id])))
-      end
-
-      def logged_in_non_admin_allowed_to_large_instances(user, permissions)
+      def logged_in_non_admin_allowed_to(user, permissions)
         # Get all projects a user has the permissions in.
         # Permissions can come from project memberships as well as entity/work_package memberships, in addition
         # to (UNION) potentially the non-member permissions.
@@ -172,16 +162,6 @@ module WorkPackages::Scopes
           .where(Project.arel_table[:active].eq(true))
       end
 
-      def allowed_to_member_relation(user, permissions)
-        Member
-          .joins(allowed_to_member_in_work_package_join)
-          .joins(active_project_join)
-          .joins(allowed_to_enabled_module_join(permissions))
-          .joins(member_roles: :role)
-          .joins(allowed_to_role_permission_join(permissions))
-          .where(member_conditions(user))
-      end
-
       def allowed_to_enabled_module_join(permissions) # rubocop:disable Metrics/AbcSize
         project_module = permissions.filter_map(&:project_module).uniq
         enabled_module_table = EnabledModule.arel_table
@@ -194,51 +174,6 @@ module WorkPackages::Scopes
                           .and(projects_table[:active].eq(true)))
                     .join_sources
         end
-      end
-
-      def allowed_to_role_permission_join(permissions) # rubocop:disable Metrics/AbcSize
-        return if permissions.all?(&:public?)
-
-        role_permissions_table = RolePermission.arel_table
-        enabled_modules_table = EnabledModule.arel_table
-        roles_table = Role.arel_table
-
-        condition = permissions.inject(Arel::Nodes::False.new) do |or_condition, permission|
-          permission_condition = role_permissions_table[:permission].eq(permission.name)
-
-          if permission.project_module.present?
-            permission_condition = permission_condition.and(enabled_modules_table[:name].eq(permission.project_module))
-          end
-
-          or_condition.or(permission_condition)
-        end
-
-        arel_table
-          .join(role_permissions_table, Arel::Nodes::InnerJoin)
-          .on(roles_table[:id].eq(role_permissions_table[:role_id])
-                              .and(condition))
-          .join_sources
-      end
-
-      def active_project_join
-        projects_table = Project.arel_table
-        arel_table
-          .join(projects_table)
-                  .on(projects_table[:active].eq(true)
-                   .and(projects_table[:id].eq(arel_table[:project_id])))
-                  .join_sources
-      end
-
-      def allowed_to_member_in_work_package_join
-        members_table = Member.arel_table
-        arel_table.join(arel_table)
-        .on(members_table[:entity_id].eq(arel_table[:id]))
-        .join_sources
-      end
-
-      def member_conditions(user)
-        Member.arel_table[:user_id].eq(user.id)
-        .and(Member.arel_table[:entity_type].eq(model_name.name))
       end
     end
   end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -651,11 +651,6 @@ module Settings
       journal_aggregation_time_minutes: {
         default: 5
       },
-      large_instance_wp_allowed_to_sql: {
-        description: "When querying for allowed work packages, use SQL better suited for instances " \
-                     "with a larger set of work packages, projects, members and users",
-        default: true
-      },
       ldap_force_no_page: {
         description: "Force LDAP to respond as a single page, in case paged responses do not work with your server.",
         format: :string,

--- a/modules/costs/spec/models/time_entries/scopes/ongoing_spec.rb
+++ b/modules/costs/spec/models/time_entries/scopes/ongoing_spec.rb
@@ -39,25 +39,15 @@ RSpec.describe TimeEntries::Scopes::Ongoing do
 
   subject { TimeEntry.visible_ongoing(user) }
 
-  shared_context "for the default use case" do
-    context "when the user has log_own_time permission directly on the work package" do
-      let(:work_package_permissions) { [:log_own_time] }
+  context "when the user has log_own_time permission directly on the work package" do
+    let(:work_package_permissions) { [:log_own_time] }
 
-      before do
-        create(:member, project: project, entity: work_package, user:, roles: [work_package_role])
-      end
-
-      it "returns the visible, ongoing time entry" do
-        expect(subject).to contain_exactly(ongoing_time_entry)
-      end
+    before do
+      create(:member, project: project, entity: work_package, user:, roles: [work_package_role])
     end
-  end
 
-  context "in regular instances", with_settings: { large_instance_wp_allowed_to_sql: false } do
-    include_context "for the default use case"
-  end
-
-  context "in large instances", with_settings: { large_instance_wp_allowed_to_sql: true } do
-    include_context "for the default use case"
+    it "returns the visible, ongoing time entry" do
+      expect(subject).to contain_exactly(ongoing_time_entry)
+    end
   end
 end

--- a/modules/costs/spec/models/work_packages/scopes/allowed_to_log_time_spec.rb
+++ b/modules/costs/spec/models/work_packages/scopes/allowed_to_log_time_spec.rb
@@ -101,200 +101,190 @@ RSpec.describe WorkPackages::Scopes::AllowedToLogTime do
   context "when the user is a non admin, logged in user" do
     let(:user) { non_admin }
 
-    shared_context "for a non admin, logged in user" do
-      context "when the user has log_own_time permission directly on the work package" do
-        let(:work_package_permissions) { [:log_own_time] }
+    context "when the user has log_own_time permission directly on the work package" do
+      let(:work_package_permissions) { [:log_own_time] }
 
+      before do
+        create(:member,
+               project: private_project,
+               entity: work_package_in_private_project,
+               user:,
+               roles: [work_package_role])
+      end
+
+      it "returns the authorized work package" do
+        expect(subject).to contain_exactly(work_package_in_private_project)
+      end
+
+      context "when the project is archived" do
         before do
-          create(:member,
-                 project: private_project,
-                 entity: work_package_in_private_project,
-                 user:,
-                 roles: [work_package_role])
+          public_project.update!(active: false)
+          private_project.update!(active: false)
         end
 
-        it "returns the authorized work package" do
-          expect(subject).to contain_exactly(work_package_in_private_project)
-        end
-
-        context "when the project is archived" do
-          before do
-            public_project.update!(active: false)
-            private_project.update!(active: false)
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the module is inactive in the project" do
-          before do
-            public_project.enabled_modules = []
-            private_project.enabled_modules = []
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the user is locked" do
-          before do
-            user.locked!
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
+        it "returns no work packages" do
+          expect(subject).to be_empty
         end
       end
 
-      context "when the user has the log_own_time permission on the project the work package belongs to" do
-        let(:project_permissions) { [:log_own_time] }
-
+      context "when the module is inactive in the project" do
         before do
-          create(:member,
-                 project: private_project,
-                 user:,
-                 roles: [project_role])
+          public_project.enabled_modules = []
+          private_project.enabled_modules = []
         end
 
-        it "returns the authorized work packages" do
-          expect(subject).to contain_exactly(
-            work_package_in_private_project,
-            other_work_package_in_private_project
-          )
-        end
-
-        context "when the project is archived" do
-          before do
-            public_project.update!(active: false)
-            private_project.update!(active: false)
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the module is inactive in the project" do
-          before do
-            public_project.enabled_modules = []
-            private_project.enabled_modules = []
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the user is locked" do
-          before do
-            user.locked!
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
+        it "returns no work packages" do
+          expect(subject).to be_empty
         end
       end
 
-      context "when the user has the log_time permission on the project the work package belongs to" do
-        let(:project_permissions) { [:log_time] }
-
+      context "when the user is locked" do
         before do
-          create(:member,
-                 project: private_project,
-                 user:,
-                 roles: [project_role])
+          user.locked!
         end
 
-        it "returns the authorized work packages" do
-          expect(subject).to contain_exactly(
-            work_package_in_private_project,
-            other_work_package_in_private_project
-          )
-        end
-
-        context "when the project is archived" do
-          before do
-            public_project.update!(active: false)
-            private_project.update!(active: false)
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the module is inactive in the project" do
-          before do
-            public_project.enabled_modules = []
-            private_project.enabled_modules = []
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the user is locked" do
-          before do
-            user.locked!
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-      end
-
-      context "when the user has a different permission on the project, but log_own_time on a specific work package" do
-        let(:project_permissions) { [:view_work_packages] }
-        let(:work_package_permissions) { %i[log_own_time] }
-
-        before do
-          create(:member, project: private_project, entity: work_package_in_private_project, user:, roles: [work_package_role])
-          create(:member, project: private_project, user:, roles: [project_role])
-        end
-
-        it "returns the authorized work packages" do
-          expect(subject).to contain_exactly(
-            work_package_in_private_project
-          )
-        end
-      end
-
-      context "when the user isn`t member in the project" do
-        before do
-          non_member_role.save!
-        end
-
-        context "with the non member role having the permission" do
-          let(:non_member_permissions) { [:log_own_time] }
-
-          it "returns work packages in the public project" do
-            expect(subject).to contain_exactly(work_package_in_public_project)
-          end
-        end
-
-        context "with the non member role lacking the permission" do
-          let(:non_member_permissions) { [] }
-
-          it "is empty" do
-            expect(subject).to be_empty
-          end
+        it "returns no work packages" do
+          expect(subject).to be_empty
         end
       end
     end
 
-    context "in non large instances", with_settings: { large_instance_wp_allowed_to_sql: false } do
-      include_context "for a non admin, logged in user"
+    context "when the user has the log_own_time permission on the project the work package belongs to" do
+      let(:project_permissions) { [:log_own_time] }
+
+      before do
+        create(:member,
+               project: private_project,
+               user:,
+               roles: [project_role])
+      end
+
+      it "returns the authorized work packages" do
+        expect(subject).to contain_exactly(
+          work_package_in_private_project,
+          other_work_package_in_private_project
+        )
+      end
+
+      context "when the project is archived" do
+        before do
+          public_project.update!(active: false)
+          private_project.update!(active: false)
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the module is inactive in the project" do
+        before do
+          public_project.enabled_modules = []
+          private_project.enabled_modules = []
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the user is locked" do
+        before do
+          user.locked!
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
     end
 
-    context "in large instances", with_settings: { large_instance_wp_allowed_to_sql: true } do
-      include_context "for a non admin, logged in user"
+    context "when the user has the log_time permission on the project the work package belongs to" do
+      let(:project_permissions) { [:log_time] }
+
+      before do
+        create(:member,
+               project: private_project,
+               user:,
+               roles: [project_role])
+      end
+
+      it "returns the authorized work packages" do
+        expect(subject).to contain_exactly(
+          work_package_in_private_project,
+          other_work_package_in_private_project
+        )
+      end
+
+      context "when the project is archived" do
+        before do
+          public_project.update!(active: false)
+          private_project.update!(active: false)
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the module is inactive in the project" do
+        before do
+          public_project.enabled_modules = []
+          private_project.enabled_modules = []
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the user is locked" do
+        before do
+          user.locked!
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+    end
+
+    context "when the user has a different permission on the project, but log_own_time on a specific work package" do
+      let(:project_permissions) { [:view_work_packages] }
+      let(:work_package_permissions) { %i[log_own_time] }
+
+      before do
+        create(:member, project: private_project, entity: work_package_in_private_project, user:, roles: [work_package_role])
+        create(:member, project: private_project, user:, roles: [project_role])
+      end
+
+      it "returns the authorized work packages" do
+        expect(subject).to contain_exactly(
+          work_package_in_private_project
+        )
+      end
+    end
+
+    context "when the user isn`t member in the project" do
+      before do
+        non_member_role.save!
+      end
+
+      context "with the non member role having the permission" do
+        let(:non_member_permissions) { [:log_own_time] }
+
+        it "returns work packages in the public project" do
+          expect(subject).to contain_exactly(work_package_in_public_project)
+        end
+      end
+
+      context "with the non member role lacking the permission" do
+        let(:non_member_permissions) { [] }
+
+        it "is empty" do
+          expect(subject).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/models/work_packages/scopes/allowed_to_spec.rb
+++ b/spec/models/work_packages/scopes/allowed_to_spec.rb
@@ -120,163 +120,153 @@ RSpec.describe WorkPackage, ".allowed_to" do
   end
 
   context "when the user is a non admin, logged in user" do
-    shared_context "for a non admin, logged in user" do
-      context "when the user has the permission directly on the work package" do
-        let(:work_package_permissions) { [action] }
+    context "when the user has the permission directly on the work package" do
+      let(:work_package_permissions) { [action] }
 
+      before do
+        create(:member, project: private_project, entity: work_package_in_private_project,
+                        user:, roles: [work_package_role])
+      end
+
+      subject { described_class.allowed_to(user, action) }
+
+      it "returns the authorized work package" do
+        expect(subject).to contain_exactly(work_package_in_private_project)
+      end
+
+      context "when the project is archived" do
         before do
-          create(:member, project: private_project, entity: work_package_in_private_project,
-                          user:, roles: [work_package_role])
+          public_project.update!(active: false)
+          private_project.update!(active: false)
         end
 
-        subject { described_class.allowed_to(user, action) }
-
-        it "returns the authorized work package" do
-          expect(subject).to contain_exactly(work_package_in_private_project)
-        end
-
-        context "when the project is archived" do
-          before do
-            public_project.update!(active: false)
-            private_project.update!(active: false)
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the module is inactive in the project" do
-          before do
-            public_project.enabled_modules = []
-            private_project.enabled_modules = []
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the user is locked" do
-          before do
-            user.locked!
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
+        it "returns no work packages" do
+          expect(subject).to be_empty
         end
       end
 
-      context "when the user has the permission on the project the work package belongs to" do
-        let(:project_permissions) { [action] }
-
+      context "when the module is inactive in the project" do
         before do
-          create(:member, project: private_project, user:, roles: [project_role])
+          public_project.enabled_modules = []
+          private_project.enabled_modules = []
         end
 
-        subject { described_class.allowed_to(user, action) }
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the user is locked" do
+        before do
+          user.locked!
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+    end
+
+    context "when the user has the permission on the project the work package belongs to" do
+      let(:project_permissions) { [action] }
+
+      before do
+        create(:member, project: private_project, user:, roles: [project_role])
+      end
+
+      subject { described_class.allowed_to(user, action) }
+
+      it "returns the authorized work packages" do
+        expect(subject).to contain_exactly(
+          work_package_in_private_project,
+          other_work_package_in_private_project
+        )
+      end
+
+      context "when the project is archived" do
+        before do
+          public_project.update!(active: false)
+          private_project.update!(active: false)
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the module is inactive in the project" do
+        before do
+          public_project.enabled_modules = []
+          private_project.enabled_modules = []
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when the user is locked" do
+        before do
+          user.locked!
+        end
+
+        it "returns no work packages" do
+          expect(subject).to be_empty
+        end
+      end
+    end
+
+    context "when the user has a different permission on the project, but the requested one on a specific work package" do
+      let(:project_permissions) { [:view_work_packages] }
+      let(:work_package_permissions) { %i[view_work_packages edit_work_packages] }
+
+      before do
+        create(:member, project: private_project, entity: work_package_in_private_project, user:, roles: [work_package_role])
+        create(:member, project: private_project, user:, roles: [project_role])
+      end
+
+      context "and requesting a permission that is only granted on the single work package" do
+        subject { described_class.allowed_to(user, :edit_work_packages) }
 
         it "returns the authorized work packages" do
-          expect(subject).to contain_exactly(
-            work_package_in_private_project,
-            other_work_package_in_private_project
-          )
-        end
-
-        context "when the project is archived" do
-          before do
-            public_project.update!(active: false)
-            private_project.update!(active: false)
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the module is inactive in the project" do
-          before do
-            public_project.enabled_modules = []
-            private_project.enabled_modules = []
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
-        end
-
-        context "when the user is locked" do
-          before do
-            user.locked!
-          end
-
-          it "returns no work packages" do
-            expect(subject).to be_empty
-          end
+          expect(subject).to contain_exactly(work_package_in_private_project)
         end
       end
 
-      context "when the user has a different permission on the project, but the requested one on a specific work package" do
-        let(:project_permissions) { [:view_work_packages] }
-        let(:work_package_permissions) { %i[view_work_packages edit_work_packages] }
+      context "and requesting a permission that is granted on the project and the work package" do
+        subject { described_class.allowed_to(user, :view_work_packages) }
 
-        before do
-          create(:member, project: private_project, entity: work_package_in_private_project, user:, roles: [work_package_role])
-          create(:member, project: private_project, user:, roles: [project_role])
-        end
-
-        context "and requesting a permission that is only granted on the single work package" do
-          subject { described_class.allowed_to(user, :edit_work_packages) }
-
-          it "returns the authorized work packages" do
-            expect(subject).to contain_exactly(work_package_in_private_project)
-          end
-        end
-
-        context "and requesting a permission that is granted on the project and the work package" do
-          subject { described_class.allowed_to(user, :view_work_packages) }
-
-          it "returns the authorized work packages" do
-            expect(subject).to contain_exactly(work_package_in_private_project, other_work_package_in_private_project)
-          end
-        end
-      end
-
-      context "when the user isn`t member in the project" do
-        let(:user) { create(:user) }
-        let(:action) { :view_work_packages }
-
-        before do
-          non_member_role.save!
-        end
-
-        subject { described_class.allowed_to(user, action) }
-
-        context "with the non member role having the permission" do
-          let(:non_member_permissions) { [action] }
-
-          it "returns work packages in the public project" do
-            expect(subject).to contain_exactly(work_package_in_public_project)
-          end
-        end
-
-        context "with the non member role lacking the permission" do
-          let(:non_member_permissions) { [] }
-
-          it "is empty" do
-            expect(subject).to be_empty
-          end
+        it "returns the authorized work packages" do
+          expect(subject).to contain_exactly(work_package_in_private_project, other_work_package_in_private_project)
         end
       end
     end
 
-    context "in non large instances", with_settings: { large_instance_wp_allowed_to_sql: false } do
-      include_context "for a non admin, logged in user"
-    end
+    context "when the user isn`t member in the project" do
+      let(:user) { create(:user) }
+      let(:action) { :view_work_packages }
 
-    context "in large instances", with_settings: { large_instance_wp_allowed_to_sql: true } do
-      include_context "for a non admin, logged in user"
+      before do
+        non_member_role.save!
+      end
+
+      subject { described_class.allowed_to(user, action) }
+
+      context "with the non member role having the permission" do
+        let(:non_member_permissions) { [action] }
+
+        it "returns work packages in the public project" do
+          expect(subject).to contain_exactly(work_package_in_public_project)
+        end
+      end
+
+      context "with the non member role lacking the permission" do
+        let(:non_member_permissions) { [] }
+
+        it "is empty" do
+          expect(subject).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v3/work_packages/index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/index_resource_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe "API v3 Work package resource",
       end
     end
 
-    shared_examples_for "when providing timestamps", with_ee: %i[baseline_comparison] do
+    context "when providing timestamps", with_ee: %i[baseline_comparison] do
       subject do
         get path
         last_response
@@ -1349,14 +1349,6 @@ RSpec.describe "API v3 Work package resource",
           end
         end
       end
-    end
-
-    context "without large_instance_wp_allowed_to_sql active", with_settings: { large_instance_wp_allowed_to_sql: false } do
-      it_behaves_like "when providing timestamps"
-    end
-
-    context "with large_instance_wp_allowed_to_sql active", with_settings: { large_instance_wp_allowed_to_sql: true } do
-      it_behaves_like "when providing timestamps"
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68675

# What are you trying to accomplish?

Remove the setting introduced at a point in time the reworked allowed_to sql wasn't the default yet.

# Merge checklist

- [x] Added/updated tests
