### PR TITLE
[#70356] add character p for capabilities filter

### DIFF
--- a/app/models/queries/capabilities/filters/context_filter.rb
+++ b/app/models/queries/capabilities/filters/context_filter.rb
@@ -35,7 +35,8 @@ class Queries::Capabilities::Filters::ContextFilter < Queries::Capabilities::Fil
 
   def split_values
     values.map do |value|
-      if (matches = value.match(/\A([gw])(\d*)\z/))
+      # @deprecated Remove the context `p` for projects for 17.2
+      if (matches = value.match(/\A([gwp])(\d*)\z/))
         {
           context_key: matches[1],
           context_id: matches[2]

--- a/app/models/queries/capabilities/filters/id_filter.rb
+++ b/app/models/queries/capabilities/filters/id_filter.rb
@@ -35,7 +35,8 @@ class Queries::Capabilities::Filters::IdFilter < Queries::Capabilities::Filters:
 
   def split_values
     values.map do |value|
-      if (matches = value.match(/\A(\w+\/\w+)\/([wg])(\d*)-(\d+)\z/))
+      # @deprecated Remove the context `p` for projects for 17.2
+      if (matches = value.match(/\A(\w+\/\w+)\/([gwp])(\d*)-(\d+)\z/))
         {
           action: matches[1],
           context_key: matches[2],

--- a/docs/api/apiv3/paths/capabilities.yml
+++ b/docs/api/apiv3/paths/capabilities.yml
@@ -10,7 +10,11 @@ get:
 
       + principal: Get all capabilities of a principal
 
-      + context: Get all capabilities within a context. Note that for a workspace context the client needs to provide `w{id}`, e.g. `w5` and for the global context a `g`
+      + context: Get all capabilities within a context. Note that for a workspace context the client needs to
+        provide `w{id}`, e.g. `w5` and for the global context a `g`.
+
+        + **Deprecation**: The now deprecated context `p` for project still works, but must eventually be replaced
+          with the `w` for the workspace context.
     example: '[{ "principal": { "operator": "=", "values": ["1"] }" }]'
     in: query
     name: filters

--- a/docs/system-admin-guide/integrations/share-point/site-guide/README.md
+++ b/docs/system-admin-guide/integrations/share-point/site-guide/README.md
@@ -45,5 +45,4 @@ To the same URL above but as a POST request
 
 ```shell
 POST https://graph.microsoft.com/v1.0/sites/<SHAREPOINT HOSTNAME>:/sites/<SITE NAME>:/permissions
-
 ```

--- a/spec/models/queries/capabilities/filters/context_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/context_filter_spec.rb
@@ -50,12 +50,20 @@ RSpec.describe Queries::Capabilities::Filters::ContextFilter do
         let(:values) { [] }
 
         it "is invalid" do
-          expect(instance)
-            .to be_invalid
+          expect(instance).not_to be_valid
         end
       end
 
       context "with valid value" do
+        it "is valid" do
+          expect(instance)
+            .to be_valid
+        end
+      end
+
+      context "with deprecated but still supported values" do
+        let(:values) { ["p3"] }
+
         it "is valid" do
           expect(instance)
             .to be_valid
@@ -75,8 +83,7 @@ RSpec.describe Queries::Capabilities::Filters::ContextFilter do
         let(:values) { ["a5"] }
 
         it "is invalid" do
-          expect(instance)
-            .to be_invalid
+          expect(instance).not_to be_valid
         end
       end
     end

--- a/spec/models/queries/capabilities/filters/id_filter_spec.rb
+++ b/spec/models/queries/capabilities/filters/id_filter_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe Queries::Capabilities::Filters::IdFilter do
         let(:values) { [] }
 
         it "is invalid" do
-          expect(instance)
-            .to be_invalid
+          expect(instance).not_to be_valid
         end
       end
 
@@ -63,7 +62,16 @@ RSpec.describe Queries::Capabilities::Filters::IdFilter do
       end
 
       context "with multiple valid values" do
-        let(:values) { ["memberships/create/w3-5", "users/create/g-5"] }
+        let(:values) { %w[memberships/create/w3-5 users/create/g-5] }
+
+        it "is valid" do
+          expect(instance)
+            .to be_valid
+        end
+      end
+
+      context "with deprecated but still supported values" do
+        let(:values) { ["memberships/create/p3-5"] }
 
         it "is valid" do
           expect(instance)
@@ -75,8 +83,7 @@ RSpec.describe Queries::Capabilities::Filters::IdFilter do
         let(:values) { ["foo/bar/baz-5"] }
 
         it "is invalid" do
-          expect(instance)
-            .to be_invalid
+          expect(instance).not_to be_valid
         end
       end
     end


### PR DESCRIPTION
# Ticket
[#70356](https://community.openproject.org/work_packages/70356)

# What are you trying to accomplish?
- allow older API client to use `p` for the context filters while deprecation round

# What approach did you choose and why?
- readd p for projects in context and id filter
- add deprecation warning - to be removed in 17.2

