### PR TITLE
[#67719] Checking off participants in a meeting does not keep scroll position  

### DIFF
--- a/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
@@ -1,35 +1,37 @@
 <%=
-  flex_layout(align_items: :center, justify_content: :space_between) do |row|
-    row.with_column(flex: 1, classes: "ellipsis") do
-      render(
-        Users::AvatarComponent.new(
-          user: @participant.user,
-          classes: "op-principal_flex",
-          hover_card: { active: true, target: :custom }
-        )
-      )
-    end
-    row.with_column do
-      flex_layout(align_items: :center, justify_content: :space_between) do |actions|
-        if @meeting.in_progress?
-          actions.with_column(ml: 2) do
-            render(Meetings::Participants::AttendedToggleButtonComponent.new(meeting: @meeting, participant: @participant))
-          end
-        end
-        actions.with_column(ml: 2) do
-          render(
-            Primer::Beta::IconButton.new(
-              scheme: :invisible,
-              tag: :a,
-              href: meeting_participant_path(@meeting, @participant),
-              icon: :x,
-              aria: { label: I18n.t("meeting.participants.label.remove_participant") },
-              data: {
-                turbo_method: :delete,
-                test_selector: "remove_button_#{@participant.user_id}"
-              }
-            )
+  component_wrapper do
+    flex_layout(align_items: :center, justify_content: :space_between) do |row|
+      row.with_column(flex: 1, classes: "ellipsis") do
+        render(
+          Users::AvatarComponent.new(
+            user: @participant.user,
+            classes: "op-principal_flex",
+            hover_card: { active: true, target: :custom }
           )
+        )
+      end
+      row.with_column do
+        flex_layout(align_items: :center, justify_content: :space_between) do |actions|
+          if @meeting.in_progress?
+            actions.with_column(ml: 2) do
+              render(Meetings::Participants::AttendedToggleButtonComponent.new(meeting: @meeting, participant: @participant))
+            end
+          end
+          actions.with_column(ml: 2) do
+            render(
+              Primer::Beta::IconButton.new(
+                scheme: :invisible,
+                tag: :a,
+                href: meeting_participant_path(@meeting, @participant),
+                icon: :x,
+                aria: { label: I18n.t("meeting.participants.label.remove_participant") },
+                data: {
+                  turbo_method: :delete,
+                  test_selector: "remove_button_#{@participant.user_id}"
+                }
+              )
+            )
+          end
         end
       end
     end

--- a/modules/meeting/app/components/meetings/participants/box_row_component.rb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.rb
@@ -41,5 +41,9 @@ module Meetings
       @meeting = meeting
       @participant = participant
     end
+
+    def wrapper_uniq_by
+      @participant.id
+    end
   end
 end

--- a/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
+++ b/modules/meeting/app/controllers/concerns/meetings/agenda_component_streams.rb
@@ -95,6 +95,12 @@ module Meetings
         )
       end
 
+      def update_box_row_component_via_turbo_stream(participant:, meeting: @meeting)
+        update_via_turbo_stream(
+          component: Meetings::Participants::BoxRowComponent.new(meeting:, participant:)
+        )
+      end
+
       def update_show_items_via_turbo_stream(meeting: @meeting, current_occurrence: nil)
         meeting.sections.each do |meeting_section|
           update_show_items_of_section_via_turbo_stream(meeting_section:, current_occurrence:)

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -65,8 +65,7 @@ class MeetingParticipantsController < ApplicationController
   def toggle_attendance
     @participant.toggle!(:attended)
 
-    update_add_user_form_component_via_turbo_stream
-    update_list_component_via_turbo_stream
+    update_box_row_component_via_turbo_stream(participant: @participant)
     update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
 
     respond_with_turbo_streams


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67719

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Ensure scroll position is kept when toggling attendance for a long list of participants so that it is less annoying to do

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
- Toggling attendance now updates the specific participant row instead of the entire list
- I'm not sure why the `add_user_form` was being updated on toggling attendance before, but that caused the whole list to scroll back up even when only a single participant row was updated and so I've removed it from the toggle action. Hopefully nothing breaks 🤞🏽 