### PR TITLE
rename `Project status` to `Status`

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -561,7 +561,7 @@ en:
         text: "This action will not delete any project the list contains. Are you sure you want to delete this project list?"
     settings:
       header_details: Basic details
-      header_status: Project status
+      header_status: Status
       header_relations: Project relations
       button_update_details: Update details
       button_update_status_description: Update status description
@@ -668,7 +668,7 @@ en:
           Select which project attributes should be included in the project initiation request.
           This list only includes [project attributes](project_attributes_url) enabled for for this project.
     status:
-      button_edit: Edit project status
+      button_edit: Edit status
     wizard:
       sidebar_content_title: "Content"
       sections: "Sections"
@@ -1349,8 +1349,8 @@ en:
           true: "public"
           false: "private"
         queries: "Queries"
-        status_code: "Project status"
-        status_explanation: "Project status description"
+        status_code: "Status"
+        status_explanation: "Status description"
         status_codes:
           not_started: "Not started"
           on_track: "On track"
@@ -2693,7 +2693,7 @@ en:
 
   enumeration_activities: "Time tracking activities"
   enumeration_work_package_priorities: "Work package priorities"
-  enumeration_reported_project_statuses: "Reported project status"
+  enumeration_reported_project_statuses: "Reported status"
   enumeration_caption_order_changed: "Order successfully changed."
   enumeration_could_not_be_moved: "Enumeration could not be moved."
 

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -19,7 +19,7 @@ en:
           title: 'Project description'
           no_results: "No description has been written yet. One can be provided in the 'Project settings'."
         project_status:
-          title: 'Project status'
+          title: 'Status'
           not_started: 'Not started'
           on_track: 'On track'
           off_track: 'Off track'
@@ -28,7 +28,7 @@ en:
           finished: 'Finished'
           discontinued: 'Discontinued'
         project_status_beta:
-          title: 'Project status (BETA)'
+          title: 'Status (BETA)'
         subprojects:
           title: 'Subitems'
         project_favorites:

--- a/spec/components/projects/settings/general/show_component_spec.rb
+++ b/spec/components/projects/settings/general/show_component_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Projects::Settings::General::ShowComponent, type: :component do
     end
   end
 
-  describe "Project status" do
-    it_behaves_like "section with heading", "Project status"
+  describe "Status" do
+    it_behaves_like "section with heading", "Status"
 
     it "renders field" do
       expect(render_component).to have_element "opce-ckeditor-augmented-textarea",

--- a/spec/components/projects/status_button_component_spec.rb
+++ b/spec/components/projects/status_button_component_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
 
     context "when status code is not set" do
       it "renders an enabled button" do
-        expect(subject).to have_button "Not set", disabled: false, aria: { label: "Edit project status" }
+        expect(subject).to have_button "Not set", disabled: false, aria: { label: "Edit status" }
       end
 
       it "renders a Primer ActionMenu (single variant)" do
@@ -97,7 +97,7 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
         expect(subject).to have_element "action-menu", class: "op-status-button"
       end
 
-      it "renders project status options" do
+      it "renders status options" do
         subject
 
         expect(page).to have_menu do
@@ -134,7 +134,7 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
       let(:status_code) { :on_track }
 
       it "renders an enabled button" do
-        expect(subject).to have_button "On track", disabled: false, aria: { label: "Edit project status" }
+        expect(subject).to have_button "On track", disabled: false, aria: { label: "Edit status" }
       end
 
       it "renders a Primer ActionMenu (single variant)" do
@@ -142,7 +142,7 @@ RSpec.describe Projects::StatusButtonComponent, type: :component do
         expect(subject).to have_element "action-menu", class: "op-status-button"
       end
 
-      it "renders project status options" do
+      it "renders status options" do
         subject
 
         expect(page).to have_menu do

--- a/spec/features/activities/activity_page_navigation_spec.rb
+++ b/spec/features/activities/activity_page_navigation_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe "Activity page navigation", :js do
         ensure_project_details_filter_is_checked
 
         expect(page).to have_link(text: "Details")
-        expect(page.text).to include("Project status description set (Details)")
+        expect(page.text).to include("Status description set (Details)")
         within ".op-activity-list" do
           click_link("Details")
         end

--- a/spec/features/activities/project_attributes_activity_spec.rb
+++ b/spec/features/activities/project_attributes_activity_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe "Project attributes activity", :js do
         # own fields
         activity_page.expect_activity("Name changed from #{project_was.name} to #{project.name}")
         activity_page.expect_activity("Description set (Details)")
-        activity_page.expect_activity("Project status set to On track")
-        activity_page.expect_activity("Project status description set (Details)")
+        activity_page.expect_activity("Status set to On track")
+        activity_page.expect_activity("Status description set (Details)")
         activity_page.expect_activity("Visibility set to public")
         activity_page.expect_activity("No longer subproject of #{parent_project.name}")
         activity_page.expect_activity("Project unarchived")
@@ -158,8 +158,8 @@ RSpec.describe "Project attributes activity", :js do
         # own fields
         activity_page.expect_activity("Name changed from #{project_was.name} to #{project.name}")
         activity_page.expect_activity("Description set (Details)")
-        activity_page.expect_activity("Project status set to On track")
-        activity_page.expect_activity("Project status description set (Details)")
+        activity_page.expect_activity("Status set to On track")
+        activity_page.expect_activity("Status description set (Details)")
         activity_page.expect_activity("Visibility set to public")
         activity_page.expect_activity("No longer subproject of #{parent_project.name}")
         activity_page.expect_activity("Project unarchived")

--- a/spec/features/projects/attribute_help_texts_spec.rb
+++ b/spec/features/projects/attribute_help_texts_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Project attribute help texts", :js, with_flag: { new_project_ove
     grid = create(:grid)
     grid.widgets << create(:grid_widget,
                            identifier: "project_status",
-                           options: { "name" => "Project status" },
+                           options: { "name" => "Status" },
                            start_row: 1,
                            end_row: 2,
                            start_column: 1,

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -117,14 +117,14 @@ RSpec.describe "Projects", "editing settings", :js do
     end
   end
 
-  describe "editing project status" do
+  describe "editing status" do
     before do
       Pages::Projects::Settings::General.new(project).visit!
     end
 
     it "sets the project status" do
-      within_section "Project status" do
-        click_on "Edit project status"
+      within_section "Status" do
+        click_on "Edit status"
 
         within :menu, "Not set" do
           find(:menuitem, "Not started").click
@@ -133,8 +133,8 @@ RSpec.describe "Projects", "editing settings", :js do
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
-      within_section "Project status" do
-        button = find_button("Edit project status")
+      within_section "Status" do
+        button = find_button("Edit status")
         expect(button).to have_text "Not started"
         button.click
 
@@ -143,8 +143,8 @@ RSpec.describe "Projects", "editing settings", :js do
     end
 
     it "unsets the project status" do
-      within_section "Project status" do
-        click_on "Edit project status"
+      within_section "Status" do
+        click_on "Edit status"
 
         within :menu, "Not set" do
           find(:menuitem, "Finished").click
@@ -153,8 +153,8 @@ RSpec.describe "Projects", "editing settings", :js do
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
-      within_section "Project status" do
-        click_on "Edit project status"
+      within_section "Status" do
+        click_on "Edit status"
 
         within :menu, "Finished" do
           find(:menuitem, "Not set").click
@@ -163,8 +163,8 @@ RSpec.describe "Projects", "editing settings", :js do
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
-      within_section "Project status" do
-        button = find_button("Edit project status")
+      within_section "Status" do
+        button = find_button("Edit status")
         expect(button).to have_text "Not set"
         button.click
 
@@ -173,16 +173,16 @@ RSpec.describe "Projects", "editing settings", :js do
     end
 
     it "updates the project status description" do
-      within_section "Project status" do
-        fill_in_rich_text "Project status description", with: "Light-years behind 🥺"
+      within_section "Status" do
+        fill_in_rich_text "Status description", with: "Light-years behind 🥺"
 
         click_on "Update status description"
       end
 
       expect_and_dismiss_flash type: :success, message: "Successful update."
 
-      within_section "Project status" do
-        expect(page).to have_selector :rich_text, "Project status description", text: "Light-years behind 🥺"
+      within_section "Status" do
+        expect(page).to have_selector :rich_text, "Status description", text: "Light-years behind 🥺"
       end
     end
   end
@@ -242,13 +242,13 @@ RSpec.describe "Projects", "editing settings", :js do
       it "shows field labels without help text link" do
         general_page.expect_field_label_without_help_text "Name"
         general_page.expect_field_label_without_help_text "Description"
-        general_page.expect_field_label_without_help_text "Project status description"
+        general_page.expect_field_label_without_help_text "Status description"
         general_page.expect_field_label_without_help_text "Subproject of"
       end
 
       it "does not show help text link next to status button" do
-        within_section "Project status" do
-          button = find_button("Edit project status")
+        within_section "Status" do
+          button = find_button("Edit status")
           expect(page).to have_no_link accessible_name: "Show help text", right_of: button
         end
       end
@@ -268,13 +268,13 @@ RSpec.describe "Projects", "editing settings", :js do
       it "shows field labels with help text link" do
         general_page.expect_field_label_with_help_text "Name"
         general_page.expect_field_label_with_help_text "Description"
-        general_page.expect_field_label_with_help_text "Project status description"
+        general_page.expect_field_label_with_help_text "Status description"
         general_page.expect_field_label_with_help_text "Subproject of"
       end
 
       it "shows help text link next to status button", :selenium do
-        within_section "Project status" do
-          button = find_button("Edit project status")
+        within_section "Status" do
+          button = find_button("Edit status")
           expect(page).to have_link accessible_name: "Show help text", right_of: button
         end
       end

--- a/spec/features/projects/lists/columns_spec.rb
+++ b/spec/features/projects/lists/columns_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
 
       projects_page.set_columns("Name", "Status", integer_custom_field.name)
 
-      projects_page.expect_no_columns("Public", "Description", "Project status description")
+      projects_page.expect_no_columns("Public", "Description", "Project description")
 
       projects_page.within_row(project) do
         expect(page)

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       projects_page.open_filters
 
       projects_page.set_filter("project_status_code",
-                               "Project status",
+                               "Status",
                                "is (OR)",
                                ["On track"])
       wait_for_reload
@@ -270,7 +270,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       expect(page).to have_no_text(no_status_project.name)
 
       projects_page.set_filter("project_status_code",
-                               "Project status",
+                               "Status",
                                "is not empty",
                                [])
       wait_for_reload
@@ -279,7 +279,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       expect(page).to have_no_text(no_status_project.name)
 
       projects_page.set_filter("project_status_code",
-                               "Project status",
+                               "Status",
                                "is empty",
                                [])
       wait_for_reload
@@ -288,7 +288,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       expect(page).to have_text(no_status_project.name)
 
       projects_page.set_filter("project_status_code",
-                               "Project status",
+                               "Status",
                                "is not",
                                ["On track"])
       wait_for_reload

--- a/spec/forms/projects/settings/status_form_spec.rb
+++ b/spec/forms/projects/settings/status_form_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Projects::Settings::StatusForm, type: :forms do
   let(:model) { build_stubbed(:project, status_explanation: "example status info") }
 
   it "renders status description field" do
-    expect(page).to have_field "Project status description", with: "example status info", visible: :hidden
+    expect(page).to have_field "Status description", with: "example status info", visible: :hidden
     expect(page).to have_element "opce-ckeditor-augmented-textarea",
                                  "data-test-selector": "augmented-text-area-status_explanation"
     expect(page).to have_element "opce-ckeditor-augmented-textarea", "data-qa-field-name": "statusExplanation"

--- a/spec/lib/open_project/journal_formatter/project_status_code_spec.rb
+++ b/spec/lib/open_project/journal_formatter/project_status_code_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OpenProject::JournalFormatter::ProjectStatusCode do
       let(:new_value) { status_code_as_integer("off_track") }
       let(:expected) do
         I18n.t(:text_journal_set_to,
-               label: "<strong>Project status</strong>",
+               label: "<strong>Status</strong>",
                value: "<i>Off track</i>")
       end
 
@@ -57,7 +57,7 @@ RSpec.describe OpenProject::JournalFormatter::ProjectStatusCode do
       let(:new_value) { nil }
       let(:expected) do
         I18n.t(:text_journal_deleted,
-               label: "<strong>Project status</strong>",
+               label: "<strong>Status</strong>",
                old: "<strike><i>Discontinued</i></strike>")
       end
 
@@ -69,7 +69,7 @@ RSpec.describe OpenProject::JournalFormatter::ProjectStatusCode do
       let(:new_value) { status_code_as_integer("on_track") }
       let(:expected) do
         I18n.t(:text_journal_changed_plain,
-               label: "<strong>Project status</strong>",
+               label: "<strong>Status</strong>",
                linebreak: nil,
                old: "<i>Off track</i>",
                new: "<i>On track</i>")

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -707,7 +707,7 @@ RSpec.describe Exports::PDF::Common::Macro do
       let(:markdown) { "projectLabel:status_code" }
 
       it "outputs the status label" do
-        expect(formatted).to eq("Project status")
+        expect(formatted).to eq("Status")
       end
     end
 

--- a/spec/models/projects/exports/pdf_spec.rb
+++ b/spec/models/projects/exports/pdf_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Projects::Exports::PDF do
       expected_document = [
         *expected_cover_page,
         project.name,
-        "Project status description", "some explanation",
+        "Status description", "some explanation",
         "1/1", export_time_formatted, query.name
       ].join(" ")
 

--- a/spec/models/queries/projects/filters/project_status_filter_spec.rb
+++ b/spec/models/queries/projects/filters/project_status_filter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Queries::Projects::Filters::ProjectStatusFilter do
     let(:model) { Project }
     let(:attribute) { :status_code }
     let(:values) { ["On track"] }
-    let(:human_name) { "Project status" }
+    let(:human_name) { "Status" }
     let(:admin) { build_stubbed(:admin) }
     let(:user) { build_stubbed(:user) }
     let(:expected) do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70142

# What are you trying to accomplish?

* Rename all occurrences of 'Project status' to 'Status.
  * This is only done for 'en' as the other locales will have to be renamed in crowdin
  * The (project) status widget is included in the renaming as the change itself is small but not doing it would be more work now and risk missing places later.  /cc @myabc 

