### PR TITLE
[#68714] User List in cost report is generated unsorted 

### DIFF
--- a/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
+++ b/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
@@ -133,14 +133,17 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
 
   # Returns the results of the query sorted by date the time was spent on and name
   def sorted_results
-    query
-      .each_direct_result
-      .map(&:itself)
+    results = query.each_direct_result.map(&:itself)
+
+    user_ids = results.map { |r| r.fields["user_id"] }.uniq
+    users_by_id = User.where(id: user_ids).index_by(&:id)
+
+    results
       .group_by { |r| r.fields["spent_on"] }
       .sort
       .flat_map do |_, date_results|
-        date_results.sort_by { |r| User.find_by(id: r.fields["user_id"])&.name&.downcase || "" }
-      end
+      date_results.sort_by { |r| users_by_id[r.fields["user_id"]]&.name&.downcase || "" }
+    end
   end
 
   def labour_query?

--- a/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
+++ b/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
@@ -131,14 +131,16 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
     %i[user_id activity_id entity_gid comments project_id]
   end
 
-  # Returns the results of the query sorted by date the time was spent on and by id
+  # Returns the results of the query sorted by date the time was spent on and name
   def sorted_results
     query
       .each_direct_result
       .map(&:itself)
       .group_by { |r| r.fields["spent_on"] }
       .sort
-      .flat_map { |_, date_results| date_results.sort_by { |r| r.fields["id"] } }
+      .flat_map do |_, date_results|
+        date_results.sort_by { |r| User.find_by(id: r.fields["user_id"])&.name&.downcase || "" }
+      end
   end
 
   def labour_query?

--- a/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
+++ b/modules/reporting/lib/open_project/reporting/cost_entry_xls_table.rb
@@ -134,15 +134,13 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
   # Returns the results of the query sorted by date the time was spent on and name
   def sorted_results
     results = query.each_direct_result.map(&:itself)
-
-    user_ids = results.map { |r| r.fields["user_id"] }.uniq
-    users_by_id = User.where(id: user_ids).index_by(&:id)
+    users_by_id = load_users_for_results(results)
 
     results
       .group_by { |r| r.fields["spent_on"] }
       .sort
       .flat_map do |_, date_results|
-      date_results.sort_by { |r| users_by_id[r.fields["user_id"]]&.name&.downcase || "" }
+      date_results.sort_by { |r| user_name_for_sorting(r, users_by_id) }
     end
   end
 
@@ -152,5 +150,14 @@ class OpenProject::Reporting::CostEntryXlsTable < OpenProject::XlsExport::XlsVie
 
   def with_times_column?
     Setting.allow_tracking_start_and_end_times && labour_query?
+  end
+
+  def load_users_for_results(results)
+    user_ids = results.map { |r| r.fields["user_id"] }.uniq
+    User.where(id: user_ids).index_by(&:id)
+  end
+
+  def user_name_for_sorting(result, users_by_id)
+    users_by_id[result.fields["user_id"]]&.name&.downcase || ""
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/68714

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Order the report by name instead of id, matching the order of rows in the PDF export

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
Change the final `sort_by` to be on each User.name (which formats according to a setting) instead of id

# Note
I'm not sure of the performance implications of this change. Earlier it was sorting on a param but now needs to find each user's name. Can this be avoided?