### PR TITLE
[69203] Long project descriptions cause a weird layout on the new Overview

### DIFF
--- a/app/components/open_project/common/attribute_component.html.erb
+++ b/app/components/open_project/common/attribute_component.html.erb
@@ -48,7 +48,7 @@
           size: :large
         )
       ) do |component|
-        component.with_body { full_text }
+        component.with_body { helpers.format_text(description) }
         component.with_header(variant: :large)
       end %>
 </div>

--- a/app/components/open_project/common/attribute_component.rb
+++ b/app/components/open_project/common/attribute_component.rb
@@ -52,6 +52,10 @@ module OpenProject
         @formatted = formatted
       end
 
+      def render?
+        description.present?
+      end
+
       def short_text
         if multi_type?
           I18n.t(:label_preview_not_available)

--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -73,7 +73,12 @@
       if @portfolio.description.blank?
         render(Primer::Beta::Text.new(color: :muted)) { t("create_project.blank_description") }
       else
-        render(Primer::Beta::Text.new(classes: "line-clamp-5 lh-default")) { format_text(@portfolio.description) }
+        render OpenProject::Common::AttributeComponent.new(
+          "portfolio-#{@portfolio.id}-description",
+          I18n.t("activerecord.attributes.project.description"),
+          @portfolio.description,
+          lines: 3
+        )
       end
     end
 

--- a/modules/grids/app/components/grids/widgets/description.html.erb
+++ b/modules/grids/app/components/grids/widgets/description.html.erb
@@ -31,7 +31,13 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   widget_wrapper do
     if project.description.present?
-      helpers.format_text project, :description
+      render OpenProject::Common::AttributeComponent.new(
+        "project-#{project.id}-description",
+        I18n.t("activerecord.attributes.project.description"),
+        project.description,
+        lines: 15,
+        formatted: true
+      )
     else
       render(Primer::Beta::Text.new(color: :subtle)) { t(:"js.grid.widgets.project_description.no_results") }
     end

--- a/modules/grids/app/components/grids/widgets/project_status.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_status.html.erb
@@ -36,7 +36,13 @@ See COPYRIGHT and LICENSE files for more details.
         end
 
         flex.with_row do
-          format_text(project, :status_explanation)
+          render OpenProject::Common::AttributeComponent.new(
+            "project-#{project.id}-status-explanation",
+            I18n.t("activerecord.attributes.project.status_explanation"),
+            project.status_explanation,
+            lines: 5,
+            formatted: true
+          )
         end
 
         if project.project_creation_wizard_enabled


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69203

# What are you trying to accomplish?
Use shortened display representation of long texts in:
* project description widget
* project status explanation widget
* portfolio description in portfolio overview

## Screenshots
<img width="774" height="433" alt="Bildschirmfoto 2025-12-03 um 08 58 41" src="https://github.com/user-attachments/assets/52b89559-3f3f-4ac3-9fe7-fbf01f16bea0" />

