### PR TITLE
[#70184] Fix Export icon in Projects list menu

### DIFF
--- a/app/components/projects/index_page_header_component.html.erb
+++ b/app/components/projects/index_page_header_component.html.erb
@@ -132,7 +132,7 @@
             href: export_list_modal_projects_path(projects_query_params),
             content_arguments: { data: { controller: "async-dialog" }, rel: "nofollow" }
           ) do |item|
-            item.with_leading_visual_icon(icon: "sign-out")
+            item.with_leading_visual_icon(icon: :download)
           end
         end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70184

# What are you trying to accomplish?

Use "Download" rather than "Sign Out" icon.

## Screenshots

### Before

<img width="988" height="310" alt="Screenshot 2026-01-05 at 11 40 09" src="https://github.com/user-attachments/assets/dfb64387-0a39-4da4-b54f-219088608d08" />

### After

<img width="992" height="311" alt="image" src="https://github.com/user-attachments/assets/53b8ca09-3fbe-4afb-8a6a-efb7053ba8d7" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
