### PR TITLE
[#70004] Special letters like Umlaute in file links to project initiation requests

### DIFF
--- a/spec/models/exports/exporter_spec.rb
+++ b/spec/models/exports/exporter_spec.rb
@@ -27,54 +27,31 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-module Exports
-  class Exporter
-    include Redmine::I18n
-    include ActionView::Helpers::TextHelper
-    include ActionView::Helpers::NumberHelper
 
-    attr_accessor :object,
-                  :options,
-                  :current_user
+require "rails_helper"
 
-    class_attribute :model
+RSpec.describe Exports::Exporter do
+  let(:exporter) { described_class.new(nil) }
 
-    def initialize(object, options = {})
-      self.object = object
-      self.options = options
-      self.current_user = options.fetch(:current_user) { User.current }
+  context "with sane_filename" do
+    it "normalizes and replaces separators with underscores" do
+      expect(exporter.sane_filename("two  words.ext")).to eq("two_words.ext")
     end
 
-    def self.key
-      name.demodulize.underscore.to_sym
+    it "removes symbols may cause problems in popular filesystem" do
+      expect(exporter.sane_filename("invalid // , : \\ removed.ext")).to eq("invalid_removed.ext")
     end
 
-    # Remove characters that could cause problems on popular OSses
-    def sane_filename(name)
-      parts = name.split /(?<=.)\.(?=[^.])(?!.*\.[^.])/m
+    it "uses local aware transliteration of e.g. umlauts" do
+      expect(exporter.sane_filename("ä ö ü ß ẞ.ext")).to eq("a_o_u_ss_SS.ext")
 
-      parts.map! do |s|
-        # Preserve the file extension avoid eg. .xls => .khls for some languages
-        s.match?(/\A\.[a-zA-Z]+\z/) ? s : I18n.transliterate(s).gsub(/[^a-z0-9-]+/i, "_")
+      I18n.with_locale(:de) do
+        expect(exporter.sane_filename("ä ö ü ß ẞ.ext")).to eq("ae_oe_ue_ss_SS.ext")
       end
 
-      parts.join "."
-    end
-
-    # Run the export, yielding the result of the render output
-    def export!
-      raise NotImplementedError
-    end
-
-    protected
-
-    def formatter_for(attribute, export_format)
-      ::Exports::Register.formatter_for(model, attribute, export_format)
-    end
-
-    def format_attribute(object, attribute, export_format, **)
-      formatter = formatter_for(attribute, export_format)
-      formatter.format(object, **)
+      I18n.with_locale(:uk) do
+        expect(exporter.sane_filename("Київ.ext")).to eq("Kyiv.ext")
+      end
     end
   end
 end

--- a/spec/models/exports/exporter_spec.rb
+++ b/spec/models/exports/exporter_spec.rb
@@ -33,16 +33,16 @@ require "rails_helper"
 RSpec.describe Exports::Exporter do
   let(:exporter) { described_class.new(nil) }
 
-  context "with sane_filename" do
+  context "with #sane_filename" do
     it "normalizes and replaces separators with underscores" do
       expect(exporter.sane_filename("two  words.ext")).to eq("two_words.ext")
     end
 
-    it "removes symbols may cause problems in popular filesystem" do
+    it "removes symbols that may cause problems with popular filesystem" do
       expect(exporter.sane_filename("invalid // , : \\ removed.ext")).to eq("invalid_removed.ext")
     end
 
-    it "uses local aware transliteration of e.g. umlauts" do
+    it "uses locale aware transliteration of e.g. umlauts" do
       expect(exporter.sane_filename("ä ö ü ß ẞ.ext")).to eq("a_o_u_ss_SS.ext")
 
       I18n.with_locale(:de) do

--- a/spec/workers/work_packages/exports/export_job_integration_spec.rb
+++ b/spec/workers/work_packages/exports/export_job_integration_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe WorkPackages::ExportJob, "Integration" do
       expect(job_status.status).to eq "success"
 
       attachment = export.attachments.last
-      expected = "Foo_Bla_Report_No._4_2021_with_for_Case_42_Query_report_04_2021__#{test_time_s}.pdf"
+      expected = "Foo_Bla_Report_No._4_2021_with_for_Case_42_Query_report_04_2021_aou_#{test_time_s}.pdf"
       expect(attachment.filename).to eq expected
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70004

# What are you trying to accomplish?

Previously all special characters would be removed from a filename created by any exporter (XLS, CVS, PDF, ...) and replaced with an underscore. This is unsightly for latin languages and horrible for non-latin languages.

# What approach did you choose and why?

As a workaround until we know if special characters can be used directly (this could have consequences to file storage, proxy servers, etc.) a **transliteration** is used with the exporting user locale. E.g. in a German locale "Über" => "Ueber" or with Ukrainian locale "Київ" =>  "Kyiv".

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
