### PR TITLE
Code maintenance/69686 n 1 queries on custom field selects for projects

### DIFF
--- a/app/helpers/calculated_values/errors_helper.rb
+++ b/app/helpers/calculated_values/errors_helper.rb
@@ -50,7 +50,7 @@ module CalculatedValues::ErrorsHelper
 
     if %w[ERROR_MISSING_VALUE ERROR_DISABLED_VALUE].include?(error_code)
       # To keep the error message short, we only show the first custom field with a missing/disabled value.
-      # This is also N+1 problematic.
+      # TODO: This is also N+1 problematic.
       cf = CustomField.find(missing_custom_field_ids.first)
 
       if cf

--- a/app/helpers/calculated_values/errors_helper.rb
+++ b/app/helpers/calculated_values/errors_helper.rb
@@ -50,6 +50,7 @@ module CalculatedValues::ErrorsHelper
 
     if %w[ERROR_MISSING_VALUE ERROR_DISABLED_VALUE].include?(error_code)
       # To keep the error message short, we only show the first custom field with a missing/disabled value.
+      # This is also N+1 problematic.
       cf = CustomField.find(missing_custom_field_ids.first)
 
       if cf

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -374,7 +374,9 @@ class CustomField < ApplicationRecord
   def first_calculation_error(customized)
     return nil unless calculated_value?
 
-    calculated_value_errors.where(customized:).first
+    # Use a ruby finder to avoid hitting the database with N+1 queries on the project list page,
+    # the errors are eager loaded via the Queries::Projects::CustomFieldContext.
+    calculated_value_errors.find { it.customized_id == customized.id }
   end
 
   private

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Projects::Filters::CustomFieldContext
+module Queries::Projects::CustomFieldContext
   class << self
     def custom_field_class
       ::ProjectCustomField
@@ -38,8 +38,29 @@ module Queries::Projects::Filters::CustomFieldContext
       ::Project
     end
 
-    def custom_fields(_context)
+    def custom_fields(_context=nil)
       custom_field_class.visible
+    end
+
+    def find_custom_field(id)
+      custom_field_cache.fetch(id.to_i) do |key|
+        preload_custom_fields([key]).first
+      end
+    end
+
+    def preload_custom_fields(ids)
+      ids_to_load = ids.map(&:to_i) - custom_field_cache.keys
+
+      if ids_to_load.any?
+        found = custom_fields_eager_loaded
+                  .where(id: ids_to_load)
+                  .index_by(&:id)
+        # Iterating over the ids_to_load will also cache missing custom fields
+        # as nil, making sure we only try to load them once.
+        ids_to_load.map { |id| custom_field_cache[id] = found[id] }
+      end
+
+      ids.map { |id| custom_field_cache[id.to_i] }.compact
     end
 
     def where_subselect_joins(custom_field)
@@ -65,6 +86,8 @@ module Queries::Projects::Filters::CustomFieldContext
 
     private
 
+    def custom_fields_eager_loaded = custom_fields.includes(:calculated_value_errors)
+    def custom_field_cache = RequestStore.fetch("Queries::Projects::CustomFieldContext/cache") { {} }
     def cv_db_table = CustomValue.table_name
     def project_db_table = Project.table_name
   end

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -38,7 +38,7 @@ module Queries::Projects::CustomFieldContext
       ::Project
     end
 
-    def custom_fields(_context=nil)
+    def custom_fields(_context = nil)
       custom_field_class.visible
     end
 
@@ -48,7 +48,7 @@ module Queries::Projects::CustomFieldContext
       end
     end
 
-    def preload_custom_fields(ids)
+    def preload_custom_fields(ids) # rubocop:disable Metrics/AbcSize
       ids_to_load = ids.map(&:to_i) - custom_field_cache.keys
 
       if ids_to_load.any?
@@ -57,10 +57,10 @@ module Queries::Projects::CustomFieldContext
                   .index_by(&:id)
         # Iterating over the ids_to_load will also cache missing custom fields
         # as nil, making sure we only try to load them once.
-        ids_to_load.map { |id| custom_field_cache[id] = found[id] }
+        ids_to_load.each { |id| custom_field_cache[id] = found[id] }
       end
 
-      ids.map { |id| custom_field_cache[id.to_i] }.compact
+      ids.filter_map { |id| custom_field_cache[id.to_i] }
     end
 
     def where_subselect_joins(custom_field)

--- a/app/models/queries/projects/filters/custom_field_filter.rb
+++ b/app/models/queries/projects/filters/custom_field_filter.rb
@@ -30,5 +30,5 @@
 
 class Queries::Projects::Filters::CustomFieldFilter < Queries::Projects::Filters::Base
   include Queries::Filters::Shared::CustomFieldFilter
-  self.custom_field_context = ::Queries::Projects::Filters::CustomFieldContext
+  self.custom_field_context = ::Queries::Projects::CustomFieldContext
 end

--- a/app/models/queries/projects/selects/custom_field.rb
+++ b/app/models/queries/projects/selects/custom_field.rb
@@ -29,6 +29,10 @@
 # ++
 
 class Queries::Projects::Selects::CustomField < Queries::Selects::Base
+  include Queries::Selects::Shared::CustomFieldSelect
+
+  self.custom_field_context = Queries::Projects::CustomFieldContext
+
   validates :custom_field, presence: { message: I18n.t(:"activerecord.errors.messages.does_not_exist") }
 
   KEY = /\Acf_(\d+)\z/
@@ -40,8 +44,8 @@ class Queries::Projects::Selects::CustomField < Queries::Selects::Base
   def self.all_available
     return [] unless available?
 
-    ProjectCustomField
-      .visible
+    custom_field_context
+      .custom_fields
       .pluck(:id)
       .map { |id| new(:"cf_#{id}") }
   end
@@ -52,10 +56,7 @@ class Queries::Projects::Selects::CustomField < Queries::Selects::Base
 
   def custom_field
     return @custom_field if defined?(@custom_field)
-
-    @custom_field = ProjectCustomField
-                      .visible
-                      .find_by(id: attribute[KEY, 1])
+    @custom_field = custom_field_context.find_custom_field(attribute[KEY, 1])
   end
 
   def available?

--- a/app/models/queries/selects/shared/custom_field_select.rb
+++ b/app/models/queries/selects/shared/custom_field_select.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -23,46 +23,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-class Queries::Serialization::Selects
-  include Queries::Selects::AvailableSelects
-
-  def load(serialized_selects)
-    return [] if serialized_selects.nil?
-
-    load_custom_field_context(serialized_selects)
-
-    serialized_selects.map do |o|
-      select_for(o.to_sym)
+module Queries::Selects::Shared::CustomFieldSelect
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.class_eval do
+      class_attribute :custom_field_context
     end
   end
 
-  def dump(selects)
-    selects.map { |s| s.attribute.to_s }
-  end
-
-  def registered_and_available
-    ::Queries::Register
-      .selects[klass]
-      .select(&:available?)
-  end
-
-  def initialize(klass)
-    @klass = klass
-  end
-
-  attr_reader :klass
-
-  private
-
-  def load_custom_field_context(serialized_selects)
-    cf_ids = serialized_selects.filter_map { |s| s[/\Acf_(\d+)\z/, 1] }
-    return if cf_ids.empty?
-
-    Queries::Projects::CustomFieldContext.preload_custom_fields(cf_ids)
+  module ClassMethods
   end
 end

--- a/spec/models/queries/factory_project_query_spec.rb
+++ b/spec/models/queries/factory_project_query_spec.rb
@@ -64,13 +64,15 @@ RSpec.describe Queries::Factory,
               .and_return(scope)
 
       allow(scope)
-        .to receive(:find_by)
-              .and_return nil
+        .to receive(:includes)
+              .with(:calculated_value_errors)
+              .and_return(scope)
 
       allow(scope)
-        .to receive(:find_by)
-              .with(id: cf.id.to_s)
-              .and_return(cf)
+        .to receive(:where) do |conditions|
+          cf_id = conditions[:id]&.first
+          cf_id == cf.id ? [cf] : []
+        end
     end
   end
 

--- a/spec/models/queries/projects/custom_field_context_spec.rb
+++ b/spec/models/queries/projects/custom_field_context_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::Projects::CustomFieldContext do
+  shared_let(:admin) { create(:admin) }
+  shared_let(:custom_field1) { create(:project_custom_field) }
+  shared_let(:custom_field2) { create(:project_custom_field) }
+
+  before do
+    RequestStore.clear!
+    login_as(admin)
+  end
+
+  describe ".find_custom_field" do
+    it "returns the custom field for a valid id" do
+      expect(described_class.find_custom_field(custom_field1.id)).to eq(custom_field1)
+    end
+
+    it "returns nil for a non-existent id" do
+      expect(described_class.find_custom_field(0)).to be_nil
+    end
+
+    it "caches the result in RequestStore" do
+      described_class.find_custom_field(custom_field1.id)
+
+      expect { described_class.find_custom_field(custom_field1.id) }.to have_a_query_limit(0)
+    end
+
+    it "caches nil for non-existent ids" do
+      described_class.find_custom_field(0)
+
+      expect { described_class.find_custom_field(0) }.to have_a_query_limit(0)
+    end
+  end
+
+  describe ".preload_custom_fields" do
+    it "returns the custom fields for the given ids" do
+      result = described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
+
+      expect(result).to contain_exactly(custom_field1, custom_field2)
+    end
+
+    it "handles non-existent ids gracefully" do
+      result = described_class.preload_custom_fields([custom_field1.id, 0, 999999])
+
+      expect(result).to contain_exactly(custom_field1)
+    end
+
+    it "caches the results in RequestStore" do
+      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
+
+      expect do
+        described_class.find_custom_field(custom_field1.id)
+        described_class.find_custom_field(custom_field2.id)
+      end.to have_a_query_limit(0)
+    end
+
+    it "only queries for missing ids on subsequent calls" do
+      described_class.preload_custom_fields([custom_field1.id])
+
+      allow(ProjectCustomField).to receive(:visible).and_call_original
+
+      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
+
+      expect(ProjectCustomField).to have_received(:visible).once
+    end
+
+    it "does not query when all ids are already cached" do
+      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
+
+      expect do
+        described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
+      end.to have_a_query_limit(0)
+    end
+  end
+end

--- a/spec/models/queries/projects/selects/custom_field_spec.rb
+++ b/spec/models/queries/projects/selects/custom_field_spec.rb
@@ -55,14 +55,15 @@ RSpec.describe Queries::Projects::Selects::CustomField do
     let(:id) { 42 }
 
     before do
-      visible = double
+      scope = double
 
-      allow(ProjectCustomField).to receive(:visible).and_return(visible)
-      allow(visible).to receive(:find_by).with(id: id.to_s).and_return(custom_field)
+      allow(ProjectCustomField).to receive(:visible).and_return(scope)
+      allow(scope).to receive(:includes).with(:calculated_value_errors).and_return(scope)
+      allow(scope).to receive(:where).with(id: [id]).and_return([custom_field].compact)
     end
 
     context "when custom field exists" do
-      let(:custom_field) { instance_double(ProjectCustomField) }
+      let(:custom_field) { instance_double(ProjectCustomField, id:) }
 
       it "returns the custom field" do
         expect(instance.custom_field).to eq(custom_field)

--- a/spec/services/project_queries/set_attributes_service_spec.rb
+++ b/spec/services/project_queries/set_attributes_service_spec.rb
@@ -65,9 +65,13 @@ RSpec.describe ProjectQueries::SetAttributesService, type: :model do
               .and_return(scope)
 
       allow(scope)
-        .to receive(:find_by)
-              .with(id: cf.id.to_s)
-              .and_return(cf)
+        .to receive(:includes)
+              .with(:calculated_value_errors)
+              .and_return(scope)
+
+      allow(scope)
+        .to receive(:where)
+              .and_return([cf])
 
       allow(scope)
         .to receive(:pluck)

--- a/spec/support/matchers/has_a_query_limit.rb
+++ b/spec/support/matchers/has_a_query_limit.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec::Matchers.define :have_a_query_limit do |expected|
+  supports_block_expectations
+
+  match do |block|
+    query_count(&block) <= expected
+  end
+
+  failure_message do |_actual|
+    "Expected a maximum of #{expected} queries, got #{@recorder.count}:\n\n#{@recorder.message}"
+  end
+
+  def query_count(&)
+    @recorder = ActiveRecord::QueryRecorder.new(&)
+    @recorder.count
+  end
+end
+
+module ActiveRecord
+  class QueryRecorder
+    attr_reader :log
+
+    def initialize(&)
+      @log = []
+      ActiveSupport::Notifications.subscribed(method(:callback), "sql.active_record", &)
+    end
+
+    def callback(_name, _start, _finish, _message_id, values)
+      return if %w(CACHE SCHEMA).include?(values[:name])
+
+      @log << values[:sql]
+    end
+
+    delegate :count, to: :@log
+
+    def message
+      @log.join("\n\n")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69686

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Improve the page load of the project list page.

## Screenshots
<details><summary>Before improvement</summary>
<p>

<img width="880" height="653" alt="image" src="https://github.com/user-attachments/assets/1879085e-c4ea-477e-8660-3ccf5c03abd6" />


</p>
</details> 

<details><summary>After improvement</summary>
<p>

<img width="902" height="694" alt="image" src="https://github.com/user-attachments/assets/bf9d7a9e-16ec-43f7-87de-bebb9a432eb2" />


</p>
</details> 

# What approach did you choose and why?
Eliminate the N+1 queries happening while accessing the project custom field errors on the project list page.
According to my measurements there is an improvement averaging around 30-50%, reducing the projects table component load from **3s to 2s** (Wall clock). My test data had 6 calculated value columns displayed, with almost all the projects having an error on each calculated value. Displaying 100 projects per page, while having 1000+ projects in the database.

Note: The same performance improvement can be observed even on pages where the calculated project attributes do not have any errors. This happens because the N+1 query was also triggered when check for the existence of the errors.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
