### PR TITLE
[#69692] Adjust the description of Assignee when submitted field

### DIFF
--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -77,7 +77,7 @@ module Projects
           f.autocompleter(
             name: :project_creation_wizard_assignee_custom_field_id,
             label: I18n.t("settings.project_initiation_request.submission.assignee"),
-            caption: I18n.t("settings.project_initiation_request.submission.assignee_caption"),
+            caption: I18n.t("settings.project_initiation_request.submission.assignee_caption_html").html_safe,
             required: true,
             input_width: :large,
             autocomplete_options: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4764,7 +4764,7 @@ en:
         status_when_submitted_caption: "The status the generated work package will transition to once the request is submitted."
         send_confirmation_email: "Send confirmation email to the user who submitted the project initiation request"
         assignee: "Assignee when submitted"
-        assignee_caption: "The user or group assigned to this project attribute will also become the assignee of the new work package."
+        assignee_caption_html: "The user or group assigned to this project attribute will also become the assignee of the new work package. This list includes active project attributes of type <i>User</i> only."
         confirmation_email_text: "Confirmation email text"
         confirmation_email_default: "Hello,\n\nYou submitted a project initiation request for **%{project_name}**. It is now awaiting review.\nClick the link below to access the work package with your request."
         work_package_comment: "Work package comment"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69692

# What are you trying to accomplish?
Have a better explanation for the "Assignee when submitted" field in the project initiation request wizard.
## Screenshots
<img width="711" height="121" alt="image" src="https://github.com/user-attachments/assets/8f6cc364-daeb-4cf7-a3b9-a4a9de6381ac" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
