### PR TITLE
[70244] Waffle icon is too small

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -91,6 +91,10 @@ ul.SegmentedControl,
   align-self: center
   min-width: var(--control-medium-size)
 
+  &.op-app-header--modules-menu-button svg
+    height: 20px
+    width: 20px
+
   &:hover
     color: var(--header-item-font-hover-color)
 

--- a/lib/redmine/menu_manager/top_menu/module_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/module_menu.rb
@@ -38,7 +38,8 @@ module Redmine::MenuManager::TopMenu::ModuleMenu
                                        position: :left) do |dialog|
         dialog.with_show_button(icon: "op-grid-menu",
                                 scheme: :invisible,
-                                classes: "op-app-header--primer-button",
+                                size: :large,
+                                classes: "op-app-header--primer-button op-app-header--modules-menu-button",
                                 test_selector: "op-app-header--modules-menu-button",
                                 "aria-controls": "op-app-header--modules-menu-list",
                                 "aria-label": I18n.t("label_global_modules"))


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70244

# What are you trying to accomplish?
Experiment with increased waffle icon

## Screenshots
<img width="1978" height="62" alt="Bildschirmfoto 2026-01-07 um 14 06 38" src="https://github.com/user-attachments/assets/78cdd2fb-1c6f-4fe3-a762-c1bdfe22364a" />
