### PR TITLE
Fix: Webhooks show work package author instead of actual updater

### DIFF
--- a/modules/webhooks/app/workers/represented_webhook_job.rb
+++ b/modules/webhooks/app/workers/represented_webhook_job.rb
@@ -31,8 +31,9 @@
 class RepresentedWebhookJob < WebhookJob
   attr_reader :resource
 
-  def perform(webhook_id, resource, event_name)
+  def perform(webhook_id, resource, event_name, actor: nil)
     @resource = resource
+    @actor = actor
     super(webhook_id, event_name)
 
     return unless accepted_in_project?
@@ -95,6 +96,8 @@ class RepresentedWebhookJob < WebhookJob
   end
 
   def actor_payload
-    nil
+    return nil unless @actor
+
+    ::API::V3::Users::UserRepresenter.create(@actor, current_user: User.current)
   end
 end

--- a/modules/webhooks/app/workers/represented_webhook_job.rb
+++ b/modules/webhooks/app/workers/represented_webhook_job.rb
@@ -87,10 +87,14 @@ class RepresentedWebhookJob < WebhookJob
     # to_json needs to be called within the system user block in order to
     # have all the custom field visibility permissions set up correctly.
     User.system.run_given do
-      {
-        action: event_name,
-        payload_key => represented_payload
-      }.to_json
+      payload = { action: event_name, payload_key => represented_payload }
+      actor = actor_payload
+      payload[:actor] = actor if actor
+      payload.to_json
     end
+  end
+
+  def actor_payload
+    nil
   end
 end

--- a/modules/webhooks/app/workers/work_package_webhook_job.rb
+++ b/modules/webhooks/app/workers/work_package_webhook_job.rb
@@ -29,26 +29,11 @@
 #++
 
 class WorkPackageWebhookJob < RepresentedWebhookJob
-  attr_reader :journal
-
-  def perform(webhook_id, journal, event_name)
-    @journal = journal
-    @resource = journal.journable
-    super(webhook_id, @resource, event_name)
-  end
-
   def payload_key
     :work_package
   end
 
   def payload_representer_class
     ::API::V3::WorkPackages::WorkPackageRepresenter
-  end
-
-  def actor_payload
-    user = User.find_by(id: journal.user_id)
-    return nil unless user
-
-    ::API::V3::Users::UserRepresenter.create(user, current_user: User.current)
   end
 end

--- a/modules/webhooks/app/workers/work_package_webhook_job.rb
+++ b/modules/webhooks/app/workers/work_package_webhook_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,11 +29,26 @@
 #++
 
 class WorkPackageWebhookJob < RepresentedWebhookJob
+  attr_reader :journal
+
+  def perform(webhook_id, journal, event_name)
+    @journal = journal
+    @resource = journal.journable
+    super(webhook_id, @resource, event_name)
+  end
+
   def payload_key
     :work_package
   end
 
   def payload_representer_class
     ::API::V3::WorkPackages::WorkPackageRepresenter
+  end
+
+  def actor_payload
+    user = User.find_by(id: journal.user_id)
+    return nil unless user
+
+    ::API::V3::Users::UserRepresenter.create(user, current_user: User.current)
   end
 end

--- a/modules/webhooks/lib/open_project/webhooks/event_resources/work_package.rb
+++ b/modules/webhooks/lib/open_project/webhooks/event_resources/work_package.rb
@@ -50,11 +50,13 @@ module OpenProject::Webhooks::EventResources
       protected
 
       def handle_notification(payload, event_name)
-        action = payload[:journal].initial? ? "created" : "updated"
+        journal = payload[:journal]
+        action = journal.initial? ? "created" : "updated"
         event_name = prefixed_event_name(action)
-        work_package = payload[:journal].journable
+        work_package = journal.journable
+        actor = User.find_by(id: journal.user_id)
         active_webhooks.with_event_name(event_name).pluck(:id).each do |id|
-          WorkPackageWebhookJob.perform_later(id, work_package, event_name)
+          WorkPackageWebhookJob.perform_later(id, work_package, event_name, actor:)
         end
       end
     end

--- a/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
   shared_let(:request_url) { "http://example.net/test/42" }
   shared_let(:work_package) { create(:work_package, subject: title) }
   shared_let(:webhook) { create(:webhook, all_projects: true, url: request_url, secret: nil) }
-  shared_let(:journal) { work_package.journals.first }
 
   shared_examples "a work package webhook call" do
     let(:event) { "work_package:created" }
-    let(:job) { described_class.perform_now webhook.id, journal, event }
+    let(:actor) { nil }
+    let(:job) { described_class.perform_now webhook.id, work_package, event, actor: }
 
     let(:stubbed_url) { request_url }
 
@@ -172,14 +172,15 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
     let(:author) { create(:user, firstname: "Original", lastname: "Author") }
     let(:updater) { create(:user, firstname: "Update", lastname: "User") }
     let(:work_package) { create(:work_package, author:, subject: title) }
-    let(:journal) do
+
+    before do
       work_package.add_journal(user: updater, notes: "Updated the work package")
       work_package.save!
-      work_package.journals.last
     end
 
     it_behaves_like "a work package webhook call" do
       let(:event) { "work_package:updated" }
+      let(:actor) { updater }
 
       it "includes actor matching the journal user, not the work package author" do
         subject
@@ -203,10 +204,10 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
   describe "actor field on created event" do
     let(:creator) { create(:user, firstname: "Creator", lastname: "Person") }
     let(:work_package) { User.execute_as(creator) { create(:work_package, author: creator, subject: title) } }
-    let(:journal) { work_package.journals.first }
 
     it_behaves_like "a work package webhook call" do
       let(:event) { "work_package:created" }
+      let(:actor) { creator }
 
       it "includes actor matching the creator" do
         subject
@@ -221,18 +222,10 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
     end
   end
 
-  describe "actor absent when journal user has been deleted" do
-    let(:updater) { create(:user) }
-    let(:journal) do
-      work_package.add_journal(user: updater, notes: "Updated")
-      work_package.save!
-      work_package.journals.last
-    end
-
-    before { updater.destroy }
-
+  describe "actor absent when actor is nil" do
     it_behaves_like "a work package webhook call" do
       let(:event) { "work_package:updated" }
+      let(:actor) { nil }
 
       it "fires the webhook without an actor key" do
         expect { subject }.not_to raise_error
@@ -245,7 +238,7 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
     end
   end
 
-  describe "admin custom field regression with journal (PR #16912)" do
+  describe "admin custom field regression with actor (PR #16912)" do
     shared_let(:project) { work_package.project }
     shared_let(:custom_field) do
       create(:project_custom_field, :string, admin_only: true, projects: [project])
@@ -257,14 +250,10 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
              value: "wat")
     end
     let(:updater) { create(:admin) }
-    let(:journal) do
-      work_package.add_journal(user: updater, notes: "Updated")
-      work_package.save!
-      work_package.journals.last
-    end
 
     it_behaves_like "a work package webhook call" do
       let(:event) { "work_package:updated" }
+      let(:actor) { updater }
 
       it "includes the custom field value" do
         subject

--- a/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
+++ b/modules/webhooks/spec/workers/work_package_webhook_job_spec.rb
@@ -36,10 +36,11 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
   shared_let(:request_url) { "http://example.net/test/42" }
   shared_let(:work_package) { create(:work_package, subject: title) }
   shared_let(:webhook) { create(:webhook, all_projects: true, url: request_url, secret: nil) }
+  shared_let(:journal) { work_package.journals.first }
 
   shared_examples "a work package webhook call" do
     let(:event) { "work_package:created" }
-    let(:job) { described_class.perform_now webhook.id, work_package, event }
+    let(:job) { described_class.perform_now webhook.id, journal, event }
 
     let(:stubbed_url) { request_url }
 
@@ -158,6 +159,115 @@ RSpec.describe WorkPackageWebhookJob, :webmock, type: :model do
       it "includes the custom field value" do
         subject
 
+        expect(stub).to have_been_requested
+
+        log = Webhooks::Log.last
+        embedded_project = JSON.parse(log.request_body)["work_package"]["_embedded"]["project"]
+        expect(embedded_project[custom_field.attribute_name(:camel_case)]).to eq "wat"
+      end
+    end
+  end
+
+  describe "actor field on updated event" do
+    let(:author) { create(:user, firstname: "Original", lastname: "Author") }
+    let(:updater) { create(:user, firstname: "Update", lastname: "User") }
+    let(:work_package) { create(:work_package, author:, subject: title) }
+    let(:journal) do
+      work_package.add_journal(user: updater, notes: "Updated the work package")
+      work_package.save!
+      work_package.journals.last
+    end
+
+    it_behaves_like "a work package webhook call" do
+      let(:event) { "work_package:updated" }
+
+      it "includes actor matching the journal user, not the work package author" do
+        subject
+        expect(stub).to have_been_requested
+
+        log = Webhooks::Log.last
+        payload = JSON.parse(log.request_body)
+
+        expect(payload["actor"]["id"]).to eq updater.id
+        expect(payload["actor"]["name"]).to eq updater.name
+        expect(payload["actor"]["_type"]).to eq "User"
+        expect(payload["actor"]["_links"]["self"]["href"]).to eq "/api/v3/users/#{updater.id}"
+
+        # Author in the work package payload is still the original creator
+        author_href = payload["work_package"]["_links"]["author"]["href"]
+        expect(author_href).to include("/api/v3/users/#{author.id}")
+      end
+    end
+  end
+
+  describe "actor field on created event" do
+    let(:creator) { create(:user, firstname: "Creator", lastname: "Person") }
+    let(:work_package) { User.execute_as(creator) { create(:work_package, author: creator, subject: title) } }
+    let(:journal) { work_package.journals.first }
+
+    it_behaves_like "a work package webhook call" do
+      let(:event) { "work_package:created" }
+
+      it "includes actor matching the creator" do
+        subject
+        expect(stub).to have_been_requested
+
+        log = Webhooks::Log.last
+        payload = JSON.parse(log.request_body)
+
+        expect(payload["actor"]["id"]).to eq creator.id
+        expect(payload["actor"]["name"]).to eq creator.name
+      end
+    end
+  end
+
+  describe "actor absent when journal user has been deleted" do
+    let(:updater) { create(:user) }
+    let(:journal) do
+      work_package.add_journal(user: updater, notes: "Updated")
+      work_package.save!
+      work_package.journals.last
+    end
+
+    before { updater.destroy }
+
+    it_behaves_like "a work package webhook call" do
+      let(:event) { "work_package:updated" }
+
+      it "fires the webhook without an actor key" do
+        expect { subject }.not_to raise_error
+        expect(stub).to have_been_requested
+
+        log = Webhooks::Log.last
+        payload = JSON.parse(log.request_body)
+        expect(payload).not_to have_key("actor")
+      end
+    end
+  end
+
+  describe "admin custom field regression with journal (PR #16912)" do
+    shared_let(:project) { work_package.project }
+    shared_let(:custom_field) do
+      create(:project_custom_field, :string, admin_only: true, projects: [project])
+    end
+    shared_let(:custom_value) do
+      create(:custom_value,
+             custom_field:,
+             customized: project,
+             value: "wat")
+    end
+    let(:updater) { create(:admin) }
+    let(:journal) do
+      work_package.add_journal(user: updater, notes: "Updated")
+      work_package.save!
+      work_package.journals.last
+    end
+
+    it_behaves_like "a work package webhook call" do
+      let(:event) { "work_package:updated" }
+
+      it "includes the custom field value" do
+        subject
         expect(stub).to have_been_requested
 
         log = Webhooks::Log.last


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69658

## Problem

Work package webhooks show the work package **author** (original creator) in the payload context, instead of the user who actually performed the update. Webhook consumers cannot determine who triggered the event.

## Solution

Following the direction approved by @NobodysNightmare, this PR adds an explicit top-level `actor` field to webhook payloads, identifying the user who triggered the event (sourced from the journal).

### Payload shape

```json
{
  "action": "work_package:updated",
  "actor": {
    "id": 5,
    "name": "Jane Smith",
    "_type": "User",
    "_links": { "self": { "href": "/api/v3/users/5" } }
  },
  "work_package": {
    "_embedded": {
      "author": { "name": "Bob Jones" }
    }
  }
}
```

### Changes

- **`RepresentedWebhookJob`**: Added `actor_payload` hook (returns `nil` by default) and includes it in `request_body` when present. Removed `user_for_representation` — the representer now uses `User.current` (which is `User.system` inside `run_given`), preserving admin-only custom field visibility.
- **`WorkPackageWebhookJob`**: Simplified `perform` to always receive a `Journal` (the only caller already passes one). Implements `actor_payload` returning a plain hash with the journal user's id, name, type, and self link. Returns `nil` gracefully if the user has been deleted.
- **Specs**: Focused tests for the `actor` field covering: updated event, created event, deleted user fallback, and admin custom field regression (PR #16912).

### Design decisions

- Field name `actor` was chosen to parallel `action`, as approved by @NobodysNightmare.
- The actor is a plain hash (not a full HAL representer) to keep it lightweight and avoid coupling to user permissions.
- Backward compatibility for passing a `WorkPackage` directly was removed — the single caller (`EventResources::WorkPackage`) already passes a `Journal`.