### PR TITLE
[#70336] Sections in meeting agenda not displayed correctly when moved

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -460,7 +460,8 @@ class MeetingsController < ApplicationController
 
     @meeting = scope
       .visible
-      .includes([:project, :author, { participants: :user }, :sections, { agenda_items: :outcomes }])
+      .includes([:project, :author, { participants: :user }, { agenda_items: :outcomes }])
+      .preload(:sections)
       .find(params[:id])
   end
 

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -524,32 +524,19 @@ RSpec.describe "Meetings CRUD",
       show_page.expect_section(title: "Section B")
       show_page.expect_section(title: "Section C")
 
-      initial_positions = [section1, section2, section3].map(&:position)
-      expect(initial_positions).to eq([1, 2, 3])
-
       show_page.select_section_action(section3, "Move up")
 
       wait_for_network_idle
 
       expect([section1, section2, section3].map { |s| s.reload.position }).to eq([1, 3, 2])
 
-      sections = page.all(".op-meeting-section-container").select do |section|
-        section["data-test-selector"]&.start_with?("meeting-section-container-") &&
-          !section["data-test-selector"]&.include?("header")
-      end
-      expect(sections[0]).to have_content("Section A")
-      expect(sections[1]).to have_content("Section C")
-      expect(sections[2]).to have_content("Section B")
+      expect(show_page.section_headers)
+        .to eq(["Section A", "Section C", "Section B"])
 
-      show_page.visit!
+      show_page.reload!
 
-      sections_after_refresh = page.all(".op-meeting-section-container").select do |section|
-        section["data-test-selector"]&.start_with?("meeting-section-container-") &&
-          !section["data-test-selector"]&.include?("header")
-      end
-      expect(sections_after_refresh[0]).to have_content("Section A")
-      expect(sections_after_refresh[1]).to have_content("Section C")
-      expect(sections_after_refresh[2]).to have_content("Section B")
+      expect(show_page.section_headers)
+        .to eq(["Section A", "Section C", "Section B"])
     end
   end
 end

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_crud_spec.rb
@@ -513,5 +513,43 @@ RSpec.describe "Meetings CRUD",
         show_page.expect_blankslate
       end
     end
+
+    it "maintains section order when rendering" do
+      section1 = create(:meeting_section, meeting:, title: "Section A")
+      section2 = create(:meeting_section, meeting:, title: "Section B")
+      section3 = create(:meeting_section, meeting:, title: "Section C")
+
+      show_page.visit!
+      show_page.expect_section(title: "Section A")
+      show_page.expect_section(title: "Section B")
+      show_page.expect_section(title: "Section C")
+
+      initial_positions = [section1, section2, section3].map(&:position)
+      expect(initial_positions).to eq([1, 2, 3])
+
+      show_page.select_section_action(section3, "Move up")
+
+      wait_for_network_idle
+
+      expect([section1, section2, section3].map { |s| s.reload.position }).to eq([1, 3, 2])
+
+      sections = page.all(".op-meeting-section-container").select do |section|
+        section["data-test-selector"]&.start_with?("meeting-section-container-") &&
+          !section["data-test-selector"]&.include?("header")
+      end
+      expect(sections[0]).to have_content("Section A")
+      expect(sections[1]).to have_content("Section C")
+      expect(sections[2]).to have_content("Section B")
+
+      show_page.visit!
+
+      sections_after_refresh = page.all(".op-meeting-section-container").select do |section|
+        section["data-test-selector"]&.start_with?("meeting-section-container-") &&
+          !section["data-test-selector"]&.include?("header")
+      end
+      expect(sections_after_refresh[0]).to have_content("Section A")
+      expect(sections_after_refresh[1]).to have_content("Section C")
+      expect(sections_after_refresh[2]).to have_content("Section B")
+    end
   end
 end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -766,5 +766,9 @@ module Pages::Meetings
         element["data-reference-value"] != old_reference_value
       end
     end
+
+    def section_headers
+      page.all(".op-meeting-section-container[data-test-selector^='meeting-section-header-container-']").map(&:text)
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70336


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
I think the bug is related to https://github.com/rails/rails/issues/6769, where the :includes is messing up the default ordering, and so using :preload instead fixes the issue

However, I don't understand it fully and this might just be a band aid fix

# Merge checklist

- [x] Added/updated tests
