### PR TITLE
[#69495] The Project Initiation Request fails due to required wp field

### DIFF
--- a/app/services/projects/create_artifact_work_package_service.rb
+++ b/app/services/projects/create_artifact_work_package_service.rb
@@ -142,7 +142,7 @@ module Projects
       }
 
       create_params[:attachments] = [pdf_attachment] if store_attachment_locally?
-      WorkPackages::CreateService.new(user:).call(create_params)
+      WorkPackages::CreateService.new(user:, contract_options: { skip_custom_field_validation: true }).call(create_params)
     end
 
     def journal_notes

--- a/app/services/work_packages/create_service.rb
+++ b/app/services/work_packages/create_service.rb
@@ -32,12 +32,13 @@ class WorkPackages::CreateService < BaseServices::BaseCallable
   include ::WorkPackages::Shared::UpdateAncestors
   include ::Shared::ServiceContext
 
-  attr_reader :user, :contract_class
+  attr_reader :user, :contract_class, :contract_options
 
-  def initialize(user:, contract_class: WorkPackages::CreateContract)
+  def initialize(user:, contract_class: WorkPackages::CreateContract, contract_options: {})
     super()
     @user = user
     @contract_class = contract_class
+    @contract_options = contract_options
   end
 
   def perform
@@ -84,7 +85,7 @@ class WorkPackages::CreateService < BaseServices::BaseCallable
   end
 
   def set_attributes(attributes, work_package)
-    attributes_service_class.new(user:, model: work_package, contract_class:).call(attributes)
+    attributes_service_class.new(user:, model: work_package, contract_class:, contract_options:).call(attributes)
   end
 
   def reschedule_related(work_package)

--- a/spec/services/projects/create_artifact_work_package_service_spec.rb
+++ b/spec/services/projects/create_artifact_work_package_service_spec.rb
@@ -298,6 +298,30 @@ RSpec.describe Projects::CreateArtifactWorkPackageService do
       end
     end
 
+    context "with required work package custom fields" do
+      shared_let(:required_wp_custom_field) do
+        create(:work_package_custom_field,
+               field_format: "string",
+               name: "Required Field",
+               is_required: true,
+               projects: [project],
+               types: [type])
+      end
+
+      it "bypasses custom field validation and creates the artifact work package" do
+        result = instance.call
+
+        expect(result).to be_success
+        expect(result.errors.full_messages).to be_empty
+        project = result.result
+        expect(project.project_creation_wizard_artifact_work_package_id).to be_present
+
+        artifact_work_package = WorkPackage.find(project.project_creation_wizard_artifact_work_package_id)
+        expect(artifact_work_package).to be_persisted
+        expect(artifact_work_package.custom_value_for(required_wp_custom_field)&.value).to be_blank
+      end
+    end
+
     describe "notification email" do
       context "when confirmation email is enabled" do
         before do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69495

# What are you trying to accomplish?
Disable required custom field validation when creating artifact work packages.

# What approach did you choose and why?
Use the existing `contract_options: { skip_custom_field_validation: true }` to disable validations in the `Projects::CreateArtifactWorkPackageService#create_artifact_work_package`

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
