### PR TITLE
[#70111] Missing notification when a series is ended  

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -110,8 +110,8 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  # Send mails to browser window
-  config.action_mailer.delivery_method = :letter_opener_web
+  # Send mails to browser window (unless configured otherwise)
+  config.action_mailer.delivery_method = ENV["OPENPROJECT_EMAIL_DELIVERY_METHOD"]&.to_sym || :letter_opener_web
 
   # Set email preview locations to rspec
   config.action_mailer.preview_paths << Rails.root.join("spec/mailers/previews")

--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -89,6 +89,21 @@ class MeetingMailer < UserMailer
     end
   end
 
+  def ended_series(series, user, actor)
+    @actor = actor
+    @user = user
+    @series = series
+
+    open_project_headers "Project" => @series.project.identifier,
+                         "Meeting-Id" => @series.id
+
+    with_attached_ics(@series, user) do
+      subject = I18n.t("meeting.email.ended.header_series", title: @series.title)
+
+      mail(to: user, subject: "[#{@series.project.name}] #{subject}")
+    end
+  end
+
   def icalendar_notification(meeting, user, _actor, **)
     @meeting = meeting
 

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -119,7 +119,7 @@ module Meetings
       add_instantiated_occurrences(recurring_meeting: recurring_meeting)
     end
 
-    def add_single_recurring_occurrence(scheduled_meeting:) # rubocop:disable Metrics/AbcSize
+    def add_single_recurring_occurrence(scheduled_meeting:, cancelled: false) # rubocop:disable Metrics/AbcSize
       recurring_meeting = scheduled_meeting.recurring_meeting
       meeting = scheduled_meeting.meeting
 
@@ -144,7 +144,7 @@ module Meetings
         e.location = meeting.location.presence
 
         add_attendees(event: e, meeting: meeting)
-        e.status = if scheduled_meeting.cancelled?
+        e.status = if cancelled || scheduled_meeting.cancelled?
                      "CANCELLED"
                    else
                      "CONFIRMED"

--- a/modules/meeting/app/services/recurring_meetings/end_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/end_service.rb
@@ -48,8 +48,9 @@ module RecurringMeetings
         .call(end_after: "specific_date", end_date: Time.zone.yesterday)
 
       result.on_success do
+        send_cancellation_for_future_instantiated_occurrences if recurring_meeting.notify?
         remove_scheduled_meetings
-        remove_future_occurrences
+        send_ended_mail if recurring_meeting.notify?
       end
 
       result
@@ -57,17 +58,47 @@ module RecurringMeetings
 
     private
 
-    ##
-    # Remove any upcoming scheduled meetings (e.g., those that are instantiated or cancelled)
-    def remove_scheduled_meetings
-      recurring_meeting.scheduled_meetings.upcoming.destroy_all
+    def send_cancellation_for_future_instantiated_occurrences # rubocop:disable Metrics/AbcSize
+      recurring_meeting.scheduled_meetings.upcoming.instantiated.find_each do |scheduled_meeting|
+        meeting = scheduled_meeting.meeting
+
+        meeting.participants.where(invited: true).find_each do |participant|
+          MeetingMailer
+            .cancelled(meeting, participant.user, current_user)
+            .deliver_now
+        rescue StandardError => e
+          Rails.logger.error do
+            "Failed to deliver cancellation for meeting #{meeting.id} to #{participant.user.mail}: #{e.message}"
+          end
+        end
+      end
     end
 
     ##
-    # Remove all actual future occurrences of the meeting that remained.
-    # We do not use the DeleteService as that would send out notifications
-    def remove_future_occurrences
-      recurring_meeting.scheduled_instances.destroy_all
+    # Delete any upcoming scheduled meetings and their instantiated meetings
+    # (e.g., those that are instantiated or non-instantiated)
+    def remove_scheduled_meetings
+      upcoming = recurring_meeting.scheduled_meetings.upcoming
+
+      # First destroy the instantiated meetings
+      upcoming.instantiated.find_each do |scheduled|
+        scheduled.meeting.destroy!
+      end
+
+      # Then destroy all scheduled meetings
+      upcoming.destroy_all
+    end
+
+    def send_ended_mail # rubocop:disable Metrics/AbcSize
+      recurring_meeting.template.participants.where(invited: true).find_each do |participant|
+        MeetingMailer
+          .ended_series(recurring_meeting, participant.user, User.current)
+          .deliver_now
+      rescue StandardError => e
+        Rails.logger.error do
+          "Failed to deliver series ended notification for #{recurring_meeting.id} to #{participant.user.mail}: #{e.message}"
+        end
+      end
     end
   end
 end

--- a/modules/meeting/app/services/recurring_meetings/ical_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/ical_service.rb
@@ -57,7 +57,7 @@ module RecurringMeetings
     def generate_single_occurrence(meeting:, cancelled: false) # rubocop:disable Metrics/AbcSize
       User.execute_as(user) do
         calendar = Meetings::IcalendarBuilder.new(timezone: Time.zone || Time.zone_default)
-        calendar.add_single_recurring_occurrence(scheduled_meeting: meeting.scheduled_meeting)
+        calendar.add_single_recurring_occurrence(scheduled_meeting: meeting.scheduled_meeting, cancelled:)
         calendar.update_calendar_status(cancelled:)
 
         ServiceResult.success(result: calendar.to_ical)

--- a/modules/meeting/app/views/meeting_mailer/ended_series.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/ended_series.html.erb
@@ -1,0 +1,77 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= render layout: "mailer/spacer_table" do %>
+  <%= render partial: "mailer/mailer_header",
+             locals: {
+               user: @user,
+               summary: I18n.t("meeting.email.ended.summary_series", title: @series.title, actor: @actor),
+               bottom_spacing: false
+             } %>
+
+  <%= render layout: "mailer/border_table" do %>
+    <tr>
+      <%= placeholder_cell("24px", vertical: true) %>
+      <td>
+        <table>
+          <tr>
+            <td style="<%= placeholder_text_styles(width: "30%") %>">
+              <%= t(:label_recurring_meeting_schedule) %>
+            </td>
+            <td style="<%= placeholder_text_styles %>">
+              <%= @series.full_schedule_in_words %> (<%= formatted_time_zone_offset %>)
+            </td>
+          </tr>
+          <tr>
+            <td style="<%= placeholder_text_styles(width: "30%") %>">
+              <%= Meeting.human_attribute_name(:project) %>
+            </td>
+            <td style="<%= placeholder_text_styles %>">
+              <%= link_to @series.project.name, project_url(@series.project) %>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  <% end %>
+
+  <table>
+    <tr>
+      <%= placeholder_cell("20px", vertical: false) %>
+    </tr>
+  </table>
+
+  <%= action_button do %>
+    <%= link_to I18n.t(:label_view_meeting_series),
+                recurring_meeting_url(@series),
+                target: "_blank",
+                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;",
+                rel: "noopener" %>
+  <% end %>
+<% end %>

--- a/modules/meeting/app/views/meeting_mailer/ended_series.text.erb
+++ b/modules/meeting/app/views/meeting_mailer/ended_series.text.erb
@@ -1,0 +1,38 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= I18n.t(
+      "meeting.email.ended.summary_series",
+      title: @series.title,
+      actor: @actor
+    ) %>
+
+<%= @series.project.name %>: <%= @series.title %> (<%= recurring_meeting_url(@series) %>)
+<%= @series.author %>
+<%= t :label_recurring_meeting_schedule %>: <%= @series.full_schedule_in_words %> (<%= formatted_time_zone_offset %>)

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -253,6 +253,9 @@ en:
         summary_series: "Meeting series '%{title}' has been cancelled by %{actor}."
         summary: "'%{title}' has been cancelled by %{actor}."
         date_time: "Scheduled date/time"
+      ended:
+        header_series: "Ended: Meeting series '%{title}'"
+        summary_series: "Meeting series '%{title}' has been ended by %{actor}."
       updated:
         header: "Meeting '%{title}' has been updated"
         summary: "Meeting '%{title}' has been updated by %{actor}"

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_end_series_spec.rb
@@ -90,6 +90,40 @@ RSpec.describe "Recurring meetings end series", :js do
     expect(page).to have_text("Meeting series ended")
   end
 
+  context "with invited participants" do
+    let(:participant) do
+      create(:user,
+             member_with_permissions: { project => %i[view_meetings] })
+    end
+
+    before do
+      meeting.template.participants.create!(user: participant, invited: true)
+    end
+
+    it "sends series ended emails to each participant" do
+      show_page.visit!
+
+      show_page.end_meeting_series
+      show_page.within_modal "End meeting series" do
+        retry_block do
+          check "I understand that this deletion cannot be reversed", allow_label_click: true
+          click_on "End series now"
+        end
+      end
+
+      expect(page).to have_text("Meeting series ended")
+
+      perform_enqueued_jobs
+
+      expect(ActionMailer::Base.deliveries.size).to eq 2
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+        .to contain_exactly user.mail, participant.mail
+      subject = ActionMailer::Base.deliveries.map(&:subject).uniq.first
+      expect(subject).to include("Ended:")
+      expect(subject).to include(meeting.title)
+    end
+  end
+
   context "when meeting start time is in the future" do
     before do
       meeting.update! start_time: DateTime.parse("2025-01-30T10:30:00Z")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70111

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Add a series ended email that is sent out as part of `end_service`


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add a mailer similar to the existing `cancelled_series` that is sent out for the entire series
- Update `end_service` to also send out individual occurrence cancellations for future instantiated occurrences so they are not left orphaned
- Delete future instantiated occurrences and associated scheduled meetings as part of the service (previously, these continued to exist but were unreachable unless via url)
- Remove duplicate calls in the service (`.scheduled_instances` and `.scheduled_meetings.upcoming` had the same results)

# Merge checklist

- [x] Added/updated tests