### PR TITLE
use patched version of y-prosemirror for shadow dom support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23777,8 +23777,8 @@
     },
     "node_modules/y-prosemirror": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
-      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "resolved": "git+ssh://git@github.com/brunopagno/y-prosemirror.git#e851db771da66705eb16210baa30fdb6ce54e81f",
+      "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.109"
       },
@@ -25864,7 +25864,7 @@
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
         "uuid": "^8.3.2",
-        "y-prosemirror": "^1.3.7",
+        "y-prosemirror": "https://github.com/brunopagno/y-prosemirror#v1.3.7-patched",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.27"
       },
@@ -39735,9 +39735,8 @@
       }
     },
     "y-prosemirror": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
-      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "version": "git+ssh://git@github.com/brunopagno/y-prosemirror.git#e851db771da66705eb16210baa30fdb6ce54e81f",
+      "from": "y-prosemirror@https://github.com/brunopagno/y-prosemirror#v1.3.7-patched",
       "requires": {
         "lib0": "^0.2.109"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -185,6 +185,9 @@
   "optionalDependencies": {
     "fsevents": "*"
   },
+  "overrides": {
+    "y-prosemirror": "https://github.com/brunopagno/y-prosemirror#v1.3.7-patched"
+  },
   "browser": {
     "fs": false,
     "path": false,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/69964/activity

# What are you trying to accomplish?

Fix an issue where collaboration would break and synchronization of documents would stop working because of a library error. This happens because we're using the editor under a shadow dom.

# What approach did you choose and why?

...
