### PR TITLE
Fix artifact name typo

### DIFF
--- a/app/controllers/projects/creation_wizard_controller.rb
+++ b/app/controllers/projects/creation_wizard_controller.rb
@@ -75,7 +75,7 @@ class Projects::CreationWizardController < ApplicationController
 
   def create_work_package_artifact # rubocop:disable Metrics/AbcSize
     creation_call = User.execute_as_admin(current_user) do
-      Projects::CreateArtifactWorkPackageService
+      Projects::CreationWizard::CreateArtifactWorkPackageService
         .new(user: current_user, model: @project)
         .call
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69746

# What are you trying to accomplish?
Fix the 500 error raised when submitting the Project Initiation Wizard.

## Screenshots
<img width="1021" height="492" alt="image" src="https://github.com/user-attachments/assets/f44ceeff-a510-4760-9239-3f7d6af11d37" />

# What approach did you choose and why?
Fix the class name typo:  `Projects::CreateArtifactWorkPackageService` -> `Projects::CreationWizard::CreateArtifactWorkPackageService`
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
