### PR TITLE
[#68702] Project user filter also includes groups and placeholder users

### DIFF
--- a/app/components/filter/filter_component.rb
+++ b/app/components/filter/filter_component.rb
@@ -168,7 +168,6 @@ module Filter
         resource: "principals",
         url: ::API::V3::Utilities::PathHelper::ApiV3Path.principals,
         filters: [
-          { name: "type", operator: "=", values: ["User"] },
           { name: "status", operator: "!", values: [Principal.statuses["locked"].to_s] }
         ],
         searchKey: "any_name_attribute",

--- a/app/models/queries/filters/shared/custom_fields/user.rb
+++ b/app/models/queries/filters/shared/custom_fields/user.rb
@@ -41,6 +41,30 @@ module Queries::Filters::Shared
       def allowed_values
         @allowed_values ||= me_allowed_value + super
       end
+
+      def values_replaced
+        vals = super
+        vals += group_members_added(vals)
+        vals + user_groups_added(vals)
+      end
+
+      private
+
+      def group_members_added(vals)
+        ::User
+          .joins(:groups)
+          .where(groups_users: { id: vals })
+          .pluck(:id)
+          .map(&:to_s)
+      end
+
+      def user_groups_added(vals)
+        Group
+          .joins(:users)
+          .where(users_users: { id: vals })
+          .pluck(:id)
+          .map(&:to_s)
+      end
     end
   end
 end

--- a/app/models/queries/projects/filters/custom_field_filter.rb
+++ b/app/models/queries/projects/filters/custom_field_filter.rb
@@ -30,5 +30,6 @@
 
 class Queries::Projects::Filters::CustomFieldFilter < Queries::Projects::Filters::Base
   include Queries::Filters::Shared::CustomFieldFilter
+
   self.custom_field_context = ::Queries::Projects::CustomFieldContext
 end

--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -497,6 +497,10 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
 
   describe "user cf filter" do
     let(:some_user) { create(:user, member_with_roles: { project => [project_role] }) }
+    let!(:some_placeholder) { create(:placeholder_user, member_with_roles: { project => [project_role] }) }
+    let!(:some_group) { create(:group, members: [some_user], member_with_roles: { project => [project_role] }) }
+    let!(:empty_group) { create(:group, member_with_roles: { project => [project_role] }) }
+
     let!(:user_cf) do
       create(:user_project_custom_field,
              name: "A user CF",
@@ -505,7 +509,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       end
     end
 
-    it "filters for the project that has the corresponding value" do
+    it "filters for the project that has the correct user" do
       load_and_open_filters manager
 
       projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_user.name])
@@ -513,15 +517,71 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
       projects_page.expect_projects_listed(project)
     end
 
-    it "displays the visible project members as available options" do
+    it "filters for any group where the user is a member" do
+      load_and_open_filters manager
+
+      # Since the user is member of this group, this project will match the filter
+      projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_group.name])
+
+      projects_page.expect_projects_listed(project)
+    end
+
+    it "displays the visible project members, groups and placeholders as available options" do
       load_and_open_filters manager
 
       expected_options = [
+        { name: empty_group.name },
+        { name: some_group.name },
         { name: some_user.name, email: some_user.mail },
+        { name: some_placeholder.name },
         { name: manager.name, email: manager.mail }
       ]
 
       projects_page.expect_user_autocomplete_options_for(user_cf, expected_options)
+    end
+
+    context "with the cf field set to a group" do
+      before do
+        project.update(custom_field_values: { user_cf.id => [some_group.id] })
+      end
+
+      it "filters for the group" do
+        load_and_open_filters manager
+
+        projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_group.name])
+
+        projects_page.expect_projects_listed(project)
+      end
+
+      it "filters for users that are members of the group" do
+        load_and_open_filters manager
+
+        projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_user.name])
+
+        projects_page.expect_projects_listed(project)
+      end
+
+      it "does not match if you filter for another group" do
+        load_and_open_filters manager
+
+        projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [empty_group.name])
+
+        projects_page.expect_projects_not_listed(project)
+      end
+    end
+
+    context "with the cf field set to a placeholder user" do
+      before do
+        project.update(custom_field_values: { user_cf.id => [some_placeholder.id] })
+      end
+
+      it "filters for the placeholder user" do
+        load_and_open_filters manager
+
+        projects_page.set_filter(user_cf.column_name, user_cf.name, "is (OR)", [some_placeholder.name])
+
+        projects_page.expect_projects_listed(project)
+      end
     end
   end
 

--- a/spec/features/projects/lists/table_spec.rb
+++ b/spec/features/projects/lists/table_spec.rb
@@ -370,6 +370,7 @@ RSpec.describe "Projects lists table display and actions", :js, with_settings: {
 
   context "with valid Enterprise token" do
     shared_let(:long_text_custom_field) { create(:text_project_custom_field) }
+
     specify "CF columns and filters are not visible by default" do
       load_and_open_filters admin
 
@@ -388,7 +389,7 @@ RSpec.describe "Projects lists table display and actions", :js, with_settings: {
 
       # Admins shall be the only ones to see invisible CFs
       expect(page).to have_text(invisible_custom_field.name.upcase)
-      expect(page).to have_select("add_filter_select", with_options: [invisible_custom_field.name])
+      projects_page.expect_filter_available(invisible_custom_field.name)
     end
 
     specify "long-text fields are truncated" do

--- a/spec/models/queries/projects/filters/custom_field_filter_spec.rb
+++ b/spec/models/queries/projects/filters/custom_field_filter_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
   end
 
   describe "#type" do
-    context "integer" do
+    describe "integer" do
       let(:cf_accessor) { int_project_custom_field.column_name }
 
       it "is integer for an integer" do
@@ -144,7 +144,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "float" do
+    describe "float" do
       let(:cf_accessor) { float_project_custom_field.column_name }
 
       it "is integer for a float" do
@@ -153,7 +153,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "text" do
+    describe "text" do
       let(:cf_accessor) { text_project_custom_field.column_name }
 
       it "is text for a text" do
@@ -162,7 +162,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "list optional" do
+    describe "list optional" do
       let(:cf_accessor) { list_project_custom_field.column_name }
 
       it "is list_optional for a list" do
@@ -171,7 +171,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "user" do
+    describe "user" do
       let(:cf_accessor) { user_project_custom_field.column_name }
 
       it "is list_optional for a user" do
@@ -180,7 +180,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "version" do
+    describe "version" do
       let(:cf_accessor) { version_project_custom_field.column_name }
 
       it "is list_optional for a version" do
@@ -189,7 +189,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "version" do
+    describe "date" do
       let(:cf_accessor) { date_project_custom_field.column_name }
 
       it "is date for a date" do
@@ -198,7 +198,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "bool" do
+    describe "bool" do
       let(:cf_accessor) { bool_project_custom_field.column_name }
 
       it "is list for a bool" do
@@ -207,7 +207,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "string" do
+    describe "string" do
       let(:cf_accessor) { string_project_custom_field.column_name }
 
       it "is string for a string" do
@@ -225,7 +225,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
   end
 
   describe "#allowed_values" do
-    context "integer" do
+    describe "integer" do
       let(:cf_accessor) { int_project_custom_field.column_name }
 
       it "is nil for an integer" do
@@ -234,7 +234,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "float" do
+    describe "float" do
       let(:cf_accessor) { float_project_custom_field.column_name }
 
       it "is integer for a float" do
@@ -243,7 +243,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "text" do
+    describe "text" do
       let(:cf_accessor) { text_project_custom_field.column_name }
 
       it "is text for a text" do
@@ -252,7 +252,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "list" do
+    describe "list" do
       let(:cf_accessor) { list_project_custom_field.column_name }
 
       it "is list_optional for a list" do
@@ -261,11 +261,11 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "user" do
+    describe "user" do
       let(:cf_accessor) { user_project_custom_field.column_name }
 
       it "is list_optional for a user" do
-        bogus_return_value = ["user1", "user2"]
+        bogus_return_value = %w[user1 user2]
         allow(user_project_custom_field)
           .to receive(:possible_values_options)
           .and_return(bogus_return_value)
@@ -275,11 +275,11 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "version" do
+    describe "version" do
       let(:cf_accessor) { version_project_custom_field.column_name }
 
       it "is list_optional for a version" do
-        bogus_return_value = ["version1", "version2"]
+        bogus_return_value = %w[version1 version2]
         allow(version_project_custom_field)
           .to receive(:possible_values_options)
           .and_return(bogus_return_value)
@@ -289,7 +289,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "date" do
+    describe "date" do
       let(:cf_accessor) { date_project_custom_field.column_name }
 
       it "is nil for a date" do
@@ -298,7 +298,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "bool" do
+    describe "bool" do
       let(:cf_accessor) { bool_project_custom_field.column_name }
 
       it "is list for a bool" do
@@ -308,7 +308,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "string" do
+    describe "string" do
       let(:cf_accessor) { string_project_custom_field.column_name }
 
       it "is nil for a string" do
@@ -321,6 +321,7 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
   describe "#apply_to" do
     describe "permissions" do
       let(:user) { build_stubbed(:user) }
+
       current_user { user }
 
       it "includes the check for view_project_attributes permission" do
@@ -399,31 +400,31 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "bool cf" do
+    describe "bool cf" do
       let(:custom_field) { bool_project_custom_field }
 
       it_behaves_like "non ar filter"
     end
 
-    context "int cf" do
+    describe "int cf" do
       let(:custom_field) { int_project_custom_field }
 
       it_behaves_like "non ar filter"
     end
 
-    context "float cf" do
+    describe "float cf" do
       let(:custom_field) { float_project_custom_field }
 
       it_behaves_like "non ar filter"
     end
 
-    context "text cf" do
+    describe "text cf" do
       let(:custom_field) { text_project_custom_field }
 
       it_behaves_like "non ar filter"
     end
 
-    context "user cf" do
+    describe "user cf" do
       let(:custom_field) { user_project_custom_field }
 
       describe "#ar_object_filter?" do
@@ -436,23 +437,25 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       describe "#value_objects" do
         let(:user1) { build_stubbed(:user) }
         let(:user2) { build_stubbed(:user) }
+        let(:group) { build_stubbed(:group) }
+        let(:placeholder_user) { build_stubbed(:placeholder_user) }
 
         before do
           allow(Principal)
             .to receive(:where)
-            .and_return([user1, user2])
+            .and_return([user1, user2, group, placeholder_user])
 
-          instance.values = [user1.id.to_s, user2.id.to_s]
+          instance.values = [user1.id.to_s, user2.id.to_s, group.id.to_s, placeholder_user.id.to_s]
         end
 
         it "returns an array with users" do
           expect(instance.value_objects)
-            .to contain_exactly(user1, user2)
+            .to contain_exactly(user1, user2, group, placeholder_user)
         end
       end
     end
 
-    context "version cf" do
+    describe "version cf" do
       let(:custom_field) { version_project_custom_field }
 
       describe "#ar_object_filter?" do
@@ -482,13 +485,13 @@ RSpec.describe Queries::Projects::Filters::CustomFieldFilter do
       end
     end
 
-    context "date cf" do
+    describe "date cf" do
       let(:custom_field) { date_project_custom_field }
 
       it_behaves_like "non ar filter"
     end
 
-    context "string cf" do
+    describe "string cf" do
       let(:custom_field) { string_project_custom_field }
 
       it_behaves_like "non ar filter"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68702

# What are you trying to accomplish?

Remove the type = User restriction on the filter component, so that groups and placeholder users can also be found.

Included some minor drive-by rubocop fixes for neighboring specs.

## Screenshots

<img width="1139" height="678" alt="image" src="https://github.com/user-attachments/assets/9e465660-a9f9-4ae4-9a59-f1a32690d6ac" />


# What approach did you choose and why?
Simply removed the restriction from the base class that only matched on principals of type user. Apart from the project filter, the meetings filter is inheriting from the base class, too. Therefore, this change alters meetings filters – in theory. In practice, there is no user custom field filter for meetings, so this change has no effect on meetings.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
