### PR TITLE
[#69979] Show Edit in Workflow Summary page header

### DIFF
--- a/app/components/workflows/page_header_component.html.erb
+++ b/app/components/workflows/page_header_component.html.erb
@@ -45,17 +45,33 @@ See COPYRIGHT and LICENSE files for more details.
       t(:button_copy)
     end
 
-    header.with_action_button(
-      tag: :a,
-      mobile_icon: :info,
-      mobile_label: t(:label_workflow_summary),
-      size: :medium,
-      href: workflows_path,
-      aria: { label: I18n.t(:label_workflow_summary) },
-      title: I18n.t(:label_workflow_summary)
-    ) do |button|
-      button.with_leading_visual_icon(icon: :info)
-      t(:label_workflow_summary)
+    case @state
+    when :show
+      header.with_action_button(
+        tag: :a,
+        mobile_icon: :pencil,
+        mobile_label: t(:button_edit),
+        size: :medium,
+        href: edit_workflows_path,
+        aria: { label: I18n.t(:button_edit) },
+        title: I18n.t(:button_edit)
+      ) do |button|
+        button.with_leading_visual_icon(icon: :pencil)
+        t(:button_edit)
+      end
+    else
+      header.with_action_button(
+        tag: :a,
+        mobile_icon: :info,
+        mobile_label: t(:label_workflow_summary),
+        size: :medium,
+        href: workflows_path,
+        aria: { label: I18n.t(:label_workflow_summary) },
+        title: I18n.t(:label_workflow_summary)
+      ) do |button|
+        button.with_leading_visual_icon(icon: :info)
+        t(:label_workflow_summary)
+      end
     end
   end
 %>

--- a/app/components/workflows/page_header_component.html.erb
+++ b/app/components/workflows/page_header_component.html.erb
@@ -32,21 +32,22 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_title { title }
     header.with_breadcrumbs(breadcrumb_items)
 
-    header.with_action_button(
-      tag: :a,
-      mobile_icon: :copy,
-      mobile_label: t(:button_copy),
-      size: :medium,
-      href: copy_workflows_path,
-      aria: { label: I18n.t(:button_copy) },
-      title: I18n.t(:button_copy)
-    ) do |button|
-      button.with_leading_visual_icon(icon: :copy)
-      t(:button_copy)
+    if @state != :copy
+      header.with_action_button(
+        tag: :a,
+        mobile_icon: :copy,
+        mobile_label: t(:button_copy),
+        size: :medium,
+        href: copy_workflows_path,
+        aria: { label: I18n.t(:button_copy) },
+        title: I18n.t(:button_copy)
+      ) do |button|
+        button.with_leading_visual_icon(icon: :copy)
+        t(:button_copy)
+      end
     end
 
-    case @state
-    when :show
+    if @state != :edit
       header.with_action_button(
         tag: :a,
         mobile_icon: :pencil,
@@ -59,7 +60,9 @@ See COPYRIGHT and LICENSE files for more details.
         button.with_leading_visual_icon(icon: :pencil)
         t(:button_edit)
       end
-    else
+    end
+
+    if @state != :show
       header.with_action_button(
         tag: :a,
         mobile_icon: :info,

--- a/spec/features/workflows/copy_spec.rb
+++ b/spec/features/workflows/copy_spec.rb
@@ -61,4 +61,22 @@ RSpec.describe "Workflow copy" do
       expect(page).to have_content("--- #{I18n.t(:actionview_instancetag_blank_option)} ---")
     end
   end
+
+  it "allows navigating to Workflow edit page" do
+    within ".PageHeader-actions" do
+      click_on "Edit"
+    end
+
+    expect(page).to have_heading "Workflow"
+    expect(page).to have_current_path(edit_workflows_path)
+  end
+
+  it "allows navigating to Workflow summary page" do
+    within ".PageHeader-actions" do
+      click_on "Summary"
+    end
+
+    expect(page).to have_heading "Summary"
+    expect(page).to have_current_path(workflows_path)
+  end
 end

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -171,4 +171,22 @@ RSpec.describe "Workflow edit" do
       assert !w.assignee
     end
   end
+
+  it "allows navigating to Workflow summary page" do
+    within ".PageHeader-actions" do
+      click_on "Summary"
+    end
+
+    expect(page).to have_heading "Summary"
+    expect(page).to have_current_path(workflows_path)
+  end
+
+  it "allows navigating to Workflow copy page" do
+    within ".PageHeader-actions" do
+      click_on "Copy"
+    end
+
+    expect(page).to have_heading "Copy workflow"
+    expect(page).to have_current_path(copy_workflows_path)
+  end
 end

--- a/spec/features/workflows/summary_spec.rb
+++ b/spec/features/workflows/summary_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "rails_helper"
+
+RSpec.describe "Workflow summary", :js do
+  let(:role) { create(:project_role, name: "Hauptrolle") }
+  let(:type) { create(:type, name: "Ungeziefer") }
+  let(:admin)  { create(:admin) }
+  let(:statuses) { (1..3).map { create(:status) } }
+  let!(:workflow) do
+    create(:workflow, role_id: role.id,
+                      type_id: type.id,
+                      old_status_id: statuses[0].id,
+                      new_status_id: statuses[1].id,
+                      author: false,
+                      assignee: false)
+  end
+
+  current_user { admin }
+
+  before do
+    visit url_for(controller: "/workflows", action: :show)
+  end
+
+  it "displays a simple summary" do
+    expect(page).to have_heading "Summary"
+
+    within :table do
+      expect(page).to have_selector :row, "Ungeziefer"
+      expect(page).to have_selector :columnheader, "Hauptrolle"
+    end
+  end
+
+  it "allows navigating to Workflow edit page" do
+    within ".PageHeader-actions" do
+      click_on "Edit"
+    end
+
+    expect(page).to have_heading "Workflow"
+    expect(page).to have_current_path(edit_workflows_path)
+  end
+
+  it "allows navigating to Workflow copy page" do
+    within ".PageHeader-actions" do
+      click_on "Copy"
+    end
+
+    expect(page).to have_heading "Copy workflow"
+    expect(page).to have_current_path(copy_workflows_path)
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69979

# What are you trying to accomplish?

Fix navigation via Page Header buttons.

- Shows the Edit button in the Summary page header, rather than the Summary button.
- Shows the Edit button in the Copy workflows page header, rather than Copy button.

## Screenshots

| Page    | Before | After |
|---------|--------|--------|
| Summary | <img width="1244" height="500" alt="Screenshot 2025-12-15 at 21 27 32" src="https://github.com/user-attachments/assets/6a8d88bd-5c31-4105-834c-c6ab0b2af1ae" /> | <img width="1195" height="500" alt="Screenshot 2025-12-15 at 21 27 17" src="https://github.com/user-attachments/assets/9f888041-946d-434f-aee0-261c770af3ef" /> | 
| Copy | <img width="1393" height="671" alt="Screenshot 2025-12-17 at 19 51 41" src="https://github.com/user-attachments/assets/260f751e-805f-4104-9e77-bf3b2b2557c6" /> | <img width="1345" height="674" alt="Screenshot 2025-12-17 at 19 50 52" src="https://github.com/user-attachments/assets/208f7e75-f6bd-4139-a278-2e4d03950993" /> |

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
