### PR TITLE
Save form when requested from ckeditor

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -216,11 +216,8 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
         (evt.submitter as HTMLInputElement).disabled = false;
       }
 
-      if (this.turboMode) {
-        // If the form has a stimulus action defined, we ONLY want to submit it via stimulus
-        if (!this.formElement.dataset.action) {
-          navigator.submitForm(this.formElement, evt?.submitter || undefined);
-        }
+      if (this.turboMode && !this.formElement.dataset.action) {
+        navigator.submitForm(this.formElement, evt?.submitter ?? undefined);
       } else {
         this.formElement.requestSubmit(evt?.submitter);
       }

--- a/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_outcomes_crud_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Meeting Outcomes CRUD", :js do
         show_page.add_outcome_from_menu(item) do
           field.expect_active!
           field.set_value "Can't hold it back anymore"
-          click_link_or_button "Save"
+          field.submit_by_enter
         end
 
         show_page.expect_outcome "Let it go, let it go"


### PR DESCRIPTION
This got added in
https://github.com/opf/openproject/commit/21a7eea8320227645d5ad0cc240e47b80a1639cc, but the code is no longer in use, and saving the activities works just fine as far as I can tell.

https://community.openproject.org/projects/meetings-stream/work_packages/69974/activity
