### PR TITLE
[#69731] User with 'Create meeting' permissions but without 'Manage agenda' cannot open first meeting occurrence  

### DIFF
--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -77,7 +77,7 @@ module Meetings
 
     def finish_setup_enabled?
       @meeting.draft? &&
-        User.current.allowed_in_project?(:create_meetings, @meeting.project)
+        User.current.allowed_in_project?(:edit_meetings, @meeting.project)
     end
 
     def action_button_params

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -64,7 +64,7 @@ module OpenProject::Meeting
         permission :edit_meetings,
                    {
                      meetings: %i[edit cancel_edit update update_title change_state toggle_notifications_dialog
-                                  details_dialog update_details toggle_notifications],
+                                  details_dialog update_details toggle_notifications exit_draft_mode_dialog exit_draft_mode],
                      recurring_meetings: %i[edit cancel_edit update update_title details_dialog update_details
                                             notify end_series end_series_dialog],
                      work_package_meetings_tab: %i[add_work_package_to_meeting_dialog add_work_package_to_meeting refresh_form],
@@ -88,7 +88,6 @@ module OpenProject::Meeting
                    require: :member
         permission :manage_agendas,
                    {
-                     meetings: %i[change_state exit_draft_mode_dialog exit_draft_mode],
                      meeting_agenda_items: %i[new cancel_new create edit cancel_edit update destroy drop move
                                               move_to_next_meeting move_to_next_meeting_dialog
                                               duplicate_in_next_meeting duplicate_in_next_meeting_dialog

--- a/modules/meeting/spec/features/meeting_backlogs_spec.rb
+++ b/modules/meeting/spec/features/meeting_backlogs_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Meeting Backlogs", :js do
     create :user,
            lastname: "First",
            preferences: { time_zone: "Etc/UTC" },
-           member_with_permissions: { project => %i[view_meetings manage_agendas manage_outcomes] }
+           member_with_permissions: { project => %i[view_meetings edit_meetings manage_agendas manage_outcomes] }
   end
   shared_let(:reader) do
     create :user,


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/69731

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
- Use 'edit_meetings' instead of 'create_meetings' to show the button as that action changes meeting state
- Move all meeting state changing actions to use 'edit_meetings' instead of other permissions for consistency