### PR TITLE
Use gsub to match all found elements of the regexp

### DIFF
--- a/app/models/exports/pdf/common/macro.rb
+++ b/app/models/exports/pdf/common/macro.rb
@@ -102,12 +102,10 @@ module Exports::PDF::Common::Macro
   end
 
   def replace_macro(text, macro, in_html, context)
-    new_text = text.dup
-    text.to_enum(:scan, macro.regexp).each do |matched_string|
+    text.gsub(macro.regexp) do |matched_string|
       match = Regexp.last_match
-      new_text[match.begin(0)...match.end(0)] = replace_macro_match(match, matched_string, macro, in_html, context)
+      replace_macro_match(match, matched_string, macro, in_html, context)
     end
-    new_text
   end
 
   def replace_macro_match(match, matched_string, macro, in_html, context)

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -381,6 +381,14 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
+    describe "with two macros in a single line" do
+      let(:markdown) { 'workPackageValue:"Custom Field 1" workPackageValue:subject' }
+
+      it "renders both macro values" do
+        expect(formatted).to eq("Custom value 1 Work package 1")
+      end
+    end
+
     describe "with markdown formatting" do
       let(:markdown) { "**workPackageValue:subject**" }
 


### PR DESCRIPTION
The macro replacement iterates matches manually to substrings by index. When multiple macros appeared in the same text segment (e.g., workPackageValue:"dueDate" workPackageValue:"startDate"), the first replacement left later macros in the line unprocessed, so raw macro markup ended up being in the PDF output.

Using gsub with the macro regexp ensures we replace every match in a single pass even when multiple macros are used in a row

https://community.openproject.org/work_packages/70083