### PR TITLE
Add authorization server metadata endpoint

### DIFF
--- a/app/controllers/oauth_metadata_controller.rb
+++ b/app/controllers/oauth_metadata_controller.rb
@@ -29,9 +29,24 @@
 #++
 
 class OAuthMetadataController < ApplicationController
-  no_authorization_required! :protected_resource
+  no_authorization_required! :authorization_server, :protected_resource
 
   skip_before_action :check_if_login_required
+
+  def authorization_server
+    grant_types = Doorkeeper.configuration.grant_flows
+    grant_types += ["refresh_token"] if Doorkeeper.configuration.refresh_token_enabled?
+    render json: {
+      issuer: local_issuer,
+      authorization_endpoint: oauth_authorization_url,
+      token_endpoint: oauth_token_url,
+      introspection_endpoint: oauth_introspect_url,
+      scopes_supported: Doorkeeper.configuration.scopes.to_a,
+      response_types_supported: response_types(Doorkeeper.configuration.grant_flows),
+      grant_types_supported: grant_types,
+      service_documentation: OpenProject::Static::Links.url_for(:oauth_applications)
+    }
+  end
 
   def protected_resource
     render json: {
@@ -45,6 +60,17 @@ class OAuthMetadataController < ApplicationController
   end
 
   private
+
+  def response_types(grant_types)
+    grant_types.filter_map do |grant|
+      case grant
+      when "authorization_code"
+        "code"
+      when "implicit"
+        "token"
+      end
+    end
+  end
 
   def authorization_servers
     OpenIDConnect::Provider.where(available: true).map(&:issuer) + [local_issuer]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
   get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
   match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 
+  get "/.well-known/oauth-authorization-server", to: "oauth_metadata#authorization_server", as: :authorization_server_metadata
   get "/.well-known/oauth-protected-resource", to: "oauth_metadata#protected_resource", as: :protected_resource_metadata
 
   # In case assets are actually delivered by a node server (e.g. in test env)

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -107,6 +107,8 @@ manual_installation:
 newsletter:
   href: https://www.openproject.org/newsletter
   label: homescreen.links.newsletter
+oauth_applications:
+  href: https://www.openproject.org/docs/system-admin-guide/authentication/oauth-applications/
 security_alerts:
   href: https://www.openproject.org/security-and-privacy/#mailing-list
   label: homescreen.links.security_alerts


### PR DESCRIPTION
Allowing OAuth clients to discover automatically how the OAuth authorization server integrated into OpenProject is behaving.

# Ticket
https://community.openproject.org/wp/69537

# Merge dependencies

* merge after https://github.com/opf/openproject/pull/21310