### PR TITLE
[#68936] Filter changes are not persisted when editing an existing project query

### DIFF
--- a/app/components/projects/index_page_header_component.rb
+++ b/app/components/projects/index_page_header_component.rb
@@ -151,11 +151,12 @@ class Projects::IndexPageHeaderComponent < ApplicationComponent
       mobile_icon: nil, # Do not show on mobile as it is already part of the menu
       mobile_label: nil,
       href:,
+      target: "_self",
       data: {
         turbo_stream: true,
         turbo_method: method
       },
-      target: ""
+      test_selector: "header-save-button"
     ) do
       render(
         Primer::Beta::Octicon.new(

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe "Project list sharing",
 
           wait_for_reload
 
-          projects_index_page.expect_can_only_save_as_label
+          projects_index_page.expect_save_as_label
           projects_index_page.save_query_as("Member-of and active list")
 
           wait_for_network_idle
@@ -290,7 +290,7 @@ RSpec.describe "Project list sharing",
 
             projects_index_page.open_filters
             projects_index_page.filter_by_active("yes")
-            projects_index_page.expect_can_only_save_as_label
+            projects_index_page.expect_save_as_label
             projects_index_page.save_query_as("Member-of and active list")
 
             wait_for_network_idle

--- a/spec/features/projects/persisted_lists_spec.rb
+++ b/spec/features/projects/persisted_lists_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe "Persisted lists on projects index page",
       projects_page.open_filters
       projects_page.filter_by_membership("yes")
 
-      wait_for_reload # chnaging filters is still done via page reload
+      wait_for_reload # changing filters is still done via page reload
 
       # Since the query is static, no save button an no menu item is shown
       projects_page.expect_no_notification("Save")
@@ -584,6 +584,71 @@ RSpec.describe "Persisted lists on projects index page",
           value: list_custom_field.possible_values.first.value
         )
       end
+    end
+
+    it "allows saving queries via the header save button" do
+      projects_page.visit!
+      projects_page.set_sidebar_filter("Active projects")
+
+      expect_angular_frontend_initialized
+
+      # Modify the query
+      projects_page.open_filters
+      projects_page.filter_by_membership("yes")
+
+      # The "Save as" button and label should be visible
+      projects_page.expect_header_save_button
+      projects_page.expect_save_as_label
+
+      # Save the query via the header save button and the inline form
+      projects_page.save_query_via_header
+      projects_page.fill_in_the_name("My filtered projects")
+      projects_page.click_on "Save"
+
+      wait_for_network_idle
+
+      # The "Save as" button should not be visible after saving the query.
+      projects_page.expect_no_header_save_button
+
+      # The new query should be saved and selected
+      projects_page.expect_sidebar_filter("My filtered projects", selected: true)
+
+      # The filters should be stored
+      projects_page.expect_filter_count(2)
+      projects_page.expect_filter_set("active")
+      projects_page.expect_filter_set("member_of")
+
+      # Modify the saved query and save it again
+      projects_page.open_filters
+      projects_page.set_filter(list_custom_field.column_name,
+                               list_custom_field.name,
+                               "is (OR)",
+                               [list_custom_field.possible_values.first.value])
+      wait_for_reload
+
+      # The "Save" button and label should be visible
+      projects_page.expect_header_save_button
+      projects_page.expect_save_label
+
+      # Save the query
+      projects_page.save_query_via_header
+      wait_for_reload
+
+      # The "Save" button should not be visible after saving the query.
+      projects_page.expect_no_header_save_button
+
+      # Reload the query and verify all filters were saved
+      projects_page.set_sidebar_filter("Active projects")
+      projects_page.set_sidebar_filter("My filtered projects")
+
+      # All filters should be stored
+      projects_page.expect_filter_count(3)
+      projects_page.expect_filter_set "member_of"
+      projects_page.expect_filter_set "active"
+      projects_page.expect_filter_set(
+        list_custom_field.column_name,
+        value: list_custom_field.possible_values.first.value
+      )
     end
 
     it "cannot access another user`s list" do

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -43,12 +43,12 @@ module Components
         if filter_name == "name_and_identifier"
           expect(page.find_by_id(filter_name).value).not_to be_empty
         elsif value
-          within("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :hidden) do
+          within("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :all) do
             expect(page).to have_css(".advanced-filters--filter-value", text: value, visible: :all)
           end
         else
           expect(page)
-            .to have_css("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :hidden)
+            .to have_css("li[data-filter-name='#{filter_name}']:not(.hidden)", visible: :all)
         end
       end
 

--- a/spec/support/pages/projects/index.rb
+++ b/spec/support/pages/projects/index.rb
@@ -351,6 +351,19 @@ module Pages
         wait_for_network_idle
       end
 
+      def save_query_via_header
+        page.find('[data-test-selector="header-save-button"]').click
+        wait_for_network_idle
+      end
+
+      def expect_header_save_button
+        expect(page).to have_css('[data-test-selector="header-save-button"]')
+      end
+
+      def expect_no_header_save_button
+        expect(page).to have_no_css('[data-test-selector="header-save-button"]')
+      end
+
       def save_query_as(name)
         click_more_menu_item("Save as")
 
@@ -359,8 +372,12 @@ module Pages
         click_on "Save"
       end
 
-      def expect_can_only_save_as_label
+      def expect_save_as_label
         expect(page).to have_text(I18n.t("lists.can_be_saved_as"))
+      end
+
+      def expect_save_label
+        expect(page).to have_text(I18n.t("lists.can_be_saved"))
       end
 
       def fill_in_the_name(name)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/68936

# What are you trying to accomplish?
Fix the project query save button in the project list header. This save button appears only when the query has been modified.

## Screenshots

<figure>
  <figcaption>List modified: Save</figcaption>
  <img width="945" height="91" alt="image" src="https://github.com/user-attachments/assets/fe4e3ae1-abfe-4879-a7c3-b53c768238a9" />
</figure>


<figure>
  <figcaption>The modifications can only be saved in a new list: Save as</figcaption>
  <img width="946" height="98" alt="image" src="https://github.com/user-attachments/assets/bb37982f-5ee2-4de6-899c-36e677dd84bc" />
</figure>

# What approach did you choose and why?
Primer automatically appends a `target="_top"` attribute to links, which disables the execution of turbo enabled links. Unfortunately not setting the target attribute will default to `"_top"`, so the solution is to explicitly define the link target and set it to `"_self"`.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
