### PR TITLE
Bug/68916 changing the schedule of a recurring meeting leads to multiple entries in the ical export for past dates

### DIFF
--- a/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/create_contract.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,6 +31,7 @@
 module RecurringMeetings
   class CreateContract < BaseContract
     attribute :uid
+    attribute :current_schedule_start
 
     validate :user_allowed_to_add
     validate :project_is_present

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -175,6 +175,13 @@ class RecurringMeeting < ApplicationRecord
     end
   end
 
+  def ical_schedule
+    @ical_schedule ||= IceCube::Schedule.new(current_schedule_start, duration: template&.duration).tap do |s|
+      s.add_recurrence_rule count_rule(frequency_rule, only_upcoming_iterations: true)
+      exclude_non_working_days(s) if frequency_working_days?
+    end
+  end
+
   def base_schedule
     case frequency
     when "daily"
@@ -338,12 +345,18 @@ class RecurringMeeting < ApplicationRecord
     end
   end
 
-  def count_rule(rule)
+  def count_rule(rule, only_upcoming_iterations: false)
     case end_after
     when "specific_date"
       rule.until((end_date + 1.day).to_time(:utc))
     when "iterations"
-      rule.count(iterations)
+      if only_upcoming_iterations
+        # For most schedules it would not matter, but counting the occurences that already happened is easier
+        # than calculating the number of upcoming ones manually
+        rule.count(iterations - schedule.occurrences_between(start_time, current_schedule_start).size)
+      else
+        rule.count(iterations)
+      end
     else
       rule
     end

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -157,6 +157,10 @@ class RecurringMeeting < ApplicationRecord
     super&.in_time_zone(time_zone)
   end
 
+  def current_schedule_end
+    start_time + template.duration.hours
+  end
+
   def time_zone_differs?
     time_zone != User.current.time_zone
   end
@@ -353,7 +357,7 @@ class RecurringMeeting < ApplicationRecord
       if only_upcoming_iterations
         # For most schedules it would not matter, but counting the occurences that already happened is easier
         # than calculating the number of upcoming ones manually
-        rule.count(iterations - schedule.occurrences_between(start_time, current_schedule_start).size)
+        rule.count(iterations - schedule.occurrences_between(start_time, current_schedule_start - 1.minute).size)
       else
         rule.count(iterations)
       end

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -319,7 +319,7 @@ class RecurringMeeting < ApplicationRecord
       .where(date: start_date...)
       .pluck(:date)
       .each do |date|
-      schedule.add_exception_time(date.to_time(:utc))
+        schedule.add_exception_time(date.to_time(:utc))
     end
   end
 

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -262,12 +262,12 @@ class RecurringMeeting < ApplicationRecord
 
   delegate :occurs_at?, to: :schedule
 
-  def remaining_occurrences
+  def remaining_occurrences(after_time: Time.current)
     case end_after
     when "specific_date"
-      schedule.occurrences_between(Time.current, end_date.to_time(:utc).end_of_day)
+      schedule.occurrences_between(after_time, end_date.to_time(:utc).end_of_day)
     when "iterations"
-      schedule.remaining_occurrences(Time.current)
+      schedule.remaining_occurrences(after_time)
     end
   end
 
@@ -354,15 +354,17 @@ class RecurringMeeting < ApplicationRecord
     when "specific_date"
       rule.until((end_date + 1.day).to_time(:utc))
     when "iterations"
-      if only_upcoming_iterations
-        # For most schedules it would not matter, but counting the occurences that already happened is easier
-        # than calculating the number of upcoming ones manually
-        rule.count(iterations - schedule.occurrences_between(start_time, current_schedule_start - 1.minute).size)
-      else
-        rule.count(iterations)
-      end
+      rule.count(iterations_for_schedule(only_upcoming_iterations: only_upcoming_iterations))
     else
       rule
+    end
+  end
+
+  def iterations_for_schedule(only_upcoming_iterations:)
+    if only_upcoming_iterations
+      remaining_occurrences(after_time: current_schedule_start).size
+    else
+      iterations
     end
   end
 

--- a/modules/meeting/app/seeders/meetings/demo_data/meeting_series_seeder.rb
+++ b/modules/meeting/app/seeders/meetings/demo_data/meeting_series_seeder.rb
@@ -80,6 +80,7 @@ module Meetings
           author: seed_data.find_reference(meeting_data["author"]),
           duration: minutes_to_hours(meeting_data["duration"]),
           start_time: Time.current.next_weekday + 10.hours,
+          current_schedule_start: Time.current.next_weekday + 10.hours,
           frequency: meeting_data["frequency"],
           interval: meeting_data["interval"],
           time_zone: meeting_data["time_zone"],

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -90,9 +90,9 @@ module Meetings
         e.last_modified = [recurring_meeting.template.updated_at, recurring_meeting.updated_at].max.utc
         e.sequence = recurring_meeting.template.lock_version
 
-        e.rrule = recurring_meeting.schedule.rrules.first.to_ical # We currently only have one recurrence rule
-        e.dtstart = ical_datetime(recurring_meeting.template.start_time, timezone: recurring_meeting.time_zone)
-        e.dtend = ical_datetime(recurring_meeting.template.end_time, timezone: recurring_meeting.time_zone)
+        e.rrule = recurring_meeting.ical_schedule.rrules.first.to_ical # We currently only have one recurrence rule
+        e.dtstart = ical_datetime(recurring_meeting.current_schedule_start, timezone: recurring_meeting.time_zone)
+        e.dtend = ical_datetime(recurring_meeting.current_schedule_end, timezone: recurring_meeting.time_zone)
         e.location = recurring_meeting.template.location.presence
         e.status = if cancelled
                      "CANCELLED"

--- a/modules/meeting/app/services/recurring_meetings/create_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/create_service.rb
@@ -38,7 +38,14 @@ module RecurringMeetings
       return call unless call.success?
 
       recurring_meeting = call.result
-      call.merge! create_meeting_template(recurring_meeting) if call.success?
+      if call.success?
+        create_template_call = create_meeting_template(recurring_meeting)
+
+        # make sure that the template is correctly loaded in the association
+        call.result.reload_template if create_template_call.success?
+
+        call.merge! create_template_call
+      end
 
       call
     end

--- a/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -38,6 +39,8 @@ module RecurringMeetings
         if model.frequency_working_days?
           model.interval = 1
         end
+
+        model.current_schedule_start = model.next_occurrence(from_time: Time.current)
       end
     end
 

--- a/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/set_attributes_service.rb
@@ -40,7 +40,7 @@ module RecurringMeetings
           model.interval = 1
         end
 
-        model.current_schedule_start = model.next_occurrence(from_time: Time.current)
+        model.current_schedule_start = model.next_occurrence(from_time: Time.current) || model.start_time
       end
     end
 

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -47,6 +47,7 @@ module RecurringMeetings
 
       if should_reschedule?(recurring_meeting)
         reschedule_future_occurrences(recurring_meeting)
+        update_start_date(recurring_meeting)
         reschedule_init_job(recurring_meeting)
         send_updated_mail(recurring_meeting)
       end
@@ -72,6 +73,16 @@ module RecurringMeetings
       else
         remove_cancelled_schedules(recurring_meeting)
         reschedule_all_occurrences(recurring_meeting)
+      end
+    end
+
+    def update_start_date(recurring_meeting)
+      next_occurrence = recurring_meeting.next_occurrence&.in_time_zone(recurring_meeting.time_zone)
+      return if next_occurrence.nil?
+
+      Meeting.transaction do
+        recurring_meeting.update_column(:start_time, next_occurrence)
+        recurring_meeting.template.update_column(:start_time, next_occurrence)
       end
     end
 
@@ -146,8 +157,8 @@ module RecurringMeetings
         .where(recurring_meeting:)
         .cancelled
         .find_each do |scheduled|
-        occurring = recurring_meeting.schedule.occurs_at?(scheduled.start_time)
-        scheduled.delete unless occurring
+          occurring = recurring_meeting.schedule.occurs_at?(scheduled.start_time)
+          scheduled.delete unless occurring
       end
     end
 
@@ -159,17 +170,17 @@ module RecurringMeetings
         .participants
         .invited
         .find_each do |participant|
-        # Generate old schedule in each participant's locale
-        old_schedule = User.execute_as(participant.user) do
-          @old_schedule_model.full_schedule_in_words
-        end
+          # Generate old schedule in each participant's locale
+          old_schedule = User.execute_as(participant.user) do
+            @old_schedule_model.full_schedule_in_words
+          end
 
-        MeetingSeriesMailer.updated(
-          recurring_meeting,
-          participant.user,
-          User.current,
-          changes: { old_schedule:, old_location: @old_location }
-        ).deliver_now
+          MeetingSeriesMailer.updated(
+            recurring_meeting,
+            participant.user,
+            User.current,
+            changes: { old_schedule:, old_location: @old_location }
+          ).deliver_now
       end
     end
 

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -105,7 +105,10 @@ module RecurringMeetings
 
         Meeting.transaction do
           scheduled.update_column(:start_time, new_time)
-          scheduled.meeting.update_column(:start_time, new_time) if scheduled.meeting_id.present?
+          if scheduled.meeting_id.present? && scheduled.meeting.start_time.future?
+            # for past meetings we do not change the time
+            scheduled.meeting.update_column(:start_time, new_time)
+          end
         end
       end
     end
@@ -120,7 +123,7 @@ module RecurringMeetings
     def reschedule_all_occurrences(recurring_meeting)
       # Get all future scheduled meetings that have been instantiated, ordered by start time
       future_meetings = recurring_meeting
-        .scheduled_instances
+        .scheduled_instances(upcoming: true)
         .instantiated
         .not_cancelled
 

--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -47,7 +47,6 @@ module RecurringMeetings
 
       if should_reschedule?(recurring_meeting)
         reschedule_future_occurrences(recurring_meeting)
-        update_start_date(recurring_meeting)
         reschedule_init_job(recurring_meeting)
         send_updated_mail(recurring_meeting)
       end
@@ -73,16 +72,6 @@ module RecurringMeetings
       else
         remove_cancelled_schedules(recurring_meeting)
         reschedule_all_occurrences(recurring_meeting)
-      end
-    end
-
-    def update_start_date(recurring_meeting)
-      next_occurrence = recurring_meeting.next_occurrence&.in_time_zone(recurring_meeting.time_zone)
-      return if next_occurrence.nil?
-
-      Meeting.transaction do
-        recurring_meeting.update_column(:start_time, next_occurrence)
-        recurring_meeting.template.update_column(:start_time, next_occurrence)
       end
     end
 

--- a/modules/meeting/db/migrate/20260108111032_add_current_schedule_start_date_to_recurring_meetings.rb
+++ b/modules/meeting/db/migrate/20260108111032_add_current_schedule_start_date_to_recurring_meetings.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddCurrentScheduleStartDateToRecurringMeetings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :recurring_meetings, :current_schedule_start_date, :date
+
+    execute <<~SQL.squish
+      UPDATE recurring_meetings SET current_schedule_start_date = (start_time AT TIME ZONE time_zone)::date;
+    SQL
+
+    change_column_null :recurring_meetings, :current_schedule_start_date, false
+  end
+end

--- a/modules/meeting/db/migrate/20260108111032_add_current_schedule_start_date_to_recurring_meetings.rb
+++ b/modules/meeting/db/migrate/20260108111032_add_current_schedule_start_date_to_recurring_meetings.rb
@@ -2,12 +2,14 @@
 
 class AddCurrentScheduleStartDateToRecurringMeetings < ActiveRecord::Migration[8.0]
   def change
-    add_column :recurring_meetings, :current_schedule_start_date, :date
+    add_column :recurring_meetings, :current_schedule_start, :datetime
 
-    execute <<~SQL.squish
-      UPDATE recurring_meetings SET current_schedule_start_date = (start_time AT TIME ZONE time_zone)::date;
-    SQL
+    up_only do
+      execute <<~SQL.squish
+        UPDATE recurring_meetings SET current_schedule_start = (start_time AT TIME ZONE time_zone);
+      SQL
 
-    change_column_null :recurring_meetings, :current_schedule_start_date, false
+      change_column_null :recurring_meetings, :current_schedule_start, false
+    end
   end
 end

--- a/modules/meeting/spec/factories/recurring_meeting_factory.rb
+++ b/modules/meeting/spec/factories/recurring_meeting_factory.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     author factory: :user
     project
     start_time { Date.tomorrow + 10.hours }
-    current_schedule_start { Date.tomorrow + 10.hours }
+    current_schedule_start { start_time }
     end_date { 1.year.from_now }
     duration { 1.0 }
     frequency { "weekly" }

--- a/modules/meeting/spec/factories/recurring_meeting_factory.rb
+++ b/modules/meeting/spec/factories/recurring_meeting_factory.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
     author factory: :user
     project
     start_time { Date.tomorrow + 10.hours }
+    current_schedule_start { Date.tomorrow + 10.hours }
     end_date { 1.year.from_now }
     duration { 1.0 }
     frequency { "weekly" }

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -237,6 +237,8 @@ RSpec.describe RecurringMeeting,
               end_after: "iterations",
               iterations: 5,
               current_schedule_start: DateTime.parse("2024-10-15T12:00Z"))
+
+        # Occurrences on 2024-10-01, 2024-10-08, 2024-10-15, 2024-10-22, 2024-10-29
       end
 
       it "builds an IceCube schedule for iCal based on current_schedule_start" do
@@ -248,7 +250,7 @@ RSpec.describe RecurringMeeting,
         rrule = schedule.rrules.first
 
         expect(rrule).to be_a(IceCube::WeeklyRule)
-        expect(rrule.occurrence_count).to eq(2) # 15th is the 3rd occurrence, so 2 remaining
+        expect(rrule.occurrence_count).to eq(3) # 15th is the 3rd occurrence, so with it 3 remaining
       end
 
       it "builds an IceCube schedule for based on start_time" do

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 require_module_spec_helper
 
@@ -227,7 +228,79 @@ RSpec.describe RecurringMeeting,
     end
   end
 
-  describe "uid" do
+  describe "#ical_schedule / #schedule" do
+    context "with a schedule with number of iterations" do
+      let(:recurring_meeting) do
+        build(:recurring_meeting,
+              start_time: DateTime.parse("2024-10-01T12:00Z"),
+              frequency: "weekly",
+              end_after: "iterations",
+              iterations: 5,
+              current_schedule_start: DateTime.parse("2024-10-15T12:00Z"))
+      end
+
+      it "builds an IceCube schedule for iCal based on current_schedule_start" do
+        schedule = recurring_meeting.ical_schedule
+
+        expect(schedule.start_time).to eq(recurring_meeting.current_schedule_start)
+        expect(schedule.rrules.count).to eq 1
+
+        rrule = schedule.rrules.first
+
+        expect(rrule).to be_a(IceCube::WeeklyRule)
+        expect(rrule.occurrence_count).to eq(2) # 15th is the 3rd occurrence, so 2 remaining
+      end
+
+      it "builds an IceCube schedule for based on start_time" do
+        schedule = recurring_meeting.schedule
+
+        expect(schedule.start_time).to eq(recurring_meeting.start_time)
+        expect(schedule.rrules.count).to eq 1
+
+        rrule = schedule.rrules.first
+
+        expect(rrule).to be_a(IceCube::WeeklyRule)
+        expect(rrule.occurrence_count).to eq(5)
+      end
+    end
+
+    context "with a schedule until a specific date" do
+      let(:recurring_meeting) do
+        build(:recurring_meeting,
+              start_time: DateTime.parse("2024-10-01T12:00Z"),
+              frequency: "weekly",
+              end_after: "specific_date",
+              end_date: Date.parse("2024-11-05"),
+              current_schedule_start: DateTime.parse("2024-10-15T12:00Z"))
+      end
+
+      it "builds an IceCube schedule for iCal based on current_schedule_start" do
+        schedule = recurring_meeting.ical_schedule
+
+        expect(schedule.start_time).to eq(recurring_meeting.current_schedule_start)
+        expect(schedule.rrules.count).to eq 1
+
+        rrule = schedule.rrules.first
+
+        expect(rrule).to be_a(IceCube::WeeklyRule)
+        expect(rrule.until_time).to eq(recurring_meeting.end_date + 1.day)
+      end
+
+      it "builds an IceCube schedule for based on start_time" do
+        schedule = recurring_meeting.schedule
+
+        expect(schedule.start_time).to eq(recurring_meeting.start_time)
+        expect(schedule.rrules.count).to eq 1
+
+        rrule = schedule.rrules.first
+
+        expect(rrule).to be_a(IceCube::WeeklyRule)
+        expect(rrule.until_time).to eq(recurring_meeting.end_date + 1.day)
+      end
+    end
+  end
+
+  describe "#uid" do
     it "assigns a uid on create" do
       series = build(:recurring_meeting)
       expect(series.uid).to be_present

--- a/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated schedule",
+               with_settings: { mail_from: "openproject@example.org", app_title: "OpenProject Testing" } do
+  let(:user) { create(:user) }
+  let(:timezone) { "Europe/Berlin" }
+  let(:start_time) { Time.use_zone(timezone) { 1.week.from_now.change(hour: 10, min: 0, sec: 0, usec: 0) } }
+  let(:project) { create(:project, public: true) }
+
+  let(:recurring_meeting) do
+    create(
+      :recurring_meeting,
+      project:,
+      author: user,
+      start_time: start_time,
+      current_schedule_start: start_time,
+      time_zone: timezone,
+      duration: 1.5,
+      frequency: "weekly",
+      interval: 2,
+      end_after: "iterations",
+      iterations: 26,
+      end_date: nil
+    )
+  end
+
+  let(:builder) do
+    described_class.new(timezone: timezone, user: user)
+  end
+
+  let(:parsed_calendar) do
+    Icalendar::Calendar.parse(subject).first
+  end
+
+  subject { builder.to_ical }
+
+  context "when the schedule was not updated and no meeting is instantiated" do
+    it "starts the ical schedule with the original start time" do
+      builder.add_series_event(recurring_meeting: recurring_meeting)
+
+      # we only have the recurring meeting event
+      expect(parsed_calendar.events.count).to eq(1)
+
+      # our event starts at the original start time
+      event = parsed_calendar.events.first
+      expect(event.dtstart).to eq start_time
+
+      # the RRULE reflects the original schedule
+      rrule = event.rrule.first
+      expect(rrule.frequency).to eq("WEEKLY")
+      expect(rrule.interval).to eq(2)
+      expect(rrule.count).to eq(26)
+    end
+  end
+
+  context "when the schedule was not updated and the first meeting is instantiated" do
+    let!(:first_meeting) do
+      RecurringMeetings::InitOccurrenceService
+       .new(user: User.system, recurring_meeting: recurring_meeting)
+       .call(start_time: start_time)
+       .result
+    end
+
+    it "starts the ical schedule with the original start time" do
+      builder.add_series_event(recurring_meeting: recurring_meeting)
+
+      # we have the recurring meeting event + the first instantiated meeting
+      expect(parsed_calendar.events.count).to eq(2)
+
+      # our recurring event starts at the original start time
+      event = parsed_calendar.events.find { |e| e.recurrence_id.nil? }
+      expect(event.dtstart).to eq start_time
+
+      rrule = event.rrule.first
+      # the RRULE reflects the original schedule
+      expect(rrule.frequency).to eq("WEEKLY")
+      expect(rrule.interval).to eq(2)
+      expect(rrule.count).to eq(26)
+
+      # the first recurring meeting is part of the calendar with the fitting recurrence id
+      first_meeting_event = parsed_calendar.events.find { |e| e.recurrence_id.present? }
+      expect(first_meeting_event.dtstart).to eq first_meeting.start_time
+      expect(first_meeting_event.recurrence_id).to eq first_meeting.start_time
+      expect(first_meeting_event.rrule).to be_empty
+    end
+  end
+
+  context "when modifying the schedule by only changing time of day after the first occurrence happened" do
+    let!(:first_meeting) do
+      RecurringMeetings::InitOccurrenceService
+       .new(user: User.system, recurring_meeting: recurring_meeting)
+       .call(start_time: start_time)
+       .result
+    end
+
+    # we are 2 days after the start time of the recurring meeting
+    # we schedule the meeting to now start at 13:00 instead of 10:00
+    before do
+      travel_to start_time + 2.days do
+        RecurringMeetings::UpdateService
+          .new(model: recurring_meeting, user: User.system)
+          .call({ start_time_hour: "13:00" })
+
+        recurring_meeting.reload
+      end
+    end
+
+    it "starts the ical schedule with the updated start time and does not touch the first occurence" do
+      builder.add_series_event(recurring_meeting: recurring_meeting)
+
+      # we have the recurring meeting event + the first instantiated meeting before the update
+      # and the update service has also made sure that the next occurrence in the schedule is created
+      expect(parsed_calendar.events.count).to eq(3)
+
+      # our recurring event starts at the updated start time
+      event = parsed_calendar.events.first
+      # updated start time is the next occurrence of the meeting after the time of our change
+      new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
+      expect(event.dtstart).to eq(new_start_time)
+
+      rrule = event.rrule.first
+      # the RRULE reflects the updated schedule
+      expect(rrule.frequency).to eq("WEEKLY")
+      expect(rrule.interval).to eq(2)
+      expect(rrule.count).to eq(25) # one iteration less since the first already happened
+
+      # the first occurrence is part of the calendar and the start time is not updated
+      first_occurrence_event = parsed_calendar.events.second
+      expect(first_occurrence_event.dtstart).to eq first_meeting.start_time
+      expect(first_occurrence_event.rrule).to be_empty
+
+      # the second occurence is already using the new starting times
+      second_occurrence_event = parsed_calendar.events.third
+      expect(second_occurrence_event.dtstart).to eq new_start_time
+      expect(second_occurrence_event.rrule).to be_empty
+    end
+  end
+
+  context "when modifying the schedule by changing frequency and start_time after the first occurrence happened" do
+    let!(:first_meeting) do
+      RecurringMeetings::InitOccurrenceService
+       .new(user: User.system, recurring_meeting: recurring_meeting)
+       .call(start_time: start_time)
+       .result
+    end
+
+    # we are 2 days after the start time of the recurring meeting
+    # we schedule the meeting to now start at 13:00 instead of 10:00
+    before do
+      travel_to start_time + 2.days do
+        RecurringMeetings::UpdateService
+          .new(model: recurring_meeting, user: User.system)
+          .call({ start_time_hour: "13:00", frequency: "daily", interval: 1 })
+
+        recurring_meeting.reload
+      end
+    end
+
+    it "starts the ical schedule with the updated start time and does not touch the first occurence" do
+      builder.add_series_event(recurring_meeting: recurring_meeting)
+
+      # we have the recurring meeting event + the first instantiated meeting before the update
+      # and the update service has also made sure that the next occurrence in the schedule is created
+      expect(parsed_calendar.events.count).to eq(3)
+
+      # our recurring event starts at the updated start time
+      event = parsed_calendar.events.first
+      # updated start time is the next occurrence of the meeting after the time of our change
+      new_start_time = recurring_meeting.next_occurrence(from_time: start_time + 2.days)
+      expect(event.dtstart).to eq(new_start_time)
+
+      rrule = event.rrule.first
+      # the RRULE reflects the updated schedule
+      expect(rrule.frequency).to eq("DAILY")
+      expect(rrule.count).to eq(24) # two iterations less since the first two already happened
+
+      # the first occurrence is part of the calendar and the start time is not updated
+      first_occurrence_event = parsed_calendar.events.second
+      expect(first_occurrence_event.dtstart).to eq first_meeting.start_time
+      expect(first_occurrence_event.rrule).to be_empty
+
+      # the second occurence is already using the new starting times
+      second_occurrence_event = parsed_calendar.events.third
+      expect(second_occurrence_event.dtstart).to eq new_start_time
+      expect(second_occurrence_event.rrule).to be_empty
+    end
+  end
+end

--- a/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe RecurringMeetings::SetAttributesService, type: :model do
+  let(:current_user) { build_stubbed(:user) }
+
+  let(:instance) do
+    described_class.new(user: current_user, model: model_instance, contract_class: RecurringMeetings::CreateContract)
+  end
+  let(:model_instance) { RecurringMeeting.new }
+
+  let(:params) { {} }
+
+  subject { instance.call(params) }
+
+  context "with attributes without any special behavior" do
+    let(:start_time) { Time.current.change(usec: 0) }
+    let(:params) do
+      {
+        title: "A title",
+        start_time: Time.current.iso8601,
+        frequency: "daily"
+      }
+    end
+
+    it "sets the attributes on the model" do
+      subject
+
+      expect(model_instance.title).to eq "A title"
+      expect(model_instance.start_time).to eq(start_time)
+      expect(model_instance).to be_frequency_daily
+    end
+  end
+
+  context "when setting frequency to working_days" do
+    let(:params) do
+      {
+        frequency: "working_days"
+      }
+    end
+
+    it "sets the interval to 1" do
+      subject
+
+      expect(model_instance).to be_frequency_working_days
+      expect(model_instance.interval).to eq 1
+    end
+  end
+
+  context "when updating schedule related attributes" do
+    let(:params) do
+      {
+        start_time: "2026-01-01T10:00:00Z",
+        frequency: "weekly",
+        interval: 2,
+        end_after: "specific_date",
+        end_date: "2026-12-31"
+      }
+    end
+
+    it "sets the current_schedule_start_date to the next occurrence from now" do
+      travel_to Time.utc(2026, 6, 15, 9, 0, 0) do
+        subject
+
+        # Meeting runs from 01.01.2026 10:00 UTC, every 2 weeks and ends at 31.12.2026
+        # The next occurrence from 15.06.2026 09:00 UTC is 18.06.2026 10:00 UTC
+        expect(model_instance.current_schedule_start).to eq("2026-06-18 10:00:00 UTC")
+      end
+    end
+  end
+
+  context "when calling without params to set default attributes" do
+    let(:params) { {} }
+
+    it "sets the time zone from the user" do
+      subject
+
+      expect(model_instance.time_zone).to eq current_user.time_zone
+    end
+
+    it "sets the author to the user" do
+      subject
+
+      expect(model_instance.author).to eq current_user
+    end
+
+    it "sets a default duration" do
+      subject
+
+      expect(model_instance.duration).to eq 1
+    end
+  end
+end

--- a/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/set_attributes_service_spec.rb
@@ -87,13 +87,23 @@ RSpec.describe RecurringMeetings::SetAttributesService, type: :model do
       }
     end
 
-    it "sets the current_schedule_start_date to the next occurrence from now" do
+    it "sets the current_schedule_start to the next occurrence from now" do
       travel_to Time.utc(2026, 6, 15, 9, 0, 0) do
         subject
 
         # Meeting runs from 01.01.2026 10:00 UTC, every 2 weeks and ends at 31.12.2026
         # The next occurrence from 15.06.2026 09:00 UTC is 18.06.2026 10:00 UTC
         expect(model_instance.current_schedule_start).to eq("2026-06-18 10:00:00 UTC")
+      end
+    end
+
+    it "sets the current_schedule_start to the start_time if there is no next occurrence" do
+      travel_to Time.utc(2027, 1, 1, 9, 0, 0) do
+        subject
+
+        # Meeting runs from 01.01.2026 10:00 UTC, every 2 weeks and ends at 31.12.2026
+        # There is no next occurrence from 01.01.2027 09:00 UTC, so we set it to start_time
+        expect(model_instance.current_schedule_start).to eq(model_instance.start_time)
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/meetings-stream/work_packages/68916

# What are you trying to accomplish?
- Correctly handle rescheduled recurring meetings

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
