### PR TITLE
[69599] News widget is also shown if module is deactivated

### DIFF
--- a/modules/grids/app/components/grids/widgets/news.html.erb
+++ b/modules/grids/app/components/grids/widgets/news.html.erb
@@ -28,29 +28,36 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <%=
   widget_wrapper do |container|
-    if no_news?
-      render(Primer::Beta::Blankslate.new(test_selector: "news-widget-empty")) do |component|
-        component.with_visual_icon(icon: :megaphone)
-        component.with_heading(tag: :h3).with_content(title)
-        component.with_description { t("grids.widgets.empty") }
+    if can_view_news?
+      if no_news?
+        render(Primer::Beta::Blankslate.new(test_selector: "news-widget-empty")) do |component|
+          component.with_visual_icon(icon: :megaphone)
+          component.with_heading(tag: :h3).with_content(title)
+          component.with_description { t("grids.widgets.empty") }
 
-        if project.present? && can_manage_news?
-          component.with_primary_action(
-            tag: :a,
-            href: new_project_news_path(project),
-            test_selector: "news-widget-add-button",
-            scheme: :secondary
-          ) do |button|
-            button.with_leading_visual_icon(icon: :plus)
-            t(:label_news_singular)
+          if project.present? && can_manage_news?
+            component.with_primary_action(
+              tag: :a,
+              href: new_project_news_path(project),
+              test_selector: "news-widget-add-button",
+              scheme: :secondary
+            ) do |button|
+              button.with_leading_visual_icon(icon: :plus)
+              t(:label_news_singular)
+            end
+          end
+        end
+      else
+        newest.each do |item|
+          container.with_row do
+            render(Item.new(item:, project:))
           end
         end
       end
     else
-      newest.each do |item|
-        container.with_row do
-          render(Item.new(item:, project:))
-        end
+      render(Primer::Beta::Blankslate.new(test_selector: "news-widget-no-permission")) do |component|
+        component.with_heading(tag: :h3).with_content(title)
+        component.with_description { t("grids.widgets.not_available") }
       end
     end
   end

--- a/modules/grids/app/components/grids/widgets/news.rb
+++ b/modules/grids/app/components/grids/widgets/news.rb
@@ -69,6 +69,12 @@ module Grids
       def can_manage_news?
         current_user.allowed_in_project?(:manage_news, project)
       end
+
+      def can_view_news?
+        return true unless project
+
+        project.enabled_modules.map(&:name).include?("news")
+      end
     end
   end
 end

--- a/modules/grids/spec/components/grids/widgets/news_spec.rb
+++ b/modules/grids/spec/components/grids/widgets/news_spec.rb
@@ -121,7 +121,11 @@ RSpec.describe Grids::Widgets::News, type: :component do
       project.enabled_module_names -= %w[news]
     end
 
-    it_behaves_like "empty-state with action"
+    it "renders blankslate without action with not available text" do
+      expect(rendered_component).to have_test_selector("news-widget-no-permission")
+      expect(rendered_component).to have_text("This widget is not available.")
+      expect(rendered_component).to have_no_test_selector("news-widget-add-button")
+    end
   end
 
   context "when the user does not have permission to manage news" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69599

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
 Like other widgets, show unavailable blankslate in news widget when news module is not activated for the current project.
