### PR TITLE
[#70191] Allow searching for work package types and status when selecting work package for time entries

### DIFF
--- a/app/components/work_package_relations_tab/add_work_package_hierarchy_form_component.html.erb
+++ b/app/components/work_package_relations_tab/add_work_package_hierarchy_form_component.html.erb
@@ -30,7 +30,7 @@
               visually_hide_label: false,
               autocomplete_options: {
                 resource: "work_packages",
-                searchKey: "subjectOrId",
+                searchKey: "typeahead",
                 url:,
                 openDirectly: false,
                 focusDirectly: true,

--- a/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
+++ b/app/components/work_package_relations_tab/work_package_relation_form_component.html.erb
@@ -46,7 +46,7 @@
                 autocomplete_options: {
                   resource: "work_packages",
                   url:,
-                  searchKey: "subjectOrId",
+                  searchKey: "typeahead",
                   openDirectly: false,
                   focusDirectly: true,
                   dropdownPosition: "bottom",

--- a/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subtasks/board-subtasks-action.service.ts
@@ -56,7 +56,7 @@ export class BoardSubtasksActionService extends BoardActionService {
     filters.add('project', '=', [this.currentProject.id || '']);
 
     if (matching) {
-      filters.add('subjectOrId', '**', [matching]);
+      filters.add('typeahead', '**', [matching]);
     }
 
     return this

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -74,7 +74,7 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
     const filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
     const results = this.querySpace.results.value;
 
-    filters.add('subjectOrId', '**', [searchString]);
+    filters.add('typeahead', '**', [searchString]);
 
     if (results && results.elements.length > 0) {
       filters.add('id', '!', results.elements.map((wp:WorkPackageResource) => wp.id!));

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -90,7 +90,7 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
       .apiV3Service
       .withOptionalProject(this.CurrentProject.id)
       .work_packages
-      .filtered(filters)
+      .filtered(filters, { sortBy: '[["updatedAt","desc"]]' })
       .get()
       .pipe(
         map((collection) => collection.elements),

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -114,8 +114,10 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
       .initialRequest$
       .pipe(
         switchMap((initialLoad) => {
-          // If we already loaded all values, just compare in the frontend
-          if (initialLoad.count === initialLoad.total) {
+          // If we already loaded all values, just compare in the frontend.
+          // However, for work package ID filter, always make XHR requests to use typeahead filter
+          // which supports searching by type and status names.
+          if (this.filter.id !== 'id' && initialLoad.count === initialLoad.total) {
             return this.matchingItems(this.filterEmptyElements(initialLoad.elements), matching);
           }
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -69,7 +69,7 @@ describe('autocompleter', () => {
 
     fixture.componentInstance.resource = 'work_packages' as TOpAutocompleterResource;
     fixture.componentInstance.filters = [];
-    fixture.componentInstance.searchKey = 'subjectOrId';
+    fixture.componentInstance.searchKey = 'typeahead';
     fixture.componentInstance.appendTo = 'body';
     fixture.componentInstance.multiple = false;
     fixture.componentInstance.closeOnSelect = true;

--- a/frontend/src/app/shared/components/fields/edit/field-types/work-package-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/work-package-edit-field.component.ts
@@ -81,7 +81,7 @@ export class WorkPackageEditFieldComponent extends SelectEditFieldComponent {
     if (query) {
       const filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
 
-      filters.add('subjectOrId', '**', [query]);
+      filters.add('typeahead', '**', [query]);
 
       filterParams = { filters: filters.toJson() };
     }

--- a/lib/primer/open_project/forms/dsl/work_package_autocompleter_input.rb
+++ b/lib/primer/open_project/forms/dsl/work_package_autocompleter_input.rb
@@ -9,7 +9,7 @@ module Primer
             options.reverse_merge(
               component: "opce-autocompleter",
               resource: "work_packages",
-              searchKey: "subjectOrId"
+              searchKey: "typeahead"
             )
           end
         end

--- a/lookbook/previews/open_project/common/autocomplete_preview/work_package.html.erb
+++ b/lookbook/previews/open_project/common/autocomplete_preview/work_package.html.erb
@@ -7,7 +7,7 @@
         visually_hide_label: true,
         autocomplete_options: {
           resource: "work_packages",
-          searchKey: "subjectOrId",
+          searchKey: "typeahead",
           openDirectly: false,
           focusDirectly: false,
           dropdownPosition: "bottom"

--- a/modules/costs/app/components/time_entries/entity_form.rb
+++ b/modules/costs/app/components/time_entries/entity_form.rb
@@ -54,7 +54,7 @@ module TimeEntries
                                        focusDirectly: false,
                                        append_to: "#time-entry-dialog",
                                        url: work_package_completer_url,
-                                       searchKey: "subjectOrId",
+                                       searchKey: "typeahead",
                                        filters: work_package_completer_filters
                                      }
       else

--- a/modules/reporting/lib/widget/filters/work_package.rb
+++ b/modules/reporting/lib/widget/filters/work_package.rb
@@ -47,7 +47,7 @@ class Widget::Filters::WorkPackage < Widget::Filters::Base
                                     model: selected_values.compact,
                                     url: ::API::V3::Utilities::PathHelper::ApiV3Path.work_packages,
                                     resource: "work_packages",
-                                    searchKey: "subjectOrId"
+                                    searchKey: "typeahead"
                                   },
                                   id: "#{filter_class.underscore_name}_select_1",
                                   class: "filter-value advanced-filters--ng-select"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70191

# What are you trying to accomplish?

I want to allow the same search and filter (type, status, meta status, project name) capabilities when picking a work package

- [x] to book time on
- [x] to add to board 
- [x] to create relations, parent or child 
- [x] to filter on work package IDs
  - [x] Don't filter on loaded data but always use the backend's full capabilities ([Oliver Günther](https://community.openproject.org/users/9177) Specially about this part I would love to know your opinion) 
- [x] to add to meeting agenda 
- [x] to filter cost reports

We already have  this in the global search and when hash mentioning a work package. Users get used to it and miss it in the other places.

# What approach did you choose and why?

This PR replaces the `subjectOrId` filters by `typeahead` filters which comes with more user friendly capabilities.

When filtering work packages by ID, the filter's frontend component allowed to search by subject or ID. And when the data set was already loaded to the frontend, it did search directly on the loaded data, as it does for other attributes. As I want the user to have all the typeahead features also in that situation, I added an exception so that it now will still use the backend for the typeahead logic. I am not sure if that has stronger performance implications as I don't know why that exactly it was built like this in the first place.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
