### PR TITLE
Refactor how filtering in MCP tools works

### DIFF
--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -65,6 +65,43 @@ module McpTools
         @output_schema
       end
 
+      ##
+      # Defines a filter for selecting results through input parameters. Only one of filter_proc and filter_class are allowed at
+      # the same time. If none is provided, a default where-based filter is created, using name as the filtered attribute name.
+      #
+      # Filters defined here can later be applied by the tool implementation using #apply_filters.
+      #
+      # @param name [Symbol] The name of the input parameter used for filtering.
+      # @param filter_class [Queries::Filters::Base] A shared filter implementation to be used to perform filtering.
+      # @param operator [String] When using a filter_class, this is the operator that will be used for filtering. Default: "="
+      # @param filter_proc [Proc] A callback procedure used for filtering that must accept two arguments:
+      #                           The base scope that the filter applies to and the value that's used as a filter input.
+      # @example
+      #   filter :id
+      #
+      # @example
+      #   filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+      #
+      # @example
+      #   filter :status, filter_proc: ->(scope, value) { scope.where(status_name: value) }
+      def filter(name, filter_class: nil, filter_proc: nil, operator: "=")
+        if filter_class && filter_proc
+          raise ArgumentError, "filter_proc and filter_class are mutually exclusive, please only specify one"
+        end
+
+        if filter_class
+          filter_proc = ->(scope, value) { filter_class.create!(operator:, values: Array(value)).apply_to(scope) }
+        elsif !filter_proc
+          filter_proc = ->(scope, value) { scope.where(name.to_sym => value) }
+        end
+
+        filters[name.to_sym] = filter_proc
+      end
+
+      def filters
+        @filters ||= {}
+      end
+
       def tool
         config = McpConfiguration.find_by(identifier: qualified_name)
         return nil if config.nil?
@@ -98,9 +135,26 @@ module McpTools
       MCP::Tool::Response.new([{ type: "text", text: result.to_json }], structured_content: result)
     end
 
+    private
+
     # Intended to be implemented by subclasses. It should return a structured result (e.g. a Hash or Array).
     def call(**)
       raise NotImplemented, "#{self.class} needs to implement #call method"
+    end
+
+    # Usable by tool implementations. Takes a scope and filters it according to the passed params.
+    # Filtering happens based on the filters defined for the tool, see .filter.
+    def apply_filters(scope, params)
+      params.each do |name, value|
+        filter_proc = filter_proc_for(name)
+        scope = filter_proc.call(scope, value)
+      end
+
+      scope
+    end
+
+    def filter_proc_for(name)
+      self.class.filters[name] || raise(ArgumentError, "Don't know how to handle filter argument called #{name}")
     end
   end
 end

--- a/app/services/mcp_tools/search_project.rb
+++ b/app/services/mcp_tools/search_project.rb
@@ -39,6 +39,10 @@ module McpTools
 
     name "search_project"
 
+    filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
+    filter :identifier
+    filter :status_code
+
     input_schema(
       properties: {
         name: { type: "string", description: "Name of the project. Accepts partial project names, not case-sensitive." },
@@ -52,23 +56,9 @@ module McpTools
       items: JsonSchemaLoader.new.load("project_model")
     )
 
-    def call(name: nil, identifier: nil, status_code: nil)
-      query = { name:, identifier:, status_code: }.compact
-      if query.present?
-        projects = projects_for_query(query)
-        projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user: User.current) }
-      else
-        []
-      end
-    end
-
-    private
-
-    def projects_for_query(query)
-      name = query.delete(:name)
-      projects = Project.visible.where(query).limit(MAX_SIZE)
-      projects = projects.where("name ILIKE '%#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(name)}%'") if name
-      projects
+    def call(**query)
+      projects = apply_filters(Project.visible.limit(MAX_SIZE), query)
+      projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user: User.current) }
     end
   end
 end

--- a/spec/models/queries/projects/filters/project_status_filter_spec.rb
+++ b/spec/models/queries/projects/filters/project_status_filter_spec.rb
@@ -57,4 +57,10 @@ RSpec.describe Queries::Projects::Filters::ProjectStatusFilter do
       end
     end
   end
+
+  it_behaves_like "list_optional query filter" do
+    let(:attribute) { :status_code }
+    let(:model) { Project }
+    let(:valid_values) { ["0", "1", "2"] }
+  end
 end


### PR DESCRIPTION
Filters are now defined declaratively during tool definition. In addition to simple where-based filters (like the ones we've been using in SearchProject), we now also support using query filters that are defined for other purposes already. Though we keep supporting custom filtering, since pre-existing classes are often not available and necessary for very simple filtering operations.

As a side-find, specs for the ProjectStatusFilter have been extended.

# Ticket
This is effectively code maintenance in the scope of https://community.openproject.org/wp/62781