### PR TITLE
Validate schema of examples stored outside of schema definition

### DIFF
--- a/docs/api/apiv3/components/examples/activity_response.yml
+++ b/docs/api/apiv3/components/examples/activity_response.yml
@@ -17,16 +17,16 @@ value:
       _type: Collection
       total: 1
       count: 1
-      _hint: Attachments resource shortened for brevity.
+      _abbreviated: Attachments resource shortened for brevity.
     workPackage:
       id: 207
       _type: WorkPackage
-      _hint: Work package resource shortened for brevity.
+      _abbreviated: Work package resource shortened for brevity.
     emojiReactions:
       _type: Collection
       total: 1
       count: 1
-      _hint: Emoji reactions resource shortened for brevity.
+      _abbreviated: Emoji reactions resource shortened for brevity.
   _links:
     attachments:
       href: "/api/v3/activities/1478/attachments"

--- a/docs/api/apiv3/components/examples/date_alert_notification.yml
+++ b/docs/api/apiv3/components/examples/date_alert_notification.yml
@@ -9,12 +9,12 @@ value:
   updatedAt: '2022-04-06T09:03:24.347Z'
   _embedded:
     project:
-      _hint: Project resource shortened for brevity
+      _abbreviated: Project resource shortened for brevity
       _type: Project
       id: 11
       name: Jedi Remnant Locator
     resource:
-      _hint: WorkPackage resource shortened for brevity
+      _abbreviated: WorkPackage resource shortened for brevity
       _type: WorkPackage
       id: 77
       subject: Educate Visas Marr

--- a/docs/api/apiv3/components/examples/grid-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/grid-simple-collection-response.yml
@@ -14,18 +14,21 @@ value:
         columnCount: 5
         widgets:
           - _type: GridWidget
+            id: 1
             identifier: time_entries_current_user
             startRow: 1
             endRow: 8
             startColumn: 1
             endColumn: 3
           - _type: GridWidget
+            id: 2
             identifier: news
             startRow: 3
             endRow: 8
             startColumn: 4
             endColumn: 5
           - _type: GridWidget
+            id: 3
             identifier: documents
             startRow: 1
             endRow: 3
@@ -45,3 +48,12 @@ value:
             method: post
           self:
             href: "/api/v3/grids/2"
+  _links:
+    self:
+      href: "/api/v3/grids"
+    jumpTo:
+      href: '/api/v3/grids?filters=%5B%5D&offset=%7Boffset%7D&pageSize=20'
+      templated: true
+    changeSize:
+      href: '/api/v3/grids?filters=%5B%5D&offset=1&pageSize=%7Bsize%7D'
+      templated: true

--- a/docs/api/apiv3/components/examples/grid-simple-response.yml
+++ b/docs/api/apiv3/components/examples/grid-simple-response.yml
@@ -7,18 +7,21 @@ value:
   columnCount: 5
   widgets:
     - _type: GridWidget
+      id: 1
       identifier: tasks
       startRow: 1
       endRow: 8
       startColumn: 1
       endColumn: 3
     - _type: GridWidget
+      id: 2
       identifier: news
       startRow: 3
       endRow: 8
       startColumn: 4
       endColumn: 5
     - _type: GridWidget
+      id: 3
       identifier: documents
       startRow: 1
       endRow: 3

--- a/docs/api/apiv3/components/examples/hierarchy_item_collection_filtered_response.yml
+++ b/docs/api/apiv3/components/examples/hierarchy_item_collection_filtered_response.yml
@@ -20,6 +20,8 @@ value:
           parent:
             href: /api/v3/custom_field_items/1337
             name: null
+          branch:
+            href: /api/v3/custom_field_items/1338/branch
           children:
             - href: /api/v3/custom_field_items/1340
               name: ST-377
@@ -39,6 +41,8 @@ value:
           parent:
             href: /api/v3/custom_field_items/1338
             name: Stormtroopers
+          branch:
+            href: /api/v3/custom_field_items/1340/branch
           children:
             - href: /api/v3/custom_field_items/1480
               name: ST-377-200
@@ -58,6 +62,8 @@ value:
           parent:
             href: /api/v3/custom_field_items/1338
             name: Stormtroopers
+          branch:
+            href: /api/v3/custom_field_items/1341/branch
           children:
             - href: /api/v3/custom_field_items/1580
               name: ST-422-137

--- a/docs/api/apiv3/components/examples/hierarchy_item_collection_response.yml
+++ b/docs/api/apiv3/components/examples/hierarchy_item_collection_response.yml
@@ -16,9 +16,8 @@ value:
         _links:
           self:
             href: /api/v3/custom_field_items/1337
-            name: null
-          parent:
-            href: null
+          branch:
+            href: /api/v3/custom_field_items/1337/branch
           children:
             - href: /api/v3/custom_field_items/1338
               name: Stormtroopers
@@ -37,21 +36,27 @@ value:
             name: Stormtroopers
           parent:
             href: /api/v3/custom_field_items/1337
-            name: null
+            name: Imperial Troopers
+          branch:
+            href: /api/v3/custom_field_items/1338/branch
           children:
             - href: /api/v3/custom_field_items/1340
               name: ST-377
             - href: /api/v3/custom_field_items/1341
               name: ST-422
       - _type: HierarchyItem
-        _hint: hierarchy item shortened for brevity
         id: 1340
         label: ST-377
         short: null
         weight: null
         formattedWeight: null
         depth: 2
-      - _hint: hierarchy item shortened for brevity
+        _links:
+          self:
+            href: /api/v3/custom_field_items/1340
+          branch:
+            href: /api/v3/custom_field_items/1340/branch
+          children: []
   _links:
     self:
       href: /api/v3/custom_field/42/items

--- a/docs/api/apiv3/components/examples/hierarchy_item_response.yml
+++ b/docs/api/apiv3/components/examples/hierarchy_item_response.yml
@@ -5,6 +5,8 @@ value:
   id: 1338
   label: Stormtroopers
   short: ST
+  weight: null
+  formattedWeight: null
   depth: 1
   _links:
     self:
@@ -13,6 +15,8 @@ value:
     parent:
       href: /api/v3/custom_field_items/1337
       name: null
+    branch:
+      href: /api/v3/custom_field_items/1338/branch
     children:
       - href: /api/v3/custom_field_items/1340
         name: ST-377

--- a/docs/api/apiv3/components/examples/membership-form-response.yml
+++ b/docs/api/apiv3/components/examples/membership-form-response.yml
@@ -1,4 +1,4 @@
-description: |- 
+description: |-
   A simple form response example.
 value:
   _type: Form
@@ -19,19 +19,19 @@ value:
         roles: [ ]
     schema:
       _type: Schema
-      _hint: Schema resource shortened for brevity
+      _abbreviated: Schema resource shortened for brevity
     validationErrors:
       roles:
         _type: Error
         errorIdentifier: urn:openproject-org:api:v3:errors:PropertyConstraintViolation
         message: Roles need to be assigned.
-        _embedded: 
-          details: 
+        _embedded:
+          details:
             attribute: roles
   _links:
-    self: 
+    self:
       href: '/api/v3/memberships/form'
       method: post
-    validate: 
+    validate:
       href: '/api/v3/memberships/form'
       method: post

--- a/docs/api/apiv3/components/examples/membership-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/membership-simple-collection-response.yml
@@ -2,8 +2,8 @@ description: |-
   A simple membership collection response example.
 value:
   _type: Collection
-  total: 2
-  count: 2
+  total: 1
+  count: 1
   pageSize: 20
   offset: 1
   _embedded:
@@ -33,9 +33,6 @@ value:
           roles:
             - href: '/api/v3/roles/4'
               title: Sith Lord
-      - _type: Membership
-        id: 12
-        _hint: Membership resource shortened for brevity
   _links:
     self:
       href: '/api/v3/memberships'

--- a/docs/api/apiv3/components/examples/membership-simple-response.yml
+++ b/docs/api/apiv3/components/examples/membership-simple-response.yml
@@ -9,15 +9,15 @@ value:
     project:
       _type: Project
       id: 3
-      _hint: Project resource shortened for brevity
+      _abbreviated: Project resource shortened for brevity
     principal:
       _type: User
       id: 5
-      _hint: User resource shortened for brevity
+      _abbreviated: User resource shortened for brevity
     roles:
       - _type: Role
         id: 4
-        _hint: Roles resource shortened for brevity
+        _abbreviated: Roles resource shortened for brevity
   _links:
     self:
       href: '/api/v3/memberships/11'

--- a/docs/api/apiv3/components/examples/mentioned_notification.yml
+++ b/docs/api/apiv3/components/examples/mentioned_notification.yml
@@ -9,22 +9,22 @@ value:
   updatedAt: '2022-04-06T09:03:24.591Z'
   _embedded:
     author:
-      _hint: User resource shortened for brevity
+      _abbreviated: User resource shortened for brevity
       _type: User
       id: 13
       name: Darth Nihilus
     project:
-      _hint: Project resource shortened for brevity
+      _abbreviated: Project resource shortened for brevity
       _type: Project
       id: 11
       name: Jedi Remnant Locator
     activity:
-      _hint: Activity resource shortened for brevity
+      _abbreviated: Activity resource shortened for brevity
       _type: Activity::Comment
       id: 180
       version: 3
     resource:
-      _hint: WorkPackage resource shortened for brevity
+      _abbreviated: WorkPackage resource shortened for brevity
       _type: WorkPackage
       id: 77
       subject: Educate Visas Marr

--- a/docs/api/apiv3/components/examples/notification_collection.yml
+++ b/docs/api/apiv3/components/examples/notification_collection.yml
@@ -8,11 +8,11 @@ value:
   pageSize: 20
   _embedded:
     elements:
-      - _hint: Notification resource shortened for brevity
+      - _abbreviated: Notification resource shortened for brevity
         id: 1
         readIAN: false
         reason: mentioned
-      - _hint: Notification resource shortened for brevity
+      - _abbreviated: Notification resource shortened for brevity
         id: 2
         readIAN: false
         reason: dateAlert

--- a/docs/api/apiv3/components/examples/relation_collection_response.yml
+++ b/docs/api/apiv3/components/examples/relation_collection_response.yml
@@ -7,6 +7,7 @@ value:
   pageSize: 20
   offset: 1
   _embedded:
+    elements:
     - _type: Relation
       id: 650
       name: duplicated by

--- a/docs/api/apiv3/components/examples/relation_response.yml
+++ b/docs/api/apiv3/components/examples/relation_response.yml
@@ -12,11 +12,11 @@ value:
     from:
       id: 108
       _type: WorkPackage
-      _hint: Work package resource shortened for brevity.
+      _abbreviated: Work package resource shortened for brevity.
     to:
       id: 78
       _type: WorkPackage
-      _hint: Work package resource shortened for brevity.
+      _abbreviated: Work package resource shortened for brevity.
   _links:
     self:
       href: /api/v3/relations/650

--- a/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
+++ b/docs/api/apiv3/components/examples/storages-simple-collection-response.yml
@@ -63,3 +63,14 @@ value:
             href: /api/v3/project_storages?filters=[{"storageId":{"operator":"=","values":["1338"]}}]
           oauthClientCredentials:
             href: /api/v3/oauth_client_credentials/44
+  _links:
+    self:
+      href: /api/v3/storages?filters=%5B%5D&offset=1&pageSize=20
+    jumpTo:
+      href: /api/v3/storages?filters=%5B%5D&offset=%7Boffset%7D&pageSize=20
+      templated: true
+    changeSize:
+      href: /api/v3/storages?filters=%5B%5D&offset=1&pageSize=%7Bsize%7D
+      templated: true
+    nextByOffset:
+      href: /api/v3/storages?filters=%5B%5D&offset=2&pageSize=20

--- a/docs/api/apiv3/components/examples/work_package_create_valid.yml
+++ b/docs/api/apiv3/components/examples/work_package_create_valid.yml
@@ -2,15 +2,15 @@ description: |-
   A valid request body to create or edit a work package with a couple of properties.
 value:
   subject: Install Dromund Kass planetary shield
-  description: 
+  description:
     format: markdown
     raw: |-
       # TODO
-      
+
       The planetary shield of Dromund Kass needs to be installed to protect the planet from orbital bombardment.
   startDate: '2877-07-21'
   duration: P1337D
-  estimatedTime: P1Y5DT13H
+  estimatedTime: P370DT13H
   ignoreNonWorkingDays: true
   project:
     href: /api/v3/projects/42

--- a/docs/api/apiv3/components/examples/work_package_with_meta_validation.yml
+++ b/docs/api/apiv3/components/examples/work_package_with_meta_validation.yml
@@ -2,5 +2,6 @@ description: |-
   A request body to edit a work package with custom field validation enabled via the _meta object.
 value:
   subject: Replace GNK power droids
+  lockVersion: 42
   _meta:
     validateCustomFields: true

--- a/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
+++ b/docs/api/apiv3/components/schemas/hierarchy_item_read_model.yml
@@ -19,7 +19,9 @@ properties:
     type: integer
     description: Hierarchy item identifier
   label:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: The label of the hierarchy item
   short:
     type:
@@ -76,7 +78,7 @@ properties:
             - $ref: './link.yml'
             - description: |-
                 A hierarchy item that is a child of the current hierarchy item
-                
+
                 **Resource**: HierarchyItem
       branch:
         allOf:

--- a/docs/api/apiv3/components/schemas/notification_model.yml
+++ b/docs/api/apiv3/components/schemas/notification_model.yml
@@ -68,14 +68,13 @@ properties:
       - actor
       - activity
       - resource
-      - details
     properties:
       self:
         allOf:
           - "$ref": "./link.yml"
           - description: |-
               This notification
-              
+
               **Resource**: Notification
       readIAN:
         allOf:
@@ -92,7 +91,7 @@ properties:
           - "$ref": "./link.yml"
           - description: |-
               The workspace the notification originated in
-              
+
               **Resource**: Workspace
       actor:
         allOf:
@@ -100,7 +99,7 @@ properties:
           - description: |-
               The user that caused the notification. This might be null in
               case no user triggered the notification.
-              
+
               **Resource**: User
       resource:
         allOf:
@@ -117,13 +116,3 @@ properties:
               case no activity triggered the notification.
 
               **Resource**: Activity
-      details:
-        type: array
-        items:
-          allOf:
-            - "$ref": "./link.yml"
-            - description: |-
-                A list of objects including detailed information about the notification. The contents of
-                and type of this can vary widely between different notification reasons.
-
-                **Resource**: Polymorphic (e.g. Values::Property)

--- a/docs/api/apiv3/components/schemas/query_filter_instance_model.yml
+++ b/docs/api/apiv3/components/schemas/query_filter_instance_model.yml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - _links
+  - _type
+  - name
+properties:
+  _links:
+    type: object
+    required:
+      - filter
+      - schema
+    properties:
+      filter:
+        "$ref": "./link.yml"
+      schema:
+        "$ref": "./link.yml"
+      operator:
+        "$ref": "./link.yml"
+  _type:
+    type: string
+  name:
+    type: string

--- a/docs/api/apiv3/components/schemas/query_model.yml
+++ b/docs/api/apiv3/components/schemas/query_model.yml
@@ -20,7 +20,7 @@ properties:
       to determine the resulting work packages
     readOnly: false
     items:
-      $ref: './query_filter_instance_schema_model.yml'
+      $ref: './query_filter_instance_model.yml'
   sums:
     type: boolean
     description: Should sums (of supported properties) be shown?

--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -33,17 +33,21 @@ properties:
 
       This is only required for authentication through single-sign-on and so far only supported for provider type Nextcloud.
   tenantId:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: |-
       The tenant id of a file storage of type OneDrive.
 
-      Ignored if the provider type is not OneDrive.
+      Ignored if the provider type is not OneDrive. May be null if the storage is not configured completely.
   driveId:
-    type: string
+    type:
+      - "string"
+      - "null"
     description: |-
       The drive id of a file storage of type OneDrive.
 
-      Ignored if the provider type is not OneDrive.
+      Ignored if the provider type is not OneDrive. May be null if the storage is not configured completely.
   hasApplicationPassword:
     type: boolean
     description: |-

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -879,6 +879,8 @@ components:
       "$ref": "./components/schemas/query_create_form.yml"
     Query_FilterModel:
       "$ref": "./components/schemas/query_filter_model.yml"
+    Query_Filter_Instance_Model:
+      "$ref": "./components/schemas/query_filter_instance_model.yml"
     Query_Filter_Instance_SchemaModel:
       "$ref": "./components/schemas/query_filter_instance_schema_model.yml"
     Query_Filter_Instance_SchemasModel:

--- a/spec/docs/external_schema_examples_spec.rb
+++ b/spec/docs/external_schema_examples_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Examples documented in separate files" do # rubocop:disable RSpec/DescribeClass
+  examples_map = {} # rubocop:disable RSpec/LeakyLocalVariable
+  Dir[
+    Rails.root.join("docs/api/apiv3/paths/*.yml").to_s
+  ].each do |f|
+    yaml = YAML.load_file(f)
+    yaml.each_value do |method_doc|
+      request = method_doc.dig("requestBody", "content", "application/json")
+      responses = method_doc.fetch("responses", {}).values.filter_map { |resp| resp.dig("content", "application/hal+json") }
+      (responses + [request]).compact.each do |content_doc|
+        example_files = content_doc.fetch("examples", {}).values.filter_map { |e| e["$ref"] }
+        example_matches = example_files.filter_map do |example_file|
+          %r{\.\./components/examples/([\w-]+).yml}.match(example_file)
+        end
+        schema_match = %r{\.\./components/schemas/([\w-]+)\.yml}.match(content_doc.dig("schema", "$ref"))
+        next if schema_match.nil?
+
+        schema_name = schema_match[1]
+        examples_map[schema_name] ||= []
+        examples_map[schema_name] = (examples_map[schema_name] + example_matches.map { |m| m[1] }).uniq
+      end
+    end
+  end
+
+  # List of [schema, example]-pairs that shall be skipped
+  skipped_combinations = { # rubocop:disable RSpec/LeakyLocalVariable
+    %w[grid_write_model grid-simple-patch-model] => "schema needs to be split into write and read schema",
+    %w[portfolio_model portfolio_body] => "schema needs to be split into write and read schema",
+    %w[program_model program_body] => "schema needs to be split into write and read schema",
+    %w[project_model project_body] => "schema needs to be split into write and read schema",
+    %w[relation_write_model relation_update_request] => "schema is intended for create request... split or weaken schema?"
+  }
+
+  it "auto-discovers schemas and examples [SELF-TEST]" do
+    # heuristic self-test, when writing this spec there were 59 examples to be discovered. This number should
+    # grow over time, but usually not get smaller (unless doc restructuring breaks the auto-discovery)
+    expect(examples_map.values.sum(&:size)).to be > 55
+  end
+
+  examples_map.each do |schema_name, example_names|
+    describe schema_name do
+      let(:schema) { JsonSchemaLoader.new.load(schema_name) }
+
+      example_names.each do |example_name|
+        it "is implemented by #{example_name}" do
+          skip(skipped_combinations.fetch([schema_name, example_name])) if skipped_combinations.key?([schema_name, example_name])
+
+          example = YAML.load_file(Rails.root.join("docs/api/apiv3/components/examples/#{example_name}.yml"))
+                        .deep_symbolize_keys
+                        .fetch(:value)
+
+          # TODO: It would be nice to just skip the abbreviated element from "required" validations, instead of skipping the
+          #       entire validation of the schema
+          if all_keys(example).exclude?(:_abbreviated)
+            expect(example.to_json).to match_json_schema(schema)
+          end
+        end
+      end
+    end
+  end
+
+  def all_keys(object)
+    return object.flat_map { |e| all_keys(e) } if object.is_a?(Array)
+    return [] unless object.is_a?(Hash)
+
+    object.flat_map { |k, v| [k, all_keys(v)].flatten }
+  end
+end


### PR DESCRIPTION
Those are usually linked through other OpenAPI specification documents and different examples can refer to the same specification.

Fixed violations along the way, most of them were typos in either the schema or the example. In one case a wrong schema was referenced, most likely because the name was sufficiently confusing. The reference went to `query_filter_instance_schema_model`, when it should have been `query_filter_instance_model`. Sadly, the latter didn't even exist as a schema. I changed the reference and added a schema based on what I could find in our implemented representer. It was consistent with examples.

# Ticket
https://community.openproject.org/wp/69707