### PR TITLE
Fix flaky spec

### DIFF
--- a/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
+++ b/spec/support/components/autocompleter/ng_select_autocomplete_helpers.rb
@@ -103,21 +103,24 @@ module Components::Autocompleter
 
       query = query.to_s
 
-      if query.length > 1
-        # Send all keys, and then with a delay the last one
-        # to emulate normal typing
-        if using_cuprite?
-          input.native.node.type(query[0..-2])
-          sleep 0.2
-          input.native.node.type(query[-1])
-        else
-          input.send_keys(query[0..-2])
-          sleep 0.2
-          input.send_keys(query[-1])
-        end
-      end
+      # Send all keys but last one, and then with a delay the last one
+      # to emulate normal typing
+      send_keys(input, query.to_s[0..-2], after_typing_sleep: 0.2)
+      send_keys(input, query.to_s[-1])
 
       wait_for_network_idle if using_cuprite? && wait_for_fetched_options
+    end
+
+    def send_keys(input, text, after_typing_sleep: nil)
+      return if text.blank?
+
+      if using_cuprite?
+        input.native.node.type(text)
+      else
+        input.send_keys(text)
+      end
+
+      sleep after_typing_sleep if after_typing_sleep
     end
 
     ##


### PR DESCRIPTION
spec is ./spec/features/work_packages/details/relations/hierarchy_spec.rb:64 workflow run is https://github.com/opf/openproject/actions/runs/19865114022/job/56995802896?pr=21312

Seen in PR #21312

Actually, the issue in the workflow run is not the same as the one being fixed with this commit. Still it's fixing a flakiness.

in `Components::Autocompleter::NgSelectAutocompleteHelpers#ng_enter_query` the keys are sent only if length is greater than 1.

Problem is that sometimes the query is only one character, for instance when typing a work package id. If the database is new, ids are small and their length is 1. So they are not typed and the test fails.

It is flaky because it does not occur when ids are greater than 10.

Fix is to remove that condition and always type the query string.
