### PR TITLE
Bug/69520 deep links to the create project form are not redirected after login

### DIFF
--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -32,16 +32,11 @@
 #
 # Note that _some_ actions (such as #new) are handled by the project controller since portfolios behave mostly like
 # projects in these cases.
-class PortfoliosController < ApplicationController
-  include OpTurbo::ComponentStream
-
-  include QueriesHelper
-  include Queries::Loading
-
-  authorization_checked! :index
-
+class PortfoliosController < ProjectsController
   before_action :authorize_portfolio_access, only: %i[index]
   before_action :not_authorized_on_feature_flag_inactive
+
+  skip_before_action :load_query_or_deny_access # skip using the superclass's before action because the next must be called first
   before_action :set_default_query, only: %i[index] # Must be called before `load_query_or_deny_access`
   before_action :load_query_or_deny_access, only: %i[index]
 
@@ -91,9 +86,5 @@ class PortfoliosController < ApplicationController
   def authorize_portfolio_access
     render_403 unless User.current.allowed_globally?(:add_portfolios) ||
                        Project.portfolio.allowed_to(User.current, :view_project).any?
-  end
-
-  def not_authorized_on_feature_flag_inactive
-    render_403 unless OpenProject::FeatureDecisions.portfolio_models_active?
   end
 end

--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+class ProgramsController < ProjectsController
+  before_action :not_authorized_on_feature_flag_inactive
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -342,6 +342,10 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def login_back_url_params
+    params.permit(:parent_id, :template_id, :step, :next_section)
+  end
+
   def portfolio_management_feature_required? = params[:workspace_type].in?(%w[portfolio program])
 
   def portfolio_management_feature_missing?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -40,9 +40,6 @@ class ProjectsController < ApplicationController
                 only: %i[copy_form copy deactivate_work_package_attachments export_list_modal export_project_initiation_pdf]
   before_action :authorize_global, only: %i[new create]
   before_action :require_admin, only: %i[destroy destroy_info]
-  before_action :not_authorized_on_feature_flag_inactive,
-                only: %i[new create],
-                if: :portfolio_management_feature_required?
   before_action :find_optional_parent, only: :new
   before_action :find_optional_template, only: %i[new create]
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -39,7 +39,7 @@ Rails.application.reloader.to_prepare do
                      dependencies: :add_project_from_template
 
       map.permission :add_portfolios,
-                     { projects: %i[new create] },
+                     { portfolios: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
                      visible: -> { OpenProject::FeatureDecisions.portfolio_models_active? },
@@ -47,7 +47,7 @@ Rails.application.reloader.to_prepare do
                      dependencies: :add_portfolios_from_template
 
       map.permission :add_programs,
-                     { projects: %i[new create] },
+                     { programs: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
                      visible: -> { OpenProject::FeatureDecisions.portfolio_models_active? },
@@ -62,13 +62,13 @@ Rails.application.reloader.to_prepare do
                      contract_actions: { projects: %i[create] }
 
       map.permission :add_portfolios_from_template,
-                     { projects: %i[new create] },
+                     { portfolios: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
                      visible: -> { OpenProject::FeatureDecisions.create_from_template_permissions_active? }
 
       map.permission :add_programs_from_template,
-                     { projects: %i[new create] },
+                     { programs: %i[new create] },
                      permissible_on: :global,
                      require: :loggedin,
                      visible: -> { OpenProject::FeatureDecisions.create_from_template_permissions_active? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,11 +274,12 @@ Rails.application.routes.draw do
     resource :menu, only: %i[show]
   end
 
-  # Extracted from the resources definition right below so that the
-  # default parameters can be defined.
-  resources :projects,
-            only: %i[new create],
-            defaults: { workspace_type: "project" }
+  %w[portfolio project program].each do |workspace_type|
+    resources workspace_type.pluralize,
+              only: %i[new create],
+              defaults: { workspace_type: },
+              controller: workspace_type.pluralize
+  end
 
   resources :projects, except: %i[new create show edit update] do
     scope module: "projects" do
@@ -507,14 +508,6 @@ Rails.application.routes.draw do
           constraints: { rev: /[\w.-]+/, repo_path: /.*/ },
           as: "show_revisions_path"
     end
-  end
-
-  # Portfolio and program creation is handled by the projects controller
-  %w[portfolio program].each do |workspace_type|
-    resources workspace_type.pluralize,
-              only: %i[new create],
-              defaults: { workspace_type: },
-              controller: "projects"
   end
 
   resources :portfolios,

--- a/spec/controllers/programs_controller_spec.rb
+++ b/spec/controllers/programs_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,19 +26,21 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
 require "spec_helper"
 
-RSpec.describe PortfoliosController, with_flag: { portfolio_models: true } do
+RSpec.describe ProgramsController, with_flag: { portfolio_models: true } do
   shared_let(:admin) { create(:admin) }
-  shared_let(:restricted_user) { create(:user) }
+  shared_let(:add_programs_user) { create(:user, global_permissions: [:add_programs]) }
+  shared_let(:no_permission_user) { create(:user) }
 
   let(:user) { admin }
 
+  current_user { user }
+
   describe "#new" do
     before do
-      login_as user
       get :new, params: { parent_id: parent&.id, template_id: template&.id, workspace_type: }
     end
 
@@ -86,7 +88,7 @@ RSpec.describe PortfoliosController, with_flag: { portfolio_models: true } do
       end
     end
 
-    let(:workspace_type) { "portfolio" }
+    let(:workspace_type) { "program" }
 
     let(:template) { nil }
     let(:parent) { nil }
@@ -104,8 +106,8 @@ RSpec.describe PortfoliosController, with_flag: { portfolio_models: true } do
       end
     end
 
-    context "as a non-admin with global add_portfolios permission" do
-      let(:user) { create(:user, global_permissions: [:add_portfolios]) }
+    context "as a non-admin with global add_programs permission" do
+      let(:user) { add_programs_user }
 
       context "with flag enabled", with_flag: { portfolio_models: true } do
         it_behaves_like "successful request"
@@ -119,8 +121,8 @@ RSpec.describe PortfoliosController, with_flag: { portfolio_models: true } do
       end
     end
 
-    context "as a non-admin without add_portfolios permission" do
-      let(:user) { create(:user) }
+    context "as a non-admin without add_programs permission" do
+      let(:user) { no_permission_user }
 
       context "with flag enabled", with_flag: { portfolio_models: true } do
         it "returns 403 Not Authorized" do
@@ -132,89 +134,49 @@ RSpec.describe PortfoliosController, with_flag: { portfolio_models: true } do
 
     context "when not being logged in but login is required", with_settings: { login_required: true } do
       let(:user) { User.anonymous }
-      let(:workspace_type) { "portfolio" }
+      let(:workspace_type) { "program" }
       let(:parent) { build_stubbed(:project) }
       let(:template) { build_stubbed(:project) }
 
       it "redirects to the sign in page with the parameters provided in the back url" do
         expect(response).to be_redirect
-        expect(response).to redirect_to signin_path(back_url: new_portfolio_url(parent_id: parent.id,
-                                                                                template_id: template.id))
+        expect(response).to redirect_to signin_path(back_url: new_program_url(parent_id: parent.id,
+                                                                              template_id: template.id))
       end
     end
   end
 
-  describe "#index" do
-    shared_let(:portfolio_a) { create(:portfolio, name: "Portfolio A", public: false, active: true) }
-    shared_let(:portfolio_b) { create(:portfolio, name: "Portfolio B", public: false, active: true) }
-    shared_let(:portfolio_c) { create(:portfolio, name: "Portfolio C", public: true, active: true) }
-    shared_let(:portfolio_d) { create(:portfolio, name: "Portfolio D", public: true, active: false) }
+  describe "#create" do
+    let(:project) { build_stubbed(:project) }
+    let(:service_result) { ServiceResult.success(result: project) }
+    let(:parent) { nil }
 
     before do
-      login_as(user)
-      get "index"
+      creation_service = instance_double(Projects::CreateService, call: service_result)
+
+      allow(Projects::CreateService)
+        .to receive(:new)
+              .with(user:)
+              .and_return(creation_service)
+
+      post :create, params: { project: { name: "New Program" }, parent_id: parent&.id }
     end
 
-    shared_examples_for "successful index" do
-      it "is success" do
-        expect(response).to be_successful
-      end
+    context "as a non-admin without global add_programs permission", with_flag: { portfolio_models: true } do
+      let(:user) { no_permission_user }
 
-      it "renders the index template" do
-        expect(response).to render_template "index"
-      end
-    end
-
-    shared_examples_for "forbidden index request" do
-      it "returns 403 Forbidden" do
+      it "returns 403 Not Authorized" do
         expect(response).not_to be_successful
         expect(response).to have_http_status :forbidden
       end
     end
 
-    context "without the portfolio feature flag set", with_flag: { portfolio_models: false } do
-      it_behaves_like "forbidden index request"
-    end
+    context "as a non-admin with global add_programs permission", with_flag: { portfolio_models: true } do
+      let(:user) { add_programs_user }
 
-    context "with the portfolio feature flag set" do
-      it_behaves_like "successful index"
-
-      it "includes active portfolios in the result" do
-        query = assigns(:query)
-        expect(query).to be_a_new(ProjectQuery)
-        expect(query).to be_valid
-
-        expect(query.results.portfolio).to eq([portfolio_a, portfolio_b, portfolio_c])
-      end
-
-      context "with a user who does not have permission to see the portfolio module" do
-        let(:user) { restricted_user }
-
-        it_behaves_like "forbidden index request"
-      end
-
-      context "with a user who has permission to see the portfolio module" do
-        context "when the user has the global add_portfolios permission" do
-          let(:user) { create(:user, global_permissions: [:add_portfolios]) }
-
-          it_behaves_like "successful index"
-        end
-
-        context "when the user has a view_project permission on an active portfolio" do
-          let(:user) do
-            create(:user, member_with_permissions: { portfolio_a => [:view_project] })
-          end
-
-          it_behaves_like "successful index"
-        end
-
-        context "when the user has a view_project permission on an inactive portfolio" do
-          let(:user) do
-            create(:user, member_with_permissions: { portfolio_d => [:view_project] })
-          end
-
-          it_behaves_like "forbidden index request"
-        end
+      it "redirects to project show", :aggregate_failures do
+        expect(response).to redirect_to project_path(project)
+        expect(flash[:notice]).to eq I18n.t(:notice_successful_create)
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe ProjectsController do
   let(:user) { admin }
 
   before do
-    allow(controller).to receive(:set_localization)
-
     login_as user
   end
 
@@ -223,6 +221,19 @@ RSpec.describe ProjectsController do
             expect(response).to have_http_status :forbidden
           end
         end
+      end
+    end
+
+    context "when not being logged in but login is required", with_settings: { login_required: true } do
+      let(:user) { User.anonymous }
+      let(:workspace_type) { "portfolio" }
+      let(:parent) { build_stubbed(:project) }
+      let(:template) { build_stubbed(:project) }
+
+      it "redirects to the sign in page with the parameters provided in the back url" do
+        expect(response).to be_redirect
+        expect(response).to redirect_to signin_path(back_url: new_project_url(parent_id: parent.id,
+                                                                              template_id: template.id))
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -134,96 +134,6 @@ RSpec.describe ProjectsController do
       end
     end
 
-    context "for portfolio" do
-      let(:template) { nil }
-      let(:workspace_type) { "portfolio" }
-      let(:parent) { nil }
-
-      context "as an admin" do
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it_behaves_like "successful request"
-        end
-
-        context "with flag disabled", with_flag: { portfolio_models: false } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-
-      context "as a non-admin with global add_portfolios permission" do
-        let(:user) { create(:user, global_permissions: [:add_portfolios]) }
-
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it_behaves_like "successful request"
-        end
-
-        context "with flag disabled", with_flag: { portfolio_models: false } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-
-      context "as a non-admin without add_portfolios permission" do
-        let(:user) { create(:user) }
-
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-    end
-
-    context "for program" do
-      let(:template) { nil }
-      let(:workspace_type) { "program" }
-      let(:parent) { nil }
-
-      context "as an admin" do
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it_behaves_like "successful request"
-        end
-
-        context "with flag disabled", with_flag: { portfolio_models: false } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-
-      context "as a non-admin with global add_programs permission" do
-        let(:user) { create(:user, global_permissions: [:add_programs]) }
-
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it_behaves_like "successful request"
-        end
-
-        context "with flag disabled", with_flag: { portfolio_models: false } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-
-      context "as a non-admin without add_programs permission" do
-        let(:user) { create(:user) }
-
-        context "with flag enabled", with_flag: { portfolio_models: true } do
-          it "returns 403 Not Authorized" do
-            expect(response).not_to be_successful
-            expect(response).to have_http_status :forbidden
-          end
-        end
-      end
-    end
-
     context "when not being logged in but login is required", with_settings: { login_required: true } do
       let(:user) { User.anonymous }
       let(:workspace_type) { "portfolio" }
@@ -303,18 +213,6 @@ RSpec.describe ProjectsController do
 
           it_behaves_like "successful create request"
         end
-      end
-
-      context "as a non-admin with global add_portfolios permission", with_flag: { portfolio_models: true } do
-        let(:user) { create(:user, global_permissions: [:add_portfolios]) }
-
-        it_behaves_like "successful create request"
-      end
-
-      context "as a non-admin with global add_programs permission", with_flag: { portfolio_models: true } do
-        let(:user) { create(:user, global_permissions: [:add_programs]) }
-
-        it_behaves_like "successful create request"
       end
     end
 
@@ -544,7 +442,7 @@ RSpec.describe ProjectsController do
     end
   end
 
-  describe "index.html" do
+  describe "#index" do
     shared_let(:project_a) { create(:project, name: "Project A", public: false, active: true) }
     shared_let(:project_b) { create(:project, name: "Project B", public: false, active: true) }
     shared_let(:project_c) { create(:project, name: "Project C", public: true, active: true) }

--- a/spec/routing/portfolios_spec.rb
+++ b/spec/routing/portfolios_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe PortfoliosController do
+  describe "index" do
+    it do
+      expect(get("/portfolios")).to route_to(
+        controller: "portfolios", action: "index"
+      )
+    end
+  end
+
+  describe "new" do
+    it do
+      expect(get("/portfolios/new")).to route_to(
+        controller: "portfolios", action: "new", workspace_type: "portfolio"
+      )
+    end
+  end
+
+  describe "create" do
+    it do
+      expect(post("/portfolios")).to route_to(
+        controller: "portfolios", action: "create", workspace_type: "portfolio"
+      )
+    end
+  end
+end

--- a/spec/routing/programs_spec.rb
+++ b/spec/routing/programs_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe ProgramsController do
+  describe "new" do
+    it do
+      expect(get("/programs/new")).to route_to(
+        controller: "programs", action: "new", workspace_type: "program"
+      )
+    end
+  end
+
+  describe "create" do
+    it do
+      expect(post("/programs")).to route_to(
+        controller: "programs", action: "create", workspace_type: "program"
+      )
+    end
+  end
+end

--- a/spec/routing/project_routing_spec.rb
+++ b/spec/routing/project_routing_spec.rb
@@ -57,36 +57,12 @@ RSpec.describe ProjectsController do
         controller: "projects", action: "new", workspace_type: "project"
       )
     end
-
-    it do
-      expect(get("/portfolios/new")).to route_to(
-        controller: "projects", action: "new", workspace_type: "portfolio"
-      )
-    end
-
-    it do
-      expect(get("/programs/new")).to route_to(
-        controller: "projects", action: "new", workspace_type: "program"
-      )
-    end
   end
 
   describe "create" do
     it do
       expect(post("/projects")).to route_to(
         controller: "projects", action: "create", workspace_type: "project"
-      )
-    end
-
-    it do
-      expect(post("/portfolios")).to route_to(
-        controller: "projects", action: "create", workspace_type: "portfolio"
-      )
-    end
-
-    it do
-      expect(post("/programs")).to route_to(
-        controller: "projects", action: "create", workspace_type: "program"
       )
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69520

# What are you trying to accomplish?

Allow known parameters in back url used for login. Since redirecting to programs/new and portfolios/new was also not working, there are now dedicated controllers for those which are mostly empty. For portfolios, the controller existed before but now it also inherits from projects to allow new and create. 

# Merge checklist

- [x] Tests added