### PR TITLE
[69677] Project creation modal: Screen overflow on mobile

### DIFF
--- a/app/components/projects/wizard/page_component.sass
+++ b/app/components/projects/wizard/page_component.sass
@@ -59,3 +59,11 @@
 
   @media screen and (max-width: $breakpoint-md)
     grid-template-columns: 170px 1fr
+
+  @media screen and (max-width: $breakpoint-sm)
+    grid-template-areas: "main"
+    grid-template-columns: 1fr
+
+    &--sidebar,
+    &--help
+      display: none


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/project-inititation-requests/work_packages/69677/activity#comment-1614735

# What are you trying to accomplish?
Hide sidebar on mobile as there is not enough space

# What approach did you choose and why?
The actual issue is that we enfoce user autocompleters to have a dropdown with `min-width: 300px` . On small screens, this does not fit due to the sidebar being still present.

