### PR TITLE
[#70183] Fix Work Package Export dialog resizing on switching format

### DIFF
--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -1,7 +1,7 @@
 <%= render(
       Primer::Alpha::Dialog.new(
         title: I18n.t("export.dialog.title"),
-        size: :xlarge,
+        size: :medium_portrait,
         id: MODAL_ID,
         data: {
           controller: "work-packages--export--dialog"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70183

# What are you trying to accomplish?

Fixes Work Package Export dialog resizing by changing size to `medium_portrait`.

## Screenshots

|        | BEFORE | AFTER |
|--------|--------|--------|
| CSV | <img width="987" height="491" alt="Screenshot 2026-01-05 at 13 36 53" src="https://github.com/user-attachments/assets/62acdfc8-8241-4bd6-aecd-168f91782eb7" /> | <img width="505" height="545" alt="Screenshot 2026-01-05 at 13 36 11" src="https://github.com/user-attachments/assets/cce61557-b066-470f-98ca-b64e2c6e385e" /> |
| PDF | <img width="985" height="623" alt="Screenshot 2026-01-05 at 13 36 47" src="https://github.com/user-attachments/assets/3b677b8b-f13a-43b5-a5f0-3be54e47b3a4" /> | <img width="498" height="625" alt="Screenshot 2026-01-05 at 13 36 18" src="https://github.com/user-attachments/assets/b7708812-2bc8-4ad8-879a-627a845031b6" /> | 


# What approach did you choose and why?

This PR makes the Export dialog portrait - which IMO looks better.  An alternative strategy could be to add a minimum height, but I think that probably warrants discussion with UX/UI team first.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
