### PR TITLE
Fix error when users table does not exist

### DIFF
--- a/config/initializers/log_slow_sql_queries.rb
+++ b/config/initializers/log_slow_sql_queries.rb
@@ -42,8 +42,8 @@ Rails.application.configure do
       # Skip transaction that may be blocked
       next if data[:sql].match?(/BEGIN|COMMIT/)
 
-      # Skip tenant creation (load dump)
-      next if data[:sql][..120].include?("Dumped by pg_dump")
+      # Skip tenant creation (load dump sql which is around 300kB)
+      next if data[:sql][..120].include?("Dumped by pg_dump") || data[:sql].size > 200_000
 
       # Skip smaller durations
       duration = ((finish - start) * 1000).round(4)

--- a/lib/open_project/logging/log_delegator.rb
+++ b/lib/open_project/logging/log_delegator.rb
@@ -28,7 +28,9 @@ module OpenProject
 
           # Set current contexts
           context[:level] ||= context[:exception] ? :error : :info
-          context[:current_user] ||= User.current
+          if current_user
+            context[:current_user] ||= current_user
+          end
 
           registered_handlers.values.each do |handler|
             handler.call message, context
@@ -102,6 +104,14 @@ module OpenProject
           payload = context.slice(%i[current_user project reference]).compact
           extended = OpenProject::Logging.extend_payload!(payload, context)
           OpenProject::Logging.formatter.call extended
+        end
+
+        def current_user
+          User.current if users_table_exists?
+        end
+
+        def users_table_exists?
+          User.connection.data_source_exists?(User.table_name)
         end
       end
     end

--- a/lib/open_project/logging/log_delegator.rb
+++ b/lib/open_project/logging/log_delegator.rb
@@ -5,7 +5,7 @@ module OpenProject
         ##
         # Consume a message and let it be handled
         # by all handlers
-        def log(exception, context = {})
+        def log(exception, context = {}) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
           # in case we're getting ActionController::Parameters
           context = if context.respond_to?(:to_unsafe_h)
                       context.to_unsafe_h
@@ -28,11 +28,11 @@ module OpenProject
 
           # Set current contexts
           context[:level] ||= context[:exception] ? :error : :info
-          if current_user
-            context[:current_user] ||= current_user
+          if the_current_user = current_user
+            context[:current_user] ||= the_current_user
           end
 
-          registered_handlers.values.each do |handler|
+          registered_handlers.each_value do |handler|
             handler.call message, context
           rescue StandardError => e
             Rails.logger.error "Failed to delegate log to #{handler.inspect}: #{e.inspect}\nMessage: #{message.inspect}"
@@ -107,11 +107,11 @@ module OpenProject
         end
 
         def current_user
-          User.current if users_table_exists?
-        end
-
-        def users_table_exists?
-          User.connection.data_source_exists?(User.table_name)
+          User.current
+        # Probably more performant to rescue "ActiveRecord::StatementInvalid: PG::UndefinedTable"
+        # than to check for table existence with `User.connection.data_source_exists?(User.table_name)`
+        rescue StandardError
+          nil
         end
       end
     end


### PR DESCRIPTION
In multitenant context, when schema is switched to and the tables are not created yet, getting `User.current` will fail with

    ActiveRecord::StatementInvalid:"PG::UndefinedTable: ERROR:  relation \"users\" does not exist" [...]

To prevent it, check if the table exists first and return `nil` if not.

This is happening during tenant seeding: it tries to log the info that the sql to create the database is long, and fails to do so because the users table does not exist.

There's probably a performance penalty at checking table presence on each log.
Maybe it would be better to `rescue nil`?

Also try avoiding logging database creation.