### PR TITLE
[#69906] fixed turbo target of item link

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -38,7 +38,13 @@ See COPYRIGHT and LICENSE files for more details.
             render(Primer::OpenProject::DragHandle.new(draggable: true))
           end
           item_information.with_column(mr: 2) do
-            render(Primer::Beta::Link.new(href: item_link, underline: false)) do
+            render(
+              Primer::Beta::Link.new(
+                href: item_link,
+                underline: false,
+                data: { turbo_frame: Admin::CustomFields::Hierarchy::ItemsComponent.wrapper_key }
+              )
+            ) do
               render(Primer::Beta::Text.new(font_weight: :bold)) { model.label }
             end
           end


### PR DESCRIPTION
# Ticket
[#69906](https://community.openproject.org/work_packages/69906)

# What are you trying to accomplish?
- improve page load on navigating through items and avoid flicker

# What approach did you choose and why?
- target items frame specifically when clicking on a single item
