### PR TITLE
exempt favorited property from being cached

### DIFF
--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -189,7 +189,10 @@ module API
 
         property :favorited,
                  exec_context: :decorator,
-                 getter: ->(*) { represented.favorited_by?(current_user) }
+                 uncacheable: true, # this is user specific
+                 getter: ->(*) {
+                   represented.favorited_by?(current_user)
+                 }
 
         formattable_property :description,
                              cache_if: current_user_view_allowed_lambda

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -163,8 +163,22 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
       let(:value) { project.public }
     end
 
-    it_behaves_like "property", :favorited do
-      let(:value) { true }
+    describe "favorited" do
+      it_behaves_like "property", :favorited do
+        let(:value) { true }
+      end
+
+      it "is not cached" do
+        representer.to_json
+
+        allow(project)
+          .to receive(:favorited_by?)
+                .and_return(!favorited)
+
+        expect(representer.to_json)
+          .to be_json_eql((!favorited).to_json)
+                .at_path("favorited")
+      end
     end
 
     it_behaves_like "formattable property", :description do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69598

# What are you trying to accomplish?

Since the favorited property on the project representer is user specific it should not be cached.

# Merge checklist

- [x] Added/updated tests
