### PR TITLE
[65066] Global search is not usable via keyboard

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -57,10 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
 </noscript>
 <opce-toasts-container></opce-toasts-container>
 <opce-modal-overlay></opce-modal-overlay>
-<live-region>
-  <div id="polite" aria-live="polite" aria-atomic="true" class="sr-only"></div>
-  <div id="assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
-</live-region>
+<live-region></live-region>
 <span id="open-blank-target-link-description" class="sr-only"><%= I18n.t("open_link_in_a_new_tab") %></span>
 <opce-spot-drop-modal-portal></opce-spot-drop-modal-portal>
 <% main_menu = render_main_menu(local_assigns.fetch(:menu_name, nil), @project) %>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1197,6 +1197,7 @@ en:
     global_search:
       all_projects: "In all projects"
       close_search: "Close search"
+      items_available: "%{count} items available"
       current_project_and_all_descendants: "In this project + subprojects"
       current_project: "In this project"
       recently_viewed: "Recently viewed"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1198,6 +1198,7 @@ en:
       all_projects: "In all projects"
       close_search: "Close search"
       items_available: "%{count} items available"
+      direct_hit_available: "Work package with exact ID found. Press Enter to open it."
       current_project_and_all_descendants: "In this project + subprojects"
       current_project: "In this project"
       recently_viewed: "Recently viewed"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -1,8 +1,4 @@
 <div role="search" class="top-menu-search" [attr.aria-label]="placeholder">
-  <div aria-live="polite" class="sr-only">
-    {{ liveMessage }}
-  </div>
-
   @if (expanded) {
     <button
       type="button"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -1,4 +1,7 @@
 <div role="search" class="top-menu-search" [attr.aria-label]="placeholder">
+  <div aria-live="polite" class="sr-only">
+    {{ liveMessage }}
+  </div>
 
   @if (expanded) {
     <button
@@ -21,6 +24,7 @@
     [attr.aria-label]="text.search"
     [class.-input-focused]="expanded"
     (click)="handleClick($event)"
+    tabindex="-1"
     >
     <op-icon icon-classes="icon5 icon-search ellipsis" />
   </button>
@@ -30,6 +34,7 @@
     [name]="'global-search-input'"
     [id]="'global-search-input'"
     [accesskey]="4"
+    [markFirst]="false"
     class="global-search"
     [placeholder]="effectivePlaceholder"
     [ariaLabel]="effectivePlaceholder"
@@ -38,6 +43,7 @@
     [inputAttrs]="{ 'class': 'global-search--input', 'name': 'global-search--input', autocomplete: 'off'}"
     [openOnEnter]="true"
     [labelRequired]="false"
+    [clearAllText]="text.close_search"
     [focusDirectly]="isFocusedDirectly"
     [model]="selectedItem"
     [searchFn]="customSearchFn"

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -254,7 +254,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   // If Enter key is pressed before result list is loaded, wait for the results to come
   // in and then decide what to do. If a direct hit is present, follow that. Otherwise,
   // go to the search in the current scope.
-  public onEnterBeforeResultsLoaded(): void {
+  public onEnterBeforeResultsLoaded():void {
     this.markable$.pipe(first()).subscribe(() => {
       if (this.selectedItem) {
         this.followSelectedItem();
@@ -370,12 +370,12 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.selectedItem = results.find((wp) => wp.id?.toString() === query) || searchOptions[0];
 
     if (this.selectedItem instanceof WorkPackageResource) {
-      announce(this.I18n.t('js.global_search.direct_hit_available'), { politeness: 'polite' });
+      void announce(this.I18n.t('js.global_search.direct_hit_available'), { politeness: 'polite' });
       this.setMarkedOption();
     }
     else {
       const resultCount = results.length + searchOptions.length;
-      announce(this.I18n.t('js.global_search.items_available', { count: resultCount }), { politeness: 'polite' });
+      void announce(this.I18n.t('js.global_search.items_available', { count: resultCount }), { politeness: 'polite' });
     }
 
     return [

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -39,6 +39,7 @@ import { RecentItemsService } from 'core-app/core/recent-items.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { NgOption } from '@ng-select/ng-select/index';
+import { announce } from '@primer/live-region-element';
 
 interface SearchResultItem {
   id:string;
@@ -369,12 +370,12 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     this.selectedItem = results.find((wp) => wp.id?.toString() === query) || searchOptions[0];
 
     if (this.selectedItem instanceof WorkPackageResource) {
-      this.liveMessage = this.I18n.t('js.global_search.direct_hit_available');
+      announce(this.I18n.t('js.global_search.direct_hit_available'), { politeness: 'polite' });
       this.setMarkedOption();
     }
     else {
       const resultCount = results.length + searchOptions.length;
-      this.liveMessage = this.I18n.t('js.global_search.items_available', { count: resultCount });
+      announce(this.I18n.t('js.global_search.items_available', { count: resultCount }), { politeness: 'polite' });
     }
 
     return [

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -38,6 +38,7 @@ import {
 import { RecentItemsService } from 'core-app/core/recent-items.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
+import { NgOption } from '@ng-select/ng-select/index';
 
 interface SearchResultItem {
   id:string;
@@ -252,10 +253,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   // If Enter key is pressed before result list is loaded, wait for the results to come
   // in and then decide what to do. If a direct hit is present, follow that. Otherwise,
   // go to the search in the current scope.
-  public onEnterBeforeResultsLoaded():void {
-    this.markable$.pipe(
-      first((v) => v),
-    ).subscribe(() => {
+  public onEnterBeforeResultsLoaded(): void {
+    this.markable$.pipe(first()).subscribe(() => {
       if (this.selectedItem) {
         this.followSelectedItem();
       } else {
@@ -368,8 +367,16 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     const searchOptions = this.detailedSearchOptions();
     // If we have a direct hit, we choose it to be the selected element.
     this.selectedItem = results.find((wp) => wp.id?.toString() === query) || searchOptions[0];
-    const resultCount = results.length + searchOptions.length;
-    this.liveMessage = this.I18n.t('js.global_search.items_available', { count: resultCount });
+
+    if (this.selectedItem instanceof WorkPackageResource) {
+      this.liveMessage = this.I18n.t('js.global_search.direct_hit_available');
+      this.setMarkedOption();
+    }
+    else {
+      const resultCount = results.length + searchOptions.length;
+      this.liveMessage = this.I18n.t('js.global_search.items_available', { count: resultCount });
+    }
+
     return [
       ...searchOptions,
       ...results,
@@ -391,6 +398,40 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     searchOptions.push('all_projects');
 
     return searchOptions.map((suggestion:string) => ({ projectScope: suggestion, text: this.text[suggestion] }));
+  }
+
+  /*
+   * Set the marked ng-option within ng-select and apply the class to highlight marked options.
+   *
+   * ng-select differentiates between the selected and the marked option. The selected optinon is the option
+   * that is binded via ng-model. The marked option is the one that the user is currently selecting (via mouse or keyboard up/down).
+   * When hitting enter, the marked option is taken to be the new selected option. Ng-select will retain the index of the marked
+   * option between individual searches. The selected option has no influence on the marked option. This is problematic
+   * in our use case as the user might have:
+   *   * the mouse hovering (deliberately or not) over the search options which will mark that option.
+   *   * marked an option for a previous search but might then have decided to add/remove additional characters to the search.
+   *
+   * In both cases, whenever the user presses enter then, ng-select assigns the marked option to the ng-model.
+   *
+   * Our goal however is to either:
+   *  * mark the direct hit (id matches) if it available
+   *  * mark the first item if there is no direct hit
+   *
+   * And we need to update the marked option after every search.
+   *
+   * There is no way of doing this via the interface provided in the template. There is only [markFirst] and it neither allows us
+   * to mark a direct hit, nor does it reset after a search. We handle this then by selecting the desired element once the
+   * search results are back. We then set the marked option to be the selected option.
+   *
+   * In order to avoid flickering, a -markable modifyer class is unset/set before/after searching. This will unset the background until we
+   * have marked the element we wish to.
+   */
+  private setMarkedOption():void {
+
+    this.markable = true;
+    this.ngSelectComponent.ngSelectInstance.itemsList.markItem(this.selectedItem as NgOption);
+
+    this.cdRef.detectChanges();
   }
 
   private searchInScope(scope:string):void {

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -115,6 +115,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   public isFocusedDirectly = !!this.currentQuery && this.selectedItem instanceof HalResource;
 
+  public liveMessage = '';
+
   private unregisterGlobalListener:(() => unknown)|undefined;
 
   public text:Record<string, string> = {
@@ -308,10 +310,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
       .fetchSearchResults(hashFreeQuery, hashFreeQuery !== query)
       .get()
       .pipe(
-        map((collection) => this.searchResultsToOptions(collection.elements, hashFreeQuery)),
-        tap(() => {
-          this.setMarkedOption();
-        }),
+        map((collection) => this.searchResultsToOptions(collection.elements, hashFreeQuery))
       );
   }
 
@@ -369,7 +368,8 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     const searchOptions = this.detailedSearchOptions();
     // If we have a direct hit, we choose it to be the selected element.
     this.selectedItem = results.find((wp) => wp.id?.toString() === query) || searchOptions[0];
-
+    const resultCount = results.length + searchOptions.length;
+    this.liveMessage = this.I18n.t('js.global_search.items_available', { count: resultCount });
     return [
       ...searchOptions,
       ...results,
@@ -391,39 +391,6 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     searchOptions.push('all_projects');
 
     return searchOptions.map((suggestion:string) => ({ projectScope: suggestion, text: this.text[suggestion] }));
-  }
-
-  /*
-   * Set the marked ng-option within ng-select and apply the class to highlight marked options.
-   *
-   * ng-select differentiates between the selected and the marked option. The selected optinon is the option
-   * that is binded via ng-model. The marked option is the one that the user is currently selecting (via mouse or keyboard up/down).
-   * When hitting enter, the marked option is taken to be the new selected option. Ng-select will retain the index of the marked
-   * option between individual searches. The selected option has no influence on the marked option. This is problematic
-   * in our use case as the user might have:
-   *   * the mouse hovering (deliberately or not) over the search options which will mark that option.
-   *   * marked an option for a previous search but might then have decided to add/remove additional characters to the search.
-   *
-   * In both cases, whenever the user presses enter then, ng-select assigns the marked option to the ng-model.
-   *
-   * Our goal however is to either:
-   *  * mark the direct hit (id matches) if it available
-   *  * mark the first item if there is no direct hit
-   *
-   * And we need to update the marked option after every search.
-   *
-   * There is no way of doing this via the interface provided in the template. There is only [markFirst] and it neither allows us
-   * to mark a direct hit, nor does it reset after a search. We handle this then by selecting the desired element once the
-   * search results are back. We then set the marked option to be the selected option.
-   *
-   * In order to avoid flickering, a -markable modifyer class is unset/set before/after searching. This will unset the background until we
-   * have marked the element we wish to.
-   */
-  private setMarkedOption():void {
-    this.markable = true;
-    this.ngSelectComponent.ngSelectInstance.itemsList.markItem(this.ngSelectComponent.ngSelectInstance.itemsList.selectedItems[0]);
-
-    this.cdRef.detectChanges();
   }
 
   private searchInScope(scope:string):void {

--- a/lookbook/docs/patterns/accessibility/18-aria-live.md.erb
+++ b/lookbook/docs/patterns/accessibility/18-aria-live.md.erb
@@ -14,8 +14,6 @@ We have decided to use a single global ARIA live region in `base.html` to ensure
 ### Live Region in `base.html`
 ```html
 <live-region>
-  <div id="polite" aria-live="polite" aria-atomic="true" class="sr-only"></div>
-  <div id="assertive" aria-live="assertive" aria-atomic="true" class="sr-only"></div>
 </live-region>
 ```
 

--- a/spec/features/search/recently_viewed_work_packages_spec.rb
+++ b/spec/features/search/recently_viewed_work_packages_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe "Recently viewed work packages",
 
       # work package is displayed and marked
       global_search.expect_work_package_option(work_package)
-      global_search.expect_work_package_marked(work_package)
 
       # clicking goes to the work package view
       global_search.click_work_package(work_package)

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -178,9 +178,8 @@ RSpec.describe "Search", :js, :selenium, with_settings: { per_page_options: "5" 
       input = page.find(".top-menu-search--input")
       input.set "Subject"
 
-      # Select ONLY the global search’s aria-live region, not ng-select's
       live_region = page.find(
-        ".top-menu-search > .sr-only[aria-live='polite']",
+        "live-region",
         visible: :all
       )
 

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -173,6 +173,19 @@ RSpec.describe "Search", :js, :selenium, with_settings: { per_page_options: "5" 
       expect(current_url).to include("filter=work_packages")
       expect(current_url).to include("scope=all")
     end
+
+    it "announces the number of items via aria-live" do
+      input = page.find(".top-menu-search--input")
+      input.set "Subject"
+
+      # Select ONLY the global search’s aria-live region, not ng-select's
+      live_region = page.find(
+        ".top-menu-search > .sr-only[aria-live='polite']",
+        visible: :all
+      )
+
+      expect(live_region).to have_text(/\d+ items available/, wait: 5)
+    end
   end
 
   describe "search for work packages" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65066

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

When the input is focused, the focus should stay in the input and show number of items for the screen reader.
Search icon shouldn't be tabable.
First item shouldn't be checked. User can navigate through items using arrow keys.
