### PR TITLE
[70165] Page Header buttons disappear off the page when editing Workflow

### DIFF
--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -28,7 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_administration), t(:label_workflow_plural) -%>
 
-<%= render Workflows::EditPageHeaderComponent.new(tabs: workflow_tabs) %>
+<% content_for :content_header do %>
+  <%= render Workflows::EditPageHeaderComponent.new(tabs: workflow_tabs) %>
+<% end %>
 
 <%= styled_form_tag({}, method: "get") do %>
   <%= hidden_field_tag "tab", params[:tab] || "always" %>

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,12 +1,6 @@
 .controller-workflows
   #content-body
-    display: grid
-    grid-area: auto
-    padding-top: 0
     overflow-x: scroll
-
-    .workflows-page-header
-      padding-top: 1rem
 
 #workflow_form
   .generic-table--results-container


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70165

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Move page header of workflows table to content_header
