### PR TITLE
[#70420] Rework filter close buttons as IconButtons, fixing accessibility issues 

### DIFF
--- a/app/components/filter/filter_component.html.erb
+++ b/app/components/filter/filter_component.html.erb
@@ -34,10 +34,18 @@
             }
           ) do %>
         <fieldset class="advanced-filters--container">
-          <a title="<%= t("js.close_form_title") %>"
-             href=""
-             class="advanced-filters--close icon-context icon-close"
-             data-action="filter--filters-form#toggleDisplayFilters"></a>
+          <%=
+            render(
+              Primer::Beta::IconButton.new(
+                icon: :x,
+                scheme: :invisible,
+                classes: "advanced-filters--close",
+                tooltip_direction: :se,
+                aria: { label: t("js.close_form_title") },
+                data: { action: "filter--filters-form#toggleDisplayFilters" }
+              )
+            )
+          %>
           <legend><%= t(:label_filter_plural) %></legend>
           <ul class="advanced-filters--filters">
             <% each_filter do |filter, filter_active, additional_options| %>

--- a/app/components/individual_principal_base_filter_component.html.erb
+++ b/app/components/individual_principal_base_filter_component.html.erb
@@ -32,10 +32,18 @@ See COPYRIGHT and LICENSE files for more details.
   <fieldset class="simple-filters--container <%= collapsed_class %>" data-members-form-target="filterContainer">
     <legend><%= t(:label_filter_plural) %></legend>
     <% if has_close_icon? %>
-      <a title="<%= t("js.close_form_title") %>"
-         data-action="members-form#toggleMemberFilter"
-         class="toggle-member-filter-link simple-filters--close icon-context icon-close">
-      </a>
+      <%=
+        render(
+          Primer::Beta::IconButton.new(
+            icon: :x,
+            scheme: :invisible,
+            classes: "simple-filters--close",
+            tooltip_direction: :se,
+            aria: { label: t("js.close_form_title") },
+            data: { action: "members-form#toggleMemberFilter" }
+          )
+        )
+      %>
     <% end %>
     <ul class="simple-filters--filters">
       <% if has_statuses? %>

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -225,6 +225,8 @@ en:
         add_table: "Add table of related work packages"
         edit_query: "Edit query"
         new_group: "New group"
+        delete_group: "Delete group"
+        remove_attribute: "Remove from group"
         reset_to_defaults: "Reset to defaults"
 
       working_days:

--- a/frontend/src/app/features/admin/types/attribute-group.component.html
+++ b/frontend/src/app/features/admin/types/attribute-group.component.html
@@ -4,7 +4,15 @@
     <op-group-edit-in-place [name]="group.name"
       (onValueChange)="rename($event)"
       class="group-name" />
-    <span class="delete-group icon-small icon-close" (click)="deleteGroup.emit()"></span>
+      <primer-icon-button
+        icon="x"
+        scheme="invisible"
+        size="small"
+        class="delete-group"
+        tooltip-direction="w"
+        [label]="text.delete_group"
+        (clicked)="deleteGroup.emit()"
+      />
   </div>
   <div class="attributes" dragula="attributes" [(dragulaModel)]="group.attributes">
     @for (attribute of group.attributes; track attribute) {
@@ -20,7 +28,15 @@
             </span>
           }
         </span>
-        <span class="delete-attribute icon-small icon-close" (click)="removeFromGroup(attribute)"></span>
+        <primer-icon-button
+          icon="x"
+          scheme="invisible"
+          size="small"
+          class="delete-attribute"
+          tooltip-direction="w"
+          [label]="text.remove_attribute"
+          (clicked)="removeFromGroup(attribute)"
+        />
       </div>
     }
   </div>

--- a/frontend/src/app/features/admin/types/attribute-group.component.ts
+++ b/frontend/src/app/features/admin/types/attribute-group.component.ts
@@ -19,6 +19,8 @@ export class TypeFormAttributeGroupComponent {
 
   text = {
     custom_field: this.I18n.t('js.admin.type_form.custom_field'),
+    delete_group: this.I18n.t('js.admin.type_form.delete_group'),
+    remove_attribute: this.I18n.t('js.admin.type_form.remove_attribute')
   };
 
   constructor(private I18n:I18nService,

--- a/frontend/src/app/features/admin/types/query-group.component.html
+++ b/frontend/src/app/features/admin/types/query-group.component.html
@@ -4,7 +4,15 @@
         <op-group-edit-in-place [name]="group.name"
                 (onValueChange)="rename($event)"
                 class="group-name" />
-        <span class="delete-group icon-small icon-close" (click)="deleteGroup.emit()"></span>
+        <primer-icon-button
+          icon="x"
+          scheme="invisible"
+          size="small"
+          class="delete-group"
+          tooltip-direction="w"
+          [label]="text.delete_group"
+          (clicked)="deleteGroup.emit()"
+        />
     </div>
     <div class="type-form-query">
         <span class="type-form-query-group--edit-button" (click)="editQuery.emit()">

--- a/frontend/src/app/features/admin/types/query-group.component.ts
+++ b/frontend/src/app/features/admin/types/query-group.component.ts
@@ -13,6 +13,7 @@ import { TypeGroup } from 'core-app/features/admin/types/type-form-configuration
 export class TypeFormQueryGroupComponent {
   text = {
     edit_query: this.I18n.t('js.admin.type_form.edit_query'),
+    delete_group: this.I18n.t('js.admin.type_form.delete_group')
   };
 
   @Input() public group:TypeGroup;

--- a/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.html
@@ -2,11 +2,14 @@
   <fieldset id="filters" class="advanced-filters--container">
     <legend [textContent]="text.selected_filter_list"></legend>
     @if (showCloseFilter) {
-      <a
-        [attr.title]="text.close_form"
-        class="advanced-filters--close icon-context icon-close"
-        (click)="closeFilter()">
-      </a>
+      <primer-icon-button 
+        icon="x"
+        scheme="invisible"
+        class="advanced-filters--close"
+        tooltip-direction="se"
+        [label]="text.close_form"
+        (clicked)="closeFilter()"
+      />
     }
     <ul class="advanced-filters--filters">
       <li id="filter_search"

--- a/frontend/src/app/shared/components/primer/abstract-base-button.directive.ts
+++ b/frontend/src/app/shared/components/primer/abstract-base-button.directive.ts
@@ -1,0 +1,57 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { booleanAttribute, Directive, input } from '@angular/core';
+
+type ButtonType = 'button' | 'reset' | 'submit';
+
+@Directive({})
+export abstract class AbstractBaseButtonDirective {
+  readonly type = input<ButtonType>('button');
+
+  /**
+   * Whether button is full-width with `display: block`
+   *
+   * @default false
+   */
+  readonly block = input(false, { transform: booleanAttribute });
+
+  /**
+   * Whether or not the button is disabled. If true, this option forces `tag` to `button`.
+   *
+   * @default false
+   */
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  /**
+   * Whether the button looks visually disabled, but can still accept all the same interactions as an enabled button.
+   *
+   * @default false
+   */
+  readonly inactive = input(false, { transform: booleanAttribute });
+}

--- a/frontend/src/app/shared/components/primer/base-button.directive.ts
+++ b/frontend/src/app/shared/components/primer/base-button.directive.ts
@@ -1,0 +1,49 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @angular-eslint/directive-selector */
+
+import { Directive } from '@angular/core';
+import { AbstractBaseButtonDirective } from './abstract-base-button.directive';
+
+@Directive({
+  selector: `
+    button[primerBaseButton],
+    a[primerBaseButton],
+    summary[primerBaseButton],
+    clipboard-copy[primerBaseButton]
+  `,
+  host: {
+    '[class.btn-block]': 'block()',
+    '[class.Button--inactive]': 'inactive()',
+    '[disabled]': 'disabled()',
+    '[attr.type]': 'type()',
+  }
+})
+export class PrimerBaseButtonDirective extends AbstractBaseButtonDirective {
+}

--- a/frontend/src/app/shared/components/primer/dynamic-icon-map.ts
+++ b/frontend/src/app/shared/components/primer/dynamic-icon-map.ts
@@ -1,0 +1,35 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { starIconData, SVGData, xIconData } from '@openproject/octicons-angular';
+
+export const ICON_MAP:Record<string, SVGData> = {
+  x: xIconData,
+  star: starIconData,
+  // TODO add more icons
+};

--- a/frontend/src/app/shared/components/primer/dynamic-icon.directive.spec.ts
+++ b/frontend/src/app/shared/components/primer/dynamic-icon.directive.spec.ts
@@ -1,0 +1,208 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any */
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DynamicIconDirective } from './dynamic-icon.directive';
+
+@Component({
+  template: '<svg octicon [icon]="iconName" [size]="iconSize"></svg>',
+  imports: [DynamicIconDirective],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+class TestHostComponent {
+  iconName = '';
+  iconSize:'small'|'medium'|'large' = 'medium';
+}
+
+describe('DynamicIconDirective', () => {
+  let component:TestHostComponent;
+  let fixture:ComponentFixture<TestHostComponent>;
+  let svgElement:SVGElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    svgElement = fixture.nativeElement.querySelector('svg');
+  });
+
+  it('should create', () => {
+    component.iconName = 'star';
+    fixture.detectChanges();
+
+    expect(component).toBeDefined();
+    expect(svgElement).toBeDefined();
+  });
+
+  it('should render a valid star icon', () => {
+    component.iconName = 'star';
+    fixture.detectChanges();
+
+    // Check that SVG attributes are set correctly
+    expect(svgElement.getAttribute('viewBox')).toBeTruthy();
+    expect(svgElement.getAttribute('fill')).toBe('currentColor');
+    expect(svgElement.style.height).toBeTruthy();
+    expect(svgElement.style.width).toBeTruthy();
+
+    // Check that path elements are created
+    const paths = svgElement.querySelectorAll('path');
+
+    expect(paths.length).toBeGreaterThan(0);
+
+    // Check that each path has a 'd' attribute
+    paths.forEach(path => {
+      expect(path.getAttribute('d')).toBeTruthy();
+    });
+  });
+
+  it('should render a valid x icon', () => {
+    component.iconName = 'x';
+    fixture.detectChanges();
+
+    // Check that SVG attributes are set correctly
+    expect(svgElement.getAttribute('viewBox')).toBeTruthy();
+    expect(svgElement.getAttribute('fill')).toBe('currentColor');
+    expect(svgElement.style.height).toBeTruthy();
+    expect(svgElement.style.width).toBeTruthy();
+
+    // Check that path elements are created
+    const paths = svgElement.querySelectorAll('path');
+
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  describe('icon sizes', () => {
+    it('should render small icons with correct dimensions', () => {
+      component.iconName = 'star';
+      component.iconSize = 'small';
+      fixture.detectChanges();
+
+      expect(svgElement.style.height).toBe('16px');
+    });
+
+    it('should render large icons with correct dimensions', () => {
+      // Create a fresh fixture for the large size test
+      const largeFixture = TestBed.createComponent(TestHostComponent);
+      const largeComponent = largeFixture.componentInstance;
+      const largeSvgElement = largeFixture.nativeElement.querySelector('svg');
+
+      largeComponent.iconName = 'star';
+      largeComponent.iconSize = 'large';
+      largeFixture.detectChanges();
+
+      expect(largeSvgElement.style.height).toBe('64px');
+    });
+
+    it('should render medium icons by default', () => {
+      component.iconName = 'star';
+      // iconSize defaults to 'medium'
+      fixture.detectChanges();
+
+      expect(svgElement.style.height).toBe('32px');
+    });
+  });
+
+  it('should clear existing content when rendering new icon', () => {
+    component.iconName = 'star';
+    fixture.detectChanges();
+
+    const initialPaths = svgElement.querySelectorAll('path');
+
+    expect(initialPaths.length).toBeGreaterThan(0);
+
+    component.iconName = 'x';
+    fixture.detectChanges();
+
+    // Should have cleared and re-rendered
+    const newPaths = svgElement.querySelectorAll('path');
+
+    expect(newPaths.length).toBeGreaterThan(0);
+  });
+
+  it('should warn when rendering unknown icon', () => {
+    spyOn(console, 'warn');
+    
+    component.iconName = 'unknown-icon';
+    fixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalledWith('Unknown icon: unknown-icon');
+  });
+
+  it('should not render anything for unknown icon', () => {
+    spyOn(console, 'warn');
+    
+    component.iconName = 'unknown-icon';
+    fixture.detectChanges();
+
+    // Should not have set viewBox or other attributes
+    expect(svgElement.getAttribute('viewBox')).toBeNull();
+    expect(svgElement.getAttribute('fill')).toBeNull();
+    
+    // Should not have any paths
+    const paths = svgElement.querySelectorAll('path');
+
+    expect(paths.length).toBe(0);
+  });
+
+  it('should handle empty icon name', () => {
+    spyOn(console, 'warn');
+    
+    component.iconName = '';
+    fixture.detectChanges();
+
+    // Should not warn or render anything
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(svgElement.getAttribute('viewBox')).toBeNull();
+    
+    const paths = svgElement.querySelectorAll('path');
+
+    expect(paths.length).toBe(0);
+  });
+
+  it('should only render once when loaded', () => {
+    spyOn(console, 'warn');
+    const directive = fixture.debugElement.children[0].injector.get(DynamicIconDirective);
+    spyOn(directive as any, 'renderIcon').and.callThrough();
+    
+    component.iconName = 'star';
+    fixture.detectChanges();
+    
+    // Change icon name after initial load - should not re-render
+    component.iconName = 'x';
+    fixture.detectChanges();
+
+    expect((directive as any).renderIcon).toHaveBeenCalledTimes(1);
+    expect((directive as any).renderIcon).toHaveBeenCalledWith('star');
+  });
+});

--- a/frontend/src/app/shared/components/primer/dynamic-icon.directive.ts
+++ b/frontend/src/app/shared/components/primer/dynamic-icon.directive.ts
@@ -1,0 +1,95 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @angular-eslint/directive-selector */
+
+import { Directive, effect, ElementRef, inject, input, Renderer2 } from '@angular/core';
+import { closestNaturalHeight, sizeMap, SVGData, SVGSize } from '@openproject/octicons-angular';
+import { ICON_MAP } from './dynamic-icon-map';
+
+@Directive({ selector: 'svg[octicon]' })
+export class DynamicIconDirective {
+  private el = inject<ElementRef<SVGElement>>(ElementRef);
+  private renderer = inject(Renderer2);
+
+  readonly icon = input.required<string>();
+  readonly size = input<SVGSize>('medium');
+
+  private loaded = false;
+
+  constructor() {
+    effect(() => {
+      const name = this.icon();
+      if (!name || this.loaded) return;
+
+      this.loaded = true;
+      this.renderIcon(name);
+    });
+  }
+
+  private renderIcon(name:string) {
+    const data = ICON_MAP[name];
+
+    if (!data) {
+      console.warn(`Unknown icon: ${name}`);
+      return;
+    }
+
+    renderIconData(
+      this.el.nativeElement,
+      data,
+      this.size(),
+      this.renderer
+    );
+  }
+}
+
+function renderIconData(
+  svg:SVGElement,
+  iconData:SVGData,
+  size:SVGSize = 'medium',
+  renderer:Renderer2,
+) {
+  const height = sizeMap[size];
+  const naturalHeight = closestNaturalHeight(Object.keys(iconData), height);
+  const { width, paths } = iconData[naturalHeight.toString()];
+  const elWidth =  height * (width / naturalHeight);
+
+  renderer.setAttribute(svg, 'viewBox', `0 0 ${width} ${naturalHeight}`);
+  renderer.setAttribute(svg, 'fill', 'currentColor');
+  renderer.setStyle(svg, 'height', `${height}px`);
+  renderer.setStyle(svg, 'width', `${elWidth}px`);
+
+  svg.innerHTML = '';
+
+  for (const d of paths) {
+    const path = renderer.createElement('path', 'svg') as SVGPathElement;
+    renderer.setAttribute(path, 'd', d);
+    renderer.appendChild(svg, path);
+  }
+}

--- a/frontend/src/app/shared/components/primer/icon-button.component.html
+++ b/frontend/src/app/shared/components/primer/icon-button.component.html
@@ -1,0 +1,30 @@
+<button
+  primerBaseButton
+  [attr.id]="buttonId()"
+  [attr.aria-label]="ariaLabel()"
+  [attr.aria-description]="ariaDescription()"
+  [attr.aria-labelledby]="ariaLabelledBy()"
+  [attr.aria-describedby]="ariaDescribedBy()"
+  [class]="['Button', 'Button--iconOnly', buttonClass(), `Button--${size()}`]"
+  [class.Button--primary]="scheme() === 'primary'"
+  [class.Button--secondary]="scheme() === 'default' || scheme() === 'secondary'"
+  [class.Button--danger]="scheme() === 'danger'"
+  [class.Button--invisible]="scheme() === 'invisible'"
+  [block]="block()"
+  [disabled]="disabled()"
+  [inactive]="inactive()"
+  [type]="type()"
+  (click)="clicked.emit()"
+  >
+  <svg octicon size="small" class="Button-visual" [icon]="icon()"></svg>
+</button>
+@if (showTooltip()) {
+  <tool-tip
+    class="sr-only position-absolute"
+    popover="manual"
+    [attr.for]="buttonId()"
+    [attr.id]="tooltipId()"
+    [attr.data-direction]="tooltipDirection()"
+    [attr.data-type]="tooltipType()"
+    >{{ tooltipText() }}</tool-tip>
+}

--- a/frontend/src/app/shared/components/primer/icon-button.component.spec.ts
+++ b/frontend/src/app/shared/components/primer/icon-button.component.spec.ts
@@ -1,0 +1,119 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { PrimerIconButtonComponent } from './icon-button.component';
+
+describe('PrimerIconButtonComponent', () => {
+  let component:PrimerIconButtonComponent;
+  let fixture:ComponentFixture<PrimerIconButtonComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({imports: [PrimerIconButtonComponent]});
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PrimerIconButtonComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.componentRef.setInput('icon', 'star');
+    fixture.componentRef.setInput('label', 'Star');
+    fixture.detectChanges();
+
+    expect(component).toBeDefined();
+  });
+
+  it('renders', () => {
+    fixture.componentRef.setInput('icon', 'star');
+    fixture.componentRef.setInput('label', 'Star');
+    fixture.detectChanges();
+
+    const container:HTMLElement = fixture.nativeElement;
+    const button = container.querySelector('.Button.Button--iconOnly');
+
+    expect(button).not.toBeNull();
+    expect(button?.querySelector('.Button-visual')).not.toBeNull();
+
+    const tooltip = container.querySelector('tool-tip');
+
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toEqual('Star');
+
+    const tooltipId = tooltip!.id;
+
+    expect(container.querySelector(`.Button.Button--iconOnly[aria-labelledby='${tooltipId}']`)).not.toBeNull();
+  });
+
+  it('renders description tooltip', () => {
+    fixture.componentRef.setInput('icon', 'star');
+    fixture.componentRef.setInput('label', 'Star');
+    fixture.componentRef.setInput('description', 'Star this repository');
+    fixture.detectChanges();
+
+    const container:HTMLElement = fixture.nativeElement;
+
+    const tooltip = container.querySelector('tool-tip');
+
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toEqual('Star this repository');
+
+    const tooltipId = tooltip!.id;
+
+    expect(container.querySelector(`.Button.Button--iconOnly[aria-describedby='${tooltipId}']`)).not.toBeNull();
+  });
+
+  it('allows hiding tooltip', () => {
+    fixture.componentRef.setInput('icon', 'star');
+    fixture.componentRef.setInput('label', 'Star');
+    fixture.componentRef.setInput('showTooltip', false);
+    fixture.detectChanges();
+
+    const container:HTMLElement = fixture.nativeElement;
+
+    const tooltip = container.querySelector('tool-tip');
+
+    expect(tooltip).toBeNull();
+  });
+
+  it('sets aria-label when tooltips are hidden', () => {
+    fixture.componentRef.setInput('icon', 'star');
+    fixture.componentRef.setInput('label', 'Star');
+    fixture.componentRef.setInput('showTooltip', false);
+    fixture.detectChanges();
+
+    const container:HTMLElement = fixture.nativeElement;
+
+    const button = container.querySelector('[aria-label=\'Star\']');
+
+    expect(button).not.toBeNull();
+  });
+});

--- a/frontend/src/app/shared/components/primer/icon-button.component.ts
+++ b/frontend/src/app/shared/components/primer/icon-button.component.ts
@@ -1,0 +1,107 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+/* eslint-disable @angular-eslint/component-selector, @angular-eslint/no-input-rename */
+
+import { ChangeDetectionStrategy, Component, computed, CUSTOM_ELEMENTS_SCHEMA, input, output } from '@angular/core';
+import { generateId } from 'core-app/shared/helpers/dom-helpers';
+import { IconModule } from '../icon/icon.module';
+import { AbstractBaseButtonDirective } from './abstract-base-button.directive';
+import { PrimerBaseButtonDirective } from './base-button.directive';
+import { DynamicIconDirective } from './dynamic-icon.directive';
+
+type Scheme = 'default' | 'primary' | 'secondary' | 'danger' | 'invisible';
+type Size = 'small' | 'medium' | 'large';
+type TooltipDirection = 's' | 'n' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+@Component({
+  selector: 'primer-icon-button',
+  templateUrl: './icon-button.component.html',
+  imports: [PrimerBaseButtonDirective, DynamicIconDirective, IconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class PrimerIconButtonComponent extends AbstractBaseButtonDirective {
+  readonly buttonId = input(generateId('icon-button'));
+  readonly buttonClass = input('', { alias: 'button-class' });
+
+  readonly icon = input.required<string>();
+  readonly scheme = input<Scheme>('default');
+  readonly size = input<Size>('medium');
+
+  /**
+   * String that can be read by assistive technology. A label should be short
+   * and concise. See the accessibility section for more information.
+   */
+  readonly label = input.required<string>();
+
+  /**
+   * String that can be read by assistive technology. A description can be
+   * longer as it is intended to provide more context and information. See the
+   * accessibility section for more information.
+   */
+  readonly description = input<string>();
+
+  /**
+   * Whether or not to show a tooltip when this button is hovered. Tooltips
+   * should only be hidden if the aria label is redundant, i.e. if the icon has
+   * a widely understood definition.
+   *
+   * @default true
+   */
+  readonly showTooltip = input(true);
+  readonly tooltipId = input(generateId('tooltip'));
+  readonly tooltipDirection = input<TooltipDirection>('s', { alias: 'tooltip-direction' });
+
+  readonly clicked = output();
+
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  readonly tooltipText = computed(() => this.description() || this.label());
+  readonly tooltipType = computed(() => this.description() ? 'description' : 'label');
+
+  readonly ariaLabel = computed(() => this.whenNoTooltip(() => this.label()));
+  readonly ariaDescription = computed(() => this.whenNoTooltip(() => this.description()));
+
+  readonly ariaLabelledBy = computed(() =>
+    this.whenTooltipType('label', () => this.tooltipId())
+  );
+
+  readonly ariaDescribedBy = computed(() =>
+    this.whenTooltipType('description', () => this.tooltipId())
+  );
+
+  private whenNoTooltip<T>(value:() => T) {
+    return this.showTooltip() ? undefined : value();
+  }
+
+  private whenTooltipType<T>(type:'label' | 'description', value:() => T) {
+    return this.showTooltip() && this.tooltipType() === type
+      ? value()
+      : undefined;
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -84,6 +84,7 @@ import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.m
 import { FullCalendarModule } from '@fullcalendar/angular';
 import { OpDatePickerModule } from 'core-app/shared/components/datepicker/datepicker.module';
 import { OpBreadcrumbsComponent } from './components/breadcrumbs/op-breadcrumbs.component';
+import { PrimerIconButtonComponent } from './components/primer/icon-button.component';
 
 export function bootstrapModule(injector:Injector):void {
   // Ensure error reporter is run
@@ -125,6 +126,8 @@ export function bootstrapModule(injector:Injector):void {
     AttributeHelpTextModule,
     FullCalendarModule,
     OpDatePickerModule,
+
+    PrimerIconButtonComponent
   ],
   exports: [
     // Re-export all commonly used
@@ -177,6 +180,8 @@ export function bootstrapModule(injector:Injector):void {
     OpLoadingProjectListComponent,
 
     OpNonWorkingDaysListComponent,
+
+    PrimerIconButtonComponent
   ],
   providers: [
     CopyToClipboardService,

--- a/frontend/src/global_styles/content/_advanced_filters.sass
+++ b/frontend/src/global_styles/content/_advanced_filters.sass
@@ -46,16 +46,13 @@ $advanced-filters--grid-gap: 10px
 
   .advanced-filters--close
     position: absolute
-    top: 0.75rem
-    right: 0.75rem
+    top: var(--stack-padding-condensed)
+    right: var(--stack-padding-condensed)
     z-index: 2
-
-  .advanced-filters--filters
-    margin-top: 20px
 
 .advanced-filters--filters
   list-style-type: none
-  margin: 0
+  margin: var(--base-size-32) 0 0 0
 
   > .advanced-filters--filter
     display: grid

--- a/frontend/src/global_styles/content/_advanced_filters.sass
+++ b/frontend/src/global_styles/content/_advanced_filters.sass
@@ -48,7 +48,6 @@ $advanced-filters--grid-gap: 10px
     position: absolute
     top: 0.75rem
     right: 0.75rem
-    width: 1rem
     z-index: 2
 
   .advanced-filters--filters

--- a/frontend/src/global_styles/content/_simple_filters.sass
+++ b/frontend/src/global_styles/content/_simple_filters.sass
@@ -39,7 +39,7 @@ $filters--border-color: var(--borderColor-default) !default
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr))
   grid-gap:         10px 40px
   list-style-type:  none
-  margin:           10px 0 0 0
+  margin:           var(--base-size-32) 0 0 0
 
 .simple-filters--container
   @extend %filters--container
@@ -60,8 +60,8 @@ $filters--border-color: var(--borderColor-default) !default
 
   .simple-filters--close
     position: absolute
-    top: 5px
-    right: 5px
+    top: var(--stack-padding-condensed)
+    right: var(--stack-padding-condensed)
     z-index: 2
 
 .simple-filters--filters

--- a/frontend/src/global_styles/content/_simple_filters.sass
+++ b/frontend/src/global_styles/content/_simple_filters.sass
@@ -62,7 +62,6 @@ $filters--border-color: var(--borderColor-default) !default
     position: absolute
     top: 5px
     right: 5px
-    width: 1rem
     z-index: 2
 
 .simple-filters--filters

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -17,9 +17,9 @@
       display: inline-block
       .group-edit-in-place--input
         color: var(--fgColor-white)
-    .delete-group:before
-      vertical-align: bottom
-      color: var(--fgColor-white)
+    .delete-group
+      .Button-visual
+        color: var(--fgColor-white)
   .attributes
     min-height: 29px
 
@@ -34,24 +34,17 @@
       border-color: var(--borderColor-default)
       background: var(--control-bgColor-activ)
 
-  .delete-group,
-  .delete-attribute
-    cursor: pointer
-
   &.-error
     background: var(--content-form-error-color)
     .group-name
       border-color: var(--content-form-error-color)
-    .group-handle,
-    .delete-group:before
+    .group-handle
       color: var(--fgColor-white)
 
 
 #type-form-conf-inactive-group
   background: var(--fgColor-muted)
-  .visibility-check,
-  .delete-group,
-  .delete-attribute
+  .visibility-check
     visibility: hidden
   .group-head
     display: block


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70420
https://community.openproject.org/wp/70167

# What are you trying to accomplish?

Fixes accessibility issues detected by both ERBLint and eslint relating to close buttons on the following parts of the UI:

- filter components
- Types > Form Configuration page group headers

Also adjusts (harmonizes) the positioning of the filter close button.

## Screenshots


# What approach did you choose and why?

These improvements have been extracted from the following Pull Requests (which are otherwise still WIP):

- #21503
- #21339

Introduces Angular `octicon` directive (dynamic icon component) that allows rendering an icon by name

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
