### PR TITLE
[69972] Inconsistent widget name for "project description" widget on project home page

### DIFF
--- a/modules/grids/app/components/grids/widgets/project_status.rb
+++ b/modules/grids/app/components/grids/widgets/project_status.rb
@@ -37,7 +37,7 @@ module Grids
       param :project
 
       def title
-        Project.human_attribute_name(:status_code)
+        Project.human_attribute_name(:status)
       end
     end
   end

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -16,10 +16,10 @@ en:
         news:
           title: 'News'
         project_description:
-          title: 'Project description'
+          title: 'Description'
           no_results: "No description has been written yet. One can be provided in the 'Project settings'."
         project_status:
-          title: 'Project status'
+          title: 'Status'
           not_started: 'Not started'
           on_track: 'On track'
           off_track: 'Off track'


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69972

# What are you trying to accomplish?
Omit the word "project" from the widget titles since they also apply for programs and portfolios

