### PR TITLE
Add field initializer for status on portfolio and program

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
@@ -135,6 +135,8 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
         ['estimatedTime', 'remainingTime', 'percentageDone'],
       )
       .addSpecificFieldType('Project', ProjectStatusEditFieldComponent, 'status', ['status'])
+      .addSpecificFieldType('Portfolio', ProjectStatusEditFieldComponent, 'status', ['status'])
+      .addSpecificFieldType('Program', ProjectStatusEditFieldComponent, 'status', ['status'])
       .addSpecificFieldType('TimeEntry', PlainFormattableEditFieldComponent, 'comment', ['comment'])
       .addSpecificFieldType('TimeEntry', HoursDurationEditFieldComponent, 'hours', ['hours']);
 


### PR DESCRIPTION
I couldn't reproduce this locally, but the error looks like it fails to select the status field component, which is only defined for a "Project" type.

https://community.openproject.org/projects/openproject/work_packages/69921/activity
