### PR TITLE
bug/67443 Use default scheme for secondary link as per designs

### DIFF
--- a/modules/documents/app/components/documents/admin/document_categories/deprecation_notice_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_categories/deprecation_notice_component.html.erb
@@ -44,7 +44,7 @@
       ).with_content(I18n.t("documents.document_categories_deprecation_notice.primary_action"))
 
       component.with_secondary_action(
-        scheme: :secondary,
+        scheme: :default,
         label: I18n.t("documents.document_categories_deprecation_notice.secondary_action"),
         tag: :a,
         href: OpenProject::Static::Links.url_for(:documents_docs)


### PR DESCRIPTION
https://community.openproject.org/wp/67443

<img width="2466" height="405" alt="Screenshot 2025-12-02 at 12 07 10 PM" src="https://github.com/user-attachments/assets/e8e4199d-7615-41da-8e1f-449ff0d29a61" />
