### PR TITLE
[FIX] Add Turbo Stream support for health status report

### DIFF
--- a/modules/storages/app/controllers/storages/admin/health_status_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/health_status_controller.rb
@@ -51,6 +51,7 @@ module Storages
 
         respond_to do |format|
           format.html
+          format.turbo_stream
           format.text do
             timestamp = (@report&.latest_timestamp || Time.zone.now).iso8601
             filename = "#{@storage.name.underscore}_health_report_#{timestamp}.txt"
@@ -62,7 +63,15 @@ module Storages
       def create
         create_and_cache_report
 
-        redirect_to admin_settings_storage_health_status_report_path(@storage), status: :see_other
+        respond_to do |format|
+          format.turbo_stream do
+            @report = Rails.cache.read(validator.report_cache_key)
+            render :show
+          end
+          format.html do
+            redirect_to admin_settings_storage_health_status_report_path(@storage), status: :see_other
+          end
+        end
       end
 
       def create_health_status_report

--- a/modules/storages/app/views/storages/admin/health_status/_health_status.html.erb
+++ b/modules/storages/app/views/storages/admin/health_status/_health_status.html.erb
@@ -1,0 +1,85 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% page_title = I18n.t("storages.health.title") %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { page_title }
+    header.with_description do
+      if @report.present?
+        I18n.t("storages.health.checked", datetime: format_time(@report.latest_timestamp))
+      else
+        I18n.t("storages.health.no_report")
+      end
+    end
+    header.with_breadcrumbs(
+      [
+        { href: admin_index_path, text: t("label_administration") },
+        { href: admin_settings_storages_path, text: t("project_module_storages") },
+        { href: edit_admin_settings_storage_path(@storage), text: @storage.name },
+        page_title
+      ]
+    )
+  end
+%>
+
+<%=
+  if @report.present?
+    button_label = I18n.t("storages.health.actions.rerun_checks")
+    download_label = I18n.t("storages.health.actions.download_report")
+
+    render(Primer::OpenProject::SubHeader.new) do |subheader|
+      subheader.with_action_button(
+        scheme: :secondary,
+        leading_icon: :download,
+        label: download_label,
+        tag: :a,
+        href: admin_settings_storage_health_status_report_path(@storage, format: :txt),
+        data: { turbo: true },
+      ) do
+        download_label
+      end
+
+      subheader.with_action_button(
+        scheme: :primary,
+        leading_icon: :plus,
+        label: button_label,
+        tag: :a,
+        href: admin_settings_storage_health_status_report_path(@storage),
+        data: { turbo_method: :post, turbo: true },
+      ) do
+        button_label
+      end
+    end
+  end
+%>
+
+<%= render(Storages::Admin::Health::HealthReportComponent.new(storage: @storage, report: @report)) %>
+

--- a/modules/storages/app/views/storages/admin/health_status/show.turbo_stream.erb
+++ b/modules/storages/app/views/storages/admin/health_status/show.turbo_stream.erb
@@ -16,7 +16,7 @@ of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
@@ -27,10 +27,5 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% page_title = I18n.t("storages.health.title") %>
+<%= turbo_stream.update "health_status_report", partial: "health_status" %>
 
-<% html_title(t(:label_administration), t(:project_module_storages), @storage.name, page_title) -%>
-
-<%= turbo_frame_tag "health_status_report", refresh: :morph do %>
-  <%= render "health_status" %>
-<% end %>

--- a/modules/storages/spec/controllers/storages/admin/health_status_controller_spec.rb
+++ b/modules/storages/spec/controllers/storages/admin/health_status_controller_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Storages::Admin::HealthStatusController do
       expect(response).to render_template "show"
     end
 
+    it "renders turbo_stream format when requested" do
+      get :show, params: params, as: :turbo_stream
+      expect(response).to be_successful
+      expect(response).to render_template "show"
+      expect(response.content_type).to include("text/vnd.turbo-stream.html")
+    end
+
     it "sends the text version of the report when requested" do
       # Creating an actual report result and caching it so we can test the rendering of the response
       validator = Storages::Adapters::Registry["nextcloud.validators.connection"].new(storage)
@@ -100,6 +107,14 @@ RSpec.describe Storages::Admin::HealthStatusController do
     it "creates and caches a health status report and redirects to show" do
       post :create, params: params
       expect(response.status).to redirect_to admin_settings_storage_health_status_report_path(storage)
+      expect(Rails.cache.read(cache_key)).to be_a(Storages::Adapters::ConnectionValidators::ValidatorResult)
+    end
+
+    it "creates and caches a health status report and renders turbo_stream when requested" do
+      post :create, params: params, as: :turbo_stream
+      expect(response).to be_successful
+      expect(response).to render_template "show"
+      expect(response.content_type).to include("text/vnd.turbo-stream.html")
       expect(Rails.cache.read(cache_key)).to be_a(Storages::Adapters::ConnectionValidators::ValidatorResult)
     end
   end


### PR DESCRIPTION
# Ticket
N/A

# What are you trying to accomplish?
Introduces Turbo Stream responses to the health status controller and views, enabling dynamic updates of the health status report without a full page reload. Refactors the view logic into a partial for reuse and adds a Turbo Stream template for report updates.

Before this fix, the report was not showing snow on the page. 

## Screenshots
<img width="1620" height="850" alt="Screenshot 2026-01-06 at 15 54 39" src="https://github.com/user-attachments/assets/f594d186-28ea-4aa2-b6b0-5ef2e8e93900" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
