### PR TITLE
[69417] Show breadcrumb with full project hierachy in Project Overview showing portfolios and programs

### DIFF
--- a/lookbook/docs/components/page-header.md.erb
+++ b/lookbook/docs/components/page-header.md.erb
@@ -33,7 +33,7 @@ By default, every PageHeader should include breadcrumbs. They are a core part of
 
 Breadcrumbs should not include the instance name, because users can already return to the instance home page by clicking the instance logo or using the waffle menu.
 
-There are a few exceptional cases where the PageHeader may be rendered without breadcrumbs — for example, My Page and the Project Overview page.
+There are a few exceptional cases where the PageHeader may be rendered without breadcrumbs — for example, My Page.
 Since the instance name has been removed from the breadcrumbs, these pages would only display their own name in the breadcrumb, which provides no additional navigational value.
 Therefore, omitting the breadcrumb on these pages ensures a cleaner and more meaningful user experience.
 

--- a/modules/overviews/app/components/overviews/page_header_component.html.erb
+++ b/modules/overviews/app/components/overviews/page_header_component.html.erb
@@ -1,7 +1,7 @@
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title(variant: :medium) { page_title }
-    header.with_breadcrumbs(nil)
+    header.with_breadcrumbs(breadcrumb_items)
 
     header.with_action_icon_button(
       icon: favorited? ? "star-fill" : "star",

--- a/modules/overviews/app/components/overviews/page_header_component.rb
+++ b/modules/overviews/app/components/overviews/page_header_component.rb
@@ -52,7 +52,7 @@ module Overviews
             skip_for_mobile: true
           }
         end
-      items << project.name
+      items << page_title
 
       items
     end

--- a/modules/overviews/app/components/overviews/page_header_component.rb
+++ b/modules/overviews/app/components/overviews/page_header_component.rb
@@ -42,10 +42,19 @@ module Overviews
     private
 
     def breadcrumb_items
-      [
-        { href: project_path(project), text: project.name, skip_for_mobile: true },
-        page_title
-      ]
+      return nil if project.ancestors.blank?
+
+      items =
+        project.ancestors.map do |ancestor|
+          {
+            href: project_path(ancestor),
+            text: ancestor.name,
+            skip_for_mobile: true
+          }
+        end
+      items << project.name
+
+      items
     end
 
     def page_title

--- a/modules/overviews/spec/components/overviews/page_header_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/page_header_component_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Overviews::PageHeaderComponent, type: :component do
         expect(rendered_component).to have_css ".PageHeader"
         expect(rendered_component).to have_link grandparent.name
         expect(rendered_component).to have_link parent.name
-        expect(rendered_component).to have_text project.name
+        expect(rendered_component).to have_heading page.title, class: "PageHeader-title"
       end
     end
   end

--- a/modules/overviews/spec/components/overviews/page_header_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/page_header_component_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Overviews::PageHeaderComponent, type: :component do
     end
   end
 
-  describe "breadcrumbs", with_flag: { new_project_overview: true } do
+  describe "breadcrumbs" do
     context "when the project has no parent" do
       before do
         allow(project).to receive(:ancestors).and_return([])

--- a/modules/overviews/spec/components/overviews/page_header_component_spec.rb
+++ b/modules/overviews/spec/components/overviews/page_header_component_spec.rb
@@ -226,4 +226,32 @@ RSpec.describe Overviews::PageHeaderComponent, type: :component do
       end
     end
   end
+
+  describe "breadcrumbs", with_flag: { new_project_overview: true } do
+    context "when the project has no parent" do
+      before do
+        allow(project).to receive(:ancestors).and_return([])
+      end
+
+      it "does not render breadcrumbs" do
+        expect(rendered_component).to have_css ".PageHeader--noBreadcrumb"
+      end
+    end
+
+    context "when the project has ancestors" do
+      let(:grandparent) { build_stubbed(:project) }
+      let(:parent) { build_stubbed(:project) }
+
+      before do
+        allow(project).to receive(:ancestors).and_return([grandparent, parent])
+      end
+
+      it "renders the full hierarchy breadcrumb path and ends with the current project name", :aggregate_failures do
+        expect(rendered_component).to have_css ".PageHeader"
+        expect(rendered_component).to have_link grandparent.name
+        expect(rendered_component).to have_link parent.name
+        expect(rendered_component).to have_text project.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69417

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Show breadcrumbs on the project overview page
