### PR TITLE
Ensure a project role is created before copy of dependencies

### DIFF
--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -56,7 +56,7 @@ module BaseServices
       in_context(model, send_notifications:, &)
     end
 
-    def perform
+    def perform # rubocop:disable Metrics/AbcSize
       self.params, send_notifications = extract(params, :send_notifications)
       service_context(send_notifications:) do
         service_call = validate_params

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -64,6 +64,7 @@ module BaseServices
         service_call = validate_contract(service_call) if service_call.success?
         service_call = after_validate(service_call) if service_call.success?
         service_call = persist(service_call) if service_call.success?
+        service_call = after_persist(service_call) if service_call.success?
         service_call = after_perform(service_call) if service_call.success?
 
         service_call
@@ -106,6 +107,11 @@ module BaseServices
     alias_method :after_save, :after_perform
 
     def persist(call)
+      # nothing for now but subclasses can override
+      call
+    end
+
+    def after_persist(call)
       # nothing for now but subclasses can override
       call
     end

--- a/app/services/base_services/copy.rb
+++ b/app/services/base_services/copy.rb
@@ -74,6 +74,12 @@ module BaseServices
       # Return only the unsaved copy
       return call if params[:attributes_only]
 
+      super
+    end
+
+    def after_persist(call)
+      return call unless call.result&.persisted?
+
       super.tap do |super_call|
         copy_instance = super_call.result
         self.class.copy_dependencies.each do |service_cls|

--- a/app/services/projects/concerns/new_project_service.rb
+++ b/app/services/projects/concerns/new_project_service.rb
@@ -38,7 +38,7 @@ module Projects::Concerns
       end
     end
 
-    def after_perform(attributes_call)
+    def after_persist(attributes_call)
       new_project = attributes_call.result
 
       set_default_role(new_project) unless user.admin?

--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -45,6 +45,9 @@ module Projects::Copy
     protected
 
     def copy_dependency(*)
+      # Ensure we get the default role added for the copied project
+      target.members.reload
+
       # Copy users and placeholder users first,
       # then groups to handle members with inherited and given roles
       source_memberships.sort_by { |m| m.principal.is_a?(Group) ? 1 : 0 }.each do |member|
@@ -52,20 +55,28 @@ module Projects::Copy
       end
     end
 
-    def create_membership(member)
+    def create_membership(member) # rubocop:disable Metrics/AbcSize
       # only copy non inherited roles
       # inherited roles will be added when copying the group membership
       role_ids = member.member_roles.reject(&:inherited?).map(&:role_id)
-
       return if role_ids.empty?
 
-      attributes = member
-                     .attributes.dup.except("id", "project_id", "created_at", "updated_at")
-                     .merge(role_ids:, project: target)
+      # There should only be zero or one members in this new project
+      # which gets created from the default +ProjectRole.in_new_project+ if enabled.
+      target_member = target.members.detect { |m| m.principal == member.user }
+      if target_member
+        Members::UpdateService
+          .new(model: target_member, user: User.current, contract_class: EmptyContract)
+          .call(role_ids: (target_member.role_ids + role_ids).uniq)
+      else
+        attributes = member
+          .attributes.dup.except("id", "project_id", "created_at", "updated_at")
+          .merge(role_ids:, project: target)
 
-      Members::CreateService
-        .new(user: User.current, contract_class: EmptyContract)
-        .call(attributes)
+        Members::CreateService
+          .new(user: User.current, contract_class: EmptyContract)
+          .call(attributes)
+      end
     end
   end
 end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe(
     create(:user,
            member_with_roles: { source => role })
   end
+  let(:other_user) do
+    create(:user,
+           member_with_roles: { source => role })
+  end
   let(:instance) { described_class.new(source:, user: current_user) }
   let(:only_args) { nil }
   let(:target_project_params) do
@@ -92,7 +96,7 @@ RSpec.describe(
   before do
     allow(Setting)
       .to receive(:new_project_user_role_id)
-            .and_return(new_project_role.id.to_s)
+            .and_return(new_project_role&.id&.to_s)
   end
 
   describe ".copyable_dependencies" do
@@ -376,7 +380,7 @@ RSpec.describe(
 
         # Default role being assigned according to setting
         #  merged with the role the user already had.
-        member = project_copy.members.last
+        member = project_copy.members.reload.last
         expect(member.principal).to eql(current_user)
         expect(member.roles.reload).to contain_exactly(role, new_project_role)
 
@@ -939,7 +943,7 @@ RSpec.describe(
             custom_field
             # Void the custom field caching
             RequestStore.clear!
-            work_package.send(custom_field.attribute_setter, current_user.id)
+            work_package.send(custom_field.attribute_setter, other_user.id)
             work_package.save!(validate: false)
           end
 
@@ -949,7 +953,7 @@ RSpec.describe(
             it "copies the custom_field" do
               expect(subject).to be_success
               wp = project_copy.work_packages.find_by(subject: work_package.subject)
-              expect(wp.send(custom_field.attribute_getter)).to eql current_user
+              expect(wp.send(custom_field.attribute_getter)).to eql other_user
             end
           end
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/69667

Ensures that the `ProjectRole.in_new_project` gets applied early in the copy process, if it is set. As a side-effect of this, the members copy service have to deal with the fact that there is one membership already present

For that to work, we need a separate action in the service that runs after `persist`, but before `after_perform`, as all these are taking. I've introduced another callback `after_persist` for that use case