### PR TITLE
[#69482] Documents: UI optimisations on file list when there are attachments

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.html.erb
@@ -47,6 +47,7 @@
         api_v3_document_resource(document),
         inputs: {
           allowUploading: allow_uploading,
+          showTimestamp: false,
           externalUploadButton: "#documents-add-attachments"
         }
       )


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69482

# What are you trying to accomplish?
Remove time when an attachment was uploaded from document's file list.

## Screenshots
<img width="588" height="405" alt="image" src="https://github.com/user-attachments/assets/5b16fa1b-6cde-4091-937d-f310be96179e" />

I was unsure if I should write a test for that. It seems not to be tested elsewhere and the test would probably be flaky or not very useful in the future, so I decided against it.
