### PR TITLE
[#69802] Programs name not truncated in the project dropdown star not visible

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -95,7 +95,8 @@
         max-width: 100%
         width: 100%
 
-        &:has(.description)
+        &:has(.description),
+        &:has(.op-primer--star-icon)
           display: flex
           align-items: center
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/69802

# What are you trying to accomplish?
Make favorite star visible when project name is truncated in the project dropdown.

## Screenshots
<img width="462" height="610" alt="image" src="https://github.com/user-attachments/assets/753a00af-27fc-4412-925c-34ca326d0971" />


# What approach did you choose and why?
Apply the same rule as for the `.description` class.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
