### PR TITLE
Bug/69432 global modules general menu to the left of the logo is not showing enterprise icons

### DIFF
--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -198,17 +198,17 @@ module Redmine::MenuManager::MenuHelper
     link_text += content_tag(:span,
                              class: "#{menu_class}--item-title#{badge_class}",
                              lang: menu_item_locale(item)) do
-      title_text = "".html_safe + content_tag(:span, caption, class: "ellipsis") + badge_for(item)
+      title_text = content_tag(:span, caption, class: "ellipsis") + badge_for(item)
       if item.enterprise_feature.present? && !EnterpriseToken.allows_to?(item.enterprise_feature)
-        title_text += ("".html_safe + render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons",
-                                                                       classes: "upsell-colored",
-                                                                       ml: 2)))
+        title_text += render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons",
+                                                       classes: "upsell-colored",
+                                                       ml: 2))
       end
       title_text
     end
 
     if item.icon_after.present?
-      link_text += ("".html_safe + render(Primer::Beta::Octicon.new(icon: item.icon_after, classes: "trailing-icon")))
+      link_text += render(Primer::Beta::Octicon.new(icon: item.icon_after, classes: "trailing-icon"))
     end
 
     html_options = item.html_options(selected:)

--- a/lib/redmine/menu_manager/menu_helper.rb
+++ b/lib/redmine/menu_manager/menu_helper.rb
@@ -199,7 +199,7 @@ module Redmine::MenuManager::MenuHelper
                              class: "#{menu_class}--item-title#{badge_class}",
                              lang: menu_item_locale(item)) do
       title_text = content_tag(:span, caption, class: "ellipsis") + badge_for(item)
-      if item.enterprise_feature.present? && !EnterpriseToken.allows_to?(item.enterprise_feature)
+      if item.enterprise_feature_missing?
         title_text += render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons",
                                                        classes: "upsell-colored",
                                                        ml: 2))

--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -174,4 +174,8 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
   def heading?
     @is_heading || false
   end
+
+  def enterprise_feature_missing?
+    @enterprise_feature.present? && !EnterpriseToken.allows_to?(@enterprise_feature)
+  end
 end

--- a/lib/redmine/menu_manager/top_menu/module_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/module_menu.rb
@@ -76,14 +76,24 @@ module Redmine::MenuManager::TopMenu::ModuleMenu
 
   def render_action_list_items(list, items)
     items.each do |item|
+      label = if item.enterprise_feature_missing?
+                h(item.caption) + upsell_icon
+              else
+                item.caption
+              end
+
       list.with_item(
         href: url_for(item.url),
-        label: item.caption,
+        label:,
         test_selector: "op-menu--item-action"
       ) do |menu_item|
         menu_item.with_leading_visual_icon(icon: item.icon) if item.icon
       end
     end
+  end
+
+  def upsell_icon
+    render(Primer::Beta::Octicon.new(icon: "op-enterprise-addons", classes: "upsell-colored", ml: 2))
   end
 
   def module_top_menu_item_groups


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69432

# What are you trying to accomplish?
Show upsell icon for items in top menu

## Screenshots
<img width="534" height="1874" alt="image" src="https://github.com/user-attachments/assets/73ede92d-b251-422e-a8d6-2a65f6147444" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
