### PR TITLE
[70290] Project copy nilifies user fields if members are excluded 

### DIFF
--- a/app/services/projects/copy/members_dependent_service.rb
+++ b/app/services/projects/copy/members_dependent_service.rb
@@ -66,7 +66,7 @@ module Projects::Copy
 
       # There should only be zero or one members in this new project
       # which gets created from the default +ProjectRole.in_new_project+ if enabled.
-      target_member = target.members.detect { |m| m.principal == member.user }
+      target_member = target.members.detect { |m| m.principal == member.principal }
       if target_member
         Members::UpdateService
           .new(model: target_member, user: User.current, contract_class: EmptyContract)

--- a/app/services/projects/copy/work_packages_dependent_service.rb
+++ b/app/services/projects/copy/work_packages_dependent_service.rb
@@ -149,13 +149,11 @@ module Projects::Copy
     end
 
     def work_package_assigned_to_id(source_work_package)
-      possible_principal_id(source_work_package.assigned_to_id,
-                            source_work_package.project)
+      possible_principal_id(source_work_package.assigned_to_id)
     end
 
     def work_package_responsible_id(source_work_package)
-      possible_principal_id(source_work_package.responsible_id,
-                            source_work_package.project)
+      possible_principal_id(source_work_package.responsible_id)
     end
 
     def custom_value_attributes(source_work_package, user_cf_ids)
@@ -168,10 +166,10 @@ module Projects::Copy
       end
     end
 
-    def possible_principal_id(principal_id, project)
+    def possible_principal_id(principal_id)
       return unless principal_id
 
-      @principals ||= Principal.possible_assignee(project).pluck(:id).to_set
+      @principals ||= Principal.possible_assignee(target).pluck(:id).to_set
       principal_id if @principals.include?(principal_id)
     end
 

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -130,6 +130,14 @@ RSpec.describe(
     let(:all_modules) { described_class.copyable_dependencies.pluck(:identifier) }
     let(:project_copy) { subject.result }
 
+    def copy_of(work_package)
+      copied_work_package = project_copy.work_packages.find_by(subject: work_package.subject)
+      expect(copied_work_package).not_to be_nil,
+                                         "Expected work package '#{work_package.subject}' to be copied to " \
+                                         "project '#{project_copy.name}' but was not"
+      copied_work_package
+    end
+
     shared_examples_for "copies public attribute" do
       describe "#public" do
         before do
@@ -969,8 +977,7 @@ RSpec.describe(
 
             it "copies the assigned_to" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].assigned_to)
-                .to eql assigned_user
+              expect(copy_of(work_package).assigned_to).to eq(assigned_user)
               # The assignee of the new work package receives a notification
               expect { perform_enqueued_jobs }
                 .to change(Notification.where(recipient: assigned_user), :count)
@@ -984,8 +991,7 @@ RSpec.describe(
 
             it "nils the assigned_to" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].assigned_to)
-                .to be_nil
+              expect(copy_of(work_package).assigned_to).to be_nil
               # No notification is sent out
               expect { perform_enqueued_jobs }
                 .not_to change(Notification.where(recipient: assigned_user), :count)
@@ -1008,8 +1014,7 @@ RSpec.describe(
 
             it "copies the responsible" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].responsible)
-                .to eql responsible_user
+              expect(copy_of(work_package).responsible).to eq(responsible_user)
               # The responsible of the new work package receives a notification
               expect { perform_enqueued_jobs }
                 .to change(Notification.where(recipient: responsible_user), :count)
@@ -1021,9 +1026,9 @@ RSpec.describe(
           context "with the member being not copied" do
             let(:only_args) { %w[work_packages] }
 
-            it "nils the assigned_to" do
+            it "nils the responsible" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].responsible).to be_nil
+              expect(copy_of(work_package).responsible).to be_nil
               # No notification is sent out
               expect { perform_enqueued_jobs }
                 .not_to change(Notification.where(recipient: responsible_user), :count)
@@ -1052,8 +1057,7 @@ RSpec.describe(
 
             it "copies the custom_field" do
               expect(subject).to be_success
-              wp = project_copy.work_packages.find_by(subject: work_package.subject)
-              expect(wp.send(custom_field.attribute_getter)).to eql other_user
+              expect(copy_of(work_package).send(custom_field.attribute_getter)).to eql other_user
             end
           end
 
@@ -1062,8 +1066,7 @@ RSpec.describe(
 
             it "nils the custom_field" do
               expect(subject).to be_success
-              wp = project_copy.work_packages.find_by(subject: work_package.subject)
-              expect(wp.send(custom_field.attribute_getter)).to be_nil
+              expect(copy_of(work_package).send(custom_field.attribute_getter)).to be_nil
             end
           end
         end

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -130,10 +130,10 @@ RSpec.describe(
     let(:all_modules) { described_class.copyable_dependencies.pluck(:identifier) }
     let(:project_copy) { subject.result }
 
-    def copy_of(work_package)
-      copied_work_package = project_copy.work_packages.find_by(subject: work_package.subject)
+    def copy_of(original_work_package)
+      copied_work_package = project_copy.work_packages.find_by(subject: original_work_package.subject)
       expect(copied_work_package).not_to be_nil,
-                                         "Expected work package '#{work_package.subject}' to be copied to " \
+                                         "Expected work package '#{original_work_package.subject}' to be copied to " \
                                          "project '#{project_copy.name}' but was not"
       copied_work_package
     end
@@ -516,7 +516,7 @@ RSpec.describe(
 
           it "produces a valid query that is mapped in the new project" do
             expect(subject).to be_success
-            copied_wp = project_copy.work_packages.find_by(subject: "source wp")
+            copied_wp = copy_of(source_wp)
             copied = project_copy.queries.find_by(name: query.name)
             expect(copied.filters[1].values).to eq [copied_wp.id.to_s]
           end
@@ -661,8 +661,7 @@ RSpec.describe(
           expect(subject).to be_success
 
           expect(source.work_packages.count).to eq(project_copy.work_packages.count)
-          copied_wp = project_copy.work_packages.find_by(subject: "source wp")
-          expect(copied_wp.budget).to be_nil
+          expect(copy_of(source_wp).budget).to be_nil
         end
 
         context "if categories are copied" do
@@ -673,7 +672,7 @@ RSpec.describe(
 
             expect(subject).to be_success
 
-            wp = project_copy.work_packages.find_by(subject: source_wp.subject)
+            wp = copy_of(source_wp)
             expect(wp.category.name).to eq "Stock management"
             # Category got copied
             expect(wp.category.id).not_to eq source_category.id
@@ -692,7 +691,7 @@ RSpec.describe(
           it "updates the version" do
             expect(subject).to be_success
 
-            wp = project_copy.work_packages.find_by(subject: source_wp.subject)
+            wp = copy_of(source_wp)
             expect(wp.version.name).to eq "Assigned Issues"
             expect(wp.version).to be_closed
             expect(wp.version.id).not_to eq assigned_version.id
@@ -712,7 +711,7 @@ RSpec.describe(
               expect(subject).to be_success
               expect(project_copy.work_packages.count).to eq(3)
 
-              wp = project_copy.work_packages.find_by(subject: work_package.subject)
+              wp = copy_of(work_package)
               expect(wp.attachments.count).to eq(1)
               expect(wp.attachments.first.author).to eql(current_user)
             end
@@ -723,7 +722,7 @@ RSpec.describe(
               expect(subject).to be_success
               expect(project_copy.work_packages.count).to eq(3)
 
-              wp = project_copy.work_packages.find_by(subject: work_package.subject)
+              wp = copy_of(work_package)
               expect(wp.attachments.count).to eq(0)
             end
           end
@@ -802,9 +801,9 @@ RSpec.describe(
           it do
             expect(subject).to be_success
 
-            grandparent_wp_copy = project_copy.work_packages.find_by(subject: work_package3.subject)
-            parent_wp_copy = project_copy.work_packages.find_by(subject: work_package2.subject)
-            child_wp_copy = project_copy.work_packages.find_by(subject: work_package.subject)
+            grandparent_wp_copy = copy_of(work_package3)
+            parent_wp_copy = copy_of(work_package2)
+            child_wp_copy = copy_of(work_package)
 
             expect([grandparent_wp_copy, parent_wp_copy, child_wp_copy]).to all be_present
             expect(child_wp_copy.parent).to eq(parent_wp_copy)
@@ -825,7 +824,7 @@ RSpec.describe(
 
           it do
             expect(subject).to be_success
-            wp = project_copy.work_packages.find_by(subject: work_package.subject)
+            wp = copy_of(work_package)
             expect(cat = wp.category).not_to be_nil
             expect(cat.project).to eq(project_copy)
           end
@@ -847,7 +846,7 @@ RSpec.describe(
 
             it "does copy active watchers but does not add the copying user as a watcher" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].watcher_users)
+              expect(copy_of(work_package).watcher_users)
                 .to contain_exactly(watcher)
             end
           end
@@ -866,7 +865,7 @@ RSpec.describe(
 
             it "does not copy locked watchers and does not add the copying user as a watcher" do
               expect(subject).to be_success
-              expect(project_copy.work_packages[0].watcher_users).to be_empty
+              expect(copy_of(work_package).watcher_users).to be_empty
             end
           end
         end
@@ -908,8 +907,7 @@ RSpec.describe(
               expect(shared_wp_member.principal).to eq(source_wp_shared_with_user)
               expect(shared_wp_member.roles).to contain_exactly(wp_role)
 
-              copied_wp = project_copy.work_packages.find_by(subject: "source wp")
-              expect(shared_wp_member.entity).to eq(copied_wp)
+              expect(shared_wp_member.entity).to eq(copy_of(source_wp))
             end
           end
 
@@ -953,12 +951,9 @@ RSpec.describe(
 
           it "assigns the work packages to copies of the versions" do
             expect(subject).to be_success
-            expect(project_copy.work_packages.detect { |wp| wp.subject == work_package.subject }.version.name)
-              .to eql version.name
-            expect(project_copy.work_packages.detect { |wp| wp.subject == work_package2.subject }.version.name)
-              .to eql version2.name
-            expect(project_copy.work_packages.detect { |wp| wp.subject == work_package3.subject }.version)
-              .to be_nil
+            expect(copy_of(work_package).version.name).to eq version.name
+            expect(copy_of(work_package2).version.name).to eq version2.name
+            expect(copy_of(work_package3).version).to be_nil
           end
         end
 
@@ -1084,8 +1079,8 @@ RSpec.describe(
             expect(subject).to be_success
 
             expect(source.work_packages.count).to eq(project_copy.work_packages.count)
-            copied_wp = project_copy.work_packages.find_by(subject: "source wp")
-            copied_wp2 = project_copy.work_packages.find_by(subject: "source wp2")
+            copied_wp = copy_of(source_wp)
+            copied_wp2 = copy_of(source_wp2)
 
             # First issue with a relation on project
             # copied relation + reflexive relation
@@ -1111,12 +1106,10 @@ RSpec.describe(
             expect(subject).to be_success
             expect(project_copy.work_packages.count).to eq(2)
 
-            copied_wp = project_copy.work_packages.find_by(subject: source_wp.subject)
-            expect(copied_wp.project_phase_definition_id).to eq(source_project_phase.definition_id)
+            expect(copy_of(source_wp).project_phase_definition_id).to eq(source_project_phase.definition_id)
 
             [source_wp, source_wp_locked].each do |wp|
-              copied_wp = project_copy.work_packages.find_by(subject: wp.subject)
-              expect(copied_wp.project_phase_definition_id).to eq(wp.project_phase_definition_id)
+              expect(copy_of(wp).project_phase_definition_id).to eq(wp.project_phase_definition_id)
             end
           end
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70290

# What are you trying to accomplish?

When a project is copied, and members are excluded from the copy (uncheck "Project members" in "Copy project" page), then all work packages having a user assigned should still be copied, and the user fields should be cleared.

# What approach did you choose and why?

This fixes the regression introduced in https://github.com/opf/openproject/commit/5ea185ef66a4b3f556394e60afd39edfcc3604da: the `possible_principal_id` was run against the source project instead of the target project, leading to always return something.

Fix is to always run `possible_principal_id` against the target project.

This was not detected by the unit tests: original tests were taking the first work package of the copied project to check that the user field was `nil`, assuming the first work package would be the copy of the one having the user field set, but actually the work package was not copied, so another work package is picked and this one has all user fields `nil` because the original work package has all user fields `nil`.

The test was fixed by explicitly getting the copied work package using the subject of the original work package, and failing if the copied work package is not found.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
