### PR TITLE
remove ability to select subportfolio template

### DIFF
--- a/app/controllers/projects/settings/subitems_controller.rb
+++ b/app/controllers/projects/settings/subitems_controller.rb
@@ -42,10 +42,6 @@ class Projects::Settings::SubitemsController < Projects::SettingsController
       update_template_assignment("program", params[:program_template])
     end
 
-    if params.key?(:portfolio_template)
-      update_template_assignment("portfolio", params[:portfolio_template])
-    end
-
     flash[:notice] = I18n.t(:notice_successful_update)
     redirect_to project_settings_subitems_path(@project)
   end

--- a/app/forms/projects/settings/subitems_template_form.rb
+++ b/app/forms/projects/settings/subitems_template_form.rb
@@ -42,27 +42,6 @@ module Projects
 
       form do |f|
         if project.portfolio?
-          portfolio_template = assignments.detect(&:portfolio?)
-
-          f.select_list(
-            name: :portfolio_template,
-            scope_name_to_model: false,
-            label: I18n.t("projects.settings.subitems.portfolio_template_label"),
-            caption: I18n.t("projects.settings.subitems.portfolio_template_caption"),
-            input_width: :large,
-            include_blank: I18n.t("projects.settings.subitems.no_template")
-          ) do |list|
-            available_templates
-              .workspace_type(:portfolio)
-              .find_each do |template|
-              list.option(
-                value: template.id,
-                label: template.name,
-                selected: template.id == portfolio_template&.template_id
-              )
-            end
-          end
-
           program_template = assignments.detect(&:program?)
 
           f.select_list(

--- a/app/models/subproject_template_assignment.rb
+++ b/app/models/subproject_template_assignment.rb
@@ -34,8 +34,7 @@ class SubprojectTemplateAssignment < ApplicationRecord
 
   enum :workspace_type, {
     project: "project",
-    program: "program",
-    portfolio: "portfolio"
+    program: "program"
   }, validate: true
 
   validates :project_id, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,8 +579,6 @@ en:
         project_template_caption: "Select a template project to be used as the default for new subitems of this type."
         program_template_label: "Template for programs"
         program_template_caption: "Select a template program to be used as the default for new subitems of this type."
-        portfolio_template_label: "Template for portfolios"
-        portfolio_template_caption: "Select a template portfolio to be used as the default for new subitems of this type."
         no_template: "No predefined template"
       actions:
         label_enable_all: "Enable all"

--- a/spec/factories/subproject_template_assignment_factory.rb
+++ b/spec/factories/subproject_template_assignment_factory.rb
@@ -43,10 +43,5 @@ FactoryBot.define do
       workspace_type { "program" }
       template { association(:project, templated: true, workspace_type: :program) }
     end
-
-    trait :for_portfolio do
-      workspace_type { "portfolio" }
-      template { association(:project, templated: true, workspace_type: :portfolio) }
-    end
   end
 end

--- a/spec/features/projects/settings/subitems_settings_spec.rb
+++ b/spec/features/projects/settings/subitems_settings_spec.rb
@@ -91,35 +91,29 @@ RSpec.describe "Projects", "subitems settings", :js do
   describe "for a portfolio" do
     let(:project) { create(:project, workspace_type: :portfolio) }
 
-    it "allows setting templates for both projects and programs" do
+    it "allows setting templates for both projects and programs but not for portfolios" do
       subitems_settings_page.visit!
 
       subitems_settings_page.expect_selected_project_template(nil)
       subitems_settings_page.expect_selected_program_template(nil)
-      subitems_settings_page.expect_selected_portfolio_template(nil)
 
       subitems_settings_page.select_project_template(project_template)
       subitems_settings_page.select_program_template(program_template)
-      subitems_settings_page.select_portfolio_template(portfolio_template)
       subitems_settings_page.save
       expect_and_dismiss_flash(message: "Successful update")
 
       subitems_settings_page.expect_selected_project_template(project_template.name)
       subitems_settings_page.expect_selected_program_template(program_template.name)
-      subitems_settings_page.expect_selected_portfolio_template(portfolio_template.name)
 
       expect(project.subproject_template_assignments.project.first&.template).to eq(project_template)
       expect(project.subproject_template_assignments.program.first&.template).to eq(program_template)
-      expect(project.subproject_template_assignments.portfolio.first&.template).to eq(portfolio_template)
       subitems_settings_page.select_project_template(nil)
       subitems_settings_page.select_program_template(nil)
-      subitems_settings_page.select_portfolio_template(nil)
       subitems_settings_page.save
       expect_and_dismiss_flash(message: "Successful update")
 
       subitems_settings_page.expect_selected_project_template(nil)
       subitems_settings_page.expect_selected_program_template(nil)
-      subitems_settings_page.expect_selected_portfolio_template(nil)
       expect(project.subproject_template_assignments).to be_empty
     end
 
@@ -132,8 +126,7 @@ RSpec.describe "Projects", "subitems settings", :js do
       expect(page).to have_select("program_template", with_options: [program_template.name])
       expect(page).to have_no_select("program_template", with_options: [project_template.name, portfolio_template.name])
 
-      expect(page).to have_select("portfolio_template", with_options: [portfolio_template.name])
-      expect(page).to have_no_select("portfolio_template", with_options: [project_template.name, program_template.name])
+      expect(page).to have_no_select("portfolio_template")
     end
   end
 

--- a/spec/models/subproject_template_assignment_spec.rb
+++ b/spec/models/subproject_template_assignment_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe SubprojectTemplateAssignment do
 
   describe "enums" do
     it "defines workspace_type enum" do
-      expect(described_class.workspace_types).to eq({ "project" => "project", "program" => "program",
-                                                      "portfolio" => "portfolio" })
+      expect(described_class.workspace_types).to eq({ "project" => "project", "program" => "program" })
     end
 
     it "allows setting workspace_type to project" do
@@ -63,20 +62,16 @@ RSpec.describe SubprojectTemplateAssignment do
       expect(assignment.workspace_type).to eq("program")
       expect(assignment).to be_program
     end
-
-    it "allows setting workspace_type to portfolio" do
-      assignment = build(:subproject_template_assignment, workspace_type: :portfolio)
-      expect(assignment.workspace_type).to eq("portfolio")
-      expect(assignment).to be_portfolio
-    end
   end
 
   describe "validations" do
+    let(:workspace_type) { "project" }
+
     subject(:assignment) do
       build(:subproject_template_assignment,
             project:,
             template:,
-            workspace_type: "project")
+            workspace_type:)
     end
 
     it { is_expected.to validate_presence_of(:project_id) }
@@ -139,6 +134,31 @@ RSpec.describe SubprojectTemplateAssignment do
         end
       end
     end
+
+    describe "workspace_type" do
+      context "for 'project'" do
+        it "is valid" do
+          expect(assignment).to be_valid
+        end
+      end
+
+      context "for 'program'" do
+        let(:workspace_type) { "program" }
+
+        it "is valid" do
+          expect(assignment).to be_valid
+        end
+      end
+
+      context "for 'portfolio'" do
+        let(:workspace_type) { "portfolio" }
+
+        it "is invalid" do
+          expect(assignment).not_to be_valid
+          expect(assignment.errors.symbols_for(:workspace_type)).to match [:inclusion]
+        end
+      end
+    end
   end
 
   describe "cascading deletes" do
@@ -181,14 +201,6 @@ RSpec.describe SubprojectTemplateAssignment do
       expect(assignment).to be_valid
       expect(assignment.workspace_type).to eq("program")
       expect(assignment.template.workspace_type).to eq("program")
-      expect(assignment.template).to be_templated
-    end
-
-    it "creates a valid assignment with :for_portfolio trait" do
-      assignment = create(:subproject_template_assignment, :for_portfolio)
-      expect(assignment).to be_valid
-      expect(assignment.workspace_type).to eq("portfolio")
-      expect(assignment.template.workspace_type).to eq("portfolio")
       expect(assignment.template).to be_templated
     end
   end

--- a/spec/support/pages/projects/settings/subitems.rb
+++ b/spec/support/pages/projects/settings/subitems.rb
@@ -51,20 +51,12 @@ module Pages
           select_template("program_template", template)
         end
 
-        def select_portfolio_template(template)
-          select_template("portfolio_template", template)
-        end
-
         def expect_selected_project_template(template_name)
           expect_selected_template("project_template", template_name)
         end
 
         def expect_selected_program_template(template_name)
           expect_selected_template("program_template", template_name)
-        end
-
-        def expect_selected_portfolio_template(template_name)
-          expect_selected_template("portfolio_template", template_name)
         end
 
         def expect_no_program_template_field


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69467

# What are you trying to accomplish?

Remove ability to select a template for subportfolios as having subportfolios is no longer supported.
