### PR TITLE
Extract blocknote localisation to reusable `useBlockNoteLocale` hook

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -30,7 +30,6 @@
 
 import { BlockNoteEditorOptions, BlockNoteSchema, filterSuggestionItems } from '@blocknote/core';
 import { User } from '@blocknote/core/comments';
-import * as blockNoteLocales from '@blocknote/core/locales';
 import { BlockNoteView } from '@blocknote/mantine';
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
@@ -39,6 +38,7 @@ import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaborati
 import { initializeOpBlockNoteExtensions, openProjectWorkPackageBlockSpec, openProjectWorkPackageSlashMenu } from 'op-blocknote-extensions';
 import { firstValueFrom } from 'rxjs';
 import * as Y from 'yjs';
+import { BlockNoteLocaleResult, useBlockNoteLocale } from './hooks/useBlockNoteLocale';
 import { useCollaboration } from './hooks/useCollaboration';
 import { useOpTheme } from './hooks/useOpTheme';
 
@@ -72,12 +72,9 @@ export default function OpBlockNoteContainer({ inputField,
                                                attachmentsUploadUrl,
                                                attachmentsCollectionKey,
                                                hocuspocusProvider }:OpBlockNoteContainerProps) {
+  const { localeString, localeDictionary }:BlockNoteLocaleResult = useBlockNoteLocale(window.I18n.locale);
 
-  const userLocale = window.I18n.locale;
-  const blockNoteLocaleString = Object.keys(blockNoteLocales).includes(userLocale) ? userLocale : 'en';
-  const blockNoteLocale = blockNoteLocales[blockNoteLocaleString as keyof typeof blockNoteLocales];
-
-  initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: blockNoteLocaleString});
+  initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
 
   let doc = LiveCollaborationManager.ydoc;
 
@@ -95,7 +92,7 @@ export default function OpBlockNoteContainer({ inputField,
         } as unknown as CollaborativeUser,
         showCursorLabels: 'activity'
       },
-      dictionary: blockNoteLocale,
+      dictionary: localeDictionary,
       ...(isReadyForAttachmentUpload() && { uploadFile }),
     };
   } else { // collaboration disabled
@@ -119,7 +116,7 @@ export default function OpBlockNoteContainer({ inputField,
           color: '#333333',
         },
       },
-      dictionary: blockNoteLocale,
+      dictionary: localeDictionary,
       ...(isReadyForAttachmentUpload() && { uploadFile }),
     };
   }

--- a/frontend/src/react/hooks/useBlockNoteLocale.ts
+++ b/frontend/src/react/hooks/useBlockNoteLocale.ts
@@ -1,0 +1,50 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import * as blockNoteLocales from '@blocknote/core/locales';
+import { useMemo } from 'react';
+
+export interface BlockNoteLocaleResult {
+  localeString:string; // e.g. 'en', 'de'
+  localeDictionary:typeof blockNoteLocales[keyof typeof blockNoteLocales];
+}
+
+/*
+ * BlockNote locale resolution hook
+ */
+export function useBlockNoteLocale(userLocale:string):BlockNoteLocaleResult {
+  return useMemo(() => {
+    const localeString = Object.keys(blockNoteLocales).includes(userLocale) ? userLocale : 'en';
+    const localeDictionary = blockNoteLocales[localeString as keyof typeof blockNoteLocales];
+    return { localeString, localeDictionary };
+  }, [userLocale]);
+}
+
+export default useBlockNoteLocale;


### PR DESCRIPTION
https://community.openproject.org/wp/69534

Refactors how BlockNote locale handling is implemented in the `OpBlockNoteContainer` React component. The main improvement is the extraction of a custom React hook to encapsulate locale resolution logic, making the code more modular and easier to maintain.