### PR TITLE
[#67287] Meeting email update is sent in sender's OP language  

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -35,7 +35,7 @@ module RecurringMeetings
     protected
 
     def validate_params
-      @old_schedule = model.full_schedule_in_words
+      @old_schedule_model = model.dup
       @old_location = model.template.location
       super
     end
@@ -159,11 +159,16 @@ module RecurringMeetings
         .participants
         .invited
         .find_each do |participant|
+        # Generate old schedule in each participant's locale
+        old_schedule = User.execute_as(participant.user) do
+          @old_schedule_model.full_schedule_in_words
+        end
+
         MeetingSeriesMailer.updated(
           recurring_meeting,
           participant.user,
           User.current,
-          changes: { old_schedule: @old_schedule, old_location: @old_location }
+          changes: { old_schedule:, old_location: @old_location }
         ).deliver_now
       end
     end

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -192,6 +192,54 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
           .to eq "[#{project.name}] Meeting series '#{series.title}' has been updated"
       end
     end
+
+    context "when updating only the location with recipients with different locales" do
+      let(:german_author) do
+        create(:user,
+               language: "de",
+               member_with_permissions: { project => %i(view_meetings edit_meetings) })
+      end
+
+      let(:english_recipient) do
+        create(:user,
+               language: "en",
+               member_with_permissions: { project => %i(view_meetings) })
+      end
+
+      let(:german_recipient) do
+        create(:user,
+               language: "de",
+               member_with_permissions: { project => %i(view_meetings) })
+      end
+
+      let(:instance) { described_class.new(model: series, user: german_author) }
+
+      let(:params) { { location: "New location" } }
+
+      before do
+        series.update!(author: german_author)
+        series.template.participants.delete_all
+        series.template.participants << MeetingParticipant.new(user: english_recipient, invited: true)
+        series.template.participants << MeetingParticipant.new(user: german_recipient, invited: true)
+        series.template.update!(location: "Old location")
+      end
+
+      it "does not send a schedule update when not necessary (Bug #67287)" do
+        expect(service_result).to be_success
+        perform_enqueued_jobs
+
+        expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+        english_mail = ActionMailer::Base.deliveries.find { |m| m.to.include?(english_recipient.mail) }
+        german_mail = ActionMailer::Base.deliveries.find { |m| m.to.include?(german_recipient.mail) }
+
+        expect(english_mail.html_part.body).to include("Every day")
+        expect(english_mail.html_part.body).not_to include("Jeden Tag")
+
+        expect(german_mail.html_part.body).to include("Jeden Tag")
+        expect(german_mail.html_part.body).not_to include("Every day")
+      end
+    end
   end
 
   describe "rescheduling occurrences" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67287

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Store the older model object instead of just the schedule string and use this to generate the old schedule per email recipient in their own locales

# Merge checklist

- [x] Added/updated tests