### PR TITLE
Revise LDAP group synchronization guide

### DIFF
--- a/docs/system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/README.md
+++ b/docs/system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/README.md
@@ -10,9 +10,8 @@ keywords: synchronize ldap groups
 
 Note: This feature is available for the Enterprise on-premises only, for OpenProject versions 7.4+. For more information and differences to Community edition, [see this page](https://www.openproject.org/enterprise-edition/).
 
-In OpenProject Enterprise on-premises, you can synchronize LDAP group memberships defined through the [groupOfNames](https://tools.ietf.org/html/rfc4519#section-3.5) LDAP object class. This guide assumes that you:
+In OpenProject Enterprise on-premises, you can provision and periodically synchronize groups and their members from your existing LDAP or Active Directory. Group memberships using the [groupOfNames](https://tools.ietf.org/html/rfc4519#section-3.5) LDAP object class are supported for this. This guide assumes that you:
 
-- have at least one group defined in OpenProject (See the “[Managing groups](../../../users-permissions/groups/)” guide for more information on how to create and edit groups),
 - have set up your LDAP authentication source (See the “[Manage LDAP authentication](../../ldap-connections/)” guide)
 - have at least one LDAP entry with a *groupOfNames* object class and members of that group to contain the *`memberOf: <DN of the group>`* attribute to determine the members of a group entry. Right now we do not support LDAP instances that only have *member* attributes, but not the inverse *memberOf* property.
 
@@ -25,49 +24,24 @@ For the sake of simplicity, we assume that in this guide, your LDAP structure lo
 
 You have two groups *cn=groupA,ou=groups,ou=example,ou=com and cn=groupB,ou=groups,ou=example,ou=com* with two and one users, respectively*.* Your base DN is *ou=people,ou=example,ou=com.*
 
-## LDAP group synchronization
+You can use this integration in the following two ways:
 
-LDAP group synchronization augments the memberships defined by  administrators in an existing OpenProject group. Important things to  note are:
-
-- Only existing groups and users in OpenProject can be synchronized. The functionality will not simply create all entries in the LDAP group  base nor will it synchronize users that do not exist in OpenProject.
-- Group synchronization have to be enabled by an administrator by creating a *synchronized LDAP group* that ties the OpenProject group to an LDAP entry.
-- Only synchronized memberships will be removed from the OpenProject group. If you want to add a user outside your LDAP authentication to an  OpenProject group, you can safely do so without the membership being  removed.
-
-## Configure LDAP group synchronization filters
-
-Instead of manually synchronizing groups from a given DN, you can also create filter objects that will query the LDAP not only for group members, but the groups themselves.
-
-When the synchronization task is executed, the filter is being queried against the LDAP and resulting group objects will be created as synchronized groups *and* as OpenProject groups.
-
-![LDAP synchronized filter form in OpenProject administration](openproject_system_guide_add_ldap_filter.png)
-
-### Create a synchronized filter
-
-To create a new synchronized filter, use the button on the top right of the index page. There, you will select your LDAP authentication source that should be queried. The following properties can be set:
-
-- **Name:** Name of the LDAP filter, only for organizational purposes
-- **Group name attribute:** The attribute used for naming the associated OpenProject groups.
-- **Sync users:** Check this option if you want members of all synchronized groups this filter creates to be automatically created in OpenProject. When unchecked, only members of any group that also are existing users in OpenProject can be synchronized.
-- **LDAP connection:** Select the LDAP connection you want this synchronized filter to use. Users created by group synchronization will be tied to that LDAP and may bind against it for authentication.
-- **Search base DN:** (optional) Enter the base DN of the LDAP subtree you want to perform the search in. If you leave this unset, the base DN of the LDAP connection will be used instead. The DN specified here must contain the base DN of the LDAP connection to be valid.
-- **LDAP filter:** The LDAP filter string to be used for identifying LDAP group entries to be synchronized with OpenProject.
-
-Click on *Create* to finish the creation of the synchronized  filter. This filter is being executed hourly as part of the background job before the actual group synchronization runs.
-
-> [!NOTE]
-> If you manually create a synchronized group that is also found by a filter, its properties (such as the *Sync users* setting) is being overridden by the filter setting.
-
-## Configure synchronized LDAP groups
+1. Synchronizing a single LDAP group
+2. Specifying an LDAP filter that targets a set of groups and their members
 
 In order to get to the LDAP group sync administration pane, expand the LDAP authentication menu item in your administration.
 
-### Define group base and key settings
+## Synchronized group: Synchronizing a single LDAP group
 
-In order for the LDAP groups plugin to locate your group entries, you first need to set the *group key* to **cn** (the identifying attribute of the group entries) and *group base* to **ou=groups,ou=example,ou=com** as shown in the following screenshot.
+Synchronizing a single LDAP group allows you to connect an existing group in OpenProject with one from LDAP.
 
-![LDAP group synchronization settings in OpenProject administration](openproject_system_guide_add_ldap_group.png)
+LDAP group synchronization extends the memberships defined by  administrators in an existing OpenProject group. Important things to  note are:
 
-### Create a synchronized group
+- You need to have created at least one manual group in the OpenProject administration before you continue.
+- Group synchronization for this group is enabled by an administrator cerating a *synchronized LDAP group* that ties the OpenProject group to an LDAP entry.
+- Only synchronized memberships will be removed from the OpenProject group. If you want to add a user outside your LDAP authentication to an OpenProject group, you can do so without the membership being affected from the group synchronization.
+
+### Single synchronized groups
 
 To create a new synchronized group, use the button on the top right  of the page. There, you will select your LDAP authentication source that contains the group, as well as the existing OpenProject group that  members should be synchronized to. The following options can be set:
 
@@ -88,6 +62,31 @@ sudo openproject run bundle exec rake ldap_groups:synchronize
 This method of creating synchronized groups is well-suited for a small number of groups, or a very individual set of groups that you need to synchronize. It is very flexible by allowing individual groups to synchronize users into OpenProject.
 
 If you need to synchronize a large number of groups that follow a common pattern, consider using the following filter functionality.
+
+
+## Automatic groups using synchronized filters
+
+Instead of manually synchronizing groups from a given group DN in your LDAP, you can also create filter objects that will query the LDAP not only for group members, but the groups themselves.
+
+When the synchronization task is executed, the filter is being queried against the LDAP and resulting group objects will be created as synchronized groups *and* as OpenProject groups.
+
+![LDAP synchronized filter form in OpenProject administration](openproject_system_guide_add_ldap_filter.png)
+
+### Create a synchronized filter
+
+To create a new synchronized filter, use the button on the top right of the index page. There, you will select your LDAP authentication source that should be queried. The following properties can be set:
+
+- **Name:** Name of the LDAP filter, only for organizational purposes
+- **Group name attribute:** The attribute used for naming the associated OpenProject groups.
+- **Sync users:** Check this option if you want members of all synchronized groups this filter creates to be automatically created in OpenProject. When unchecked, only members of any group that also are existing users in OpenProject can be synchronized.
+- **LDAP connection:** Select the LDAP connection you want this synchronized filter to use. Users created by group synchronization will be tied to that LDAP and may bind against it for authentication.
+- **Search base DN:** (optional) Enter the base DN of the LDAP subtree you want to perform the search in. If you leave this unset, the base DN of the LDAP connection will be used instead. The DN specified here must contain the base DN of the LDAP connection to be valid.
+- **LDAP filter:** The LDAP filter string to be used for identifying LDAP group entries to be synchronized with OpenProject.
+
+Click on *Create* to finish the creation of the synchronized  filter. This filter is being executed hourly as part of the background job before the actual group synchronization runs.
+
+> [!NOTE]
+> If you manually create a synchronized group that is also found by a filter, its properties (such as the *Sync users* setting) is being overridden by the filter setting.
 
 ## FAQ
 


### PR DESCRIPTION
Updated the LDAP group synchronization documentation to clarify the synchronization process and configuration options.