### PR TITLE
[#70006] Fix grammar on attribute help texts form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
 
   attribute_help_texts:
     caption: "This short version will be displayed as caption of the attribute."
-    note_public: "Any text and images you add to this field is publicly visible to all logged in users."
+    note_public: "Any text and images you add to this field are publicly visible to all logged in users."
     text_overview: "In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute."
     show_preview: "Preview text"
     add_new: "Add help text"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70006

# What are you trying to accomplish?

Fixes grammar on attribute help texts form. Replaces:

> Any text and images you add to this field is publicly visible to all logged in users.

with: 

> Any text and images you add to this field _are_ publicly visible to all logged in users


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
