### PR TITLE
Use the same call for storage upload service

### DIFF
--- a/app/services/projects/creation_wizard/artifact_exporter.rb
+++ b/app/services/projects/creation_wizard/artifact_exporter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects::CreationWizard
+  module ArtifactExporter
+    private
+
+    def store_attachment_locally?
+      project.project_creation_wizard_artifact_export_type == "attachment"
+    end
+
+    def project_storage
+      return @project_storage if defined?(@project_storage)
+
+      @project_storage = project
+        .project_storages
+        .find_by(id: project.project_creation_wizard_artifact_export_storage)
+    end
+
+    def create_pdf_export!
+      Project::PDFExport::ProjectInitiation.new(project).export!
+    end
+
+    def upload_artifact_to_storage
+      export = create_pdf_export!
+
+      Storages::UploadFileService
+        .call(
+          container: artifact_work_package,
+          project_storage:,
+          file_path: artifact_storage_folder_name,
+          file_data: StringIO.new(export.content),
+          filename: export.title
+        )
+    end
+
+    def artifact_storage_folder_name
+      I18n.t(project.project_creation_wizard_artifact_name,
+             locale: Setting.default_language,
+             default: :project_initiation_request,
+             scope: "settings.project_initiation_request.name.options")
+    end
+  end
+end

--- a/app/services/projects/creation_wizard/create_artifact_work_package_service.rb
+++ b/app/services/projects/creation_wizard/create_artifact_work_package_service.rb
@@ -28,10 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Projects
+module Projects::CreationWizard
   class CreateArtifactWorkPackageService < ::BaseServices::BaseContracted
     include Contracted
     include ProjectHelper
+    include ArtifactExporter
     include Rails.application.routes.url_helpers
     prepend Projects::Concerns::UpdateDemoData
 
@@ -92,20 +93,7 @@ module Projects
         return service_call
       end
 
-      upload_artifact_to_storage(service_call)
-    end
-
-    def upload_artifact_to_storage(service_call)
-      export = create_pdf_export!
-
-      storage_call = Storages::UploadFileService
-        .call(
-          container: artifact_work_package,
-          project_storage:,
-          file_path: artifact_storage_folder_name,
-          file_data: StringIO.new(export.content),
-          filename: export.title
-        )
+      storage_call = upload_artifact_to_storage
 
       storage_call.on_failure do
         service_call.merge!(storage_call, without_success: true)
@@ -114,27 +102,12 @@ module Projects
       service_call
     end
 
-    def artifact_storage_folder_name
-      I18n.t(project.project_creation_wizard_artifact_name,
-             locale: Setting.default_language,
-             default: :project_initiation_request,
-             scope: "settings.project_initiation_request.name.options")
-    end
-
     def send_notification_email
       return unless project.project_creation_wizard_send_confirmation_email
 
       ProjectArtifactsMailer
         .creation_wizard_submitted(user, project, artifact_work_package)
         .deliver_later
-    end
-
-    def project_storage
-      return @project_storage if defined?(@project_storage)
-
-      @project_storage = project
-        .project_storages
-        .find_by(id: project.project_creation_wizard_artifact_export_storage)
     end
 
     def create_artifact_work_package
@@ -181,10 +154,6 @@ module Projects
              wizard_name: project_creation_wizard_name(project))
     end
 
-    def store_attachment_locally?
-      project.project_creation_wizard_artifact_export_type == "attachment"
-    end
-
     def assigned_to_id
       project.custom_value_for(assignee_custom_field).value
     end
@@ -198,10 +167,6 @@ module Projects
 
       @assignee_custom_field = project.available_custom_fields
                                       .find_by(id: project.project_creation_wizard_assignee_custom_field_id)
-    end
-
-    def create_pdf_export!
-      Project::PDFExport::ProjectInitiation.new(project).export!
     end
 
     def pdf_attachment

--- a/app/services/projects/creation_wizard/reupload_artifact_on_status_changes_service.rb
+++ b/app/services/projects/creation_wizard/reupload_artifact_on_status_changes_service.rb
@@ -32,16 +32,17 @@ module Projects::CreationWizard
   class ReuploadArtifactOnStatusChangesService
     include Contracted
     include ProjectHelper
+    include ArtifactExporter
     include Rails.application.routes.url_helpers
     prepend Projects::Concerns::UpdateDemoData
 
-    attr_reader :current_user, :work_package
+    attr_reader :current_user, :artifact_work_package
 
-    delegate :project, to: :work_package
+    delegate :project, to: :artifact_work_package
 
     def initialize(current_user:, work_package:)
       @current_user = current_user
-      @work_package = work_package
+      @artifact_work_package = work_package
     end
 
     def call!(changes:)
@@ -55,7 +56,7 @@ module Projects::CreationWizard
     end
 
     def update_is_artifact_work_package?
-     project.project_creation_wizard_artifact_work_package_id.to_s == work_package.id.to_s
+      project.project_creation_wizard_artifact_work_package_id.to_s == artifact_work_package.id.to_s
     end
 
     private
@@ -63,9 +64,9 @@ module Projects::CreationWizard
     def update_artifact
       call = store_artifact
       if call.success?
-        Rails.logger.debug { "Updated artifact for creation wizard in ##{work_package.id}" }
+        Rails.logger.debug { "Updated artifact for creation wizard in ##{artifact_work_package.id}" }
       else
-        Rails.logger.error("Failed to process artifact change for work package ##{work_package.id}: ##{call.message}")
+        Rails.logger.error("Failed to process artifact change for ##{artifact_work_package.id}: ##{call.message}")
       end
     end
 
@@ -81,31 +82,6 @@ module Projects::CreationWizard
       upload_artifact_to_storage
     end
 
-    def store_attachment_locally?
-      project.project_creation_wizard_artifact_export_type == "attachment"
-    end
-
-    def upload_artifact_to_storage
-      export = create_pdf_export!
-
-      Storages::UploadFileService
-        .call(
-          container: work_package,
-          project_storage:,
-          file_path: project.project_creation_wizard_artifact_name,
-          file_data: StringIO.new(export.content),
-          filename: export.title
-        )
-    end
-
-    def project_storage
-      return @project_storage if defined?(@project_storage)
-
-      @project_storage = project
-        .project_storages
-        .find_by(id: project.project_creation_wizard_artifact_export_storage)
-    end
-
     def add_attachment_locally
       export = create_pdf_export!
       file = OpenProject::Files.create_uploaded_file(
@@ -115,7 +91,7 @@ module Projects::CreationWizard
         binary: true
       )
 
-      attachment = work_package.attachments.create(
+      attachment = artifact_work_package.attachments.create(
         author: current_user,
         file:
       )
@@ -125,10 +101,6 @@ module Projects::CreationWizard
       else
         ServiceResult.failure(result: attachment, errors: attachment.errors)
       end
-    end
-
-    def create_pdf_export!
-      Project::PDFExport::ProjectInitiation.new(project).export!
     end
   end
 end

--- a/spec/services/projects/creation_wizard/create_artifact_work_package_service_spec.rb
+++ b/spec/services/projects/creation_wizard/create_artifact_work_package_service_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe Projects::CreateArtifactWorkPackageService do
+RSpec.describe Projects::CreationWizard::CreateArtifactWorkPackageService do
   shared_let(:status_new) { create(:status, name: "New") }
   shared_let(:type) { create(:type, name: "Project initiation") }
   shared_let(:user_custom_field) { create(:user_project_custom_field, name: "Project Manager") }

--- a/spec/services/projects/creation_wizard/reupload_artifact_on_status_changes_service_spec.rb
+++ b/spec/services/projects/creation_wizard/reupload_artifact_on_status_changes_service_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Projects::CreationWizard::ReuploadArtifactOnStatusChangesService,
           .to have_received(:call)
           .with(container: work_package,
                 project_storage:,
-                file_path: "project_mandate",
+                file_path: "Project mandate",
                 filename: /.*_Project_mandate_#{status_new.name}_#{date}_\d+-\d+.pdf/,
                 file_data: instance_of(StringIO))
       end


### PR DESCRIPTION
`ReuploadArtifactOnStatusChangesService` was developed in parallel and did not receive the update to the PIR folder naming.

https://community.openproject.org/projects/openproject/work_packages/69560/activity?query_id=5331