### PR TITLE
[#69927] Fix "since X days" on Notifications page

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -598,7 +598,7 @@ en:
       date_alerts:
         milestone_date: "Milestone date"
         overdue: "Overdue"
-        overdue_since: "since %{difference_in_days}."
+        overdue_since: "for %{difference_in_days}."
         property_today: "is today."
         property_is: "is in %{difference_in_days}."
         property_was: "was %{difference_in_days} ago."

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Notification center date alert and mention",
       center.within_item(notification_date_alert) do
         expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nDate alert, Mentioned")
         expect(page).to have_no_text("Actor User")
-        expect(page).to have_text("Overdue since 1 day.")
+        expect(page).to have_text("Overdue for 1 day.")
       end
     end
   end

--- a/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alerts_spec.rb
@@ -212,10 +212,10 @@ RSpec.describe "Notification center date alerts", :js, with_settings: { journal_
       center.expect_item(notification_wp_start_past, "Start date was 1 day ago.")
       center.expect_item(notification_wp_start_future, "Start date is in 7 days.")
 
-      center.expect_item(notification_wp_due_past, "Overdue since 3 days.")
+      center.expect_item(notification_wp_due_past, "Overdue for 3 days.")
       center.expect_item(notification_wp_due_future, "Finish date is in 3 days.")
 
-      center.expect_item(notification_milestone_past, "Overdue since 2 days.")
+      center.expect_item(notification_milestone_past, "Overdue for 2 days.")
       center.expect_item(notification_milestone_future, "Milestone date is in 1 day.")
 
       center.expect_item(notification_wp_unset_date, "Finish date is deleted.")

--- a/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Notification center reminder, mention and date alert",
     it "shows the reminder alert within aggregation with date alert + reminder note" do
       center.within_item(notification_reminder) do
         expect(page).to have_text("##{work_package.id}\n- #{project.name} -\nDate alert, Mentioned, Reminder")
-        expect(page).to have_text("Overdue since 1 day.\nNote: “This is an important reminder”")
+        expect(page).to have_text("Overdue for 1 day.\nNote: “This is an important reminder”")
       end
     end
   end

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to have_text("Overdue since 3 days.")
+          expect(mail_body).to have_text("Overdue for 3 days.")
         end
       end
 
@@ -194,7 +194,7 @@ RSpec.describe DigestMailer do
         end
 
         it "matches generated text" do
-          expect(mail_body).to include('<span style="color: #C92A2A">Overdue since 2 days.</span>')
+          expect(mail_body).to include('<span style="color: #C92A2A">Overdue for 2 days.</span>')
         end
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69927

# What are you trying to accomplish?

This should read "for X days" in English.

## Screenshots



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
