### PR TITLE
[69355] Missing padding on top of project attributes list

### DIFF
--- a/app/views/projects/settings/creation_wizard/_attributes.html.erb
+++ b/app/views/projects/settings/creation_wizard/_attributes.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div>
   <%=
-    render Primer::Beta::Text.new(tag: :p, mb: 2) do
+    render Primer::Beta::Text.new(tag: :p, my: 3) do
       link_translate(
         "projects.settings.creation_wizard.project_attributes_description",
         links: { project_attributes_url: project_settings_project_custom_fields_path },


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69355

# What are you trying to accomplish?
Increase spacing aroung descriptional text

## Screenshots
<img width="1658" height="495" alt="Bildschirmfoto 2025-12-03 um 15 26 38" src="https://github.com/user-attachments/assets/73c0c043-bba3-472d-b8ab-4a191594b7e3" />
