### PR TITLE
Add permission check for modifying order of WPs in a query

### DIFF
--- a/lib/api/v3/queries/order/query_order_api.rb
+++ b/lib/api/v3/queries/order/query_order_api.rb
@@ -71,6 +71,10 @@ module API
               optional :delta, type: Hash
             end
             patch do
+              authorize_by_policy(:update) do
+                raise API::Errors::NotFound
+              end
+
               params[:delta].each do |work_package_id, new_position|
                 if new_position == -1
                   remove_order(work_package_id)

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe "Board management spec", :js, :selenium, with_ee: %i[board_view] 
         view_work_packages
         edit_work_packages
         manage_public_queries
+        save_queries
       ]
     end
     let(:board_view) { create(:board_grid_with_query, project:) }
@@ -253,8 +254,10 @@ RSpec.describe "Board management spec", :js, :selenium, with_ee: %i[board_view] 
     end
   end
 
-  context "with view boards + edit work package and change work package status permissions" do
-    let(:permissions) { %i[show_board_views view_work_packages add_work_packages edit_work_packages] }
+  context "with view boards + edit work package + save and manage public queries and change work package status permissions" do
+    let(:permissions) do
+      %i[show_board_views view_work_packages add_work_packages edit_work_packages save_queries manage_public_queries]
+    end
     let(:board_view) { create(:board_grid_with_queries, project:) }
 
     it "allows viewing boards index and moving items around" do

--- a/spec/requests/api/v3/queries/order/query_order_api_spec.rb
+++ b/spec/requests/api/v3/queries/order/query_order_api_spec.rb
@@ -31,8 +31,10 @@ require "spec_helper"
 require "rack/test"
 
 RSpec.describe "/api/v3/queries/:id/order" do
-  let(:user) { create(:admin) }
-  let(:query) { create(:query, name: "A Query", user:) }
+  let(:project) { create(:project) }
+  let(:user) { create(:user, member_with_permissions: { project => [:view_work_packages] }) }
+  let(:query_owner) { create(:user) }
+  let(:query) { create(:query, name: "A Query", user: query_owner, project: project) }
   let(:path) { "/api/v3/queries/#{query.id}/order" }
 
   subject(:body) { JSON.parse(last_response.body) }
@@ -42,21 +44,37 @@ RSpec.describe "/api/v3/queries/:id/order" do
     header "Content-Type", "application/json"
   end
 
-  describe "with order present" do
-    let(:wp1) { create(:work_package) }
-    let(:wp2) { create(:work_package) }
+  describe "#get" do
+    describe "with order present" do
+      let(:wp1) { create(:work_package) }
+      let(:wp2) { create(:work_package) }
 
-    before do
-      query.ordered_work_packages.create(work_package_id: wp1.id, position: 0)
-      query.ordered_work_packages.create(work_package_id: wp2.id, position: 8192)
-    end
+      before do
+        query.ordered_work_packages.create!(work_package_id: wp1.id, position: 0)
+        query.ordered_work_packages.create!(work_package_id: wp2.id, position: 8192)
+      end
 
-    it "returns the order" do
-      get path
+      context "when being allowed to view the query, because it is public" do
+        before do
+          query.update!(public: true)
+        end
 
-      expect(last_response).to have_http_status :ok
-      expect(body).to be_a Hash
-      expect(body).to eq({ wp1.id => 0, wp2.id => 8192 }.stringify_keys)
+        it "returns the order" do
+          get path
+
+          expect(last_response).to have_http_status :ok
+          expect(body).to be_a Hash
+          expect(body).to eq({ wp1.id => 0, wp2.id => 8192 }.stringify_keys)
+        end
+      end
+
+      context "when not being allowed to view the query" do
+        it "responds with 404 Not Found" do
+          get path
+
+          expect(last_response).to have_http_status :not_found
+        end
+      end
     end
   end
 
@@ -70,22 +88,43 @@ RSpec.describe "/api/v3/queries/:id/order" do
       query.ordered_work_packages.create(work_package_id: wp1.id, position: 0)
     end
 
-    it "allows inserting a delta" do
-      patch path, { delta: { wp2.id.to_s => 1234 } }.to_json
-      expect(last_response).to have_http_status :ok
+    context "when the query is public" do
+      before do
+        query.update!(public: true)
+      end
 
-      query.reload
-      expect(body).to eq("t" => timestamp)
-      expect(query.ordered_work_packages.find_by(work_package: wp2).position).to eq 1234
-    end
+      context "and not being allowed to update public queries" do
+        it "responds with 404 Not Found" do
+          patch path, { delta: { wp2.id.to_s => 1234 } }.to_json
+          expect(last_response).to have_http_status :not_found
+        end
+      end
 
-    it "allows removing an item" do
-      patch path, { delta: { wp1.id.to_s => -1 } }.to_json
-      expect(last_response).to have_http_status :ok
+      context "and being allowed to update public queries" do
+        before do
+          mock_permissions_for(user) do |mock|
+            mock.allow_in_project :view_work_packages, :manage_public_queries, project: query.project
+          end
+        end
 
-      query.reload
-      expect(body).to eq("t" => timestamp)
-      expect(query.ordered_work_packages.to_a).to be_empty
+        it "allows inserting a delta" do
+          patch path, { delta: { wp2.id.to_s => 1234 } }.to_json
+          expect(last_response).to have_http_status :ok
+
+          query.reload
+          expect(body).to eq("t" => timestamp)
+          expect(query.ordered_work_packages.find_by(work_package: wp2).position).to eq 1234
+        end
+
+        it "allows removing an item" do
+          patch path, { delta: { wp1.id.to_s => -1 } }.to_json
+          expect(last_response).to have_http_status :ok
+
+          query.reload
+          expect(body).to eq("t" => timestamp)
+          expect(query.ordered_work_packages.to_a).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69929

# What are you trying to accomplish?
- With access to the query, you also could update the order of WorkPackages within that query
- This action should be bound to the `:manage_public_queries` permission for public queries and `:save_queries` for the user owned queries

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
