### PR TITLE
Bug/70005 project attribute help text tab is called attribute help texts

### DIFF
--- a/app/components/admin/custom_fields/edit_form_header_component.rb
+++ b/app/components/admin/custom_fields/edit_form_header_component.rb
@@ -67,7 +67,7 @@ module Admin
             {
               name: "attribute_help_text",
               path: attribute_help_text_custom_field_path(@custom_field),
-              label: AttributeHelpText.human_plural_model_name
+              label: AttributeHelpText.human_attribute_name(:help_text)
             }
         end
 

--- a/app/components/settings/project_custom_fields/edit_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/edit_form_header_component.rb
@@ -72,7 +72,7 @@ module Settings
           {
             name: "attribute_help_text",
             path: attribute_help_text_admin_settings_project_custom_field_path(@custom_field),
-            label: AttributeHelpText.human_plural_model_name
+            label: AttributeHelpText.human_attribute_name(:help_text)
           }
 
         tabs

--- a/spec/features/admin/settings/project_custom_fields/attribute_help_text_spec.rb
+++ b/spec/features/admin/settings/project_custom_fields/attribute_help_text_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Project custom field attribute help text", :js do
       visit edit_admin_settings_project_custom_field_path(project_custom_field)
 
       # Navigate to attribute help text tab
-      click_on AttributeHelpText.human_plural_model_name
+      click_on AttributeHelpText.human_attribute_name(:help_text)
 
       expect(page).to have_current_path(
         attribute_help_text_admin_settings_project_custom_field_path(project_custom_field)
@@ -176,7 +176,7 @@ RSpec.describe "Project custom field attribute help text", :js do
       visit edit_admin_settings_project_custom_field_path(project_custom_field)
 
       # Navigate to attribute help text tab
-      click_on AttributeHelpText.human_plural_model_name
+      click_on AttributeHelpText.human_attribute_name(:help_text)
 
       expect(page).to have_current_path(
         attribute_help_text_admin_settings_project_custom_field_path(project_custom_field)
@@ -190,7 +190,7 @@ RSpec.describe "Project custom field attribute help text", :js do
       )
 
       # Navigate back to attribute help text tab
-      click_on AttributeHelpText.human_plural_model_name
+      click_on AttributeHelpText.human_attribute_name(:help_text)
 
       expect(page).to have_current_path(
         attribute_help_text_admin_settings_project_custom_field_path(project_custom_field)

--- a/spec/features/admin/settings/project_custom_fields/attribute_help_text_spec.rb
+++ b/spec/features/admin/settings/project_custom_fields/attribute_help_text_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "Project custom field attribute help text", :js do
+  include Flash::Expectations
+
   shared_let(:admin) { create(:admin) }
   shared_let(:project_custom_field_section) { create(:project_custom_field_section) }
   shared_let(:project_custom_field) do
@@ -201,9 +203,9 @@ RSpec.describe "Project custom field attribute help text", :js do
   describe "help text display uniqueness" do
     it "creates separate help texts for different custom fields" do
       other_custom_field = create(:project_custom_field,
-                                   name: "Project Priority",
-                                   field_format: "text",
-                                   project_custom_field_section:)
+                                  name: "Project Priority",
+                                  field_format: "text",
+                                  project_custom_field_section:)
 
       # Create help text for first custom field
       visit attribute_help_text_admin_settings_project_custom_field_path(project_custom_field)
@@ -211,11 +213,15 @@ RSpec.describe "Project custom field attribute help text", :js do
       editor.set_markdown("Help for rating")
       click_button "Save"
 
+      expect_and_dismiss_flash(message: "Successful update")
+
       # Create help text for second custom field
       visit attribute_help_text_admin_settings_project_custom_field_path(other_custom_field)
       fill_in "Caption", with: "Priority help"
       editor.set_markdown("Help for priority")
       click_button "Save"
+
+      expect_and_dismiss_flash(message: "Successful update")
 
       # Verify both help texts exist and are different
       rating_help = AttributeHelpText::Project.find_by(


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70005

# What are you trying to accomplish?

Change the label of the tab from "Attribute help text" to "Help text"

Before:
<img width="936" height="175" alt="image" src="https://github.com/user-attachments/assets/a0793c01-e780-4801-af5c-f53d21bff593" />

After:
<img width="809" height="186" alt="image" src="https://github.com/user-attachments/assets/924e69bb-c0c9-42d6-8d4f-a880cf4982ce" />

It also fixes a flickering spec that was fixed by waiting for the saving to have happened before querying the database for the expected changes.

# Merge checklist

- [x] Added/updated tests