### PR TITLE
[69356] "X-icon" above the project create form

### DIFF
--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -27,9 +27,27 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
+<% close_href =
+     if @parent
+       project_overview_path(@parent.id)
+     else
+       home_path
+     end %>
+
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { title }
+
+    header.with_action_icon_button(
+      tag: :a,
+      size: :small,
+      icon: :x,
+      mobile_icon: :x,
+      label: I18n.t(:button_close),
+      href: close_href,
+      aria: { label: I18n.t(:button_close) },
+      title: I18n.t(:button_close)
+    )
 
     if @parent
       header.with_breadcrumbs(

--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -27,12 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% close_href =
-     if @parent
-       project_overview_path(@parent.id)
-     else
-       home_path
-     end %>
+<% close_href = workspace_creation_cancel_href(@new_project, @parent) %>
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|

--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -27,8 +27,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<% close_href = workspace_creation_cancel_href(@new_project, @parent) %>
-
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { title }
@@ -39,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
       icon: :x,
       mobile_icon: :x,
       label: I18n.t(:button_close),
-      href: close_href,
+      href: workspace_creation_cancel_href(@new_project, @parent),
       test_selector: "new_project_form_close_icon"
     )
 

--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -39,7 +39,8 @@ See COPYRIGHT and LICENSE files for more details.
       icon: :x,
       mobile_icon: :x,
       label: I18n.t(:button_close),
-      href: close_href
+      href: close_href,
+      test_selector: "new_project_form_close_icon"
     )
 
     if @parent

--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -45,8 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
       mobile_icon: :x,
       label: I18n.t(:button_close),
       href: close_href,
-      aria: { label: I18n.t(:button_close) },
-      title: I18n.t(:button_close)
+      aria: { label: I18n.t(:button_close) }
     )
 
     if @parent

--- a/app/views/projects/_new_header.erb
+++ b/app/views/projects/_new_header.erb
@@ -44,8 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
       icon: :x,
       mobile_icon: :x,
       label: I18n.t(:button_close),
-      href: close_href,
-      aria: { label: I18n.t(:button_close) }
+      href: close_href
     )
 
     if @parent

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -73,6 +73,21 @@ RSpec.describe "Projects", "creation",
     expect(page).to have_content "Foo bar"
   end
 
+  it "redirects to the parent project page when users cancels while creating subproject" do
+    # Go to parent project page
+    visit project_overview_path(project.id)
+
+    # Start creating a subproject from parent context
+    page.find_test_selector("quick-add-menu-button").click
+    page.find_test_selector("quick-add-menu-item", text: "Project", wait: 5).click
+
+    expect(page).to have_heading "New project"
+
+    click_on "Cancel"
+
+    expect(page).to have_current_path project_overview_path(project.id)
+  end
+
   it "redirects to projects#index when users cancels" do
     visit new_project_path
 
@@ -98,13 +113,13 @@ RSpec.describe "Projects", "creation",
     expect(page).to have_current_path project_overview_path(project.id)
   end
 
-  it "redirects to projects#index when users click on close icon while creating subproject" do
+  it "redirects to projects#index when users click on close icon" do
     visit new_project_path
 
     expect(page).to have_heading "New project"
 
     find_test_selector("new_project_form_close_icon").click
-    expect(page).to have_current_path project_overview_path(project.id)
+    expect(page).to have_current_path projects_path
   end
 
   it "does not create a project with an already existing identifier" do

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -82,6 +82,31 @@ RSpec.describe "Projects", "creation",
     expect(page).to have_current_path projects_path
   end
 
+  it "redirects to the parent project page when users press the close icon while creating subproject" do
+    # Go to parent project page
+    visit project_overview_path(project.id)
+
+    # Start creating a subproject from parent context
+    page.find_test_selector("quick-add-menu-button").click
+    page.find_test_selector("quick-add-menu-item", text: "Project", wait: 5).click
+
+    expect(page).to have_heading "New project"
+
+    # Click the close (X) icon in the header
+    find_test_selector("new_project_form_close_icon").click
+
+    expect(page).to have_current_path project_overview_path(project.id)
+  end
+
+  it "redirects to projects#index when users click on close icon while creating subproject" do
+    visit new_project_path
+
+    expect(page).to have_heading "New project"
+
+    find_test_selector("new_project_form_close_icon").click
+    expect(page).to have_current_path project_overview_path(project.id)
+  end
+
   it "does not create a project with an already existing identifier" do
     projects_page.create_new_workspace
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69356

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add a close icon button to the project create form.

## Screenshots
<img width="1883" height="152" alt="Screenshot 2026-01-12 at 15 52 29" src="https://github.com/user-attachments/assets/680c4ca5-048e-477d-9582-2a1227868a61" />

