### PR TITLE
Disable controls for readonly users on documents

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.html.erb
@@ -34,23 +34,33 @@
     panel.with_section do |section|
       section.with_title { t(:label_attachment_plural) }
 
-      section.with_footer_button(
-        color: :accent,
-        id: "documents-add-attachments",
-        classes: "hide-when-print"
-      ) do |button|
-        button.with_leading_visual_icon(icon: "op-add-attachment")
-        I18n.t("js.label_add_attachments")
-      end
+      if allow_uploading?
+        section.with_footer_button(
+          color: :accent,
+          id: "documents-add-attachments",
+          classes: "hide-when-print"
+        ) do |button|
+          button.with_leading_visual_icon(icon: "op-add-attachment")
+          I18n.t("js.label_add_attachments")
+        end
 
-      list_attachments(
-        api_v3_document_resource(document),
-        inputs: {
-          allowUploading: allow_uploading,
-          showTimestamp: false,
-          externalUploadButton: "#documents-add-attachments"
-        }
-      )
+        list_attachments(
+          api_v3_document_resource(document),
+          inputs: {
+            allowUploading: true,
+            showTimestamp: false,
+            externalUploadButton: "#documents-add-attachments"
+          }
+        )
+      else
+        list_attachments(
+          api_v3_document_resource(document),
+          inputs: {
+            allowUploading: false,
+            showTimestamp: false
+          }
+        )
+      end
     end
   end
 %>

--- a/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/attachments_side_panel_component.rb
@@ -36,11 +36,13 @@ module Documents
       include AttachmentsHelper
       include DocumentsHelper
 
-      options allow_uploading: true
+      options :readonly
 
       alias_method :document, :model
 
       private
+
+      def allow_uploading? = !readonly
 
       def current_user
         User.current

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -43,7 +43,7 @@
     component.with_main(classes: "op-document-view--main") do
       flex_layout(align_items: :center) do |flex|
         flex.with_row(classes: "op-document-view--header") do
-          render Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:)
+          render Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:, readonly:)
         end
 
         flex.with_row(classes: "op-document-view--editor") do
@@ -65,7 +65,7 @@
       px: 3,
       classes: "op-document-view--sidebar"
     ) do
-      render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document)
+      render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document, readonly:)
     end
   end
 %>

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -33,21 +33,28 @@
   component_wrapper do
     flex_layout(tag: :div, align_items: :center, test_selector: "document-info-line") do |flex|
       flex.with_column(hide: :sm, mr: 3) do
-        render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
-          menu.with_show_button do |button|
+        if allowed_to_manage_documents?
+          render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
+            menu.with_show_button do |button|
+              button.with_trailing_visual_icon(icon: :"triangle-down")
+              document.type.name
+            end
+
+            other_document_types.each do |name, id|
+              menu.with_item(
+                label: name,
+                href: update_type_document_path(document),
+                form_arguments: {
+                  method: :put,
+                  inputs: [{ name: "type_id", value: id }]
+                }
+              )
+            end
+          end
+        else
+          render(Primer::Beta::Button.new(disabled: true)) do |button|
             button.with_trailing_visual_icon(icon: :"triangle-down")
             document.type.name
-          end
-
-          other_document_types.each do |name, id|
-            menu.with_item(
-              label: name,
-              href: update_type_document_path(document),
-              form_arguments: {
-                method: :put,
-                inputs: [{ name: "type_id", value: id }]
-              }
-            )
           end
         end
       end

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.rb
@@ -45,6 +45,10 @@ module Documents
         def other_document_types
           DocumentType.where.not(id: document.type_id).pluck(:name, :id)
         end
+
+        def allowed_to_manage_documents?
+          User.current.allowed_in_project?(:manage_documents, document.project)
+        end
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/69644/activity

# What are you trying to accomplish?

The idea is to disable/remove from the UI actions that the user cannot do.

## Screenshots

<img width="1736" height="1083" alt="Captura desde 2025-12-15 07-39-52" src="https://github.com/user-attachments/assets/1c149f1e-a208-404c-93ba-1a502e009cc9" />


# What approach did you choose and why?

- Disabled the type selection button
- Removed the `Attach files` link on the attachments list

