### PR TITLE
Validate JSON schema of API representers

### DIFF
--- a/app/services/json_schema_loader.rb
+++ b/app/services/json_schema_loader.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class JsonSchemaLoader
+  def initialize(base_path: "docs/api/apiv3/components/schemas")
+    @base_path = base_path
+  end
+
+  def load(schema_name)
+    load_file("#{@base_path}/#{schema_name}.yml")
+  end
+
+  private
+
+  def load_file(file_name)
+    return schema_cache.fetch(file_name) if schema_cache.key?(file_name)
+
+    schema = YAML.load_file(file_name).deep_symbolize_keys
+    schema = resolve_references(schema, file_name)
+    schema_cache[file_name] = schema
+  end
+
+  def resolve_references(schema, file_name)
+    if schema.key?(:$ref)
+      ref_file = File.join(File.dirname(file_name), schema.fetch(:$ref))
+      return load_file(ref_file)
+    end
+
+    schema.to_h do |key, value|
+      next [key, resolve_references(value, file_name)] if value.is_a?(Hash)
+
+      if value.is_a?(Array)
+        next [
+          key,
+          value.map { |v| v.is_a?(Hash) ? resolve_references(v, file_name) : v }
+        ]
+      end
+
+      [key, value]
+    end
+  end
+
+  def schema_cache
+    @schema_cache ||= {}
+  end
+end

--- a/docs/api/apiv3/components/schemas/attachment_model.yml
+++ b/docs/api/apiv3/components/schemas/attachment_model.yml
@@ -27,11 +27,11 @@ properties:
   status:
     type: string
     enum:
-    - uploaded
-    - prepared
-    - scanned
-    - quarantined
-    - rescan
+      - uploaded
+      - prepared
+      - scanned
+      - quarantined
+      - rescan
   contentType:
     type: string
     description: The files MIME-Type as determined by the server

--- a/docs/api/apiv3/components/schemas/attachment_model.yml
+++ b/docs/api/apiv3/components/schemas/attachment_model.yml
@@ -2,9 +2,9 @@
 ---
 type: object
 required:
-  - title
   - fileName
   - description
+  - status
   - contentType
   - digest
   - createdAt
@@ -13,9 +13,6 @@ properties:
     type: integer
     description: Attachment's id
     minimum: 1
-  title:
-    type: string
-    description: The name of the file
   fileName:
     type: string
     description: The name of the uploaded file
@@ -27,12 +24,30 @@ properties:
     allOf:
     - $ref: "./formattable.yml"
     - description: A user provided description of the file
+  status:
+    type: string
+    enum:
+    - uploaded
+    - prepared
+    - scanned
+    - quarantined
+    - rescan
   contentType:
     type: string
     description: The files MIME-Type as determined by the server
   digest:
-    type: string
+    type: object
     description: A checksum for the files content
+    required:
+      - algorithm
+      - hash
+    properties:
+      algorithm:
+        type: string
+        description: "The algorithm used to generate the digest."
+      hash:
+        type: string
+        description: "The hexadecimal representation of the digested hash value."
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/components/schemas/project_model.yml
+++ b/docs/api/apiv3/components/schemas/project_model.yml
@@ -42,10 +42,6 @@ properties:
     required:
       - self
       - categories
-      - types
-      - versions
-      - memberships
-      - workPackages
     properties:
       update:
         allOf:

--- a/docs/api/apiv3/components/schemas/status_model.yml
+++ b/docs/api/apiv3/components/schemas/status_model.yml
@@ -17,7 +17,9 @@ properties:
     type: boolean
     description: Indicates, whether work package of this status are considered closed
   color:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: hex-code
     description: The color of the status
   isDefault:

--- a/docs/api/apiv3/components/schemas/status_model.yml
+++ b/docs/api/apiv3/components/schemas/status_model.yml
@@ -17,7 +17,7 @@ properties:
     type: boolean
     description: Indicates, whether work package of this status are considered closed
   color:
-    type: string
+    type: [string, null]
     format: hex-code
     description: The color of the status
   isDefault:
@@ -49,5 +49,5 @@ properties:
           - $ref: './link.yml'
           - description: |-
               This status
-              
+
               **Resource**: Status

--- a/docs/api/apiv3/components/schemas/user_model.yml
+++ b/docs/api/apiv3/components/schemas/user_model.yml
@@ -12,7 +12,9 @@ allOf:
         enum:
           - User
       avatar:
-        type: [string, null]
+        type:
+          - "string"
+          - "null"
         format: uri
         description: URL to user's avatar
       login:

--- a/docs/api/apiv3/components/schemas/user_model.yml
+++ b/docs/api/apiv3/components/schemas/user_model.yml
@@ -12,43 +12,43 @@ allOf:
         enum:
           - User
       avatar:
-        type: string
+        type: [string, null]
         format: uri
         description: URL to user's avatar
       login:
         type: string
         description: |-
           The user's login name
-    
+
           # Conditions
-    
+
           - User is self, or `create_user` or `manage_user` permission globally
         maxLength: 256
       firstName:
         type: string
         description: |-
           The user's first name
-    
+
           # Conditions
-    
+
           - User is self, or `create_user` or `manage_user` permission globally
         maxLength: 30
       lastName:
         type: string
         description: |-
           The user's last name
-    
+
           # Conditions
-    
+
           - User is self, or `create_user` or `manage_user` permission globally
         maxLength: 30
       email:
         type: string
         description: |-
           The user's email address
-    
+
           # Conditions
-    
+
           - E-Mail address not hidden
           - User is not a new record
           - User is self, or `create_user` or `manage_user` permission globally
@@ -57,15 +57,15 @@ allOf:
         type: boolean
         description: |-
           Flag indicating whether or not the user is an admin
-    
+
           # Conditions
-    
+
           - `admin`
       status:
         type: string
         description: |-
           The current activation status of the user.
-          
+
           # Conditions
 
           - User is self, or `create_user` or `manage_user` permission globally
@@ -73,9 +73,9 @@ allOf:
         type: string
         description: |-
           User's language | ISO 639-1 format
-    
+
           # Conditions
-    
+
           - User is self, or `create_user` or `manage_user` permission globally
       identityUrl:
         type:
@@ -84,9 +84,9 @@ allOf:
         description: |-
           User's identity_url for OmniAuth authentication.
           **Deprecated:** It will be removed in the near future.
-    
+
           # Conditions
-    
+
           - User is self, or `create_user` or `manage_user` permission globally
         deprecated: true
       createdAt:
@@ -115,18 +115,18 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   A link to update the user resource.
-    
+
                   # Conditions
-                  
+
                   - `admin`
           lock:
             allOf:
               - $ref: './link.yml'
               - description: |-
                   Restrict the user from logging in and performing any actions.
-    
+
                   # Conditions
-    
+
                   - User is not locked
                   - `admin`
           unlock:
@@ -134,9 +134,9 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   Allow a locked user to login and act again.
-    
+
                   # Conditions
-                  
+
                   - User is not locked
                   - `admin`
           delete:
@@ -144,9 +144,9 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   Permanently remove a user from the instance
-    
+
                   # Conditions
-    
+
                   either:
                     - `admin`
                     - Setting `users_deletable_by_admin` is set
@@ -158,8 +158,8 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   Permanently remove a user from the instance
-    
+
                   # Conditions
-                  
+
                   - LDAP authentication configured
                   - `admin`

--- a/docs/api/apiv3/components/schemas/version_model.yml
+++ b/docs/api/apiv3/components/schemas/version_model.yml
@@ -21,10 +21,14 @@ properties:
     - "$ref": "./formattable.yml"
     - {}
   startDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
   endDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
   status:
     type: string

--- a/docs/api/apiv3/components/schemas/version_model.yml
+++ b/docs/api/apiv3/components/schemas/version_model.yml
@@ -21,10 +21,10 @@ properties:
     - "$ref": "./formattable.yml"
     - {}
   startDate:
-    type: string
+    type: [string, null]
     format: date
   endDate:
-    type: string
+    type: [string, null]
     format: date
   status:
     type: string
@@ -117,7 +117,7 @@ example:
     raw: This version has a description
     html: This version has a description
   startDate: '2014-11-20'
-  endDate: 
+  endDate:
   status: open
   sharing: system
   customField14: '1234567890'

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -36,15 +36,15 @@ properties:
     type: boolean
     description: If true, the work package is in a readonly status so with the exception of the status, no other property can be altered.
   startDate:
-    type: string
+    type: [string, null]
     format: date
     description: Scheduled beginning of a work package
   dueDate:
-    type: string
+    type: [string, null]
     format: date
     description: Scheduled end of a work package
   date:
-    type: string
+    type: [string, null]
     format: date
     description: Date on which a milestone is achieved
   derivedStartDate:
@@ -62,18 +62,18 @@ properties:
       two dates can deviate.
     readOnly: true
   duration:
-    type: string
+    type: [string, null]
     format: duration
     description: |-
       **(NOT IMPLEMENTED)** The amount of time in hours the work package needs to be completed.
       Not available for milestone type of work packages.
     readOnly: true
   estimatedTime:
-    type: string
+    type: [string, null]
     format: duration
     description: Time a work package likely needs to be completed excluding its descendants
   derivedEstimatedTime:
-    type: string
+    type: [string, null]
     format: duration
     description: Time a work package likely needs to be completed including its descendants
     readOnly: true
@@ -99,7 +99,7 @@ properties:
     minimum: 0
     maximum: 100
   derivedPercentageDone:
-    type: integer
+    type: [integer, null]
     description: Amount of total completion for a work package derived from itself and its descendant work packages
     readOnly: true
     minimum: 0
@@ -120,9 +120,7 @@ properties:
       - self
       - schema
       - ancestors
-      - attachments
       - author
-      - children
       - priority
       - project
       - status

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -36,15 +36,21 @@ properties:
     type: boolean
     description: If true, the work package is in a readonly status so with the exception of the status, no other property can be altered.
   startDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
     description: Scheduled beginning of a work package
   dueDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
     description: Scheduled end of a work package
   date:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
     description: Date on which a milestone is achieved
   derivedStartDate:
@@ -62,18 +68,24 @@ properties:
       two dates can deviate.
     readOnly: true
   duration:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: duration
     description: |-
       **(NOT IMPLEMENTED)** The amount of time in hours the work package needs to be completed.
       Not available for milestone type of work packages.
     readOnly: true
   estimatedTime:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: duration
     description: Time a work package likely needs to be completed excluding its descendants
   derivedEstimatedTime:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: duration
     description: Time a work package likely needs to be completed including its descendants
     readOnly: true
@@ -99,7 +111,9 @@ properties:
     minimum: 0
     maximum: 100
   derivedPercentageDone:
-    type: [integer, null]
+    type:
+      - "integer"
+      - "null"
     description: Amount of total completion for a work package derived from itself and its descendant work packages
     readOnly: true
     minimum: 0

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -581,8 +581,7 @@ module API
                                 }
                               else
                                 {
-                                  href: nil,
-                                  title: nil
+                                  href: nil
                                 }
                               end
                             },

--- a/modules/avatars/app/helpers/avatar_helper.rb
+++ b/modules/avatars/app/helpers/avatar_helper.rb
@@ -58,11 +58,11 @@ module AvatarHelper
     elsif avatar_manager.gravatar_enabled?
       build_gravatar_image_url user, options
     else
-      "".html_safe
+      nil
     end
   rescue StandardError => e
     Rails.logger.error "Failed to create avatar url for #{user}: #{e}"
-    "".html_safe
+    nil
   end
 
   def local_avatar?(user)

--- a/modules/avatars/spec/helpers/avatar_helper_spec.rb
+++ b/modules/avatars/spec/helpers/avatar_helper_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe AvatarHelper, with_settings: { protocol: "http" } do
       let(:enable_gravatars) { false }
       let(:enable_local_avatars) { false }
 
-      it "returns blank" do
-        expect(helper.avatar_url(user)).to eq ""
+      it "returns nil" do
+        expect(helper.avatar_url(user)).to be_nil
       end
     end
   end
@@ -185,12 +185,12 @@ RSpec.describe AvatarHelper, with_settings: { protocol: "http" } do
       expect(helper.avatar(mail)).to eq("")
     end
 
-    it "returns an empty string if a non parsable (e-mail) string url is provided" do
-      expect(helper.avatar_url("just the name")).to eq("")
+    it "returns nil if a non parsable (e-mail) string url is provided" do
+      expect(helper.avatar_url("just the name")).to be_nil
     end
 
-    it "returns an empty string if nil url is provided" do
-      expect(helper.avatar_url(nil)).to eq("")
+    it "returns nil if nil url is provided" do
+      expect(helper.avatar_url(nil)).to be_nil
     end
   end
 
@@ -199,11 +199,12 @@ RSpec.describe AvatarHelper, with_settings: { protocol: "http" } do
     let(:enable_local_avatars) { false }
 
     it "returns an empty string for avatar if gravatar is disabled" do
+      # ??? Expectation and title deviate... why do we expect an avatar tag when everything is disabled?
       expect(helper.avatar(user)).to be_html_eql(expected_user_avatar_tag(user))
     end
 
-    it "returns an empty string for avatar_url if gravatar is disabled" do
-      expect(helper.avatar_url(user)).to eq("")
+    it "returns nil for avatar_url" do
+      expect(helper.avatar_url(user)).to be_nil
     end
   end
 

--- a/spec/fixtures/files/test_schema.yml
+++ b/spec/fixtures/files/test_schema.yml
@@ -1,0 +1,15 @@
+type: object
+required: foo
+properties:
+  foo:
+    type: string
+    enum:
+    - one
+    - two
+    - three
+  referenced:
+    $ref: "./test_schema_reference.yml"
+  combined:
+    allOf:
+    - type: string
+    - $ref: "./test_schema_reference.yml"

--- a/spec/fixtures/files/test_schema_reference.yml
+++ b/spec/fixtures/files/test_schema_reference.yml
@@ -1,0 +1,1 @@
+description: "This is a referenced value."

--- a/spec/lib/api/v3/attachments/attachment_representer_spec.rb
+++ b/spec/lib/api/v3/attachments/attachment_representer_spec.rb
@@ -62,7 +62,11 @@ RSpec.describe API::V3::Attachments::AttachmentRepresenter do
     end
   end
 
-  subject { representer.to_json }
+  subject(:generated) { representer.to_json }
+
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("attachment_model")
+  end
 
   it { is_expected.to be_json_eql("Attachment".to_json).at_path("_type") }
   it { is_expected.to be_json_eql(attachment.id.to_json).at_path("id") }

--- a/spec/lib/api/v3/priorities/priority_representer_spec.rb
+++ b/spec/lib/api/v3/priorities/priority_representer_spec.rb
@@ -37,7 +37,11 @@ RSpec.describe API::V3::Priorities::PriorityRepresenter do
   include API::V3::Utilities::PathHelper
 
   context "generation" do
-    subject { representer.to_json }
+    subject(:generated) { representer.to_json }
+
+    it "fulfills the documented schema" do
+      expect(generated).to match_json_schema.from_docs("priority_model")
+    end
 
     it "indicates its type" do
       expect(subject).to include_json("Priority".to_json).at_path("_type")

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -116,6 +116,10 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
     end
   end
 
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("project_model")
+  end
+
   it { is_expected.to include_json("Project".to_json).at_path("_type") }
 
   describe "properties" do

--- a/spec/lib/api/v3/statuses/status_representer_spec.rb
+++ b/spec/lib/api/v3/statuses/status_representer_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe API::V3::Statuses::StatusRepresenter do
 
     it { is_expected.to include_json("Status".to_json).at_path("_type") }
 
+    it "fulfills the documented schema" do
+      expect(generated).to match_json_schema.from_docs("status_model")
+    end
+
     describe "status" do
       it { is_expected.to have_json_path("id") }
       it { is_expected.to have_json_path("name") }

--- a/spec/lib/api/v3/types/type_representer_spec.rb
+++ b/spec/lib/api/v3/types/type_representer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe API::V3::Types::TypeRepresenter do
   include API::V3::Utilities::PathHelper
 
   context "generation" do
-    subject { representer.to_json }
+    subject(:generated) { representer.to_json }
 
     describe "links" do
       it_behaves_like "has a titled link" do
@@ -45,6 +45,10 @@ RSpec.describe API::V3::Types::TypeRepresenter do
         let(:href) { api_v3_paths.type(type.id) }
         let(:title) { type.name }
       end
+    end
+
+    it "fulfills the documented schema" do
+      expect(generated).to match_json_schema.from_docs("type_model")
     end
 
     it "indicates its id" do

--- a/spec/lib/api/v3/users/user_representer_spec.rb
+++ b/spec/lib/api/v3/users/user_representer_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe API::V3::Users::UserRepresenter do
         expect(subject).not_to have_json_path("email")
         expect(subject).not_to have_json_path("language")
       end
+
+      it "fulfills the documented schema" do
+        expect(generated).to match_json_schema.from_docs("user_model")
+      end
     end
 
     context "as the represented user" do
@@ -79,6 +83,10 @@ RSpec.describe API::V3::Users::UserRepresenter do
 
         expect(subject).not_to have_json_path("admin")
       end
+
+      it "fulfills the documented schema" do
+        expect(generated).to match_json_schema.from_docs("user_model")
+      end
     end
 
     context "as admin" do
@@ -94,6 +102,10 @@ RSpec.describe API::V3::Users::UserRepresenter do
         expect(subject).to have_json_path("email")
         expect(subject).to have_json_path("admin")
         expect(subject).to have_json_path("language")
+      end
+
+      it "fulfills the documented schema" do
+        expect(generated).to match_json_schema.from_docs("user_model")
       end
 
       it_behaves_like "has UTC ISO 8601 date and time" do

--- a/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/versions/version_representer_rendering_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe API::V3::Versions::VersionRepresenter, "rendering" do
     end
   end
 
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("version_model")
+  end
+
   it { is_expected.to include_json("Version".to_json).at_path("_type") }
 
   describe "links" do

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
 
   include_context "eager loaded work package representer"
 
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("work_package_model")
+  end
+
   describe "properties" do
     it { is_expected.to include_json("WorkPackage".to_json).at_path("_type") }
 

--- a/spec/services/json_schema_loader_spec.rb
+++ b/spec/services/json_schema_loader_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe JsonSchemaLoader do
+  subject { described_class.new(base_path: "spec/fixtures/files").load("test_schema") }
+
+  it "loads the schema as a aymbolized hash" do
+    expect(subject.dig(:properties, :foo, :type)).to eq("string")
+  end
+
+  it "resolves $ref attributes" do
+    expect(subject.dig(:properties, :referenced, :description)).to eq("This is a referenced value.")
+  end
+
+  it "resolves $ref attributes inside arrays" do
+    expect(subject.dig(:properties, :combined, :allOf, 1, :description)).to eq("This is a referenced value.")
+  end
+end

--- a/spec/support/matchers/match_json_schema.rb
+++ b/spec/support/matchers/match_json_schema.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec::Matchers.define :match_json_schema do |expected|
+  chain :from_docs do |docs_schema|
+    @docs_schema = docs_schema
+  end
+
+  match do |actual|
+    raise ArgumentError, "Do not pass arguments to match_json_schema, when using .from_docs." if expected && @docs_schema
+
+    schema = @docs_schema ? JsonSchemaLoader.new.load(@docs_schema) : expected
+
+    validator = JSONSchemer.schema(schema)
+
+    @actual = validator.validate(JSON.parse(actual)).map { |result| result.fetch("error") }
+    @actual.empty?
+  end
+
+  failure_message do |actual|
+    actual.join("\n")
+  end
+
+  failure_message_when_negated do
+    "expected schema to not match, but it did."
+  end
+end


### PR DESCRIPTION
This PR introduces some basic building blocks to load and validate schemas and starts using it.

Those self-tests are "basic" in the sense that they only validate
their compliance with our documented schema in one representation.

These test cases don't yet cover/validate whether the generated
representation also fulfills the schema under different circumstances,
for example when rendering for a user with fewer privileges, not allowed
to see certain fields.

Where necessary, the schema was changed to reflect the reality, e.g.
when those tests revealed that a "required" field might be missing due to
a lack of permissions.

# Ticket

https://community.openproject.org/wp/69707

# Notes

In a few cases the implementation was adapted to allow for stricter guarantees
of the specified schema, for example:

* links are allowed to leave out the title key already, so its not necessary to emit `title: nil` in cases where a title is
not known.
* `avatars` were documented to be in url format, though missing avatars were indicated as an empty string
    * this has been changed to representing missing avatars as nil, functionality does not appear to be affected by this