### PR TITLE
[#70200] Introduce Fieldset component, input group

### DIFF
--- a/app/components/op_primer/fieldset_component.html.erb
+++ b/app/components/op_primer/fieldset_component.html.erb
@@ -1,0 +1,8 @@
+<% unless legend? %>
+  <% with_legend { @legend_text } # set the default %>
+<% end %>
+
+<%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
+  <%= legend %>
+  <%= content %>
+<% end %>

--- a/app/components/op_primer/fieldset_component.rb
+++ b/app/components/op_primer/fieldset_component.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpPrimer
+  # A low-level component for building fieldsets with unopinionated styling.
+  #
+  # This component is not designed to be used directly, but rather a primitive for
+  # authors of other components and form controls.
+  class FieldsetComponent < Primer::Component
+    attr_reader :legend_text
+
+    renders_one :legend, ->(**system_arguments) {
+      LegendComponent.new(visually_hide_legend: @visually_hide_legend, **system_arguments)
+    }
+
+    # @param legend_text [String] A legend should be short and concise. The String will also be read by assistive technology.
+    # @param visually_hide_legend [Boolean] Controls if the legend is visible. If `true`, screen reader only text will be added.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(legend_text: nil, visually_hide_legend: false, **system_arguments) # rubocop:disable Lint/MissingSuper
+      @legend_text = legend_text
+      @visually_hide_legend = visually_hide_legend
+      @system_arguments = deny_tag_argument(**system_arguments)
+      @system_arguments[:tag] = :fieldset
+
+      deny_aria_key(
+        :label,
+        "instead of `aria-label`, include `legend_text` and set `visually_hide_legend` to `true` on the component initializer.",
+        **@system_arguments
+      )
+    end
+
+    def render?
+      content? && (legend_text.present? || legend?)
+    end
+
+    class LegendComponent < Primer::Component
+      attr_reader :text
+
+      def initialize(text: nil, visually_hide_legend: false, **system_arguments) # rubocop:disable Lint/MissingSuper
+        @text = text
+
+        @system_arguments = deny_tag_argument(**system_arguments)
+        @system_arguments[:tag] = :legend
+        @system_arguments[:classes] = class_names(
+          @system_arguments[:classes],
+          { "sr-only" => visually_hide_legend }
+        )
+      end
+
+      def call
+        render(Primer::BaseComponent.new(**@system_arguments)) { legend_content }
+      end
+
+      private
+
+      def legend_content
+        @legend_content ||= content || text
+      end
+    end
+  end
+end

--- a/config/initializers/primer_forms.rb
+++ b/config/initializers/primer_forms.rb
@@ -30,5 +30,6 @@
 
 Rails.application.config.to_prepare do
   Primer::Forms::Dsl::FormObject.include(Primer::OpenProject::Forms::Dsl::InputMethods)
+  Primer::Forms::Dsl::FormObject.include(Primer::OpenProject::Forms::Dsl::FormObjectMethods)
   Primer::Forms::Dsl::InputGroup.include(Primer::OpenProject::Forms::Dsl::InputMethods)
 end

--- a/lib/primer/open_project/forms/dsl/fieldset_input_group.rb
+++ b/lib/primer/open_project/forms/dsl/fieldset_input_group.rb
@@ -28,39 +28,37 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
-#
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
-module Settings
-  class FormObjectDecorator < SimpleDelegator
-    include ::ApplicationHelper
-    include InputMethods
+module Primer
+  module OpenProject
+    module Forms
+      module Dsl
+        # :nodoc:
+        class FieldsetInputGroup
+          include Primer::Forms::Dsl::InputMethods
+          include InputMethods
 
-    # @!attribute [r] object
-    #   @return [Primer::Forms::Dsl::FormObject] the original form object
-    alias object __getobj__
+          attr_reader :builder, :form, :system_arguments
 
-    # @!method initialize(object)
-    #   Initializes a new {Settings::FormObjectDecorator}
-    #
-    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    #   @return [FormObjectDecorator]
+          def initialize(builder:, form:, **system_arguments)
+            @builder = builder
+            @form = form
+            @system_arguments = system_arguments
 
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      object.group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
-    end
+            yield(self) if block_given?
+          end
 
-    def fieldset_group(**, &)
-      object.fieldset_group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
+          def to_component
+            FieldsetGroup.new(inputs: inputs, builder: builder, form: form, **@system_arguments)
+          end
+
+          def type
+            :group
+          end
+
+          def input?
+            true
+          end
+        end
       end
     end
   end

--- a/lib/primer/open_project/forms/dsl/form_object_methods.rb
+++ b/lib/primer/open_project/forms/dsl/form_object_methods.rb
@@ -28,39 +28,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
-#
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
-module Settings
-  class FormObjectDecorator < SimpleDelegator
-    include ::ApplicationHelper
-    include InputMethods
-
-    # @!attribute [r] object
-    #   @return [Primer::Forms::Dsl::FormObject] the original form object
-    alias object __getobj__
-
-    # @!method initialize(object)
-    #   Initializes a new {Settings::FormObjectDecorator}
-    #
-    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    #   @return [FormObjectDecorator]
-
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      object.group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
-    end
-
-    def fieldset_group(**, &)
-      object.fieldset_group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
+module Primer
+  module OpenProject
+    module Forms
+      module Dsl
+        module FormObjectMethods
+          def fieldset_group(**, &)
+            add_input FieldsetInputGroup.new(builder:, form:, **, &)
+          end
+        end
       end
     end
   end

--- a/lib/primer/open_project/forms/fieldset_group.html.erb
+++ b/lib/primer/open_project/forms/fieldset_group.html.erb
@@ -1,0 +1,10 @@
+<%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
+  <%= render(OpPrimer::FieldsetComponent.new(**@fieldset_arguments)) do %>
+    <%=
+      render(Primer::Beta::Subhead.new) do |component|
+        component.with_heading(**@heading_arguments).with_content(@title)
+      end
+    %>
+    <%= render(Primer::Forms::Group.new(**@group_arguments)) %>
+  <% end %>
+<% end %>

--- a/lib/primer/open_project/forms/fieldset_group.rb
+++ b/lib/primer/open_project/forms/fieldset_group.rb
@@ -38,8 +38,11 @@ module Primer
         # @param inputs [Array<Primer::Forms::Dsl::Input>] Array of form inputs to be grouped
         # @param builder [ActionView::Helpers::FormBuilder] The form builder instance
         # @param form [Primer::Forms::BaseForm] The form object
-        # @param layout [Symbol] Layout style for the input group (default: Primer::Forms::Group::DEFAULT_LAYOUT)
-        # @param heading_arguments [Hash] Arguments passed to the heading component (id, tag, size)
+        # @param layout [Symbol] Layout style for the input group (default: :default_layout)
+        # @param heading_arguments [Hash] Arguments passed to the heading component
+        # @option heading_arguments [String] :id The ID for the heading element
+        # @option heading_arguments [Symbol] :tag The HTML tag for the heading (default: :h3)
+        # @option heading_arguments [Symbol] :size The size of the heading (default: :medium)
         # @param group_arguments [Hash] Arguments passed to the input group component
         # @param system_arguments [Hash] Additional system arguments passed to the section wrapper
         def initialize( # rubocop:disable Metrics/AbcSize

--- a/lib/primer/open_project/forms/fieldset_group.rb
+++ b/lib/primer/open_project/forms/fieldset_group.rb
@@ -28,39 +28,43 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
-#
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
-module Settings
-  class FormObjectDecorator < SimpleDelegator
-    include ::ApplicationHelper
-    include InputMethods
+module Primer
+  module OpenProject
+    module Forms
+      # :nodoc:
+      class FieldsetGroup < Primer::Forms::BaseComponent
+        def initialize( # rubocop:disable Metrics/AbcSize
+          title:,
+          inputs:,
+          builder:,
+          form:,
+          layout: Primer::Forms::Group::DEFAULT_LAYOUT,
+          heading_arguments: {},
+          group_arguments: {},
+          **system_arguments
+        )
+          super()
 
-    # @!attribute [r] object
-    #   @return [Primer::Forms::Dsl::FormObject] the original form object
-    alias object __getobj__
+          @title = title
 
-    # @!method initialize(object)
-    #   Initializes a new {Settings::FormObjectDecorator}
-    #
-    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    #   @return [FormObjectDecorator]
+          @heading_arguments = heading_arguments
+          @heading_arguments[:id] ||= "subhead-#{SecureRandom.uuid}"
+          @heading_arguments[:tag] ||= :h3
+          @heading_arguments[:size] ||= :medium
 
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      object.group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
-    end
+          @fieldset_arguments = {
+            legend_text: @title,
+            visually_hide_legend: true,
+            aria: { labelledby: @heading_arguments[:id] }
+          }
+          @group_arguments = group_arguments.merge(inputs:, builder:, form:, layout:)
 
-    def fieldset_group(**, &)
-      object.fieldset_group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
+          @system_arguments = system_arguments
+          @system_arguments[:tag] = :section
+          @system_arguments[:aria] ||= {}
+          @system_arguments[:aria][:labelledby] = @heading_arguments[:id]
+          @system_arguments[:hidden] = :none if inputs.all?(&:hidden?)
+        end
       end
     end
   end

--- a/lib/primer/open_project/forms/fieldset_group.rb
+++ b/lib/primer/open_project/forms/fieldset_group.rb
@@ -33,6 +33,15 @@ module Primer
     module Forms
       # :nodoc:
       class FieldsetGroup < Primer::Forms::BaseComponent
+        ##
+        # @param title [String] The title displayed as the heading for the fieldset
+        # @param inputs [Array<Primer::Forms::Dsl::Input>] Array of form inputs to be grouped
+        # @param builder [ActionView::Helpers::FormBuilder] The form builder instance
+        # @param form [Primer::Forms::BaseForm] The form object
+        # @param layout [Symbol] Layout style for the input group (default: Primer::Forms::Group::DEFAULT_LAYOUT)
+        # @param heading_arguments [Hash] Arguments passed to the heading component (id, tag, size)
+        # @param group_arguments [Hash] Arguments passed to the input group component
+        # @param system_arguments [Hash] Additional system arguments passed to the section wrapper
         def initialize( # rubocop:disable Metrics/AbcSize
           title:,
           inputs:,

--- a/lib/primer/open_project/forms/fieldset_group.rb
+++ b/lib/primer/open_project/forms/fieldset_group.rb
@@ -73,6 +73,7 @@ module Primer
 
           @system_arguments = system_arguments
           @system_arguments[:tag] = :section
+          @system_arguments[:mb] ||= 4
           @system_arguments[:aria] ||= {}
           @system_arguments[:aria][:labelledby] = @heading_arguments[:id]
           @system_arguments[:hidden] = :none if inputs.all?(&:hidden?)

--- a/lookbook/previews/op_primer/fieldset_component_preview.rb
+++ b/lookbook/previews/op_primer/fieldset_component_preview.rb
@@ -28,40 +28,15 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
-#
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
-module Settings
-  class FormObjectDecorator < SimpleDelegator
-    include ::ApplicationHelper
-    include InputMethods
-
-    # @!attribute [r] object
-    #   @return [Primer::Forms::Dsl::FormObject] the original form object
-    alias object __getobj__
-
-    # @!method initialize(object)
-    #   Initializes a new {Settings::FormObjectDecorator}
-    #
-    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    #   @return [FormObjectDecorator]
-
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      object.group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
+module OpPrimer
+  # @logical_path OpenProject/Primer
+  class FieldsetComponentPreview < Lookbook::Preview
+    def default
+      render_with_template
     end
 
-    def fieldset_group(**, &)
-      object.fieldset_group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
+    def with_legend_text
+      render_with_template
     end
   end
 end

--- a/lookbook/previews/op_primer/fieldset_component_preview/default.html.erb
+++ b/lookbook/previews/op_primer/fieldset_component_preview/default.html.erb
@@ -1,0 +1,12 @@
+<%# preview: FieldsetComponentPreview#default %>
+<%# N.B. This is an unstyled component! %>
+<%= render(OpPrimer::FieldsetComponent.new) do |component| %>
+  <% component.with_legend(font_size: 4) do %>
+    Account details
+  <% end %>
+
+  <div class="d-flex flex-column gap-2 mt-2">
+    <label for="username">Username</label>
+    <input type="text" id="username" autocomplete="username" placeholder="@myxyz">
+  </div>
+<% end %>

--- a/lookbook/previews/op_primer/fieldset_component_preview/with_legend_text.html.erb
+++ b/lookbook/previews/op_primer/fieldset_component_preview/with_legend_text.html.erb
@@ -1,0 +1,15 @@
+<%# preview: FieldsetComponentPreview#with_legend_text %>
+<%# N.B. This is an unstyled component! %>
+<%= render(OpPrimer::FieldsetComponent.new(legend_text: "Notification preferences")) do %>
+  <div class="d-flex flex-column">
+    <label>
+      <input type="radio" name="notifications" checked>
+      <span>Email me about important updates</span>
+    </label>
+
+    <label>
+      <input type="radio" name="notifications">
+      <span>Only notify me about security issues</span>
+    </label>
+  </div>
+<% end %>

--- a/spec/components/op_primer/fieldset_component_spec.rb
+++ b/spec/components/op_primer/fieldset_component_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpPrimer::FieldsetComponent, type: :component do
+  def render_component(**, &)
+    render_inline(described_class.new(**), &)
+  end
+
+  shared_examples_for "rendering fieldset" do
+    it "renders fieldset" do
+      expect(rendered_component).to have_element :fieldset do |fieldset|
+        expect(fieldset).to have_element :legend, text: "My legend"
+        expect(fieldset).to have_content "Fieldset content"
+      end
+    end
+  end
+
+  context "with legend slot and text param" do
+    subject(:rendered_component) do
+      render_component do |component|
+        component.with_legend(text: "My legend")
+
+        "Fieldset content"
+      end
+    end
+
+    it_behaves_like "rendering fieldset"
+  end
+
+  context "with legend slot and content" do
+    subject(:rendered_component) do
+      render_component do |component|
+        component.with_legend { "My legend" }
+
+        "Fieldset content"
+      end
+    end
+
+    it_behaves_like "rendering fieldset"
+  end
+
+  context "with legend_text" do
+    subject(:rendered_component) do
+      render_component(legend_text: "My legend") do
+        "Fieldset content"
+      end
+    end
+
+    it_behaves_like "rendering fieldset"
+  end
+
+  context "without legend slot or legend_text" do
+    subject(:rendered_component) do
+      render_component do
+        "Fieldset content"
+      end
+    end
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_blank
+    end
+  end
+
+  context "without content" do
+    subject(:rendered_component) do
+      render_component(legend_text: "My legend")
+    end
+
+    it "renders nothing" do
+      expect(rendered_component.to_s).to be_blank
+    end
+  end
+end

--- a/spec/lib/primer/open_project/forms/dsl/form_object_methods_spec.rb
+++ b/spec/lib/primer/open_project/forms/dsl/form_object_methods_spec.rb
@@ -27,41 +27,30 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-
-# Decorates a form object to provide a more convenient interface for
-# rendering settings.
 #
-# It automatically sets the label, value, and disabled properties from the
-# setting name and its definition attributes.
-module Settings
-  class FormObjectDecorator < SimpleDelegator
-    include ::ApplicationHelper
-    include InputMethods
+require "spec_helper"
 
-    # @!attribute [r] object
-    #   @return [Primer::Forms::Dsl::FormObject] the original form object
-    alias object __getobj__
+RSpec.describe Primer::OpenProject::Forms::Dsl::FormObjectMethods, type: :forms do
+  let(:form_object) { Primer::Forms::Dsl::FormObject.extend(described_class) }
+  let(:builder) { instance_double(ActionView::Helpers::FormBuilder, object: model) }
+  let(:form) { instance_double(ApplicationForm, model:, caption_template?: false) }
+  let(:form_dsl) { form_object.new(builder:, form:) }
 
-    # @!method initialize(object)
-    #   Initializes a new {Settings::FormObjectDecorator}
-    #
-    #   @param object [Primer::Forms::Dsl::FormObject] The form object to be decorated
-    #   @return [FormObjectDecorator]
+  let(:options) { {} }
 
-    # Creates a group for a setting
-    #
-    # @param ** [Hash] Additional options for the group
-    # @see Primer::Forms::Dsl::FormObject#group
-    def group(**, &)
-      object.group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
+  let(:model) { build_stubbed(:project) }
+
+  subject(:field) { field_group.first }
+
+  shared_examples_for "input class" do |input_class|
+    it "instantiates correct input class" do
+      expect(field).to be_a(input_class)
     end
+  end
 
-    def fieldset_group(**, &)
-      object.fieldset_group(**) do |g|
-        yield Settings::FormObjectDecorator.new(g)
-      end
-    end
+  describe "#fieldset_group" do
+    let(:field_group) { form_dsl.fieldset_group(title: "Title", **options) }
+
+    include_examples "input class", Primer::OpenProject::Forms::Dsl::FieldsetInputGroup
   end
 end

--- a/spec/lib/primer/open_project/forms/fieldset_group_spec.rb
+++ b/spec/lib/primer/open_project/forms/fieldset_group_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Primer::OpenProject::Forms::FieldsetGroup, type: :forms do
+  include ViewComponent::TestHelpers
+
+  describe "rendering" do
+    let(:params) { {} }
+    let(:model) { build_stubbed(:comment) }
+
+    def render_form
+      render_in_view_context(model, params) do |model, params|
+        primer_form_with(url: "/foo", model:) do |f|
+          render_inline_form(f) do |check_form|
+            check_form.fieldset_group(title: "Ultimate answers", **params) do |group|
+              group.check_box(name: :one, label: "One", caption: "Pick me")
+              group.check_box(name: :two, label: "Two", caption: "Don't pick me")
+              group.check_box(name: :three, label: "Three")
+            end
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "renders the heading (default level 3)" do
+      expect(rendered_form).to have_selector :heading, "Ultimate answers", level: 3
+    end
+
+    it "renders the section" do
+      expect(rendered_form).to have_selector :section, "Ultimate answers"
+    end
+
+    it "renders the fieldset" do
+      expect(rendered_form).to have_selector :fieldset, "Ultimate answers"
+    end
+
+    it "renders the fields" do
+      expect(rendered_form).to have_field count: 3, type: :checkbox, fieldset: "Ultimate answers"
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70200

# What are you trying to accomplish?

Introduces both an unstyled, low-level `FieldsetComponent` and the `fieldset_group` input group for use with the Primer Forms DSL.

## Screenshots

See #21365 for `fieldset_group` in action.

### Unstyled component (see lookbook docs)

<img width="963" height="151" alt="Screenshot 2026-01-08 at 19 43 50" src="https://github.com/user-attachments/assets/a0c7565b-f04e-410d-9296-9dbfe5d90ab2" />

<img width="957" height="191" alt="Screenshot 2026-01-08 at 19 43 41" src="https://github.com/user-attachments/assets/7a2667e7-82c7-4621-b8dd-4fdae5232cc7" />

# What approach did you choose and why?

As with other recent components I've worked on (e.g. `DataTable`), i've chosen to introduce a low-level unstyled / "headless" component that just renders the HTML and validates semantics.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
