### PR TITLE
Use reloaded project to not show settings you have no access to

### DIFF
--- a/app/controllers/projects/settings/template_controller.rb
+++ b/app/controllers/projects/settings/template_controller.rb
@@ -58,7 +58,7 @@ class Projects::Settings::TemplateController < Projects::SettingsController
       .call(templated: ActiveRecord::Type::Boolean.new.cast(params[:value]))
 
     render_error_flash_message_via_turbo_stream(message: call.message) if call.failure?
-    update_via_turbo_stream(component: Projects::Settings::Template::SettingsComponent.new(@project))
+    update_via_turbo_stream(component: Projects::Settings::Template::SettingsComponent.new(@project.reload))
 
     respond_with_turbo_streams do |format|
       format.html { project_settings_template_path(@project) }


### PR DESCRIPTION
The project was not saved, but you get the erroneous project back from the service (with templated = true), which is enough to show the settings you shouldn't see as it's not templated after all

https://community.openproject.org/projects/openproject/work_packages/69805/activity?query_id=5331