### PR TITLE
[#68478] Unable to save meeting agenda name after using browser autocomplete 

### DIFF
--- a/modules/meeting/app/forms/meeting_agenda_item/duration.rb
+++ b/modules/meeting/app/forms/meeting_agenda_item/duration.rb
@@ -38,6 +38,7 @@ class MeetingAgendaItem::Duration < ApplicationForm
       visually_hide_label: true,
       max: 1440,
       type: :number,
+      autocomplete: "off",
       disabled: @disabled
     )
   end

--- a/modules/meeting/app/forms/meeting_section/title.rb
+++ b/modules/meeting/app/forms/meeting_section/title.rb
@@ -36,6 +36,7 @@ class MeetingSection::Title < ApplicationForm
       visually_hide_label: true,
       required: true,
       autofocus: true,
+      autocomplete: "off",
       bg: :default,
       data: {
         action: "keydown.esc->meetings--section-form#cancel"


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
 https://community.openproject.org/work_packages/68478

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Disable autocomplete for the problematic section title field
- Also disable autocomplete for the agenda item duration field for consistency, as the agenda item title already has that option from before
