### PR TITLE
[OP-18546] Fix `FrozenError` when diffing commits

### DIFF
--- a/lib_static/redmine/diff.rb
+++ b/lib_static/redmine/diff.rb
@@ -75,9 +75,7 @@ module Redmine
     private
 
     def line_to_html(line, offsets)
-      line_to_html_raw(line, offsets).tap do |html_str|
-        html_str.force_encoding("UTF-8")
-      end
+      line_to_html_raw(line, offsets).dup.force_encoding("UTF-8")
     end
 
     def line_to_html_raw(line, offsets)

--- a/spec/lib/redmine/unified_diff_spec.rb
+++ b/spec/lib/redmine/unified_diff_spec.rb
@@ -383,4 +383,39 @@ RSpec.describe Redmine::UnifiedDiff do
         .to eq 1
     end
   end
+
+  describe "frozen string handling" do
+    context "when diff line has no offsets" do
+      let(:diff) do
+        <<~DIFF
+          --- old.txt Wed Nov 11 14:24:58 2009
+          +++ new.txt Wed Nov 11 14:25:02 2009
+          @@ -1,3 +1,3 @@
+           unchanged line
+          -old line
+          +new line
+        DIFF
+      end
+
+      it "handles frozen strings without raising FrozenError" do
+        # Find a line with nil offsets (unchanged line)
+        diff_line = instance.first.find { |line| line.offsets.nil? }
+
+        # Ensure we have a line with nil offsets
+        expect(diff_line).not_to be_nil
+        expect(diff_line.offsets).to be_nil
+
+        # Calling html_line methods should not raise a FrozenError
+        # when line_to_html_raw returns a frozen string directly (offsets is nil)
+        # The fix (adding .dup before .force_encoding in line_to_html) prevents this
+        expect { diff_line.html_line }.not_to raise_error
+        expect { diff_line.html_line_left }.not_to raise_error
+        expect { diff_line.html_line_right }.not_to raise_error
+
+        # Verify the output is correct and properly encoded
+        expect(diff_line.html_line).to be_a(String)
+        expect(diff_line.html_line.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-18546

# What are you trying to accomplish?

Fixes a Ruby `FrozenError`.

<img width="1448" height="753" alt="Screenshot 2025-12-22 at 20 58 54" src="https://github.com/user-attachments/assets/2b57a1fa-6edf-4df4-aafb-b942425d6235" />

Possibly a result of [50be32c](https://github.com/opf/openproject/pull/19980/commits/50be32c606ca34254473892d2b9a997cab7a22f4) / #19980



# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
