### PR TITLE
Bug/69483 timer cannot be started if log time modal has a mandatory field

### DIFF
--- a/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
+++ b/lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb
@@ -52,7 +52,24 @@ module Redmine
              validate: false,
              autosave: true
 
-          validation_options = options[:validate_on] ? { on: options[:validate_on] } : {}
+          validation_options = {}
+
+          if options[:validate_on]
+            validation_options[:on] = options[:validate_on]
+          end
+
+          if options[:validate_except_on]
+            validation_options[:except_on] = options[:validate_except_on]
+          end
+
+          if options[:validate_if]
+            validation_options[:if] = options[:validate_if]
+          end
+
+          if options[:validate_unless]
+            validation_options[:unless] = options[:validate_unless]
+          end
+
           validate :validate_custom_values, **validation_options
           send :include, Redmine::Acts::Customizable::InstanceMethods
 

--- a/modules/costs/app/models/time_entry.rb
+++ b/modules/costs/app/models/time_entry.rb
@@ -44,7 +44,7 @@ class TimeEntry < ApplicationRecord
   MAX_TIME = (60 * 24) - 1 # => 23:59
   SECONDS_PER_HOUR = 3600.0
 
-  acts_as_customizable
+  acts_as_customizable validate_unless: ->(te) { te.new_record? && te.ongoing? }
 
   acts_as_journalized
 

--- a/modules/costs/spec/models/time_entry_spec.rb
+++ b/modules/costs/spec/models/time_entry_spec.rb
@@ -663,5 +663,64 @@ RSpec.describe TimeEntry do
             comments: "lorem")
     end
     let!(:custom_field) { create(:time_entry_custom_field, :string, is_required: false) }
+
+    context "with a required custom field" do
+      let!(:custom_field) { create(:time_entry_custom_field, :string, is_required: true) }
+
+      before do
+        new_model_instance.activate_custom_field_validations!
+      end
+
+      context "for a new not-ongoing entry" do
+        let!(:new_model_instance) do
+          build(:time_entry, entity: work_package, spent_on: date, hours:, user:, ongoing: false)
+        end
+
+        it "validates presence of the custom field" do
+          new_model_instance.custom_field_values = { custom_field.id => nil }
+          expect(new_model_instance).not_to be_valid
+
+          new_model_instance.custom_field_values = { custom_field.id => "Some value" }
+          expect(new_model_instance).to be_valid
+        end
+      end
+
+      context "for a new ongoing entry" do
+        let!(:new_model_instance) do
+          build(:time_entry, entity: work_package, spent_on: date, hours:, user:, ongoing: true)
+        end
+
+        it "does not validate presence of the custom field" do
+          new_model_instance.custom_field_values = { custom_field.id => nil }
+          expect(new_model_instance).to be_valid
+        end
+      end
+
+      context "for a persisted not-ongoing entry" do
+        let!(:new_model_instance) do
+          create(:time_entry, entity: work_package, spent_on: date, hours:, user:, ongoing: false)
+        end
+
+        it "validates presence of the custom field" do
+          new_model_instance.custom_field_values = { custom_field.id => nil }
+
+          expect(new_model_instance).not_to be_valid
+
+          new_model_instance.custom_field_values = { custom_field.id => "Some value" }
+          expect(new_model_instance).to be_valid
+        end
+      end
+
+      context "for a persisted ongoing entry" do
+        let!(:new_model_instance) do
+          create(:time_entry, entity: work_package, spent_on: date, hours:, user:, ongoing: true)
+        end
+
+        it "validates presence of the custom field" do
+          new_model_instance.custom_field_values = { custom_field.id => nil }
+          expect(new_model_instance).not_to be_valid
+        end
+      end
+    end
   end
 end

--- a/spec/lib/redmine/acts/customizable_validation_skipping_spec.rb
+++ b/spec/lib/redmine/acts/customizable_validation_skipping_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Redmine::Acts::Customizable, "validation skipping" do
+  let(:klass) do
+    Class.new(ApplicationRecord) do
+      include Redmine::Acts::Customizable
+
+      # Just setting it to some existing table to avoid problems
+      self.table_name = "users"
+      def self.name = "CustomizableModelForSpec"
+    end
+  end
+
+  describe ".acts_as_customizable" do
+    # rubocop:disable RSpec/MessageSpies
+    context "with :validate_on option" do
+      it "calls the validation with on: option" do
+        expect(klass).to receive(:validate).with(:validate_custom_values, on: :update)
+        klass.acts_as_customizable validate_on: :update
+      end
+    end
+
+    context "with :validate_except_on option" do
+      it "calls the validation with except: option" do
+        expect(klass).to receive(:validate).with(:validate_custom_values, except_on: :create)
+        klass.acts_as_customizable validate_except_on: :create
+      end
+    end
+
+    context "with :validate_if option" do
+      it "calls the validation with if: option" do
+        condition = ->(model) { model.some_condition? }
+        expect(klass).to receive(:validate).with(:validate_custom_values, if: condition)
+        klass.acts_as_customizable validate_if: condition
+      end
+    end
+
+    context "with :validate_unless option" do
+      it "calls the validation with unless: option" do
+        condition = ->(model) { model.some_condition? }
+        expect(klass).to receive(:validate).with(:validate_custom_values, unless: condition)
+        klass.acts_as_customizable validate_unless: condition
+      end
+    end
+    # rubocop:enable RSpec/MessageSpies
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/69483/activity

# What are you trying to accomplish?
- We already allow setting `:validate_on` option on `acts_as_customizable` to forward it as the `on:` option on the validation
- This PR adds all the other validation options (`:except_on`, `:if` and `:unless`) as well
- Uses the new `unless` option on the `TimeEntry` to skip validation for creating ongoing timers.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
