### PR TITLE
Bump Octicons to 19.32.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -417,6 +417,6 @@ gemfiles.each do |file|
   send(:eval_gemfile, file) if File.readable?(file)
 end
 
-gem "openproject-octicons", "~>19.31.1"
-gem "openproject-octicons_helper", "~>19.31.1"
+gem "openproject-octicons", "~>19.32.0"
+gem "openproject-octicons_helper", "~>19.32.0"
 gem "openproject-primer_view_components", "~>0.78.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -878,10 +878,10 @@ GEM
       validate_email
       validate_url
       webfinger (~> 2.0)
-    openproject-octicons (19.31.1)
-    openproject-octicons_helper (19.31.1)
+    openproject-octicons (19.32.0)
+    openproject-octicons_helper (19.32.0)
       actionview
-      openproject-octicons (= 19.31.1)
+      openproject-octicons (= 19.32.0)
       railties
     openproject-primer_view_components (0.78.1)
       actionview (>= 7.2.0)
@@ -1654,8 +1654,8 @@ DEPENDENCIES
   openproject-job_status!
   openproject-ldap_groups!
   openproject-meeting!
-  openproject-octicons (~> 19.31.1)
-  openproject-octicons_helper (~> 19.31.1)
+  openproject-octicons (~> 19.32.0)
+  openproject-octicons_helper (~> 19.32.0)
   openproject-openid_connect!
   openproject-primer_view_components (~> 0.78.1)
   openproject-recaptcha!
@@ -2034,8 +2034,8 @@ CHECKSUMS
   openproject-job_status (1.0.0)
   openproject-ldap_groups (1.0.0)
   openproject-meeting (1.0.0)
-  openproject-octicons (19.31.1) sha256=8f357d4bf5967f7bdc76e0cfe45bf8834d25a2b34327477f21c040835cdadcfa
-  openproject-octicons_helper (19.31.1) sha256=ad4250cf57c06ada9226500891a0c7506556f025bee66ecfb37fe1c6606bc1de
+  openproject-octicons (19.32.0) sha256=e9c908e7c4310d57e1dece8fc506339862f18b67b3b67d549e8f56a7b763d48b
+  openproject-octicons_helper (19.32.0) sha256=687a8b173c6436634397477c1f05b0a575e52745a5cc1aef03351272e73e3832
   openproject-openid_connect (1.0.0)
   openproject-primer_view_components (0.78.1) sha256=aead310868ecd2fb2c7c9d9ce733f4d9fab9a95427304ec1d104832b416f2757
   openproject-recaptcha (1.0.0)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,7 +55,7 @@
         "@ng-select/ng-option-highlight": "^20.6.3",
         "@ng-select/ng-select": "^20.1.0",
         "@ngneat/content-loader": "^7.0.0",
-        "@openproject/octicons-angular": "^19.31.1",
+        "@openproject/octicons-angular": "^19.32.0",
         "@openproject/primer-view-components": "^0.78.1",
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^22.0.2",
@@ -6430,9 +6430,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@openproject/octicons-angular": {
-      "version": "19.31.1",
-      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.31.1.tgz",
-      "integrity": "sha512-rrx75lWfGq8/2QHX90v3n+LYES892ocq0TSMfMe7WuYFLblk/aHtnfgSQOfuDtelT8rOJ0P+hTG8jhds21nVUA==",
+      "version": "19.32.0",
+      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.32.0.tgz",
+      "integrity": "sha512-tMGoKKju4kDi2uO9UQXncgkpDFuRN5CLxC+S3978TWm6WbYiv9ppf7uejF766aWkqqS13T5CK/LtYovPuBSrnQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -27837,9 +27837,9 @@
       "integrity": "sha512-iFrvar5SOMtKFOSjYvs4z9UlLqDdJbMx0mgISLcPedv+g0ac5sgeETLGtipHCVIae6HJPclNEH5aCyD1RZaEHw=="
     },
     "@openproject/octicons-angular": {
-      "version": "19.31.1",
-      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.31.1.tgz",
-      "integrity": "sha512-rrx75lWfGq8/2QHX90v3n+LYES892ocq0TSMfMe7WuYFLblk/aHtnfgSQOfuDtelT8rOJ0P+hTG8jhds21nVUA==",
+      "version": "19.32.0",
+      "resolved": "https://registry.npmjs.org/@openproject/octicons-angular/-/octicons-angular-19.32.0.tgz",
+      "integrity": "sha512-tMGoKKju4kDi2uO9UQXncgkpDFuRN5CLxC+S3978TWm6WbYiv9ppf7uejF766aWkqqS13T5CK/LtYovPuBSrnQ==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,7 +110,7 @@
     "@ng-select/ng-option-highlight": "^20.6.3",
     "@ng-select/ng-select": "^20.1.0",
     "@ngneat/content-loader": "^7.0.0",
-    "@openproject/octicons-angular": "^19.31.1",
+    "@openproject/octicons-angular": "^19.32.0",
     "@openproject/primer-view-components": "^0.78.1",
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^22.0.2",


### PR DESCRIPTION
# Ticket

Relates to https://community.openproject.org/wp/69674

# What are you trying to accomplish?

**Bumps Octicons - ⚠️ targets 17.0**. Normally we only bump dependencies on dev but this "out of band" release is to fix an accessiblity bug.

See https://github.com/opf/openproject-octicons/blob/main/CHANGELOG.md#19320

# What approach did you choose and why?

See https://github.com/opf/openproject-octicons/pull/147

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
