### PR TITLE
[#69906] remove descendants check from tree view callbacks

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/change_item_parent_dialog_component.html.erb
@@ -44,15 +44,14 @@ See COPYRIGHT and LICENSE files for more details.
             filter_mode_control_arguments: { hidden: true }
           )
         ) do |tree_view|
-          current_fn = lambda { |item| item.id == @hierarchy_item.id }
-          disabled_fn = lambda { |item| current_fn.call(item) || item.id == @hierarchy_item.parent.id }
-          expanded_fn = lambda { |item| hierarchy_service.descendant_of?(item: @hierarchy_item, parent: item).success? }
+          parent = @hierarchy_item.parent
+          descendants = hierarchy_service.get_descendants(item: @hierarchy_item).value!
 
           item_options = {
             select_variant: :single,
-            expanded_fn:,
-            current_fn:,
-            disabled_fn:
+            expanded: [parent],
+            current: @hierarchy_item,
+            disabled: [parent] + descendants
           }
 
           populate_tree_view(tree_view, @custom_field, show_root: true, item_options:)

--- a/app/components/admin/custom_fields/hierarchy/tree_view_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/tree_view_component.html.erb
@@ -30,12 +30,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::Alpha::TreeView.new(node_variant: :anchor)) do |tree_view|
-    href_fn = lambda { |item| href_for(item) }
-    current_fn = lambda { |item| item == @active_item }
-    expanded_fn = lambda do |item|
-      item == @active_item || @hierarchy_service.descendant_of?(item: @active_item, parent: item).success?
-    end
+    item_options = {
+      href_fn: lambda { |item| href_for(item) },
+      expanded: [@active_item, @active_item.parent],
+      current: @active_item
+    }
 
-    populate_tree_view(tree_view, @custom_field, item_options: { expanded_fn:, href_fn:, current_fn: })
+    populate_tree_view(tree_view, @custom_field, item_options:)
   end
 %>

--- a/app/components/admin/custom_fields/hierarchy/tree_view_component.rb
+++ b/app/components/admin/custom_fields/hierarchy/tree_view_component.rb
@@ -39,7 +39,6 @@ module Admin
 
           @custom_field = custom_field
           @active_item = active_item
-          @hierarchy_service = ::CustomFields::Hierarchy::HierarchicalItemService.new
         end
 
         def href_for(item)

--- a/app/helpers/custom_field_hierarchy_tree_view_helper.rb
+++ b/app/helpers/custom_field_hierarchy_tree_view_helper.rb
@@ -63,9 +63,9 @@ module CustomFieldHierarchyTreeViewHelper
       value: item.id,
       select_variant: options[:select_variant] || :none,
       checked: options[:checked_fn]&.call(item) || false,
-      current: options[:current_fn]&.call(item) || false,
-      disabled: options[:disabled_fn]&.call(item) || false,
-      expanded: options[:expanded_fn]&.call(item) || false,
+      current: options[:current] == item,
+      disabled: options[:disabled]&.include?(item) || false,
+      expanded: options[:expanded]&.include?(item) || false,
       href: options[:href_fn]&.call(item)
     }
   end


### PR DESCRIPTION
# Ticket
[#69906](https://community.openproject.org/work_packages/69906)

# What are you trying to accomplish?
- improve loading performance for huge hierarchies

# What approach did you choose and why?
- switch expanded, disabled and current from callback to simple arguments
  - this way data must be preloaded and can be optimized in a way
  - no more traps of n+1 when having unnecessary sql queries in callbacks
- removed check for ancestors completely, as tree view can expand the path of an expanded node by itself
