### PR TITLE
bug/69722 Properly clean up event listeners and ydoc provider instances

### DIFF
--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -34,7 +34,6 @@ import { BlockNoteView } from '@blocknote/mantine';
 import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { IUploadFile } from 'core-app/core/upload/upload.service';
-import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { initializeOpBlockNoteExtensions, openProjectWorkPackageBlockSpec, openProjectWorkPackageSlashMenu } from 'op-blocknote-extensions';
 import { firstValueFrom } from 'rxjs';
 import * as Y from 'yjs';
@@ -76,10 +75,12 @@ export default function OpBlockNoteContainer({ inputField,
 
   initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
 
-  let doc = LiveCollaborationManager.ydoc;
+  let doc:Y.Doc;
 
   let editorParams:Partial<BlockNoteEditorOptions<typeof schema.blockSchema, typeof schema.inlineContentSchema, typeof schema.styleSchema>>;
   if(hocuspocusProvider) {
+    doc = hocuspocusProvider.document;
+
     editorParams = {
       schema,
       collaboration: {
@@ -95,7 +96,9 @@ export default function OpBlockNoteContainer({ inputField,
       dictionary: localeDictionary,
       ...(isReadyForAttachmentUpload() && { uploadFile }),
     };
-  } else { // collaboration disabled
+  } else { // collaboration disabled (for test environments)
+    doc = new Y.Doc();
+
     if (inputText) {
       try {
         const update = Uint8Array.from(atob(inputText), c => c.charCodeAt(0));

--- a/frontend/src/react/hooks/useCollaboration.ts
+++ b/frontend/src/react/hooks/useCollaboration.ts
@@ -81,7 +81,6 @@ function useCollaborationProvider(
     return () => {
       provider.off('synced', onSynced);
       provider.off('disconnect', onDisconnect);
-      provider.destroy();
     };
   }, [provider, onSynced, onDisconnect]);
 }

--- a/frontend/src/react/hooks/useCollaboration.ts
+++ b/frontend/src/react/hooks/useCollaboration.ts
@@ -99,6 +99,7 @@ function useLocalDocumentSync(doc:Y.Doc, inputField:HTMLInputElement, enabled:bo
 
     return () => {
       doc.off('update', updateInput);
+      doc.destroy();
     };
   }, [doc, inputField, enabled]);
 }

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -44,14 +44,14 @@ export default class extends Controller {
   declare readonly documentNameValue:string;
 
   connect():void {
-    LiveCollaborationManager.initializeYjsProvider(
-      new HocuspocusProvider({
-        url: this.hocuspocusUrlValue,
-        name: this.documentNameValue,
-        token: this.oauthTokenValue,
-        document: LiveCollaborationManager.ydoc,
-      })
-    );
+    const provider = new HocuspocusProvider({
+      url: this.hocuspocusUrlValue,
+      name: this.documentNameValue,
+      token: this.oauthTokenValue,
+      document: LiveCollaborationManager.ydoc,
+    });
+
+    LiveCollaborationManager.initializeYjsProvider(provider);
   }
 
   disconnect():void {

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -31,6 +31,8 @@
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Controller } from '@hotwired/stimulus';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
+import type { Doc } from 'yjs';
+import * as Y from 'yjs';
 
 export default class extends Controller {
   static values = {
@@ -44,14 +46,15 @@ export default class extends Controller {
   declare readonly documentNameValue:string;
 
   connect():void {
+    const ydoc:Doc = new Y.Doc();
     const provider = new HocuspocusProvider({
       url: this.hocuspocusUrlValue,
       name: this.documentNameValue,
       token: this.oauthTokenValue,
-      document: LiveCollaborationManager.ydoc,
+      document: ydoc,
     });
 
-    LiveCollaborationManager.initializeYjsProvider(provider);
+    LiveCollaborationManager.initializeYjsProvider(provider, ydoc);
   }
 
   disconnect():void {

--- a/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
@@ -42,7 +42,7 @@ export default class extends ApplicationController {
   declare readonly usersTarget:HTMLElement;
   declare readonly popoverTarget:HTMLElement;
 
-  private provider:HocuspocusProvider|undefined;
+  private provider:HocuspocusProvider|null = null;
   private currentUsers = new Map<number, LiveUser>();
 
   connect() {
@@ -57,8 +57,11 @@ export default class extends ApplicationController {
 
   disconnect() {
     this.currentUsers.clear();
+
     this.provider?.off('awarenessUpdate', this.onAwarenessUpdate);
-    this.provider?.on('stateless', this.onStateless);
+    this.provider?.off('stateless', this.onStateless);
+
+    this.provider = null;
   }
 
   toggle_popover() {

--- a/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
@@ -69,7 +69,11 @@ export default class extends ApplicationController {
   }
 
   private onAwarenessUpdate = (data:onAwarenessUpdateParameters) => {
-    const changed = this.updateUsers(data.states);
+    const awarenessStates = data.states;
+
+    if (awarenessStates.length === 0) return;
+
+    const changed = this.updateUsers(awarenessStates);
     if (changed) {
       this.triggerUpdateUsersUI();
     }

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -30,57 +30,41 @@
 
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import type { Doc } from 'yjs';
-import * as Y from 'yjs';
 
 type Listener = (provider:HocuspocusProvider) => void;
 
 class LiveCollaborationManagerClass {
-  ydocInstance:Doc|null = null;
   yjsProviderInstance:HocuspocusProvider|null = null;
+  yjsDocInstance:Doc|null = null;
 
   private listeners:Listener[] = [];
 
   /**
    * Initializes the YJS Provider
    * @param provider The provider to use
+   * @param doc The Y.Doc instance to use
    * @returns void
    */
-  initializeYjsProvider(provider:HocuspocusProvider) {
-    this.destroyYjsProvider(); // Clean up old state first
+  initializeYjsProvider(provider:HocuspocusProvider, doc:Doc) {
+    this.destroy(); // Clean up old state first
     this.yjsProviderInstance = provider;
+    this.yjsDocInstance = doc;
     this.listeners.forEach((listener) => listener(this.yjsProviderInstance!));
   }
 
   /**
-   * Gets a shared Y.Doc instance
-   */
-  get ydoc():Doc {
-    this.ydocInstance ??= new Y.Doc();
-
-    return this.ydocInstance;
-  }
-
-  /**
-   * Cleans up the shared Y.Doc instance and provider.
+   * Cleans up the collaboration provider and Y.Doc instance.
    * This method should be called when a collaboration session is ended
    */
   destroy():void {
-    this.destroyYjsProvider();
-    this.destroyYdoc();
-    this.listeners = [];
-  }
-
-  private destroyYjsProvider():void {
     if (this.yjsProviderInstance) {
       this.yjsProviderInstance.destroy();
       this.yjsProviderInstance = null;
     }
-  }
 
-  private destroyYdoc():void {
-    if (this.ydocInstance) {
-      this.ydocInstance.destroy();
-      this.ydocInstance = null;
+    if (this.yjsDocInstance) {
+      this.yjsDocInstance.destroy();
+      this.yjsDocInstance = null;
     }
   }
 

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -46,6 +46,7 @@ class LiveCollaborationManagerClass {
    * @returns void
    */
   initializeYjsProvider(provider:HocuspocusProvider) {
+    this.destroyYjsProvider(); // Clean up old state first
     this.yjsProviderInstance = provider;
     this.listeners.forEach((listener) => listener(this.yjsProviderInstance!));
   }
@@ -60,11 +61,27 @@ class LiveCollaborationManagerClass {
   }
 
   /**
-   * Cleans up the shared Y.Doc instance.
+   * Cleans up the shared Y.Doc instance and provider.
    * This method should be called when a collaboration session is ended
    */
   destroy():void {
-    this.ydocInstance = null;
+    this.destroyYjsProvider();
+    this.destroyYdoc();
+    this.listeners = [];
+  }
+
+  private destroyYjsProvider():void {
+    if (this.yjsProviderInstance) {
+      this.yjsProviderInstance.destroy();
+      this.yjsProviderInstance = null;
+    }
+  }
+
+  private destroyYdoc():void {
+    if (this.ydocInstance) {
+      this.ydocInstance.destroy();
+      this.ydocInstance = null;
+    }
   }
 
   /**


### PR DESCRIPTION
https://community.openproject.org/wp/69722

Improve the cleanup logic for live collaboration sessions, ensuring that resources are properly released when a session ends. The main focus is on handling the destruction of provider and document instances to prevent memory leaks and unexpected behavior.