### PR TITLE
Fix flickering spec

### DIFF
--- a/spec/features/work_packages/details/relations/hierarchy_spec.rb
+++ b/spec/features/work_packages/details/relations/hierarchy_spec.rb
@@ -63,7 +63,7 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
 
     it "allows to manage hierarchy" do
       # Add parent
-      relations.add_parent(parent.id, parent)
+      relations.add_parent(parent)
       wp_page.expect_and_dismiss_toaster(message: "Successful update.")
       relations.expect_parent(parent)
       tabs.expect_counter(relations_tab, 1)
@@ -150,7 +150,7 @@ RSpec.shared_examples "work package relations tab", :js, :with_cuprite do
 
         it "is able to link parent and children" do
           # Add parent
-          relations.add_parent(parent.id, parent)
+          relations.add_parent(parent)
           wp_page.expect_and_dismiss_toaster(message: "Successful update.")
           relations.expect_parent(parent)
           tabs.expect_counter(relations_tab, 3)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -307,7 +307,7 @@ module Components
         expect(page).to have_test_selector("no-relations-blankslate", text: "This work package does not have any relations yet.")
       end
 
-      def add_parent(query, work_package)
+      def add_parent(work_package)
         # Open the parent edit
         SeleniumHubWaiter.wait
         find(".wp-relation--parent-change").click
@@ -316,9 +316,8 @@ module Components
         SeleniumHubWaiter.wait
         autocomplete = page.find_test_selector("wp-relations-autocomplete")
         select_autocomplete autocomplete,
-                            query:,
-                            results_selector: ".ng-dropdown-panel-items",
-                            select_text: work_package.id
+                            query: work_package.subject,
+                            results_selector: ".ng-dropdown-panel-items"
       end
 
       def expect_parent(work_package)


### PR DESCRIPTION
Selection by work package ID was unreliable, because the text that's selected by is from anywhere in the selected element.

The element shows different information:
* WP subject
* WP ID
* Project name
* status name

The intention of the original code was to uniquely select work packages by their ID, however it was also perfectly possible to have a project named "Project 123" as the parent of all work packages. So if the WP id happens to be 123 as well, the selection would be effectively random across the work packages.

(Credit for discovering the root cause of this flicker goes to Christophe Bliard if anyone is asking ;-) )

Fixes flickers of spec/features/work_packages/details/relations/hierarchy_spec.rb,

Reproduction instructions as provided by Christophe:

    rm -f db/structure.sql; \
    bin/rails db:drop db:create db:migrate RAILS_ENV=test > /dev/null ; \
    CI=true TZ=UTC OPENPROJECT_LOG__LEVEL=info CAPYBARA_PUMA_THREADS=0:4 DISABLE_SPRING=1 \
    bin/rspec --seed 34872 -fd \
    'spec/features/work_packages/details/relations/hierarchy_spec.rb[1:1:1:1]' \
    spec/features/work_packages/work_package_index_spec.rb:46