### PR TITLE
[69589] Blankslate button of subitems widget should be renamed

### DIFF
--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -106,7 +106,7 @@ See COPYRIGHT and LICENSE files for more details.
               scheme: :secondary
             ) do |button|
               button.with_leading_visual_icon(icon: :plus)
-              t(".button_text")
+              t(:label_subproject)
             end
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69589

# What are you trying to accomplish?
Rename button

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
<img width="342" height="251" alt="Bildschirmfoto 2025-12-02 um 14 38 39" src="https://github.com/user-attachments/assets/67862d0c-3945-436e-9e88-0577e52e6b20" />


