### PR TITLE
bug/70367 Automatically dismiss document connection recovery notice

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -30,6 +30,8 @@
 
 import { User } from '@blocknote/core/comments';
 import { HocuspocusProvider } from '@hocuspocus/provider';
+import { Application } from '@hotwired/stimulus';
+import FlashController from 'core-stimulus/controllers/flash.controller';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { ShadowDomWrapper } from 'op-blocknote-extensions';
 import React from 'react';
@@ -41,15 +43,20 @@ class BlockNoteElement extends HTMLElement {
   private mount:HTMLDivElement;
   private errorContainer:HTMLDivElement;
   private reactRoot:Root|null = null;
+  private stimulusApp:Application|null = null;
 
   constructor() {
     super();
 
     const shadowRoot = this.attachShadow({ mode: 'open' });
+
     // Container for connection error/recovery messages (rendered by React via fetchConnectionTemplate)
     this.errorContainer = document.createElement('div');
     this.errorContainer.id = 'documents-show-edit-view-connection-error-notice-component';
+    this.errorContainer.dataset.controller = 'flash';
+    this.errorContainer.dataset.flashAutohideValue = 'true';
     this.mount = document.createElement('div');
+
     shadowRoot.appendChild(this.errorContainer);
     shadowRoot.appendChild(this.mount);
 
@@ -71,6 +78,11 @@ class BlockNoteElement extends HTMLElement {
   }
 
   connectedCallback() {
+    // Initialize Stimulus application within shadow DOM
+    this.stimulusApp = Application.start(this.errorContainer);
+    this.stimulusApp.register('flash', FlashController);
+
+    // Initialize React application within shadow DOM
     this.reactRoot = createRoot(this.mount);
 
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
@@ -87,6 +99,11 @@ class BlockNoteElement extends HTMLElement {
     if (this.reactRoot) {
       this.reactRoot.unmount();
       this.reactRoot = null;
+    }
+
+    if (this.stimulusApp) {
+      this.stimulusApp.stop();
+      this.stimulusApp = null;
     }
   }
 


### PR DESCRIPTION
https://community.openproject.org/work_packages/70367

Register the flash controller within the shadow dom so that it can auto-hide the connection recovery template that arises from a (custom) turbo stream flash action

![auto-hide-reconnection-banner](https://github.com/user-attachments/assets/1c3c49cb-7599-4a97-be2a-c44283d9c3b1)