### PR TITLE
[#69627] Not possible to add create_project role when the template permission is invisible

### DIFF
--- a/app/contracts/roles/base_contract.rb
+++ b/app/contracts/roles/base_contract.rb
@@ -77,12 +77,14 @@ module Roles
     end
 
     def check_permission_prerequisites
+      hidden_permissions = OpenProject::AccessControl.permissions.select(&:hidden?).map(&:name)
+
       model.permissions.each do |name|
         permission = OpenProject::AccessControl.permission(name)
 
         next unless permission
 
-        unmet_dependencies = permission.dependencies - model.permissions
+        unmet_dependencies = permission.dependencies - model.permissions - hidden_permissions
 
         unmet_dependencies.each do |unmet_dependency|
           add_unmet_dependency_error(name, unmet_dependency)

--- a/spec/contracts/roles/shared_contract_examples.rb
+++ b/spec/contracts/roles/shared_contract_examples.rb
@@ -69,6 +69,17 @@ RSpec.shared_examples_for "roles contract" do
       it "is invalid" do
         expect_valid(false, permissions: %i(dependency_missing))
       end
+
+      context "when the dependency is hidden" do
+        before do
+          dependency_permission = OpenProject::AccessControl.permission(:view_members)
+          allow(dependency_permission).to receive(:hidden?).and_return(true)
+        end
+
+        it "is valid" do
+          expect_valid(true)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69627

# What are you trying to accomplish?
Fix the bug where adding a `create_project` permission is not possible if the `create_project_from_template` permission is hidden.

# What approach did you choose and why?

Filter out hidden dependencies from the list of unmet dependencies when validating permissions.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
