### PR TITLE
[69549] Project selector contrast is too low in high contrast mode

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/toggle.sass
+++ b/frontend/src/app/spot/styles/sass/components/toggle.sass
@@ -49,3 +49,7 @@
   &--button
     margin: 0
     font-weight: normal
+    background-color: var(--controlTrack-bgColor-rest)
+
+    &.-active
+      background-color: var(--controlKnob-bgColor-rest) !important

--- a/frontend/src/app/spot/styles/sass/components/toggle.sass
+++ b/frontend/src/app/spot/styles/sass/components/toggle.sass
@@ -52,4 +52,4 @@
     background-color: var(--controlTrack-bgColor-rest)
 
     &.-active
-      background-color: var(--controlKnob-bgColor-rest) !important
+      background-color: var(--controlKnob-bgColor-rest)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69459

## Screenshots
Before:
<img width="127" height="57" alt="Screenshot 2025-12-03 at 11 24 10" src="https://github.com/user-attachments/assets/5bd74862-c205-4b6a-88ec-1ebd3bb0f833" />

After:
<img width="143" height="67" alt="Screenshot 2025-12-03 at 11 23 22" src="https://github.com/user-attachments/assets/6a33be28-32db-4af2-8a72-48d43dec0dc6" />

