### PR TITLE
First implementation of MCP API server in OpenProject

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -161,6 +161,8 @@ gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues
 # prawn implicitly depends on matrix gem no longer in ruby core with 3.1
 gem "matrix", "~> 0.4.3"
 
+gem "mcp", "~> 0.4.0"
+
 gem "meta-tags", "~> 2.22.2"
 
 gem "paper_trail", "~> 17.0.0"
@@ -200,7 +202,7 @@ gem "aws-sdk-core", "~> 3.240"
 # File upload via fog + screenshots on travis
 gem "aws-sdk-s3", "~> 1.209"
 
-gem "openproject-token", "~> 8.3.0"
+gem "openproject-token", "~> 8.4.0"
 
 gem "plaintext", "~> 0.3.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -580,8 +580,6 @@ GEM
     ffi (1.17.2-arm-linux-gnu)
     ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
-    ffi (1.17.2-x86-linux-musl)
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
@@ -647,12 +645,6 @@ GEM
       bigdecimal
       rake (>= 13)
     google-protobuf (4.32.1-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.32.1-x86-linux-gnu)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.32.1-x86-linux-musl)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.32.1-x86_64-darwin)
@@ -745,6 +737,7 @@ GEM
       faraday-follow_redirects
     json-schema (4.3.1)
       addressable (>= 2.8)
+    json_rpc_handler (0.1.1)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -808,6 +801,9 @@ GEM
     marcel (1.1.0)
     markly (0.15.0)
     matrix (0.4.3)
+    mcp (0.4.0)
+      json-schema (>= 4.1)
+      json_rpc_handler (~> 0.1)
     messagebird-rest (5.0.0)
       jwt (< 4)
     meta-tags (2.22.2)
@@ -844,9 +840,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.10-aarch64-linux-musl)
@@ -895,7 +888,7 @@ GEM
       activesupport (>= 7.2.0)
       openproject-octicons (>= 19.30.1)
       view_component (>= 3.1, < 5.0)
-    openproject-token (8.3.0)
+    openproject-token (8.4.0)
       activemodel
     openssl (3.3.1)
     openssl-signature_algorithm (1.3.0)
@@ -1540,9 +1533,6 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
-  ruby
-  x86-linux-gnu
-  x86-linux-musl
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu
@@ -1636,6 +1626,7 @@ DEPENDENCIES
   mail (= 2.9.0)
   markly (~> 0.15)
   matrix (~> 0.4.3)
+  mcp (~> 0.4.0)
   md_to_pdf!
   meta-tags (~> 2.22.2)
   mini_magick (~> 5.3.0)
@@ -1671,7 +1662,7 @@ DEPENDENCIES
   openproject-reporting!
   openproject-storages!
   openproject-team_planner!
-  openproject-token (~> 8.3.0)
+  openproject-token (~> 8.4.0)
   openproject-two_factor_authentication!
   openproject-webhooks!
   openproject-xls_export!
@@ -1908,8 +1899,6 @@ CHECKSUMS
   ffi (1.17.2-arm-linux-gnu) sha256=d4a438f2b40224ae42ec72f293b3ebe0ba2159f7d1bd47f8417e6af2f68dbaa5
   ffi (1.17.2-arm-linux-musl) sha256=977dfb7f3a6381206dbda9bc441d9e1f9366bf189a634559c3b7c182c497aaa3
   ffi (1.17.2-arm64-darwin) sha256=54dd9789be1d30157782b8de42d8f887a3c3c345293b57ffb6b45b4d1165f813
-  ffi (1.17.2-x86-linux-gnu) sha256=95d8f9ebea23c39888e2ab85a02c98f54acb2f4e79b829250d7267ce741dc7b0
-  ffi (1.17.2-x86-linux-musl) sha256=41741449bab2b9530f42a47baa5c26263925306fad0ac2d60887f51af2e3b24c
   ffi (1.17.2-x86_64-darwin) sha256=981f2d4e32ea03712beb26e55e972797c2c5a7b0257955d8667ba58f2da6440e
   ffi (1.17.2-x86_64-linux-gnu) sha256=05d2026fc9dbb7cfd21a5934559f16293815b7ce0314846fee2ac8efbdb823ea
   ffi (1.17.2-x86_64-linux-musl) sha256=97c0eb3981414309285a64dc4d466bd149e981c279a56371ef811395d68cb95c
@@ -1934,8 +1923,6 @@ CHECKSUMS
   google-protobuf (4.32.1-aarch64-linux-gnu) sha256=b2254c50085b86a0395b2adea11d9742fe703a135b67689991dcc03a1c9bc179
   google-protobuf (4.32.1-aarch64-linux-musl) sha256=a9cdae8e14ccb781b40efb996ec7ca151fe8521c46cfd40e2b05d62867ab555c
   google-protobuf (4.32.1-arm64-darwin) sha256=ef2b6c138847f03af94eeed58ee8aaf00263dd66490ec659202c06dc3b2f0c29
-  google-protobuf (4.32.1-x86-linux-gnu) sha256=f8509ecd53e2e494222105a2ebf451ab5ac9f4d014ccd7c8c81699984f3295c2
-  google-protobuf (4.32.1-x86-linux-musl) sha256=3214d6025b4e4a995233c6500e38f954dfddffc985bb59d3cfe144d0b965fc00
   google-protobuf (4.32.1-x86_64-darwin) sha256=2e1fe608d8bbd09514258d84e2a281178214473f95f248ab82e0553c5ab6a8a3
   google-protobuf (4.32.1-x86_64-linux-gnu) sha256=2d209c1980dbdeb4114c7d839a3305fb78dc90bde42fb9a22974c8a4841e0263
   google-protobuf (4.32.1-x86_64-linux-musl) sha256=d5314aea8817bd372177205667b4f4442a5884212bcaccb1ba569ec8a1a06ec4
@@ -1972,6 +1959,7 @@ CHECKSUMS
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   json-jwt (1.17.0) sha256=6ff99026b4c54281a9431179f76ceb81faa14772d710ef6169785199caadc4cc
   json-schema (4.3.1) sha256=d5e68dc32b94408d0b06ad04f9382ccbb6fe5a44910e066f8547f56c471a7825
+  json_rpc_handler (0.1.1) sha256=ea248c8cb4d5490dde320db316ac5e3caf8137a20b5ff9035a4bfc1d19438d90
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   json_spec (1.1.5) sha256=7a77b97a92c787e2aa3fbc4a1239afc3342c781151dc98cfb81461b3b7cad10f
   jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
@@ -1992,6 +1980,7 @@ CHECKSUMS
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   markly (0.15.0) sha256=63328dac2f7c14d8fd4b9f9ed4c50f02f63a2b3e43ddeb8516aae528086f47ec
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mcp (0.4.0) sha256=4d1dd2b99fbd81a5fdc808d258c38a4f57dd69751ee1e5f62b3ab40e31625a36
   md_to_pdf (0.2.5)
   messagebird-rest (5.0.0) sha256=da4cc1efba3d5e4aa021fad07426c2cb6b326ce5670da5104bb8f6056a39d59c
   meta-tags (2.22.2) sha256=7fe78af4a92be12091f473cb84a21f6bddbd37f24c4413172df76cd14fff9e83
@@ -2014,7 +2003,6 @@ CHECKSUMS
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.4) sha256=d95dee68e0bb251b8ff90ac3423a511e3b784124e5db7ff5f4813a220ae73ca9
-  nokogiri (1.18.10) sha256=d5cc0731008aa3b3a87b361203ea3d19b2069628cb55e46ac7d84a0445e69cc1
   nokogiri (1.18.10-aarch64-linux-gnu) sha256=7fb87235d729c74a2be635376d82b1d459230cc17c50300f8e4fcaabc6195344
   nokogiri (1.18.10-aarch64-linux-musl) sha256=7e74e58314297cc8a8f1b533f7212d1999dbe2639a9ee6d97b483ea2acc18944
   nokogiri (1.18.10-arm-linux-gnu) sha256=51f4f25ab5d5ba1012d6b16aad96b840a10b067b93f35af6a55a2c104a7ee322
@@ -2054,7 +2042,7 @@ CHECKSUMS
   openproject-reporting (1.0.0)
   openproject-storages (1.0.0)
   openproject-team_planner (1.0.0)
-  openproject-token (8.3.0) sha256=67fcbc2319e050e4b64ee970477769a8589c5e94ec4be842cdd554ff715db7b7
+  openproject-token (8.4.0) sha256=12c2e17c74130b58507c2470bf9b75f02ce0330afbb2dbedc6e48d7ef0e5fb1a
   openproject-two_factor_authentication (1.0.0)
   openproject-webhooks (1.0.0)
   openproject-xls_export (1.0.0)

--- a/app/models/mcp_configuration.rb
+++ b/app/models/mcp_configuration.rb
@@ -28,42 +28,5 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  class Mcp < ::API::RootAPI
-    CONFIGURATION_IDENTIFIER = "mcp_server"
-
-    include ::API::AppsignalAPI
-
-    default_format :json
-
-    error_representer ::API::Mcp::ErrorRepresenter, :json
-    authentication_scope OpenProject::Authentication::Scope::MCP_SCOPE
-
-    helpers do
-      def server_config
-        @server_config ||= McpConfiguration.find_or_initialize_by(identifier: CONFIGURATION_IDENTIFIER)
-      end
-    end
-
-    post "/" do
-      if !OpenProject::FeatureDecisions.mcp_server_active? || !EnterpriseToken.allows_to?(:mcp_server) || !server_config.enabled?
-        status 404
-        return "MCP server is not available."
-      end
-
-      server = MCP::Server.new(
-        name: "openproject_mcp",
-        title: server_config.title,
-        # description: server_config.description, # not yet supported by mcp gem
-        version: "1.0.0",
-        tools: McpTools.enabled.map(&:tool),
-        server_context: { user_id: User.current.id }
-      )
-
-      status 200
-
-      # HACK: Grape is JSON-serializing whatever we return here, but handle_json already returns serialized JSON
-      JSON.parse server.handle_json(request.body.read)
-    end
-  end
+class McpConfiguration < ApplicationRecord
 end

--- a/app/seeders/mcp_configuration_seeder.rb
+++ b/app/seeders/mcp_configuration_seeder.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+class McpConfigurationSeeder < Seeder
+  def seed_data!
+    seed_server_config if server_missing?
+
+    seed_tool_configs
+  end
+
+  def applicable?
+    server_missing? || tools_missing?
+  end
+
+  def not_applicable_message
+    "No seeding of additional MCP configuration necessary."
+  end
+
+  private
+
+  def seed_server_config
+    McpConfiguration.create!(
+      identifier: API::Mcp::CONFIGURATION_IDENTIFIER,
+      title: Setting.app_title,
+      description: "Performs project management tasks on the given installation of OpenProject.",
+      enabled: true
+    )
+  end
+
+  def seed_tool_configs
+    McpTools.all.each do |thing| # rubocop:disable Rails/FindEach
+      next if McpConfiguration.find_by(identifier: thing.qualified_name)
+
+      McpConfiguration.create!(
+        identifier: thing.qualified_name,
+        title: thing.default_title,
+        description: thing.default_description,
+        enabled: true
+      )
+    end
+  end
+
+  def server_missing?
+    McpConfiguration.where(identifier: API::Mcp::CONFIGURATION_IDENTIFIER).empty?
+  end
+
+  def tools_missing?
+    (McpTools.all.map(&:qualified_name) - McpConfiguration.pluck(:identifier)).any?
+  end
+end

--- a/app/seeders/root_seeder.rb
+++ b/app/seeders/root_seeder.rb
@@ -81,6 +81,7 @@ class RootSeeder < Seeder
     seed_development_data if seed_development_data?
     seed_plugins_data
     seed_env_data
+    seed_mcp_configuration
     cleanup_seed_data
   end
 
@@ -177,6 +178,12 @@ class RootSeeder < Seeder
       print_status "*** Loading #{engine.engine_name} seed data"
       engine.load_seed
     end
+  end
+
+  def seed_mcp_configuration
+    print_status "*** Seeding MCP configuration"
+    McpConfigurationSeeder.new(seed_data).seed!
+    McpConfigurationSeeder
   end
 
   def desired_lang

--- a/app/services/mcp_tools.rb
+++ b/app/services/mcp_tools.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class << self
+    def all
+      [
+        McpTools::SearchProject
+      ]
+    end
+  end
+end

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class Base
+    class << self
+      def qualified_name
+        "tools/#{name}"
+      end
+
+      def default_title(title = nil)
+        @default_title = title if title.present?
+
+        @default_title
+      end
+
+      def default_description(description = nil)
+        @default_description = description if description.present?
+
+        @default_description
+      end
+
+      def name(name = nil)
+        @name = name if name.present?
+
+        @name
+      end
+
+      def input_schema(schema = nil)
+        @input_schema = schema if schema.present?
+
+        @input_schema
+      end
+
+      def output_schema(schema = nil)
+        @output_schema = schema if schema.present?
+
+        @output_schema
+      end
+
+      def tool
+        config = McpConfiguration.find_by(identifier: qualified_name)
+        return nil if config.nil?
+
+        implementation = self
+        MCP::Tool.define(
+          name:,
+          title: config.title,
+          description: config.description,
+          input_schema:,
+          output_schema:
+        ) do |opts|
+          implementation.new(tool_context: self).handle_request(**opts)
+        end
+      end
+    end
+
+    def initialize(tool_context:)
+      @tool_context = tool_context
+    end
+
+    def handle_request(**)
+      result = call(**)
+
+      if Rails.env.local?
+        # We are only validating the output during development, so we can see errors during dev, but do not break the
+        # API in production due to minor schema differences.
+        @tool_context.output_schema.validate_result(result.to_json)
+      end
+
+      MCP::Tool::Response.new([{ type: "text", text: result.to_json }], structured_content: result)
+    end
+
+    # Intended to be implemented by subclasses. It should return a structured result (e.g. a Hash or Array).
+    def call(**)
+      raise NotImplemented, "#{self.class} needs to implement #call method"
+    end
+  end
+end

--- a/app/services/mcp_tools/search_project.rb
+++ b/app/services/mcp_tools/search_project.rb
@@ -29,12 +29,15 @@
 #++
 
 module McpTools
-  class SearchProject < MCP::Tool
+  class SearchProject < Base
     # TODO: The mcp gem does not support pagination, so we only limit the number of results for now
     MAX_SIZE = 100
-    tool_name "search_project"
-    description "Search projects matching all of the passed input parameters. Parameters not passed are ignored. " \
-                "Results are limited to a maximum of #{MAX_SIZE} projects."
+
+    default_title "Search projects"
+    default_description "Search projects matching all of the passed input parameters. " \
+                        "Parameters not passed are ignored. Results are limited to a maximum of #{MAX_SIZE} projects."
+
+    name "search_project"
 
     input_schema(
       properties: {
@@ -49,36 +52,23 @@ module McpTools
       items: JsonSchemaLoader.new.load("project_model")
     )
 
-    class << self
-      def call(name: nil, identifier: nil, status_code: nil)
-        query = { name:, identifier:, status_code: }.compact
-        result = if query.present?
-                   projects = projects_for_query(query)
-                   projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user: User.current) }
-                 else
-                   []
-                 end
-
-        if Rails.env.development?
-          # We are only validating the output during development, so we can see errors during dev, but do not break the
-          # API in production due to minor schema differences.
-          output_schema.validate_result(result.to_json)
-        end
-
-        MCP::Tool::Response.new(
-          [{ type: "text", text: result.to_json }],
-          structured_content: result
-        )
+    def call(name: nil, identifier: nil, status_code: nil)
+      query = { name:, identifier:, status_code: }.compact
+      if query.present?
+        projects = projects_for_query(query)
+        projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user: User.current) }
+      else
+        []
       end
+    end
 
-      private
+    private
 
-      def projects_for_query(query)
-        name = query.delete(:name)
-        projects = Project.visible.where(query).limit(MAX_SIZE)
-        projects = projects.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(name)}%'") if name
-        projects
-      end
+    def projects_for_query(query)
+      name = query.delete(:name)
+      projects = Project.visible.where(query).limit(MAX_SIZE)
+      projects = projects.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(name)}%'") if name
+      projects
     end
   end
 end

--- a/app/services/mcp_tools/search_project.rb
+++ b/app/services/mcp_tools/search_project.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpTools
+  class SearchProject < MCP::Tool
+    # TODO: The mcp gem does not support pagination, so we only limit the number of results for now
+    MAX_SIZE = 100
+    tool_name "search_project"
+    description "Search projects matching all of the passed input parameters. Parameters not passed are ignored. " \
+                "Results are limited to a maximum of #{MAX_SIZE} projects."
+
+    input_schema(
+      properties: {
+        name: { type: "string", description: "Name of the project. Accepts partial project names, not case-sensitive." },
+        identifier: { type: "string", description: "Project indentifier. Case-sensitive, matching exactly." },
+        status_code: { type: "string", enum: Project.status_codes.keys, description: "The project status." }
+      }
+    )
+
+    output_schema(
+      type: :array,
+      items: JsonSchemaLoader.new.load("project_model")
+    )
+
+    class << self
+      def call(name: nil, identifier: nil, status_code: nil)
+        query = { name:, identifier:, status_code: }.compact
+        result = if query.present?
+                   projects = projects_for_query(query)
+                   projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user: User.current) }
+                 else
+                   []
+                 end
+
+        if Rails.env.development?
+          # We are only validating the output during development, so we can see errors during dev, but do not break the
+          # API in production due to minor schema differences.
+          output_schema.validate_result(result.to_json)
+        end
+
+        MCP::Tool::Response.new(
+          [{ type: "text", text: result.to_json }],
+          structured_content: result
+        )
+      end
+
+      private
+
+      def projects_for_query(query)
+        name = query.delete(:name)
+        projects = Project.visible.where(query).limit(MAX_SIZE)
+        projects = projects.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(name)}%'") if name
+        projects
+      end
+    end
+  end
+end

--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -52,6 +52,9 @@ OpenProject::FeatureDecisions.add :calculated_value_project_attribute,
 OpenProject::FeatureDecisions.add :beta_widgets,
                                   description: "Enables BETA versions of widgets."
 
+OpenProject::FeatureDecisions.add :mcp_server,
+                                  description: "Enables the experimental MCP API."
+
 OpenProject::FeatureDecisions.add :minutes_styling_meeting_pdf,
                                   description: "Allow exporting a meeting with FITKO styling. " \
                                                "See #65124 for details."

--- a/config/initializers/mcp.rb
+++ b/config/initializers/mcp.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+MCP.configure do |config|
+  config.exception_reporter = lambda do |exception, server_context|
+    cause = exception.cause
+    message = "Unhandled exception occured during MCP request: #{exception}"
+    if cause
+      message += ", caused by #{cause} at #{cause.backtrace.first}"
+    end
+
+    Rails.logger.error message
+    OpenProject::Appsignal.trace_exception(exception, server_context) if OpenProject::Appsignal.enabled?
+    OpenProject::OpenTelemetry.trace_exception(exception, server_context) if OpenProject::OpenTelemetry.enabled?
+  end
+end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -58,6 +58,10 @@ OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope
   %i[oauth jwt_oidc]
 end
 
+OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope::MCP_SCOPE, { store: false }) do |_|
+  %i[oauth jwt_oidc]
+end
+
 Rails.application.configure do |app|
   app.config.middleware.use OpenProject::Authentication::Manager, intercept_401: false # rubocop:disable Naming/VariableNumber
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
 
   get "/api/docs" => "api_docs#index"
 
+  mount API::Mcp => "/mcp"
+
   # Redirect deprecated issue links to new work packages uris
   get "/issues(/)" => redirect("#{rails_relative_url_root}/work_packages")
   # The URI.escape doesn't escape / unless you ask it to.

--- a/db/migrate/20251218133700_create_mcp_configurations.rb
+++ b/db/migrate/20251218133700_create_mcp_configurations.rb
@@ -28,42 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  class Mcp < ::API::RootAPI
-    CONFIGURATION_IDENTIFIER = "mcp_server"
-
-    include ::API::AppsignalAPI
-
-    default_format :json
-
-    error_representer ::API::Mcp::ErrorRepresenter, :json
-    authentication_scope OpenProject::Authentication::Scope::MCP_SCOPE
-
-    helpers do
-      def server_config
-        @server_config ||= McpConfiguration.find_or_initialize_by(identifier: CONFIGURATION_IDENTIFIER)
-      end
-    end
-
-    post "/" do
-      if !OpenProject::FeatureDecisions.mcp_server_active? || !EnterpriseToken.allows_to?(:mcp_server) || !server_config.enabled?
-        status 404
-        return "MCP server is not available."
-      end
-
-      server = MCP::Server.new(
-        name: "openproject_mcp",
-        title: server_config.title,
-        # description: server_config.description, # not yet supported by mcp gem
-        version: "1.0.0",
-        tools: McpTools.enabled.map(&:tool),
-        server_context: { user_id: User.current.id }
-      )
-
-      status 200
-
-      # HACK: Grape is JSON-serializing whatever we return here, but handle_json already returns serialized JSON
-      JSON.parse server.handle_json(request.body.read)
+class CreateMcpConfigurations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :mcp_configurations do |t|
+      t.string :identifier, null: false
+      t.string :title, null: false
+      t.string :description, null: false
+      t.boolean :enabled, null: false, default: false
+      t.timestamps null: false
     end
   end
 end

--- a/lib/api/mcp.rb
+++ b/lib/api/mcp.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  class Mcp < ::API::RootAPI
+    include ::API::AppsignalAPI
+
+    default_format :json
+
+    error_representer ::API::Mcp::ErrorRepresenter, :json
+    authentication_scope OpenProject::Authentication::Scope::MCP_SCOPE
+
+    post "/" do
+      if !OpenProject::FeatureDecisions.mcp_server_active? || !EnterpriseToken.allows_to?(:mcp_server)
+        status 404
+        return "MCP server is not available."
+      end
+
+      server = MCP::Server.new(
+        name: "openproject_mcp",
+        version: "1.0.0",
+        tools: McpTools.all,
+        server_context: { user_id: User.current.id }
+      )
+
+      status 200
+
+      # HACK: Grape is JSON-serializing whatever we return here, but handle_json already returns serialized JSON
+      JSON.parse server.handle_json(request.body.read)
+    end
+  end
+end

--- a/lib/api/mcp/error_representer.rb
+++ b/lib/api/mcp/error_representer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  class Mcp
+    class ErrorRepresenter
+      INVALID_REQUEST = -32600
+      INTERNAL_ERROR = -32603
+
+      def initialize(error)
+        @error = error
+      end
+
+      def to_json(*)
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: map_code(@error.code),
+            message: @error.message,
+            data: @error.details
+          }
+        }.to_json(*)
+      end
+
+      private
+
+      def map_code(code)
+        return INTERNAL_ERROR if code >= 500
+
+        INVALID_REQUEST
+      end
+    end
+  end
+end

--- a/lib_static/open_project/appsignal.rb
+++ b/lib_static/open_project/appsignal.rb
@@ -42,17 +42,21 @@ module OpenProject
 
     def exception_handler(message, log_context = {})
       if (exception = log_context[:exception])
-        if ::Appsignal::Transaction.current?
-          ::Appsignal.set_error(exception) do |transaction|
-            transaction.set_tags tags(log_context)
-          end
-        else
-          ::Appsignal.send_error(exception) do |transaction|
-            transaction.set_tags tags(log_context)
-          end
-        end
+        trace_exception(exception, log_context)
       else
         Rails.logger.warn "Ignoring non-exception message for appsignal #{message.inspect}"
+      end
+    end
+
+    def trace_exception(exception, context = {})
+      if ::Appsignal::Transaction.current?
+        ::Appsignal.set_error(exception) do |transaction|
+          transaction.set_tags tags(context)
+        end
+      else
+        ::Appsignal.send_error(exception) do |transaction|
+          transaction.set_tags tags(context)
+        end
       end
     end
 

--- a/lib_static/open_project/authentication.rb
+++ b/lib_static/open_project/authentication.rb
@@ -95,6 +95,7 @@ module OpenProject
     module Scope
       API_V3 = :api_v3
       SCIM_V2 = :scim_v2
+      MCP_SCOPE = :mcp
 
       class << self
         def values

--- a/lib_static/open_project/opentelemetry.rb
+++ b/lib_static/open_project/opentelemetry.rb
@@ -42,17 +42,21 @@ module OpenProject
       exception = log_context[:exception]
       return if exception.nil?
 
+      trace_exception(exception, log_context)
+    end
+
+    def trace_exception(exception, context = {})
       current_span = ::OpenTelemetry::Trace.current_span
       if current_span.context.valid?
         # Add exception to current span
         current_span.record_exception(exception)
-        set_span_attributes(current_span, tags(log_context))
+        set_span_attributes(current_span, tags(context))
       else
         # Create a new span for the exception if no current span
         tracer = ::OpenTelemetry.tracer_provider.tracer("openproject")
         tracer.in_span("exception") do |span|
           span.record_exception(exception)
-          set_span_attributes(span, tags(log_context))
+          set_span_attributes(span, tags(context))
         end
       end
     end

--- a/spec/factories/mcp_configuration_factory.rb
+++ b/spec/factories/mcp_configuration_factory.rb
@@ -23,25 +23,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module McpTools
-  class << self
-    def all
-      [
-        McpTools::SearchProject
-      ]
-    end
-
-    def enabled
-      McpConfiguration.where(enabled: true).pluck(:identifier).filter_map { |name| tools_by_name[name] }
-    end
-
-    def tools_by_name
-      all.index_by(&:qualified_name)
-    end
+FactoryBot.define do
+  factory :mcp_configuration do
+    identifier { "tools/tool_name" }
+    title { "The fancy tool" }
+    description { "This tool is very fancy and can be utilized for fancy tooling." }
+    enabled { true }
   end
 end

--- a/spec/requests/api/v3/support/mcp_examples.rb
+++ b/spec/requests/api/v3/support/mcp_examples.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.shared_examples_for "MCP result response" do
+  let(:json_rpc_response_schema) do
+    {
+      required: %w[jsonrpc id result],
+      properties: {
+        id: { type: "string" },
+        jsonrpc: { type: "string", enum: ["2.0"] },
+        result: { type: "object" }
+      }
+    }
+  end
+
+  it "returns a success" do
+    subject
+    expect(last_response).to have_http_status(200)
+  end
+
+  it "has no WWW-Authenticate header" do
+    subject
+    expect(last_response.headers["WWW-Authenticate"]).to be_nil
+  end
+
+  it "fulfills the schema of a JSON RPC response" do
+    subject
+    expect(last_response.body).to match_json_schema(json_rpc_response_schema)
+  end
+end
+
+RSpec.shared_examples_for "MCP response with structured content" do
+  let(:result_schema) do
+    {
+      required: %w[result],
+      properties: {
+        result: {
+          required: %w[isError content structuredContent],
+          properties: {
+            isError: { type: "boolean" },
+            content: { type: "array" },
+            structuredContent: { type: ["object", "array"] }
+          }
+        }
+      }
+    }
+  end
+
+  include_context "MCP result response"
+
+  it "fulfills the schema of a structured MCP response" do
+    subject
+    expect(last_response.body).to match_json_schema(json_rpc_response_schema)
+  end
+end
+
+RSpec.shared_examples_for "MCP error response" do
+  let(:json_rpc_response_schema) do
+    {
+      required: %w[jsonrpc id error],
+      properties: {
+        id: { type: "string" },
+        jsonrpc: { type: "string", enum: ["2.0"] },
+        error: {
+          type: "object",
+          required: %w[code message data],
+          properties: {
+            code: { type: "number" },
+            message: { type: "string" },
+            data: { type: "string" }
+          }
+        }
+      }
+    }
+  end
+
+  it "returns a success" do
+    subject
+    expect(last_response).to have_http_status(200)
+  end
+
+  it "has no WWW-Authenticate header" do
+    subject
+    expect(last_response.headers["WWW-Authenticate"]).to be_nil
+  end
+
+  it "fulfills the schema of a JSON RPC response" do
+    subject
+    expect(last_response.body).to match_json_schema(json_rpc_response_schema)
+  end
+end
+
+RSpec.shared_examples_for "MCP unauthenticated response" do
+  it "returns a 401 Unauthenticated" do
+    subject
+    expect(last_response).to have_http_status(401)
+  end
+
+  it "has a WWW-Authenticate header" do
+    subject
+    expect(last_response.headers["WWW-Authenticate"]).to be_present
+  end
+end

--- a/spec/requests/mcp/tools/search_project_spec.rb
+++ b/spec/requests/mcp/tools/search_project_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe "MCP search_project tool", with_flag: { mcp_server: true } do
   let!(:project_a) { create(:project, identifier: "abc", name: "The ABC Project", status_code: :on_track) }
   let!(:project_b) { create(:project, identifier: "def", name: "The DEF Project", status_code: :off_track) }
 
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: McpTools::SearchProject.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+  end
+
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
     it_behaves_like "MCP response with structured content"
 
@@ -138,6 +146,12 @@ RSpec.describe "MCP search_project tool", with_flag: { mcp_server: true } do
         subject
         expect(parsed_results.fetch("structuredContent")).to be_empty
       end
+    end
+
+    context "when the tool is disabled via configuration" do
+      let(:tool_config) { create(:mcp_configuration, identifier: McpTools::SearchProject.qualified_name, enabled: false) }
+
+      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/tools/search_project_spec.rb
+++ b/spec/requests/mcp/tools/search_project_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "MCP search_project tool", with_flag: { mcp_server: true } do
+  subject do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "X-Authentication-Scheme", "Bearer"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp", resource_owner: user) }
+  let(:user) { create(:admin) } # using an admin, so that projects are visible
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/call",
+      params: {
+        name: "search_project",
+        arguments: call_args
+      }
+    }
+  end
+  let(:call_args) { { identifier: "abc" } }
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  let!(:project_a) { create(:project, identifier: "abc", name: "The ABC Project", status_code: :on_track) }
+  let!(:project_b) { create(:project, identifier: "def", name: "The DEF Project", status_code: :off_track) }
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP response with structured content"
+
+    it "finds a project by identifier" do
+      subject
+      expect(parsed_results.fetch("structuredContent")).to be_present
+    end
+
+    it "responds with a properly formatted project" do
+      subject
+      project = parsed_results.fetch("structuredContent").first
+      expect(project.to_json).to match_json_schema.from_docs("project_model")
+    end
+
+    context "when passing a non-exact identifier" do
+      let(:call_args) { { identifier: "Abc" } }
+
+      it "does not find the project" do
+        subject
+        expect(parsed_results.fetch("structuredContent")).to be_empty
+      end
+    end
+
+    context "when passing an exact name" do
+      let(:call_args) { { name: "The ABC Project" } }
+
+      it "finds the project" do
+        subject
+        expect(parsed_results.fetch("structuredContent")).to be_present
+      end
+    end
+
+    context "when passing a non-exact name" do
+      let(:call_args) { { name: "The abc" } }
+
+      it "finds the project" do
+        subject
+        expect(parsed_results.fetch("structuredContent")).to be_present
+      end
+    end
+
+    context "when passing a project status" do
+      let(:call_args) { { status_code: "on_track" } }
+
+      it "finds the project" do
+        subject
+        expect(parsed_results.fetch("structuredContent")).to be_present
+      end
+
+      context "and when passing a project identifier" do
+        let(:call_args) { { status_code: "on_track", identifier: "abc" } }
+
+        it "finds the project" do
+          subject
+          expect(parsed_results.fetch("structuredContent")).to be_present
+        end
+      end
+
+      context "and when passing the project identifier of a project in a different status" do
+        let(:call_args) { { status_code: "on_track", identifier: "def" } }
+
+        it "does not find the project" do
+          subject
+          expect(parsed_results.fetch("structuredContent")).to be_empty
+        end
+      end
+    end
+
+    context "when passing an invalid project status" do
+      let(:call_args) { { status_code: "blubb" } }
+
+      it_behaves_like "MCP error response"
+    end
+
+    context "when user can't see projects" do
+      let(:user) { create(:user) }
+
+      it "does not find the project" do
+        subject
+        expect(parsed_results.fetch("structuredContent")).to be_empty
+      end
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds in a 404" do
+      subject
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end

--- a/spec/requests/mcp/tools_list_spec.rb
+++ b/spec/requests/mcp/tools_list_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
   end
   let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
 
+  let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
+  let(:tool_config) { create(:mcp_configuration, identifier: McpTools::SearchProject.qualified_name) }
+
+  before do
+    server_config.save!
+    tool_config.save!
+  end
+
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
     it_behaves_like "MCP result response"
 
@@ -57,6 +65,8 @@ RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
 
       tool = parsed_results.fetch("tools").find { |t| t.fetch("name") == "search_project" }
       expect(tool).not_to be_nil
+      expect(tool.fetch("title")).to eq(tool_config.title)
+      expect(tool.fetch("description")).to eq(tool_config.description)
     end
 
     context "when not passing a Bearer token" do
@@ -73,6 +83,15 @@ RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
       let(:access_token) { create(:oauth_access_token, scopes: "api_v3") }
 
       it_behaves_like "MCP unauthenticated response"
+    end
+
+    context "when the MCP server is disabled via configuration" do
+      let(:server_config) { create(:mcp_configuration, identifier: "mcp_server", enabled: false) }
+
+      it "responds in a 404" do
+        subject
+        expect(last_response).to have_http_status(404)
+      end
     end
   end
 

--- a/spec/requests/mcp/tools_list_spec.rb
+++ b/spec/requests/mcp/tools_list_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
+  subject do
+    header "Authorization", "Bearer #{access_token.plaintext_token}"
+    header "X-Authentication-Scheme", "Bearer"
+    header "Content-Type", "application/json"
+    post "/mcp", request_body.to_json
+  end
+
+  let(:access_token) { create(:oauth_access_token, scopes: "mcp") }
+  let(:request_body) do
+    {
+      jsonrpc: "2.0",
+      id: "Test-Request",
+      method: "tools/list",
+      params: {}
+    }
+  end
+  let(:parsed_results) { JSON.parse(last_response.body).fetch("result") }
+
+  context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
+    it_behaves_like "MCP result response"
+
+    it "includes the search_project tool" do
+      subject
+
+      tool = parsed_results.fetch("tools").find { |t| t.fetch("name") == "search_project" }
+      expect(tool).not_to be_nil
+    end
+
+    context "when not passing a Bearer token" do
+      subject do
+        header "X-Authentication-Scheme", "Bearer"
+        header "Content-Type", "application/json"
+        post "/mcp", request_body.to_json
+      end
+
+      it_behaves_like "MCP unauthenticated response"
+    end
+
+    context "when passing a Bearer token with a wrong scope" do
+      let(:access_token) { create(:oauth_access_token, scopes: "api_v3") }
+
+      it_behaves_like "MCP unauthenticated response"
+    end
+  end
+
+  context "when the mcp_server enterprise feature is disabled" do
+    it "responds in a 404" do
+      subject
+      expect(last_response).to have_http_status(404)
+    end
+  end
+end


### PR DESCRIPTION
So far the MCP server only offers a single tool, but authentication and integration is already built in a way that's intended to last.

Ideally extensions to this happen by adding additional tools or resources, but will not require further architectural changes, though realistically we'll probably identify more potential for reuse, once we added a few more tools.

The exact representation of results is still slightly to-be-discussed. Right now we are using vanilla APIv3 representation, which might be enough, but possibly we want to represent linked resources differently, so that they can be recognized
to be fetchable via MCP resources more easily.

# Ticket
* https://community.openproject.org/wp/68683
* https://community.openproject.org/wp/69992