### PR TITLE
bug/69389 Documents Index page breadcrumb UI skewed

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
@@ -1,4 +1,4 @@
-.controller-documents
+.controller-documents:has(.op-document-view)
   @include extended-content--top
   @include extended-content--bottom
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/69389

Apply layout overrides only on the document show/edit view- which does not use the conventional pageheader full width layout

_Before_

<img width="1769" height="520" alt="Screenshot 2025-12-08 at 11 11 40 AM" src="https://github.com/user-attachments/assets/6d2345bb-6c44-4e5a-b299-dc394cab1d7d" />

_After_

<img width="2194" height="436" alt="Screenshot 2025-12-08 at 11 11 22 AM" src="https://github.com/user-attachments/assets/8b7ace41-a764-4348-b5c7-65722753b267" />

