### PR TITLE
[69111] Mobile web - Create WP button does not launch WP create form

### DIFF
--- a/frontend/src/app/features/work-packages/routing/split-view-routes.template.ts
+++ b/frontend/src/app/features/work-packages/routing/split-view-routes.template.ts
@@ -115,8 +115,7 @@ export function makeSplitViewRoutes(baseRoute:string,
         bodyClasses: 'router--work-packages-partitioned-split-view-new',
         // Remember the base route so we can route back to it anywhere
         baseRoute,
-        parent: baseRoute,
-        mobileAlternative: showMobileAlternative ? 'work-packages.new' : undefined,
+        parent: baseRoute
       },
       views: {
         // Retarget and by that override the grandparent views

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -42,6 +42,7 @@ import { TypeResource } from 'core-app/features/hal/resources/type-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { extendSearchParams } from 'core-stimulus/helpers/url-helpers';
+import { BrowserDetector } from 'core-app/core/browser/browser-detector.service';
 
 @Directive({
   selector: '[opTypesCreateDropdown]',
@@ -65,6 +66,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
     readonly $state:StateService,
     readonly pathHelper:PathHelperService,
     readonly currentProject:CurrentProjectService,
+    readonly browser:BrowserDetector,
   ) {
     super(elementRef, opContextMenu);
   }
@@ -113,7 +115,7 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
       ariaLabel: type.name,
       class: Highlighting.inlineClass('type', type.id!),
       onClick: (event:MouseEvent) => {
-        if (this.routedFromAngular) {
+        if (this.routedFromAngular && !this.browser.isMobile) {
           this.isOpen = false;
           if (isClickedWithModifier(event)) {
             return false;


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69111

# What are you trying to accomplish?
Take care that on mobile the user is redirected to the full WP Create page instead of split. That was previously solved with the mobileGuard in the agular router which does not work any more since the WP full view is rendered via rails
