### PR TITLE
add a imagemagick policy.xml file to be used with mini_magick gem

### DIFF
--- a/config/imagemagick/policy.xml
+++ b/config/imagemagick/policy.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+        <!ELEMENT policymap (policy)*>
+        <!ATTLIST policymap xmlns CDATA #FIXED "">
+        <!ELEMENT policy EMPTY>
+        <!ATTLIST policy xmlns CDATA #FIXED "">
+        <!ATTLIST policy domain NMTOKEN #REQUIRED>
+        <!ATTLIST policy name NMTOKEN #IMPLIED>
+        <!ATTLIST policy pattern CDATA #IMPLIED>
+        <!ATTLIST policy rights NMTOKEN #IMPLIED>
+        <!ATTLIST policy stealth NMTOKEN #IMPLIED>
+        <!ATTLIST policy value CDATA #IMPLIED>
+        ]>
+<!--
+  Creating a security policy that fits your specific local environment
+  before making use of ImageMagick is highly advised. You can find guidance on
+  setting up this policy at https://imagemagick.org/script/security-policy.php,
+  and it's important to verify your policy using the validation tool located
+  at https://imagemagick-secevaluator.doyensec.com/.
+
+
+  Web-safe ImageMagick security policy:
+
+  This security protocol designed for web-safe usage focuses on situations
+  where ImageMagick is applied in publicly accessible contexts, like websites.
+  It deactivates the capability to read from or write to any image formats
+  other than web-safe formats like GIF, JPEG, and PNG. Additionally, this
+  policy prohibits the execution of image filters and indirect reads, thereby
+  thwarting potential security breaches. By implementing these limitations,
+  the web-safe policy fortifies the safeguarding of systems accessible to
+  the public, reducing the risk of exploiting ImageMagick's capabilities
+  for potential attacks.
+-->
+<policymap>
+  <!-- Dynamically yield the CPU relative to the system load average. -->
+  <policy domain="resource" name="dynamic-throttle" value="false"/>
+  <!-- Force memory initialization by memory mapping select memory allocations. -->
+  <policy domain="cache" name="memory-map" value="anonymous"/>
+  <!-- Ensure all image data is fully flushed and synchronized to disk. -->
+  <policy domain="cache" name="synchronize" value="true"/>
+  <!-- Do not permit any delegates to execute. -->
+  <policy domain="delegate" rights="none" pattern="*"/>
+  <!-- Do not permit any image filters to load. -->
+  <policy domain="filter" rights="none" pattern="*"/>
+  <!-- Don't read/write from/to stdin/stdout. -->
+  <policy domain="path" rights="none" pattern="-"/>
+  <!-- don't read sensitive paths. -->
+  <policy domain="path" rights="none" pattern="/etc/*"/>
+  <!-- Indirect reads are not permitted. -->
+  <policy domain="path" rights="none" pattern="@*"/>
+  <!-- Deny all image modules and specifically exempt reading or writing web-safe image formats. -->
+  <policy domain="module" rights="none" pattern="*" />
+  <!-- Allow only web-safe image formats. -->
+  <policy domain="module" rights="read | write" pattern="{GIF,JPEG,PNG,WEBP}" />
+  <!-- Disable PDF -->
+  <policy domain="coder" rights="none" pattern="PDF" />
+  <!-- CVE-2016–3714  https://imagetragick.com/ -->
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+</policymap>

--- a/config/initializers/mini_magick.rb
+++ b/config/initializers/mini_magick.rb
@@ -1,0 +1,13 @@
+require "mini_magick"
+
+# Ensure ImageMagick reads the project-local policy.xml (websafe)
+# ENV["MAGICK_CONFIGURE_PATH"] ||= Rails.root.join("config/imagemagick").to_s
+
+MiniMagick.configure do |config|
+  # configure MiniMagick CLI to use ImageMagick (not GraphicsMagick)
+  config.graphicsmagick = false
+  # also set the MAGICK_CONFIGURE_PATH for the CLI commands
+  config.cli_env = {
+    "MAGICK_CONFIGURE_PATH" => Rails.root.join("config/imagemagick").to_s
+  }
+end

--- a/config/initializers/mini_magick.rb
+++ b/config/initializers/mini_magick.rb
@@ -1,3 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 require "mini_magick"
 
 # Ensure ImageMagick reads the project-local policy.xml (websafe)


### PR DESCRIPTION
add a imagemagick policy.xml file to be used with mini_magick gem which **disables** not used modules and coders like SVG, PDF, etc.