### PR TITLE
[#70148] Fix ERb/HTML markup errors detected by Herb parser

### DIFF
--- a/app/components/users/index_page_header_component.html.erb
+++ b/app/components/users/index_page_header_component.html.erb
@@ -1,9 +1,7 @@
-<%=
-  render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t(:label_user_plural) }
-    header.with_breadcrumbs(breadcrumb_items)
-    header.with_description do
-%>
+<%= render(Primer::OpenProject::PageHeader.new) do |header| %>
+  <% header.with_title { t(:label_user_plural) } %>
+  <% header.with_breadcrumbs(breadcrumb_items) %>
+  <% header.with_description do %>
     <%= t(:label_enterprise_active_users, current: OpenProject::Enterprise.active_user_count, limit: user_limit) %>
     &nbsp;
     <%= render(

--- a/app/views/admin/backups/show.html.erb
+++ b/app/views/admin/backups/show.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% html_title t(:label_administration), t(:label_backup) -%>
 
@@ -36,24 +36,22 @@ See COPYRIGHT and LICENSE files for more details.
 </p>
 
 <% if Token::Backup.count > 0 %>
-  <p>
-    <span><%= I18n.t("backup.label_token_users") %></span>:
+  <span><%= I18n.t("backup.label_token_users") %></span>:
 
-    <div class="wiki">
-      <ul>
-        <% Token::Backup.includes(:user).each do |token| %>
-          <li>
-            <% if current_user.allowed_globally?(:manage_user) %>
-              <%= link_to token.user.name, edit_user_path(token.user) %>
-            <% else %>
-              <%= token.user.name %>
-            <% end %>
-            <%= token.user == current_user ? "(#{I18n.t(:you)})" : "" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </p>
+  <div class="wiki">
+    <ul>
+      <% Token::Backup.includes(:user).each do |token| %>
+        <li>
+          <% if current_user.allowed_globally?(:manage_user) %>
+            <%= link_to token.user.name, edit_user_path(token.user) %>
+          <% else %>
+            <%= token.user.name %>
+          <% end %>
+          <%= token.user == current_user ? "(#{I18n.t(:you)})" : "" %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
 <% end %>
 
 <% if @backup_token.present? %>

--- a/app/views/custom_fields/_form.html.erb
+++ b/app/views/custom_fields/_form.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% format_dependent = OpenProject::CustomFieldFormatDependent.new(@custom_field.field_format) %>
 
@@ -159,8 +159,8 @@ See COPYRIGHT and LICENSE files for more details.
 </section>
 
 <section class="form--section">
-  <% case @custom_field.class.name
-     when "WorkPackageCustomField" %>
+  <% case @custom_field.class.name %>
+  <% when "WorkPackageCustomField" %>
     <div class="form--field">
       <%= f.check_box :is_required %>
       <div class="form--field-instructions">

--- a/app/views/custom_fields/_tab.html.erb
+++ b/app/views/custom_fields/_tab.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% if @tab == "WorkPackageCustomField" %>
   <%= render(EnterpriseEdition::BannerComponent.new(:custom_field_hierarchies)) %>
@@ -141,8 +141,9 @@ See COPYRIGHT and LICENSE files for more details.
                       <%= t(:label_x_projects, count: custom_field.projects.count) %>
                     </span>
                   <% elsif !custom_field.is_for_all? %>
-                    <%= t(:label_x_projects, count: custom_field.projects.count) %></td>
+                    <%= t(:label_x_projects, count: custom_field.projects.count) %>
                   <% end %>
+                </td>
                 <td>
                   <% type_links = custom_field.types.map { |t| link_to(t.name, edit_type_form_configuration_path(t)) } %>
                   <% if type_links.empty? %>

--- a/app/views/doorkeeper/authorizations/error.html.erb
+++ b/app/views/doorkeeper/authorizations/error.html.erb
@@ -3,7 +3,7 @@
     <p>
       <strong><%= t("oauth.authorization_error") %></strong>
       <br>
-      <%= @pre_auth.error_response.body[:error_description] %></pre>
+      <%= @pre_auth.error_response.body[:error_description] %>
     </p>
   </div>
 </div>

--- a/app/views/user_mailer/activation_limit_reached.html.erb
+++ b/app/views/user_mailer/activation_limit_reached.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <p>
     <% mail_link = "<a href=\"mailto:#{@email}\">#{@email}</a>" %>
@@ -34,14 +34,12 @@ See COPYRIGHT and LICENSE files for more details.
     <%= t("mail_user_activation_limit_reached.message", email: mail_link, host: host_link).html_safe %>
 </p>
 
-<p>
-    <span><%= t("mail_user_activation_limit_reached.steps.label") %></span>
-    <ul>
-        <li>
-            <%= link_translate("mail_user_activation_limit_reached.steps.a", links: { upgrade_url: OpenProject::Enterprise.upgrade_url }) %>
-        </li>
-        <li>
-            <%= link_translate("mail_user_activation_limit_reached.steps.b", links: { users_url: users_url }) %>
-        </li>
-    </ul>
-</p>
+<span><%= t("mail_user_activation_limit_reached.steps.label") %></span>
+<ul>
+    <li>
+        <%= link_translate("mail_user_activation_limit_reached.steps.a", links: { upgrade_url: OpenProject::Enterprise.upgrade_url }) %>
+    </li>
+    <li>
+        <%= link_translate("mail_user_activation_limit_reached.steps.b", links: { users_url: users_url }) %>
+    </li>
+</ul>

--- a/app/views/user_mailer/attachments_added.html.erb
+++ b/app/views/user_mailer/attachments_added.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,13 +25,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
-<p>
-  <%= link_to @added_to, @added_to_url %><br>
-  <ul>
-    <% @attachments.each do |attachment | %>
-      <li><%= attachment.filename %></li>
-    <% end %>
-  </ul>
-</p>
+
+<%= link_to @added_to, @added_to_url %><br>
+<ul>
+  <% @attachments.each do |attachment | %>
+    <li><%= attachment.filename %></li>
+  <% end %>
+</ul>

--- a/app/views/wiki/history.html.erb
+++ b/app/views/wiki/history.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 <% html_title t("activerecord.models.wiki"), t(:label_history) %>
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
@@ -68,7 +68,6 @@ See COPYRIGHT and LICENSE files for more details.
                   </label>
                 </div>
               </div>
-            </th>
             </th>
             <th>
               <div class="generic-table--empty-header">

--- a/app/views/work_packages/bulk/destroy.html.erb
+++ b/app/views/work_packages/bulk/destroy.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 <%= error_messages_for work_packages.first %>
 
 <%=
@@ -115,6 +115,7 @@ See COPYRIGHT and LICENSE files for more details.
                            "history.back()",
                            title: t(:button_cancel),
                            class: "button -with-icon icon-cancel" %>
+    </div>
   </section>
 
 <% end %>

--- a/modules/auth_saml/app/views/saml/providers/confirm_destroy.html.erb
+++ b/modules/auth_saml/app/views/saml/providers/confirm_destroy.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 <%= styled_form_tag(
       saml_provider_path(@provider),
       class: "danger-zone",
@@ -39,10 +39,10 @@ See COPYRIGHT and LICENSE files for more details.
       <%= t("provider.delete_warning.provider", name: content_tag(:strong, @provider.display_name)).html_safe %>
     </p>
     <ul class="mb-3">
-      <li> <%= t("provider.delete_warning.delete_result_1") %>
-      <li> <%= t("provider.delete_warning.delete_result_user_count", count: @provider.user_count) %>
+      <li><%= t("provider.delete_warning.delete_result_1") %></li>
+      <li><%= t("provider.delete_warning.delete_result_user_count", count: @provider.user_count) %></li>
       <% if Setting.omniauth_direct_login_provider == @provider.slug %>
-      <li> <%= t("provider.delete_warning.delete_result_direct") %>
+      <li><%= t("provider.delete_warning.delete_result_direct") %></li>
       <% end %>
     </ul>
     <p class="danger-zone--warning">

--- a/modules/bim/app/views/bim/bcf/issues/_render_issues.html.erb
+++ b/modules/bim/app/views/bim/bcf/issues/_render_issues.html.erb
@@ -18,7 +18,6 @@
               <% issue.errors.full_messages.each do |message| %>
                 <p><%= message %></p>
               <% end %>
-              </ul>
             </div>
           </div>
         <% else %>

--- a/modules/budgets/app/views/budgets/_list.html.erb
+++ b/modules/budgets/app/views/budgets/_list.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <%= form_tag({}) do -%>
 
@@ -105,13 +105,13 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
         <% if budgets.length > 0 %>
         <tr>
-          <td />
-          <td />
+          <td></td>
+          <td></td>
           <td class="currency"><strong><%= number_to_currency(total_budget, precision: 0) %></strong></td>
           <td class="currency"><strong><%= number_to_currency(spent, precision: 0) %></strong></td>
           <td class="currency"><strong><%= number_to_currency(total_budget - spent, precision: 0) %></strong></td>
-          <td />
-        <tr>
+          <td></td>
+        </tr>
         <% end %>
       </tbody>
     </table>

--- a/modules/costs/app/views/admin/cost_types/edit.html.erb
+++ b/modules/costs/app/views/admin/cost_types/edit.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% if(@cost_type.id) %>
   <% html_title t(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
@@ -132,4 +132,3 @@ See COPYRIGHT and LICENSE files for more details.
   </div>
   <%= styled_button_tag t(:button_save), class: "-with-icon icon-checkmark" %>
 <% end %>
-</costs-subform>

--- a/modules/costs/app/views/costlog/edit.html.erb
+++ b/modules/costs/app/views/costlog/edit.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% html_title t(:label_log_costs) %>
 
@@ -99,7 +99,7 @@ See COPYRIGHT and LICENSE files for more details.
                    required: true,
                    class: "remote-field--input",
                    data: { "remote-field-key": "cost_type_id" }
-                 } %></p>
+                 } %>
   </div>
   <div class="form--field -required">
     <% if @cost_entry.cost_type.nil? %>

--- a/modules/documents/app/views/help/wiki_syntax_detailed.html.erb
+++ b/modules/documents/app/views/help/wiki_syntax_detailed.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <% content_for :styles do %>
     body { font:80% Verdana,Tahoma,Arial,sans-serif; }
@@ -253,9 +253,9 @@ To go live, all you need to add is a database and a web server.
 
     <p>OpenProject has the following builtin macros:</p>
 
-    <p><dl><dt><code>hello_world</code></dt><dd><p>Sample macro.</p></dd><dt><code>include</code></dt><dd><p>Include a wiki page. Example:</p>
+    <dl><dt><code>hello_world</code></dt><dd><p>Sample macro.</p></dd><dt><code>include</code></dt><dd><p>Include a wiki page. Example:</p>
 
-    <pre><code>{{include(Foo)}}</code></pre></dd><dt><code>macro_list</code></dt><dd><p>Displays a list of all available macros, including description if available.</p></dd></dl></p>
+    <pre><code>{{include(Foo)}}</code></pre></dd><dt><code>macro_list</code></dt><dd><p>Displays a list of all available macros, including description if available.</p></dd></dl>
 
     <h2><a name="13" class="wiki-page"></a>Code highlighting</h2>
 

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/destroy_info.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_filters/destroy_info.html.erb
@@ -35,6 +35,7 @@
               </div>
             </th>
             </thead>
+            <tbody>
             <% @filter.groups.find_each do |synced_group| %>
               <tr>
                 <td><%= link_to synced_group.group.name,

--- a/modules/openid_connect/app/views/openid_connect/providers/confirm_destroy.html.erb
+++ b/modules/openid_connect/app/views/openid_connect/providers/confirm_destroy.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 <%= styled_form_tag(
       openid_connect_provider_path(@provider),
       class: "danger-zone",
@@ -39,10 +39,10 @@ See COPYRIGHT and LICENSE files for more details.
       <%= t("provider.delete_warning.provider", name: content_tag(:strong, @provider.display_name)).html_safe %>
     </p>
     <ul class="mb-3">
-      <li> <%= t("provider.delete_warning.delete_result_1") %>
-      <li> <%= t("provider.delete_warning.delete_result_user_count", count: @provider.user_count) %>
+      <li><%= t("provider.delete_warning.delete_result_1") %></li>
+      <li><%= t("provider.delete_warning.delete_result_user_count", count: @provider.user_count) %></li>
       <% if Setting.omniauth_direct_login_provider == @provider.slug %>
-      <li> <%= t("provider.delete_warning.delete_result_direct") %>
+      <li><%= t("provider.delete_warning.delete_result_direct") %></li>
       <% end %>
     </ul>
     <p class="danger-zone--warning">

--- a/modules/storages/app/components/storages/admin/storages/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/admin/storages/destroy_confirmation_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <%=
   render(
@@ -47,9 +47,9 @@ See COPYRIGHT and LICENSE files for more details.
         <% end %>
         <% flex.with_row do %>
           <ul>
-            <li> <%= t("storages.delete_warning.storage_delete_result_1") %>
-            <li> <%= t("storages.delete_warning.storage_delete_result_2") %>
-            <li> <%= t("storages.delete_warning.storage_delete_result_3") %>
+            <li><%= t("storages.delete_warning.storage_delete_result_1") %></li>
+            <li><%= t("storages.delete_warning.storage_delete_result_2") %></li>
+            <li><%= t("storages.delete_warning.storage_delete_result_3") %></li>
           </ul>
         <% end %>
       <% end %>

--- a/modules/storages/app/components/storages/project_storages/projects/destroy_confirmation_dialog_component.html.erb
+++ b/modules/storages/app/components/storages/project_storages/projects/destroy_confirmation_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
 <%=
   render(
@@ -47,8 +47,8 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
       <% flex.with_row do %>
         <ul>
-          <li> <%= t("storages.delete_warning.project_storage_delete_result_1") %>
-          <li> <%= t("storages.delete_warning.project_storage_delete_result_2") %>
+          <li><%= t("storages.delete_warning.project_storage_delete_result_1") %></li>
+          <li><%= t("storages.delete_warning.project_storage_delete_result_2") %></li>
         </ul>
       <% end %>
     <% end %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/settings.html.erb
@@ -64,7 +64,7 @@
       <fieldset class="form--fieldset">
         <legend class="form--fieldset-legend"><%= t(:label_setting_plural) %></legend>
         <div class="form--field">
-          <label class="form--label" for='settings_enforced'><%= t("two_factor_authentication.settings.label_enforced") %></label>
+          <label class="form--label" for="settings_enforced"><%= t("two_factor_authentication.settings.label_enforced") %></label>
           <div class="form--field-container ">
             <%= styled_check_box_tag "settings[enforced]",
                                      "1",
@@ -77,7 +77,7 @@
           </div>
         </div>
         <div class="form--field">
-          <label class="form--label" for='settings[allow_remember_for_days]'><%= t("two_factor_authentication.settings.label_remember") %></label>
+          <label class="form--label" for="settings[allow_remember_for_days]"><%= t("two_factor_authentication.settings.label_remember") %></label>
           <div class="form--field-container">
             <%= styled_number_field_tag "settings[allow_remember_for_days]",
                                         configuration["allow_remember_for_days"],
@@ -93,5 +93,5 @@
       </fieldset>
       <%= styled_submit_tag t(:button_apply), class: "-primary" %>
     <% end %>
-    </section>
   <% end %>
+</section>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70148

# What are you trying to accomplish?

Fixes malformed HTML including:

- unmatched closing tags
- illegal HTML nesting (e.g. lists within a `<p>` tag)

Found while experimenting with [the new HTML-aware ERb parser, Herb](https://herb-tools.dev/).

```
gem install herb
herb analyze .
```

## Screenshots

There should be no visual changes.

# What approach did you choose and why?


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
