### PR TITLE
Avoid deprecation warnings for time and cost entries representers

### DIFF
--- a/lib/api/decorators/linked_resource.rb
+++ b/lib/api/decorators/linked_resource.rb
@@ -90,7 +90,6 @@ module API
                      show_if: ->(*) { true },
                      skip_render: nil,
                      embedded: true)
-
           link(link_attr(name, uncacheable_link, link_cache_if), &link)
 
           property name,
@@ -113,7 +112,6 @@ module API
                       show_if: ->(*) { true },
                       skip_render: nil,
                       embedded: true)
-
           links(link_attr(name, uncacheable_link, link_cache_if), &link)
 
           property name,
@@ -131,7 +129,6 @@ module API
                           setter:,
                           getter:,
                           show_if: ->(*) { true })
-
           resource(name,
                    getter: ->(*) {},
                    setter:,
@@ -154,16 +151,18 @@ module API
                                 skip_link: skip_render,
                                 undisclosed: false,
                                 link_title_attribute: :name,
+                                link_getter: :"#{name}_id",
+                                link_property_name: nil,
                                 uncacheable_link: false,
                                 getter: associated_resource_default_getter(name, representer),
                                 setter: associated_resource_default_setter(name, as, v3_path),
-                                link: associated_resource_default_link(name,
+                                link: associated_resource_default_link(link_property_name || name,
                                                                        v3_path:,
                                                                        skip_link:,
                                                                        undisclosed:,
-                                                                       title_attribute: link_title_attribute))
-
-          resource((as || name),
+                                                                       title_attribute: link_title_attribute,
+                                                                       getter: link_getter))
+          resource(as || name,
                    getter:,
                    setter:,
                    link:,
@@ -240,7 +239,6 @@ module API
                                                                          v3_path:,
                                                                          skip_link:,
                                                                          title_attribute: link_title_attribute))
-
           resources(as,
                     getter:,
                     setter:,
@@ -251,7 +249,6 @@ module API
 
         def associated_resources_default_getter(name,
                                                 representer)
-
           representer ||= default_representer(name.to_s.singularize)
 
           ->(*) do

--- a/modules/costs/lib/api/v3/cost_entries/cost_entry_representer.rb
+++ b/modules/costs/lib/api/v3/cost_entries/cost_entry_representer.rb
@@ -45,7 +45,9 @@ module API
 
         # TODO: DEPRECATED!
         associated_resource :work_package,
-                            skip_render: ->(*) { represented.entity_type != "WorkPackage" }
+                            skip_render: ->(*) { represented.entity_type != "WorkPackage" },
+                            link_property_name: :entity, # to avoid deprecation warnings with cost_entry.work_package
+                            link_getter: :entity_id # to avoid deprecation warnings with cost_entry.work_package_id
 
         property :id, render_nil: true
         property :units, as: :spentUnits

--- a/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
+++ b/modules/costs/lib/api/v3/time_entries/time_entry_representer.rb
@@ -101,6 +101,8 @@ module API
         # TODO: DEPRECATED!
         associated_resource :work_package,
                             skip_render: ->(*) { represented.entity_type != "WorkPackage" },
+                            link_property_name: :entity, # to avoid deprecation warnings with time_entry.work_package
+                            link_getter: :entity_id, # to avoid deprecation warnings with time_entry.work_package_id
                             getter: ->(*) { represented.entity if represented.entity_type == "WorkPackage" },
                             setter: ::API::V3::TimeEntries::EntityRepresenterFactory.create_setter_lambda(:entity)
 

--- a/modules/costs/spec/lib/api/v3/cost_entries/cost_entry_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/cost_entries/cost_entry_representer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe API::V3::CostEntries::CostEntryRepresenter do
   it_behaves_like "has a titled link" do
     let(:link) { "entity" }
     let(:href) { api_v3_paths.work_package cost_entry.entity.id }
-    let(:title) { cost_entry.work_package.subject }
+    let(:title) { cost_entry.entity.subject }
   end
 
   it "has an id" do


### PR DESCRIPTION
They both use `work_package` and `work_package_id` to render links, which generates verbose deprecation warnings. They are filling up logs.

Force usage of `entity` and `entity_id` instead in the api representers to reduce the burden.

This is a backport of 5292033e1ba from `release/17.0` to `release/16.6` branch.
