### PR TITLE
bug/69476 documents UX/UI optimisations in the info line in the page header of a document

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -32,7 +32,7 @@
 <%=
   component_wrapper do
     flex_layout(tag: :div, align_items: :center, test_selector: "document-info-line") do |flex|
-      flex.with_column(hide: :sm, mr: 2) do
+      flex.with_column(hide: :sm, mr: 3) do
         render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
           menu.with_show_button do |button|
             button.with_trailing_visual_icon(icon: :"triangle-down")
@@ -52,7 +52,7 @@
         end
       end
 
-      flex.with_column(mr: 2) do
+      flex.with_column(mr: 3) do
         render(Documents::ShowEditView::PageHeader::LiveUsersComponent.new)
       end
 

--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
@@ -51,7 +51,9 @@
             end
           end
 
-          flex_container.with_column { active_editors }
+          flex_container.with_column do
+            render(Primer::Beta::Link.new(href: "#", muted: true)) { active_editors }
+          end
         end
       )
 

--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.rb
@@ -47,9 +47,7 @@ module Documents
         end
 
         def active_editors
-          safe_join [
-            I18n.t("documents.active_editors_count", count: users.count).html_safe
-          ]
+          I18n.t("documents.active_editors_count", count: users.count).html_safe
         end
       end
     end

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -108,7 +108,9 @@ en:
     last_updated_at: "Last saved %{time}."
 
     active_editors: "Active editors"
-    active_editors_count: "%{count} active editors"
+    active_editors_count:
+      one: "1 active editor"
+      other: "%{count} active editors"
 
     label_attachment_author: "Attachment author"
     label_categories: "Categories"

--- a/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Show/Edit Document View",
 
     aggregate_failures "can see live users" do
       within_test_selector("live-events") do
-        expect(page).to have_content("1 active editors")
+        expect(page).to have_content("1 active editor")
       end
     end
 


### PR DESCRIPTION
https://community.openproject.org/wp/69476

- [ ] https://github.com/opf/openproject/pull/21343 The avatars are rendered correctly in the avatar stack. They don't necessarily have to be the same avatar as in the popover, but it should be something (ideally initials contained in a round coloured badge) 
- [x] The '{n} active editors' text should be rendered as a [Muted link](https://qa.openproject-edge.com/lookbook/inspect/primer/beta/link/default?underline=false&muted=true)It should also handle pluralisation correction so that it says "1 active editor" in the singular
- [x] https://github.com/opf/openproject/pull/21245 Update "Last updated" to "Last saved" 
- [x] For each element on this line(type, # active editors, last edited), change margin-right between elements from 8px to 16px: var(--base-size-16, 16px) !importan

<img width="830" height="254" alt="Screenshot 2025-12-05 at 11 37 08 AM" src="https://github.com/user-attachments/assets/0c51cf86-6c01-4026-88bf-caf3d07368a0" />
<img width="828" height="303" alt="Screenshot 2025-12-05 at 11 36 45 AM" src="https://github.com/user-attachments/assets/159b38d5-8fcf-4daf-9eba-42709ff57424" />
