### PR TITLE
Bug/70334 project dropdown active project close button is misaligned

### DIFF
--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.html
@@ -51,55 +51,54 @@
         @if (currentProjectService.id === project.id.toString()) {
           <a
             [href]="extendedUrl(null)"
+            class="spot-list--item-remove"
             data-test-selector="op-header-project-select--item-remove-icon"
-            >
-            <svg
-              x-circle-icon
-              size="small"
-            ></svg></a>
-          }
-        </a>
-      }
-      @if (project.disabled) {
+          >
+            <svg x-circle-icon size="small" />
+          </a>
+        }
+      </a>
+    }
+    @if (project.disabled) {
+      <span
+        class="spot-list--item-action spot-list--item-action_disabled"
+        [ngClass]="{
+          'spot-list--item-action_active': (searchableProjectListService.selectedItemID$ | async) === project.id
+        }"
+      >
         <span
-          class="spot-list--item-action spot-list--item-action_disabled"
-          [ngClass]="{
-            'spot-list--item-action_active': (searchableProjectListService.selectedItemID$ | async) === project.id
-          }"
-          >
-          <span
-            class="spot-list--item-title spot-list--item-title_ellipse-text"
-            data-test-selector="op-header-project-select--item-disabled-title"
-          >
-            <span>{{ project.name }}</span>
-            @if (portfolioModelsEnabled) {
-              @switch (project._type) {
-                @case ('Portfolio') {
-                  <span class="description">
-                    <svg briefcase-icon size="xsmall" />
-                    {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
-                  </span>
-                }
-                @case ('Program') {
-                  <span class="description">
-                    <svg versions-icon size="xsmall" />
-                    {{ this.I18n.t('js.include_workspaces.types.program') }}
-                  </span>
-                }
+          class="spot-list--item-title spot-list--item-title_ellipse-text"
+          data-test-selector="op-header-project-select--item-disabled-title"
+        >
+          <span>{{ project.name }}</span>
+          @if (portfolioModelsEnabled) {
+            @switch (project._type) {
+              @case ('Portfolio') {
+                <span class="description">
+                  <svg briefcase-icon size="xsmall" />
+                  {{ this.I18n.t('js.include_workspaces.types.portfolio') }}
+                </span>
+              }
+              @case ('Program') {
+                <span class="description">
+                  <svg versions-icon size="xsmall" />
+                  {{ this.I18n.t('js.include_workspaces.types.program') }}
+                </span>
               }
             }
-          </span>
+          }
         </span>
-      }
-      @if (project.children.length) {
-        <ul
-          op-header-project-select-list
-          [projects]="project.children"
-          [displayMode]="displayMode"
-          [favorited]="favorited"
-          [selected]="selected"
-          [searchText]="searchText"
-        ></ul>
-      }
-    </li>
-  }
+      </span>
+    }
+    @if (project.children.length) {
+      <ul
+        op-header-project-select-list
+        [projects]="project.children"
+        [displayMode]="displayMode"
+        [favorited]="favorited"
+        [selected]="selected"
+        [searchText]="searchText"
+      ></ul>
+    }
+  </li>
+}

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -108,6 +108,9 @@
         .description
           @extend %autocomplete-description
 
+    &-remove
+      margin-left: $spot-spacing-0_5
+
     &-action_disabled &-title
       opacity: 0.5
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70334

# What are you trying to accomplish?
Align the project close button in the project dropdown.

## Screenshots

<details><summary>Before</summary>
<p>

<img width="478" height="307" alt="image" src="https://github.com/user-attachments/assets/e3698f53-3a6a-4ba5-a0f9-7564c68d8c85" />


</p>
</details> 
<details><summary>After</summary>
<p>

<img width="470" height="377" alt="image" src="https://github.com/user-attachments/assets/e75d7f05-9252-4329-83d7-40719ca81b2b" />


</p>
</details> 

# What approach did you choose and why?
Move the close button inside the span with the flex spacing.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
