### PR TITLE
[#69906] deferred loading of item actions

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item/actions_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item/actions_component.html.erb
@@ -1,0 +1,30 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render(Primer::Alpha::ActionMenu::List.new(menu_id:)) { |menu| menu_items(menu) } %>

--- a/app/components/admin/custom_fields/hierarchy/item/actions_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item/actions_component.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin
+  module CustomFields
+    module Hierarchy
+      module Item
+        class ActionsComponent < ApplicationComponent
+          include OpPrimer::ComponentHelpers
+
+          def initialize(item)
+            super
+
+            @root = item.root
+          end
+
+          def menu_id
+            ItemComponent.menu_id(item:)
+          end
+
+          def menu_items(menu) # rubocop:disable Metrics/AbcSize
+            with_item_group(menu) { edit_action_item(menu) }
+
+            with_item_group(menu) do
+              add_above_action_item(menu)
+              add_below_action_item(menu)
+              add_sub_item_action_item(menu)
+            end
+
+            with_item_group(menu) { change_parent_item(menu) }
+
+            with_item_group(menu) do
+              unless first_item?
+                move_to_top_action_item(menu)
+                move_up_action_item(menu)
+              end
+              unless last_item?
+                move_down_action_item(menu)
+                move_to_bottom_action_item(menu)
+              end
+            end
+
+            with_item_group(menu) { deletion_action_item(menu) }
+          end
+
+          private
+
+          alias_method :item, :model
+
+          def first_item?
+            item.sort_order == 0
+          end
+
+          def last_item?
+            item.sort_order == item.parent.children.length - 1
+          end
+
+          def project_custom_field_context?
+            @root.custom_field.is_a?(ProjectCustomField)
+          end
+
+          def custom_field_id = @root.custom_field_id
+
+          def edit_action_item(menu)
+            href = if project_custom_field_context?
+                     edit_admin_settings_project_custom_field_item_path(custom_field_id, item)
+                   else
+                     edit_custom_field_item_path(custom_field_id, item)
+                   end
+
+            menu.with_item(label: I18n.t(:button_edit), tag: :a, href:) do |item|
+              item.with_leading_visual_icon(icon: :pencil)
+            end
+          end
+
+          def add_above_action_item(menu)
+            parent = item.parent
+            position = item.sort_order
+            href = if project_custom_field_context?
+                     new_child_admin_settings_project_custom_field_item_path(custom_field_id, parent, position:)
+                   else
+                     new_child_custom_field_item_path(custom_field_id, parent, position:)
+                   end
+
+            menu.with_item(
+              label: I18n.t(:button_add_item_above),
+              tag: :a,
+              href:,
+              content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
+            ) { it.with_leading_visual_icon(icon: "fold-up") }
+          end
+
+          def add_below_action_item(menu)
+            parent = item.parent
+            position = item.sort_order + 1
+            href = if project_custom_field_context?
+                     new_child_admin_settings_project_custom_field_item_path(custom_field_id, parent, position:)
+                   else
+                     new_child_custom_field_item_path(custom_field_id, parent, position:)
+                   end
+
+            menu.with_item(
+              label: I18n.t(:button_add_item_below),
+              tag: :a,
+              href:,
+              content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
+            ) { it.with_leading_visual_icon(icon: "fold-down") }
+          end
+
+          def add_sub_item_action_item(menu)
+            children = item.children
+            position = children.any? ? children.maximum(:sort_order) + 1 : 0
+            href = if project_custom_field_context?
+                     new_child_admin_settings_project_custom_field_item_path(custom_field_id, item, position:)
+                   else
+                     new_child_custom_field_item_path(custom_field_id, item, position:)
+                   end
+
+            menu.with_item(
+              label: I18n.t(:button_add_sub_item),
+              tag: :a,
+              href:,
+              content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
+            ) { it.with_leading_visual_icon(icon: "op-arrow-in") }
+          end
+
+          def change_parent_item(menu)
+            href = if project_custom_field_context?
+                     change_parent_admin_settings_project_custom_field_item_path(project_custom_field_id: custom_field_id,
+                                                                                 id: item.id)
+                   else
+                     change_parent_custom_field_item_path(custom_field_id:, id: item.id)
+                   end
+
+            menu.with_item(
+              label: I18n.t(:label_change_parent),
+              tag: :a,
+              href:,
+              content_arguments: { data: { controller: "async-dialog" } }
+            ) { it.with_leading_visual_icon(icon: "arrow-switch") }
+          end
+
+          def move_to_top_action_item(menu)
+            form_inputs = [{ name: "new_sort_order", value: 0 }]
+            href = if project_custom_field_context?
+                     move_admin_settings_project_custom_field_item_path(custom_field_id, item)
+                   else
+                     move_custom_field_item_path(custom_field_id, item)
+                   end
+
+            menu.with_item(label: I18n.t(:label_sort_highest),
+                           tag: :button,
+                           href:,
+                           content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                           form_arguments: { method: :post, inputs: form_inputs }) do |item|
+              item.with_leading_visual_icon(icon: "move-to-top")
+            end
+          end
+
+          def move_up_action_item(menu)
+            form_inputs = [{ name: "new_sort_order", value: item.sort_order - 1 }]
+            href = if project_custom_field_context?
+                     move_admin_settings_project_custom_field_item_path(custom_field_id, item)
+                   else
+                     move_custom_field_item_path(custom_field_id, item)
+                   end
+
+            menu.with_item(label: I18n.t(:label_sort_higher),
+                           tag: :button,
+                           href:,
+                           content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                           form_arguments: { method: :post, inputs: form_inputs }) do |item|
+              item.with_leading_visual_icon(icon: "chevron-up")
+            end
+          end
+
+          def move_down_action_item(menu)
+            form_inputs = [{ name: "new_sort_order", value: item.sort_order + 2 }]
+            href = if project_custom_field_context?
+                     move_admin_settings_project_custom_field_item_path(custom_field_id, item)
+                   else
+                     move_custom_field_item_path(custom_field_id, item)
+                   end
+
+            menu.with_item(label: I18n.t(:label_sort_lower),
+                           tag: :button,
+                           href:,
+                           content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                           form_arguments: { method: :post, inputs: form_inputs }) do |item|
+              item.with_leading_visual_icon(icon: "chevron-down")
+            end
+          end
+
+          def move_to_bottom_action_item(menu)
+            form_inputs = [{ name: "new_sort_order", value: item.parent.children.length + 1 }]
+            href = if project_custom_field_context?
+                     move_admin_settings_project_custom_field_item_path(custom_field_id, item)
+                   else
+                     move_custom_field_item_path(custom_field_id, item)
+                   end
+
+            menu.with_item(label: I18n.t(:label_sort_lowest),
+                           tag: :button,
+                           href:,
+                           content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
+                           form_arguments: { method: :post, inputs: form_inputs }) do |item|
+              item.with_leading_visual_icon(icon: "move-to-bottom")
+            end
+          end
+
+          def deletion_action_item(menu)
+            href = if project_custom_field_context?
+                     delete_admin_settings_project_custom_field_item_path(project_custom_field_id: custom_field_id,
+                                                                          id: item.id)
+                   else
+                     delete_custom_field_item_path(custom_field_id:, id: item.id)
+                   end
+
+            menu.with_item(label: I18n.t(:button_delete),
+                           scheme: :danger,
+                           tag: :a,
+                           href:,
+                           content_arguments: { data: { controller: "async-dialog" } }) do |item|
+              item.with_leading_visual_icon(icon: :trash)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -58,13 +58,18 @@ See COPYRIGHT and LICENSE files for more details.
         end
 
         item_container.with_column do
-          render(Primer::Alpha::ActionMenu.new(test_selector: "op-hierarchy-item--action-menu")) do |menu|
+          render(
+            Primer::Alpha::ActionMenu.new(
+              menu_id:,
+              src: item_actions_href,
+              test_selector: "op-hierarchy-item--action-menu"
+            )
+          ) do |menu|
             menu.with_show_button(
               icon: "kebab-horizontal",
               scheme: :invisible,
               "aria-label": I18n.t("custom_fields.admin.items.actions")
             )
-            menu_items(menu)
           end
         end
       end

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -35,6 +35,12 @@ module Admin
         include OpTurbo::Streamable
         include OpPrimer::ComponentHelpers
 
+        class << self
+          def menu_id(item:)
+            "op-custom-field-hierarchy-item-#{item.id}-action-menu"
+          end
+        end
+
         def initialize(item:, show_edit_form: false)
           super(item)
           @show_edit_form = show_edit_form
@@ -45,13 +51,23 @@ module Admin
           model.id
         end
 
-        def item_link
-          custom_field = @root.custom_field
+        def menu_id
+          self.class.menu_id(item: model)
+        end
 
+        def item_link
           if project_custom_field_context?
-            admin_settings_project_custom_field_item_path(custom_field.id, model)
+            admin_settings_project_custom_field_item_path(custom_field_id, model)
           else
-            custom_field_item_path(custom_field.id, model)
+            custom_field_item_path(custom_field_id, model)
+          end
+        end
+
+        def item_actions_href
+          if project_custom_field_context?
+            item_actions_admin_settings_project_custom_field_item_path(custom_field_id, model)
+          else
+            item_actions_custom_field_item_path(custom_field_id, model)
           end
         end
 
@@ -61,39 +77,6 @@ module Admin
           I18n.t("custom_fields.admin.hierarchy.subitems", count: model.children.count)
         end
 
-        def first_item?
-          model.sort_order == 0
-        end
-
-        def last_item?
-          model.sort_order == model.parent.children.length - 1
-        end
-
-        def menu_items(menu) # rubocop:disable Metrics/AbcSize
-          with_item_group(menu) { edit_action_item(menu) }
-
-          with_item_group(menu) do
-            add_above_action_item(menu)
-            add_below_action_item(menu)
-            add_sub_item_action_item(menu)
-          end
-
-          with_item_group(menu) { change_parent_item(menu) }
-
-          with_item_group(menu) do
-            unless first_item?
-              move_to_top_action_item(menu)
-              move_up_action_item(menu)
-            end
-            unless last_item?
-              move_down_action_item(menu)
-              move_to_bottom_action_item(menu)
-            end
-          end
-
-          with_item_group(menu) { deletion_action_item(menu) }
-        end
-
         private
 
         def project_custom_field_context?
@@ -101,170 +84,6 @@ module Admin
         end
 
         def custom_field_id = @root.custom_field_id
-
-        def edit_action_item(menu)
-          href = if project_custom_field_context?
-                   edit_admin_settings_project_custom_field_item_path(custom_field_id, model)
-                 else
-                   edit_custom_field_item_path(custom_field_id, model)
-                 end
-
-          menu.with_item(label: I18n.t(:button_edit), tag: :a, href:) do |item|
-            item.with_leading_visual_icon(icon: :pencil)
-          end
-        end
-
-        def add_above_action_item(menu)
-          parent = model.parent
-          position = model.sort_order
-          href = if project_custom_field_context?
-                   new_child_admin_settings_project_custom_field_item_path(custom_field_id, parent, position:)
-                 else
-                   new_child_custom_field_item_path(custom_field_id, parent, position:)
-                 end
-
-          menu.with_item(
-            label: I18n.t(:button_add_item_above),
-            tag: :a,
-            href:,
-            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
-          ) { it.with_leading_visual_icon(icon: "fold-up") }
-        end
-
-        def add_below_action_item(menu)
-          parent = model.parent
-          position = model.sort_order + 1
-          href = if project_custom_field_context?
-                   new_child_admin_settings_project_custom_field_item_path(custom_field_id, parent, position:)
-                 else
-                   new_child_custom_field_item_path(custom_field_id, parent, position:)
-                 end
-
-          menu.with_item(
-            label: I18n.t(:button_add_item_below),
-            tag: :a,
-            href:,
-            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
-          ) { it.with_leading_visual_icon(icon: "fold-down") }
-        end
-
-        def add_sub_item_action_item(menu)
-          children = model.children
-          position = children.any? ? children.maximum(:sort_order) + 1 : 0
-          href = if project_custom_field_context?
-                   new_child_admin_settings_project_custom_field_item_path(custom_field_id, model, position:)
-                 else
-                   new_child_custom_field_item_path(custom_field_id, model, position:)
-                 end
-
-          menu.with_item(
-            label: I18n.t(:button_add_sub_item),
-            tag: :a,
-            href:,
-            content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } }
-          ) { it.with_leading_visual_icon(icon: "op-arrow-in") }
-        end
-
-        def change_parent_item(menu)
-          href = if project_custom_field_context?
-                   change_parent_admin_settings_project_custom_field_item_path(project_custom_field_id: custom_field_id,
-                                                                               id: model.id)
-                 else
-                   change_parent_custom_field_item_path(custom_field_id:, id: model.id)
-                 end
-
-          menu.with_item(
-            label: I18n.t(:label_change_parent),
-            tag: :a,
-            href:,
-            content_arguments: { data: { controller: "async-dialog" } }
-          ) { it.with_leading_visual_icon(icon: "arrow-switch") }
-        end
-
-        def move_to_top_action_item(menu)
-          form_inputs = [{ name: "new_sort_order", value: 0 }]
-          href = if project_custom_field_context?
-                   move_admin_settings_project_custom_field_item_path(custom_field_id, model)
-                 else
-                   move_custom_field_item_path(custom_field_id, model)
-                 end
-
-          menu.with_item(label: I18n.t(:label_sort_highest),
-                         tag: :button,
-                         href:,
-                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
-                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
-            item.with_leading_visual_icon(icon: "move-to-top")
-          end
-        end
-
-        def move_up_action_item(menu)
-          form_inputs = [{ name: "new_sort_order", value: model.sort_order - 1 }]
-          href = if project_custom_field_context?
-                   move_admin_settings_project_custom_field_item_path(custom_field_id, model)
-                 else
-                   move_custom_field_item_path(custom_field_id, model)
-                 end
-
-          menu.with_item(label: I18n.t(:label_sort_higher),
-                         tag: :button,
-                         href:,
-                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
-                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
-            item.with_leading_visual_icon(icon: "chevron-up")
-          end
-        end
-
-        def move_down_action_item(menu)
-          form_inputs = [{ name: "new_sort_order", value: model.sort_order + 2 }]
-          href = if project_custom_field_context?
-                   move_admin_settings_project_custom_field_item_path(custom_field_id, model)
-                 else
-                   move_custom_field_item_path(custom_field_id, model)
-                 end
-
-          menu.with_item(label: I18n.t(:label_sort_lower),
-                         tag: :button,
-                         href:,
-                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
-                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
-            item.with_leading_visual_icon(icon: "chevron-down")
-          end
-        end
-
-        def move_to_bottom_action_item(menu)
-          form_inputs = [{ name: "new_sort_order", value: model.parent.children.length + 1 }]
-          href = if project_custom_field_context?
-                   move_admin_settings_project_custom_field_item_path(custom_field_id, model)
-                 else
-                   move_custom_field_item_path(custom_field_id, model)
-                 end
-
-          menu.with_item(label: I18n.t(:label_sort_lowest),
-                         tag: :button,
-                         href:,
-                         content_arguments: { data: { turbo_frame: ItemsComponent.wrapper_key } },
-                         form_arguments: { method: :post, inputs: form_inputs }) do |item|
-            item.with_leading_visual_icon(icon: "move-to-bottom")
-          end
-        end
-
-        def deletion_action_item(menu)
-          href = if project_custom_field_context?
-                   delete_admin_settings_project_custom_field_item_path(project_custom_field_id: custom_field_id,
-                                                                        id: model.id)
-                 else
-                   delete_custom_field_item_path(custom_field_id:, id: model.id)
-                 end
-
-          menu.with_item(label: I18n.t(:button_delete),
-                         scheme: :danger,
-                         tag: :a,
-                         href:,
-                         content_arguments: { data: { controller: "async-dialog" } }) do |item|
-            item.with_leading_visual_icon(icon: :trash)
-          end
-        end
       end
     end
   end

--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -130,6 +130,10 @@ module Admin
           )
         end
 
+        def item_actions
+          render Item::ActionsComponent.new(@active_item), layout: false
+        end
+
         private
 
         def item_service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
             get :change_parent, action: :change_parent_dialog
             post :change_parent, action: :change_parent
             get :delete, action: :deletion_dialog
+            get :item_actions
             post :move
             get :new_child, action: :new
             post :new_child, action: :create
@@ -683,6 +684,7 @@ Rails.application.routes.draw do
             get :change_parent, action: :change_parent_dialog
             post :change_parent, action: :change_parent
             get :delete, action: :deletion_dialog
+            get :item_actions
             post :move
             get :new_child, action: :new
             post :new_child, action: :create


### PR DESCRIPTION
# Ticket
[#69906](https://community.openproject.org/work_packages/69906)

# What are you trying to accomplish?
- increase load performance

# What approach did you choose and why?
- load item actions only when clicking on three dots menu
- drastically reduce response size when initially load all items of a single level