### PR TITLE
bug/69069 Collaborative editing: user name tooltip is cut off in the first line of the document

### DIFF
--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -19,4 +19,5 @@ $blocknote-max-width: 800px
       overflow: auto
       width: 100%
       background-color: transparent
+      padding-top: 10px // Small padding to display cursor label when at the very top
       padding-inline: 0 // No inline padding necessary given transparent background

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.sass
@@ -15,6 +15,9 @@
 .op-document-view
   height: 100%
 
+  .PageHeader
+    margin-bottom: var(--base-size-8) // Compensate for .bn-editor padding-top increase to maintain visual spacing
+
   &--main,
   &--sidebar
     padding-top: var(--main-menu-toggler-top-spacing)


### PR DESCRIPTION
https://community.openproject.org/work_packages/69069

Reinstate some padding (removed in https://github.com/opf/openproject/pull/20943/files#diff-ce3024d4ee8d75304bb7ee24f7eb9110b8c97f9ec9bb21b3b887e7e2f25b0c41)

Set padding top of 10px to allow cursor label on first line to be visible- compensate the spacing by reducing the page header margin bottom

Bug:

https://github.com/user-attachments/assets/03119356-9fa7-4e42-9dd5-48329720f0ca

Fix:


https://github.com/user-attachments/assets/35ae3540-c5e6-4e16-9493-e00a3ccc8114

