### PR TITLE
bug/69230 Use enhanced `Primer::OpenProject::AvatarWithFallback` to render initials in a styled SVG when avatar img src is nil/blank

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
@@ -42,11 +42,11 @@
       concat(
         flex_layout do |flex_container|
           flex_container.with_column do
-            render Primer::Beta::AvatarStack.new(
+            render Primer::OpenProject::AvatarStack.new(
               data: { "documents--live-events-target": "users" }
             ) do |component|
               users.map do |user|
-                component.with_avatar(src: avatar_url(user), alt: user.name)
+                component.with_avatar_with_fallback(**avatar_options_for(user))
               end
             end
           end
@@ -67,14 +67,12 @@
           component.with_body(caret: :top_left) do
             flex_layout do |container|
               users.each do |user|
-                container.with_row do
-                  render Users::AvatarComponent.new(
-                    user: user,
-                    show_name: true,
-                    link: false,
-                    hover_card: { active: false },
-                    size: :mini
-                  )
+                container.with_column do
+                  render Primer::OpenProject::AvatarWithFallback.new(**avatar_options_for(user))
+                end
+
+                container.with_column(ml: 2) do
+                  render(Primer::Beta::Text.new(color: :subtle)) { user.name }
                 end
               end
             end

--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.rb
@@ -49,6 +49,14 @@ module Documents
         def active_editors
           I18n.t("documents.active_editors_count", count: users.count).html_safe
         end
+
+        def avatar_options_for(user)
+          {
+            src: avatar_url(user),
+            alt: user.name,
+            unique_id: user.id
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/69230

⚠️ Depends on:
- https://github.com/opf/primer_view_components/pull/387
- https://github.com/opf/openproject/pull/21577

<img width="820" height="331" alt="Screenshot 2026-01-08 at 3 26 08 PM" src="https://github.com/user-attachments/assets/f8912256-4078-49c2-b995-5c1261b6ebda" />

> [!NOTE]
> Handling for broken image links (gravatar urls) will followup separately. See: https://github.com/opf/primer_view_components/pull/396