### PR TITLE
[69677] Project creation modal: Screen overflow on mobile

### DIFF
--- a/app/components/step_wizard/footer_component.sass
+++ b/app/components/step_wizard/footer_component.sass
@@ -37,6 +37,9 @@
   gap: var(--base-size-16, 1rem)
   align-items: center
 
+  @media screen and (max-width: $breakpoint-sm)
+    grid-template-columns: 1fr 1fr
+
   &--actions-left,
   &--actions-right
     display: flex
@@ -53,6 +56,9 @@
     justify-content: center
     align-items: center
     margin: 0 auto
+
+    @media screen and (max-width: $breakpoint-sm)
+      display: none
 
   &--progress-bar
     width: 200px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69677

# What are you trying to accomplish?
Hide the progress bar on very small screens to gain more space for the buttons

## Screenshots

<img width="280" height="650" alt="Bildschirmfoto 2026-01-05 um 13 59 35" src="https://github.com/user-attachments/assets/c6c52ead-8105-4252-9e8b-effe30fa2c0c" />
