### PR TITLE
Code maintenance/69596 improve static hover cards by using templates

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -40,7 +40,7 @@
                 size: :large,
                 data: {
                   hover_card_trigger_target: "trigger",
-                  hover_card_popover_id: sub_status_hover_card_id,
+                  hover_card_popover_template_id: sub_status_hover_card_id,
                   test_selector: "op-portfolios--sub-status-bar"
                 }
               )

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -166,9 +166,8 @@
 <%=
   # Card that appears when hovering over the progress bar
   if render_sub_status_bar?
-    content_tag(:div, class: "op-hover-card--hidden-container") do
+    content_tag(:template, id: sub_status_hover_card_id) do
       flex_layout(
-        id: sub_status_hover_card_id,
         classes: "op-portfolios--popover",
         data: {
           test_selector: "op-portfolios--hover-card-#{portfolio.id}"

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -52,5 +52,5 @@ $status_not-set: var(--progressBar-track-bgColor) // invisible background color
       margin-top: var(--base-size-16, 1rem)
       margin-bottom: var(--base-size-16, 1rem) !important
 
-.op-hover-card:has(.op-portfolios--popover)
+.op-hover-card:has(> .op-portfolios--popover)
   width: fit-content

--- a/app/components/portfolios/details_component.sass
+++ b/app/components/portfolios/details_component.sass
@@ -51,3 +51,6 @@ $status_not-set: var(--progressBar-track-bgColor) // invisible background color
     @media screen and (max-width: $breakpoint-sm)
       margin-top: var(--base-size-16, 1rem)
       margin-bottom: var(--base-size-16, 1rem) !important
+
+.op-hover-card:has(.op-portfolios--popover)
+  width: fit-content

--- a/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.html.erb
@@ -50,9 +50,8 @@
         # As a courtesy to users, we show a hover card explaining why the toggle is disabled.
         if toggle_disabled?
           concat(
-            content_tag(:div, class: "op-hover-card--hidden-container") do
+            content_tag(:template, id: unique_hovercard_id) do
               flex_layout(
-                id: unique_hovercard_id,
                 classes: "op-project-custom-field--popover",
                 data: {
                   test_selector: "op-project-custom-field--hover-card-#{@project_custom_field.id}"

--- a/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.rb
+++ b/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.rb
@@ -72,7 +72,7 @@ module Projects
               if toggle_disabled?
                 # Add hover card that explains why this toggle switch is disabled
                 data[:hover_card_trigger_target] = "trigger"
-                data[:hover_card_popover_id] = unique_hovercard_id
+                data[:hover_card_popover_template_id] = unique_hovercard_id
               end
             end
           end

--- a/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.html.erb
@@ -56,9 +56,8 @@
         # As a courtesy to users, we show a hover card explaining why the toggle is disabled.
         if toggle_disabled?
           concat(
-            content_tag(:div, class: "op-hover-card--hidden-container") do
+            content_tag(:template, id: unique_hovercard_id) do
               flex_layout(
-                id: unique_hovercard_id,
                 classes: "op-project-custom-field--popover",
                 data: {
                   test_selector: "op-project-custom-field--hover-card-#{@project_custom_field.id}"

--- a/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.rb
+++ b/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.rb
@@ -87,7 +87,7 @@ module Projects
             if toggle_disabled?
               # Add hover card that explains why this toggle switch is disabled
               data[:hover_card_trigger_target] = "trigger"
-              data[:hover_card_popover_id] = unique_hovercard_id
+              data[:hover_card_popover_template_id] = unique_hovercard_id
             end
           end
         end

--- a/frontend/src/global_styles/content/_hover_cards.sass
+++ b/frontend/src/global_styles/content/_hover_cards.sass
@@ -52,6 +52,3 @@
 
   &:popover-open
     opacity: 1
-
-  &--hidden-container
-    display: none

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -273,7 +273,7 @@ export default class HoverCardTriggerController extends ApplicationController {
   }
 
   private getPopoverTemplateFromId(el:HTMLElement):HTMLTemplateElement|null {
-    const id = el.getAttribute('data-hover-card-popover-id');
+    const id = el.getAttribute('data-hover-card-popover-template-id');
     if (!id) { return null; }
 
     return document.getElementById(id) as HTMLTemplateElement;

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -277,9 +277,7 @@ export default class HoverCardTriggerController extends ApplicationController {
     if (!id) { return null; }
 
     const element = document.getElementById(id);
-    if (!element || !(element instanceof HTMLTemplateElement)) {
-      return null;
-    }
+    if (!(element instanceof HTMLTemplateElement)) { return null; }
 
     return element;
   }

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -318,12 +318,13 @@ export default class HoverCardTriggerController extends ApplicationController {
   }
 
   private popoverFromTemplate(overlay:HTMLElement, template:HTMLTemplateElement):HTMLElement {
-    const popoverFragment = template.content.cloneNode(true) as DocumentFragment;
-
-    overlay.appendChild(popoverFragment);
-
-    const popover = overlay.children[0] as HTMLElement;
+    const popover = document.createElement('div');
     this.setPopoverAttributes(popover);
+
+    const popoverFragment = template.content.cloneNode(true) as DocumentFragment;
+    popover.appendChild(popoverFragment);
+
+    overlay.appendChild(popover);
 
     return popover;
   }

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -146,8 +146,8 @@ export default class HoverCardTriggerController extends ApplicationController {
     this.close(true);
 
     const turboFrameUrl = this.parseHoverCardUrl(el);
-    const popoverEl = this.getPopoverFromId(el);
-    if (!turboFrameUrl && !popoverEl) { return; }
+    const popoverTemplate = this.getPopoverTemplateFromId(el);
+    if (!turboFrameUrl && !popoverTemplate) { return; }
 
     // Reset close timer for when hovering over multiple triggers in quick succession.
     // A timer from a previous hover card might still be running. We do not want it to
@@ -156,11 +156,11 @@ export default class HoverCardTriggerController extends ApplicationController {
 
     // Set a delay before showing the hover card
     this.hoverTimeout = window.setTimeout(() => {
-      this.showHoverCard(el, turboFrameUrl, popoverEl);
+      this.showHoverCard(el, turboFrameUrl, popoverTemplate);
     }, this.OPEN_DELAY_IN_MS);
   }
 
-  private showHoverCard(el:HTMLElement, turboFrameUrl:string, popoverElement:HTMLElement|null) {
+  private showHoverCard(el:HTMLElement, turboFrameUrl:string, popoverTemplate:HTMLTemplateElement|null) {
     // Abort if the trigger element is no longer present in the DOM. This can happen when this method is called after a delay.
     if (!this.element.contains(el)) { return; }
     // Do not try to show two hover cards at the same time.
@@ -168,8 +168,8 @@ export default class HoverCardTriggerController extends ApplicationController {
     // The mouse might have left the trigger while we were waiting for the hover delay.
     if (!this.mouseIsHoveringOverTrigger) { return; }
 
-    if (popoverElement) {
-      this.showHoverCardViaExistingElement(el, popoverElement);
+    if (popoverTemplate) {
+      this.showHoverCardViaExistingElement(el, popoverTemplate);
     } else {
       this.loadAndShowHoverCardViaTurboFrame(el, turboFrameUrl);
     }
@@ -194,13 +194,13 @@ export default class HoverCardTriggerController extends ApplicationController {
     });
   }
 
-  private showHoverCardViaExistingElement(targetEl:HTMLElement, protoPopover:HTMLElement) {
+  private showHoverCardViaExistingElement(targetEl:HTMLElement, popoverTemplate:HTMLTemplateElement) {
     const overlay = this.getAndResetOverlay();
     if (!overlay) { return; }
 
     this.moveOverlayToAppropriateParent(overlay, targetEl);
 
-    const popover = this.cloneStaticPopover(overlay, protoPopover);
+    const popover = this.popoverFromTemplate(overlay, popoverTemplate);
 
     this.isShowingHoverCard = true;
     this.previousTarget = targetEl;
@@ -272,11 +272,11 @@ export default class HoverCardTriggerController extends ApplicationController {
     return url === 'about:blank' ? '' : url;
   }
 
-  private getPopoverFromId(el:HTMLElement):HTMLElement|null {
+  private getPopoverTemplateFromId(el:HTMLElement):HTMLTemplateElement|null {
     const id = el.getAttribute('data-hover-card-popover-id');
     if (!id) { return null; }
 
-    return document.getElementById(id);
+    return document.getElementById(id) as HTMLTemplateElement;
   }
 
   private async reposition(element:HTMLElement, target:HTMLElement) {
@@ -317,13 +317,13 @@ export default class HoverCardTriggerController extends ApplicationController {
     return { turboFrame, popover };
   }
 
-  private cloneStaticPopover(overlay:HTMLElement, staticPopover:HTMLElement):HTMLElement {
-    const popover = staticPopover.cloneNode(true) as HTMLElement;
+  private popoverFromTemplate(overlay:HTMLElement, template:HTMLTemplateElement):HTMLElement {
+    const popoverFragment = template.content.cloneNode(true) as DocumentFragment;
 
-    popover.removeAttribute('id');
+    overlay.appendChild(popoverFragment);
+
+    const popover = overlay.children[0] as HTMLElement;
     this.setPopoverAttributes(popover);
-
-    overlay.appendChild(popover);
 
     return popover;
   }

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -276,7 +276,12 @@ export default class HoverCardTriggerController extends ApplicationController {
     const id = el.getAttribute('data-hover-card-popover-template-id');
     if (!id) { return null; }
 
-    return document.getElementById(id) as HTMLTemplateElement;
+    const element = document.getElementById(id);
+    if (!element || !(element instanceof HTMLTemplateElement)) {
+      return null;
+    }
+
+    return element;
   }
 
   private async reposition(element:HTMLElement, target:HTMLElement) {

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -326,7 +326,7 @@ export default class HoverCardTriggerController extends ApplicationController {
     const popover = document.createElement('div');
     this.setPopoverAttributes(popover);
 
-    const popoverFragment = template.content.cloneNode(true) as DocumentFragment;
+    const popoverFragment = document.importNode(template.content, true);
     popover.appendChild(popoverFragment);
 
     overlay.appendChild(popover);

--- a/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
+++ b/frontend/src/stimulus/controllers/hover-card-trigger.controller.ts
@@ -262,7 +262,7 @@ export default class HoverCardTriggerController extends ApplicationController {
    * When there is no URL or if the URL is invalid, will return an empty string.
    */
   private parseHoverCardUrl(el:HTMLElement) {
-    let url = el.getAttribute('data-hover-card-url');
+    let url = el.dataset.hoverCardUrl;
     if (!url) { return ''; }
 
     url = sanitizeUrl(url);
@@ -273,7 +273,7 @@ export default class HoverCardTriggerController extends ApplicationController {
   }
 
   private getPopoverTemplateFromId(el:HTMLElement):HTMLTemplateElement|null {
-    const id = el.getAttribute('data-hover-card-popover-template-id');
+    const id = el.dataset.hoverCardPopoverTemplateId;
     if (!id) { return null; }
 
     const element = document.getElementById(id);
@@ -335,7 +335,7 @@ export default class HoverCardTriggerController extends ApplicationController {
   private setPopoverAttributes(popover:HTMLElement) {
     popover.classList.add('op-hover-card');
     popover.setAttribute('popover', 'auto');
-    popover.setAttribute('data-hover-card-trigger-target', 'card');
+    popover.dataset.hoverCardTriggerTarget = 'card';
   }
 
   /*

--- a/lookbook/docs/components/hover-cards.md.erb
+++ b/lookbook/docs/components/hover-cards.md.erb
@@ -59,8 +59,8 @@ The content of a hover card can be defined in two ways:
 
 1. Via a turbo frame that is fetched from a URL. This is the preferred way if you want to lazily load the contents
    of the hover card when needed.
-2. Via an existing DOM element that is present (but hidden) in the document on page load. This is useful when the
-   content is already present and no additional fetching is necessary.
+2. Via an existing `<template>` element that is present (but hidden) in the document on page load. This is useful when the
+   content is already there and no additional fetching of data is necessary.
 
 ### Asynchronous hover cards via turbo frame
 
@@ -130,31 +130,27 @@ trigger element.
     </a>
   </body>
 ```
-The hover card content can be placed at a convenient place in the DOM. The following attributes must be set on the
-element to ensure it will be displayed correctly:
+The hover card content can be placed at a convenient place in the DOM. It is recommended to use a
+[template element](https://www.w3schools.com/TagS/tag_template.asp) for that purpose. Whichever element you use: it is
+required to assign the ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
 
-1. The ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
-2. The element from 1 should be placed into a container that is hidden. You *can* use the
-   class `op-hover-card--hidden-container` for that or define your own CSS to hide the container.
+When a template is used, the hover card will be hidden automatically. If another type of element is used, you are
+responsible for ensuring its invisibility on your own.
 
-On page load, the hover card will be hidden automatically. When hovering over the trigger, the hover card will be
-shown next to it.
+When hovering over the trigger, the hover card will be rendered floating next to it.
 
-Please note that the hover card "blueprint" provided in the DOM will be cloned and moved into another location as part
-of displaying the card. The cloned elements ID will be removed to avoid duplicate IDs in the DOM.
-
-This is to say: do not apply logic or styling that depends on the ID of the hover card element itself, as the ID
-will remain with the hidden original element.
+Please note that technically, the contents of the template will be *copied* into a popover element that is then
+placed next to the trigger. To avoid ID clashes, do not use IDs in the contents of the hover card.
 
 **Card content**:
 ```html
   <!-- Somewhere else in the DOM... -->
 
-  <!-- Hidden container, so that the popover is hidden on page load -->
-  <div class="op-hover-card--hidden-container">
-    <!-- Actual hover card contents that will be rendered in a popover. Note the ID: -->
-    <div id="work-package-hover-card-14" class="your-styling-classes">
+  <!-- Template, so that the popover is hidden on page load. Note the ID: -->
+  <template id="work-package-hover-card-14">
+    <!-- Actual hover card contents that will be rendered in a popover: -->
+    <div class="your-styling-classes">
       <p>Hover card with description text of work package 14!</p>
     </div>
-  </div>
+  </template>
 ```

--- a/lookbook/docs/components/hover-cards.md.erb
+++ b/lookbook/docs/components/hover-cards.md.erb
@@ -114,8 +114,8 @@ Note that the user example is simplified. For actual use in the application, it 
 ### Static hover cards via existing DOM elements
 
 If the content of a hover card is already present in the DOM, it is possible to define hover cards contents by
-pointing to the ID of an existing element. To do so, you must provide the attribute `data-hover-card-popover-id` on the
-trigger element.
+pointing to the ID of an existing element. To do so, you must provide the attribute `data-hover-card-popover-template-id`
+on the trigger element.
 
 **Trigger**:
 ```html
@@ -124,18 +124,17 @@ trigger element.
 
     <!-- A hover card will be shown when hovering over this link: -->
     <a href="work_packages/14/activity"
-       data-hover-card-popover-id="work-package-hover-card-14"
+       data-hover-card-popover-template-id="work-package-hover-card-14"
        data-hover-card-trigger-target="trigger">
       #14
     </a>
   </body>
 ```
-The hover card content can be placed at a convenient place in the DOM. It is recommended to use a
-[template element](https://www.w3schools.com/TagS/tag_template.asp) for that purpose. Whichever element you use: it is
-required to assign the ID that was inserted in the trigger's `data-hover-card-popover-id` attribute.
 
-When a template is used, the hover card will be hidden automatically. If another type of element is used, you are
-responsible for ensuring its invisibility on your own.
+The hover card content can be placed at a convenient place in the DOM. You must use a
+[template element](https://www.w3schools.com/TagS/tag_template.asp) for that purpose. Conveniently, the content will
+be hidden automatically until the card is displayed.
+It is required to assign the ID that was inserted in the trigger's `data-hover-card-popover-template-id` attribute.
 
 When hovering over the trigger, the hover card will be rendered floating next to it.
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69596

- [x] Wait for #21279 to be merged first.

Refactors hover cards to make use of HTML `template` elements. This conveys the correct semantic meaning, since an existing DOM element is copied and rendered in a different location -> exactly what a template should do.

This elegant change additionally allowed us to streamline the behavior of the `HoverCardTriggerController` for both async and sync hover cards.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
