### PR TITLE
[69503] Application title input field is unnecessary long

### DIFF
--- a/app/forms/admin/settings/general_settings/welcome_block_form.rb
+++ b/app/forms/admin/settings/general_settings/welcome_block_form.rb
@@ -33,7 +33,7 @@ module Admin
     module GeneralSettings
       class WelcomeBlockForm < ApplicationForm
         settings_form do |sf|
-          sf.text_field(name: :welcome_title)
+          sf.text_field(name: :welcome_title, input_width: :medium)
 
           sf.rich_text_area(
             name: :welcome_text,

--- a/app/forms/admin/settings/general_settings_form.rb
+++ b/app/forms/admin/settings/general_settings_form.rb
@@ -37,7 +37,8 @@ module Admin
 
       settings_form do |sf|
         sf.text_field(
-          name: :app_title
+          name: :app_title,
+          input_width: :medium
         )
 
         sf.text_field(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69503

# What are you trying to accomplish?
Reduce width of application title input

## Screenshots

<img width="374" height="191" alt="Bildschirmfoto 2025-12-03 um 14 02 46" src="https://github.com/user-attachments/assets/a9e61d59-b024-48ac-b0a6-e6571f60ffaa" />
