### PR TITLE
bug/69542 Document connection recovery/reconnect banners flood the page

### DIFF
--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -89,7 +89,8 @@ class DocumentsController < ApplicationController
 
   def render_connection_recovery
     render_success_flash_message_via_turbo_stream(
-      message: I18n.t("documents.show_edit_view.connection_recovery_notice.description")
+      message: I18n.t("documents.show_edit_view.connection_recovery_notice.description"),
+      unique_key: "document-connection-recovery-notice-#{@document.id}"
     )
 
     respond_with_turbo_streams


### PR DESCRIPTION
https://community.openproject.org/work_packages/69542

Adds a unique key to the recovery flash notice so that we only get one notice for every document. The recovery (success) flash message will autohide based on the users preference.

Lookbook: https://qa.openproject-edge.com/lookbook/inspect/OpenProject/Primer/flash/unique_key

<details> <summary> Reproduce locally by sending multiple streams on recovery </summary>

```rb
diff --git a/modules/documents/app/controllers/documents_controller.rb b/modules/documents/app/controllers/documents_controller.rb
index 18361879643..fb59f68b659 100644
--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -90,7 +90,14 @@ class DocumentsController < ApplicationController
   def render_connection_recovery
     render_success_flash_message_via_turbo_stream(
       message: I18n.t("documents.show_edit_view.connection_recovery_notice.description"),
-      unique_key: "document-connection-recovery-notice-#{@document.id}"
+      unique_key: "document-connection-recovery-notice-#{@document.id}",
+      dismiss_scheme: :none
+    )
+
+    render_success_flash_message_via_turbo_stream(
+      message: I18n.t("documents.show_edit_view.connection_recovery_notice.description"),
+      unique_key: "document-connection-recovery-notice-#{@document.id}",
+      dismiss_scheme: :none
     )
 
     respond_with_turbo_streams
```

</details>

<img width="1746" height="1250" alt="Screenshot 2025-12-02 at 10 33 03 AM" src="https://github.com/user-attachments/assets/c54900f6-3e6f-46dd-97fd-089d70679996" />
