### PR TITLE
Fix "Enter text or type '/' for commands" position

### DIFF
--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -6,6 +6,7 @@ $blocknote-max-width: 800px
 
 .block-note-editor-container
   align-items: center
+  position: relative
   display: flex
   flex-direction: column-reverse
   gap: 10px


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/communicator-stream/work_packages/69971/activity
and it might fix https://community.openproject.org/projects/communicator-stream/work_packages/69970/activity

# What are you trying to accomplish?

Fix issue where the position of the placeholder would be in the wrong place when the page was scrolled.

**before**
<img width="1081" height="524" alt="imagen" src="https://github.com/user-attachments/assets/d4bab138-698a-4b5f-ac1c-ad0d563a6c9b" />

## Screenshots

**after**
<img width="1081" height="524" alt="imagen" src="https://github.com/user-attachments/assets/6690e30d-b056-4c85-85d7-04b6a65bd883" />


# What approach did you choose and why?

The placeholder text is set on a css `::before` using a `position: absolute`. I just made sure the document has a `position: relative` for the component to attach to.

But I am not sure this is the proper approach.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
