### PR TITLE
Bug/70217 missing wrong translations for required project attributes

### DIFF
--- a/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/project_custom_field_sections/custom_field_row_component.html.erb
@@ -26,7 +26,7 @@
         if @project_custom_field.required?
           title_container.with_column(pt: 1) do
             render(Primer::Beta::Label.new(scheme: :attention, size: :medium)) do
-              t("label_required")
+              ProjectCustomField.human_attribute_name(:required)
             end
           end
         end

--- a/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/projects/settings/project_custom_field_sections/custom_field_row_component.html.erb
@@ -26,7 +26,7 @@
         if @project_custom_field.required?
           title_container.with_column(pt: 1) do
             render(Primer::Beta::Label.new(scheme: :attention, size: :medium)) do
-              t("label_required")
+              ProjectCustomField.human_attribute_name(:required)
             end
           end
         end

--- a/app/components/settings/project_custom_field_sections/custom_field_row_component.html.erb
+++ b/app/components/settings/project_custom_field_sections/custom_field_row_component.html.erb
@@ -34,7 +34,7 @@
         if @project_custom_field.required?
           content_container.with_column do
             render(Primer::Beta::Label.new(scheme: :attention, size: :medium)) do
-              t("label_required")
+              ProjectCustomField.human_attribute_name(:required)
             end
           end
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1374,7 +1374,6 @@ en:
         work_packages: "Work Packages"
         workspace_type: "Workspace type"
       project_custom_field:
-        is_required: "Required"
         custom_field_section: Section
       subproject_template_assignment:
         workspace_type: "Workspace type"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,7 +379,7 @@ en:
     instructions:
       is_required:
         all: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new resources. Existing resources will not require a value when being updated."
-        project: "Check to enable this attribute and make it required in all projects. It cannot be deactivated for individual projects. Existing projects will not require a value when being updated."
+        project: "Required attributes need to be filled out by the user on project creation if the field is active ('For all projects' set or copying from a project/template in which the field is active). Existing projects will not require a value when being updated."
       is_for_all:
         all: "Mark the custom field as available in all existing and new projects."
         project: "Mark the attribute as available in all existing and new projects."


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70217

# What are you trying to accomplish?

* Clarify 'is required' for project attributes
* Avoid using the generic 'is_required' label in favor of using the attribute translation as this avoids using e.g. "benötigt von" in German which is off. This is done in all the lists where custom fields are marked as "required"
* removing the override of 'is_required' for `project_custom_fields` as that is again the same as for `custom_fields`. One less i18n key.

## Screenshots

Changed pill labels in lists (locale is de)

<img width="1255" height="342" alt="image" src="https://github.com/user-attachments/assets/7910efbc-6396-4851-84d0-8375479c2f6a" />

Changed caption (locale is en)

<img width="774" height="147" alt="image" src="https://github.com/user-attachments/assets/413e931a-9b80-4c9f-a12e-88c27503f484" />
