### PR TITLE
[#70419] Fix usages of `Blankslate` description slot

### DIFF
--- a/app/components/admin/custom_fields/hierarchy/items_component.html.erb
+++ b/app/components/admin/custom_fields/hierarchy/items_component.html.erb
@@ -59,7 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
 
                     component.with_heading(tag: :h3).with_content(I18n.t(blank_header_text))
                     component.with_description { I18n.t(blank_description_text) }
-                    component.with_primary_action(tag: :a, href: new_item_path) do |button|
+                    component.with_primary_action(href: new_item_path) do |button|
                       button.with_leading_visual_icon(icon: :plus)
                       I18n.t(:label_item)
                     end

--- a/app/components/groups/table_component.rb
+++ b/app/components/groups/table_component.rb
@@ -54,7 +54,7 @@ module Groups
         component.with_visual_icon(icon: blank_icon, size: :medium) if blank_icon
         component.with_heading(tag: :h2) { blank_title }
         component.with_description { blank_description }
-        component.with_primary_action(label: t(:label_group_new), tag: :a, href: new_group_path) do |button|
+        component.with_primary_action(label: t(:label_group_new), href: new_group_path) do |button|
           button.with_leading_visual_icon(icon: :plus)
           t("activerecord.models.group")
         end

--- a/app/components/projects/settings/creation_wizard/blank_slate_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/blank_slate_component.html.erb
@@ -33,28 +33,12 @@ See COPYRIGHT and LICENSE files for more details.
       render(Primer::Beta::Blankslate.new) do |component|
         component.with_visual_icon(icon: :"project-template")
         component.with_heading(tag: :h2).with_content(title)
-        component.with_description do
-          flex_layout do |flex|
-            flex.with_row(mb: 2) do
-              render(Primer::Beta::Text.new(color: :subtle)) { description }
-            end
-
-            flex.with_row(mt: 4) do
-              render(
-                Primer::Beta::Button.new(
-                  scheme: :primary,
-                  mobile_icon: nil,
-                  mobile_label: label,
-                  aria: { label: },
-                  tag: :a,
-                  href: helpers.toggle_project_settings_creation_wizard_path(@project),
-                  data: { turbo_method: :post }
-                )
-              ) do
-                label
-              end
-            end
-          end
+        component.with_description_content(description)
+        component.with_primary_action(
+          href: helpers.toggle_project_settings_creation_wizard_path(@project),
+          data: { turbo_method: :post }
+        ) do
+          label
         end
       end
     end

--- a/app/components/shares/empty_state_component.html.erb
+++ b/app/components/shares/empty_state_component.html.erb
@@ -3,13 +3,5 @@
       component.with_heading(tag: :h2).with_content(
         blankslate_config[:heading_text]
       )
-      component.with_description do
-        flex_layout do |flex|
-          flex.with_row(mb: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) do
-              blankslate_config[:description_text]
-            end
-          end
-        end
-      end
+      component.with_description_content(blankslate_config[:description_text])
     end %>

--- a/app/components/shares/project_queries/empty_state_component.html.erb
+++ b/app/components/shares/project_queries/empty_state_component.html.erb
@@ -3,13 +3,5 @@
       component.with_heading(tag: :h2).with_content(
         blankslate_config[:heading_text]
       )
-      component.with_description do
-        flex_layout do |flex|
-          flex.with_row(mb: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) do
-              blankslate_config[:description_text]
-            end
-          end
-        end
-      end
+      component.with_description_content(blankslate_config[:description_text])
     end %>

--- a/app/views/groups/_synchronized_groups.html.erb
+++ b/app/views/groups/_synchronized_groups.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
     render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
       blankslate.with_heading(tag: :h2) { t(".blankslate.title") }
       blankslate.with_description { t(".blankslate.description") }
-      blankslate.with_primary_action(tag: :a, href: admin_settings_authentication_path) { t(".blankslate.action") }
+      blankslate.with_primary_action(href: admin_settings_authentication_path) { t(".blankslate.action") }
     end
   %>
 <% end %>

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
@@ -72,7 +72,6 @@
       component.with_description { I18n.t("documents.admin.enable_text_collaboration.description") }
 
       component.with_primary_action(
-        scheme: :primary,
         label: I18n.t("documents.admin.enable_text_collaboration.primary_action"),
         href: url_helpers.admin_settings_document_collaboration_settings_path,
         data: { turbo_method: :post }

--- a/modules/documents/app/components/documents/admin/document_categories/deprecation_notice_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_categories/deprecation_notice_component.html.erb
@@ -37,16 +37,12 @@
 
       component.with_description { I18n.t("documents.document_categories_deprecation_notice.description") }
       component.with_primary_action(
-        scheme: :primary,
         label: I18n.t("documents.document_categories_deprecation_notice.primary_action"),
-        tag: :a,
         href: admin_settings_document_types_path
       ).with_content(I18n.t("documents.document_categories_deprecation_notice.primary_action"))
 
       component.with_secondary_action(
-        scheme: :default,
         label: I18n.t("documents.document_categories_deprecation_notice.secondary_action"),
-        tag: :a,
         href: OpenProject::Static::Links.url_for(:documents_docs)
       ).with_content(I18n.t("documents.document_categories_deprecation_notice.secondary_action"))
     end %>

--- a/modules/grids/app/components/grids/widgets/members.html.erb
+++ b/modules/grids/app/components/grids/widgets/members.html.erb
@@ -77,7 +77,6 @@ See COPYRIGHT and LICENSE files for more details.
 
           if can_manage_members?
             component.with_primary_action(
-              tag: :a,
               href: project_members_path(@project),
               scheme: :secondary,
               test_selector: "members-widget-add-button"

--- a/modules/grids/app/components/grids/widgets/news.html.erb
+++ b/modules/grids/app/components/grids/widgets/news.html.erb
@@ -36,7 +36,6 @@ See COPYRIGHT and LICENSE files for more details.
 
         if project_scoped? && can_manage_news?
           component.with_primary_action(
-            tag: :a,
             href: new_project_news_path(project),
             test_selector: "news-widget-add-button",
             scheme: :secondary

--- a/modules/grids/app/components/grids/widgets/subitems.html.erb
+++ b/modules/grids/app/components/grids/widgets/subitems.html.erb
@@ -100,7 +100,6 @@ See COPYRIGHT and LICENSE files for more details.
 
           if can_manage_subprojects?
             component.with_primary_action(
-              tag: :a,
               href: new_project_path(parent_id: project.id),
               test_selector: "subitems-widget-add-button",
               scheme: :secondary

--- a/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.html.erb
@@ -2,31 +2,18 @@
   render(Primer::Beta::Blankslate.new(test_selector: "meeting-blankslate")) do |component|
     component.with_visual_icon(icon: :book)
     component.with_heading(tag: :h2).with_content(title)
-    component.with_description do
-      flex_layout do |flex|
-        if template?
-          flex.with_row(mb: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) { t(:"recurring_meeting.template.description") }
-          end
-        else
-          flex.with_row(mb: 2) do
-            render(Primer::Beta::Text.new(color: :subtle)) { t(:text_meeting_empty_description1) }
-          end
-          flex.with_row do
-            render(Primer::Beta::Text.new(color: :subtle)) { t(:text_meeting_empty_description2) }
-          end
-        end
+    component.with_description_content(description)
 
-        if can_finalize_template?
-          flex.with_row(mt: 2) do
-            render(Primer::Beta::Text.new(font_weight: :bold, color: :subtle)) do
-              t(
-                :"recurring_meeting.template.blankslate_finalize",
-                button_title: t("recurring_meeting.template.button_finalize")
-              )
-            end
-          end
-        end
+    if can_finalize_template?
+      component.with_secondary_action(
+        href: exit_draft_mode_dialog_project_meeting_path(@meeting.project, @meeting),
+        data: {
+          action: "click->meetings--submit#intercept",
+          href: exit_draft_mode_dialog_project_meeting_path(@meeting.project, @meeting),
+          method: "GET"
+        }
+      ) do
+        t(:"recurring_meeting.template.blankslate_finalize")
       end
     end
   end

--- a/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.html.erb
@@ -3,18 +3,5 @@
     component.with_visual_icon(icon: :book)
     component.with_heading(tag: :h2).with_content(title)
     component.with_description_content(description)
-
-    if can_finalize_template?
-      component.with_secondary_action(
-        href: exit_draft_mode_dialog_project_meeting_path(@meeting.project, @meeting),
-        data: {
-          action: "click->meetings--submit#intercept",
-          href: exit_draft_mode_dialog_project_meeting_path(@meeting.project, @meeting),
-          method: "GET"
-        }
-      ) do
-        t(:"recurring_meeting.template.blankslate_finalize")
-      end
-    end
   end
 %>

--- a/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
@@ -59,11 +59,5 @@ module MeetingAgendaItems
         t(%i[text_meeting_empty_description1 text_meeting_empty_description2]).join(" ")
       end
     end
-
-    def can_finalize_template?
-      template? &&
-        User.current.allowed_in_project?(:create_meetings, @meeting.project) &&
-        @meeting.recurring_meeting.scheduled_meetings.none?
-    end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/blank_slate_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -48,6 +49,14 @@ module MeetingAgendaItems
         t(:"recurring_meeting.template.blank_title")
       else
         t(:text_meeting_empty_heading)
+      end
+    end
+
+    def description
+      if template?
+        t(:"recurring_meeting.template.description")
+      else
+        t(%i[text_meeting_empty_description1 text_meeting_empty_description2]).join(" ")
       end
     end
 

--- a/modules/meeting/app/components/meetings/participants/list_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/list_component.html.erb
@@ -17,13 +17,7 @@
               render(Primer::Beta::Blankslate.new) do |blankslate|
                 blankslate.with_visual_icon(icon: :people, size: :medium)
                 blankslate.with_heading(tag: :h2).with_content(I18n.t("meeting.participants.blankslate.heading"))
-                blankslate.with_description do
-                  flex_layout do |flex|
-                    flex.with_row(mb: 4) do
-                      render(Primer::Beta::Text.new(color: :subtle)) { I18n.t("meeting.participants.blankslate.description") }
-                    end
-                  end
-                end
+                blankslate.with_description_content(I18n.t("meeting.participants.blankslate.description"))
               end
             end
           else

--- a/modules/meeting/app/views/recurring_meetings/_show_upcoming.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/_show_upcoming.html.erb
@@ -33,8 +33,7 @@ See COPYRIGHT and LICENSE files for more details.
       component.with_visual_icon(icon: :book)
       component.with_heading(tag: :h2).with_content(t("recurring_meeting.ended_blankslate.title"))
       component.with_description do
-        concat render(Primer::Beta::Text.new(tag: :p, color: :subtle)) { t("recurring_meeting.ended_blankslate.message") }
-        concat render(Primer::Beta::Text.new(tag: :p, color: :subtle)) { t("recurring_meeting.ended_blankslate.action") }
+        t(["recurring_meeting.ended_blankslate.message", "recurring_meeting.ended_blankslate.action"]).join(" ")
       end
     end
   %>

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -419,8 +419,6 @@ en:
       description: >
         This template will be used whenever new meetings in the series get created.
         You can add agenda items, participants, and attachments to this template.
-      blankslate_finalize: >
-        Finish setup and schedule first meeting
       label_view_template: "View template"
       label_edit_template: "Edit template"
       banner_html: >

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -420,8 +420,7 @@ en:
         This template will be used whenever new meetings in the series get created.
         You can add agenda items, participants, and attachments to this template.
       blankslate_finalize: >
-        When you're done preparing this template,
-        click the '%{button_title}' button above to finish the setup and schedule the first meeting of the series.
+        Finish setup and schedule first meeting
       label_view_template: "View template"
       label_edit_template: "Edit template"
       banner_html: >

--- a/modules/storages/app/components/storages/admin/health/health_report_component.html.erb
+++ b/modules/storages/app/components/storages/admin/health/health_report_component.html.erb
@@ -37,7 +37,6 @@ See COPYRIGHT and LICENSE files for more details.
             placeholder.with_heading(tag: :h3) { I18n.t("storages.health.no_report") }
             placeholder.with_description { I18n.t("storages.health.no_report_description") }
             placeholder.with_primary_action(
-              tag: :a,
               href: admin_settings_storage_health_status_report_path(model),
               data: { turbo_method: :post, turbo: true },
               aria: { label: I18n.t("storages.health.actions.run_checks") }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70419

# What are you trying to accomplish?

**Fixes generated HTML** 

Content passed to `#with_description` **must not include HTML block elements** (such as flex layouts). Blankslate always renders descriptions within a `p` element, which may only contain inline HTML elements.

**FYI @opf/sirius** 

## Screenshots

In most cases, the appearance should be virtually unchanged. However in the case of the Meetings template page, making the secondary action _actionable_ requires cutting down the text (_[thereby following these guidelines](https://primer.style/product/components/blankslate/guidelines/#secondary-action)_).

**Before**

<img width="905" height="318" alt="Screenshot 2026-01-11 at 16 19 15" src="https://github.com/user-attachments/assets/c0857bda-8d86-4675-a6cc-f4d313be20e8" />

**After**

<img width="900" height="290" alt="image" src="https://github.com/user-attachments/assets/dc3015ec-35bf-455f-9fd6-06542b526111" />


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
