### PR TITLE
experiment using shadow dom, but not working properly

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -29,59 +29,36 @@
  */
 
 import { User } from '@blocknote/core/comments';
-import type { HocuspocusProvider } from '@hocuspocus/provider';
-import { Controller } from '@hotwired/stimulus';
+import { HocuspocusProvider } from '@hocuspocus/provider';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import OpBlockNoteContainer from '../../../react/OpBlockNoteContainer';
+import OpBlockNoteContainer from '../react/OpBlockNoteContainer';
 
 // @ts-ignore - loading css
 import mantineStyles from '@blocknote/mantine/style.css?url';
 
-export default class extends Controller {
-  static targets = [
-    'blockNoteEditor',
-    'blockNoteInputField',
-  ];
+class BlockNoteElement extends HTMLElement {
+  private mount:HTMLDivElement;
 
-  declare readonly blockNoteEditorTarget:HTMLElement;
-  declare readonly blockNoteInputFieldTarget:HTMLInputElement;
+  constructor() {
+    super();
 
-  static values = {
-    inputText: String,
-    activeUser: Object,
-    readonly: Boolean,
-    openProjectUrl: String,
-    attachmentsUploadUrl: String,
-    attachmentsCollectionKey: String,
+    const shadowRoot = this.attachShadow({ mode: 'open' });
+    this.mount = document.createElement('div');
+    shadowRoot.appendChild(this.mount);
 
-    collaborationEnabled: Boolean,
-  };
-
-  declare readonly inputTextValue:string;
-  declare readonly activeUserValue:User;
-  declare readonly readonlyValue:boolean;
-  declare readonly openProjectUrlValue:string;
-  declare readonly attachmentsUploadUrlValue:string;
-  declare readonly attachmentsCollectionKeyValue:string;
-
-  declare readonly collaborationEnabledValue:string;
-
-  connect() {
-    const container = this.blockNoteEditorTarget;
-    const shadow = container.attachShadow({ mode: 'open' });
-    const mount = document.createElement('div');
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = mantineStyles;
-    shadow.appendChild(link);
-    shadow.appendChild(mount);
-    const root = createRoot(mount);
+    shadowRoot.appendChild(link);
+  }
 
-    // const root = createRoot(this.blockNoteEditorTarget);
+  connectedCallback() {
+    const root = createRoot(this.mount);
 
-    if (this.collaborationEnabledValue) {
+    const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
+    if (collaborationEnabled) {
       LiveCollaborationManager.onReady((hocuspocusProvider) => {
         root.render(this.BlockNoteReactContainer(hocuspocusProvider));
       });
@@ -92,14 +69,14 @@ export default class extends Controller {
 
   BlockNoteReactContainer(hocuspocusProvider?:HocuspocusProvider) {
     return React.createElement(OpBlockNoteContainer, {
-      // inputField: this.blockNoteInputFieldTarget,
-      // inputText: this.inputTextValue,
-      activeUser: this.activeUserValue,
-      readOnly: this.readonlyValue,
-      openProjectUrl: this.openProjectUrlValue,
-      attachmentsUploadUrl: this.attachmentsUploadUrlValue,
-      attachmentsCollectionKey: this.attachmentsCollectionKeyValue,
+      activeUser: this.getAttribute('active-user') as unknown as User,
+      readOnly: this.getAttribute('read-only') === 'true',
+      openProjectUrl: this.getAttribute('open-project-url') || '',
+      attachmentsUploadUrl: this.getAttribute('attachments-upload-url') || '',
+      attachmentsCollectionKey: this.getAttribute('attachments-collection-key') || '',
       hocuspocusProvider: hocuspocusProvider,
     });
   }
 }
+
+customElements.define('op-block-note', BlockNoteElement);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,6 +8,7 @@ import { environment } from './environments/environment';
 import { configureErrorReporter } from 'core-app/core/errors/configure-reporter';
 import { initializeGlobalListeners } from 'core-app/core/setup/globals/global-listeners';
 import { getMetaElement } from 'core-app/core/setup/globals/global-helpers';
+import "core-elements/block-note-element";
 
 import 'core-app/core/setup/init-vendors';
 import 'core-app/core/setup/init-globals';

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -49,8 +49,8 @@ interface CollaborativeUser {
 }
 
 export interface OpBlockNoteContainerProps {
-  inputField:HTMLInputElement;
-  inputText?:string;
+  // inputField:HTMLInputElement;
+  // inputText?:string;
   activeUser:User;
   readOnly:boolean;
   openProjectUrl:string;
@@ -67,9 +67,7 @@ const schema = BlockNoteSchema.create().extend({
 
 const detectTheme = ():OpColorMode => { return window.OpenProject.theme.detectOpColorMode(); };
 
-export default function OpBlockNoteContainer({ inputField,
-                                               inputText,
-                                               activeUser,
+export default function OpBlockNoteContainer({ activeUser,
                                                readOnly,
                                                openProjectUrl,
                                                attachmentsUploadUrl,
@@ -105,15 +103,15 @@ export default function OpBlockNoteContainer({ inputField,
       ...(isReadyForAttachmentUpload() && { uploadFile }),
     };
   } else { // collaboration disabled
-    if (inputText) {
-      try {
-        const update = Uint8Array.from(atob(inputText), c => c.charCodeAt(0));
-        Y.applyUpdate(doc, update);
-      } catch (e) {
-        console.error('Failed to load document binary', e);
-        doc = new Y.Doc();
-      }
-    }
+    // if (inputText) {
+    //   try {
+    //     const update = Uint8Array.from(atob(inputText), c => c.charCodeAt(0));
+    //     Y.applyUpdate(doc, update);
+    //   } catch (e) {
+    //     console.error('Failed to load document binary', e);
+    //     doc = new Y.Doc();
+    //   }
+    // }
 
     editorParams = {
       schema,
@@ -173,11 +171,11 @@ export default function OpBlockNoteContainer({ inputField,
   };
 
   useEffect(() => {
-    const updateInput = () => {
-      const update = Y.encodeStateAsUpdate(doc);
-      const b64 = btoa(String.fromCharCode(...update));
-      inputField.value = b64;
-    };
+    // const updateInput = () => {
+    //   const update = Y.encodeStateAsUpdate(doc);
+    //   const b64 = btoa(String.fromCharCode(...update));
+    //   inputField.value = b64;
+    // };
 
     let connectionTimeout:ReturnType<typeof setTimeout> | null = null;
 
@@ -206,9 +204,9 @@ export default function OpBlockNoteContainer({ inputField,
 
       hocuspocusProvider.on('synced', editorReady);
       hocuspocusProvider.on('disconnect', handleDisconnect);
-    } else {
-      doc.on('update', updateInput);
-      setIsLoading(false);
+    // } else {
+    //   doc.on('update', updateInput);
+    //   setIsLoading(false);
     }
 
     return () => {
@@ -218,9 +216,9 @@ export default function OpBlockNoteContainer({ inputField,
         hocuspocusProvider.off('synced', editorReady);
         hocuspocusProvider.off('disconnect', handleDisconnect);
         hocuspocusProvider.destroy();
-      } else {
-        // disable Yjs update listener. Opposite of doc.on('update', ...);
-        doc.off('update', updateInput);
+      // } else {
+      //   // disable Yjs update listener. Opposite of doc.on('update', ...);
+      //   doc.off('update', updateInput);
       }
     };
   }, [hocuspocusProvider]);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,6 +22,7 @@
       "@ng-select/ng-select/*": ["./node_modules/@ng-select/ng-select/*"],
       "core-app/*": ["./src/app/*"],
       "core-components/*": ["./src/app/components/*"],
+      "core-elements/*": ["./src/elements/*"],
       "core-stimulus/*": ["./src/stimulus/*"],
       "core-turbo/*": ["./src/turbo/*"],
       "core-typings/*": ["./src/typings/*"],

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -34,23 +34,27 @@
     input: @input,
     class: @input.classes,
     data: {
-      controller: "block-note",
-      block_note_input_text_value: value,
-      block_note_active_user_value: active_user,
-      block_note_readonly_value: readonly,
-      block_note_attachments_upload_url_value: attachments_upload_url,
-      block_note_attachments_collection_key_value: attachments_collection_key,
-      block_note_collaboration_enabled_value: collaboration_enabled,
+      # controller: "block-note",
+      # block_note_input_text_value: value,
+      # block_note_active_user_value: active_user,
+      # block_note_readonly_value: readonly,
+      # block_note_attachments_upload_url_value: attachments_upload_url,
+      # block_note_attachments_collection_key_value: attachments_collection_key,
+      # block_note_collaboration_enabled_value: collaboration_enabled,
       test_selector: "blocknote-document-description"
     }
   ) do
 %>
-  <%= @input.builder.hidden_field(name, value:, data: { block_note_target: "blockNoteInputField" }) %>
   <%=
     render(
       Primer::BaseComponent.new(
-        tag: :div, mt: 1, mb: 1,
-        data: { block_note_target: "blockNoteEditor" }
+        tag: "op-block-note", mt: 1, mb: 1,
+        "collaboration-enabled": collaboration_enabled,
+        "active-user": active_user,
+        "read-only": readonly,
+        "open-project-url": root_url,
+        "attachments-upload-url": attachments_upload_url,
+        "attachments-collection-key": attachments_collection_key
       )
     )
   %>


### PR DESCRIPTION
This is here only as a reference and should be closed in the near future.

---

Attempted to move the whole React root + BlockNote to a shadow-dom root, so that tiptap and angular do not interfere with each other when listening to mutations on the DOM. But this causes other issues with BlockNote. More precisely errors like:

```
Uncaught Error: [tiptap error]: The editor view is not available. Cannot access view['dom']. The editor may not be mounted yet
```

and

```
Uncaught TypeError: can't access property "getBoundingClientRect", t is null
```