### PR TITLE
[#69905] Fix missing "Custom logo mobile" caption

### DIFF
--- a/app/views/custom_styles/_branding.html.erb
+++ b/app/views/custom_styles/_branding.html.erb
@@ -49,7 +49,8 @@ See COPYRIGHT and LICENSE files for more details.
             nil,
   img_class: "custom-logo-mobile-preview",
   accept: "image/*",
-  delete_path: custom_style_logo_mobile_delete_path
+  delete_path: custom_style_logo_mobile_delete_path,
+  instructions: I18n.t("text_custom_logo_mobile_instructions")
 } } %>
 
 <%= render partial: "custom_styles/uploads/image",  locals: { image:{

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4873,6 +4873,10 @@ en:
     The logo automatically scales to fit the header.
     For best results, upload a white logo on a transparent 130×47px image.
     You can add as much spacing inside that image as you like.
+  text_custom_logo_mobile_instructions: >
+    The logo automatically scales to fit the header.
+    For best results, upload a white logo on a transparent 130×33px image.
+    You can add as much spacing inside that image as you like.
   text_custom_export_logo_instructions: >
     This is the logo that appears in your PDF exports.
     It needs to be a PNG or JPEG image file.


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69905

# What are you trying to accomplish?

Adds instructions to match Desktop logo field.

## Screenshots

**Before**

<img width="1031" height="351" alt="image" src="https://github.com/user-attachments/assets/23d9ce29-b8ca-43ec-916a-8778752a9e3b" />

**After**

<img width="1196" height="362" alt="image" src="https://github.com/user-attachments/assets/98cbb71f-05e3-40f1-a933-c8b466f99caa" />


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
