### PR TITLE
Validate schema of embedded examples in a spec

### DIFF
--- a/docs/api/apiv3/components/examples/project_collection.yml
+++ b/docs/api/apiv3/components/examples/project_collection.yml
@@ -8,13 +8,13 @@ value:
   offset: 1
   _embedded:
     elements:
-      - _hint: Project resource shortened for brevity
+      - _abbreviated: Project resource shortened for brevity
         id: 1
         identifier: initialproject
         name: DeathStar construction
         active: true
         public: true
-      - _hint: Project resource shortened for brevity
+      - _abbreviated: Project resource shortened for brevity
         id: 2
         identifier: mysecret
         name: Palpatine's secret plan

--- a/docs/api/apiv3/components/schemas/activity_model.yml
+++ b/docs/api/apiv3/components/schemas/activity_model.yml
@@ -224,6 +224,15 @@ example:
         project:
           href: "/api/v3/projects/918"
           title: "RVC Test"
+        schema:
+          href: "/api/v3/work_packages/schemas/11-2"
+        author:
+          href: "/api/v3/users/1"
+          title: OpenProject Admin - admin
+        priority:
+          href: "/api/v3/priorities/2"
+          title: Normal
+        ancestors: []
   _links:
     self:
       href: "/api/v3/activity/1"

--- a/docs/api/apiv3/components/schemas/attachment_model.yml
+++ b/docs/api/apiv3/components/schemas/attachment_model.yml
@@ -113,6 +113,7 @@ example:
   id: 1
   fileName: cat.png
   filesize: 24
+  status: uploaded
   description:
     format: plain
     raw: A picture of a cute cat

--- a/docs/api/apiv3/components/schemas/custom_action_model.yml
+++ b/docs/api/apiv3/components/schemas/custom_action_model.yml
@@ -31,15 +31,15 @@ properties:
           - description: |-
               Execute this custom action.
 
-examples:
-  - _type: CustomAction
-    name: Change project and type
-    description: Changes project and type in one go
-    _links:
-      executeImmediately:
-        href: "/api/v3/custom_actions/2/execute"
-        title: Execute Change project and type
-        method: post
-      self:
-        href: "/api/v3/custom_actions/2"
-        title: Change project and type
+example:
+  _type: CustomAction
+  name: Change project and type
+  description: Changes project and type in one go
+  _links:
+    executeImmediately:
+      href: "/api/v3/custom_actions/2/execute"
+      title: Execute Change project and type
+      method: post
+    self:
+      href: "/api/v3/custom_actions/2"
+      title: Change project and type

--- a/docs/api/apiv3/components/schemas/document_model.yml
+++ b/docs/api/apiv3/components/schemas/document_model.yml
@@ -11,8 +11,9 @@ properties:
     type: string
     description: The title chosen for the document
   description:
-    type: string
-    description: A text describing the document
+    allOf:
+      - $ref: './formattable.yml'
+      - description: A text describing the document
   # content_binary:
   #  type: string
   #  description: The binary content of the document, base64 encoded

--- a/docs/api/apiv3/components/schemas/file_link_collection_read_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_collection_read_model.yml
@@ -12,7 +12,7 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   This file links collection
-                  
+
                   **Resource**: FileLinkCollectionReadModel
       _embedded:
         type: object
@@ -44,7 +44,7 @@ example:
         createdAt: '2021-12-20T13:37:00.211Z'
         updatedAt: '2021-12-20T13:37:00.211Z'
         originData:
-          id: 5503
+          id: "5503"
           name: logo.png
           mimeType: image/png
           size: 16042

--- a/docs/api/apiv3/components/schemas/file_link_collection_write_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_collection_write_model.yml
@@ -1,26 +1,24 @@
 # Schema: FileLinkCollectionWriteModel
 ---
-allOf:
-  - $ref: './collection_model.yml'
-  - type: object
+type: object
+required:
+  - _embedded
+properties:
+  _embedded:
+    type: object
     required:
-      - _embedded
+      - elements
     properties:
-      _embedded:
-        type: object
-        required:
-          - elements
-        properties:
-          elements:
-            type: array
-            items:
-              $ref: './file_link_write_model.yml'
+      elements:
+        type: array
+        items:
+          $ref: './file_link_write_model.yml'
 
 example:
   _embedded:
     elements:
       - originData:
-          id: 5503
+          id: "5503"
           name: logo.png
           mimeType: image/png
           size: 16042
@@ -31,5 +29,3 @@ example:
         _links:
           storage:
             href: /api/v3/storage/42
-      - _hint: File Link resource shortened for brevity
-        id: 1338

--- a/docs/api/apiv3/components/schemas/file_link_read_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_read_model.yml
@@ -27,8 +27,6 @@ properties:
     properties:
       storage:
         $ref: './storage_read_model.yml'
-      container:
-        $ref: './work_package_model.yml'
   _links:
     type: object
     properties:
@@ -123,7 +121,7 @@ example:
   createdAt: '2021-12-20T13:37:00.211Z'
   updatedAt: '2021-12-20T13:37:00.211Z'
   originData:
-    id: 5503
+    id: "5503"
     name: logo.png
     mimeType: image/png
     size: 16042
@@ -147,6 +145,10 @@ example:
           title: Nextcloud
         origin:
           href: https://nextcloud.deathstar.rocks/
+        open:
+          href: https://example.com/a-link-to-open-the-file
+        authorizationState:
+          href: urn:openproject-org:api:v3:storages:authorization:Connected
     container:
       _hint: Work package resource shortened for brevity
       _type: WorkPackage

--- a/docs/api/apiv3/components/schemas/file_link_write_model.yml
+++ b/docs/api/apiv3/components/schemas/file_link_write_model.yml
@@ -18,7 +18,7 @@ properties:
               - $ref: './link.yml'
               - description: |-
                   The storage resource of the linked file.
-                  
+
                   **Resource**: Storage
       - type: object
         required:
@@ -29,12 +29,12 @@ properties:
               - $ref: './link.yml'
               - description: |-
                   The storage url the file link references to.
-                  
+
                   **Resource**: N/A
 
 example:
   originData:
-    id: 5503
+    id: "5503"
     name: logo.png
     mimeType: image/png
     size: 16042

--- a/docs/api/apiv3/components/schemas/group_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/group_collection_model.yml
@@ -61,5 +61,5 @@ example:
               title: ST-097E
             - href: '/api/v3/users/60'
               title: ST-C-334
-      - _hint: Group resource shortened for brevity
+      - _abbreviated: Group resource shortened for brevity
         id: 1338

--- a/docs/api/apiv3/components/schemas/help_text_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/help_text_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This help text collection
-                  
+
                   **Resource**: HelpTextCollectionModel
       _embedded:
         type: object
@@ -39,6 +39,14 @@ example:
         _links:
           self:
             href: "/api/v3/help_texts/1"
+          editText:
+            href: '/admin/attribute_help_texts/1/edit'
+            type: text/html
+          attachments:
+            href: '/api/v3/help_texts/1/attachments'
+          addAttachment:
+            href: '/api/v3/help_texts/1/attachments'
+            method: post
         id: 1
         attribute: id
         attributeCaption: ID
@@ -51,6 +59,14 @@ example:
         _links:
           self:
             href: "/api/v3/help_texts/2"
+          editText:
+            href: '/admin/attribute_help_texts/2/edit'
+            type: text/html
+          attachments:
+            href: '/api/v3/help_texts/2/attachments'
+          addAttachment:
+            href: '/api/v3/help_texts/2/attachments'
+            method: post
         id: 2
         attribute: status
         attributeCaption: Status

--- a/docs/api/apiv3/components/schemas/help_text_model.yml
+++ b/docs/api/apiv3/components/schemas/help_text_model.yml
@@ -80,6 +80,6 @@ example:
       type: text/html
     attachments:
       href: '/api/v3/help_texts/1/attachments'
-    addAttachments:
+    addAttachment:
       href: '/api/v3/help_texts/1/attachments'
       method: post

--- a/docs/api/apiv3/components/schemas/news_create_model.yml
+++ b/docs/api/apiv3/components/schemas/news_create_model.yml
@@ -31,6 +31,7 @@ example:
   summary: Celebrer spiculum colo viscus claustrum atque. Id nulla culpa sumptus.
     Comparo crapula depopulo demonstro.
   description:
+    format: markdown
     raw: '**Videlicet deserunt aequitas cognatus**. Concedo quia est quia pariatur vorago
       vallum. Calco autem atavus accusamus conscendo cornu ulterius. Tam patria ago
       consectetur ventito sustineo nihil caecus. Supra officiis eos velociter somniculosus

--- a/docs/api/apiv3/components/schemas/news_model.yml
+++ b/docs/api/apiv3/components/schemas/news_model.yml
@@ -16,9 +16,10 @@ properties:
     description: A short summary
     readOnly: true
   description:
-    type: string
-    description: The main body of the news with all the details
-    readOnly: true
+    allOf:
+    - "$ref": "./formattable.yml"
+    - description: The main body of the news with all the details
+      readOnly: true
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
+++ b/docs/api/apiv3/components/schemas/oauth_application_read_model.yml
@@ -7,7 +7,7 @@ required:
   - name
   - clientId
   - confidential
-  - _link
+  - _links
 properties:
   id:
     type: integer
@@ -77,7 +77,7 @@ properties:
             - $ref: './link.yml'
             - description: |-
                 A redirect URI of the OAuth application
-  
+
                 **Resource**: N/A
 
 example:

--- a/docs/api/apiv3/components/schemas/oauth_client_credentials_read_model.yml
+++ b/docs/api/apiv3/components/schemas/oauth_client_credentials_read_model.yml
@@ -58,7 +58,7 @@ example:
   confidential: true
   createdAt: '2022-12-07T12:56:42.836Z'
   updatedAt: '2022-12-07T12:56:42.836Z'
-  _link:
+  _links:
     self:
       href: '/api/v3/oauth_client_credentials/1337'
     integration:

--- a/docs/api/apiv3/components/schemas/placeholder_user_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/placeholder_user_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This placeholder user collection
-                  
+
                   **Resource**: Collection
       _embedded:
         type: object
@@ -38,9 +38,9 @@ example:
       href: '/api/v3/placeholder_users'
   _embedded:
     elements:
-      - _hint: PlaceholderUser resource shortened for brevity
+      - _abbreviated: PlaceholderUser resource shortened for brevity
         _type: PlaceholderUser
         id: 1337
-      - _hint: PlaceholderUser resource shortened for brevity
+      - _abbreviated: PlaceholderUser resource shortened for brevity
         _type: PlaceholderUser
         id: 1338

--- a/docs/api/apiv3/components/schemas/principal_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/principal_collection_model.yml
@@ -28,12 +28,12 @@ example:
       href: '/api/v3/principals'
   _embedded:
     elements:
-      - _hint: User resource shortened for brevity
+      - _abbreviated: User resource shortened for brevity
         _type: User
         id: 1337
-      - _hint: Group resource shortened for brevity
+      - _abbreviated: Group resource shortened for brevity
         _type: Group
         id: 1338
-      - _hint: PlaceholderUser resource shortened for brevity
+      - _abbreviated: PlaceholderUser resource shortened for brevity
         _type: PlaceholderUser
         id: 1339

--- a/docs/api/apiv3/components/schemas/project_phase_definition_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/project_phase_definition_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This file links collection
-                  
+
                   **Resource**: ProjectPhaseDefinitionCollectionModel
       _embedded:
         type: object
@@ -40,8 +40,8 @@ example:
       - id: 14
         name: "Initiating"
         _type: ProjectPhaseDefinition
-        _hint: project phase definition resource shortened for brevity
+        _abbreviated: project phase definition resource shortened for brevity
       - id: 15
         name: "Executing"
         _type: ProjectPhaseDefinition
-        _hint: project phase definition resource shortened for brevity
+        _abbreviated: project phase definition resource shortened for brevity

--- a/docs/api/apiv3/components/schemas/project_phase_definition_model.yml
+++ b/docs/api/apiv3/components/schemas/project_phase_definition_model.yml
@@ -6,7 +6,9 @@ required:
   - id
   - name
   - startGate
+  - startGateName
   - finishGate
+  - finishGateName
   - createdAt
   - updatedAt
 properties:
@@ -23,11 +25,11 @@ properties:
   startGate:
     type: boolean
   startGateName:
-    type: string
+    type: [string, null]
   finishGate:
     type: boolean
   finishGateName:
-    type: string
+    type: [string, null]
   createdAt:
     type: string
     format: date-time
@@ -51,7 +53,7 @@ properties:
 example:
   _type: 'ProjectPhaseDefinition'
   id: 1337
-  title: 'Initiating'
+  name: 'Initiating'
   startGate: true
   startGateName: "Before Initiating"
   finishGate: true

--- a/docs/api/apiv3/components/schemas/project_phase_definition_model.yml
+++ b/docs/api/apiv3/components/schemas/project_phase_definition_model.yml
@@ -25,11 +25,15 @@ properties:
   startGate:
     type: boolean
   startGateName:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
   finishGate:
     type: boolean
   finishGateName:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/components/schemas/project_phase_model.yml
+++ b/docs/api/apiv3/components/schemas/project_phase_model.yml
@@ -60,7 +60,7 @@ properties:
 example:
   _type: 'ProjectPhase'
   id: 1337
-  title: 'Initiating'
+  name: 'Initiating'
   active: true
   createdAt: '2023-01-20T14:30:00.368Z'
   updatedAt: '2023-05-23T11:57:48.618Z'

--- a/docs/api/apiv3/components/schemas/project_storage_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/project_storage_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: "./link.yml"
               - description: |-
                   This file links collection
-                  
+
                   **Resource**: ProjectStorageCollectionModel
       _embedded:
         type: object
@@ -40,8 +40,8 @@ example:
     elements:
       - id: 1337
         _type: ProjectStorage
-        _hint: project storage resource shortened for brevity
+        _abbreviated: project storage resource shortened for brevity
       - id: 1338
         _type: ProjectStorage
-        _hint: File Link resource shortened for brevity
+        _abbreviated: File Link resource shortened for brevity
 

--- a/docs/api/apiv3/components/schemas/query_filter_instance_schema_model.yml
+++ b/docs/api/apiv3/components/schemas/query_filter_instance_schema_model.yml
@@ -3,15 +3,12 @@
 type: object
 required:
 - name
-- filter
+- _links
 properties:
   name:
     type: string
     description: Describes the name attribute
     readOnly: true
-  filter:
-    type: string
-    description: QuerySortBy name
   _links:
     type: object
     required:
@@ -56,19 +53,7 @@ example:
           hasDefault: false
           writable: true
           _links: {}
-  name:
-    type: String
-    name: Name
-    required: true
-    hasDefault: true
-    writable: false
-  filter:
-    type: QueryFilter
-    name: Filter
-    required: true
-    hasDefault: false
-    writable: true
-    _links: {}
+  name: "A name"
   _links:
     self:
       href: "/api/v3/queries/filter_instance_schemas/author"

--- a/docs/api/apiv3/components/schemas/storage_file_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_file_model.yml
@@ -28,7 +28,7 @@ allOf:
 
                   **Resource**: urn:openproject-org:api:v3:storages:storage_file:no_link_provided
 example:
-  id: 42
+  id: "42"
   name: readme.md
   _type: StorageFile
   location: '/readme.md'

--- a/docs/api/apiv3/components/schemas/storage_files_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_files_model.yml
@@ -36,12 +36,12 @@ properties:
           - $ref: "./link.yml"
           - description: |-
               Not provided
-              
+
               **Resource**: urn:openproject-org:api:v3:storages:storage_file:no_link_provided
 example:
   _type: StorageFiles
   files:
-    - id: 42
+    - id: "42"
       name: readme.md
       _type: StorageFile
       location: '/readme.md'
@@ -54,7 +54,7 @@ example:
       _links:
         self:
           href: 'urn:openproject-org:api:v3:storages:storage_file:no_link_provided'
-    - id: 43
+    - id: "43"
       name: readme.pdf
       _type: StorageFile
       location: '/readme.pdf'
@@ -68,8 +68,9 @@ example:
         self:
           href: 'urn:openproject-org:api:v3:storages:storage_file:no_link_provided'
   parent:
-    id: 41
+    id: "41"
     name: '/'
+    _type: StorageFile
     location: '/'
     mimeType: 'application/x-op-directory'
     size: 6144
@@ -84,4 +85,4 @@ example:
   _links:
     self:
       href: 'urn:openproject-org:api:v3:storages:storage_file:no_link_provided'
-  
+

--- a/docs/api/apiv3/components/schemas/time_entry_activity_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_activity_model.yml
@@ -50,7 +50,7 @@ properties:
           - $ref: './link.yml'
           - description: |-
               This time entry activity
-              
+
               **Resource**: TimeEntriesActivity
       projects:
         type: array
@@ -59,23 +59,23 @@ properties:
             - $ref: './link.yml'
             - description: |-
                 One of the projects the time entry is active in.
-                
+
                 **Resource**: Project
 
-examples:
-  - _type: TimeEntriesActivity
-    id: 18
-    name: Management
-    position: 8
-    default: false
-    _embedded:
-      projects: [ ]
-    _links:
-      self:
-        href: "/api/v3/time_entries/activities/18"
-        title: Management
-      projects:
-        - href: "/api/v3/projects/death_star_v2"
-          title: DeathStarV2
-        - href: "/api/v3/projects/star_killer_base"
-          title: StarKillerBase
+example:
+  _type: TimeEntriesActivity
+  id: 18
+  name: Management
+  position: 8
+  default: false
+  _embedded:
+    projects: [ ]
+  _links:
+    self:
+      href: "/api/v3/time_entries/activities/18"
+      title: Management
+    projects:
+      - href: "/api/v3/projects/death_star_v2"
+        title: DeathStarV2
+      - href: "/api/v3/projects/star_killer_base"
+        title: StarKillerBase

--- a/docs/api/apiv3/components/schemas/time_entry_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_collection_model.yml
@@ -30,88 +30,88 @@ allOf:
             items:
               $ref: "./time_entry_model.yml"
 
-examples:
-  - _type: Collection
-    total: 39
-    count: 2
-    pageSize: 2
-    offset: 1
-    _embedded:
-      elements:
-        - _type: TimeEntry
-          id: 5
-          comment:
-            format: plain
-            raw: Some comment
-            html: "<p>Some comment</p>"
-          spentOn: "2015-03-20"
-          hours: PT5H
-          startTime: "2015-03-20T10:00:00.000Z"
-          endTime: "2015-03-20T15:00:00.000Z"
-          createdAt: "2015-03-20T12:56:56.803Z"
-          updatedAt: "2015-03-20T12:56:56.803Z"
-          _links:
-            self:
-              href: "/api/v3/time_entries/1"
-            updateImmediately:
-              href: "/api/v3/time_entries/1"
-              method: patch
-            delete:
-              href: "/api/v3/time_entries/1"
-              method: delete
-            project:
-              href: "/api/v3/projects/1"
-              title: Some project
-            entity:
-              href: "/api/v3/work_packages/1"
-              title: Some work package
-            user:
-              href: "/api/v3/users/2"
-              title: Some user
-            activity:
-              href: "/api/v3/time_entries/activities/18"
-              title: Some time entry activity
-        - _type: TimeEntry
-          id: 10
-          comment:
-            format: plain
-            raw: Another comment
-            html: "<p>Another comment</p>"
-          spentOn: "2015-03-21"
-          hours: PT7H
-          startTime: "2015-03-20T15:00:00.000Z"
-          endTime: "2015-03-20T22:00:00.000Z"
-          createdAt: "2015-03-20T12:56:56.569Z"
-          updatedAt: "2015-03-20T12:56:56.371Z"
-          _links:
-            self:
-              href: "/api/v3/time_entries/2"
-            project:
-              href: "/api/v3/projects/42"
-              title: Some other project
-            entity:
-              href: "/api/v3/work_packages/541"
-              title: Some other work package
-            user:
-              href: "/api/v3/users/6"
-              title: Some other project
-            activity:
-              href: "/api/v3/time_entries/activities/14"
-              title: some other time entry activity
-    _links:
-      self:
-        href: "/api/v3/time_entries?offset=1&pageSize=2"
-      jumpTo:
-        href: "/api/v3/time_entries?offset=%7Boffset%7D&pageSize=2"
-        templated: true
-      changeSize:
-        href: "/api/v3/time_entries?offset=1&pageSize=%7Bsize%7D"
-        templated: true
-      nextByOffset:
-        href: "/api/v3/time_entries?offset=2&pageSize=2"
-      createTimeEntry:
-        href: "/api/v3/time_entries/form"
-        method: post
-      createTimeEntryImmediately:
-        href: "/api/v3/time_entries"
-        method: post
+example:
+  _type: Collection
+  total: 39
+  count: 2
+  pageSize: 2
+  offset: 1
+  _embedded:
+    elements:
+      - _type: TimeEntry
+        id: 5
+        comment:
+          format: plain
+          raw: Some comment
+          html: "<p>Some comment</p>"
+        spentOn: "2015-03-20"
+        hours: PT5H
+        startTime: "2015-03-20T10:00:00.000Z"
+        endTime: "2015-03-20T15:00:00.000Z"
+        createdAt: "2015-03-20T12:56:56.803Z"
+        updatedAt: "2015-03-20T12:56:56.803Z"
+        _links:
+          self:
+            href: "/api/v3/time_entries/1"
+          updateImmediately:
+            href: "/api/v3/time_entries/1"
+            method: patch
+          delete:
+            href: "/api/v3/time_entries/1"
+            method: delete
+          project:
+            href: "/api/v3/projects/1"
+            title: Some project
+          entity:
+            href: "/api/v3/work_packages/1"
+            title: Some work package
+          user:
+            href: "/api/v3/users/2"
+            title: Some user
+          activity:
+            href: "/api/v3/time_entries/activities/18"
+            title: Some time entry activity
+      - _type: TimeEntry
+        id: 10
+        comment:
+          format: plain
+          raw: Another comment
+          html: "<p>Another comment</p>"
+        spentOn: "2015-03-21"
+        hours: PT7H
+        startTime: "2015-03-20T15:00:00.000Z"
+        endTime: "2015-03-20T22:00:00.000Z"
+        createdAt: "2015-03-20T12:56:56.569Z"
+        updatedAt: "2015-03-20T12:56:56.371Z"
+        _links:
+          self:
+            href: "/api/v3/time_entries/2"
+          project:
+            href: "/api/v3/projects/42"
+            title: Some other project
+          entity:
+            href: "/api/v3/work_packages/541"
+            title: Some other work package
+          user:
+            href: "/api/v3/users/6"
+            title: Some other project
+          activity:
+            href: "/api/v3/time_entries/activities/14"
+            title: some other time entry activity
+  _links:
+    self:
+      href: "/api/v3/time_entries?offset=1&pageSize=2"
+    jumpTo:
+      href: "/api/v3/time_entries?offset=%7Boffset%7D&pageSize=2"
+      templated: true
+    changeSize:
+      href: "/api/v3/time_entries?offset=1&pageSize=%7Bsize%7D"
+      templated: true
+    nextByOffset:
+      href: "/api/v3/time_entries?offset=2&pageSize=2"
+    createTimeEntry:
+      href: "/api/v3/time_entries/form"
+      method: post
+    createTimeEntryImmediately:
+      href: "/api/v3/time_entries"
+      method: post

--- a/docs/api/apiv3/components/schemas/time_entry_model.yml
+++ b/docs/api/apiv3/components/schemas/time_entry_model.yml
@@ -7,8 +7,9 @@ properties:
     description: The id of the time entry
     minimum: 1
   comment:
-    type: string
-    description: A comment to the time entry
+    allOf:
+      - $ref: './formattable.yml'
+      - description: A comment to the time entry
   spentOn:
     type: string
     format: date
@@ -129,42 +130,42 @@ properties:
 
               **Resource**: TimeEntriesActivity
 
-examples:
-  - _type: TimeEntry
-    id: 42
-    comment:
-      format: plain
-      raw: "The force shall set me free."
-      html: "<p>The force shall set me free.</p>"
-    spentOn: "2023-01-11"
-    hours: "PT4H"
-    startTime: "2023-01-11T09:58:00.000Z"
-    endTime: "2023-01-11T13:58:00.000Z"
-    createdAt: "2023-01-11T13:58:24.927Z"
-    updatedAt: "2023-01-11T13:58:24.927Z"
-    _links:
-      self:
-        href: "/api/v3/time_entries/42"
-      updateImmediately:
-        href: "/api/v3/time_entries/42"
-        method: patch
-      update:
-        href: "/api/v3/time_entries/42/form"
-        method: post
-      delete:
-        href: "/api/v3/time_entries/42"
-        method: delete
-      schema:
-        href: "/api/v3/time_entries/schema"
-      project:
-        href: "/api/v3/projects/11"
-        title: DeathStarV2
-      entity:
-        href: "/api/v3/work_packages/77"
-        title: Build new hangar
-      user:
-        href: "/api/v3/users/3"
-        title: Darth Vader
-      activity:
-        href: "/api/v3/time_entries/activities/1"
-        title: Management
+example:
+  _type: TimeEntry
+  id: 42
+  comment:
+    format: plain
+    raw: "The force shall set me free."
+    html: "<p>The force shall set me free.</p>"
+  spentOn: "2023-01-11"
+  hours: "PT4H"
+  startTime: "2023-01-11T09:58:00.000Z"
+  endTime: "2023-01-11T13:58:00.000Z"
+  createdAt: "2023-01-11T13:58:24.927Z"
+  updatedAt: "2023-01-11T13:58:24.927Z"
+  _links:
+    self:
+      href: "/api/v3/time_entries/42"
+    updateImmediately:
+      href: "/api/v3/time_entries/42"
+      method: patch
+    update:
+      href: "/api/v3/time_entries/42/form"
+      method: post
+    delete:
+      href: "/api/v3/time_entries/42"
+      method: delete
+    schema:
+      href: "/api/v3/time_entries/schema"
+    project:
+      href: "/api/v3/projects/11"
+      title: DeathStarV2
+    entity:
+      href: "/api/v3/work_packages/77"
+      title: Build new hangar
+    user:
+      href: "/api/v3/users/3"
+      title: Darth Vader
+    activity:
+      href: "/api/v3/time_entries/activities/1"
+      title: Management

--- a/docs/api/apiv3/components/schemas/type_model.yml
+++ b/docs/api/apiv3/components/schemas/type_model.yml
@@ -1,6 +1,15 @@
 # Schema: TypeModel
 ---
 type: object
+required:
+- id
+- name
+- color
+- position
+- isDefault
+- isMilestone
+- createdAt
+- updatedAt
 properties:
   id:
     type: integer

--- a/docs/api/apiv3/components/schemas/user_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/user_collection_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   This user collection
-                  
+
                   **Resource**: Collection
       _embedded:
         type: object
@@ -38,9 +38,9 @@ example:
       href: '/api/v3/users'
   _embedded:
     elements:
-      - _hint: User resource shortened for brevity
+      - _abbreviated: User resource shortened for brevity
         _type: User
         id: 1337
-      - _hint: User resource shortened for brevity
+      - _abbreviated: User resource shortened for brevity
         _type: User
         id: 1338

--- a/docs/api/apiv3/components/schemas/version_model.yml
+++ b/docs/api/apiv3/components/schemas/version_model.yml
@@ -125,3 +125,5 @@ example:
   status: open
   sharing: system
   customField14: '1234567890'
+  createdAt: "2025-12-10T13:37:00Z"
+  updatedAt: "2025-12-10T13:37:00Z"

--- a/docs/api/apiv3/components/schemas/watchers_model.yml
+++ b/docs/api/apiv3/components/schemas/watchers_model.yml
@@ -59,6 +59,7 @@ example:
       login: j.sheppard
       firstName: John
       lastName: Sheppard
+      name: John Sheppard
       mail: shep@mail.com
       avatar: https://example.org/users/1/avatar
       status: active
@@ -81,6 +82,7 @@ example:
       login: j.sheppard2
       firstName: Jim
       lastName: Sheppard
+      name: Jim Sheppard
       mail: shep@mail.net
       avatar: https://example.org/users/1/avatar
       status: active

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -54,14 +54,18 @@ properties:
     format: date
     description: Date on which a milestone is achieved
   derivedStartDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
     description: Similar to start date but is not set by a client but rather deduced
       by the work packages' descendants. If manual scheduleManually is active, the
       two dates can deviate.
     readOnly: true
   derivedDueDate:
-    type: [string, null]
+    type:
+      - "string"
+      - "null"
     format: date
     description: Similar to due date but is not set by a client but rather deduced
       by the work packages' descendants. If manual scheduleManually is active, the
@@ -106,7 +110,9 @@ properties:
       **Permission** view time entries
     readOnly: true
   percentageDone:
-    type: [integer, null]
+    type:
+      - "integer"
+      - "null"
     description: Amount of total completion for a work package
     minimum: 0
     maximum: 100

--- a/docs/api/apiv3/components/schemas/work_package_model.yml
+++ b/docs/api/apiv3/components/schemas/work_package_model.yml
@@ -54,14 +54,14 @@ properties:
     format: date
     description: Date on which a milestone is achieved
   derivedStartDate:
-    type: string
+    type: [string, null]
     format: date
     description: Similar to start date but is not set by a client but rather deduced
       by the work packages' descendants. If manual scheduleManually is active, the
       two dates can deviate.
     readOnly: true
   derivedDueDate:
-    type: string
+    type: [string, null]
     format: date
     description: Similar to due date but is not set by a client but rather deduced
       by the work packages' descendants. If manual scheduleManually is active, the
@@ -106,7 +106,7 @@ properties:
       **Permission** view time entries
     readOnly: true
   percentageDone:
-    type: integer
+    type: [integer, null]
     description: Amount of total completion for a work package
     minimum: 0
     maximum: 100

--- a/docs/api/apiv3/components/schemas/work_packages_model.yml
+++ b/docs/api/apiv3/components/schemas/work_packages_model.yml
@@ -17,7 +17,7 @@ allOf:
               - $ref: './link.yml'
               - description: |-
                   The work package collection
-                  
+
                   **Resource**: WorkPackageCollection
                 readOnly: true
       _embedded:
@@ -39,13 +39,13 @@ example:
   _type: Collection
   _embedded:
     elements:
-      - _hint: Work package resource shortened for brevity
+      - _abbreviated: Work package resource shortened for brevity
         _type: WorkPackage
         _links:
           self:
             href: '/api/v3/work_packages/1'
         id: 1
-      - _hint: Work package resource shortened for brevity
+      - _abbreviated: Work package resource shortened for brevity
         _type: WorkPackage
         _links:
           self:

--- a/docs/api/apiv3/components/schemas/workspaces_schema_model.yml
+++ b/docs/api/apiv3/components/schemas/workspaces_schema_model.yml
@@ -101,14 +101,14 @@ example:
   - _type: ProjectFormCustomFieldSection
     name: Project Details
     attributes:
-      customField30
-      customField34
+    - customField30
+    - customField34
   - _type: ProjectFormCustomFieldSection
     name: Budget Information
     attributes:
-      customField31
-      customField32
-      customField35
+    - customField31
+    - customField32
+    - customField35
   id:
     type: Integer
     name: ID

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "rendering" do
     described_class.create(time_entry, current_user:, embed_links:)
   end
 
-  subject { representer.to_json }
+  subject(:generated) { representer.to_json }
 
   before do
     mock_permissions_for(current_user) do |mock|
@@ -68,6 +68,10 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "rendering" do
     allow(time_entry)
       .to receive(:available_custom_fields)
       .and_return([])
+  end
+
+  it "fulfills the documented schema" do
+    expect(generated).to match_json_schema.from_docs("time_entry_model")
   end
 
   include_context "eager loaded work package representer"

--- a/spec/docs/embedded_schema_examples_spec.rb
+++ b/spec/docs/embedded_schema_examples_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Examples embedded in APIv3 schemas" do # rubocop:disable RSpec/DescribeClass
+  schema_names = Dir[ # rubocop:disable RSpec/LeakyLocalVariable
+    Rails.root.join("docs/api/apiv3/components/schemas/*").to_s
+  ].map { |f| File.basename(f).split(".", 2).first }.grep(/model$/)
+
+  it "auto-discovers schemas [SELF-TEST]" do
+    # heuristic self-test, when writing this spec there were 159 schemas to be discovered. This number should
+    # grow over time, but usually not get smaller (unless doc restructuring breaks the auto-discovery)
+    expect(schema_names.size).to be > 150
+  end
+
+  schema_names.each do |schema_name|
+    it "has no schema errors in #{schema_name}" do
+      schema = JsonSchemaLoader.new.load(schema_name)
+      example = schema[:example]
+
+      # TODO: It would be nice to just skip the abbreviated element from "required" validations, instead of skipping the
+      #       entire validation of the schema
+      if example && all_keys(example).exclude?(:_abbreviated)
+        expect(example.to_json).to match_json_schema(schema)
+      end
+    end
+  end
+
+  def all_keys(object)
+    return object.flat_map { |e| all_keys(e) } if object.is_a?(Array)
+    return [] unless object.is_a?(Hash)
+
+    object.flat_map { |k, v| [k, all_keys(v)].flatten }
+  end
+end


### PR DESCRIPTION
Our schemas often contain embedded examples that show what a representation will look like.
These specs ensure that those embedded examples conform to the schema that they are an example for.

Some collection examples contained abbreviated examples for what they look like. To support these, the previously added _hint key was replaced with an explicit _abbreviated key and examples that include this key are skipped.

# Ticket
https://community.openproject.org/wp/69707