### PR TITLE
Add default framework headers removed in secure_headers

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -145,14 +145,13 @@ Rails.application.config.action_controller.raise_on_open_redirects = true
 
 # https://guides.rubyonrails.org/configuring.html#config-action-dispatch-default-headers
 # Change the default headers to disable browsers' flawed legacy XSS protection.
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Download-Options" => "noopen",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Download-Options" => "noopen",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 # https://guides.rubyonrails.org/configuring.html#config-active-support-cache-format-version
 # ** Please read carefully, this must be configured in config/application.rb **

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -92,6 +92,9 @@ module API
 
         content_type attachment_content_type(attachment)
         header["Content-Disposition"] = attachment.content_disposition
+        # Ensure we set nosniff on attachments served from our app
+        # so that browsers do not reinterpret the content
+        header["X-Content-Type-Options"] = "nosniff"
         env["api.format"] = :binary
         sendfile attachment.diskfile.path
       end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -469,6 +469,10 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
           expect(expires_time > Time.now.utc + max_age - 60).to be_truthy
         end
 
+        it "includes X-Content-Type-Options nosniff header to prevent content type sniffing" do
+          expect(subject.headers["X-Content-Type-Options"]).to eq "nosniff"
+        end
+
         it "sends the file in binary" do
           expect(subject.body)
             .to match(mock_file.read)

--- a/spec/requests/dynamic_content_security_policy_spec.rb
+++ b/spec/requests/dynamic_content_security_policy_spec.rb
@@ -60,5 +60,12 @@ RSpec.describe "" do
         end
       end
     end
+
+    it "includes X-Content-Type-Options nosniff header to prevent content type sniffing" do
+      get "/"
+
+      expect(last_response).to have_http_status(200)
+      expect(last_response.headers["X-Content-Type-Options"]).to eq "nosniff"
+    end
   end
 end


### PR DESCRIPTION
Headers manually added through secure_headers were dropped when switching to Rails CSP:

https://github.com/opf/openproject/blob/v15.5.1/config/initializers/secure_headers.rb#L43

https://community.openproject.org/work_packages/70384
