### PR TITLE
Fix issue when synchronizing documents with editors under a shadow dom

### DIFF
--- a/frontend/src/app/core/setup/init-js-patches.ts
+++ b/frontend/src/app/core/setup/init-js-patches.ts
@@ -1,0 +1,34 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) 2023 the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+// @ts-expect-error TS(2339): Property `createRange` does not exist on type 'ShadowRoot'
+// See: https://github.com/yjs/y-prosemirror/pull/36
+ShadowRoot.prototype.createRange = document.createRange.bind(document);
+

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import { OpenProjectModule } from 'core-app/app.module';
 import { enableProdMode } from '@angular/core';
 
 import 'core-app/core/setup/init-jquery';
+import 'core-app/core/setup/init-js-patches';
 
 import { initializeLocale } from 'core-app/core/setup/init-locale';
 import { environment } from './environments/environment';


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/69964/activity

# What are you trying to accomplish?

Fix an issue where documents could become desynchronized while being used in a shadow root.

# What approach did you choose and why?

Monkey patching the shadow root to be able to create ranges. The issue happens because the library `y-prosemirror` attempts to create a range from a ShadowRoot node, where the function is not available - https://github.com/yjs/y-prosemirror/blob/master/src/plugins/sync-plugin.js#L375

The fix sets the `ShadowRoot.createRange` function so that it behaves the same as `document.createRange`