### PR TITLE
[69449] Date field is unnecessary long on My account page

### DIFF
--- a/app/forms/custom_fields/inputs/date.rb
+++ b/app/forms/custom_fields/inputs/date.rb
@@ -34,6 +34,6 @@ class CustomFields::Inputs::Date < CustomFields::Inputs::Base::Input
   end
 
   def input_attributes
-    super.merge({ type: "date" })
+    super.merge({ input_width: :xsmall, type: "date" })
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69449

# What are you trying to accomplish?
Make date fields smaller per default

## Screenshots

<img width="274" height="164" alt="Bildschirmfoto 2025-12-02 um 14 58 55" src="https://github.com/user-attachments/assets/49f1bbec-66f2-4b9c-8c8b-1dc41be4b86b" />
