### PR TITLE
[69203] Long project descriptions cause a weird layout on the new Overview

### DIFF
--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -39,6 +39,7 @@ $widget-box--enumeration-width: 20px
     .widget-box
       flex: 1
       flex-basis: 32%
+      max-height: 750px // Avoid that individual widgets blow the whole grid
       display: flex
       flex-direction: column
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69203

# What are you trying to accomplish?
Give wigets a max-height to avoid that individual widgets blow up the whole grid

# What approach did you choose and why?
This is an alternative solution to https://github.com/opf/openproject/pull/21315 which tried to use the `OpenProject::Common::AttributeComponent` which we already have in other places. However, this component was designed for places where there is only little space. So there, either only the formating is ignored completely, or only the first paragraph is shown.
For the description which is supposed to be shown completely in most case, this does not work out. I therefore decided to simply give the widgets a max-height. This also has the advantage that it applies to all widgets and not only description and status.