### PR TITLE
Update button styles on meeting presentation mode

### DIFF
--- a/modules/meeting/app/components/meetings/presentation_mode/footer_component.html.erb
+++ b/modules/meeting/app/components/meetings/presentation_mode/footer_component.html.erb
@@ -1,15 +1,21 @@
-<%= component_wrapper(class: "op-meeting-presentation--footer",
-                      data: { "test-selector": "meeting-presentation-footer" }) do %>
+<%= component_wrapper(
+      class: "op-meeting-presentation--footer",
+      data: { "test-selector": "meeting-presentation-footer" }
+    ) do %>
   <div class="op-meeting-presentation--footer-left">
-    <%= render(Primer::Beta::Button.new(
-      tag: :a,
-      scheme: :link,
-      href: project_meeting_presentation_path(@project, @meeting, current_id: @current_item.id, action_type: "previous", started_at: @started_at),
-      data: { "meetings--presentation-target": "previousButton" },
-      disabled: !has_previous?
-    )) do |button| %>
+    <%= render(
+          Primer::Beta::Button.new(
+            tag: :a,
+            scheme: :link,
+            color: has_previous? ? :default : :subtle,
+            underline: false,
+            href: project_meeting_presentation_path(@project, @meeting, current_id: @current_item.id, action_type: "previous", started_at: @started_at),
+            data: { "meetings--presentation-target": "previousButton" },
+            disabled: !has_previous?
+          )
+        ) do |button| %>
       <% button.with_leading_visual_icon(icon: :"chevron-left") %>
-      <%= t('meeting.presentation_mode.previous') %>
+      <%= t("meeting.presentation_mode.previous") %>
     <% end %>
     <% if previous_item %>
       <div class="op-meeting-presentation--footer-agenda-item">
@@ -31,14 +37,18 @@
   </div>
 
   <div class="op-meeting-presentation--footer-right">
-    <%= render(Primer::Beta::Button.new(
-      tag: :a,
-      scheme: :link,
-      href: project_meeting_presentation_path(@project, @meeting, current_id: @current_item.id, action_type: "next", started_at: @started_at),
-      data: { "meetings--presentation-target": "nextButton" },
-      disabled: !has_next?
-    )) do |button| %>
-      <%= t('meeting.presentation_mode.next') %>
+    <%= render(
+          Primer::Beta::Button.new(
+            tag: :a,
+            scheme: :link,
+            color: :default,
+            underline: false,
+            href: project_meeting_presentation_path(@project, @meeting, current_id: @current_item.id, action_type: "next", started_at: @started_at),
+            data: { "meetings--presentation-target": "nextButton" },
+            disabled: !has_next?
+          )
+        ) do |button| %>
+      <%= t("meeting.presentation_mode.next") %>
       <% button.with_trailing_visual_icon(icon: :"chevron-right") %>
     <% end %>
     <div class="op-meeting-presentation--footer-agenda-item">

--- a/modules/meeting/app/components/meetings/presentation_mode/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/presentation_mode/header_component.html.erb
@@ -2,24 +2,24 @@
   component_wrapper(
     class: "op-meeting-presentation--header-container",
     data: { "test-selector": "meeting-presentation-header" }
-  ) do %>
+  ) do
+%>
   <%=
     render Primer::OpenProject::PageHeader.new(classes: "op-meeting-presentation-header") do |header|
       header.with_breadcrumbs([])
       header.with_title_content(@meeting.title)
 
-      header.with_action_button(
+      header.with_action_icon_button(
         tag: :a,
+        icon: :x,
         mobile_icon: :x,
         scheme: :invisible,
         mobile_label: t(:"meeting.presentation_mode.exit"),
+        label: t(:"meeting.presentation_mode.exit"),
         href: meeting_path(@meeting),
         aria: { label: t(:"meeting.presentation_mode.exit") },
-        title: t(:"meeting.presentation_mode.exit")
-      ) do |button|
-        button.with_leading_visual_icon(icon: :x)
-        t(:"meeting.presentation_mode.exit")
-      end
+        test_selector: "exit-presentation-button"
+      )
     end
   %>
   <div class="op-meeting-presentation--header">

--- a/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
+++ b/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "Meeting Presentation Mode",
     end
 
     # 4. Close the presentation
-    click_link_or_button "Exit presentation"
+    page.find_test_selector("exit-presentation-button").click
 
     # Verify we're back on the show page
     expect(page).to have_current_path(project_meeting_path(project, meeting), ignore_query: true)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69605
https://community.openproject.org/wp/69209

# What are you trying to accomplish?
* Make "next" and "previous" links look less like links
* Change "Exit presentation" button to icon only

## Screenshots

<img width="959" height="427" alt="Bildschirmfoto 2025-12-03 um 12 21 52" src="https://github.com/user-attachments/assets/5a12c690-522d-4c35-bb72-4ea7b200e862" />
