### PR TITLE
[69309] Fix error when duplicating an automatically scheduled work package

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
@@ -154,6 +154,11 @@ export class WorkPackageCreateService extends UntilDestroyedMixin {
       .then((form:FormResource) => {
         const changeset = this.fromCreateForm(form);
 
+        // Override scheduleManually to true when copying a single work package.
+        // Has a copy cannot have children nor predecessors, it must be manually
+        // scheduled despite the scheduling mode of the source work package.
+        changeset.setValue('scheduleManually', true);
+
         return changeset;
       });
   }

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -141,15 +141,33 @@ RSpec.describe "Work package copy", :js, :selenium do
       wp_page.visit!
       wp_page.ensure_page_loaded
 
-      # Go to add cost entry page
-      find("#action-show-more-dropdown-menu .button").click
-      find(".menu-item", text: "Duplicate", exact_text: true).click
+      wp_page.select_from_context_menu("Duplicate")
 
       to_copy_work_package_page = Pages::FullWorkPackageCreate.new(original_work_package:)
       to_copy_work_package_page.update_attributes Description: "Copied WP Description"
       to_copy_work_package_page.save!
 
-      to_copy_work_package_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_create")
+      wp_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_create")
+    end
+  end
+
+  describe "when source work package is an automatically scheduled parent" do
+    before do
+      create(:work_package, project:, parent: original_work_package, subject: "Child")
+      original_work_package.update!(schedule_manually: false)
+    end
+
+    it "still allows copying through menu (Bug #69309)" do
+      wp_page = Pages::FullWorkPackage.new(original_work_package, project)
+      wp_page.visit!
+      wp_page.ensure_page_loaded
+
+      wp_page.select_from_context_menu("Duplicate")
+
+      to_copy_work_package_page = Pages::FullWorkPackageCreate.new(original_work_package:)
+      to_copy_work_package_page.save!
+
+      wp_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_create")
     end
   end
 end

--- a/spec/features/work_packages/copy_spec.rb
+++ b/spec/features/work_packages/copy_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Work package copy", :js, :selenium do
     to_copy_work_package_page.expect_current_path
     to_copy_work_package_page.expect_fully_loaded
 
-    to_copy_work_package_page.update_attributes Description: "Copied WP Description"
+    to_copy_work_package_page.fill_in_attributes Description: "Copied WP Description"
     to_copy_work_package_page.save!
 
     expect(page).to have_css(".op-toast--content",

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -213,9 +213,10 @@ module Pages
       end
     end
 
-    def update_attributes(save: !create_page?, **key_value_map)
+    def fill_in_attributes(save: !create_page?, **key_value_map)
       set_attributes(key_value_map, save:)
     end
+    alias :update_attributes :fill_in_attributes
 
     def set_attributes(key_value_map, save: !create_page?)
       key_value_map.each_with_index.map do |(key, value), index|

--- a/spec/support/pages/work_packages/abstract_work_package_create.rb
+++ b/spec/support/pages/work_packages/abstract_work_package_create.rb
@@ -44,11 +44,12 @@ module Pages
       @parent_work_package = parent_work_package
     end
 
-    def update_attributes(attribute_map)
+    def fill_in_attributes(attribute_map)
       attribute_map.each do |label, value|
         work_package_field(label.downcase).set_value(value)
       end
     end
+    alias :update_attributes :fill_in_attributes
 
     def select_attribute(property, value)
       element = page.first(".inline-edit--container.#{property.downcase} select")


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/69309

# What are you trying to accomplish?

When a single work package is copied by choosing "Duplicate" in the context menu, there is an error displayed if the source work package is manually scheduled (it has children and/or predecessor).

As duplicating a work package does not copy the children and predecessors, it must always be manually scheduled (instead of using the scheduling mode of the source work package).

# What approach did you choose and why?

In Angular `WorkPackageCreateService`, always set `scheduleManually` to `true` for work package copy.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
