### PR TITLE
[69517] Dereference RecurringMeeting author_id when deleting a user

### DIFF
--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -173,8 +173,9 @@ module OpenProject::Meeting
 
     replace_principal_references "Meeting" => %i[author_id],
                                  "MeetingAgendaItem" => %i[author_id presenter_id],
+                                 "MeetingOutcome" => :author_id,
                                  "MeetingParticipant" => :user_id,
-                                 "MeetingOutcome" => :author_id
+                                 "RecurringMeeting" => :author_id
 
     extend_api_response(:v3, :work_packages, :work_package,
                         &::OpenProject::Meeting::Patches::API::WorkPackageRepresenter.extension)

--- a/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
+++ b/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Principals::DeleteJob, "Meetings", type: :model do
     let!(:meeting) { create(:meeting, author: principal) }
     let!(:meeting_agenda_item) { create(:meeting_agenda_item, presenter: principal) }
     let!(:meeting_outcome) { create(:meeting_outcome, meeting_agenda_item:, author: principal) }
+    let!(:recurring_meeting) { create(:recurring_meeting, author: principal) }
 
     it "rewrites the references" do
       job
@@ -51,6 +52,7 @@ RSpec.describe Principals::DeleteJob, "Meetings", type: :model do
       expect(meeting.reload.author).to eq deleted_user
       expect(meeting_agenda_item.reload.presenter).to eq deleted_user
       expect(meeting_outcome.reload.author).to eq deleted_user
+      expect(recurring_meeting.reload.author).to eq deleted_user
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69517

# What are you trying to accomplish?

Make deletion of user work if that user created some recurring meetings.

Note: there is also a PR for the same thing targeting `release/16.6`: #21318

# What approach did you choose and why?

Straightforward: use our helpers to get the `Principal::DeleteJob` to replace `MeetingParticipant.author_id` references.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
