### PR TITLE
[69624] StepWizard should go full width earlier

### DIFF
--- a/app/components/step_wizard/page_layout_component.sass
+++ b/app/components/step_wizard/page_layout_component.sass
@@ -34,7 +34,7 @@
   max-width: 75%
   margin: 0 auto
 
-  @media screen and (max-width: $breakpoint-lg)
+  @media screen and (max-width: $breakpoint-xl)
     max-width: 100%
     margin: 0
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69624

# What are you trying to accomplish?
Increase breakpoint at which the pageLayout goes full width

## Screenshots

<img width="684" height="719" alt="Bildschirmfoto 2025-12-03 um 15 21 52" src="https://github.com/user-attachments/assets/e4e4e762-1f7a-444c-820d-62682c405c2c" />
