### PR TITLE
Drop index correctly for new uniques on rollback

### DIFF
--- a/db/migrate/20251218100700_add_uniqueness_for_status_names.rb
+++ b/db/migrate/20251218100700_add_uniqueness_for_status_names.rb
@@ -38,10 +38,10 @@ class AddUniquenessForStatusNames < ActiveRecord::Migration[8.0]
       WHERE statuses.id = counter.id AND counter.rn > 1;
     SQL
 
-    add_index :statuses, "LOWER(name)", unique: true, algorithm: :concurrently
+    add_index :statuses, "LOWER(name)", unique: true, algorithm: :concurrently, name: "index_statuses_on_LOWER_name"
   end
 
   def down
-    remove_index :statuses, column: "LOWER(name)", algorithm: :concurrently
+    remove_index :statuses, name: "index_statuses_on_LOWER_name", algorithm: :concurrently
   end
 end

--- a/db/migrate/20251218100721_add_uniqueness_for_role_names.rb
+++ b/db/migrate/20251218100721_add_uniqueness_for_role_names.rb
@@ -38,10 +38,10 @@ class AddUniquenessForRoleNames < ActiveRecord::Migration[8.0]
       WHERE roles.id = counter.id AND counter.rn > 1;
     SQL
 
-    add_index :roles, "LOWER(name)", unique: true, algorithm: :concurrently
+    add_index :roles, "LOWER(name)", unique: true, algorithm: :concurrently, name: "index_roles_on_LOWER_name"
   end
 
   def down
-    remove_index :roles, column: "LOWER(name)", algorithm: :concurrently
+    remove_index :roles, name: "index_roles_on_LOWER_name", algorithm: :concurrently
   end
 end

--- a/db/migrate/20251218100741_add_uniqueness_for_type_names.rb
+++ b/db/migrate/20251218100741_add_uniqueness_for_type_names.rb
@@ -38,10 +38,10 @@ class AddUniquenessForTypeNames < ActiveRecord::Migration[8.0]
       WHERE types.id = counter.id AND counter.rn > 1;
     SQL
 
-    add_index :types, "LOWER(name)", unique: true, algorithm: :concurrently
+    add_index :types, "LOWER(name)", unique: true, algorithm: :concurrently, name: "index_types_on_LOWER_name"
   end
 
   def down
-    remove_index :types, column: "LOWER(name)", algorithm: :concurrently
+    remove_index :types, name: "index_types_on_LOWER_name", algorithm: :concurrently
   end
 end


### PR DESCRIPTION
This is a follow up for https://github.com/opf/openproject/pull/21481

The name is not correctly constructed for the removing of the index on rollback, so we specify the generated name properly. The name is the same that is generated by rails, so there's no need to redo the migration for people hat already did.