### PR TITLE
Bug/69365 sub item status hover card misses animation

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -160,45 +160,45 @@
         end
       end
     end
+  end
+%>
 
-    # Card that appears when hovering over the progress bar
-    if render_sub_status_bar?
-      flex.with_row(classes: "op-portfolios--popover-container") do
-        flex_layout(
-          classes: "op-portfolios--popover op-hover-card",
-          id: sub_status_hover_card_id,
-          popover: :auto,
-          data: {
-            hover_card_trigger_target: "card",
-            test_selector: "op-portfolios--hover-card-#{portfolio.id}"
-          }
-        ) do |popover|
-          popover.with_column(mr: 3) do
-            sub_item_count = sub_statuses_with_percentages.sum { |s| s[:count] }
+<%=
+  # Card that appears when hovering over the progress bar
+  if render_sub_status_bar?
+    content_tag(:div, class: "op-hover-card--hidden-container") do
+      flex_layout(
+        id: sub_status_hover_card_id,
+        classes: "op-portfolios--popover",
+        data: {
+          test_selector: "op-portfolios--hover-card-#{portfolio.id}"
+        }
+      ) do |popover|
+        popover.with_column(mr: 3) do
+          sub_item_count = sub_statuses_with_percentages.sum { |s| s[:count] }
 
-            render(Primer::Beta::Text.new(color: :muted)) do
-              t("portfolios.index.sub_items_html", count: sub_item_count)
-            end
+          render(Primer::Beta::Text.new(color: :muted)) do
+            t("portfolios.index.sub_items_html", count: sub_item_count)
           end
+        end
 
-          sub_statuses_with_percentages.each do |status|
-            status => { code:, count: }
+        sub_statuses_with_percentages.each do |status|
+          status => { code:, count: }
 
-            status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")
+          status_label = t("js.grid.widgets.project_status.#{code || 'not_set'}")
 
-            popover.with_column(mr: 3, display: :flex) do
-              concat(content_tag(:span, "", class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(code)}"))
-              concat(
-                render(Primer::Beta::Text.new(ml: 2, font_weight: :bold)) do
-                  count.to_s
-                end
-              )
-              concat(
-                render(Primer::Beta::Text.new(ml: 1)) do
-                  " #{status_label}"
-                end
-              )
-            end
+          popover.with_column(mr: 3, display: :flex) do
+            concat(content_tag(:span, "", class: "op-bubble op-bubble_mini op-bubble_squared #{helpers.project_status_css_class(code)}"))
+            concat(
+              render(Primer::Beta::Text.new(ml: 2, font_weight: :bold)) do
+                count.to_s
+              end
+            )
+            concat(
+              render(Primer::Beta::Text.new(ml: 1)) do
+                " #{status_label}"
+              end
+            )
           end
         end
       end

--- a/frontend/src/global_styles/content/_hover_cards.sass
+++ b/frontend/src/global_styles/content/_hover_cards.sass
@@ -49,8 +49,9 @@
   padding: var(--overlay-paddingBlock-normal)
   border-radius: var(--overlay-borderRadius)
   opacity: 0
-  visibility: hidden
 
   &:popover-open
     opacity: 1
-    visibility: visible
+
+  &--hidden-container
+    display: none

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -51,8 +51,6 @@ export default class HoverCardTriggerController extends ApplicationController {
   private closeTimeout:number|null = null;
   private previousTarget:HTMLElement|null = null;
 
-  private staticPopover:HTMLElement|null = null;
-
   // Track whether we currently show a hover card or not. It is important not to open multiple hover cards at
   // the same time, and refrain from closing the wrong kind of modal overlay.
   private isShowingHoverCard = false;
@@ -168,7 +166,7 @@ export default class HoverCardTriggerController extends ApplicationController {
     if (!this.mouseIsHoveringOverTrigger) { return; }
 
     if (popoverElement) {
-      this.showExistingPopover(el, popoverElement);
+      this.showHoverCardViaExistingElement(el, popoverElement);
     } else {
       this.loadAndShowHoverCardViaTurboFrame(el, turboFrameUrl);
     }
@@ -180,7 +178,7 @@ export default class HoverCardTriggerController extends ApplicationController {
 
     this.moveOverlayToAppropriateParent(overlay, targetEl);
 
-    const { turboFrame, popover } = this.constructPopover(overlay, turboFrameUrl);
+    const { turboFrame, popover } = this.buildPopoverWithTurboFrame(overlay, turboFrameUrl);
 
     this.isShowingHoverCard = true;
     this.previousTarget = targetEl;
@@ -193,10 +191,14 @@ export default class HoverCardTriggerController extends ApplicationController {
     });
   }
 
-  private showExistingPopover(targetEl:HTMLElement, popover:HTMLElement) {
-    this.getAndResetOverlay();
+  private showHoverCardViaExistingElement(targetEl:HTMLElement, protoPopover:HTMLElement) {
+    const overlay = this.getAndResetOverlay();
+    if (!overlay) { return; }
 
-    this.staticPopover = popover;
+    this.moveOverlayToAppropriateParent(overlay, targetEl);
+
+    const popover = this.cloneStaticPopover(overlay, protoPopover);
+
     this.isShowingHoverCard = true;
     this.previousTarget = targetEl;
 
@@ -232,9 +234,6 @@ export default class HoverCardTriggerController extends ApplicationController {
 
     if (this.isShowingHoverCard && !this.mouseInModal) {
       this.getAndResetOverlay();
-
-      this.staticPopover?.hidePopover();
-      this.staticPopover = null;
 
       this.isShowingHoverCard = false;
       // Allow opening this target once more, since it has been orderly closed
@@ -301,11 +300,9 @@ export default class HoverCardTriggerController extends ApplicationController {
     });
   }
 
-  private constructPopover(overlay:HTMLElement, turboFrameUrl:string) {
+  private buildPopoverWithTurboFrame(overlay:HTMLElement, turboFrameUrl:string) {
     const popover = document.createElement('div');
-    popover.className = 'op-hover-card';
-    popover.setAttribute('popover', 'auto');
-    popover.setAttribute('data-hover-card-trigger-target', 'card');
+    this.setPopoverAttributes(popover);
 
     const turboFrame = document.createElement('turbo-frame');
     turboFrame.id = 'op-hover-card-body';
@@ -315,6 +312,23 @@ export default class HoverCardTriggerController extends ApplicationController {
     overlay.appendChild(popover);
 
     return { turboFrame, popover };
+  }
+
+  private cloneStaticPopover(overlay:HTMLElement, staticPopover:HTMLElement):HTMLElement {
+    const popover = staticPopover.cloneNode(true) as HTMLElement;
+
+    popover.removeAttribute('id');
+    this.setPopoverAttributes(popover);
+
+    overlay.appendChild(popover);
+
+    return popover;
+  }
+
+  private setPopoverAttributes(popover:HTMLElement) {
+    popover.classList.add('op-hover-card');
+    popover.setAttribute('popover', 'auto');
+    popover.setAttribute('data-hover-card-trigger-target', 'card');
   }
 
   /*

--- a/lookbook/docs/components/hover-cards.md.erb
+++ b/lookbook/docs/components/hover-cards.md.erb
@@ -62,8 +62,6 @@ The content of a hover card can be defined in two ways:
 2. Via an existing DOM element that is present (but hidden) in the document on page load. This is useful when the
    content is already present and no additional fetching is necessary.
 
-Essentially the `HoverCard` is just a div which renders inside a `turboFrame`.
-
 ### Asynchronous hover cards via turbo frame
 
 The element that defines the trigger (via `data-hover-card-trigger-target="trigger"`) must provide an attribute
@@ -135,20 +133,28 @@ trigger element.
 The hover card content can be placed at a convenient place in the DOM. The following attributes must be set on the
 element to ensure it will be displayed correctly:
 
-1. `op-hover-card` class.
-2. A `popover` attribute set to `auto`.
-3. The ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
+1. The ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
+2. The element from 1 should be placed into a container that is hidden. You *can* use the
+   class `op-hover-card--hidden-container` for that or define your own CSS to hide the container.
 
 On page load, the hover card will be hidden automatically. When hovering over the trigger, the hover card will be
 shown next to it.
 
+Please note that the hover card "blueprint" provided in the DOM will be cloned and moved into another location as part
+of displaying the card. The cloned elements ID will be removed to avoid duplicate IDs in the DOM.
+
+This is to say: do not apply logic or styling that depends on the ID of the hover card element itself, as the ID
+will remain with the hidden original element.
+
 **Card content**:
 ```html
-  <!-- Somewhere else in the DOM -->
-  <div class="op-hover-card"
-       id="work-package-hover-card-14"
-       popover="auto">
+  <!-- Somewhere else in the DOM... -->
 
-    <p>Description text of work package 14!</p>
+  <!-- Hidden container, so that the popover is hidden on page load -->
+  <div class="op-hover-card--hidden-container">
+    <!-- Actual hover card contents that will be rendered in a popover. Note the ID: -->
+    <div id="work-package-hover-card-14" class="your-styling-classes">
+      <p>Hover card with description text of work package 14!</p>
+    </div>
   </div>
 ```

--- a/spec/features/portfolios/index_spec.rb
+++ b/spec/features/portfolios/index_spec.rb
@@ -188,8 +188,8 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
 
           # The status bar shows a hover card on hover:
           page.find_test_selector("op-portfolios--sub-status-bar").hover
-          portfolios_page.expect_hover_card(portfolio_a, text: /3\ssub-items\s2\sOn track\s1\sAt risk/)
         end
+        portfolios_page.expect_hover_card(portfolio_a, text: /3\ssub-items\s2\sOn track\s1\sAt risk/)
       end
 
       it "does show an empty status bar if no sub-item has a status" do
@@ -204,8 +204,9 @@ RSpec.describe "Portfolios", "index", :js, with_ee: :portfolio_management do # T
           portfolios_page.expect_status_bar_percentage(portfolio_favorited, "not_set", "100.0", find_row: false)
 
           page.find_test_selector("op-portfolios--sub-status-bar").hover
-          portfolios_page.expect_hover_card(portfolio_favorited, text: /1\ssub-item\s1\sNot set/)
         end
+
+        portfolios_page.expect_hover_card(portfolio_favorited, text: /1\ssub-item\s1\sNot set/)
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69365

# What are you trying to accomplish?
Show the default fade-in animation for portfolio sub-item hover cards.

These did not work and the hover card popped into existence without any animation.

## Videos

### Before - without fade-in animation:

https://github.com/user-attachments/assets/49d9aa35-67d0-40a4-9d9a-a81ac4cb8507

### Now - with fade-in animation:

https://github.com/user-attachments/assets/ef3d1d31-f346-43a2-8cef-555695a63312


# What approach did you choose and why?
I noticed that the animation failing indicated a bigger issue in how different flavors of hover cards were displayed. To fix the animation, I normalized how different hover cards were treated. As a drive-by fix, this reduces the amount of preparation a developer has to perform to set up hover cards. Additionally, the controller could get rid of some state and logic.

Hover cards will now always be constructed as a new DOM element and appended to an overlay container. For static hover cards, the provided element will now be cloned. For turbo frames, nothing changed.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
