### PR TITLE
[#70109] Missing notification when a one-time meeting exits draft mode  

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -355,6 +355,7 @@ class MeetingsController < ApplicationController
              .call({ state: "open", notify: meeting_params[:notify] == "1" })
 
     if call.success?
+      deliver_invitation_mails
       update_all_via_turbo_stream
       update_backlog_via_turbo_stream(collapsed: nil)
 
@@ -366,6 +367,21 @@ class MeetingsController < ApplicationController
   end
 
   private
+
+  def deliver_invitation_mails
+    return false unless @meeting.notify?
+
+    @meeting
+      .participants
+      .invited
+      .find_each do |participant|
+      MeetingMailer.invited(
+        @meeting,
+        participant.user,
+        User.current
+      ).deliver_later
+    end
+  end
 
   def load_query
     query = ParamsToQueryService.new(

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe "Meeting notifications", :js do
       show_page.open_meeting
       expect(meeting.reload.notify).to be true
 
+      wait_for_network_idle
+
+      # check if mail is sent on opening meeting (Bug #70109)
+      perform_enqueued_jobs
+      expect(ActionMailer::Base.deliveries.size).to eq 1
+      ActionMailer::Base.deliveries.clear
+
       # check calendar updates sidepanel component
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70109

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add missing MeetingMailer call to `#exit_draft_mode`

# Merge checklist

- [x] Added/updated tests
