### PR TITLE
Optimize number of queries on Hierarchy Custom field views.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -149,7 +151,7 @@ gem "structured_warnings", "~> 0.5.0"
 # don't require by default, instead load on-demand when actually configured
 gem "airbrake", "~> 13.0.0", require: false
 
-gem "markly", "~> 0.14" # another markdown parser like commonmarker, but with AST support used in PDF export
+gem "markly", "~> 0.14" # another Markdown parser like commonmarker, but with AST support used in PDF export
 gem "md_to_pdf", git: "https://github.com/opf/md-to-pdf", ref: "6c565541bfa390c58d90d49aa9b487777704fc66"
 gem "prawn", "~> 2.4"
 gem "ttfunk", "~> 1.7.0" # remove after https://github.com/prawnpdf/prawn/issues/1346 resolved.
@@ -246,7 +248,7 @@ gem "turbo-rails", "~> 2.0.20"
 # happenning in failing tests when WebMock or VCR stub cannot be found.
 gem "httpx", "~> 1.6.3"
 
-# Brings actual deep freezing to most ruby objects
+# Brings actual deep-freezing to most ruby objects
 gem "ice_nine"
 
 group :test do
@@ -393,6 +395,9 @@ gem "disposable", "~> 0.6.2"
 
 # Used for formula evaluation of calculated values
 gem "dentaku", "~> 3.5"
+
+# Used for more powerful counter caches
+gem "counter_culture", "~> 3.11"
 
 group :postgres do
   gem "pg", "~> 1.6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,6 +440,9 @@ GEM
     cose (1.3.1)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
+    counter_culture (3.11.4)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -1575,6 +1578,7 @@ DEPENDENCIES
   commonmarker (~> 2.5.0)
   compare-xml (~> 0.66)
   costs!
+  counter_culture (~> 3.11)
   csv (~> 3.3)
   cuprite (~> 0.17.0)
   daemons
@@ -1839,6 +1843,7 @@ CHECKSUMS
   cookiejar (0.3.4) sha256=11b16acfc4baf7a0f463c21a6212005e04e25f5554d4d9f24d97f3492dfda0df
   cose (1.3.1) sha256=d5d4dbcd6b035d513edc4e1ab9bc10e9ce13b4011c96e3d1b8fe5e6413fd6de5
   costs (1.0.0)
+  counter_culture (3.11.4) sha256=af64b6e429a2755057a7162826ea68ae354b869506199a6f521d171765c2ca38
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   css_parser (1.21.1) sha256=6cfd3ffc0a97333b39d2b1b49c95397b05e0e3b684d68f77ec471ba4ec2ef7c7

--- a/app/components/admin/custom_fields/hierarchy/item_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.html.erb
@@ -43,14 +43,13 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
 
-          label_addition = model.suffix
           if label_addition.present?
             item_information.with_column(mr: 2) do
               render(Primer::Beta::Text.new(color: :subtle)) { label_addition }
             end
           end
 
-          if model.children.any?
+          if model.children_count > 0
             item_information.with_column(mr: 2) do
               render(Primer::Beta::Text.new) { children_count }
             end

--- a/app/components/admin/custom_fields/hierarchy/item_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/item_component.rb
@@ -41,10 +41,10 @@ module Admin
           end
         end
 
-        def initialize(item:, show_edit_form: false)
+        def initialize(item:, custom_field:, show_edit_form: false)
           super(item)
           @show_edit_form = show_edit_form
-          @root = item.root || item.parent.root
+          @custom_field = custom_field
         end
 
         def wrapper_uniq_by
@@ -74,16 +74,18 @@ module Admin
         def show_form? = @show_edit_form || model.new_record?
 
         def children_count
-          I18n.t("custom_fields.admin.hierarchy.subitems", count: model.children.count)
+          I18n.t("custom_fields.admin.hierarchy.subitems", count: model.children_count)
         end
+
+        def label_addition = model.suffix
 
         private
 
         def project_custom_field_context?
-          @root.custom_field.is_a?(ProjectCustomField)
+          @project_custom_field_context ||= @custom_field.is_a?(ProjectCustomField)
         end
 
-        def custom_field_id = @root.custom_field_id
+        def custom_field_id = @custom_field.id
       end
     end
   end

--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -86,7 +86,7 @@ See COPYRIGHT and LICENSE files for more details.
                                   end
 
                   box.with_row(**drag_controls) do
-                    render Admin::CustomFields::Hierarchy::ItemComponent.new(item: item)
+                    render Admin::CustomFields::Hierarchy::ItemComponent.new(item: item, custom_field: root.custom_field)
                   end
                 end
               end

--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -78,7 +78,9 @@ module Admin
               ->(*) { redirect_to action: :show, id: @active_item.parent, status: :see_other },
               lambda do |validation_result|
                 add_errors_to_edit_form(validation_result)
-                update_via_turbo_stream(component: ItemComponent.new(item: @active_item, show_edit_form: true))
+                update_via_turbo_stream(
+                  component: ItemComponent.new(item: @active_item, custom_field: @custom_field, show_edit_form: true)
+                )
                 respond_with_turbo_streams
               end
             )
@@ -112,7 +114,11 @@ module Admin
           item_service
             .delete_branch(item: @active_item)
             .either(
-              ->(_) { update_via_turbo_stream(component: ItemsComponent.new(item: @active_item.parent.reload)) },
+              ->(_) do
+                update_via_turbo_stream(
+                  component: ItemsComponent.new(item: @active_item.parent.reload)
+                )
+              end,
               ->(errors) { render_error_flash_message_via_turbo_stream(message: errors.full_messages) }
             )
 

--- a/app/models/custom_field/hierarchy/item.rb
+++ b/app/models/custom_field/hierarchy/item.rb
@@ -33,6 +33,7 @@ class CustomField::Hierarchy::Item < ApplicationRecord
 
   belongs_to :custom_field
   has_closure_tree order: "sort_order", numeric_order: true, dont_order_roots: true, dependent: :destroy
+  counter_culture :parent, column_name: :children_count
 
   scope :including_children, -> { includes(children: :children) }
 

--- a/app/views/admin/custom_fields/hierarchy/items/edit.html.erb
+++ b/app/views/admin/custom_fields/hierarchy/items/edit.html.erb
@@ -31,4 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Admin::CustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
 
-<%= render(Admin::CustomFields::Hierarchy::ItemComponent.new(item: @active_item, show_edit_form: true)) %>
+<%= render(Admin::CustomFields::Hierarchy::ItemComponent.new(item: @active_item, custom_field: @custom_field, show_edit_form: true)) %>

--- a/app/views/admin/settings/project_custom_fields/hierarchy/items/edit.html.erb
+++ b/app/views/admin/settings/project_custom_fields/hierarchy/items/edit.html.erb
@@ -31,4 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Settings::ProjectCustomFields::EditFormHeaderComponent.new(custom_field: @custom_field, selected: :items)) %>
 
-<%= render(Admin::CustomFields::Hierarchy::ItemComponent.new(item: @active_item, show_edit_form: true)) %>
+<%= render(Admin::CustomFields::Hierarchy::ItemComponent.new(item: @active_item, custom_field: @custom_field, show_edit_form: true)) %>

--- a/app/workers/custom_fields/update_hierarchy_item_children_counts_job.rb
+++ b/app/workers/custom_fields/update_hierarchy_item_children_counts_job.rb
@@ -28,8 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AddsChildrenCountToHierarchyItems < ActiveRecord::Migration[8.0]
-  def change
-    add_column :hierarchical_items, :children_count, :integer, default: 0
+module CustomFields
+  class UpdateHierarchyItemChildrenCountsJob < ApplicationJob
+    def perform(*)
+      CustomField::Hierarchy::Item.counter_culture_fix_counts
+    end
   end
 end

--- a/db/migrate/20251216155857_adds_children_count_to_hierarchy_items.rb
+++ b/db/migrate/20251216155857_adds_children_count_to_hierarchy_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddsChildrenCountToHierarchyItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :hierarchical_items, :children_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20251217105019_update_hierarchy_item_children_counts.rb
+++ b/db/migrate/20251217105019_update_hierarchy_item_children_counts.rb
@@ -28,8 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class AddsChildrenCountToHierarchyItems < ActiveRecord::Migration[8.0]
-  def change
-    add_column :hierarchical_items, :children_count, :integer, default: 0
+class UpdateHierarchyItemChildrenCounts < ActiveRecord::Migration[8.0]
+  def up
+    CustomFields::UpdateHierarchyItemChildrenCountsJob.perform_later
   end
+
+  def down; end
 end


### PR DESCRIPTION
Reduce the number of queries needed to render the view components by around 70%.

Most of the work was removing unnecessary calls to `root.custom_field` and introducing a counter cache for descendants.

[OP#69906](https://community.openproject.org/projects/document-workflows-stream/work_packages/69906/activity)