### PR TITLE
Bug/70147 newly created project attributes are added as columns to the default project list

### DIFF
--- a/app/services/custom_fields/create_service.rb
+++ b/app/services/custom_fields/create_service.rb
@@ -56,10 +56,6 @@ module CustomFields
     def after_perform(call)
       cf = call.result
 
-      if cf.is_a?(ProjectCustomField)
-        add_cf_to_visible_columns(cf)
-      end
-
       if cf.field_format_calculated_value? && cf.is_required?
         enqueue_recalculate_values(cf)
       end
@@ -72,10 +68,6 @@ module CustomFields
     end
 
     private
-
-    def add_cf_to_visible_columns(custom_field)
-      Setting.enabled_projects_columns |= [custom_field.column_name]
-    end
 
     def enqueue_recalculate_values(custom_field)
       CustomFields::RecalculateValuesJob.perform_later(

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe CustomFields::CreateService, type: :model do
     context "when creating a project cf" do
       let(:model_instance) { build_stubbed(:project_custom_field) }
 
-      it "modifies the settings on successful call" do
-        subject
-        expect(Setting.enabled_projects_columns).to include(model_instance.column_name)
+      it "no longer changes the enabled_projects_columns setting" do
+        expect { subject }
+          .not_to change(Setting, :enabled_projects_columns)
+        expect(subject).to be_success
       end
     end
   end

--- a/spec/services/custom_fields/create_service_spec.rb
+++ b/spec/services/custom_fields/create_service_spec.rb
@@ -45,20 +45,21 @@ RSpec.describe CustomFields::CreateService, type: :model do
 
   describe "#call" do
     shared_let(:user) { create(:admin) }
-    let(:contract_class) { CustomFields::CreateContract }
-    let(:contract_instance) { instance_double(contract_class, validate: true) }
 
-    let(:instance) do
-      described_class.new(user:)
+    let!(:contract_instance) do
+      instance_double(contract_class, validate: true).tap do |contract|
+        allow(contract_class)
+          .to receive(:new).with(instance_of(custom_field_class), user, options: {}).and_return(contract)
+      end
     end
+
+    let(:contract_class) { CustomFields::CreateContract }
+    let(:custom_field_class) { ProjectCustomField }
+    let(:instance) { described_class.new(user:) }
+
+    current_user { user }
 
     subject(:instance_call) { instance.call(attributes) }
-
-    before do
-      User.current = user
-      allow(contract_class)
-        .to receive(:new).with(instance_of(ProjectCustomField), user, options: {}).and_return(contract_instance)
-    end
 
     describe "calculated value custom field",
              with_ee: %i[calculated_values],
@@ -75,7 +76,7 @@ RSpec.describe CustomFields::CreateService, type: :model do
 
       let(:common_attributes) do
         {
-          type: "ProjectCustomField",
+          type: custom_field_class.to_s,
           field_format: "calculated_value",
           name: "foo",
           custom_field_section_id: project_custom_field_section.id


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70147

# What are you trying to accomplish?

Project cf are no longer added to the default project lists. The administrator will have to do that consciously now. 

# Merge checklist

- [x] Added/updated tests