### PR TITLE
[#68226] show formatted weights in workpackages 

### DIFF
--- a/docs/api/apiv3/components/examples/hierarchy_item_collection_filtered_response.yml
+++ b/docs/api/apiv3/components/examples/hierarchy_item_collection_filtered_response.yml
@@ -10,6 +10,8 @@ value:
         id: 1338
         label: Stormtroopers
         short: ST
+        weight: null
+        formattedWeight: null
         depth: 1
         _links:
           self:
@@ -27,6 +29,8 @@ value:
         id: 1340
         label: ST-377
         short: null
+        weight: null
+        formattedWeight: null
         depth: 2
         _links:
           self:
@@ -44,6 +48,8 @@ value:
         id: 1341
         label: ST-422
         short: null
+        weight: null
+        formattedWeight: null
         depth: 2
         _links:
           self:

--- a/docs/api/apiv3/components/examples/hierarchy_item_collection_response.yml
+++ b/docs/api/apiv3/components/examples/hierarchy_item_collection_response.yml
@@ -10,6 +10,8 @@ value:
         id: 1337
         label: null
         short: null
+        weight: null
+        formattedWeight: null
         depth: 0
         _links:
           self:
@@ -26,6 +28,8 @@ value:
         id: 1338
         label: Stormtroopers
         short: ST
+        weight: null
+        formattedWeight: null
         depth: 1
         _links:
           self:
@@ -44,6 +48,8 @@ value:
         id: 1340
         label: ST-377
         short: null
+        weight: null
+        formattedWeight: null
         depth: 2
       - _hint: hierarchy item shortened for brevity
   _links:

--- a/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
+++ b/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
@@ -1,6 +1,15 @@
 # Schema: HierarchyItemReadModel
 ---
 type: object
+required:
+  - _type
+  - id
+  - label
+  - short
+  - weight
+  - formattedWeight
+  - depth
+  - _links
 properties:
   _type:
     type: string
@@ -41,6 +50,10 @@ properties:
     description: The hierarchy depth. The root item has a depth of 0.
   _links:
     type: object
+    required:
+      - self
+      - children
+      - branch
     properties:
       self:
         allOf:
@@ -65,3 +78,10 @@ properties:
                 A hierarchy item that is a child of the current hierarchy item
                 
                 **Resource**: HierarchyItem
+      branch:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The branch of the hierarchy item, ordered from root to node.
+
+              **Resource**: HierarchyItemCollection

--- a/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
+++ b/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
@@ -13,8 +13,29 @@ properties:
     type: string
     description: The label of the hierarchy item
   short:
-    type: string
-    description: The short name of the hierarchy item
+    type:
+      - string
+      - "null"
+    description: |-
+      The short name of the hierarchy item. If this attribute is set, the `weight` and
+      the `formattedWeight` are `null`.
+  weight:
+    type:
+      - string
+      - "null"
+    description: |-
+      The accurate weight of the hierarchy item. As a decimal precision number it is written as a string to
+      not loose precision with conversion to a floating point number.
+      If this attribute is set, the `short` is null.
+  formattedWeight:
+    type:
+      - string
+      - "null"
+    description: |-
+      The formatted weight of the hierarchy item. The standard formatting of the OpenProject server is used to
+      convert this number into a representable format - i.e. falling back to scientific notation for very small and
+      very big numbers.
+      If this attribute is set, the `short` is null.
   depth:
     type: integer
     description: The hierarchy depth. The root item has a depth of 0.

--- a/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
@@ -70,7 +70,7 @@ function spansFromAncestors(ancestors:CollectionResource):HTMLSpanElement[] {
         spans.push(short);
       } else if (el.weight !== null) {
         const weight = document.createElement('span');
-        weight.textContent = `(${el.weight})`;
+        weight.textContent = `(${el.formattedWeight})`;
         weight.className = 'color-fg-subtle';
         spans.push(weight);
       }

--- a/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/render-hierarchy-item.ts
@@ -68,6 +68,11 @@ function spansFromAncestors(ancestors:CollectionResource):HTMLSpanElement[] {
         short.textContent = `(${el.short})`;
         short.className = 'color-fg-subtle';
         spans.push(short);
+      } else if (el.weight !== null) {
+        const weight = document.createElement('span');
+        weight.textContent = `(${el.weight})`;
+        weight.className = 'color-fg-subtle';
+        spans.push(weight);
       }
     });
 

--- a/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
@@ -45,6 +45,8 @@ module API
           end
 
           def title
+            return nil if root?
+
             ::CustomFields::Hierarchy::HierarchicalItemFormatter.default.format(item:)
           end
 

--- a/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
@@ -40,9 +40,28 @@ module API
             @depth = depth
           end
 
+          def weight
+            weight_formatter.format(item:)
+          end
+
+          def title
+            ::CustomFields::Hierarchy::HierarchicalItemFormatter.default.format(item:)
+          end
+
           private
 
           attr_accessor :item
+
+          def weight_formatter
+            @weight_formatter ||= ::CustomFields::Hierarchy::HierarchicalItemFormatter
+                                    .new(path: false,
+                                         label: false,
+                                         suffix: true,
+                                         suffix_parentheses: false,
+                                         number_length_limit: 9,
+                                         number_integer_digit_limit: 8,
+                                         number_precision: 4)
+          end
         end
       end
     end

--- a/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchical_item_aggregate.rb
@@ -33,14 +33,16 @@ module API
         class HierarchicalItemAggregate
           attr_accessor :depth
 
-          delegate :id, :label, :short, :parent, :children, :root?, to: :item
+          delegate :id, :label, :short, :weight, :parent, :children, :root?, to: :item
 
           def initialize(item:, depth:)
             @item = item
             @depth = depth
           end
 
-          def weight
+          def formatted_weight
+            return nil if weight.nil?
+
             weight_formatter.format(item:)
           end
 

--- a/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
@@ -46,6 +46,8 @@ module API
 
           property :weight, render_nil: true
 
+          property :formatted_weight, render_nil: true
+
           property :depth,
                    render_nil: true,
                    exec_context: :decorator,

--- a/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
+++ b/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer.rb
@@ -36,19 +36,15 @@ module API
           end
 
           self_link path: :custom_field_item,
-                    title_getter: ->(*) do
-                      if represented.short.nil?
-                        represented.label
-                      else
-                        "#{represented.label} (#{represented.short})"
-                      end
-                    end
+                    title_getter: ->(*) { represented.title }
 
           property :id
 
           property :label, render_nil: true
 
           property :short, render_nil: true
+
+          property :weight, render_nil: true
 
           property :depth,
                    render_nil: true,

--- a/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/custom_fields/hierarchy/hierarchy_item_representer_rendering_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
   subject(:generated) { representer.to_json }
 
   context "if item is root" do
-    let(:item) { root }
+    let(:item) { build_aggregate(item: root, depth: 0) }
 
     describe "_links" do
       it_behaves_like "has an untitled link" do
@@ -105,7 +105,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
     end
 
     context "and depth is negative" do
-      let(:item) { API::V3::CustomFields::Hierarchy::HierarchicalItemAggregate.new(item: root, depth: -1) }
+      let(:item) { build_aggregate(item: root, depth: -1) }
 
       describe "properties" do
         it_behaves_like "property", :depth do
@@ -116,7 +116,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
   end
 
   context "if item is leave" do
-    let(:item) { mouse }
+    let(:item) { build_aggregate(item: mouse, depth: mouse.depth) }
 
     describe "_links" do
       it_behaves_like "has a titled link" do
@@ -166,7 +166,7 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
   end
 
   context "if item is intermediate" do
-    let(:item) { r2d2 }
+    let(:item) { build_aggregate(item: r2d2, depth: r2d2.depth) }
 
     describe "_links" do
       it_behaves_like "has a titled link" do
@@ -220,5 +220,11 @@ RSpec.describe API::V3::CustomFields::Hierarchy::HierarchyItemRepresenter, "rend
         let(:value) { item.depth }
       end
     end
+  end
+
+  private
+
+  def build_aggregate(item:, depth:)
+    API::V3::CustomFields::Hierarchy::HierarchicalItemAggregate.new(item:, depth:)
   end
 end


### PR DESCRIPTION
# Ticket
[#68226](https://community.openproject.org/wp/68226)

# What are you trying to accomplish?
- show weights in display fields and select edit fields

# What approach did you choose and why?
- use item formatter for APIv3 responses

