### PR TITLE
Add protected resource metadata endpoint

### DIFF
--- a/app/controllers/oauth_metadata_controller.rb
+++ b/app/controllers/oauth_metadata_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OAuthMetadataController < ApplicationController
+  no_authorization_required! :protected_resource
+
+  skip_before_action :check_if_login_required
+
+  def protected_resource
+    render json: {
+      resource: resource_url,
+      resource_name: Setting.app_title,
+      authorization_servers:,
+      scopes_supported: OpenProject::Authentication::Scope.values,
+      bearer_methods_supported: ["header"],
+      resource_documentation: OpenProject::Static::Links.url_for(:api_docs)
+    }
+  end
+
+  private
+
+  def authorization_servers
+    OpenIDConnect::Provider.where(available: true).map(&:issuer) + [local_issuer]
+  end
+
+  def instance_base_url
+    "http#{'s' if request.ssl?}://#{Setting.host_name}"
+  end
+
+  alias resource_url instance_base_url
+
+  alias local_issuer instance_base_url
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
   get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
   match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 
+  get "/.well-known/oauth-protected-resource", to: "oauth_metadata#protected_resource", as: :protected_resource_metadata
+
   # In case assets are actually delivered by a node server (e.g. in test env)
   # forward requests to the proxy
   if FrontendAssetHelper.assets_proxied?

--- a/lib_static/open_project/authentication.rb
+++ b/lib_static/open_project/authentication.rb
@@ -273,7 +273,11 @@ module OpenProject
                                   request_headers)
 
         header = %{#{scheme} realm="#{scope_realm(scope)}"}
-        header << %{, scope="#{escape_string scope}"}                         if scope && scheme == "Bearer"
+        if scheme == "Bearer"
+          header << %{, resource_metadata="#{resource_metadata}"}
+          header << %{, scope="#{escape_string scope}"} if scope
+        end
+
         header << %{, error="#{escape_string error}"}                         if error
         header << %{, error_description="#{escape_string error_description}"} if error && error_description
         header
@@ -289,6 +293,10 @@ module OpenProject
 
       def escape_string(string)
         string.to_s.dump[1..-2]
+      end
+
+      def resource_metadata
+        OpenProject::StaticRouting::StaticRouter.new.url_helpers.protected_resource_metadata_url
       end
     end
 

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "API V3 Authentication" do
       "message" => expected_message
     }
   end
+  let(:resource_metadata) { 'resource_metadata="http://test.host/.well-known/oauth-protected-resource"' }
 
   describe "oauth" do
     let(:oauth_access_token) { "" }
@@ -64,7 +65,9 @@ RSpec.describe "API V3 Authentication" do
 
     context "with an invalid access token" do
       let(:oauth_access_token) { "1337" }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       it "returns unauthorized" do
         expect(last_response).to have_http_status :unauthorized
@@ -76,7 +79,9 @@ RSpec.describe "API V3 Authentication" do
     context "with a revoked access token" do
       let(:token) { create(:oauth_access_token, resource_owner: user, revoked_at: DateTime.now) }
       let(:oauth_access_token) { token.plaintext_token }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       it "returns unauthorized" do
         expect(last_response).to have_http_status :unauthorized
@@ -88,7 +93,9 @@ RSpec.describe "API V3 Authentication" do
     context "when the token's application is disabled" do
       let(:token) { create(:oauth_access_token, resource_owner: user, application: create(:oauth_application, enabled: false)) }
       let(:oauth_access_token) { token.plaintext_token }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       it "returns unauthorized" do
         expect(last_response).to have_http_status :unauthorized
@@ -100,7 +107,9 @@ RSpec.describe "API V3 Authentication" do
     context "with an expired access token" do
       let(:token) { create(:oauth_access_token, resource_owner: user) }
       let(:oauth_access_token) { token.plaintext_token }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       around do |ex|
         Timecop.freeze(Time.current + (token.expires_in + 5).seconds) do
@@ -118,7 +127,9 @@ RSpec.describe "API V3 Authentication" do
     context "with wrong scope" do
       let(:token) { create(:oauth_access_token, resource_owner: user, scopes: "unknown_scope") }
       let(:oauth_access_token) { token.plaintext_token }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="insufficient_scope"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="insufficient_scope"}
+      end
 
       it "returns forbidden" do
         expect(last_response).to have_http_status :forbidden
@@ -131,7 +142,9 @@ RSpec.describe "API V3 Authentication" do
       let(:token) { create(:oauth_access_token, resource_owner: user, application:) }
       let(:application) { create(:oauth_application) }
       let(:oauth_access_token) { token.plaintext_token }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       around do |ex|
         user.destroy
@@ -159,7 +172,9 @@ RSpec.describe "API V3 Authentication" do
       let(:token) { create(:oauth_access_token, resource_owner: user) }
       let(:oauth_access_token) { token.plaintext_token }
       let(:user) { create(:user, :locked) }
-      let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+      end
 
       it "returns unauthorized" do
         expect(last_response).to have_http_status :unauthorized
@@ -196,7 +211,9 @@ RSpec.describe "API V3 Authentication" do
         context "and the client credentials user is locked" do
           let(:user) { create(:user, :locked) }
           let(:expected_message) { "You did not provide the correct credentials." }
-          let(:expected_www_auth_header) { 'Bearer realm="OpenProject API", scope="api_v3", error="invalid_token"' }
+          let(:expected_www_auth_header) do
+            %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3", error="invalid_token"}
+          end
 
           it "returns unauthorized" do
             expect(last_response).to have_http_status :unauthorized
@@ -500,7 +517,7 @@ RSpec.describe "API V3 Authentication" do
     let(:token_scope) { "email profile api_v3" }
     let(:expected_message) { "You did not provide the correct credentials." }
     let(:expected_www_auth_header) do
-      "Bearer realm=\"OpenProject API\", scope=\"api_v3\", error=\"#{expected_error}\", " \
+      "Bearer realm=\"OpenProject API\", #{resource_metadata}, scope=\"api_v3\", error=\"#{expected_error}\", " \
         "error_description=\"#{expected_error_description}\""
     end
     let(:expected_error) { "invalid_token" }

--- a/spec/requests/scim_v2/authentication_spec.rb
+++ b/spec/requests/scim_v2/authentication_spec.rb
@@ -126,7 +126,8 @@ RSpec.describe "SCIM API Authentication" do
         context "when scim_v2 scope is missing in token" do
           let(:token_scope) { "api_v3" }
           let(:expected_www_auth_header) do
-            'Bearer realm="OpenProject API", scope="scim_v2", error="insufficient_scope", ' \
+            'Bearer realm="OpenProject API", resource_metadata="http://test.host/.well-known/oauth-protected-resource", ' \
+              'scope="scim_v2", error="insufficient_scope", ' \
               'error_description="Requires scope scim_v2 to access this resource."'
           end
 
@@ -140,7 +141,8 @@ RSpec.describe "SCIM API Authentication" do
 
         context "when token_sub does not match a service_account" do
           let(:expected_www_auth_header) do
-            'Bearer realm="OpenProject API", scope="scim_v2", error="invalid_token", ' \
+            'Bearer realm="OpenProject API", resource_metadata="http://test.host/.well-known/oauth-protected-resource", ' \
+              'scope="scim_v2", error="invalid_token", ' \
               'error_description="The user identified by the token is not known"'
           end
 


### PR DESCRIPTION
This kind of endpoint is defined in RFC 9728
and helps API clients to identify how they can authenticate in API requests, e.g. how tokens should be transmitted, which scopes can be used and which servers are in charge to hand out access tokens.

# Ticket
https://community.openproject.org/wp/69530