### PR TITLE
Also handle the case where the user updates their interim response

### DIFF
--- a/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
+++ b/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
@@ -95,14 +95,17 @@ module AllMeetings
         # We have an instantiated meeting, so update that one
         update_participation_status(scheduled_meeting.meeting, event)
       else
-        # No instantiated meeting, so create an interim response
-        RecurringMeetingInterimResponse.create!(
+        # No instantiated meeting, create or update an interim response
+        response = RecurringMeetingInterimResponse.find_or_initialize_by(
           user: user,
           recurring_meeting: recurring_meeting,
-          start_time: recurrence_id,
-          participation_status: partstat(event),
-          comment: comment(event)
+          start_time: recurrence_id
         )
+
+        response.participation_status = partstat(event)
+        response.comment = comment(event)
+
+        response.save!
       end
 
       ServiceResult.success

--- a/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
@@ -310,6 +310,33 @@ RSpec.describe AllMeetings::HandleICalResponseService, type: :model do
           expect(interim_response.participation_status).to eq("accepted")
         end
       end
+
+      context "when an interim response already for this recurrence (the user has already responded and changes)" do
+        let(:partstat) { "DECLINED" }
+        let(:recurrence_date) { recurring_meeting.start_time + 1.month }
+        let!(:existing_response) do
+          RecurringMeetingInterimResponse.create!(
+            user: user,
+            recurring_meeting: recurring_meeting,
+            start_time: recurrence_date,
+            participation_status: "accepted"
+          )
+        end
+
+        let(:additional_ical_properties) do
+          "RECURRENCE-ID:#{recurrence_date.utc.strftime('%Y%m%dT%H%M%SZ')}"
+        end
+
+        it "updates the existing interim response" do
+          expect { subject }.not_to change(RecurringMeetingInterimResponse, :count)
+
+          expect(subject).to be_success
+
+          expect do
+            existing_response.reload
+          end.to change(existing_response, :participation_status).from("accepted").to("declined")
+        end
+      end
     end
 
     context "when responding to the series and the occurence in one mail" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/70299/activity

# What are you trying to accomplish?
- Fix error when a user responds to an uninstantiated meeting occurence multiple times 
- 
## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
