### PR TITLE
[64225] Add tabindex to the canvas

### DIFF
--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.html
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.html
@@ -5,6 +5,7 @@
     </p>
     <canvas baseChart
       role="img"
+      tabindex="0"
       aria-labelledby="chart-desc"
       [datasets]="chartData"
       [labels]="chartLabels"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64225

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add tabindex="0" to the canvas element to make it possible for the screen reader to read it.

## Screenshots
![ScreenRecording2026-01-05at11 45 52-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/76c1e8e6-f9b1-4851-b7b1-dd6c559f01a8)
