### PR TITLE
[#63744] Make Project Settings form subheadings go full width

### DIFF
--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
 
-<%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
   <%=
     render(Primer::Beta::Subhead.new) do |component|
       component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_details") }
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
   %>
 <% end %>
 
-<%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
   <%=
     render(Primer::Beta::Subhead.new) do |component|
       component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_status") }
@@ -66,7 +66,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% if parent_allowed? %>
-  <%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+  <%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
     <%=
       render(Primer::Beta::Subhead.new) do |component|
         component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_relations") }

--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,66 +25,62 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 
-<%=
-  flex_layout do |container|
-    container.with_row(mb: 3) do
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+  <%=
+    render(Primer::Beta::Subhead.new) do |component|
+      component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_details") }
+    end
+  %>
+  <%=
+    settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
+      render(
+        Primer::Forms::FormList.new(
+          Projects::Settings::NameForm.new(f),
+          Projects::Settings::DescriptionForm.new(f),
+          Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_details"))
+        )
+      )
+    end
+  %>
+<% end %>
+
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+  <%=
+    render(Primer::Beta::Subhead.new) do |component|
+      component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_status") }
+    end
+  %>
+  <%=
+    settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
+      render(
+        Primer::Forms::FormList.new(
+          Projects::StatusButtonComponent.new(project:, user: current_user),
+          Projects::Settings::StatusForm.new(f),
+          Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_status_description"))
+        )
+      )
+    end
+  %>
+<% end %>
+
+<% if parent_allowed? %>
+  <%= render(Primer::BaseComponent.new(tag: :section, mb: 3)) do %>
+    <%=
+      render(Primer::Beta::Subhead.new) do |component|
+        component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_relations") }
+      end
+    %>
+    <%=
       settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
-        concat(
-          render(Primer::Beta::Subhead.new) do |component|
-            component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_details") }
-          end
-        )
-        concat(
-          render(
-            Primer::Forms::FormList.new(
-              Projects::Settings::NameForm.new(f),
-              Projects::Settings::DescriptionForm.new(f),
-              Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_details"))
-            )
+        render(
+          Primer::Forms::FormList.new(
+            Projects::Settings::RelationsForm.new(f),
+            Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_parent_project"))
           )
         )
       end
-    end
-
-    container.with_row(mb: 3) do
-      settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
-        concat(
-          render(Primer::Beta::Subhead.new) do |component|
-            component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_status") }
-          end
-        )
-        concat(
-          render(
-            Primer::Forms::FormList.new(
-              Projects::StatusButtonComponent.new(project:, user: current_user),
-              Projects::Settings::StatusForm.new(f),
-              Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_status_description"))
-            )
-          )
-        )
-      end
-    end
-
-    if parent_allowed?
-      container.with_row(mb: 3) do
-        settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
-          concat(
-            render(Primer::Beta::Subhead.new) do |component|
-              component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_relations") }
-            end
-          )
-          concat(
-            render(
-              Primer::Forms::FormList.new(
-                Projects::Settings::RelationsForm.new(f),
-                Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_parent_project"))
-              )
-            )
-          )
-        end
-      end
-    end
-  end
-%>
+    %>
+  <% end %>
+<% end %>

--- a/app/views/projects/settings/general/show.html.erb
+++ b/app/views/projects/settings/general/show.html.erb
@@ -1,4 +1,4 @@
-<%#-- copyright
+<%# -- copyright
 OpenProject is an open source project management software.
 Copyright (C) the OpenProject GmbH
 
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.
 
-++#%>
+++# %>
 <%= render Projects::Settings::IndexPageHeaderComponent.new(project: @project) %>
 
 <%=
@@ -33,7 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
     render Primer::Alpha::Banner.new(
       scheme: :warning,
       icon: :alert,
-      mb: 2,
+      mb: 3,
       test_selector: "op-projects-public-warning"
     ) do |banner|
       banner.with_action_button(

--- a/spec/components/projects/settings/general/show_component_spec.rb
+++ b/spec/components/projects/settings/general/show_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Projects::Settings::General::ShowComponent, type: :component do
     it "renders a form" do
       render_component
 
-      expect(page.find(:heading, heading)).to have_ancestor "form"
+      expect(page.find(:section, heading)).to have_element :form
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/63744

# What are you trying to accomplish?

Ensure subheadings take up full page width.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1502" height="778" alt="Screenshot 2025-12-26 at 14 41 10" src="https://github.com/user-attachments/assets/2b685e72-23a5-40fc-949c-d3ba36d6d42d" /> | <img width="1508" height="785" alt="Screenshot 2025-12-26 at 14 40 45" src="https://github.com/user-attachments/assets/5510dd8f-0251-4b61-a097-80db378b59da" /> | 

# What approach did you choose and why?

This PR moves the subheadings (`Primer::Beta::Subhead`) outside of each of the individual forms, to ensure they take up the full width of the page.

I also removed the vertical flex layout, instead dividing the page using `section` tags with corresponding margins. This is both for good semantics and to ensure the feature specs (which rely on `within_section` from Capybara accessible selectors) still pass.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
