### PR TITLE
Avoid n+1 queries on projects/portfolio lists

### DIFF
--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -164,7 +164,7 @@ module Projects
                   .with_latest_activity
       end
 
-      if query.selects.any? { it.is_a?(Queries::Projects::Selects::CustomField) }
+      if has_custom_field_column?
         scope = scope
                   .includes(:custom_values,
                             :project_custom_fields,
@@ -212,6 +212,10 @@ module Projects
 
     def sorted_by_lft?
       query.orders.first&.attribute == :lft
+    end
+
+    def has_custom_field_column?
+      query.selects.any? { it.is_a?(Queries::Projects::Selects::CustomField) }
     end
   end
 end

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -164,8 +164,15 @@ module Projects
                   .with_latest_activity
       end
 
+      if query.selects.any? { it.is_a?(Queries::Projects::Selects::CustomField) }
+        scope = scope
+                  .includes(:custom_values,
+                            :project_custom_fields,
+                            :calculated_value_errors)
+      end
+
       scope
-        .includes(:custom_values, :enabled_modules)
+        .includes(:enabled_modules)
         .paginate(page: helpers.page_param(params), per_page: helpers.per_page_param(params))
     end
 

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -69,9 +69,20 @@ module Projects
 
     # We don't return the project row
     # but the [project, level] array from the helper
+    #
+    # The projects are also wrapped with the eager loading wrapper so that custom fields can be eager loaded.
     def rows
       @rows ||= begin
-        projects_enumerator = ->(model) { to_enum(:projects_with_levels_order_sensitive, model).to_a }
+        projects_enumerator = ->(model) {
+          projects = if has_custom_field_column?
+                       API::V3::Projects::ProjectEagerLoadingWrapper.wrap(model, eager_loaded: %i[custom_fields])
+                     else
+                       model
+                     end
+
+          to_enum(:projects_with_levels_order_sensitive, projects).to_a
+        }
+
         instance_exec(model, &projects_enumerator)
       end
     end
@@ -167,7 +178,6 @@ module Projects
       if has_custom_field_column?
         scope = scope
                   .includes(:custom_values,
-                            :project_custom_fields,
                             :calculated_value_errors)
       end
 

--- a/app/components/projects/table_component.rb
+++ b/app/components/projects/table_component.rb
@@ -225,7 +225,7 @@ module Projects
     end
 
     def has_custom_field_column?
-      query.selects.any? { it.is_a?(Queries::Projects::Selects::CustomField) }
+      query.selects.any? { it.is_a?(Queries::Projects::Selects::CustomField) } # rubocop:disable Style/PredicateWithKind
     end
   end
 end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -368,8 +368,8 @@ class CustomField < ApplicationRecord
     return nil unless calculated_value?
 
     # Use a ruby finder to avoid hitting the database with N+1 queries on the project list page,
-    # the errors are eager loaded via the Queries::Projects::CustomFieldContext.
-    calculated_value_errors.find { it.customized_id == customized.id }
+    # the errors are eager loaded via the Projects::TableComponent
+    customized.calculated_value_errors.find { it.custom_field_id == id }
   end
 
   private

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -405,8 +405,8 @@ class CustomField < ApplicationRecord
     return nil unless calculated_value?
 
     # Use a ruby finder to avoid hitting the database with N+1 queries on the project list page,
-    # the errors are eager loaded via the Queries::Projects::CustomFieldContext.
-    calculated_value_errors.find { it.customized == customized }
+    # the errors are eager loaded via the Projects::TableComponent
+    customized.calculated_value_errors.find { it.custom_field_id == id }
   end
 
   def comment_for(customized)

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -107,4 +107,8 @@ class ProjectCustomField < CustomField
       unique_by: %i[custom_field_id project_id]
     )
   end
+
+  def visible?(project:, user: User.current)
+    user.admin? || (!admin_only && user.allowed_in_project?(:view_project_attributes, project))
+  end
 end

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -157,4 +157,8 @@ class ProjectCustomField < CustomField
       unique_by: %i[custom_field_id project_id]
     )
   end
+
+  def visible?(project:, user: User.current)
+    user.admin? || (!admin_only && user.allowed_in_project?(:view_project_attributes, project))
+  end
 end

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -126,8 +126,8 @@ class ProjectCustomField < CustomField
     end
   end
 
-  def visible?(usr = User.current, project: nil)
-    self.class.visible(usr, project:).exists?(id: id)
+  def visible?(user = User.current, project: nil)
+    user.admin? || (!admin_only && user.allowed_in_project?(:view_project_attributes, project))
   end
 
   def type_name
@@ -156,9 +156,5 @@ class ProjectCustomField < CustomField
       Project.pluck(:id).map { |project_id| { project_id:, custom_field_id: id } },
       unique_by: %i[custom_field_id project_id]
     )
-  end
-
-  def visible?(project:, user: User.current)
-    user.admin? || (!admin_only && user.allowed_in_project?(:view_project_attributes, project))
   end
 end

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -60,9 +60,11 @@ module Projects::CustomFields
     # modification happens via the api, then set the available_custom_fields accordingly. This allows
     # the extension to be completely removed from the acts_as_customizable plugin.
     def all_available_custom_fields
-      @all_available_custom_fields ||= ProjectCustomField
-        .includes(:project_custom_field_section)
-        .order("custom_field_sections.position", :position_in_custom_field_section)
+      RequestStore.fetch("#{self.class}#all_available_custom_fields") do
+        ProjectCustomField
+          .includes(:project_custom_field_section)
+          .order("custom_field_sections.position", :position_in_custom_field_section)
+      end
     end
 
     def all_visible_custom_fields

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -47,7 +47,7 @@ module Projects::CustomFields
     def available_custom_fields
       return all_visible_custom_fields if new_record?
 
-      project_custom_fields.select { it.visible?(project: self) }
+      all_visible_custom_fields.where(id: project_custom_field_project_mappings.select(:custom_field_id))
     end
 
     # Note:

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -60,9 +60,11 @@ module Projects::CustomFields
     # modification happens via the api, then set the available_custom_fields accordingly. This allows
     # the extension to be completely removed from the acts_as_customizable plugin.
     def all_available_custom_fields
-      ProjectCustomField
-        .includes(:project_custom_field_section)
-        .order("custom_field_sections.position", :position_in_custom_field_section)
+      RequestStore.fetch("#{self.class}#all_available_custom_fields") do
+        ProjectCustomField
+          .includes(:project_custom_field_section)
+          .order("custom_field_sections.position", :position_in_custom_field_section)
+      end
     end
 
     def all_visible_custom_fields

--- a/app/models/projects/custom_fields.rb
+++ b/app/models/projects/custom_fields.rb
@@ -47,7 +47,7 @@ module Projects::CustomFields
     def available_custom_fields
       return all_visible_custom_fields if new_record?
 
-      all_visible_custom_fields.where(id: project_custom_field_project_mappings.select(:custom_field_id))
+      project_custom_fields.select { it.visible?(project: self) }
     end
 
     # Note:

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -43,7 +43,9 @@ module Queries::Projects::CustomFieldContext
     end
 
     def custom_fields(_context = nil)
-      custom_field_class.visible
+      RequestStore.fetch("#{self}.custom_fields") do
+        custom_field_class.visible
+      end
     end
 
     def find_custom_field(id)

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -39,7 +39,9 @@ module Queries::Projects::CustomFieldContext
     end
 
     def custom_fields(_context = nil)
-      custom_field_class.visible
+      RequestStore.fetch("#{self}.custom_fields") do
+        custom_field_class.visible
+      end
     end
 
     def find_custom_field(id)

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -49,24 +49,10 @@ module Queries::Projects::CustomFieldContext
     end
 
     def find_custom_field(id)
-      custom_field_cache.fetch(id.to_i) do |key|
-        preload_custom_fields([key]).first
-      end
-    end
+      id_int = id.to_i
 
-    def preload_custom_fields(ids) # rubocop:disable Metrics/AbcSize
-      ids_to_load = ids.map(&:to_i) - custom_field_cache.keys
-
-      if ids_to_load.any?
-        found = custom_fields_eager_loaded
-                  .where(id: ids_to_load)
-                  .index_by(&:id)
-        # Iterating over the ids_to_load will also cache missing custom fields
-        # as nil, making sure we only try to load them once.
-        ids_to_load.each { |id| custom_field_cache[id] = found[id] }
-      end
-
-      ids.filter_map { |id| custom_field_cache[id.to_i] }
+      custom_fields
+        .detect { |cf| cf.id == id_int }
     end
 
     def where_subselect_joins(custom_field)
@@ -92,8 +78,6 @@ module Queries::Projects::CustomFieldContext
 
     private
 
-    def custom_fields_eager_loaded = custom_fields.includes(:calculated_value_errors)
-    def custom_field_cache = RequestStore.fetch("Queries::Projects::CustomFieldContext/cache") { {} }
     def cv_db_table = CustomValue.table_name
     def project_db_table = Project.table_name
   end

--- a/app/models/queries/projects/custom_field_context.rb
+++ b/app/models/queries/projects/custom_field_context.rb
@@ -45,24 +45,10 @@ module Queries::Projects::CustomFieldContext
     end
 
     def find_custom_field(id)
-      custom_field_cache.fetch(id.to_i) do |key|
-        preload_custom_fields([key]).first
-      end
-    end
+      id_int = id.to_i
 
-    def preload_custom_fields(ids) # rubocop:disable Metrics/AbcSize
-      ids_to_load = ids.map(&:to_i) - custom_field_cache.keys
-
-      if ids_to_load.any?
-        found = custom_fields_eager_loaded
-                  .where(id: ids_to_load)
-                  .index_by(&:id)
-        # Iterating over the ids_to_load will also cache missing custom fields
-        # as nil, making sure we only try to load them once.
-        ids_to_load.each { |id| custom_field_cache[id] = found[id] }
-      end
-
-      ids.filter_map { |id| custom_field_cache[id.to_i] }
+      custom_fields
+        .detect { |cf| cf.id == id_int }
     end
 
     def where_subselect_joins(custom_field)
@@ -88,8 +74,6 @@ module Queries::Projects::CustomFieldContext
 
     private
 
-    def custom_fields_eager_loaded = custom_fields.includes(:calculated_value_errors)
-    def custom_field_cache = RequestStore.fetch("Queries::Projects::CustomFieldContext/cache") { {} }
     def cv_db_table = CustomValue.table_name
     def project_db_table = Project.table_name
   end

--- a/app/models/queries/projects/selects/custom_field.rb
+++ b/app/models/queries/projects/selects/custom_field.rb
@@ -56,6 +56,7 @@ class Queries::Projects::Selects::CustomField < Queries::Selects::Base
 
   def custom_field
     return @custom_field if defined?(@custom_field)
+
     @custom_field = custom_field_context.find_custom_field(attribute[KEY, 1])
   end
 

--- a/app/models/queries/serialization/selects.rb
+++ b/app/models/queries/serialization/selects.rb
@@ -34,8 +34,6 @@ class Queries::Serialization::Selects
   def load(serialized_selects)
     return [] if serialized_selects.nil?
 
-    load_custom_field_context(serialized_selects)
-
     serialized_selects.map do |o|
       select_for(o.to_sym)
     end
@@ -56,13 +54,4 @@ class Queries::Serialization::Selects
   end
 
   attr_reader :klass
-
-  private
-
-  def load_custom_field_context(serialized_selects)
-    cf_ids = serialized_selects.filter_map { |s| s[/\Acf_(\d+)\z/, 1] }
-    return if cf_ids.empty?
-
-    Queries::Projects::CustomFieldContext.preload_custom_fields(cf_ids)
-  end
 end

--- a/lib/api/v3/projects/project_eager_loading_wrapper.rb
+++ b/lib/api/v3/projects/project_eager_loading_wrapper.rb
@@ -36,16 +36,29 @@ module API
         delegate :is_a?, to: :__getobj__
 
         class << self
-          def wrap(projects)
-            if projects.present?
-              custom_fields_by_project_id = custom_fields_from_projects
-
-              ancestors = ancestor_projects(projects)
+          def wrap(projects, eager_loaded: %i[custom_fields ancestors])
+            super(projects).tap do |wrapped_projects|
+              eager_load_custom_fields(wrapped_projects) if eager_loaded.include?(:custom_fields)
+              eager_load_ancestors(wrapped_projects) if eager_loaded.include?(:ancestors)
             end
+          end
 
-            super
-              .each do |project|
+          private
+
+          def eager_load_custom_fields(projects)
+            custom_fields_by_project_id = custom_fields_from_projects(projects)
+
+            projects.each do |project|
               project.available_custom_fields = custom_fields_by_project_id[project.id]
+            end
+          end
+
+          def eager_load_ancestors(projects)
+            return if projects.empty?
+
+            ancestors = ancestor_projects(projects)
+
+            projects.each do |project|
               project.ancestors_from_root = ancestors.select { |a| a.is_ancestor_of?(project) }.sort_by(&:lft)
             end
           end
@@ -62,10 +75,11 @@ module API
             Project.where(projects_table[:lft].lt(project.lft).and(projects_table[:rgt].gt(project.rgt)))
           end
 
-          def custom_fields_from_projects
+          def custom_fields_from_projects(projects)
             ProjectCustomFieldProjectMapping
               .eager_load(:project_custom_field)
               .merge(ProjectCustomField.visible)
+              .where(project_id: projects.map(&:id))
               .where(project_id: Project.allowed_to(User.current, :view_project_attributes))
               .each_with_object(Hash.new { |h, k| h[k] = [] }) do |mapping, acc|
                 acc[mapping.project_id] << mapping.project_custom_field

--- a/spec/models/queries/factory_project_query_spec.rb
+++ b/spec/models/queries/factory_project_query_spec.rb
@@ -57,22 +57,9 @@ RSpec.describe Queries::Factory,
   end
   let(:custom_field) do
     build_stubbed(:project_custom_field, id: 1) do |cf|
-      scope = instance_double(ActiveRecord::Relation)
-
       allow(ProjectCustomField)
         .to receive(:visible)
-              .and_return(scope)
-
-      allow(scope)
-        .to receive(:includes)
-              .with(:calculated_value_errors)
-              .and_return(scope)
-
-      allow(scope)
-        .to receive(:where) do |conditions|
-          cf_id = conditions[:id]&.first
-          cf_id == cf.id ? [cf] : []
-        end
+              .and_return([cf])
     end
   end
 

--- a/spec/models/queries/projects/custom_field_context_spec.rb
+++ b/spec/models/queries/projects/custom_field_context_spec.rb
@@ -61,45 +61,4 @@ RSpec.describe Queries::Projects::CustomFieldContext do
       expect { described_class.find_custom_field(0) }.to have_a_query_limit(0)
     end
   end
-
-  describe ".preload_custom_fields" do
-    it "returns the custom fields for the given ids" do
-      result = described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
-
-      expect(result).to contain_exactly(custom_field1, custom_field2)
-    end
-
-    it "handles non-existent ids gracefully" do
-      result = described_class.preload_custom_fields([custom_field1.id, 0, 999999])
-
-      expect(result).to contain_exactly(custom_field1)
-    end
-
-    it "caches the results in RequestStore" do
-      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
-
-      expect do
-        described_class.find_custom_field(custom_field1.id)
-        described_class.find_custom_field(custom_field2.id)
-      end.to have_a_query_limit(0)
-    end
-
-    it "only queries for missing ids on subsequent calls" do
-      described_class.preload_custom_fields([custom_field1.id])
-
-      allow(ProjectCustomField).to receive(:visible).and_call_original
-
-      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
-
-      expect(ProjectCustomField).to have_received(:visible).once
-    end
-
-    it "does not query when all ids are already cached" do
-      described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
-
-      expect do
-        described_class.preload_custom_fields([custom_field1.id, custom_field2.id])
-      end.to have_a_query_limit(0)
-    end
-  end
 end

--- a/spec/models/queries/projects/selects/custom_field_spec.rb
+++ b/spec/models/queries/projects/selects/custom_field_spec.rb
@@ -55,11 +55,9 @@ RSpec.describe Queries::Projects::Selects::CustomField do
     let(:id) { 42 }
 
     before do
-      scope = double
-
-      allow(ProjectCustomField).to receive(:visible).and_return(scope)
-      allow(scope).to receive(:includes).with(:calculated_value_errors).and_return(scope)
-      allow(scope).to receive(:where).with(id: [id]).and_return([custom_field].compact)
+      allow(ProjectCustomField)
+        .to receive(:visible)
+              .and_return([custom_field].compact)
     end
 
     context "when custom field exists" do

--- a/spec/services/project_queries/set_attributes_service_spec.rb
+++ b/spec/services/project_queries/set_attributes_service_spec.rb
@@ -58,25 +58,9 @@ RSpec.describe ProjectQueries::SetAttributesService, type: :model do
   let(:params) { {} }
   let!(:custom_field) do
     build_stubbed(:project_custom_field, id: 1) do |cf|
-      scope = instance_double(ActiveRecord::Relation)
-
       allow(ProjectCustomField)
         .to receive(:visible)
-              .and_return(scope)
-
-      allow(scope)
-        .to receive(:includes)
-              .with(:calculated_value_errors)
-              .and_return(scope)
-
-      allow(scope)
-        .to receive(:where)
               .and_return([cf])
-
-      allow(scope)
-        .to receive(:pluck)
-              .with(:id)
-              .and_return([cf.id])
     end
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/69685

# What are you trying to accomplish?
Replace n+1 queries when fetching the project/portfolio index filters:

```
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 606], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.2ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 607], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.2ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 608], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.5ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 609], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.2ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 610], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 611], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 612], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 613], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 614], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 615], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 616], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 617], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 618], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 619], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 620], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 621], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 622], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.1ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 623], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.2ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 654], ["LIMIT", 1]]
  ↳ app/models/queries/filters/shared/custom_fields/base.rb:56:in 'Queries::Filters::Shared::CustomFields::Base#available?'
  ProjectCustomField Exists? (0.8ms)  SELECT 1 AS one FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2 LIMIT $3  [["type", "ProjectCustomField"], ["id", 653], ["LIMIT", 1]]
  ```
  
  and 
  
  ```
  ProjectCustomField Load (0.6ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  CACHE ProjectCustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1  [["type", "ProjectCustomField"]]
  ↳ app/models/queries/projects/filters/custom_field_context.rb:42:in 'Queries::Projects::Filters::CustomFieldContext.custom_fields'
  ```

On the project list itself, it removes the following n+1 queries:
```
  Project Exists? (0.4ms)  SELECT 1 AS one FROM "projects" WHERE "projects"."id" IN (SELECT "projects"."id" FROM "projects" WHERE "projects"."active" = TRUE) LIMIT $1  [["LIMIT", 1]]
  ↳ app/services/authorization/user_permissible_service.rb:100:in 'block in Authorization::UserPermissibleService#cached_in_any_project?'
  ProjectCustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 661]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (1.5ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 661]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ProjectCustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 675]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (0.3ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 675]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ProjectCustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 676]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (0.2ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 676]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ProjectCustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 677]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (0.3ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 677]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ProjectCustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 678]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (0.2ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 678]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ProjectCustomField Load (0.4ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."type" = $1 AND "custom_fields"."id" = $2  [["type", "ProjectCustomField"], ["id", 679]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  CalculatedValueError Load (0.3ms)  SELECT "calculated_value_errors".* FROM "calculated_value_errors" WHERE "calculated_value_errors"."custom_field_id" = $1  [["custom_field_id", 679]]
  ↳ app/models/queries/projects/custom_field_context.rb:57:in 'Queries::Projects::CustomFieldContext.preload_custom_fields'
  ```

and those in case custom field columns are selected:

```
  CACHE SQL (0.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  SQL (1.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 AND "custom_fields"."id" IN (SELECT "project_custom_field_project_mappings"."custom_field_id" FROM "project_custom_field_project_mappings" WHERE "project_custom_field_project_mappings"."project_id" = $3) ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"], ["project_id", 4]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  CACHE SQL (0.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  SQL (1.2ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 AND "custom_fields"."id" IN (SELECT "project_custom_field_project_mappings"."custom_field_id" FROM "project_custom_field_project_mappings" WHERE "project_custom_field_project_mappings"."project_id" = $3) ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"], ["project_id", 5]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE SQL (0.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  SQL (1.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 AND "custom_fields"."id" IN (SELECT "project_custom_field_project_mappings"."custom_field_id" FROM "project_custom_field_project_mappings" WHERE "project_custom_field_project_mappings"."project_id" = $3) ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"], ["project_id", 8]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE SQL (0.0ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"]]
  ↳ lib_static/plugins/acts_as_customizable/lib/acts_as_customizable.rb:345:in 'Enumerable#flat_map'
  SQL (1.1ms)  SELECT "custom_fields"."id" AS t0_r0, "custom_fields"."type" AS t0_r1, "custom_fields"."field_format" AS t0_r2, "custom_fields"."regexp" AS t0_r3, "custom_fields"."min_length" AS t0_r4, "custom_fields"."max_length" AS t0_r5, "custom_fields"."is_required" AS t0_r6, "custom_fields"."is_for_all" AS t0_r7, "custom_fields"."is_filter" AS t0_r8, "custom_fields"."position" AS t0_r9, "custom_fields"."searchable" AS t0_r10, "custom_fields"."editable" AS t0_r11, "custom_fields"."admin_only" AS t0_r12, "custom_fields"."multi_value" AS t0_r13, "custom_fields"."default_value" AS t0_r14, "custom_fields"."name" AS t0_r15, "custom_fields"."created_at" AS t0_r16, "custom_fields"."updated_at" AS t0_r17, "custom_fields"."content_right_to_left" AS t0_r18, "custom_fields"."allow_non_open_versions" AS t0_r19, "custom_fields"."custom_field_section_id" AS t0_r20, "custom_fields"."position_in_custom_field_section" AS t0_r21, "custom_fields"."formula" AS t0_r22, "custom_field_sections"."id" AS t1_r0, "custom_field_sections"."position" AS t1_r1, "custom_field_sections"."name" AS t1_r2, "custom_field_sections"."type" AS t1_r3, "custom_field_sections"."created_at" AS t1_r4, "custom_field_sections"."updated_at" AS t1_r5, "custom_field_sections"."display_representation" AS t1_r6 FROM "custom_fields" LEFT OUTER JOIN "custom_field_sections" ON "custom_field_sections"."id" = "custom_fields"."custom_field_section_id" AND "custom_field_sections"."type" = $1 WHERE "custom_fields"."type" = $2 AND "custom_fields"."id" IN (SELECT "project_custom_field_project_mappings"."custom_field_id" FROM "project_custom_field_project_mappings" WHERE "project_custom_field_project_mappings"."project_id" = $3) ORDER BY custom_field_sections.position, "custom_fields"."position_in_custom_field_section" ASC  [["type", "ProjectCustomFieldSection"], ["type", "ProjectCustomField"], ["project_id", 12]]
  ```

It does not manage to get rid of the following SQL statements:
```
CustomField Load (0.2ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.1ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  CACHE CustomField Load (0.0ms)  SELECT "custom_fields".* FROM "custom_fields" WHERE "custom_fields"."id" = $1 LIMIT $2  [["id", 517], ["LIMIT", 1]]
  ↳ app/helpers/calculated_values/errors_helper.rb:54:in 'CalculatedValues::ErrorsHelper#calculated_value_error_msg'
  ```
in scenarios where there is a calculated cf column selected and that column showing a lot of errors. But:
* Most of the time there shouldn't be that many errors.
* If this is to be addressed, it would rather be by loading the error message asynchronously. 

# What approach did you choose and why?

By using the request store, all visible project custom fields are fetched once and then reused when the context is called from multiple places.
