### PR TITLE
Bug/69450 complete specs for autocompleter changes

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
+++ b/frontend/src/app/shared/components/autocompleter/openproject-autocompleter.module.ts
@@ -61,6 +61,7 @@ import {
 import {
   ProjectPhaseAutocompleterComponent,
 } from './project-phase-autocompleter/project-phase-autocompleter.component';
+import { IconModule } from 'core-app/shared/components/icon/icon.module';
 
 export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
   CreateAutocompleterComponent,
@@ -95,6 +96,7 @@ export const OPENPROJECT_AUTOCOMPLETE_COMPONENTS = [
     DynamicModule,
     OpenprojectPrincipalRenderingModule,
     InviteUserButtonModule,
+    IconModule,
   ],
   exports: OPENPROJECT_AUTOCOMPLETE_COMPONENTS,
   declarations: OPENPROJECT_AUTOCOMPLETE_COMPONENTS,

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -11,7 +11,7 @@
       (click)="clear(item)"
       (keydown.enter)="clear(item)"
     >×</span>
-    <span class="ng-value-label d-flex gap-1">
+    <span class="ng-value-label d-flex gap-2">
       <span class="ellipsis">{{ item.name }}</span>
       @switch (item._type) {
         @case ('Portfolio') {
@@ -40,7 +40,7 @@
     class="ng-option-label"
     [ngStyle]="{ 'padding-left.px': item.numberOfAncestors * 16 }"
   >
-    <span class="d-flex gap-1">
+    <span class="d-flex gap-2">
       <span
         [title]="item.name"
         class="ellipsis"

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -7,11 +7,19 @@
     <span class="ng-value-icon left" (click)="clear(item)">×</span>
     <span class="ng-value-label d-flex gap-1">
       <span class="ellipsis">{{ item.name }}</span>
-      @if (shouldShowWorkspaceTypeBadge(item)) {
-        <span
-          class="color-fg-muted flex-shrink-0"
-          [innerHTML]="workspaceTypeIconWithLabel(item)"
-        ></span>
+      @switch (item._type) {
+        @case ('Portfolio') {
+          <span class="color-fg-muted flex-shrink-0">
+            <svg versions-icon size="small" />
+            {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+          </span>
+        }
+        @case ('Program') {
+          <span class="color-fg-muted flex-shrink-0">
+            <svg briefcase-icon size="small" />
+            {{ this.I18n.t('js.include_workspaces.types.program') }}
+          </span>
+        }
       }
     </span>
   </span>
@@ -32,11 +40,19 @@
         class="ellipsis"
         [opSearchHighlight]="search"
       >{{ item.name }}</span>
-      @if (shouldShowWorkspaceTypeBadge(item)) {
-        <span
-          class="color-fg-muted flex-shrink-0"
-          [innerHTML]="workspaceTypeIconWithLabel(item)"
-        ></span>
+      @switch (item._type) {
+        @case ('Portfolio') {
+          <span class="color-fg-muted flex-shrink-0">
+            <svg versions-icon size="small" />
+            {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+          </span>
+        }
+        @case ('Program') {
+          <span class="color-fg-muted flex-shrink-0">
+            <svg briefcase-icon size="small" />
+            {{ this.I18n.t('js.include_workspaces.types.program') }}
+          </span>
+        }
       }
     </span>
   </div>

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -10,6 +10,8 @@
       role="button"
       (click)="clear(item)"
       (keydown.enter)="clear(item)"
+      (keydown.space)="$event.preventDefault(); clear(item)"
+      [attr.aria-label]="this.I18n.t('js.autocomplete_select.remove', { name: item.name })"
     >×</span>
     <span class="ng-value-label d-flex gap-2">
       <span class="ellipsis">{{ item.name }}</span>

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -15,18 +15,20 @@
     >×</span>
     <span class="ng-value-label d-flex gap-2">
       <span class="ellipsis">{{ item.name }}</span>
-      @switch (item._type) {
-        @case ('Portfolio') {
-          <span class="color-fg-muted flex-shrink-0">
-            <svg briefcase-icon size="small" />
-            {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
-          </span>
-        }
-        @case ('Program') {
-          <span class="color-fg-muted flex-shrink-0">
-            <svg versions-icon size="small" />
-            {{ this.I18n.t('js.include_workspaces.types.program') }}
-          </span>
+      @if (portfolioModelsEnabled) {
+        @switch (item._type) {
+          @case ('Portfolio') {
+            <span class="color-fg-muted flex-shrink-0">
+              <svg briefcase-icon size="small" />
+              {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+            </span>
+          }
+          @case ('Program') {
+            <span class="color-fg-muted flex-shrink-0">
+              <svg versions-icon size="small" />
+              {{ this.I18n.t('js.include_workspaces.types.program') }}
+            </span>
+          }
         }
       }
     </span>
@@ -48,18 +50,20 @@
         class="ellipsis"
         [opSearchHighlight]="search"
       >{{ item.name }}</span>
-      @switch (item._type) {
-        @case ('Portfolio') {
-          <span class="color-fg-muted flex-shrink-0">
-            <svg briefcase-icon size="small" />
-            {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
-          </span>
-        }
-        @case ('Program') {
-          <span class="color-fg-muted flex-shrink-0">
-            <svg versions-icon size="small" />
-            {{ this.I18n.t('js.include_workspaces.types.program') }}
-          </span>
+      @if (portfolioModelsEnabled) {
+        @switch (item._type) {
+          @case ('Portfolio') {
+            <span class="color-fg-muted flex-shrink-0">
+              <svg briefcase-icon size="small" />
+              {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+            </span>
+          }
+          @case ('Program') {
+            <span class="color-fg-muted flex-shrink-0">
+              <svg versions-icon size="small" />
+              {{ this.I18n.t('js.include_workspaces.types.program') }}
+            </span>
+          }
         }
       }
     </span>

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -16,13 +16,13 @@
       @switch (item._type) {
         @case ('Portfolio') {
           <span class="color-fg-muted flex-shrink-0">
-            <svg versions-icon size="small" />
+            <svg briefcase-icon size="small" />
             {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
           </span>
         }
         @case ('Program') {
           <span class="color-fg-muted flex-shrink-0">
-            <svg briefcase-icon size="small" />
+            <svg versions-icon size="small" />
             {{ this.I18n.t('js.include_workspaces.types.program') }}
           </span>
         }
@@ -49,13 +49,13 @@
       @switch (item._type) {
         @case ('Portfolio') {
           <span class="color-fg-muted flex-shrink-0">
-            <svg versions-icon size="small" />
+            <svg briefcase-icon size="small" />
             {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
           </span>
         }
         @case ('Program') {
           <span class="color-fg-muted flex-shrink-0">
-            <svg briefcase-icon size="small" />
+            <svg versions-icon size="small" />
             {{ this.I18n.t('js.include_workspaces.types.program') }}
           </span>
         }

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -4,7 +4,13 @@
   let-clear="clear"
   >
   <span class="d-flex">
-    <span class="ng-value-icon left" (click)="clear(item)">×</span>
+    <span
+      class="ng-value-icon left"
+      tabindex="0"
+      role="button"
+      (click)="clear(item)"
+      (keydown.enter)="clear(item)"
+    >×</span>
     <span class="ng-value-label d-flex gap-1">
       <span class="ellipsis">{{ item.name }}</span>
       @switch (item._type) {

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -4,7 +4,16 @@
   let-clear="clear"
   >
   <span class="ng-value-icon left" (click)="clear(item)">×</span>
-  <span class="ng-value-label">{{ item.name }}</span>
+  <span class="ng-value-label" style="display: flex; gap: 0.5rem;">
+    <span class="ellipsis">{{ item.name }}</span>
+    @if (shouldShowWorkspaceTypeBadge(item)) {
+      <span
+        class="color-fg-muted"
+        [innerHTML]="workspaceTypeIconWithLabel(item)"
+        style="flex-shrink: 0;"
+      ></span>
+    }
+  </span>
 </ng-template>
 
 <ng-template

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.html
@@ -3,16 +3,17 @@
   let-item
   let-clear="clear"
   >
-  <span class="ng-value-icon left" (click)="clear(item)">×</span>
-  <span class="ng-value-label" style="display: flex; gap: 0.5rem;">
-    <span class="ellipsis">{{ item.name }}</span>
-    @if (shouldShowWorkspaceTypeBadge(item)) {
-      <span
-        class="color-fg-muted"
-        [innerHTML]="workspaceTypeIconWithLabel(item)"
-        style="flex-shrink: 0;"
-      ></span>
-    }
+  <span class="d-flex">
+    <span class="ng-value-icon left" (click)="clear(item)">×</span>
+    <span class="ng-value-label d-flex gap-1">
+      <span class="ellipsis">{{ item.name }}</span>
+      @if (shouldShowWorkspaceTypeBadge(item)) {
+        <span
+          class="color-fg-muted flex-shrink-0"
+          [innerHTML]="workspaceTypeIconWithLabel(item)"
+        ></span>
+      }
+    </span>
   </span>
 </ng-template>
 
@@ -25,20 +26,19 @@
     class="ng-option-label"
     [ngStyle]="{ 'padding-left.px': item.numberOfAncestors * 16 }"
   >
-    <div style="display: flex; gap: 0.5rem;">
-      <div
+    <span class="d-flex gap-1">
+      <span
         [title]="item.name"
         class="ellipsis"
         [opSearchHighlight]="search"
-      >{{ item.name }}</div>
+      >{{ item.name }}</span>
       @if (shouldShowWorkspaceTypeBadge(item)) {
-        <div
-          class="color-fg-muted"
+        <span
+          class="color-fg-muted flex-shrink-0"
           [innerHTML]="workspaceTypeIconWithLabel(item)"
-          style="flex-shrink: 0;"
-        ></div>
+        ></span>
       }
-    </div>
+    </span>
   </div>
   @if (item.disabled && item.disabledReason) {
     <div

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
@@ -33,6 +33,7 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
 
@@ -46,4 +47,7 @@ export class ProjectAutocompleterTemplateComponent implements IAutocompleterTemp
   @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
 
   readonly I18n = inject(I18nService);
+  readonly configuration = inject(ConfigurationService);
+
+  public portfolioModelsEnabled = this.configuration.activeFeatureFlags.includes('portfolioModels');
 }

--- a/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-autocompleter/project-autocompleter-template.component.ts
@@ -33,16 +33,8 @@ import {
   ViewChild,
   inject,
 } from '@angular/core';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IAutocompleterTemplateComponent } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
-import {
-  toDOMString,
-  versionsIconData,
-  briefcaseIconData,
-  SVGData,
-} from '@openproject/octicons-angular';
-import { IProjectAutocompleteItem } from './project-autocomplete-item';
 
 @Component({
   templateUrl: './project-autocompleter-template.component.html',
@@ -54,40 +46,4 @@ export class ProjectAutocompleterTemplateComponent implements IAutocompleterTemp
   @ViewChild('labelTemplate') labelTemplate?:TemplateRef<Element>;
 
   readonly I18n = inject(I18nService);
-  readonly sanitizer = inject(DomSanitizer);
-
-  shouldShowWorkspaceTypeBadge(project:IProjectAutocompleteItem):boolean {
-    return !!project._type && project._type !== 'Project';
-  }
-
-  workspaceTypeIconWithLabel(project:IProjectAutocompleteItem):SafeHtml {
-    const workspaceType = project._type;
-    if (!workspaceType) {
-      return '';
-    }
-
-    const iconData = this.workspaceTypeSVGData(workspaceType);
-    if (!iconData) {
-      return '';
-    }
-
-    const htmlString = toDOMString(iconData, 'small', { 'aria-hidden': 'true', class: 'octicon' });
-    const translatedTypeName = this.I18n.t(`js.include_workspaces.types.${workspaceType.toLowerCase()}`);
-    const iconWithText = htmlString + ' ' + translatedTypeName;
-    return this.sanitizer.bypassSecurityTrustHtml(iconWithText);
-  }
-
-  private workspaceTypeSVGData(workspaceType:string):SVGData|undefined {
-    switch (workspaceType) {
-      case 'Program': {
-        return versionsIconData;
-      }
-      case 'Portfolio': {
-        return briefcaseIconData;
-      }
-      default: {
-        return undefined;
-      }
-    }
-  }
 }

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -32,7 +32,20 @@
             ></svg>
           }
           @if (portfolioModelsEnabled) {
-            <span class="color-fg-muted" [innerHTML]="workspaceTypeIconWithLabel(project)"></span>
+            @switch (project._type) {
+              @case ('Portfolio') {
+                <span class="color-fg-muted">
+                  <svg versions-icon size="small" />
+                  {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+                </span>
+              }
+              @case ('Program') {
+                <span class="color-fg-muted">
+                  <svg briefcase-icon size="small" />
+                  {{ this.I18n.t('js.include_workspaces.types.program') }}
+                </span>
+              }
+            }
           }
         </span>
         @if (currentProjectService.id === project.id.toString()) {
@@ -60,7 +73,20 @@
           >
             <span>{{ project.name }}</span>
             @if (portfolioModelsEnabled) {
-              <span class="color-fg-muted" [innerHTML]="workspaceTypeIconWithLabel(project)"></span>
+              @switch (project._type) {
+                @case ('Portfolio') {
+                  <span class="color-fg-muted">
+                    <svg versions-icon size="small" />
+                    {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+                  </span>
+                }
+                @case ('Program') {
+                  <span class="color-fg-muted">
+                    <svg briefcase-icon size="small" />
+                    {{ this.I18n.t('js.include_workspaces.types.program') }}
+                  </span>
+                }
+              }
             }
           </span>
         </span>

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -35,13 +35,13 @@
             @switch (project._type) {
               @case ('Portfolio') {
                 <span class="color-fg-muted">
-                  <svg versions-icon size="small" />
+                  <svg briefcase-icon size="small" />
                   {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
                 </span>
               }
               @case ('Program') {
                 <span class="color-fg-muted">
-                  <svg briefcase-icon size="small" />
+                  <svg versions-icon size="small" />
                   {{ this.I18n.t('js.include_workspaces.types.program') }}
                 </span>
               }
@@ -76,13 +76,13 @@
               @switch (project._type) {
                 @case ('Portfolio') {
                   <span class="color-fg-muted">
-                    <svg versions-icon size="small" />
+                    <svg briefcase-icon size="small" />
                     {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
                   </span>
                 }
                 @case ('Program') {
                   <span class="color-fg-muted">
-                    <svg briefcase-icon size="small" />
+                    <svg versions-icon size="small" />
                     {{ this.I18n.t('js.include_workspaces.types.program') }}
                   </span>
                 }

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
@@ -20,13 +20,6 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { getMetaContent } from 'core-app/core/setup/globals/global-helpers';
-import {
-  toDOMString,
-  briefcaseIconData,
-  SVGData,
-  versionsIconData,
-} from '@openproject/octicons-angular';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
   selector: '[op-header-project-select-list]',
@@ -69,8 +62,6 @@ export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
     readonly elementRef:ElementRef,
     readonly cdRef:ChangeDetectorRef,
     readonly currentProjectService:CurrentProjectService,
-    // eslint-disable-next-line @angular-eslint/prefer-inject
-    readonly sanitizer:DomSanitizer
   ) { }
 
   ngOnInit():void {
@@ -126,32 +117,5 @@ export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
     }
 
     return `${url}?jump=${encodeURIComponent(currentMenuItem)}`;
-  }
-
-  workspaceTypeIconWithLabel(project:IProjectData):SafeHtml {
-    const workspaceType = project._type.toLowerCase();
-    const iconData = this.workspaceTypeSVGData(workspaceType);
-    if (!iconData) {
-      return '';
-    }
-
-    const htmlString = toDOMString(iconData, 'small', { 'aria-hidden': 'true', class: 'octicon' });
-    const translatedTypeName = this.I18n.t(`js.include_workspaces.types.${workspaceType}`);
-    const iconWithText = htmlString + ' ' + translatedTypeName;
-    return this.sanitizer.bypassSecurityTrustHtml(iconWithText);
-  }
-
-  private workspaceTypeSVGData(workspaceType:string):SVGData|undefined{
-    switch (workspaceType) {
-      case 'program': {
-        return versionsIconData;
-      }
-      case 'portfolio': {
-        return briefcaseIconData;
-      }
-      default: {
-        return undefined; // Case fallthrough for eslint
-      }
-    }
   }
 }

--- a/frontend/src/app/shared/components/icon/icon.module.ts
+++ b/frontend/src/app/shared/components/icon/icon.module.ts
@@ -96,8 +96,9 @@ import {
   ListUnorderedIconComponent,
   OpStopwatchStartIconComponent,
   ChevronDownIconComponent,
+  VersionsIconComponent,
+  BriefcaseIconComponent,
 } from '@openproject/octicons-angular';
-import { OpBaselineComponent } from 'core-app/features/work-packages/components/wp-baseline/baseline/baseline.component';
 
 @NgModule({
   imports: [
@@ -200,6 +201,8 @@ import { OpBaselineComponent } from 'core-app/features/work-packages/components/
     PlusIconComponent,
     ReplyIconComponent,
     TriangleDownIconComponent,
+    VersionsIconComponent,
+    BriefcaseIconComponent,
   ],
   declarations: [
     OpIconComponent,
@@ -304,6 +307,8 @@ import { OpBaselineComponent } from 'core-app/features/work-packages/components/
     PlusIconComponent,
     ReplyIconComponent,
     TriangleDownIconComponent,
+    VersionsIconComponent,
+    BriefcaseIconComponent,
   ],
 })
 

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -143,6 +143,9 @@ div.autocomplete
   .ng-value-label:not(.d-flex)
     display: initial !important
 
+  .ng-value-label.d-flex
+    min-width: 0
+
   .ng-placeholder
     // Fix overflow by providing a max width to the input
     //

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -140,7 +140,7 @@ div.autocomplete
   height: initial !important
   min-height: initial !important
 
-  .ng-value-label
+  .ng-value-label:not(.d-flex)
     display: initial !important
 
   .ng-placeholder

--- a/frontend/src/global_styles/content/_autocomplete.sass
+++ b/frontend/src/global_styles/content/_autocomplete.sass
@@ -140,10 +140,10 @@ div.autocomplete
   height: initial !important
   min-height: initial !important
 
-  .ng-value-label:not(.d-flex)
+  .ng-value-label:not(:has(> *))
     display: initial !important
 
-  .ng-value-label.d-flex
+  .ng-value-label:has(> *)
     min-width: 0
 
   .ng-placeholder

--- a/frontend/src/global_styles/content/reporting/_index.sass
+++ b/frontend/src/global_styles/content/reporting/_index.sass
@@ -73,6 +73,7 @@ div.button_form
 
 .advanced-filters--filter-value
   white-space: nowrap
+  overflow: hidden
 
 .advanced-filters--filter-value2
   margin-left: 0.5rem

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe "Projects", "editing settings", :js do
   include_context "ng-select-autocomplete helpers"
 
   let(:permissions) { %i(edit_project view_project_attributes edit_project_attributes) }
+  let(:project_memberships) { { project => permissions } }
 
   current_user do
-    create(:user, member_with_permissions: { project => permissions })
+    create(:user, member_with_permissions: project_memberships)
   end
 
   shared_let(:project) do
@@ -289,6 +290,32 @@ RSpec.describe "Projects", "editing settings", :js do
         end
         expect(page).to have_no_modal "Description"
       end
+    end
+  end
+
+  describe "workspace type badges in Subproject of field", with_flag: { portfolio_models: true } do
+    shared_let(:portfolio) { create(:portfolio, name: "Parent Portfolio") }
+    shared_let(:program) { create(:program, name: "Parent Program") }
+    shared_let(:regular_project) { create(:project, name: "Regular Project") }
+    let(:parent_permissions) { %i[add_subprojects] }
+
+    let(:project_memberships) do
+      { project => permissions,
+        portfolio => parent_permissions,
+        program => parent_permissions,
+        regular_project => parent_permissions }
+    end
+
+    it "displays workspace type badges for portfolios and programs" do
+      general_page = Pages::Projects::Settings::General.new(project)
+      general_page.visit!
+
+      parent_field = general_page.parent_project_field
+
+      # Verify badges for different project types
+      parent_field.expect_option("Parent Portfolio", workspace_badge: "Portfolio")
+      parent_field.expect_option("Parent Program", workspace_badge: "Program")
+      parent_field.expect_option("Regular Project")
     end
   end
 end

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -191,26 +191,9 @@ RSpec.describe "Projects autocomplete page", :js do
       top_menu.toggle unless top_menu.open?
       top_menu.expect_open
 
-      top_menu.expect_result project.name
-      top_menu.expect_result portfolio.name
-      top_menu.expect_result program.name
-    end
-
-    # Check that the portfolio badge is displayed
-    top_menu.within_item(portfolio) do
-      expect(page).to have_text("Test Portfolio")
-      expect(page).to have_css("svg.octicon")
-    end
-
-    # Check that the program badge is displayed
-    top_menu.within_item(program) do
-      expect(page).to have_text("Test Program")
-      expect(page).to have_css("svg.octicon")
-    end
-
-    top_menu.within_item(project) do
-      expect(page).to have_text("Plain project")
-      expect(page).to have_no_css("svg.octicon")
+      top_menu.expect_result portfolio.name, workspace_badge: "Portfolio"
+      top_menu.expect_result program.name, workspace_badge: "Program"
+      top_menu.expect_result project.name, workspace_badge: false
     end
   end
 end

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -31,35 +31,40 @@
 require "spec_helper"
 
 RSpec.describe "Projects autocomplete page", :js do
-  let!(:user) { create(:user) }
-  let(:top_menu) { Components::Projects::TopMenu.new }
+  shared_let(:user) { create(:user) }
+  # we only need the public permissions: view_project, :view_news
+  shared_let(:role) { create(:project_role, permissions: []) }
 
-  let!(:project) do
-    create(:project,
-           name: "Plain project",
-           identifier: "plain-project")
+  shared_let(:portfolio) do
+    create(:portfolio, name: "Test Portfolio", members: { user => role })
   end
-
-  let!(:project2) do
+  shared_let(:program) do
+    create(:program, name: "Test Program", members: { user => role })
+  end
+  shared_let(:project) do
+    create(:project, name: "Plain project", identifier: "plain-project", members: { user => role })
+  end
+  shared_let(:project2) do
     create(:project,
            name: "<strong>foobar</strong>",
-           identifier: "foobar")
+           identifier: "foobar",
+           members: { user => role })
   end
-
-  let!(:project3) do
+  shared_let(:project3) do
     create(:project,
            name: "Plain other project",
            parent: project2,
-           identifier: "plain-project-2")
+           identifier: "plain-project-2",
+           members: { user => role })
   end
-  let!(:project4) do
+  shared_let(:project4) do
     create(:project,
            name: "Project with different name and identifier",
            parent: project2,
-           identifier: "plain-project-4")
+           identifier: "plain-project-4",
+           members: { user => role })
   end
-
-  let!(:other_projects) do
+  shared_let(:other_projects) do
     names = [
       "Very long project name with term at the END",
       "INK14 - Foo",
@@ -70,26 +75,15 @@ RSpec.describe "Projects autocomplete page", :js do
     names.map do |name|
       identifier = name.gsub(/[ -]+/, "-").downcase
 
-      create(:project, name:, identifier:)
+      create(:project, name:, identifier:, members: { user => role })
     end
   end
-  let!(:non_member_project) do
-    create(:project)
-  end
-  let!(:public_project) do
-    create(:public_project)
-  end
-  # necessary to be able to see public projects
-  let!(:non_member_role) { create(:non_member) }
-  # we only need the public permissions: view_project, :view_news
-  let(:role) { create(:project_role, permissions: []) }
+  shared_let(:non_member_project) { create(:project) }
+  shared_let(:public_project) { create(:public_project) }
 
-  include BecomeMember
+  let(:top_menu) { Components::Projects::TopMenu.new }
 
   before do
-    ([project, project2, project3] + other_projects).each do |p|
-      add_user_to_project! user:, project: p, role:
-    end
     login_as user
     visit root_path
   end
@@ -134,13 +128,15 @@ RSpec.describe "Projects autocomplete page", :js do
 
     top_menu.expect_result "Plain project"
     top_menu.expect_result "<strong>foobar</strong>", disabled: true
-    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2, item_name: "Plain other project"
+    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
+                                              item_name: "Plain other project"
 
     # Show hierarchy of project
     top_menu.search "Plain other project"
 
     top_menu.expect_result "<strong>foobar</strong>", disabled: true
-    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2, item_name: "Plain other project"
+    top_menu.expect_item_with_hierarchy_level hierarchy_level: 2,
+                                              item_name: "Plain other project"
 
     # find terms at the end of project names
     top_menu.search "END"
@@ -166,7 +162,8 @@ RSpec.describe "Projects autocomplete page", :js do
       top_menu.search_and_select "Plain project"
     end
 
-    expect(page).to have_current_path(project_news_index_path(project), ignore_query: true)
+    expect(page).to have_current_path(project_news_index_path(project),
+                                      ignore_query: true)
     expect(page).to have_css(".news-menu-item.selected")
   end
 
@@ -186,5 +183,34 @@ RSpec.describe "Projects autocomplete page", :js do
     top_menu.autocompleter.send_keys :enter
 
     top_menu.expect_current_project project2.name
+  end
+
+  it "displays workspace type badges for portfolios and programs",
+     with_flag: { portfolio_models: true } do
+    retry_block do
+      top_menu.toggle unless top_menu.open?
+      top_menu.expect_open
+
+      top_menu.expect_result project.name
+      top_menu.expect_result portfolio.name
+      top_menu.expect_result program.name
+    end
+
+    # Check that the portfolio badge is displayed
+    top_menu.within_item(portfolio) do
+      expect(page).to have_text("Test Portfolio")
+      expect(page).to have_css("svg.octicon")
+    end
+
+    # Check that the program badge is displayed
+    top_menu.within_item(program) do
+      expect(page).to have_text("Test Program")
+      expect(page).to have_css("svg.octicon")
+    end
+
+    top_menu.within_item(project) do
+      expect(page).to have_text("Plain project")
+      expect(page).to have_no_css("svg.octicon")
+    end
   end
 end

--- a/spec/features/work_packages/table/edit_work_packages_spec.rb
+++ b/spec/features/work_packages/table/edit_work_packages_spec.rb
@@ -3,23 +3,23 @@
 require "spec_helper"
 
 RSpec.describe "Inline editing work packages", :js do
+  let(:manager_permissions) { %i[view_work_packages edit_work_packages] }
   let(:manager_role) do
-    create(:project_role,
-           permissions: %i[view_work_packages
-                           edit_work_packages])
+    create(:project_role, permissions: manager_permissions)
   end
+  let(:manager_projects) { { project => manager_role } }
   let(:manager) do
     create(:user,
            firstname: "Manager",
            lastname: "Guy",
-           member_with_roles: { project => manager_role })
+           member_with_roles: manager_projects)
   end
   let(:type) { create(:type) }
   let(:status1) { create(:status) }
   let(:status2) { create(:status) }
 
-  let(:project) { create(:project, types: [type]) }
-  let(:work_package) do
+  let(:project) { create(:project, name: "Test Project", types: [type]) }
+  let!(:work_package) do
     create(:work_package,
            project:,
            type:,
@@ -45,7 +45,6 @@ RSpec.describe "Inline editing work packages", :js do
 
   context "simple work package" do
     before do
-      work_package
       workflow
 
       wp_table.visit!
@@ -202,6 +201,56 @@ RSpec.describe "Inline editing work packages", :js do
       # Saveguard to let the background update complete
       wp_table.visit!
       wp_table.expect_work_package_listed(work_package)
+    end
+  end
+
+  context "when editing the project field with workspace types",
+          with_flag: { portfolio_models: true } do
+    let!(:portfolio) { create(:portfolio, name: "Test Portfolio") }
+    let!(:program) { create(:program, name: "Test Program") }
+    let(:manager_permissions) { %i[view_work_packages edit_work_packages move_work_packages] }
+    let(:manager_projects) do
+      {
+        project => manager_role,
+        portfolio => manager_role,
+        program => manager_role
+      }
+    end
+    let(:query) do
+      create(:public_query,
+             user: manager,
+             project: work_package.project,
+             column_names: %w[subject project])
+    end
+
+    before do
+      wp_table.visit_query query
+      wp_table.expect_work_package_listed(work_package)
+    end
+
+    it "displays workspace type badges for portfolios and programs in the project column" do
+      project_field = wp_table.edit_field(work_package, :project)
+      project_field.activate!
+
+      # Search for portfolio and verify badge
+      project_field.search_for("Test Portfolio")
+      project_field.expect_option(
+        "Test Portfolio",
+        workspace_badge: "Portfolio"
+      )
+
+      # Search for program and verify badge
+      project_field.clear_search
+      project_field.search_for("Test Program")
+      project_field.expect_option(
+        "Test Program",
+        workspace_badge: "Program"
+      )
+
+      # Search for regular project and verify there is no badge
+      project_field.clear_search
+      project_field.search_for("Project")
+      project_field.expect_option("Test Project", workspace_badge: false)
     end
   end
 end

--- a/spec/support/capybara/primer_component_selectors.rb
+++ b/spec/support/capybara/primer_component_selectors.rb
@@ -84,7 +84,10 @@ Capybara.add_selector :primer_text, locator_type: [String] do
   # `node_filter` applies the filter on the elements returned by the query so
   # that error message can list them if none matches.
   node_filter :color do |node, color|
-    actual = node[:class].scan(/(?<=color-fg-)[\w-]+/)
+    class_attr = node[:class]
+    next false unless class_attr
+
+    actual = class_attr.scan(/(?<=color-fg-)[\w-]+/)
     color = color.to_s
 
     actual.include?(color).tap do |res|
@@ -101,11 +104,10 @@ end
 Capybara.add_selector :octicon, locator_type: [String, Symbol] do
   label "Octicon"
 
-  xpath do |locator|
-    xpath = XPath.descendant(:svg)
-    xpath = builder(xpath).add_attribute_conditions(class: "octicon")
-    xpath = builder(xpath).add_attribute_conditions(class: "octicon-#{locator.to_s.downcase}") if locator
-    xpath
+  css do |locator|
+    css_selector = "svg.octicon"
+    css_selector += ".octicon-#{locator.to_s.downcase}" if locator
+    css_selector
   end
 
   expression_filter(:size, valid_values: [Numeric, *Primer::Beta::Octicon::SIZE_OPTIONS]) do |expr, size|

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -99,10 +99,13 @@ module Components
         page.find autocompleter_selector, wait: 10
       end
 
-      def expect_result(name, disabled: false, workspace_badge: false)
+      def expect_result(name, disabled: false, workspace_badge: nil)
         within search_results do
           selector = disabled ? autocompleter_item_disabled_title_selector : autocompleter_item_title_selector
           item = page.find(selector, text: name)
+
+          # Skip badge verification when workspace badge is not set
+          next if workspace_badge.nil?
 
           if workspace_badge
             expect(item).to have_octicon

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -95,6 +95,12 @@ module Components
         page.find autocompleter_results_selector, wait: 10
       end
 
+      def within_item(project, &)
+        within search_results do
+          within "[data-project-id='#{project.id}']", &
+        end
+      end
+
       def autocompleter
         page.find autocompleter_selector, wait: 10
       end

--- a/spec/support/components/projects/top_menu.rb
+++ b/spec/support/components/projects/top_menu.rb
@@ -95,22 +95,21 @@ module Components
         page.find autocompleter_results_selector, wait: 10
       end
 
-      def within_item(project, &)
-        within search_results do
-          within "[data-project-id='#{project.id}']", &
-        end
-      end
-
       def autocompleter
         page.find autocompleter_selector, wait: 10
       end
 
-      def expect_result(name, disabled: false)
+      def expect_result(name, disabled: false, workspace_badge: false)
         within search_results do
-          if disabled
-            page.find(autocompleter_item_disabled_title_selector, text: name)
+          selector = disabled ? autocompleter_item_disabled_title_selector : autocompleter_item_title_selector
+          item = page.find(selector, text: name)
+
+          if workspace_badge
+            expect(item).to have_octicon
+            expect(item).to have_primer_text(workspace_badge, color: :muted)
           else
-            page.find(autocompleter_item_title_selector, text: name)
+            expect(item).to have_no_octicon
+            expect(item).to have_no_primer_text(color: :muted)
           end
         end
       end

--- a/spec/support/edit_fields/inline_project_edit_field.rb
+++ b/spec/support/edit_fields/inline_project_edit_field.rb
@@ -28,38 +28,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-require_relative "select_edit_field"
+require_relative "project_edit_field"
 
-class ProjectEditField < SelectField
+# For work package table inline editing
+class InlineProjectEditField < ProjectEditField
   def autocompleter
-    field_container
+    field_container.find("op-project-autocompleter")
   end
 
-  def search_for(query)
-    search_autocomplete(autocompleter,
-                        query:,
-                        results_selector: ".ng-dropdown-panel-items")
-  end
-
-  def dropdown
-    ng_find_dropdown(autocompleter, results_selector: ".ng-dropdown-panel-items")
-  end
-
-  def expect_option(name, workspace_badge: false)
-    within(dropdown) do
-      option = page.find(".ng-option", text: name)
-
-      if workspace_badge
-        expect(option).to have_octicon
-        expect(option).to have_primer_text(workspace_badge, color: :muted)
-      else
-        expect(option).to have_no_octicon
-        expect(option).to have_no_primer_text(color: :muted)
-      end
-    end
-  end
-
-  def clear_search
-    ng_select_input(autocompleter).set("")
+  def field_type
+    "op-project-autocompleter"
   end
 end

--- a/spec/support/edit_fields/project_edit_field.rb
+++ b/spec/support/edit_fields/project_edit_field.rb
@@ -29,12 +29,12 @@ class ProjectEditField < SelectField
       option = page.find(".ng-option", text: name)
 
       if workspace_badge
-        expect(option).to have_css("svg.octicon")
-        expect(option).to have_css(".color-fg-muted", text: workspace_badge)
+        expect(option).to have_octicon
+        expect(option).to have_primer_text(workspace_badge, color: :muted)
       else
         # Expect no octicon SVG
-        expect(option).to have_no_css("svg.octicon")
-        expect(option).to have_no_css(".color-fg-muted")
+        expect(option).to have_no_octicon
+        expect(option).to have_no_primer_text(color: :muted)
       end
     end
   end

--- a/spec/support/edit_fields/project_edit_field.rb
+++ b/spec/support/edit_fields/project_edit_field.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "select_edit_field"
+
+class ProjectEditField < SelectField
+  def autocompleter
+    if @selector&.start_with?("op")
+      # Direct autocompleter selector (for settings pages)
+      field_container
+    else
+      # Inline edit container (for work package tables)
+      field_container.find("op-project-autocompleter")
+    end
+  end
+
+  def search_for(query)
+    search_autocomplete(autocompleter,
+                        query:,
+                        results_selector: ".ng-dropdown-panel-items")
+  end
+
+  def dropdown
+    ng_find_dropdown(autocompleter, results_selector: ".ng-dropdown-panel-items")
+  end
+
+  def expect_option(name, workspace_badge: false)
+    within(dropdown) do
+      # Find the option containing the name
+      option = page.find(".ng-option", text: name)
+
+      if workspace_badge
+        expect(option).to have_css("svg.octicon")
+        expect(option).to have_css(".color-fg-muted", text: workspace_badge)
+      else
+        # Expect no octicon SVG
+        expect(option).to have_no_css("svg.octicon")
+        expect(option).to have_no_css(".color-fg-muted")
+      end
+    end
+  end
+
+  def clear_search
+    ng_select_input(autocompleter).set("")
+  end
+end

--- a/spec/support/pages/projects/settings/general.rb
+++ b/spec/support/pages/projects/settings/general.rb
@@ -78,6 +78,12 @@ module Pages
         def find_field_label(label_text)
           page.find(:element, :label, text: label_text)
         end
+
+        def parent_project_field
+          @parent_project_field ||= within_section "Project relations" do
+            ProjectEditField.new(page, :parent, selector: "opce-project-autocompleter")
+          end
+        end
       end
     end
   end

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -390,6 +390,8 @@ module Pages
         DateEditField.new container, key, is_milestone: work_package.milestone?, is_table: true
       when :estimatedTime, :remainingTime
         ProgressEditField.new container, key
+      when :project
+        ProjectEditField.new container, key
       else
         EditField.new container, key
       end

--- a/spec/support/pages/work_packages/work_packages_table.rb
+++ b/spec/support/pages/work_packages/work_packages_table.rb
@@ -391,7 +391,7 @@ module Pages
       when :estimatedTime, :remainingTime
         ProgressEditField.new container, key
       when :project
-        ProjectEditField.new container, key
+        InlineProjectEditField.new container, key
       else
         EditField.new container, key
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69450

# What are you trying to accomplish?

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
- [X] Add specs for workspace badges in header dropdown, project settings, and WP table inline edit.
  - Add spec helper classes for the select inputs. The ProjectEditField is for the project selectors, InlineProjectEditField is for project selectors for the work package table inline editing.
- [X] Refactor icon rendering.
  - Imperatively add the icon in the template instead of programatically rendering it from the component.
  - Use the angular `@switch` block in templates instead of a component method.
- [X] Selected value now shows badges.
  - Fix badge rendering of selected values in multi select mode. 
  <img width="338" height="84" alt="image" src="https://github.com/user-attachments/assets/2f38539e-559f-41d4-858b-bd80f443d6c5" />
  
  - Fix filter list expanding over the viewport when the selected project name is long enough to leave the viewport.
  <img width="206" height="146" alt="image" src="https://github.com/user-attachments/assets/ab4e9d66-be06-4118-ba5c-69e488b8c0b7" /> <details><summary>Before and after of ellipsis not working due to the container list expanding over the viewport.</summary><b> Before</b><p> <img width="952" height="681" alt="image" src="https://github.com/user-attachments/assets/9f56b1c1-3e5c-4852-b69a-29151901ae4e" /> </p><b> After</b><p><img width="960" height="735" alt="image" src="https://github.com/user-attachments/assets/6ed1e31c-a13a-4f92-9004-f311065aa9b8" /></p></details>
  
- [X] Fix accesibility of the remove icon on the selected options in multi select mode.
  - Close icon (×) now functions as a button, can be focused and triggered by pressing enter.
  <img width="312" height="92" alt="image" src="https://github.com/user-attachments/assets/c8a08821-2a04-4a8d-a17d-c8862b28449c" />
- [X] Primer rspec selector fixes, `:octicon` selector now uses CSS instead of XPath, `:primer_text` handles nil text and color combination.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
