### PR TITLE
Bug/journaling sents out notifications even if there are no changes

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -219,11 +219,11 @@ module Journals
         ), cleanup_predecessor_data AS (
           #{cleanup_predecessor_data_sql(predecessor, notes, cause)}
         ), touch_journable AS (
-          #{touch_journable_sql(predecessor, notes, cause)}
+          #{touch_journable_sql(notes, cause)}
         ), fetch_time AS (
           #{fetch_time_sql}
         ), insert_data AS (
-          #{insert_data_sql(predecessor, notes, cause)}
+          #{insert_data_sql(notes, cause)}
         ), update_predecessor AS (
           #{update_predecessor_sql(predecessor, notes, cause)}
         ), inserted_journal AS (
@@ -386,7 +386,7 @@ module Journals
                data_type: journable.class.journal_class.name)
     end
 
-    def insert_data_sql(predecessor, notes, cause)
+    def insert_data_sql(notes, cause)
       sanitize(<<~SQL, journable_id:)
         INSERT INTO
           #{data_table_name} (
@@ -398,7 +398,7 @@ module Journals
         #{journable_data_sql_addition}
         WHERE
           #{journable_table_name}.id = :journable_id
-          #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
+          #{only_on_changed_or_forced_condition_sql(notes, cause)}
         RETURNING *
       SQL
     end
@@ -413,7 +413,7 @@ module Journals
     # Therefore, this is only carried out if:
     # * the journable doesn't already have a newer timestamp than the most recent journal AND
     # * if there are changes or a note or a cause
-    def touch_journable_sql(predecessor, notes, cause)
+    def touch_journable_sql(notes, cause)
       if journable.class.aaj_options[:timestamp].to_sym == :updated_at
         sql = <<~SQL
           UPDATE
@@ -422,7 +422,7 @@ module Journals
             updated_at = statement_timestamp()
           WHERE
             id = :id
-            #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
+            #{only_on_changed_or_forced_condition_sql(notes, cause)}
             AND NOT updated_at > (SELECT updated_at FROM max_journals)
           RETURNING updated_at
         SQL
@@ -461,7 +461,7 @@ module Journals
           validity_period = tstzrange(lower(validity_period), (SELECT updated_at FROM fetch_time), '[)')
         WHERE
           id = (SELECT id from max_journals)
-          #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
+          #{only_on_changed_or_forced_condition_sql(notes, cause)}
       SQL
     end
 
@@ -582,7 +582,7 @@ module Journals
     end
 
     def only_one_or_same_cause?(predecessor, cause)
-      predecessor.cause.empty? || cause.empty? || predecessor.cause == cause
+      predecessor.cause.empty? || cause.blank? || predecessor.cause == cause
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -118,13 +118,6 @@ module Journals
     # It consists of a couple of parts that are kept as individual queries (as CTEs) but
     # are all executed within a single database call.
     #
-    # The first four CTEs('cleanup_predecessor_data', 'cleanup_predecessor_attachable', 'cleanup_predecessor_customizable'
-    # and cleanup_predecessor_storable) strip the information of a predecessor if one exists. If no predecessor exists,
-    # a noop SQL statement is employed instead.
-    # To strip the information from the journal, the data record (e.g. from work_packages_journals) as well as the
-    # attachment and custom value information is removed. The journal itself is kept and will later on have its
-    # updated_at and possibly its notes property updated.
-    #
     # The next CTEs (`max_journals`) responsibility is to fetch the latest journal and have that available for later queries
     # (i.e. when determining the latest state of the journable, when getting the current version number and when
     # comparing the timestamps of the last journalization time and the work package's updated_at time).
@@ -146,12 +139,20 @@ module Journals
     # When comparing text based values, newlines are normalized as otherwise users having a different OS might change a text value
     # without intending to.
     #
-    # Journalization is then continued only if
+    # Journalization continues only if
     # * a change has been identified (by the `changes` CTE)
     # * OR a note is present
     # * OR a cause is present (which would be different from the cause of the predecessor as that one would otherwise be
     #   aggregated with)
     # * OR a predecessor is replaced
+    #
+    # If a change has been identified (not for a note or a cause) and a predecessor to aggregate with exists, the predecessor's
+    # data is stripped. this is done by the CTEs 'cleanup_predecessor_data' and the ones for the associated data,
+    # 'cleanup_predecessor_XYZ' (where XYZ is e.g. attachable or customizable). If no predecessor exists,
+    # a noop SQL statement is run instead.
+    # To strip the information from the journal, the data record (e.g. from work_packages_journals) as well as the
+    # associated data information is removed. The journal itself is kept and will later on have its
+    # updated_at and possibly its notes property updated.
     #
     # To enforce consistent timestamps throughout the data structure of journable and journal, the time used for further timestamp
     # setting is then calculated once between the two CTEs `touch_journable` and `fetch_time`. The auxiliary tables
@@ -411,7 +412,7 @@ module Journals
     # Whenever an attribute is updated on the journable before creating the journal, the updated_at timestamp
     # will already have been increased so nothing needs to be done.
     # But if any of the associated data is updated or if only a cause or note is added, the journable would
-    # otherwise not have receive an updated timestamp.
+    # otherwise not have received an updated timestamp.
     def touch_journable_sql(predecessor, notes, cause) # rubocop:disable Metrics/AbcSize
       if journable.class.aaj_options[:timestamp].to_sym == :updated_at
         sql = <<~SQL
@@ -450,8 +451,8 @@ module Journals
 
     # Sets the validity_period's upper boundary of the preceding journal to the created_at timestamp of the inserted journal.
     # The upper bound set is not included.
-    # If there is a predecessor (meaning we are aggregating/updating an existing journal), nothing is done since
-    # in that case the preceding journal is the one we are currently aggregating with so it will still remain
+    # If there is a predecessor (meaning we are aggregating/updating an existing journal), nothing is done.
+    # In that case, the preceding journal is the one we are currently aggregating with so it will still remain
     # the most recent one.
     def update_predecessor_sql(predecessor, notes, cause)
       return "SELECT 1" if predecessor.present?

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -310,8 +310,8 @@ module Journals
     # otherwise not have received an updated timestamp.
     #
     # Therefore, this is only carried out if:
-    # * the journable doesn't already have a newer timestamp than the most recent journal AND
     # * if there are changes or a note or a cause
+    # * AND the journable doesn't already have a newer timestamp than the most recent journal
     def touch_journable_sql(notes, cause)
       if journable.class.aaj_options[:timestamp].to_sym == :updated_at
         sql = <<~SQL
@@ -557,8 +557,8 @@ module Journals
         within_aggregation_time?(predecessor) &&
         same_user?(predecessor) &&
         only_one_or_same_cause?(predecessor, cause) &&
-        only_one_note(predecessor, notes) &&
-        same_restriction(predecessor, internal)
+        only_one_note?(predecessor, notes) &&
+        same_restriction?(predecessor, internal)
     end
 
     def aggregation_active?
@@ -569,20 +569,20 @@ module Journals
       predecessor.updated_at >= (Time.zone.now - Setting.journal_aggregation_time_minutes.to_i.minutes)
     end
 
-    def only_one_note(predecessor, notes)
-      predecessor.notes.empty? || notes.empty?
-    end
-
-    def same_restriction(predecessor, internal)
-      predecessor.internal == internal
-    end
-
     def same_user?(predecessor)
       predecessor.user_id == user.id
     end
 
     def only_one_or_same_cause?(predecessor, cause)
       predecessor.cause.empty? || cause.blank? || predecessor.cause == cause
+    end
+
+    def only_one_note?(predecessor, notes)
+      predecessor.notes.empty? || notes.empty?
+    end
+
+    def same_restriction?(predecessor, internal)
+      predecessor.internal == internal
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -212,7 +212,7 @@ module Journals
     def journal_modification_sql(predecessor, notes, internal, cause)
       <<~SQL
         max_journals AS (
-          #{select_max_journal_sql(predecessor)}
+          #{select_max_journal_sql}
         ), changes AS (
           #{select_changed_sql}
         ), cleanup_predecessor_data AS (
@@ -247,7 +247,7 @@ module Journals
       SQL
     end
 
-    def select_max_journal_sql(predecessor)
+    def select_max_journal_sql
       sanitize(<<~SQL, journable_id:, journable_type:)
         SELECT
           :journable_id journable_id,
@@ -263,21 +263,13 @@ module Journals
         ON
           journals.journable_id = :journable_id
           AND journals.journable_type = :journable_type
-          AND journals.version IN (#{max_journal_sql(predecessor)})
+          AND journals.version IN (
+            SELECT MAX(version)
+            FROM journals
+            WHERE journable_id = :journable_id
+            AND journable_type = :journable_type
+          )
       SQL
-    end
-
-    def max_journal_sql(_predecessor)
-      sql = <<~SQL
-        SELECT MAX(version)
-        FROM journals
-        WHERE journable_id = :journable_id
-        AND journable_type = :journable_type
-      SQL
-
-      sanitize sql,
-               journable_id:,
-               journable_type:
     end
 
     def select_changed_sql

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -216,7 +216,7 @@ module Journals
         ), changes AS (
           #{select_changed_sql}
         ), cleanup_predecessor_data AS (
-          #{cleanup_predecessor_data(predecessor, notes, cause)}
+          #{cleanup_predecessor_data_sql(predecessor, notes, cause)}
         ), touch_journable AS (
           #{touch_journable_sql(predecessor, notes, cause)}
         ), fetch_time AS (
@@ -292,7 +292,7 @@ module Journals
       sql
     end
 
-    def cleanup_predecessor_data(predecessor, notes, cause)
+    def cleanup_predecessor_data_sql(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               data_table_name,
                               :id,

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -198,7 +198,7 @@ module Journals
     #
     def create_journal_sql(predecessor, notes, internal, cause)
       journal_modifications = journal_modification_sql(predecessor, notes, internal, cause)
-      relation_modifications = relation_modifications_sql(predecessor)
+      relation_modifications = relation_modifications_sql(predecessor, notes, cause)
 
       journal_cte_clauses = [journal_modifications]
       journal_cte_clauses << relation_modifications if relation_modifications.any?
@@ -211,12 +211,12 @@ module Journals
 
     def journal_modification_sql(predecessor, notes, internal, cause)
       <<~SQL
-        cleanup_predecessor_data AS (
-          #{cleanup_predecessor_data(predecessor)}
-        ), max_journals AS (
+        max_journals AS (
           #{select_max_journal_sql(predecessor)}
         ), changes AS (
           #{select_changed_sql}
+        ), cleanup_predecessor_data AS (
+          #{cleanup_predecessor_data(predecessor, notes, cause)}
         ), touch_journable AS (
           #{touch_journable_sql(predecessor, notes, cause)}
         ), fetch_time AS (
@@ -231,27 +231,82 @@ module Journals
       SQL
     end
 
-    def relation_modifications_sql(predecessor)
+    def relation_modifications_sql(predecessor, notes, cause)
       associations.map do |association|
-        association_modifications_sql(association, predecessor)
+        association_modifications_sql(association, predecessor, notes, cause)
       end
     end
 
-    def association_modifications_sql(association, predecessor)
+    def association_modifications_sql(association, predecessor, notes, cause)
       <<~SQL
         cleanup_predecessor_#{association.name} AS (
-          #{association.cleanup_predecessor(predecessor)}
+          #{association.cleanup_predecessor(predecessor, notes, cause)}
         ), insert_#{association.name} AS (
           #{association.insert_sql}
         )
       SQL
     end
 
-    def cleanup_predecessor_data(predecessor)
+    def select_max_journal_sql(predecessor)
+      sanitize(<<~SQL, journable_id:, journable_type:)
+        SELECT
+          :journable_id journable_id,
+          :journable_type journable_type,
+          updated_at,
+          COALESCE(journals.version, fallback.version) AS version,
+          COALESCE(journals.id, 0) id,
+          COALESCE(journals.data_id, 0) data_id
+        FROM
+          journals
+        RIGHT OUTER JOIN
+          (SELECT 0 AS version) fallback
+        ON
+          journals.journable_id = :journable_id
+          AND journals.journable_type = :journable_type
+          AND journals.version IN (#{max_journal_sql(predecessor)})
+      SQL
+    end
+
+    def max_journal_sql(_predecessor)
+      sql = <<~SQL
+        SELECT MAX(version)
+        FROM journals
+        WHERE journable_id = :journable_id
+        AND journable_type = :journable_type
+      SQL
+
+      sanitize sql,
+               journable_id:,
+               journable_type:
+    end
+
+    def select_changed_sql
+      sql = <<~SQL
+        SELECT
+           *
+        FROM
+          (#{changes_data_sql}) data_changes
+      SQL
+
+      associations.each do |association|
+        sql += <<~SQL
+          FULL JOIN
+            (#{association.changes_sql}) #{association.name}_changes
+          ON
+            #{association.name}_changes.journable_id = data_changes.journable_id
+        SQL
+      end
+
+      sql
+    end
+
+    def cleanup_predecessor_data(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               data_table_name,
                               :id,
-                              :data_id)
+                              :data_id,
+                              notes,
+                              cause)
     end
 
     def update_or_insert_journal_sql(predecessor, notes, internal, cause)
@@ -265,11 +320,14 @@ module Journals
     def update_journal_sql(predecessor, notes, cause)
       # If there is a predecessor, we don't want to create a new one, we simply rewrite it.
       # The original data of that predecessor (data e.g. work_package_journals, customizable_journals, attachable_journals)
-      # has been deleted before but the notes need to taken over and the timestamps updated as if the
+      # has been deleted before but the notes need to be taken over and the timestamps updated as if the
       # journal would have been created.
       #
       # A lot of the data does not need to be set anew, since we only aggregate if that data stays the same
       # (e.g. the user_id).
+      #
+      # In case there is no change at all, the journal will not need to be modified. But even
+      # without a change, having notes or a cause will require to have the journal written.
       sql = <<~SQL
         UPDATE
           journals
@@ -280,6 +338,7 @@ module Journals
           cause = :cause
         FROM insert_data
         WHERE journals.id = :predecessor_id
+        #{'AND EXISTS (SELECT 1 from changes)' unless notes.present? || cause.present?}
         RETURNING
           journals.*
       SQL
@@ -416,46 +475,6 @@ module Journals
       SQL
     end
 
-    def select_max_journal_sql(predecessor)
-      sanitize(<<~SQL, journable_id:, journable_type:)
-        SELECT
-          :journable_id journable_id,
-          :journable_type journable_type,
-          updated_at,
-          COALESCE(journals.version, fallback.version) AS version,
-          COALESCE(journals.id, 0) id,
-          COALESCE(journals.data_id, 0) data_id
-        FROM
-          journals
-        RIGHT OUTER JOIN
-          (SELECT 0 AS version) fallback
-        ON
-          journals.journable_id = :journable_id
-          AND journals.journable_type = :journable_type
-          AND journals.version IN (#{max_journal_sql(predecessor)})
-      SQL
-    end
-
-    def select_changed_sql
-      sql = <<~SQL
-        SELECT
-           *
-        FROM
-          (#{changes_data_sql}) data_changes
-      SQL
-
-      associations.each do |association|
-        sql += <<~SQL
-          FULL JOIN
-            (#{association.changes_sql}) #{association.name}_changes
-          ON
-            #{association.name}_changes.journable_id = data_changes.journable_id
-        SQL
-      end
-
-      sql
-    end
-
     def changes_data_sql
       sanitize(<<~SQL, journable_id:)
         SELECT
@@ -473,26 +492,6 @@ module Journals
         WHERE
           #{journable_table_name}.id = :journable_id AND (#{data_changes_condition_sql})
       SQL
-    end
-
-    def max_journal_sql(predecessor)
-      sql = <<~SQL
-        SELECT MAX(version)
-        FROM journals
-        WHERE journable_id = :journable_id
-        AND journable_type = :journable_type
-      SQL
-
-      if predecessor
-        sanitize "#{sql} AND version < :predecessor_version",
-                 journable_id:,
-                 journable_type:,
-                 predecessor_version: predecessor.version
-      else
-        sanitize sql,
-                 journable_id:,
-                 journable_type:
-      end
     end
 
     def data_changes_condition_sql
@@ -513,19 +512,6 @@ module Journals
       end
 
       data_changes.join(" OR ")
-    end
-
-    def only_on_changed_or_forced_condition_sql(predecessor, notes, cause)
-      # The predecessor part of the condition is in in case the predecessor is being aggregated.
-      # In one of the cases, the change that is being aggregated in nullifies the changes done by the predecessor so
-      # that in effect, there would be no changes any more (compared to the predecessor's predecessor).
-      # With changes being a precondition for journalizing, no journal data would be created and the predecessor
-      # that is aggregated ends up having no data.
-      if notes.blank? && cause.blank? && predecessor.nil?
-        "AND EXISTS (SELECT * FROM changes)"
-      else
-        ""
-      end
     end
 
     def data_sink_columns

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -295,11 +295,90 @@ module Journals
 
     def cleanup_predecessor_data_sql(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               data_table_name,
                               :id,
-                              :data_id,
-                              notes,
-                              cause)
+                              :data_id)
+    end
+
+    # Updates the updated_at timestamp of the journable.
+    #
+    # Whenever an attribute is updated on the journable before creating the journal, the updated_at timestamp
+    # will already have been increased so nothing needs to be done.
+    # But if any of the associated data is updated or if only a cause or note is added, the journable would
+    # otherwise not have received an updated timestamp.
+    #
+    # Therefore, this is only carried out if:
+    # * the journable doesn't already have a newer timestamp than the most recent journal AND
+    # * if there are changes or a note or a cause
+    def touch_journable_sql(notes, cause)
+      if journable.class.aaj_options[:timestamp].to_sym == :updated_at
+        sql = <<~SQL
+          UPDATE
+            #{journable_table_name}
+          SET
+            updated_at = statement_timestamp()
+          WHERE
+            id = :id
+            #{only_on_changed_or_forced_condition_sql(notes, cause)}
+            AND NOT updated_at > (SELECT updated_at FROM max_journals)
+          RETURNING updated_at
+        SQL
+
+        sanitize(sql,
+                 id: journable.id)
+      else
+        <<~SQL
+          SELECT NULL::timestamp with time zone AS updated_at
+        SQL
+      end
+    end
+
+    # Fetches the timestamp to be used by all subsequent SQL statements e.g. for
+    # * setting the created_at and updated_at timestamps of the newly created journal
+    # * setting the updated_at timestamp on an updated (aggregated with) journal
+    # * setting the validity_period (upper bound) of the preceding journal.
+    def fetch_time_sql
+      sanitize(<<~SQL, journable_timestamp:)
+        SELECT COALESCE((SELECT updated_at FROM touch_journable), :journable_timestamp) AS updated_at
+      SQL
+    end
+
+    def insert_data_sql(notes, cause)
+      sanitize(<<~SQL, journable_id:)
+        INSERT INTO
+          #{data_table_name} (
+            #{data_sink_columns}
+          )
+        SELECT
+          #{data_source_columns}
+        FROM #{journable_table_name}
+        #{journable_data_sql_addition}
+        WHERE
+          #{journable_table_name}.id = :journable_id
+          #{only_on_changed_or_forced_condition_sql(notes, cause)}
+        RETURNING *
+      SQL
+    end
+
+    # Sets the validity_period's upper boundary of the preceding journal to the created_at timestamp of the inserted journal.
+    # The upper bound set is not included.
+    # If there is a predecessor (meaning we are aggregating/updating an existing journal), nothing is done.
+    # In that case, the preceding journal is the one we are currently aggregating with so it will still remain
+    # the most recent one.
+    def update_predecessor_sql(predecessor, notes, cause)
+      return "SELECT 1" if predecessor.present?
+
+      <<~SQL
+        UPDATE
+          journals
+        SET
+          validity_period = tstzrange(lower(validity_period), (SELECT updated_at FROM fetch_time), '[)')
+        WHERE
+          id = (SELECT id from max_journals)
+          #{only_on_changed_or_forced_condition_sql(notes, cause)}
+      SQL
     end
 
     def update_or_insert_journal_sql(predecessor, notes, internal, cause)
@@ -384,85 +463,6 @@ module Journals
                journable_type:,
                user_id: user.id,
                data_type: journable.class.journal_class.name)
-    end
-
-    def insert_data_sql(notes, cause)
-      sanitize(<<~SQL, journable_id:)
-        INSERT INTO
-          #{data_table_name} (
-            #{data_sink_columns}
-          )
-        SELECT
-          #{data_source_columns}
-        FROM #{journable_table_name}
-        #{journable_data_sql_addition}
-        WHERE
-          #{journable_table_name}.id = :journable_id
-          #{only_on_changed_or_forced_condition_sql(notes, cause)}
-        RETURNING *
-      SQL
-    end
-
-    # Updates the updated_at timestamp of the journable.
-    #
-    # Whenever an attribute is updated on the journable before creating the journal, the updated_at timestamp
-    # will already have been increased so nothing needs to be done.
-    # But if any of the associated data is updated or if only a cause or note is added, the journable would
-    # otherwise not have received an updated timestamp.
-    #
-    # Therefore, this is only carried out if:
-    # * the journable doesn't already have a newer timestamp than the most recent journal AND
-    # * if there are changes or a note or a cause
-    def touch_journable_sql(notes, cause)
-      if journable.class.aaj_options[:timestamp].to_sym == :updated_at
-        sql = <<~SQL
-          UPDATE
-            #{journable_table_name}
-          SET
-            updated_at = statement_timestamp()
-          WHERE
-            id = :id
-            #{only_on_changed_or_forced_condition_sql(notes, cause)}
-            AND NOT updated_at > (SELECT updated_at FROM max_journals)
-          RETURNING updated_at
-        SQL
-
-        sanitize(sql,
-                 id: journable.id)
-      else
-        <<~SQL
-          SELECT NULL::timestamp with time zone AS updated_at
-        SQL
-      end
-    end
-
-    # Fetches the timestamp to be used by all subsequent SQL statements e.g. for
-    # * setting the created_at and updated_at timestamps of the newly created journal
-    # * setting the updated_at timestamp on an updated (aggregated with) journal
-    # * setting the validity_period (upper bound) of the preceding journal.
-    def fetch_time_sql
-      sanitize(<<~SQL, journable_timestamp:)
-        SELECT COALESCE((SELECT updated_at FROM touch_journable), :journable_timestamp) AS updated_at
-      SQL
-    end
-
-    # Sets the validity_period's upper boundary of the preceding journal to the created_at timestamp of the inserted journal.
-    # The upper bound set is not included.
-    # If there is a predecessor (meaning we are aggregating/updating an existing journal), nothing is done.
-    # In that case, the preceding journal is the one we are currently aggregating with so it will still remain
-    # the most recent one.
-    def update_predecessor_sql(predecessor, notes, cause)
-      return "SELECT 1" if predecessor.present?
-
-      <<~SQL
-        UPDATE
-          journals
-        SET
-          validity_period = tstzrange(lower(validity_period), (SELECT updated_at FROM fetch_time), '[)')
-        WHERE
-          id = (SELECT id from max_journals)
-          #{only_on_changed_or_forced_condition_sql(notes, cause)}
-      SQL
     end
 
     def changes_data_sql

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -410,7 +410,7 @@ module Journals
           cause = :cause
         FROM insert_data
         WHERE journals.id = :predecessor_id
-        #{'AND EXISTS (SELECT 1 from changes)' unless notes.present? || cause.present?}
+        #{only_on_changed_or_forced_condition_sql(notes, cause)}
         RETURNING
           journals.*
       SQL

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -404,33 +404,30 @@ module Journals
     end
 
     # Updates the updated_at timestamp of the journable.
-    # That is only carried out if the journable doesn't already have a newer timestamp than the most recent journal or
-    # hasn't been updated by the `#save` call after which this service runs.
-    # Most recent in this case can mean one of two things:
-    #  * if there is a predecessor we are aggregating with, it is that predecessor
-    #  * otherwise, the most recent journal that we are not aggregating with.
+    #
     # Whenever an attribute is updated on the journable before creating the journal, the updated_at timestamp
     # will already have been increased so nothing needs to be done.
     # But if any of the associated data is updated or if only a cause or note is added, the journable would
     # otherwise not have received an updated timestamp.
-    def touch_journable_sql(predecessor, notes, cause) # rubocop:disable Metrics/AbcSize
+    #
+    # Therefore, this is only carried out if:
+    # * the journable doesn't already have a newer timestamp than the most recent journal AND
+    # * if there are changes or a note or a cause
+    def touch_journable_sql(predecessor, notes, cause)
       if journable.class.aaj_options[:timestamp].to_sym == :updated_at
         sql = <<~SQL
           UPDATE
             #{journable_table_name}
           SET
-            updated_at = COALESCE(:update_timestamp, statement_timestamp())
+            updated_at = statement_timestamp()
           WHERE
             id = :id
             #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
-            AND NOT updated_at > COALESCE(:predecessor_timestamp, (SELECT updated_at FROM max_journals))
+            AND NOT updated_at > (SELECT updated_at FROM max_journals)
           RETURNING updated_at
         SQL
 
-        keep_same_updated_at = journable.updated_at_previously_changed? && !journable.previously_new_record?
         sanitize(sql,
-                 update_timestamp: keep_same_updated_at ? journable.updated_at : nil,
-                 predecessor_timestamp: predecessor&.updated_at,
                  id: journable.id)
       else
         <<~SQL

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -558,7 +558,7 @@ module Journals
         aggregation_active? &&
         within_aggregation_time?(predecessor) &&
         same_user?(predecessor) &&
-        same_cause?(predecessor, cause) &&
+        only_one_or_same_cause?(predecessor, cause) &&
         only_one_note(predecessor, notes) &&
         same_restriction(predecessor, internal)
     end
@@ -583,8 +583,8 @@ module Journals
       predecessor.user_id == user.id
     end
 
-    def same_cause?(predecessor, cause)
-      (predecessor.cause.blank? && cause.blank?) || predecessor.cause == cause
+    def only_one_or_same_cause?(predecessor, cause)
+      predecessor.cause.empty? || cause.empty? || predecessor.cause == cause
     end
 
     def log_journal_creation(predecessor)

--- a/app/services/journals/create_service/agenda_itemable.rb
+++ b/app/services/journals/create_service/agenda_itemable.rb
@@ -34,11 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:agenda_items)
     end
 
-    def cleanup_predecessor(predecessor)
+    def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               "meeting_agenda_item_journals",
                               :journal_id,
-                              :id)
+                              :id,
+                              notes,
+                              cause)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/agenda_itemable.rb
+++ b/app/services/journals/create_service/agenda_itemable.rb
@@ -36,11 +36,11 @@ class Journals::CreateService
 
     def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               "meeting_agenda_item_journals",
                               :journal_id,
-                              :id,
-                              notes,
-                              cause)
+                              :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/attachable.rb
+++ b/app/services/journals/create_service/attachable.rb
@@ -36,11 +36,11 @@ class Journals::CreateService
 
     def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               "attachable_journals",
                               :journal_id,
-                              :id,
-                              notes,
-                              cause)
+                              :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/attachable.rb
+++ b/app/services/journals/create_service/attachable.rb
@@ -34,11 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:attachable?)
     end
 
-    def cleanup_predecessor(predecessor)
+    def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               "attachable_journals",
                               :journal_id,
-                              :id)
+                              :id,
+                              notes,
+                              cause)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/customizable.rb
+++ b/app/services/journals/create_service/customizable.rb
@@ -34,11 +34,13 @@ class Journals::CreateService
       journable.customizable?
     end
 
-    def cleanup_predecessor(predecessor)
+    def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               "customizable_journals",
                               :journal_id,
-                              :id)
+                              :id,
+                              notes,
+                              cause)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/customizable.rb
+++ b/app/services/journals/create_service/customizable.rb
@@ -36,11 +36,11 @@ class Journals::CreateService
 
     def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               "customizable_journals",
                               :journal_id,
-                              :id,
-                              notes,
-                              cause)
+                              :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/helpers.rb
+++ b/app/services/journals/create_service/helpers.rb
@@ -39,7 +39,7 @@ class Journals::CreateService
 
     def journable_class_name = journable.class.base_class.name
 
-    def cleanup_predecessor_for(predecessor, table_name, column, referenced_id, notes, cause)
+    def cleanup_predecessor_for(predecessor, notes, cause, table_name, column, referenced_id)
       return "SELECT 1" unless predecessor
 
       sanitize(<<~SQL.squish, column => predecessor.send(referenced_id))

--- a/app/services/journals/create_service/helpers.rb
+++ b/app/services/journals/create_service/helpers.rb
@@ -48,17 +48,12 @@ class Journals::CreateService
          #{table_name}
         WHERE
          #{column} = :#{column}
-         #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
+         #{only_on_changed_or_forced_condition_sql(notes, cause)}
       SQL
     end
 
-    def only_on_changed_or_forced_condition_sql(predecessor, notes, cause)
-      # The predecessor part of the condition is in in case the predecessor is being aggregated.
-      # In one of the cases, the change that is being aggregated in nullifies the changes done by the predecessor so
-      # that in effect, there would be no changes any more (compared to the predecessor's predecessor).
-      # With changes being a precondition for journalizing, no journal data would be created and the predecessor
-      # that is aggregated ends up having no data.
-      if notes.blank? && cause.blank? && predecessor.nil?
+    def only_on_changed_or_forced_condition_sql(notes, cause)
+      if notes.blank? && cause.blank?
         "AND EXISTS (SELECT * FROM changes)"
       else
         ""

--- a/app/services/journals/create_service/helpers.rb
+++ b/app/services/journals/create_service/helpers.rb
@@ -39,7 +39,7 @@ class Journals::CreateService
 
     def journable_class_name = journable.class.base_class.name
 
-    def cleanup_predecessor_for(predecessor, table_name, column, referenced_id)
+    def cleanup_predecessor_for(predecessor, table_name, column, referenced_id, notes, cause)
       return "SELECT 1" unless predecessor
 
       sanitize(<<~SQL.squish, column => predecessor.send(referenced_id))
@@ -48,7 +48,21 @@ class Journals::CreateService
          #{table_name}
         WHERE
          #{column} = :#{column}
+         #{only_on_changed_or_forced_condition_sql(predecessor, notes, cause)}
       SQL
+    end
+
+    def only_on_changed_or_forced_condition_sql(predecessor, notes, cause)
+      # The predecessor part of the condition is in in case the predecessor is being aggregated.
+      # In one of the cases, the change that is being aggregated in nullifies the changes done by the predecessor so
+      # that in effect, there would be no changes any more (compared to the predecessor's predecessor).
+      # With changes being a precondition for journalizing, no journal data would be created and the predecessor
+      # that is aggregated ends up having no data.
+      if notes.blank? && cause.blank? && predecessor.nil?
+        "AND EXISTS (SELECT * FROM changes)"
+      else
+        ""
+      end
     end
 
     def normalize_newlines_sql(column)

--- a/app/services/journals/create_service/project_phase.rb
+++ b/app/services/journals/create_service/project_phase.rb
@@ -36,11 +36,11 @@ class Journals::CreateService
 
     def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               "project_phase_journals",
                               :journal_id,
-                              :id,
-                              notes,
-                              cause)
+                              :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/project_phase.rb
+++ b/app/services/journals/create_service/project_phase.rb
@@ -34,11 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:phases)
     end
 
-    def cleanup_predecessor(predecessor)
+    def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               "project_phase_journals",
                               :journal_id,
-                              :id)
+                              :id,
+                              notes,
+                              cause)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/storable.rb
+++ b/app/services/journals/create_service/storable.rb
@@ -34,11 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:file_links)
     end
 
-    def cleanup_predecessor(predecessor)
+    def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
                               "storages_file_links_journals",
                               :journal_id,
-                              :id)
+                              :id,
+                              notes,
+                              cause)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/storable.rb
+++ b/app/services/journals/create_service/storable.rb
@@ -36,11 +36,11 @@ class Journals::CreateService
 
     def cleanup_predecessor(predecessor, notes, cause)
       cleanup_predecessor_for(predecessor,
+                              notes,
+                              cause,
                               "storages_file_links_journals",
                               :journal_id,
-                              :id,
-                              notes,
-                              cause)
+                              :id)
     end
 
     def insert_sql

--- a/modules/costs/spec/models/project/activity_spec.rb
+++ b/modules/costs/spec/models/project/activity_spec.rb
@@ -56,16 +56,16 @@ RSpec.describe Projects::Activity, "costs" do
 
   describe ".with_latest_activity" do
     it "set project.latest_activity_at to the latest updated budget time" do
-      budget.update(updated_at: initial_time - 10.seconds)
-      budget2.update(updated_at: initial_time - 20.seconds)
+      budget.update_columns(updated_at: initial_time - 10.seconds)
+      budget2.update_columns(updated_at: initial_time - 20.seconds)
 
       # there is a loss of precision for timestamps stored in database
       expect(latest_activity).to equal_time_without_usec(budget.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
-      work_package.update(updated_at: initial_time - 10.seconds)
-      budget.update(updated_at: initial_time - 20.seconds)
+      work_package.update_columns(updated_at: initial_time - 10.seconds)
+      budget.update_columns(updated_at: initial_time - 20.seconds)
 
       # Order:
       # work_package
@@ -73,7 +73,7 @@ RSpec.describe Projects::Activity, "costs" do
 
       expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
-      work_package.update(updated_at: budget.updated_at - 10.seconds)
+      work_package.update_columns(updated_at: budget.updated_at - 10.seconds)
 
       # Order:
       # budget

--- a/modules/costs/spec/models/time_entries/time_entry_acts_as_journalized_spec.rb
+++ b/modules/costs/spec/models/time_entries/time_entry_acts_as_journalized_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe TimeEntry do
+  describe "#journals (and the saving of them)" do
+    shared_let(:project) { create(:project) }
+    shared_let(:work_package) { create(:work_package, project:) }
+    shared_let(:user) { create(:user) }
+    shared_let(:other_user) { create(:user) }
+    shared_let(:rate) { create(:hourly_rate, user:, project:, valid_from: Date.new(2026, 1, 8), rate: 1) }
+    shared_let(:activity) { create(:time_entry_activity) }
+
+    current_user { user }
+
+    context "on creation" do
+      let!(:journable) do
+        described_class.new
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "user_id" => :user,
+                         "project_id" => :project,
+                         "comments" => "Initial comment",
+                         "hours" => 60,
+                         "activity_id" => :activity,
+                         "spent_on" => Date.new(2026, 1, 9),
+                         "overridden_costs" => 30.0,
+                         "costs" => 20.0,
+                         "logged_by_id" => :other_user,
+                         "start_time" => 22,
+                         "time_zone" => "UTC",
+                         "entity_id" => :work_package,
+                         "entity_type" => "WorkPackage"
+                       },
+                       expected_values: {
+                         "user_id" => [nil, :user],
+                         "project_id" => [nil, :project],
+                         "comments" => [nil, "Initial comment"],
+                         "hours" => [nil, 60],
+                         "activity_id" => [nil, :activity],
+                         "spent_on" => [nil, Date.new(2026, 1, 9)],
+                         # The next three are deduced from spent_on automatically
+                         "tyear" => [nil, 2026],
+                         "tmonth" => [nil, 1],
+                         "tweek" => [nil, 2],
+                         "overridden_costs" => [nil, 30.0],
+                         # This one is calculated based on the rate and the amount
+                         "costs" => [nil, 60.0],
+                         "rate_id" => [nil, :rate],
+                         "logged_by_id" => [nil, :other_user],
+                         "start_time" => [nil, 22],
+                         "time_zone" => [nil, "UTC"],
+                         "entity_id" => [nil, :work_package],
+                         "entity_type" => [nil, "WorkPackage"]
+                       },
+                       expect_new_journal: true,
+                       expect_predecessor_changed: false do
+        it "results in created_at and updated_at being the same on the time entry" do
+          journable.save!
+          # Just to ensure that there actually is nothing hidden in the DB
+          journable.reload
+
+          expect(work_package.created_at)
+            .to eql work_package.updated_at
+        end
+      end
+    end
+
+    context "when nothing is changed" do
+      context "for a time entry that has only been created (single journal)" do
+        # Not using a factory here as that already produced a journal without a data journal
+        let!(:journable) do
+          described_class.create!(
+            user:,
+            project:,
+            comments: "Initial comment",
+            hours: 60,
+            activity:,
+            spent_on: Date.new(2026, 1, 9),
+            overridden_costs: 30.0,
+            costs: 20.0,
+            logged_by: other_user,
+            start_time: 22,
+            time_zone: "UTC",
+            entity: work_package
+          )
+        end
+
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/models/project/activity_spec.rb
+++ b/modules/meeting/spec/models/project/activity_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH

--- a/modules/meeting/spec/models/project/activity_spec.rb
+++ b/modules/meeting/spec/models/project/activity_spec.rb
@@ -58,16 +58,16 @@ RSpec.describe Projects::Activity, "meeting" do
 
   describe ".with_latest_activity" do
     it "set project.latest_activity_at to the latest updated meeting time" do
-      meeting.update(updated_at: initial_time - 10.seconds)
-      meeting2.update(updated_at: initial_time - 20.seconds)
+      meeting.update_columns(updated_at: initial_time - 10.seconds)
+      meeting2.update_columns(updated_at: initial_time - 20.seconds)
 
       # there is a loss of precision for timestamps stored in database
       expect(latest_activity).to equal_time_without_usec(meeting.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
-      work_package.update(updated_at: initial_time - 10.seconds)
-      meeting.update(updated_at: initial_time - 20.seconds)
+      work_package.update_columns(updated_at: initial_time - 10.seconds)
+      meeting.update_columns(updated_at: initial_time - 20.seconds)
 
       # Order:
       # work_package
@@ -75,7 +75,7 @@ RSpec.describe Projects::Activity, "meeting" do
 
       expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
-      work_package.update(updated_at: meeting.updated_at - 10.seconds)
+      work_package.update_columns(updated_at: meeting.updated_at - 10.seconds)
 
       # Order:
       # meeting

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -110,7 +110,8 @@ FactoryBot.define do
                                                 created_at: timestamp,
                                                 updated_at: timestamp,
                                                 user: work_package.author,
-                                                version: version + 1)
+                                                version: version + 1,
+                                                notes: "")
 
           data_attributes = work_package_attributes
                               .extract!(*Journal::WorkPackageJournal.attribute_names)

--- a/spec/models/projects/activity_spec.rb
+++ b/spec/models/projects/activity_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe Projects::Activity, "core" do
 
   describe ".with_latest_activity" do
     it "is the latest work_package update" do
-      work_package.update(updated_at: initial_time - 10.seconds)
-      work_package2.update(updated_at: initial_time - 20.seconds)
+      work_package.update_columns(updated_at: initial_time - 10.seconds)
+      work_package2.update_columns(updated_at: initial_time - 20.seconds)
       work_package.reload
       work_package2.reload
 
@@ -129,8 +129,8 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest wiki_pages update" do
-      wiki_page.update(updated_at: initial_time - 10.seconds)
-      wiki_page2.update(updated_at: initial_time - 20.seconds)
+      wiki_page.update_columns(updated_at: initial_time - 10.seconds)
+      wiki_page2.update_columns(updated_at: initial_time - 20.seconds)
       wiki_page.reload
       wiki_page2.reload
 
@@ -138,8 +138,8 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest news update" do
-      news.update(updated_at: initial_time - 10.seconds)
-      news2.update(updated_at: initial_time - 20.seconds)
+      news.update_columns(updated_at: initial_time - 10.seconds)
+      news2.update_columns(updated_at: initial_time - 20.seconds)
       news.reload
       news2.reload
 
@@ -147,8 +147,8 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest changeset update" do
-      changeset.update(committed_on: initial_time - 10.seconds)
-      changeset2.update(committed_on: initial_time - 20.seconds)
+      changeset.update_columns(committed_on: initial_time - 10.seconds)
+      changeset2.update_columns(committed_on: initial_time - 20.seconds)
       changeset.reload
       changeset2.reload
 
@@ -156,8 +156,8 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest message update" do
-      message.update(updated_at: initial_time - 10.seconds)
-      message2.update(updated_at: initial_time - 20.seconds)
+      message.update_columns(updated_at: initial_time - 10.seconds)
+      message2.update_columns(updated_at: initial_time - 20.seconds)
       message.reload
       message2.reload
 
@@ -165,9 +165,9 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest time_entry update" do
-      work_package.update(updated_at: initial_time - 60.seconds)
-      time_entry.update(updated_at: initial_time - 10.seconds)
-      time_entry2.update(updated_at: initial_time - 20.seconds)
+      work_package.update_columns(updated_at: initial_time - 60.seconds)
+      time_entry.update_columns(updated_at: initial_time - 10.seconds)
+      time_entry2.update_columns(updated_at: initial_time - 20.seconds)
       time_entry.reload
       time_entry2.reload
 
@@ -175,19 +175,19 @@ RSpec.describe Projects::Activity, "core" do
     end
 
     it "is the latest project update" do
-      work_package.update(updated_at: initial_time - 60.seconds)
-      project.update(updated_at: initial_time - 10.seconds)
+      work_package.update_columns(updated_at: initial_time - 60.seconds)
+      project.update_columns(updated_at: initial_time - 10.seconds)
 
       expect(latest_activity).to equal_time_without_usec(project.updated_at)
     end
 
     it "takes the time stamp of the latest activity across models" do
-      work_package.update(updated_at: initial_time - 10.seconds)
-      wiki_page.update(updated_at: initial_time - 20.seconds)
-      news.update(updated_at: initial_time - 30.seconds)
-      changeset.update(committed_on: initial_time - 40.seconds)
-      message.update(updated_at: initial_time - 50.seconds)
-      project.update(updated_at: initial_time - 60.seconds)
+      work_package.update_columns(updated_at: initial_time - 10.seconds)
+      wiki_page.update_columns(updated_at: initial_time - 20.seconds)
+      news.update_columns(updated_at: initial_time - 30.seconds)
+      changeset.update_columns(committed_on: initial_time - 40.seconds)
+      message.update_columns(updated_at: initial_time - 50.seconds)
+      project.update_columns(updated_at: initial_time - 60.seconds)
 
       work_package.reload
       wiki_page.reload
@@ -205,7 +205,7 @@ RSpec.describe Projects::Activity, "core" do
 
       expect(latest_activity).to equal_time_without_usec(work_package.updated_at)
 
-      work_package.update(updated_at: project.updated_at - 10.seconds)
+      work_package.update_columns(updated_at: project.updated_at - 10.seconds)
 
       # Order:
       # wiki_page
@@ -217,7 +217,7 @@ RSpec.describe Projects::Activity, "core" do
 
       expect(latest_activity).to equal_time_without_usec(wiki_page.updated_at)
 
-      wiki_page.update(updated_at: work_package.updated_at - 10.seconds)
+      wiki_page.update_columns(updated_at: work_package.updated_at - 10.seconds)
 
       # Order:
       # news
@@ -229,7 +229,7 @@ RSpec.describe Projects::Activity, "core" do
 
       expect(latest_activity).to equal_time_without_usec(news.updated_at)
 
-      news.update(updated_at: wiki_page.updated_at - 10.seconds)
+      news.update_columns(updated_at: wiki_page.updated_at - 10.seconds)
 
       # Order:
       # changeset
@@ -241,7 +241,7 @@ RSpec.describe Projects::Activity, "core" do
 
       expect(latest_activity).to equal_time_without_usec(changeset.committed_on)
 
-      changeset.update(committed_on: news.updated_at - 10.seconds)
+      changeset.update_columns(committed_on: news.updated_at - 10.seconds)
 
       # Order:
       # message
@@ -253,7 +253,7 @@ RSpec.describe Projects::Activity, "core" do
 
       expect(latest_activity).to equal_time_without_usec(message.updated_at)
 
-      message.update(updated_at: changeset.committed_on - 10.seconds)
+      message.update_columns(updated_at: changeset.committed_on - 10.seconds)
 
       # Order:
       # project

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe WorkPackage do
   describe "#journals (and the saving of them)" do
+    shared_let(:user) { create(:user) }
     shared_let(:type) { create(:type) }
     shared_let(:other_type) { create(:type) }
     shared_let(:status) { create(:default_status) }
@@ -49,14 +50,11 @@ RSpec.describe WorkPackage do
     shared_let(:other_work_package) { build_stubbed(:work_package) }
     shared_let(:other_user) { create(:user) }
 
-    current_user { create(:user) }
-
-    # For the shared examples
-    let(:journable) { work_package }
+    current_user { user }
 
     context "on creation" do
-      let(:work_package) do
-        described_class.new(author: current_user)
+      let(:journable) do
+        described_class.new(author: user)
       end
 
       include_examples "journaled values for",
@@ -111,22 +109,22 @@ RSpec.describe WorkPackage do
                        expect_new_journal: true,
                        expect_predecessor_changed: false do
         it "results in created_at and updated_at being the same on the work package" do
-          work_package.save!
+          journable.save!
           # Just to ensure that there actually is nothing hidden in the DB
-          work_package.reload
+          journable.reload
 
-          expect(work_package.created_at)
-            .to eql work_package.updated_at
+          expect(journable.created_at)
+            .to eql journable.updated_at
         end
       end
     end
 
     context "when nothing is changed" do
       context "for a work package that has only been created (single journal)" do
-        let!(:work_package) do
+        shared_let(:journable) do
           create(:work_package,
                  journals: {
-                   Time.current => { user: current_user, notes: "First comment" }
+                   Time.current => { user:, notes: "First comment" }
                  })
         end
 
@@ -135,11 +133,11 @@ RSpec.describe WorkPackage do
       end
 
       context "for a work package that has been updated already (multiple journals)" do
-        let!(:work_package) do
+        shared_let(:journable) do
           create(:work_package,
                  journals: {
-                   5.days.ago => { user: current_user },
-                   4.days.ago => { user: current_user, notes: "First comment" }
+                   5.days.ago => { user: },
+                   4.days.ago => { user:, notes: "First comment" }
                  })
         end
 
@@ -149,7 +147,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes outside of aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                description: "Initial description",
@@ -162,13 +160,13 @@ RSpec.describe WorkPackage do
                duration: 1,
                estimated_hours: 3.0,
                schedule_manually: true,
-               assigned_to: current_user,
-               responsible: current_user,
+               assigned_to: user,
+               responsible: user,
                category: nil,
                version:,
                ignore_non_working_days: true,
                journals: {
-                 10.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: }
                })
       end
 
@@ -216,7 +214,7 @@ RSpec.describe WorkPackage do
                          "duration" => [1, 8],
                          "schedule_manually" => [true, false],
                          "ignore_non_working_days" => [true, false],
-                         "assigned_to_id" => %i[current_user other_user],
+                         "assigned_to_id" => %i[user other_user],
                          "responsible_id" => [:current_user, nil],
                          "parent_id" => [nil, :parent_work_package],
                          "project_phase_definition_id" => [nil, :project_phase_definition]
@@ -225,7 +223,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes within aggregation time for a work package with no update yet (single journal)" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                description: "Initial description",
@@ -238,13 +236,13 @@ RSpec.describe WorkPackage do
                duration: 1,
                estimated_hours: 3.0,
                schedule_manually: true,
-               assigned_to: current_user,
-               responsible: current_user,
+               assigned_to: user,
+               responsible: user,
                category: nil,
                version:,
                ignore_non_working_days: true,
                journals: {
-                 4.minutes.ago => { user: current_user }
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -301,7 +299,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes within aggregation time for a work package with former updates (multiple journal)" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                description: "Initial description",
@@ -314,16 +312,16 @@ RSpec.describe WorkPackage do
                duration: 1,
                estimated_hours: 3.0,
                schedule_manually: true,
-               assigned_to: current_user,
-               responsible: current_user,
+               assigned_to: user,
+               responsible: user,
                category: nil,
                version:,
                ignore_non_working_days: true,
                journals: {
                  # Both journals will be the exact same snapshot of the current state.
                  # For the sake of this test, this doesn't matter.
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -371,8 +369,8 @@ RSpec.describe WorkPackage do
                          "duration" => [1, 8],
                          "schedule_manually" => [true, false],
                          "ignore_non_working_days" => [true, false],
-                         "assigned_to_id" => %i[current_user other_user],
-                         "responsible_id" => [:current_user, nil],
+                         "assigned_to_id" => %i[user other_user],
+                         "responsible_id" => [:user, nil],
                          "parent_id" => [nil, :parent_work_package],
                          "project_phase_definition_id" => [nil, :project_phase_definition]
                        },
@@ -380,7 +378,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes within aggregation time for a different user" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                description: "Initial description",
                journals: {
@@ -399,14 +397,14 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes with aggregation disabled", with_settings: { journal_aggregation_time_minutes: 0 } do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
                  # Both journals will be the exact same snapshot of the current state.
                  # For the sake of this test, this doesn't matter.
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -424,17 +422,17 @@ RSpec.describe WorkPackage do
       let(:attachment) { build(:attachment) }
       let(:attachment_id) { "attachments_#{attachment.id}" }
 
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package)
       end
 
       before do
-        work_package.attachments << attachment
-        work_package.save!
+        journable.attachments << attachment
+        journable.save!
       end
 
       context "for new attachment" do
-        subject { work_package.last_journal.details }
+        subject { journable.last_journal.details }
 
         it { is_expected.to have_key attachment_id }
 
@@ -456,7 +454,7 @@ RSpec.describe WorkPackage do
 
       let(:custom_field_id) { "custom_fields_#{custom_value.custom_field_id}" }
 
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package)
       end
 
@@ -464,16 +462,16 @@ RSpec.describe WorkPackage do
         before do
           project.work_package_custom_fields << custom_field
           type.custom_fields << custom_field
-          work_package.reload
-          work_package.custom_values << custom_value
-          work_package.save!
+          journable.reload
+          journable.custom_values << custom_value
+          journable.save!
         end
       end
 
       context "for new custom value" do
         include_context "for work package with custom value"
 
-        subject { work_package.last_journal.details }
+        subject { journable.last_journal.details }
 
         it { is_expected.to have_key custom_field_id }
 
@@ -490,11 +488,11 @@ RSpec.describe WorkPackage do
         end
 
         before do
-          work_package.custom_values = [modified_custom_value]
-          work_package.save!
+          journable.custom_values = [modified_custom_value]
+          journable.save!
         end
 
-        subject { work_package.last_journal.details }
+        subject { journable.last_journal.details }
 
         it { is_expected.to have_key custom_field_id }
 
@@ -511,14 +509,14 @@ RSpec.describe WorkPackage do
         end
 
         before do
-          work_package.custom_values = [unmodified_custom_value]
+          journable.custom_values = [unmodified_custom_value]
         end
 
-        it { expect { work_package.save! }.not_to change(Journal, :count) }
+        it { expect { journable.save! }.not_to change(Journal, :count) }
 
         it "does not set an upper bound to the already existing journal" do
-          work_package.save
-          expect(work_package.last_journal.validity_period.end)
+          journable.save!
+          expect(journable.last_journal.validity_period.end)
             .to be_nil
         end
       end
@@ -527,11 +525,11 @@ RSpec.describe WorkPackage do
         include_context "for work package with custom value"
 
         before do
-          work_package.custom_values.delete(custom_value)
-          work_package.save!
+          journable.custom_values.delete(custom_value)
+          journable.save!
         end
 
-        subject { work_package.last_journal.details }
+        subject { journable.last_journal.details }
 
         it { is_expected.to have_key custom_field_id }
 
@@ -548,20 +546,20 @@ RSpec.describe WorkPackage do
         let(:custom_value) do
           create(:custom_value,
                  value: "",
-                 customized: work_package,
+                 customized: journable,
                  custom_field:)
         end
 
         describe "empty values are recognized as unchanged" do
           include_context "for work package with custom value"
 
-          it { expect(work_package.last_journal.customizable_journals).to be_empty }
+          it { expect(journable.last_journal.customizable_journals).to be_empty }
         end
 
         describe "empty values handled as non existing" do
           include_context "for work package with custom value"
 
-          it { expect(work_package.last_journal.customizable_journals.count).to eq(0) }
+          it { expect(journable.last_journal.customizable_journals.count).to eq(0) }
         end
       end
     end
@@ -570,17 +568,17 @@ RSpec.describe WorkPackage do
       let(:file_link) { build(:file_link) }
       let(:file_link_id) { "file_links_#{file_link.id}" }
 
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package)
       end
 
       before do
-        work_package.file_links << file_link
-        work_package.save!
+        journable.file_links << file_link
+        journable.save!
       end
 
       context "for the new file link" do
-        subject(:journal_details) { work_package.last_journal.details }
+        subject(:journal_details) { journable.last_journal.details }
 
         it { is_expected.to have_key file_link_id }
 
@@ -594,17 +592,17 @@ RSpec.describe WorkPackage do
         it {
           expect do
             file_link.save
-            work_package.save_journals
+            journable.save_journals
           end.not_to change(Journal, :count)
         }
       end
     end
 
     context "on only journal notes adding outside of aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
-                 10.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: }
                })
       end
 
@@ -618,11 +616,11 @@ RSpec.describe WorkPackage do
     end
 
     context "on only journal notes adding within aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -636,7 +634,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on only journal notes adding within aggregation time as a different user" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
                  10.minutes.ago => { user: other_user },
@@ -654,11 +652,11 @@ RSpec.describe WorkPackage do
     end
 
     context "on only journal notes adding within aggregation time with the last journal already having a note" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user, notes: "The former note" }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user:, notes: "The former note" }
                })
       end
 
@@ -672,12 +670,12 @@ RSpec.describe WorkPackage do
     end
 
     context "on changes within aggregation time for a work package with a journal with notes" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user, notes: "The former note" }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user:, notes: "The former note" }
                })
       end
 
@@ -693,11 +691,11 @@ RSpec.describe WorkPackage do
     end
 
     context "on mixed journal notes and attribute adding outside of aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
-                 10.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: }
                })
       end
 
@@ -714,13 +712,13 @@ RSpec.describe WorkPackage do
     end
 
     context "on only journal cause adding within aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
                  # Adding a second journal (even if it is empty) to avoid the changes
                  # from the wp creation to mess with the expected values.
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -740,10 +738,10 @@ RSpec.describe WorkPackage do
     end
 
     context "on adding a different cause within aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                journals: {
-                 4.minutes.ago => { user: current_user, cause: "XYZ" }
+                 4.minutes.ago => { user:, cause: "XYZ" }
                })
       end
 
@@ -757,12 +755,12 @@ RSpec.describe WorkPackage do
     end
 
     context "on adding the same cause within aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user, cause: "ABC" }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user:, cause: "ABC" }
                })
       end
 
@@ -780,11 +778,11 @@ RSpec.describe WorkPackage do
     end
 
     context "on mixed journal cause, notes and attribute adding outside of aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
-                 10.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: }
                })
       end
 
@@ -809,12 +807,12 @@ RSpec.describe WorkPackage do
     end
 
     context "on mixed journal cause, notes and attribute adding within aggregation time" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
-                 10.minutes.ago => { user: current_user },
-                 4.minutes.ago => { user: current_user }
+                 10.minutes.ago => { user: },
+                 4.minutes.ago => { user: }
                })
       end
 
@@ -839,7 +837,7 @@ RSpec.describe WorkPackage do
     end
 
     context "on mixed journal cause, notes and attribute adding within aggregation time as a different user" do
-      let!(:work_package) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject",
                journals: {
@@ -870,45 +868,43 @@ RSpec.describe WorkPackage do
 
     context "when aggregation leads to an empty change (changing back and forth)",
             with_settings: { journal_aggregation_time_minutes: 1 } do
-      let!(:work_package) do
-        User.execute_as current_user do
-          create(:work_package,
-                 :created_in_past,
-                 created_at: 5.minutes.ago,
-                 project_id: project.id,
-                 type:,
-                 description: "Description",
-                 priority:,
-                 status:,
-                 duration: 1)
-        end
+      shared_let(:journable) do
+        create(:work_package,
+               :created_in_past,
+               created_at: 5.minutes.ago,
+               project_id: project.id,
+               type:,
+               description: "Description",
+               priority:,
+               status:,
+               duration: 1)
       end
 
       let(:other_status) { create(:status) }
 
       before do
-        work_package.status = other_status
-        work_package.save!
-        work_package.status = status
-        work_package.save!
+        journable.status = other_status
+        journable.save!
+        journable.status = status
+        journable.save!
       end
 
       it "creates a new journal" do
-        expect(work_package.journals.count).to be 2
+        expect(journable.journals.count).to be 2
       end
 
       it "has the old state in the last journal`s data" do
-        expect(work_package.journals.last.data.status_id).to be status.id
+        expect(journable.journals.last.data.status_id).to be status.id
       end
     end
 
     context "on changes to newline characters" do
       context "when outside of the aggregation time" do
-        let!(:work_package) do
+        shared_let(:journable) do
           create(:work_package,
                  description: "Description\n\nwith newlines\n\nembedded",
                  journals: {
-                   1.day.ago => { user: current_user }
+                   1.day.ago => { user: }
                  })
         end
 
@@ -922,12 +918,12 @@ RSpec.describe WorkPackage do
                          expect_new_journal: true
 
         context "when multiple values are changed and the change to description is only a newline change" do
-          let!(:work_package) do
+          shared_let(:journable) do
             create(:work_package,
                    description: "Description\r\n\r\nwith newlines\r\n\r\nembedded",
                    subject: "Original subject",
                    journals: {
-                     1.day.ago => { user: current_user }
+                     1.day.ago => { user: }
                    })
           end
 
@@ -943,11 +939,11 @@ RSpec.describe WorkPackage do
         end
 
         context "when there is a legacy journal containing non-escaped newlines" do
-          let!(:work_package) do
+          shared_let(:journable) do
             create(:work_package,
                    description: "Description\r\n\r\nwith newlines\r\n\r\nembedded",
                    journals: {
-                     3.minutes.ago => { user: current_user }
+                     3.minutes.ago => { user: }
                    })
           end
 
@@ -966,10 +962,10 @@ RSpec.describe WorkPackage do
     # DETAIL:  Failing row contains (1178, WorkPackage, 481, 1252, , 2025-12-04 07:58:21.028586+00, 1,
     #          2025-12-04 07:58:21.028586+00, Journal::WorkPackageJournal, 833, {}, empty, f).
     context "on adding two notes right after creation" do
-      let(:work_package) do
+      let(:journable) do
         create(:work_package,
                subject: "Initial subject") do |wp|
-          wp.add_journal(user: current_user, notes: "First comment")
+          wp.add_journal(user:, notes: "First comment")
           wp.save!
         end
       end
@@ -984,8 +980,8 @@ RSpec.describe WorkPackage do
 
       context "when then changing an attribute" do
         before do
-          work_package.add_journal(user: current_user, notes: "Second comment")
-          work_package.save!
+          journable.add_journal(user:, notes: "Second comment")
+          journable.save!
         end
 
         include_examples "journaled values for",
@@ -1000,7 +996,7 @@ RSpec.describe WorkPackage do
 
         context "when now adding a note" do
           before do
-            work_package.update!(subject: "Changed subject")
+            journable.update!(subject: "Changed subject")
           end
 
           include_examples "journaled values for",
@@ -1013,7 +1009,7 @@ RSpec.describe WorkPackage do
 
           context "when now adding another note" do
             before do
-              work_package.add_journal(user: current_user, notes: "Third comment")
+              journable.add_journal(user:, notes: "Third comment")
             end
 
             include_examples "journaled values for",
@@ -1030,7 +1026,7 @@ RSpec.describe WorkPackage do
 
     context "on having a broken journal chain (e.g. because of legacy data)",
             with_settings: { journal_aggregation_time_minutes: 0 } do
-      let(:work_package) do
+      let(:journable) do
         create(:work_package,
                description: "Initial description") do |wp|
           wp.add_journal(notes: "Note to be deleted")

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -49,18 +49,6 @@ RSpec.describe WorkPackage do
     shared_let(:other_work_package) { build_stubbed(:work_package) }
     shared_let(:other_user) { create(:user) }
 
-    let!(:work_package) do
-      User.execute_as current_user do
-        create(:work_package,
-               project_id: project.id,
-               type:,
-               description: "Description",
-               priority:,
-               status:,
-               duration: 1)
-      end
-    end
-
     current_user { create(:user) }
 
     shared_examples_for "journaled values for" do |new_values_set:,
@@ -301,39 +289,6 @@ RSpec.describe WorkPackage do
       end
     end
 
-    # The below test was failing with the following error:
-    # ERROR:  new row for relation "journals" violates check constraint "journals_validity_period_not_empty" (PG::CheckViolation)
-    # DETAIL:  Failing row contains (1178, WorkPackage, 481, 1252, , 2025-12-04 07:58:21.028586+00, 1,
-    #          2025-12-04 07:58:21.028586+00, Journal::WorkPackageJournal, 833, {}, empty, f).
-    it "can add multiple comments right after creation" do
-      work_package
-      User.execute_as current_user do
-        # create multiple journals after creation
-        work_package.add_journal(user: current_user, notes: "First comment")
-        work_package.save_journals
-        work_package.add_journal(user: current_user, notes: "Second comment")
-        work_package.save_journals
-
-        ##### The fix is incomplete: the part below still fails.
-        ##### There may also be some issues with timestamps inaccuracies: some
-        ##### updated_at not matching the journal's validity periods.
-
-        # # create multiple journals after update
-        # work_package.update(subject: "Updated subject")
-        # work_package.add_journal(user: current_user, notes: "Third comment")
-        # work_package.save_journals
-        # work_package.add_journal(user: current_user, notes: "Fourth comment")
-        # work_package.save_journals
-
-        # # Verify journals were created with aggregation:
-        # # - Journal 1: creation + first comment (aggregated)
-        # # - Journal 2: second comment (can't aggregate - both have notes)
-        # # - Journal 3: update + third comment (aggregated)
-        # # - Journal 4: fourth comment (can't aggregate - both have notes)
-        # expect(work_package.journals.count).to eq(4)
-      end
-    end
-
     context "on creation" do
       let(:work_package) do
         described_class.new(author: current_user,
@@ -405,7 +360,16 @@ RSpec.describe WorkPackage do
                          "project_phase_definition_id" => [nil, :project_phase_definition]
                        },
                        expect_new_journal: true,
-                       expect_predecessor_changed: false
+                       expect_predecessor_changed: false do
+        it "results in created_at and updated_at being the same on the work package" do
+          work_package.save!
+          # Just to ensure that there actually is nothing hidden in the DB
+          work_package.reload
+
+          expect(work_package.created_at)
+            .to eql work_package.updated_at
+        end
+      end
     end
 
     context "when nothing is changed" do
@@ -724,6 +688,10 @@ RSpec.describe WorkPackage do
       let(:attachment) { build(:attachment) }
       let(:attachment_id) { "attachments_#{attachment.id}" }
 
+      let!(:work_package) do
+        create(:work_package)
+      end
+
       before do
         work_package.attachments << attachment
         work_package.save!
@@ -751,6 +719,10 @@ RSpec.describe WorkPackage do
       end
 
       let(:custom_field_id) { "custom_fields_#{custom_value.custom_field_id}" }
+
+      let!(:work_package) do
+        create(:work_package)
+      end
 
       shared_context "for work package with custom value" do
         before do
@@ -861,6 +833,10 @@ RSpec.describe WorkPackage do
     context "on file link changes", with_settings: { journal_aggregation_time_minutes: 0 } do
       let(:file_link) { build(:file_link) }
       let(:file_link_id) { "file_links_#{file_link.id}" }
+
+      let!(:work_package) do
+        create(:work_package)
+      end
 
       before do
         work_package.file_links << file_link
@@ -1245,6 +1221,73 @@ RSpec.describe WorkPackage do
                            },
                            # The value of description does change which is what causes update_at to change
                            expect_work_package_update_at_changed: true
+        end
+      end
+    end
+
+    # The below test was failing with the following error:
+    # ERROR:  new row for relation "journals" violates check constraint "journals_validity_period_not_empty" (PG::CheckViolation)
+    # DETAIL:  Failing row contains (1178, WorkPackage, 481, 1252, , 2025-12-04 07:58:21.028586+00, 1,
+    #          2025-12-04 07:58:21.028586+00, Journal::WorkPackageJournal, 833, {}, empty, f).
+    context "on adding two notes right after creation" do
+      let(:work_package) do
+        create(:work_package,
+               subject: "Initial subject") do |wp|
+          wp.add_journal(user: current_user, notes: "First comment")
+          wp.save!
+        end
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_notes" => "Second comment"
+                       },
+                       expected_values: {},
+                       expected_notes: "Second comment",
+                       expect_new_journal: true
+
+      context "when then changing an attribute" do
+        before do
+          work_package.add_journal(user: current_user, notes: "Second comment")
+          work_package.save!
+        end
+
+        include_examples "journaled values for",
+                         new_values_set: {
+                           "subject" => "Changed subject"
+                         },
+                         expected_values: {
+                           "subject" => ["Initial subject", "Changed subject"]
+                         },
+                         expected_notes: "Second comment",
+                         expect_new_journal: false
+
+        context "when now adding a note" do
+          before do
+            work_package.update!(subject: "Changed subject")
+          end
+
+          include_examples "journaled values for",
+                           new_values_set: {
+                             "journal_notes" => "Third comment"
+                           },
+                           expected_values: {},
+                           expected_notes: "Third comment",
+                           expect_new_journal: true
+
+          context "when now adding another note" do
+            before do
+              work_package.add_journal(user: current_user, notes: "Third comment")
+            end
+
+            include_examples "journaled values for",
+                             new_values_set: {
+                               "journal_notes" => "Fourth comment"
+                             },
+                             expected_values: {},
+                             expected_notes: "Fourth comment",
+                             expect_new_journal: true
+          end
         end
       end
     end

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -962,7 +962,7 @@ RSpec.describe WorkPackage do
     # DETAIL:  Failing row contains (1178, WorkPackage, 481, 1252, , 2025-12-04 07:58:21.028586+00, 1,
     #          2025-12-04 07:58:21.028586+00, Journal::WorkPackageJournal, 833, {}, empty, f).
     context "on adding two notes right after creation" do
-      let(:journable) do
+      shared_let(:journable) do
         create(:work_package,
                subject: "Initial subject") do |wp|
           wp.add_journal(user:, notes: "First comment")

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -51,263 +51,12 @@ RSpec.describe WorkPackage do
 
     current_user { create(:user) }
 
-    shared_examples_for "journaled values for" do |new_values_set:,
-                                                   expected_values:,
-                                                   expect_new_journal: true,
-                                                   expect_predecessor_changed: expect_new_journal,
-                                                   expect_work_package_update_at_changed: true,
-                                                   expected_cause: nil,
-                                                   expected_notes: nil|
-      def value_or_id(value)
-        value.is_a?(Symbol) ? public_send(value).id : value
-      end
-
-      def last_journal
-        work_package.journals.reload.last
-      end
-
-      before do
-        new_values_set.each do |property, value|
-          work_package.public_send("#{property}=", value_or_id(value))
-        end
-      end
-
-      expected_values.each do |property, (old_value, new_value)|
-        context "for #{property}" do
-          it "tracks the change from old value #{old_value.inspect} to new value #{new_value.inspect}" do
-            work_package.save!
-
-            expect(last_journal.old_value_for(property)).to eq(value_or_id(old_value))
-            expect(last_journal.new_value_for(property)).to eq(value_or_id(new_value))
-          end
-        end
-      end
-
-      if expected_values.empty?
-        it "has no changes tracked" do
-          work_package.save!
-
-          expect(last_journal.details.except("cause"))
-            .to be_empty
-        end
-      end
-
-      if expect_new_journal
-        it "creates a new journal" do
-          expect { work_package.save! }
-            .to change { work_package.journals.reload.count }
-                  .by(1)
-        end
-
-        it "has the timestamp of the work package update time for created_at" do
-          work_package.save!
-
-          expect(last_journal.created_at)
-            .to eql(work_package.reload.updated_at)
-        end
-
-        it "has the timestamp of the work package update time for updated_at" do
-          work_package.save!
-
-          expect(last_journal.updated_at)
-            .to eql(work_package.reload.updated_at)
-        end
-
-        it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
-          work_package.save!
-
-          expect(last_journal.validity_period)
-            .to eql(work_package.reload.updated_at...)
-        end
-
-        it "has the current user as the journal's user" do
-          work_package.save!
-
-          expect(last_journal.user)
-            .to eql(current_user)
-        end
-
-        if expect_predecessor_changed
-          it "sets the upper bound of the preceding journal to be the created_at time of the newly created journal" do
-            work_package.save!
-
-            former_last_journal = work_package.journals.reload[-2]
-            expect(former_last_journal.validity_period)
-              .to eql(former_last_journal.created_at...work_package.last_journal.created_at)
-          end
-
-          it "keeps the user of the preceding journal" do
-            former_last_journal = last_journal
-
-            work_package.save!
-
-            expect(work_package.journals.reload[-2].user)
-              .to eql(former_last_journal.user)
-          end
-        end
-      else
-        it "does not create a new journal" do
-          expect { work_package.save! }
-            .not_to change { work_package.journals.reload.count }
-        end
-
-        it "has the current user as the journal's user" do
-          work_package.save!
-
-          expect(last_journal.user)
-            .to eql(current_user)
-        end
-
-        it "keeps the journal's created_at time" do
-          expect { work_package.save! }
-            .not_to change {
-              last_journal.created_at
-            }
-        end
-
-        it "sets the journal's updated_at time to the work package's created_at time" do
-          work_package.save!
-
-          expect(last_journal.updated_at)
-            .to eql(work_package.reload.updated_at)
-        end
-
-        it "keeps created_at of the journal as the lower bound for validity_period and no upper bound" do
-          work_package.save!
-
-          expect(last_journal.validity_period)
-            .to eql(last_journal.created_at...)
-        end
-      end
-
-      it "has the current user as the journal's user" do
-        work_package.save!
-
-        expect(work_package.journals.reload.last.user)
-          .to eql(current_user)
-      end
-
-      it "sends an OpenProject notification" do
-        allow(OpenProject::Notifications)
-          .to receive(:send)
-
-        work_package.save!
-
-        expect(OpenProject::Notifications)
-          .to have_received(:send)
-                .with(OpenProject::Events::JOURNAL_CREATED,
-                      anything)
-      end
-
-      if expected_cause
-        it "has the expected cause" do
-          work_package.save!
-
-          expect(last_journal.cause)
-            .to eql(expected_cause)
-        end
-      else
-        it "has no cause" do
-          work_package.save!
-
-          expect(last_journal.cause)
-            .to be_empty
-        end
-      end
-
-      if expected_notes
-        it "has the expected notes" do
-          work_package.save!
-
-          expect(last_journal.notes)
-            .to eql(expected_notes)
-        end
-      else
-        it "has no notes" do
-          work_package.save!
-
-          expect(last_journal.notes)
-            .to be_empty
-        end
-      end
-
-      if expect_work_package_update_at_changed
-        it "updates the updated_at time of the work package" do
-          # Using this complicated form of writing to avoid problems
-          # e.g. with reloading before the work package is initially saved
-          updated_at_before = work_package.updated_at
-
-          work_package.save!
-
-          expect(work_package.reload.updated_at)
-            .not_to eql(updated_at_before)
-        end
-      else
-        it "keeps the updated_at time of the work package" do
-          # Using this complicated form of writing to avoid problems
-          # e.g. with reloading before the work package is initially saved
-          expect { work_package.save! }
-            .not_to change { work_package.reload.updated_at }
-        end
-      end
-    end
-
-    shared_examples_for "no journaled value changes for" do |new_values_set:, expect_work_package_update_at_changed: false|
-      before do
-        new_values_set.each do |property, value|
-          work_package.public_send("#{property}=", value)
-        end
-      end
-
-      it "does not create a new journal" do
-        expect { work_package.save! }
-          .not_to change(Journal, :count)
-      end
-
-      it "does not update the updated_at time of the last journal" do
-        expect { work_package.save! }
-          .not_to change {
-            work_package.journals.reload.last.updated_at
-          }
-      end
-
-      unless expect_work_package_update_at_changed
-        it "does not update the updated_at time of the work package" do
-          expect { work_package.save! }
-            .not_to change(work_package, :updated_at)
-        end
-      end
-
-      it "does not send an OpenProject notification" do
-        allow(OpenProject::Notifications)
-          .to receive(:send)
-
-        work_package.save!
-
-        expect(OpenProject::Notifications)
-          .not_to have_received(:send)
-      end
-    end
+    # For the shared examples
+    let(:journable) { work_package }
 
     context "on creation" do
       let(:work_package) do
-        described_class.new(author: current_user,
-                            subject: "Initial subject",
-                            description: "Initial description",
-                            project:,
-                            type:,
-                            priority:,
-                            status:,
-                            start_date: Date.new(2026, 1, 9),
-                            due_date: nil,
-                            duration: 1,
-                            estimated_hours: 3.0,
-                            schedule_manually: true,
-                            assigned_to: current_user,
-                            responsible: current_user,
-                            category: nil,
-                            version:,
-                            ignore_non_working_days: true)
+        described_class.new(author: current_user)
       end
 
       include_examples "journaled values for",
@@ -473,19 +222,6 @@ RSpec.describe WorkPackage do
                          "project_phase_definition_id" => [nil, :project_phase_definition]
                        },
                        expect_new_journal: true
-
-      # describe "adding journal with a missing journal and an existing journal" do
-      #  before do
-      #    allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
-      #    service = WorkPackages::UpdateService.new(user: current_user, model: work_package)
-      #    service.call(journal_notes: "note to be deleted", send_notifications: false)
-      #    work_package.reload
-      #    service.call(description: "description v2", send_notifications: false)
-      #    work_package.reload
-      #    work_package.journals.reload.find_by(notes: "note to be deleted").delete
-
-      #    service.call(description: "description v4", send_notifications: false)
-      #  end
     end
 
     context "on changes within aggregation time for a work package with no update yet (single journal)" do
@@ -1220,7 +956,7 @@ RSpec.describe WorkPackage do
                              "description" => "Description\n\nwith newlines\n\nembedded"
                            },
                            # The value of description does change which is what causes update_at to change
-                           expect_work_package_update_at_changed: true
+                           expect_journable_update_at_changed: true
         end
       end
     end
@@ -1290,6 +1026,28 @@ RSpec.describe WorkPackage do
           end
         end
       end
+    end
+
+    context "on having a broken journal chain (e.g. because of legacy data)",
+            with_settings: { journal_aggregation_time_minutes: 0 } do
+      let(:work_package) do
+        create(:work_package,
+               description: "Initial description") do |wp|
+          wp.add_journal(notes: "Note to be deleted")
+          wp.save!
+          wp.update!(description: "Changed description")
+          wp.journals.reload.find_by(notes: "Note to be deleted").destroy!
+        end
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "description" => "Changed again description"
+                       },
+                       expected_values: {
+                         "description" => ["Changed description", "Changed again description"]
+                       },
+                       expect_new_journal: true
     end
   end
 

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -31,14 +31,24 @@
 require "spec_helper"
 
 RSpec.describe WorkPackage do
-  describe "#journal" do
-    let(:type) { create(:type) }
-    let(:project) do
-      create(:project,
-             types: [type])
-    end
-    let(:status) { create(:default_status) }
-    let(:priority) { create(:priority) }
+  describe "#journals (and the saving of them)" do
+    shared_let(:type) { create(:type) }
+    shared_let(:other_type) { create(:type) }
+    shared_let(:status) { create(:default_status) }
+    shared_let(:priority) { create(:priority) }
+    shared_let(:project) { create(:project, types: [type, other_type]) }
+    shared_let(:parent_work_package) { create(:work_package) }
+    shared_let(:other_status) { create(:status) }
+    shared_let(:other_priority) { create(:priority) }
+    shared_let(:other_user) { create(:user) }
+    shared_let(:other_project) { create(:project) }
+    shared_let(:category) { create(:category) }
+    shared_let(:version) { create(:version) }
+    shared_let(:other_version) { create(:version) }
+    shared_let(:project_phase_definition) { create(:project_phase_definition) }
+    shared_let(:other_work_package) { build_stubbed(:work_package) }
+    shared_let(:other_user) { create(:user) }
+
     let!(:work_package) do
       User.execute_as current_user do
         create(:work_package,
@@ -50,9 +60,239 @@ RSpec.describe WorkPackage do
                duration: 1)
       end
     end
-    let(:other_work_package) { build_stubbed(:work_package) }
 
     current_user { create(:user) }
+
+    shared_examples_for "journaled values for" do |new_values_set:,
+                                                   expected_values:,
+                                                   expect_new_journal: true,
+                                                   expect_predecessor_changed: expect_new_journal,
+                                                   expect_work_package_update_at_changed: true,
+                                                   expected_cause: nil,
+                                                   expected_notes: nil|
+      def value_or_id(value)
+        value.is_a?(Symbol) ? public_send(value).id : value
+      end
+
+      def last_journal
+        work_package.journals.reload.last
+      end
+
+      before do
+        new_values_set.each do |property, value|
+          work_package.public_send("#{property}=", value_or_id(value))
+        end
+      end
+
+      expected_values.each do |property, (old_value, new_value)|
+        context "for #{property}" do
+          it "tracks the change from old value #{old_value.inspect} to new value #{new_value.inspect}" do
+            work_package.save!
+
+            expect(last_journal.old_value_for(property)).to eq(value_or_id(old_value))
+            expect(last_journal.new_value_for(property)).to eq(value_or_id(new_value))
+          end
+        end
+      end
+
+      if expected_values.empty?
+        it "has no changes tracked" do
+          work_package.save!
+
+          expect(last_journal.details.except("cause"))
+            .to be_empty
+        end
+      end
+
+      if expect_new_journal
+        it "creates a new journal" do
+          expect { work_package.save! }
+            .to change { work_package.journals.reload.count }
+                  .by(1)
+        end
+
+        it "has the timestamp of the work package update time for created_at" do
+          work_package.save!
+
+          expect(last_journal.created_at)
+            .to eql(work_package.reload.updated_at)
+        end
+
+        it "has the timestamp of the work package update time for updated_at" do
+          work_package.save!
+
+          expect(last_journal.updated_at)
+            .to eql(work_package.reload.updated_at)
+        end
+
+        it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
+          work_package.save!
+
+          expect(last_journal.validity_period)
+            .to eql(work_package.reload.updated_at...)
+        end
+
+        it "has the current user as the journal's user" do
+          work_package.save!
+
+          expect(last_journal.user)
+            .to eql(current_user)
+        end
+
+        if expect_predecessor_changed
+          it "sets the upper bound of the preceding journal to be the created_at time of the newly created journal" do
+            work_package.save!
+
+            former_last_journal = work_package.journals.reload[-2]
+            expect(former_last_journal.validity_period)
+              .to eql(former_last_journal.created_at...work_package.last_journal.created_at)
+          end
+
+          it "keeps the user of the preceding journal" do
+            former_last_journal = last_journal
+
+            work_package.save!
+
+            expect(work_package.journals.reload[-2].user)
+              .to eql(former_last_journal.user)
+          end
+        end
+      else
+        it "does not create a new journal" do
+          expect { work_package.save! }
+            .not_to change { work_package.journals.reload.count }
+        end
+
+        it "has the current user as the journal's user" do
+          work_package.save!
+
+          expect(last_journal.user)
+            .to eql(current_user)
+        end
+
+        it "keeps the journal's created_at time" do
+          expect { work_package.save! }
+            .not_to change {
+              last_journal.created_at
+            }
+        end
+
+        it "sets the journal's updated_at time to the work package's created_at time" do
+          work_package.save!
+
+          expect(last_journal.updated_at)
+            .to eql(work_package.reload.updated_at)
+        end
+
+        it "keeps created_at of the journal as the lower bound for validity_period and no upper bound" do
+          work_package.save!
+
+          expect(last_journal.validity_period)
+            .to eql(last_journal.created_at...)
+        end
+      end
+
+      it "has the current user as the journal's user" do
+        work_package.save!
+
+        expect(work_package.journals.reload.last.user)
+          .to eql(current_user)
+      end
+
+      it "sends an OpenProject notification" do
+        allow(OpenProject::Notifications)
+          .to receive(:send)
+
+        work_package.save!
+
+        expect(OpenProject::Notifications)
+          .to have_received(:send)
+                .with(OpenProject::Events::JOURNAL_CREATED,
+                      anything)
+      end
+
+      if expected_cause
+        it "has the expected cause" do
+          work_package.save!
+
+          expect(last_journal.cause)
+            .to eql(expected_cause)
+        end
+      else
+        it "has no cause" do
+          work_package.save!
+
+          expect(last_journal.cause)
+            .to be_empty
+        end
+      end
+
+      if expected_notes
+        it "has the expected notes" do
+          work_package.save!
+
+          expect(last_journal.notes)
+            .to eql(expected_notes)
+        end
+      else
+        it "has no notes" do
+          work_package.save!
+
+          expect(last_journal.notes)
+            .to be_empty
+        end
+      end
+
+      if expect_work_package_update_at_changed
+        it "updates the updated_at time of the work package" do
+          # Using this complicated form of writing to avoid problems
+          # e.g. with reloading before the work package is initially saved
+          updated_at_before = work_package.updated_at
+
+          work_package.save!
+
+          expect(work_package.reload.updated_at)
+            .not_to eql(updated_at_before)
+        end
+      end
+    end
+
+    shared_examples_for "no journaled value changes for" do |new_values_set:, expect_work_package_update_at_changed: false|
+      before do
+        new_values_set.each do |property, value|
+          work_package.public_send("#{property}=", value)
+        end
+      end
+
+      it "does not create a new journal" do
+        expect { work_package.save! }
+          .not_to change(Journal, :count)
+      end
+
+      it "does not update the updated_at time of the last journal" do
+        expect { work_package.save! }
+          .not_to change {
+            work_package.journals.reload.last.updated_at
+          }
+      end
+
+      unless expect_work_package_update_at_changed
+        it "does not update the updated_at time of the work package" do
+          expect { work_package.save! }
+            .not_to change(work_package, :updated_at)
+        end
+      end
+
+      it "does not send an OpenProject notification" do
+        allow(OpenProject::Notifications)
+          .to receive(:send)
+
+        work_package.save!
+
+        expect(OpenProject::Notifications)
+          .not_to have_received(:send)
+      end
+    end
 
     # The below test was failing with the following error:
     # ERROR:  new row for relation "journals" violates check constraint "journals_validity_period_not_empty" (PG::CheckViolation)
@@ -87,226 +327,393 @@ RSpec.describe WorkPackage do
       end
     end
 
-    context "for work package creation" do
-      it { expect(Journal.for_work_package.count).to eq(1) }
-
-      it "has a journal entry" do
-        expect(Journal.for_work_package.first.journable).to eq(work_package)
+    context "on creation" do
+      let(:work_package) do
+        described_class.new(author: current_user,
+                            subject: "Initial subject",
+                            description: "Initial description",
+                            project:,
+                            type:,
+                            priority:,
+                            status:,
+                            start_date: Date.new(2026, 1, 9),
+                            due_date: nil,
+                            duration: 1,
+                            estimated_hours: 3.0,
+                            schedule_manually: true,
+                            assigned_to: current_user,
+                            responsible: current_user,
+                            category: nil,
+                            version:,
+                            ignore_non_working_days: true)
       end
 
-      it "notes the changes to subject" do
-        expect(work_package.last_journal.details[:subject])
-          .to eq([nil, work_package.subject])
-      end
-
-      it "notes the changes to project" do
-        expect(work_package.last_journal.details[:project_id])
-          .to eq([nil, work_package.project_id])
-      end
-
-      it "notes the description" do
-        expect(work_package.last_journal.details[:description])
-          .to eq([nil, work_package.description])
-      end
-
-      it "notes the scheduling mode" do
-        expect(work_package.last_journal.details[:schedule_manually])
-          .to eq([nil, true])
-      end
-
-      it "has the timestamp of the work package update time for created_at" do
-        expect(work_package.last_journal.created_at)
-          .to eql(work_package.reload.updated_at)
-      end
-
-      it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
-        expect(work_package.last_journal.validity_period)
-          .to eql(work_package.reload.updated_at...)
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Initial subject",
+                         "description" => "Initial description",
+                         "type_id" => :type,
+                         "status_id" => :status,
+                         "priority_id" => :priority,
+                         "project_id" => :project,
+                         "category_id" => :category,
+                         "version_id" => :version,
+                         "start_date" => Date.new(2013, 1, 24),
+                         "due_date" => Date.new(2013, 1, 31),
+                         "done_ratio" => 100,
+                         "estimated_hours" => 40.0,
+                         "derived_estimated_hours" => 50.0,
+                         "remaining_hours" => 3.0,
+                         "story_points" => 10,
+                         "duration" => 8,
+                         "schedule_manually" => false,
+                         "ignore_non_working_days" => false,
+                         "assigned_to_id" => :other_user,
+                         "responsible_id" => :other_user,
+                         "parent_id" => :parent_work_package,
+                         "project_phase_definition_id" => :project_phase_definition
+                       },
+                       expected_values: {
+                         "subject" => [nil, "Initial subject"],
+                         "description" => [nil, "Initial description"],
+                         "type_id" => [nil, :type],
+                         "status_id" => [nil, :status],
+                         "priority_id" => [nil, :priority],
+                         "project_id" => [nil, :project],
+                         "category_id" => [nil, :category],
+                         "version_id" => [nil, :version],
+                         "start_date" => [nil, Date.new(2013, 1, 24)],
+                         "due_date" => [nil, Date.new(2013, 1, 31)],
+                         "done_ratio" => [nil, 100],
+                         "estimated_hours" => [nil, 40.0],
+                         "derived_estimated_hours" => [nil, 50.0],
+                         "remaining_hours" => [nil, 3.0],
+                         "story_points" => [nil, 10],
+                         "duration" => [nil, 8],
+                         "schedule_manually" => [nil, false],
+                         "ignore_non_working_days" => [nil, false],
+                         "assigned_to_id" => [nil, :other_user],
+                         "responsible_id" => [nil, :other_user],
+                         "parent_id" => [nil, :parent_work_package],
+                         "project_phase_definition_id" => [nil, :project_phase_definition]
+                       },
+                       expect_new_journal: true,
+                       expect_predecessor_changed: false
     end
 
     context "when nothing is changed" do
-      it { expect { work_package.save! }.not_to change(Journal, :count) }
-
-      it "does not update the updated_at time of the work package" do
-        expect { work_package.save! }.not_to change(work_package, :updated_at)
-      end
-
-      it "does not update the updated_at time on initial journals" do
-        expect { work_package.save! }
-          .not_to change {
-                    work_package.journals.reload.last.updated_at
-                  }
-      end
-
-      it "does not update the updated_at time on non initial journals" do
-        # FIXME: the journal notes should have been saved on the initial journal as well
-        work_package.journal_notes = "Some notes"
-        expect { work_package.save! }.to change {
-          work_package.journals.last.notes
-        }
-        work_package.reload
-        work_package.journal_notes = "Some other notes"
-        work_package.save!
-
-        expect { work_package.reload.save! }
-          .not_to change {
-            work_package.journals.reload.last.updated_at
-          }
-      end
-    end
-
-    context "for different newlines", with_settings: { journal_aggregation_time_minutes: 0 } do
-      let(:description) { "Description\n\nwith newlines\n\nembedded" }
-      let(:changed_description) { description.gsub("\n", "\r\n") }
-      let!(:work_package1) do
-        create(:work_package,
-               project_id: project.id,
-               type:,
-               description:,
-               priority:)
-      end
-
-      before do
-        work_package1.description = changed_description
-      end
-
-      context "when a new journal is created tracking a simultaneously applied change" do
-        before do
-          work_package1.subject += "changed"
-          work_package1.save!
-        end
-
-        describe "does not track the changed newline characters" do
-          subject { work_package1.last_journal.data.description }
-
-          it { is_expected.to eq(description) }
-        end
-
-        describe "tracks only the other change" do
-          subject { work_package1.last_journal.details }
-
-          it { is_expected.to have_key :subject }
-          it { is_expected.not_to have_key :description }
-        end
-      end
-
-      context "when there is a legacy journal containing non-escaped newlines" do
-        let!(:work_package1) do
+      context "for a work package that has only been created (single journal)" do
+        let!(:work_package) do
           create(:work_package,
                  journals: {
-                   5.minutes.ago => { description: },
-                   3.minutes.ago => { description: changed_description }
+                   Time.current => { user: current_user, notes: "First comment" }
                  })
         end
 
-        it "does not track the change to the newline characters" do
-          expect(work_package1.reload.last_journal.details).not_to have_key :description
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
+      end
+
+      context "for a work package that has been updated already (multiple journals)" do
+        let!(:work_package) do
+          create(:work_package,
+                 journals: {
+                   5.days.ago => { user: current_user },
+                   4.days.ago => { user: current_user, notes: "First comment" }
+                 })
         end
+
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
       end
     end
 
-    describe "on work package change without aggregation", with_settings: { journal_aggregation_time_minutes: 0 } do
-      let(:parent_work_package) do
+    context "on changes outside of aggregation time" do
+      let!(:work_package) do
         create(:work_package,
-               project_id: project.id,
+               subject: "Initial subject",
+               description: "Initial description",
+               project:,
                type:,
-               priority:)
-      end
-      let(:type2) { create(:type) }
-      let(:status2) { create(:status) }
-      let(:priority2) { create(:priority) }
-
-      before do
-        project.types << type2
-
-        work_package.subject = "changed"
-        work_package.description = "changed"
-        work_package.type = type2
-        work_package.status = status2
-        work_package.priority = priority2
-        work_package.start_date = Date.new(2013, 1, 24)
-        work_package.due_date = Date.new(2013, 1, 31)
-        work_package.duration = 8
-        work_package.estimated_hours = 40.0
-        work_package.assigned_to = User.current
-        work_package.responsible = User.current
-        work_package.parent = parent_work_package
-        work_package.schedule_manually = false
-
-        work_package.save!
+               priority:,
+               status:,
+               start_date: Date.new(2026, 1, 9),
+               due_date: nil,
+               duration: 1,
+               estimated_hours: 3.0,
+               schedule_manually: true,
+               assigned_to: current_user,
+               responsible: current_user,
+               category: nil,
+               version:,
+               ignore_non_working_days: true,
+               journals: {
+                 10.minutes.ago => { user: current_user }
+               })
       end
 
-      context "for last created journal" do
-        subject { work_package.last_journal.details }
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "description" => "Changed description",
+                         "type_id" => :other_type,
+                         "status_id" => :other_status,
+                         "priority_id" => :other_priority,
+                         "project_id" => :other_project,
+                         "category_id" => :category,
+                         "version_id" => :other_version,
+                         "start_date" => Date.new(2013, 1, 24),
+                         "due_date" => Date.new(2013, 1, 31),
+                         "done_ratio" => 100,
+                         "estimated_hours" => 40.0,
+                         "derived_estimated_hours" => 50.0,
+                         "remaining_hours" => 3.0,
+                         "story_points" => 10,
+                         "duration" => 8,
+                         "schedule_manually" => false,
+                         "ignore_non_working_days" => false,
+                         "assigned_to_id" => :other_user,
+                         "responsible_id" => nil,
+                         "parent_id" => :parent_work_package,
+                         "project_phase_definition_id" => :project_phase_definition
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"],
+                         "description" => ["Initial description", "Changed description"],
+                         "type_id" => %i[type other_type],
+                         "status_id" => %i[status other_status],
+                         "priority_id" => %i[priority other_priority],
+                         "project_id" => %i[project other_project],
+                         "category_id" => [nil, :category],
+                         "version_id" => %i[version other_version],
+                         "start_date" => [Date.new(2026, 1, 9), Date.new(2013, 1, 24)],
+                         "due_date" => [nil, Date.new(2013, 1, 31)],
+                         "done_ratio" => [nil, 100],
+                         "estimated_hours" => [3.0, 40.0],
+                         "derived_estimated_hours" => [nil, 50.0],
+                         "remaining_hours" => [nil, 3.0],
+                         "story_points" => [nil, 10],
+                         "duration" => [1, 8],
+                         "schedule_manually" => [true, false],
+                         "ignore_non_working_days" => [true, false],
+                         "assigned_to_id" => %i[current_user other_user],
+                         "responsible_id" => [:current_user, nil],
+                         "parent_id" => [nil, :parent_work_package],
+                         "project_phase_definition_id" => [nil, :project_phase_definition]
+                       },
+                       expect_new_journal: true
 
-        it "contains all changes" do
-          %i(subject description type_id status_id priority_id
-             start_date due_date estimated_hours assigned_to_id
-             responsible_id parent_id schedule_manually duration).each do |a|
-            expect(subject).to have_key(a.to_s), "Missing change for #{a}"
-          end
-        end
-      end
+      # describe "adding journal with a missing journal and an existing journal" do
+      #  before do
+      #    allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
+      #    service = WorkPackages::UpdateService.new(user: current_user, model: work_package)
+      #    service.call(journal_notes: "note to be deleted", send_notifications: false)
+      #    work_package.reload
+      #    service.call(description: "description v2", send_notifications: false)
+      #    work_package.reload
+      #    work_package.journals.reload.find_by(notes: "note to be deleted").delete
 
-      shared_examples_for "journaled value for" do |property:, expected_old_value:, expected_new_value:|
-        context "for #{property}", :aggregate_failures do
-          it "tracks the change from old value #{expected_old_value.inspect} to new value #{expected_new_value.inspect}" do
-            journal = work_package.last_journal
-            expect(journal.old_value_for(property)).to eq(expected_old_value)
-            expect(journal.new_value_for(property)).to eq(expected_new_value)
-          end
-        end
-      end
-
-      include_examples "journaled value for", property: "description",
-                                              expected_old_value: "Description",
-                                              expected_new_value: "changed"
-      include_examples "journaled value for", property: "schedule_manually",
-                                              expected_old_value: true,
-                                              expected_new_value: false
-      include_examples "journaled value for", property: "duration",
-                                              expected_old_value: 1,
-                                              expected_new_value: 8
-
-      describe "adding journal with a missing journal and an existing journal" do
-        before do
-          allow(WorkPackages::UpdateContract).to receive(:new).and_return(NoopContract.new)
-          service = WorkPackages::UpdateService.new(user: current_user, model: work_package)
-          service.call(journal_notes: "note to be deleted", send_notifications: false)
-          work_package.reload
-          service.call(description: "description v2", send_notifications: false)
-          work_package.reload
-          work_package.journals.reload.find_by(notes: "note to be deleted").delete
-
-          service.call(description: "description v4", send_notifications: false)
-        end
-
-        it "creates a journal for the last change" do
-          last_journal = work_package.last_journal
-
-          expect(last_journal.data.description).to eql("description v4")
-        end
-      end
-
-      it "has the timestamp of the work package update time for created_at" do
-        expect(work_package.last_journal.created_at)
-          .to eql(work_package.reload.updated_at)
-      end
-
-      it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
-        expect(work_package.last_journal.validity_period)
-          .to eql(work_package.reload.updated_at...)
-      end
-
-      it "sets the upper bound of the preceeding journal to be the created_at time of the newly created journal" do
-        former_last_journal = work_package.journals[-2]
-        expect(former_last_journal.validity_period)
-          .to eql(former_last_journal.created_at...work_package.last_journal.created_at)
-      end
+      #    service.call(description: "description v4", send_notifications: false)
+      #  end
     end
 
-    describe "attachments", with_settings: { journal_aggregation_time_minutes: 0 } do
+    context "on changes within aggregation time for a work package with no update yet (single journal)" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               description: "Initial description",
+               project:,
+               type:,
+               priority:,
+               status:,
+               start_date: Date.new(2026, 1, 9),
+               due_date: nil,
+               duration: 1,
+               estimated_hours: 3.0,
+               schedule_manually: true,
+               assigned_to: current_user,
+               responsible: current_user,
+               category: nil,
+               version:,
+               ignore_non_working_days: true,
+               journals: {
+                 4.minutes.ago => { user: current_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "description" => "Changed description",
+                         "type_id" => :other_type,
+                         "status_id" => :other_status,
+                         "priority_id" => :other_priority,
+                         "project_id" => :other_project,
+                         "category_id" => :category,
+                         "version_id" => :other_version,
+                         "start_date" => Date.new(2013, 1, 24),
+                         "due_date" => Date.new(2013, 1, 31),
+                         "done_ratio" => 100,
+                         "estimated_hours" => 40.0,
+                         "derived_estimated_hours" => 50.0,
+                         "remaining_hours" => 3.0,
+                         "story_points" => 10,
+                         "duration" => 8,
+                         "schedule_manually" => false,
+                         "ignore_non_working_days" => false,
+                         "assigned_to_id" => :other_user,
+                         "responsible_id" => nil,
+                         "parent_id" => :parent_work_package,
+                         "project_phase_definition_id" => :project_phase_definition
+                       },
+                       expected_values: {
+                         "subject" => [nil, "Changed subject"],
+                         "description" => [nil, "Changed description"],
+                         "type_id" => [nil, :other_type],
+                         "status_id" => [nil, :other_status],
+                         "priority_id" => [nil, :other_priority],
+                         "project_id" => [nil, :other_project],
+                         "category_id" => [nil, :category],
+                         "version_id" => [nil, :other_version],
+                         "start_date" => [nil, Date.new(2013, 1, 24)],
+                         "due_date" => [nil, Date.new(2013, 1, 31)],
+                         "done_ratio" => [nil, 100],
+                         "estimated_hours" => [nil, 40.0],
+                         "derived_estimated_hours" => [nil, 50.0],
+                         "remaining_hours" => [nil, 3.0],
+                         "story_points" => [nil, 10],
+                         "duration" => [nil, 8],
+                         "schedule_manually" => [nil, false],
+                         "ignore_non_working_days" => [nil, false],
+                         "assigned_to_id" => [nil, :other_user],
+                         "responsible_id" => [nil, nil],
+                         "parent_id" => [nil, :parent_work_package],
+                         "project_phase_definition_id" => [nil, :project_phase_definition]
+                       },
+                       expect_new_journal: false
+    end
+
+    context "on changes within aggregation time for a work package with former updates (multiple journal)" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               description: "Initial description",
+               project:,
+               type:,
+               priority:,
+               status:,
+               start_date: Date.new(2026, 1, 9),
+               due_date: nil,
+               duration: 1,
+               estimated_hours: 3.0,
+               schedule_manually: true,
+               assigned_to: current_user,
+               responsible: current_user,
+               category: nil,
+               version:,
+               ignore_non_working_days: true,
+               journals: {
+                 # Both journals will be the exact same snapshot of the current state.
+                 # For the sake of this test, this doesn't matter.
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "description" => "Changed description",
+                         "type_id" => :other_type,
+                         "status_id" => :other_status,
+                         "priority_id" => :other_priority,
+                         "project_id" => :other_project,
+                         "category_id" => :category,
+                         "version_id" => :other_version,
+                         "start_date" => Date.new(2013, 1, 24),
+                         "due_date" => Date.new(2013, 1, 31),
+                         "done_ratio" => 100,
+                         "estimated_hours" => 40.0,
+                         "derived_estimated_hours" => 50.0,
+                         "remaining_hours" => 3.0,
+                         "story_points" => 10,
+                         "duration" => 8,
+                         "schedule_manually" => false,
+                         "ignore_non_working_days" => false,
+                         "assigned_to_id" => :other_user,
+                         "responsible_id" => nil,
+                         "parent_id" => :parent_work_package,
+                         "project_phase_definition_id" => :project_phase_definition
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"],
+                         "description" => ["Initial description", "Changed description"],
+                         "type_id" => %i[type other_type],
+                         "status_id" => %i[status other_status],
+                         "priority_id" => %i[priority other_priority],
+                         "project_id" => %i[project other_project],
+                         "category_id" => [nil, :category],
+                         "version_id" => %i[version other_version],
+                         "start_date" => [Date.new(2026, 1, 9), Date.new(2013, 1, 24)],
+                         "due_date" => [nil, Date.new(2013, 1, 31)],
+                         "done_ratio" => [nil, 100],
+                         "estimated_hours" => [3.0, 40.0],
+                         "derived_estimated_hours" => [nil, 50.0],
+                         "remaining_hours" => [nil, 3.0],
+                         "story_points" => [nil, 10],
+                         "duration" => [1, 8],
+                         "schedule_manually" => [true, false],
+                         "ignore_non_working_days" => [true, false],
+                         "assigned_to_id" => %i[current_user other_user],
+                         "responsible_id" => [:current_user, nil],
+                         "parent_id" => [nil, :parent_work_package],
+                         "project_phase_definition_id" => [nil, :project_phase_definition]
+                       },
+                       expect_new_journal: false
+    end
+
+    context "on changes within aggregation time for a different user" do
+      let!(:work_package) do
+        create(:work_package,
+               description: "Initial description",
+               journals: {
+                 4.minutes.ago => { user: other_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "description" => "Changed description"
+                       },
+                       expected_values: {
+                         "description" => ["Initial description", "Changed description"]
+                       },
+                       expect_new_journal: true
+    end
+
+    context "on changes with aggregation disabled", with_settings: { journal_aggregation_time_minutes: 0 } do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 # Both journals will be the exact same snapshot of the current state.
+                 # For the sake of this test, this doesn't matter.
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject"
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expect_new_journal: true
+    end
+
+    context "on attachment changes", with_settings: { journal_aggregation_time_minutes: 0 } do
       let(:attachment) { build(:attachment) }
       let(:attachment_id) { "attachments_#{attachment.id}" }
 
@@ -328,7 +735,7 @@ RSpec.describe WorkPackage do
       end
     end
 
-    describe "custom values", with_settings: { journal_aggregation_time_minutes: 0 } do
+    context "on custom value changes", with_settings: { journal_aggregation_time_minutes: 0 } do
       let(:custom_field) { create(:work_package_custom_field) }
       let(:custom_value) do
         build(:custom_value,
@@ -444,7 +851,7 @@ RSpec.describe WorkPackage do
       end
     end
 
-    describe "file_links", with_settings: { journal_aggregation_time_minutes: 0 } do
+    context "on file link changes", with_settings: { journal_aggregation_time_minutes: 0 } do
       let(:file_link) { build(:file_link) }
       let(:file_link_id) { "file_links_#{file_link.id}" }
 
@@ -474,369 +881,272 @@ RSpec.describe WorkPackage do
       end
     end
 
-    context "for only journal notes adding" do
-      subject do
-        work_package.add_journal(user: User.current, notes: "some notes")
-        work_package.save
-        work_package
+    context "on only journal notes adding outside of aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 10.minutes.ago => { user: current_user }
+               })
       end
 
-      it "does not create a new journal entry" do
-        expect { subject }.not_to change(work_package, :last_journal)
-      end
-
-      it "has the timestamp of the work package update time for updated_at" do
-        expect(subject.last_journal.updated_at).to eql(work_package.reload.updated_at)
-      end
-
-      it "updates the updated_at time of the work package" do
-        expect { subject.reload }.to change(work_package, :updated_at)
-      end
-
-      it "stores the note with the existing journal entry" do
-        expect { subject }.to change { work_package.last_journal.notes }.from("").to("some notes")
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_notes" => "Some notes"
+                       },
+                       expected_values: {},
+                       expected_notes: "Some notes",
+                       expect_new_journal: true
     end
 
-    context "for mixed journal notes and attribute adding" do
-      subject do
-        work_package.add_journal(user: User.current, notes: "some notes")
-        work_package.subject = "blubs"
-        work_package.save
-        work_package
+    context "on only journal notes adding within aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user }
+               })
       end
 
-      it "does not create a new journal entry" do
-        expect { subject }.not_to change(work_package, :last_journal)
-      end
-
-      it "has the timestamp of the work package update time for updated_at" do
-        expect(subject.last_journal.updated_at).to eql(work_package.reload.updated_at)
-      end
-
-      it "updates the updated_at time of the work package" do
-        expect { subject.reload }.to change(work_package, :updated_at)
-      end
-
-      it "stores the note with the existing journal entry" do
-        expect { subject }.to change { work_package.last_journal.notes }.from("").to("some notes")
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_notes" => "Some notes"
+                       },
+                       expected_values: {},
+                       expected_notes: "Some notes",
+                       expect_new_journal: false
     end
 
-    context "for only journal cause adding" do
-      subject do
-        work_package.add_journal(
-          user: User.current,
-          cause: Journal::CausedByWorkPackagePredecessorChange.new(other_work_package)
-        )
-        work_package.save
-        work_package
+    context "on only journal notes adding within aggregation time as a different user" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 10.minutes.ago => { user: other_user },
+                 4.minutes.ago => { user: other_user }
+               })
       end
 
-      it "has the cause logged in the last journal" do
-        expect(subject.last_journal.cause).to eql({
-                                                    "type" => "work_package_predecessor_changed_times",
-                                                    "work_package_id" => other_work_package.id
-                                                  })
-      end
-
-      it "has the timestamp of the work package update time for created_at" do
-        expect(subject.last_journal.updated_at).to eql(work_package.reload.updated_at)
-      end
-
-      it "updates the updated_at time of the work package" do
-        expect { subject.reload }.to change(work_package, :updated_at)
-      end
-
-      it "does create a new journal entry" do
-        expect { subject }.to change(work_package, :last_journal)
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_notes" => "Some notes"
+                       },
+                       expected_values: {},
+                       expected_notes: "Some notes",
+                       expect_new_journal: true
     end
 
-    context "for mixed journal cause, notes and attribute adding" do
-      subject do
-        work_package.add_journal(
-          user: User.current,
-          notes: "some notes",
-          cause: Journal::CausedByWorkPackagePredecessorChange.new(other_work_package)
-        )
-        work_package.subject = "blubs"
-        work_package.save
-        work_package
+    context "on only journal notes adding within aggregation time with the last journal already having a note" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user, notes: "The former note" }
+               })
       end
 
-      it "has the timestamp of the work package update time for created_at" do
-        expect(work_package.last_journal.updated_at).to eql(work_package.reload.updated_at)
-      end
-
-      it "does create a new journal entry" do
-        expect { subject }.to change(work_package, :last_journal)
-      end
-
-      it "updates the updated_at time of the work package" do
-        updated_at_before = work_package.updated_at
-
-        expect(subject.reload.updated_at).not_to eql(updated_at_before)
-      end
-
-      it "stores the cause and note with the existing journal entry" do
-        subject
-
-        expect(work_package.last_journal.notes).to eq("some notes")
-        expect(work_package.last_journal.cause_type).to eq("work_package_predecessor_changed_times")
-        expect(work_package.last_journal.cause_work_package_id).to eq(other_work_package.id)
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_notes" => "Some notes"
+                       },
+                       expected_values: {},
+                       expected_notes: "Some notes",
+                       expect_new_journal: true
     end
 
-    context "when 2 updates with the same cause occur" do
-      before do
-        work_package.add_journal(
-          user: User.current,
-          cause: Journal::CausedByWorkPackagePredecessorChange.new(other_work_package)
-        )
-        work_package.subject = "new subject 1"
-        work_package.save
+    context "on changes within aggregation time for a work package with a journal with notes" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user, notes: "The former note" }
+               })
       end
 
-      subject do
-        work_package.add_journal(
-          user: User.current,
-          cause: Journal::CausedByWorkPackagePredecessorChange.new(other_work_package)
-        )
-        work_package.subject = "new subject 2"
-        work_package.save
-      end
-
-      it "does not create a new journal entry" do
-        expect { subject }.not_to change(work_package, :last_journal)
-      end
-
-      it "stores the last update only" do
-        subject
-
-        expect(work_package.last_journal.new_value_for(:subject)).to eq("new subject 2")
-        expect(work_package.last_journal.cause_type).to eq("work_package_predecessor_changed_times")
-        expect(work_package.last_journal.cause_work_package_id).to eq(other_work_package.id)
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject"
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_notes: "The former note",
+                       expect_new_journal: false
     end
 
-    context "when updated within aggregation time" do
-      subject(:journals) { work_package.journals }
-
-      current_user { user1 }
-
-      let(:notes) { nil }
-      let(:user1) { create(:user) }
-      let(:user2) { create(:user) }
-      let(:new_status) { build(:status) }
-      let(:changes) do
-        {
-          status: new_status,
-          journal_notes: notes
-        }.compact
+    context "on mixed journal notes and attribute adding outside of aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: current_user }
+               })
       end
 
-      before do
-        login_as(new_author)
-
-        work_package.attributes = changes
-        work_package.save!
-      end
-
-      context "as author of last change" do
-        let(:new_author) { user1 }
-
-        it "leads to a single journal" do
-          expect(subject.count).to be 1
-        end
-
-        it "is the initial journal" do
-          expect(subject.first).to be_initial
-        end
-
-        it "contains the changes of both updates with the later overwriting the former" do
-          expect(subject.first.data.status_id)
-            .to eql changes[:status].id
-
-          expect(subject.first.data.type_id)
-            .to eql work_package.type_id
-        end
-
-        context "with a comment" do
-          let(:notes) { "This is why I changed it." }
-
-          it "leads to a single journal with the comment" do
-            expect(subject.count).to be 1
-            expect(subject.first.notes)
-              .to eql notes
-          end
-
-          context "when adding a second comment" do
-            let(:second_notes) { "Another comment, unrelated to the first one." }
-
-            before do
-              work_package.add_journal(user: new_author, notes: second_notes)
-              work_package.save!
-            end
-
-            it "returns two journals" do
-              expect(subject.count).to be 2
-              expect(subject.first.notes).to eql notes
-              expect(subject.second.notes).to eql second_notes
-            end
-
-            it "has one initial journal and one non-initial journal" do
-              expect(subject.first).to be_initial
-              expect(subject.second).not_to be_initial
-            end
-          end
-
-          context "when adding another change without comment" do
-            before do
-              work_package.reload # need to update the lock_version, avoiding StaleObjectError
-              work_package.subject = "foo"
-              work_package.assigned_to = current_user
-              work_package.save!
-            end
-
-            it "leads to a single journal with the comment of the replaced journal and the state both combined" do
-              expect(subject.count).to eq 1
-
-              expect(subject.first.notes)
-                .to eql notes
-
-              expect(subject.first.data.subject)
-                .to eql "foo"
-
-              expect(subject.first.data.assigned_to)
-                .to eql current_user
-
-              expect(subject.first.data.status_id)
-                .to eql new_status.id
-            end
-          end
-
-          context "when adding another change with a customized work package" do
-            let(:custom_field) do
-              create(:work_package_custom_field,
-                     is_required: false,
-                     field_format: "list",
-                     possible_values: ["", "1", "2", "3", "4", "5", "6", "7"])
-            end
-            let(:custom_value) do
-              create(:custom_value,
-                     value: custom_field.custom_options.find { |co| co.value == "1" }.try(:id),
-                     customized: work_package,
-                     custom_field:)
-            end
-
-            before do
-              custom_value
-              work_package.reload # need to update the lock_version, avoiding StaleObjectError
-              work_package.subject = "foo"
-              work_package.save!
-            end
-
-            it "leads to a single journal with only one customizable journal" do
-              expect(subject.count).to eq 1
-
-              expect(subject.first.notes)
-                .to eql notes
-
-              expect(subject.first.data.subject)
-                .to eql "foo"
-
-              expect(subject.first.customizable_journals.count).to eq(1)
-            end
-          end
-        end
-
-        it "has the journal's creation time as the lower and no upper bound for validity_period" do
-          expect(work_package.last_journal.validity_period)
-            .to eql(work_package.last_journal.created_at...)
-        end
-      end
-
-      context "with a different author" do
-        let(:new_author) { user2 }
-
-        it "leads to two journals" do
-          expect(subject.count).to be 2
-        end
-
-        it "has the initial user as the author of the first journal" do
-          expect(subject.first.user)
-            .to eql current_user
-        end
-
-        it "has the second user as he author of the second journal" do
-          expect(subject.second.user)
-            .to eql new_author
-        end
-
-        it "has the changes (compared to the initial state) in the second journal" do
-          expect(subject.second.get_changes)
-            .to eql("status_id" => [status.id, new_status.id])
-        end
-
-        it "has the first journal's creation time as the lower and the second journal's creation time " \
-           "as the upper bound for validity_period of the first journal" do
-          expect(subject.first.validity_period)
-            .to eql(subject.first.created_at...subject.second.created_at)
-        end
-
-        it "has the second journal's creation time as the lower and no upper bound for validity_period of the second journal" do
-          expect(subject.second.validity_period)
-            .to eql(subject.second.created_at...)
-        end
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "journal_notes" => "Some notes"
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_notes: "Some notes",
+                       expect_new_journal: true
     end
 
-    context "when updated after aggregation timeout expired", with_settings: { journal_aggregation_time_minutes: 1 } do
-      let(:last_update_time) { 2.minutes.ago }
-
-      subject(:journals) { work_package.journals }
-
-      before do
-        work_package.last_journal.update_columns(created_at: last_update_time,
-                                                 updated_at: last_update_time,
-                                                 validity_period: last_update_time..)
-        work_package.update_columns(created_at: last_update_time,
-                                    updated_at: last_update_time)
-
-        work_package.status = build(:status)
-        work_package.save!
+    context "on only journal cause adding within aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 # Adding a second journal (even if it is empty) to avoid the changes
+                 # from the wp creation to mess with the expected values.
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user }
+               })
       end
 
-      it "creates a new journal" do
-        expect(journals.count).to be 2
-      end
-
-      it "has the first journal's creation time as the lower and the second journal's creation time " \
-         "as the upper bound for validity_period of the first journal" do
-        expect(subject.first.validity_period)
-          .to eql(subject.first.created_at...subject.second.created_at)
-      end
-
-      it "has the second journal's creation time as the lower and no upper bound for validity_period of the second journal" do
-        expect(subject.second.validity_period)
-          .to eql(subject.second.created_at...)
-      end
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_cause" => {
+                           "type" => "The good cause",
+                           "some_reference" => 42
+                         }
+                       },
+                       expected_values: {},
+                       expected_cause: {
+                         "type" => "The good cause",
+                         "some_reference" => 42
+                       },
+                       expect_new_journal: false
     end
 
-    context "when updating with aggregation disabled", with_settings: { journal_aggregation_time_minutes: 0 } do
-      subject(:journals) { work_package.journals }
-
-      context "when WP updated within milliseconds" do
-        before do
-          work_package.status = build(:status)
-          work_package.save!
-        end
-
-        it "creates a new journal" do
-          expect(journals.count).to be 2
-        end
+    context "on adding a different cause within aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               journals: {
+                 4.minutes.ago => { user: current_user, cause: "XYZ" }
+               })
       end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_cause" => "ABC"
+                       },
+                       expected_values: {},
+                       expected_cause: "ABC",
+                       expect_new_journal: true
+    end
+
+    context "on adding the same cause within aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user, cause: "ABC" }
+               })
+      end
+
+      # Adding the change to subject here to show that the whole change is aggregated
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "journal_cause" => "ABC",
+                         "subject" => "Changed subject"
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_cause: "ABC",
+                       expect_new_journal: false
+    end
+
+    context "on mixed journal cause, notes and attribute adding outside of aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: current_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "journal_notes" => "Some notes",
+                         "journal_cause" => {
+                           "type" => "The good cause",
+                           "some_reference" => 42
+                         }
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_notes: "Some notes",
+                       expected_cause: {
+                         "type" => "The good cause",
+                         "some_reference" => 42
+                       },
+                       expect_new_journal: true
+    end
+
+    context "on mixed journal cause, notes and attribute adding within aggregation time" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: current_user },
+                 4.minutes.ago => { user: current_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "journal_notes" => "Some notes",
+                         "journal_cause" => {
+                           "type" => "The good cause",
+                           "some_reference" => 42
+                         }
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_notes: "Some notes",
+                       expected_cause: {
+                         "type" => "The good cause",
+                         "some_reference" => 42
+                       },
+                       expect_new_journal: false
+    end
+
+    context "on mixed journal cause, notes and attribute adding within aggregation time as a different user" do
+      let!(:work_package) do
+        create(:work_package,
+               subject: "Initial subject",
+               journals: {
+                 10.minutes.ago => { user: other_user },
+                 4.minutes.ago => { user: other_user }
+               })
+      end
+
+      include_examples "journaled values for",
+                       new_values_set: {
+                         "subject" => "Changed subject",
+                         "journal_notes" => "Some notes",
+                         "journal_cause" => {
+                           "type" => "The good cause",
+                           "some_reference" => 42
+                         }
+                       },
+                       expected_values: {
+                         "subject" => ["Initial subject", "Changed subject"]
+                       },
+                       expected_notes: "Some notes",
+                       expected_cause: {
+                         "type" => "The good cause",
+                         "some_reference" => 42
+                       },
+                       expect_new_journal: true
     end
 
     context "when aggregation leads to an empty change (changing back and forth)",
@@ -870,6 +1180,65 @@ RSpec.describe WorkPackage do
 
       it "has the old state in the last journal`s data" do
         expect(work_package.journals.last.data.status_id).to be status.id
+      end
+    end
+
+    context "on changes to newline characters" do
+      context "when outside of the aggregation time" do
+        let!(:work_package) do
+          create(:work_package,
+                 description: "Description\n\nwith newlines\n\nembedded",
+                 journals: {
+                   1.day.ago => { user: current_user }
+                 })
+        end
+
+        include_examples "journaled values for",
+                         new_values_set: {
+                           "description" => "New description"
+                         },
+                         expected_values: {
+                           "description" => ["Description\n\nwith newlines\n\nembedded", "New description"]
+                         },
+                         expect_new_journal: true
+
+        context "when multiple values are changed and the change to description is only a newline change" do
+          let!(:work_package) do
+            create(:work_package,
+                   description: "Description\r\n\r\nwith newlines\r\n\r\nembedded",
+                   subject: "Original subject",
+                   journals: {
+                     1.day.ago => { user: current_user }
+                   })
+          end
+
+          include_examples "journaled values for",
+                           new_values_set: {
+                             "description" => "Description\r\n\r\nwith newlines\r\n\r\nembedded",
+                             "subject" => "New subject"
+                           },
+                           expected_values: {
+                             "subject" => ["Original subject", "New subject"]
+                           },
+                           expect_new_journal: true
+        end
+
+        context "when there is a legacy journal containing non-escaped newlines" do
+          let!(:work_package) do
+            create(:work_package,
+                   description: "Description\r\n\r\nwith newlines\r\n\r\nembedded",
+                   journals: {
+                     3.minutes.ago => { user: current_user }
+                   })
+          end
+
+          include_examples "no journaled value changes for",
+                           new_values_set: {
+                             "description" => "Description\n\nwith newlines\n\nembedded"
+                           },
+                           # The value of description does change which is what causes update_at to change
+                           expect_work_package_update_at_changed: true
+        end
       end
     end
   end

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -131,6 +131,29 @@ RSpec.describe WorkPackage do
       it "does not update the updated_at time of the work package" do
         expect { work_package.save! }.not_to change(work_package, :updated_at)
       end
+
+      it "does not update the updated_at time on initial journals" do
+        expect { work_package.save! }
+          .not_to change {
+                    work_package.journals.reload.last.updated_at
+                  }
+      end
+
+      it "does not update the updated_at time on non initial journals" do
+        # FIXME: the journal notes should have been saved on the initial journal as well
+        work_package.journal_notes = "Some notes"
+        expect { work_package.save! }.to change {
+          work_package.journals.last.notes
+        }
+        work_package.reload
+        work_package.journal_notes = "Some other notes"
+        work_package.save!
+
+        expect { work_package.reload.save! }
+          .not_to change {
+            work_package.journals.reload.last.updated_at
+          }
+      end
     end
 
     context "for different newlines", with_settings: { journal_aggregation_time_minutes: 0 } do

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -254,6 +254,13 @@ RSpec.describe WorkPackage do
           expect(work_package.reload.updated_at)
             .not_to eql(updated_at_before)
         end
+      else
+        it "keeps the updated_at time of the work package" do
+          # Using this complicated form of writing to avoid problems
+          # e.g. with reloading before the work package is initially saved
+          expect { work_package.save! }
+            .not_to change { work_package.reload.updated_at }
+        end
       end
     end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -591,8 +591,7 @@ RSpec.describe WorkPackage do
 
     before do
       without_timestamping do
-        work_package1.updated_at = 1.minute.ago
-        work_package1.save!
+        work_package1.update_column(:updated_at, 1.minute.ago)
       end
     end
 

--- a/spec/support/shared/acts_as_journalized.rb
+++ b/spec/support/shared/acts_as_journalized.rb
@@ -39,10 +39,6 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
     value.is_a?(Symbol) ? public_send(value).id : value
   end
 
-  def last_journal
-    journable.journals.reload.last
-  end
-
   before do
     new_values_set.each do |property, value|
       journable.public_send("#{property}=", value_or_id(value))
@@ -54,8 +50,8 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
       it "tracks the change from old value #{old_value.inspect} to new value #{new_value.inspect}" do
         journable.save!
 
-        expect(last_journal.old_value_for(property)).to eq(value_or_id(old_value))
-        expect(last_journal.new_value_for(property)).to eq(value_or_id(new_value))
+        expect(journable.last_journal.old_value_for(property)).to eq(value_or_id(old_value))
+        expect(journable.last_journal.new_value_for(property)).to eq(value_or_id(new_value))
       end
     end
   end
@@ -64,7 +60,7 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
     it "has no changes tracked" do
       journable.save!
 
-      expect(last_journal.details.except("cause"))
+      expect(journable.last_journal.details.except("cause"))
         .to be_empty
     end
   end
@@ -76,34 +72,28 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
               .by(1)
     end
 
-    it "has the timestamp of the work package update time for created_at" do
+    it "the journal has the timestamp of the journable update time for created_at" do
       journable.save!
 
-      expect(last_journal.created_at)
+      expect(journable.last_journal.created_at)
         .to eql(journable.reload.updated_at)
     end
 
-    it "has the timestamp of the work package update time for updated_at" do
+    it "the journal has the timestamp of the journable update time for updated_at" do
       journable.save!
 
-      expect(last_journal.updated_at)
+      expect(journable.last_journal.updated_at)
         .to eql(journable.reload.updated_at)
     end
 
-    it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
+    it "has the updated_at of the journable as the lower bound for validity_period and no upper bound" do
       journable.save!
 
-      expect(last_journal.validity_period)
+      expect(journable.last_journal.validity_period)
         .to eql(journable.reload.updated_at...)
     end
 
-    it "has the current user as the journal's user" do
-      journable.save!
-
-      expect(last_journal.user)
-        .to eql(current_user)
-    end
-
+    # This is currently only used if there is no predecessor
     if expect_predecessor_changed
       it "sets the upper bound of the preceding journal to be the created_at time of the newly created journal" do
         journable.save!
@@ -114,7 +104,7 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
       end
 
       it "keeps the user of the preceding journal" do
-        former_last_journal = last_journal
+        former_last_journal = journable.last_journal
 
         journable.save!
 
@@ -128,37 +118,31 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
         .not_to change { journable.journals.reload.count }
     end
 
-    it "has the current user as the journal's user" do
-      journable.save!
-
-      expect(last_journal.user)
-        .to eql(current_user)
-    end
-
     it "keeps the journal's created_at time" do
       expect { journable.save! }
-        .not_to change(last_journal, :created_at)
+        .not_to change { journable.last_journal.created_at }
     end
 
-    it "sets the journal's updated_at time to the work package's created_at time" do
-      journable.save!
+    it "updates both the journal's updated_at time and the journable's updated_at time to the same value" do
+      expect { journable.save! }
+       .to change { journable.last_journal.updated_at }
 
-      expect(last_journal.updated_at)
+      expect(journable.last_journal.updated_at)
         .to eql(journable.reload.updated_at)
     end
 
     it "keeps created_at of the journal as the lower bound for validity_period and no upper bound" do
       journable.save!
 
-      expect(last_journal.validity_period)
-        .to eql(last_journal.created_at...)
+      expect(journable.last_journal.validity_period)
+        .to eql(journable.last_journal.created_at...)
     end
   end
 
   it "has the current user as the journal's user" do
     journable.save!
 
-    expect(journable.journals.reload.last.user)
+    expect(journable.last_journal.user)
       .to eql(current_user)
   end
 
@@ -178,14 +162,14 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
     it "has the expected cause" do
       journable.save!
 
-      expect(last_journal.cause)
+      expect(journable.last_journal.cause)
         .to eql(expected_cause)
     end
   else
     it "has no cause" do
       journable.save!
 
-      expect(last_journal.cause)
+      expect(journable.last_journal.cause)
         .to be_empty
     end
   end
@@ -194,22 +178,22 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
     it "has the expected notes" do
       journable.save!
 
-      expect(last_journal.notes)
+      expect(journable.last_journal.notes)
         .to eql(expected_notes)
     end
   else
     it "has no notes" do
       journable.save!
 
-      expect(last_journal.notes)
+      expect(journable.last_journal.notes)
         .to be_empty
     end
   end
 
   if expect_journable_update_at_changed
-    it "updates the updated_at time of the work package" do
+    it "updates the updated_at time of the journable" do
       # Using this complicated form of writing to avoid problems
-      # e.g. with reloading before the work package is initially saved
+      # e.g. with reloading before the journable is initially saved
       updated_at_before = journable.updated_at
 
       journable.save!
@@ -218,9 +202,9 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
         .not_to eql(updated_at_before)
     end
   else
-    it "keeps the updated_at time of the work package" do
+    it "keeps the updated_at time of the journable" do
       # Using this complicated form of writing to avoid problems
-      # e.g. with reloading before the work package is initially saved
+      # e.g. with reloading before the journable is initially saved
       expect { journable.save! }
         .not_to change { journable.reload.updated_at }
     end
@@ -251,7 +235,7 @@ RSpec.shared_examples_for "no journaled value changes for" do |new_values_set:, 
   end
 
   unless expect_journable_update_at_changed
-    it "does not update the updated_at time of the work package" do
+    it "does not update the updated_at time of the journable" do
       expect { journable.save! }
         .not_to change(journable, :updated_at)
     end

--- a/spec/support/shared/acts_as_journalized.rb
+++ b/spec/support/shared/acts_as_journalized.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+RSpec.shared_examples_for "journaled values for" do |new_values_set:,
+                                                     expected_values:,
+                                                     expect_new_journal: true,
+                                                     expect_predecessor_changed: expect_new_journal,
+                                                     expect_journable_update_at_changed: true,
+                                                     expected_cause: nil,
+                                                     expected_notes: nil|
+  def value_or_id(value)
+    value.is_a?(Symbol) ? public_send(value).id : value
+  end
+
+  def last_journal
+    journable.journals.reload.last
+  end
+
+  before do
+    new_values_set.each do |property, value|
+      journable.public_send("#{property}=", value_or_id(value))
+    end
+  end
+
+  expected_values.each do |property, (old_value, new_value)|
+    context "for #{property}" do
+      it "tracks the change from old value #{old_value.inspect} to new value #{new_value.inspect}" do
+        journable.save!
+
+        expect(last_journal.old_value_for(property)).to eq(value_or_id(old_value))
+        expect(last_journal.new_value_for(property)).to eq(value_or_id(new_value))
+      end
+    end
+  end
+
+  if expected_values.empty?
+    it "has no changes tracked" do
+      journable.save!
+
+      expect(last_journal.details.except("cause"))
+        .to be_empty
+    end
+  end
+
+  if expect_new_journal
+    it "creates a new journal" do
+      expect { journable.save! }
+        .to change { journable.journals.reload.count }
+              .by(1)
+    end
+
+    it "has the timestamp of the work package update time for created_at" do
+      journable.save!
+
+      expect(last_journal.created_at)
+        .to eql(journable.reload.updated_at)
+    end
+
+    it "has the timestamp of the work package update time for updated_at" do
+      journable.save!
+
+      expect(last_journal.updated_at)
+        .to eql(journable.reload.updated_at)
+    end
+
+    it "has the updated_at of the work package as the lower bound for validity_period and no upper bound" do
+      journable.save!
+
+      expect(last_journal.validity_period)
+        .to eql(journable.reload.updated_at...)
+    end
+
+    it "has the current user as the journal's user" do
+      journable.save!
+
+      expect(last_journal.user)
+        .to eql(current_user)
+    end
+
+    if expect_predecessor_changed
+      it "sets the upper bound of the preceding journal to be the created_at time of the newly created journal" do
+        journable.save!
+
+        former_last_journal = journable.journals.reload[-2]
+        expect(former_last_journal.validity_period)
+          .to eql(former_last_journal.created_at...journable.last_journal.created_at)
+      end
+
+      it "keeps the user of the preceding journal" do
+        former_last_journal = last_journal
+
+        journable.save!
+
+        expect(journable.journals.reload[-2].user)
+          .to eql(former_last_journal.user)
+      end
+    end
+  else
+    it "does not create a new journal" do
+      expect { journable.save! }
+        .not_to change { journable.journals.reload.count }
+    end
+
+    it "has the current user as the journal's user" do
+      journable.save!
+
+      expect(last_journal.user)
+        .to eql(current_user)
+    end
+
+    it "keeps the journal's created_at time" do
+      expect { journable.save! }
+        .not_to change(last_journal, :created_at)
+    end
+
+    it "sets the journal's updated_at time to the work package's created_at time" do
+      journable.save!
+
+      expect(last_journal.updated_at)
+        .to eql(journable.reload.updated_at)
+    end
+
+    it "keeps created_at of the journal as the lower bound for validity_period and no upper bound" do
+      journable.save!
+
+      expect(last_journal.validity_period)
+        .to eql(last_journal.created_at...)
+    end
+  end
+
+  it "has the current user as the journal's user" do
+    journable.save!
+
+    expect(journable.journals.reload.last.user)
+      .to eql(current_user)
+  end
+
+  it "sends an OpenProject notification" do
+    allow(OpenProject::Notifications)
+      .to receive(:send)
+
+    journable.save!
+
+    expect(OpenProject::Notifications)
+      .to have_received(:send)
+            .with(OpenProject::Events::JOURNAL_CREATED,
+                  anything)
+  end
+
+  if expected_cause
+    it "has the expected cause" do
+      journable.save!
+
+      expect(last_journal.cause)
+        .to eql(expected_cause)
+    end
+  else
+    it "has no cause" do
+      journable.save!
+
+      expect(last_journal.cause)
+        .to be_empty
+    end
+  end
+
+  if expected_notes
+    it "has the expected notes" do
+      journable.save!
+
+      expect(last_journal.notes)
+        .to eql(expected_notes)
+    end
+  else
+    it "has no notes" do
+      journable.save!
+
+      expect(last_journal.notes)
+        .to be_empty
+    end
+  end
+
+  if expect_journable_update_at_changed
+    it "updates the updated_at time of the work package" do
+      # Using this complicated form of writing to avoid problems
+      # e.g. with reloading before the work package is initially saved
+      updated_at_before = journable.updated_at
+
+      journable.save!
+
+      expect(journable.reload.updated_at)
+        .not_to eql(updated_at_before)
+    end
+  else
+    it "keeps the updated_at time of the work package" do
+      # Using this complicated form of writing to avoid problems
+      # e.g. with reloading before the work package is initially saved
+      expect { journable.save! }
+        .not_to change { journable.reload.updated_at }
+    end
+  end
+end
+
+RSpec.shared_examples_for "no journaled value changes for" do |new_values_set:, expect_journable_update_at_changed: false|
+  def value_or_id(value)
+    value.is_a?(Symbol) ? public_send(value).id : value
+  end
+
+  before do
+    new_values_set.each do |property, value|
+      journable.public_send("#{property}=", value_or_id(value))
+    end
+  end
+
+  it "does not create a new journal" do
+    expect { journable.save! }
+      .not_to change(Journal, :count)
+  end
+
+  it "does not update the updated_at time of the last journal" do
+    expect { journable.save! }
+      .not_to change {
+        journable.journals.reload.last.updated_at
+      }
+  end
+
+  unless expect_journable_update_at_changed
+    it "does not update the updated_at time of the work package" do
+      expect { journable.save! }
+        .not_to change(journable, :updated_at)
+    end
+  end
+
+  it "does not send an OpenProject notification" do
+    allow(OpenProject::Notifications)
+      .to receive(:send)
+
+    journable.save!
+
+    expect(OpenProject::Notifications)
+      .not_to have_received(:send)
+  end
+
+  it "has a data journal" do
+    journable.save!
+
+    expect(journable.last_journal.data)
+      .not_to be_nil
+  end
+end

--- a/spec/support/shared/acts_as_journalized.rb
+++ b/spec/support/shared/acts_as_journalized.rb
@@ -146,7 +146,7 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
       .to eql(current_user)
   end
 
-  it "sends an OpenProject notification" do
+  it "sends an OpenProject JOURNAL_CREATED notification" do
     allow(OpenProject::Notifications)
       .to receive(:send)
 
@@ -154,8 +154,16 @@ RSpec.shared_examples_for "journaled values for" do |new_values_set:,
 
     expect(OpenProject::Notifications)
       .to have_received(:send)
-            .with(OpenProject::Events::JOURNAL_CREATED,
-                  anything)
+            .with(OpenProject::Events::JOURNAL_CREATED, anything)
+            .once
+
+    # only one notification is sent even if the journable is saved multiple times
+    journable.save!
+
+    expect(OpenProject::Notifications)
+    .to have_received(:send)
+          .with(OpenProject::Events::JOURNAL_CREATED, anything)
+          .once
   end
 
   if expected_cause


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70535

# What are you trying to accomplish?

Sits on top of #21332 to address certain unwanted behaviour identified:

* Even without a change in the journalized object
  * The journal gets its timestamp updated if the journal is aggregated even if there are no changes.
  * A notification (`OpenProject::Events::JOURNAL_CREATED`) is always sent out if a journal is aggregated, even if there are no changes. Since saving of unchanged models in AR normally is an operation without side effects, journaling should behave the same. The code calls save repeatedly in a number of services and it should be ok to do so. This is also the reason for why multiple notifications are sent out on a PIR.
* The data and associated data of a journal is always deleted and then recreated. As of now, this didn't cause issues but it is just unnecessary.

The behaviour of the journal creation has now been changed:
* The predecessor's data is only removed now if a [change is detected or if a note or cause is present](https://github.com/opf/openproject/pull/21590/changes#diff-845a670f88e6d7028197a149915fdf3cc0acec7b42f85e4191d8314efeceaa2aR51).
* Because of this, the predecessor's data also only has to be recreated if the previous condition (changes, note, cause) applies. Before, this was always done if a predecessor was aggregated. 
* The `max_journal` CTE now considers an aggregatable predecessor to also be within its scope. 
* The above changes simplify the code quite a bit as changes are now compared to the predecessor to aggregate with (if it exist). This helps in the case of there only being one journal (after the creation of the journable without further changes so far). Before, the current state was compared to the state before the journable was saved. This then lead to the SQL always detecting changes which is not always true. 
* The journals `updated_at` is now [only updated if there are changes, a note or a cause](https://github.com/opf/openproject/pull/21590/changes#diff-6b8f9ee1bcd6c1ec2932434e0ad42f7d05c1f1d65e2c9a7a5b727ee5ea4914f4R413). This was also intended before but didn't work in all cases.  
* The above is true now for the creation of a `OpenProject::Events::JOURNAL_CREATED` notification.

The whole behaviour has been specced thoroughly with reusable specs. For every case, the whole expected state of the journable, the last journal and the predecessor will be checked now.

## Out of scope

* The reusable specs are as of now mostly used to test work packages. It could also be applied to the other journables. 
* Custom values, attachments and storage is not yet covered by the spec helper.

# Merge checklist

- [x] Added/updated tests