### PR TITLE
Enable Rails/SaveBang cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -180,6 +180,9 @@ Rails/HttpPositionalArguments:
 Rails/RequireDependency:
   Enabled: true
 
+Rails/SaveBang:
+  Enabled: true
+
 # For feature specs, we tend to have longer specs that cover a larger part of the functionality.
 # This is done for multiple reasons:
 # * performance, as setting up integration tests is costly


### PR DESCRIPTION
It should remind us to either check the
result of calls to persisting active_record methods or use the "bang" version, which raises exceptions instead.

This ensures that not saving a record is always noticed one way or another.