### PR TITLE
bug/69230 fix avatar and name alignment in live users popover

### DIFF
--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_users_component.html.erb
@@ -67,12 +67,16 @@
           component.with_body(caret: :top_left) do
             flex_layout do |container|
               users.each do |user|
-                container.with_column do
-                  render Primer::OpenProject::AvatarWithFallback.new(**avatar_options_for(user))
-                end
+                container.with_row(mb: 2) do
+                  flex_layout(align_items: :center) do |user_row|
+                    user_row.with_column do
+                      render Primer::OpenProject::AvatarWithFallback.new(**avatar_options_for(user))
+                    end
 
-                container.with_column(ml: 2) do
-                  render(Primer::Beta::Text.new(color: :subtle)) { user.name }
+                    user_row.with_column(ml: 2) do
+                      render(Primer::Beta::Text.new(color: :subtle)) { user.name }
+                    end
+                  end
                 end
               end
             end


### PR DESCRIPTION
https://community.openproject.org/wp/69230

Wrap each user's avatar and name in a nested flex_layout row to ensure proper vertical stacking and horizontal alignment within the active editors popover.

_Fixes #21343 which changed layout from row to column erroneously_

_Before_

<img width="789" height="393" alt="Screenshot 2026-01-13 at 1 29 18 PM" src="https://github.com/user-attachments/assets/942d6efb-0cd5-40f4-b769-2a5d6e01f8b7" />

_After_

<img width="840" height="504" alt="Screenshot 2026-01-13 at 2 46 17 PM" src="https://github.com/user-attachments/assets/ab78ddb9-ac67-424a-aa7c-919443f29890" />

