### PR TITLE
Enable React Strict mode for `OpBlockNoteContainer`

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -86,12 +86,17 @@ class BlockNoteElement extends HTMLElement {
     this.reactRoot = createRoot(this.mount);
 
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
-    if (collaborationEnabled) {
-      LiveCollaborationManager.onReady((hocuspocusProvider) =>
-        this.reactRoot?.render(this.BlockNoteReactContainer(hocuspocusProvider))
+
+    const render = (provider?:HocuspocusProvider) => {
+      this.reactRoot?.render(
+        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
       );
+    };
+
+    if (collaborationEnabled) {
+      LiveCollaborationManager.onReady(render);
     } else {
-      this.reactRoot.render(this.BlockNoteReactContainer());
+      render();
     }
   }
 


### PR DESCRIPTION
Strict mode enables extra dev-only checks for the entire component tree. These checks help find common bugs early in the dev process.

* **Double-invoke effects** in development to catch bugs related to missing cleanup
* **Warn about deprecated APIs** like legacy context or string refs
* **Detect unexpected side effects** during rendering
* **Warn about legacy findDOMNode usage**

The double-invocation of effects is particularly useful for catching issues with `useEffect` cleanup functions and ensuring components are resilient to mounting/unmounting.

Ref: https://react.dev/reference/react/StrictMode

<img width="1572" height="375" alt="Screenshot 2025-12-13 at 8 20 47 PM" src="https://github.com/user-attachments/assets/31e629e5-b84b-4769-a1e6-b8da4f5b2f47" />
