### PR TITLE
[69517] Dereference RecurringMeeting author_id when deleting a user

### DIFF
--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -176,11 +176,10 @@ module OpenProject::Meeting
     patch_with_namespace :BasicData, :SettingSeeder
 
     replace_principal_references "Meeting" => %i[author_id],
-                                 "MeetingAgenda" => %i[author_id],
-                                 "MeetingMinutes" => %i[author_id],
                                  "MeetingAgendaItem" => %i[author_id presenter_id],
+                                 "MeetingOutcome" => :author_id,
                                  "MeetingParticipant" => :user_id,
-                                 "MeetingOutcome" => :author_id
+                                 "RecurringMeeting" => :author_id
 
     extend_api_response(:v3, :work_packages, :work_package,
                         &::OpenProject::Meeting::Patches::API::WorkPackageRepresenter.extension)

--- a/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
+++ b/modules/meeting/spec/services/principals/delete_job_integration_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Principals::DeleteJob, "Meetings", type: :model do
     let!(:meeting) { create(:meeting, author: principal) }
     let!(:meeting_agenda_item) { create(:meeting_agenda_item, presenter: principal) }
     let!(:meeting_outcome) { create(:meeting_outcome, meeting_agenda_item:, author: principal) }
+    let!(:recurring_meeting) { create(:recurring_meeting, author: principal) }
 
     it "rewrites the references" do
       job
@@ -51,6 +52,7 @@ RSpec.describe Principals::DeleteJob, "Meetings", type: :model do
       expect(meeting.reload.author).to eq deleted_user
       expect(meeting_agenda_item.reload.presenter).to eq deleted_user
       expect(meeting_outcome.reload.author).to eq deleted_user
+      expect(recurring_meeting.reload.author).to eq deleted_user
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69517

# What are you trying to accomplish?

Make deletion of user work if that user created some recurring meetings.

# What approach did you choose and why?

Simply remove the reference to RecurringMeeting. A better fix will be in 17.0 but this one is needed in 16.6 branch to ensure existing customers do not end up in a bad state.

Also partly backport b1840ebff90 from `release/17.0` branch to try to minimize future git conflicts when that gets merged. It removes the `:author_id` references from `MeetingAgenda` and `MeetingMinutes`. They are old tables that are no longer in use since 16.0.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
