### PR TITLE
[#69625] Error in PDF exports if font file storage is broken

### DIFF
--- a/app/models/exports/pdf/common/common.rb
+++ b/app/models/exports/pdf/common/common.rb
@@ -62,8 +62,11 @@ module Exports::PDF::Common::Common
            mime_type: "application/pdf"
   end
 
-  def error(message)
-    raise ::Exports::ExportError.new message
+  def error(pdf_error, custom_message = nil)
+    message = custom_message || I18n.t(:error_pdf_failed_to_export, error: pdf_error.message)
+    result = ::Exports::ExportError.new message
+    result.set_backtrace pdf_error.backtrace
+    raise result
   end
 
   def with_padding(opts, &)

--- a/app/models/exports/pdf/common/view.rb
+++ b/app/models/exports/pdf/common/view.rb
@@ -59,13 +59,25 @@ class Exports::PDF::Common::View
   end
 
   def self.valid_custom_font?
-    CustomStyle.current.present? &&
-      CustomStyle.current.export_font_regular.present? &&
-      CustomStyle.current.export_font_regular.local_file.present?
+    cs = CustomStyle.current
+    return false if cs.blank?
+
+    valid_custom_font_cut?(cs.export_font_regular) &&
+      valid_optional_custom_font_cut?(cs.export_font_bold) &&
+      valid_optional_custom_font_cut?(cs.export_font_italic) &&
+      valid_optional_custom_font_cut?(cs.export_font_bold_italic)
+    # Something in the remote storage failed. Log, but do not stop PDF generation
+  rescue StandardError => e
+    Rails.logger.error "Failed to apply custom PDF font to export: #{e.message}:\n#{e.backtrace.join("\n")}"
+    false
   end
 
   def self.valid_custom_font_cut?(cut)
     cut.present? && cut.local_file.present?
+  end
+
+  def self.valid_optional_custom_font_cut?(cut)
+    cut.blank? || cut.local_file.present?
   end
 
   def options

--- a/app/models/exports/pdf/demo_generator.rb
+++ b/app/models/exports/pdf/demo_generator.rb
@@ -65,8 +65,7 @@ module Exports::PDF
       render_demo
       success(pdf.render)
     rescue StandardError => e
-      Rails.logger.error "Failed to generate demo PDF: #{e.message}:\n#{e.backtrace.join("\n")}"
-      error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+      error(e)
     ensure
       delete_all_resized_images
     end

--- a/app/models/project/pdf_export/project_initiation.rb
+++ b/app/models/project/pdf_export/project_initiation.rb
@@ -68,8 +68,7 @@ class Project::PDFExport::ProjectInitiation < Exports::Exporter
     render_doc
     success(pdf.render)
   rescue StandardError => e
-    Rails.logger.error "Failed to generate project creation PDF:  #{e.message}:\n#{e.backtrace.join("\n")}"
-    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+    error(e)
   ensure
     delete_all_resized_images
   end

--- a/app/models/projects/exports/pdf.rb
+++ b/app/models/projects/exports/pdf.rb
@@ -60,8 +60,7 @@ module Projects::Exports
       file = render_pdf(all_projects)
       success(file)
     rescue StandardError => e
-      Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-      error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+      error(e)
     end
 
     def title

--- a/app/models/work_package/pdf_export/document_generator.rb
+++ b/app/models/work_package/pdf_export/document_generator.rb
@@ -59,8 +59,7 @@ class WorkPackage::PDFExport::DocumentGenerator < Exports::Exporter
     render_doc
     success(pdf.render)
   rescue StandardError => e
-    Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+    error(e)
   ensure
     delete_all_resized_images
   end

--- a/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_list_to_pdf.rb
@@ -83,23 +83,16 @@ class WorkPackage::PDFExport::WorkPackageListToPdf < WorkPackage::Exports::Query
   end
 
   def export!
-    handle_export_errors do
-      success(render_work_packages(query.results.work_packages))
-    end
+    success(render_work_packages(query.results.work_packages))
+  rescue Prawn::Errors::CannotFit => e
+    error(e, I18n.t(:error_pdf_export_too_many_columns))
+  rescue Exports::PDF::Components::Gantt::InvalidDateRangeError => e
+    error(e, e.message)
+  rescue StandardError => e
+    error(e)
   end
 
   private
-
-  def handle_export_errors
-    yield
-  rescue Prawn::Errors::CannotFit
-    error(I18n.t(:error_pdf_export_too_many_columns))
-  rescue Exports::PDF::Components::Gantt::InvalidDateRangeError => e
-    error(e.message)
-  rescue StandardError => e
-    Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
-  end
 
   def setup_page!
     self.pdf = get_pdf

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -59,8 +59,7 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
     render_work_package
     success(pdf.render)
   rescue StandardError => e
-    Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+    error(e)
   ensure
     delete_all_resized_images
   end

--- a/modules/meeting/app/workers/meetings/pdf/common/exporter.rb
+++ b/modules/meeting/app/workers/meetings/pdf/common/exporter.rb
@@ -59,8 +59,7 @@ module Meetings::PDF::Common
       render_doc
       success(pdf.render)
     rescue StandardError => e
-      Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-      error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+      error(e)
     ensure
       delete_all_resized_images
     end

--- a/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
+++ b/modules/reporting/app/workers/cost_query/pdf/timesheet_generator.rb
@@ -118,8 +118,7 @@ class CostQuery::PDF::TimesheetGenerator
     render_doc_again_with_total_page_nrs! if wants_total_page_nrs?
     pdf.render
   rescue StandardError => e
-    Rails.logger.error "Failed to generate PDF export:  #{e.message}:\n#{e.backtrace.join("\n")}"
-    error(I18n.t(:error_pdf_failed_to_export, error: e.message))
+    error(e)
   end
 
   def render_doc

--- a/spec/models/exports/pdf/common/view_spec.rb
+++ b/spec/models/exports/pdf/common/view_spec.rb
@@ -181,4 +181,15 @@ RSpec.describe Exports::PDF::Common::View do
       expect(doc.font_families["TestFamily"][:bold][:font]).to eq("TestFamily-Bold")
     end
   end
+
+  describe "handle broken custom font storage" do
+    it "falls back to default font without raising" do
+      broken = instance_double(CustomStyle)
+      allow(broken).to receive(:export_font_regular).and_raise("An error occurred while accessing the font file")
+      allow(CustomStyle).to receive(:current).and_return(broken)
+
+      expect { view.document }.not_to raise_error
+      expect(view.document.font.family).to eq described_class.default_font
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69625

# What are you trying to achieve?

A custom font file is uploaded, but its storage is broken or file is missing. 
Instead of a pointless `The PDF export could not be saved: undefined method 'body' for nil` message, the export should continue without the font applied.

# Issue

We use an ancient version of the carrierwave gem, so a bug in that library causes this issue, where even just checking for the existence of a file triggers an exception. (We are on version 1.3.4 from 2021, current version is 3.1.2)
https://github.com/carrierwaveuploader/carrierwave/issues/2524
Maintenance ticket is here: https://community.openproject.org/projects/openproject/work_packages/67626

# What approach did you choose and why?

* Cleaned up error handling in all PDF exports, as stacktrace was swallowed due to re-raising with a different exception message.
* Catch a possible storage error (occurred in simply calling `CustomStyle.current.export_font_regular.local_file.present?`)
* Check all other font cuts, too: _bold_, _italic_, _bold_italic_, if present

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
