### PR TITLE
Keep size of status and progress bar on portfolio

### DIFF
--- a/app/components/portfolios/details_component.html.erb
+++ b/app/components/portfolios/details_component.html.erb
@@ -21,7 +21,7 @@
         end
 
         unless archived?
-          header.with_column(mr: 2, test_selector: "op-portfolios--status") do
+          header.with_column(mr: 2, test_selector: "op-portfolios--status", flex_shrink: 0) do
             render(
               Projects::StatusButtonComponent.new(
                 user: @current_user,
@@ -34,7 +34,7 @@
         end
 
         if render_sub_status_bar?
-          header.with_column(classes: "op-portfolios--progress") do
+          header.with_column(classes: "op-portfolios--progress", flex_shrink: 0) do
             render(
               Primer::Beta::ProgressBar.new(
                 size: :large,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69563

# What are you trying to accomplish?

Prevent shrinking of status and that the status text overlays the progress bar. The progress bar's width is also enforced. The last one is personal taste. IMO it leads to a more harmonic page layout.

## Screenshots

Before:

<img width="706" height="227" alt="image" src="https://github.com/user-attachments/assets/784e61cc-b35c-456a-b186-9e8849a860a2" />


After:

<img width="702" height="277" alt="image" src="https://github.com/user-attachments/assets/7ff581ae-5ac9-48a3-8170-980bc788ee94" />