### PR TITLE
Add check for Enterprise Plan when editing Types Form configuration

### DIFF
--- a/app/contracts/work_package_types/update_form_configuration_contract.rb
+++ b/app/contracts/work_package_types/update_form_configuration_contract.rb
@@ -30,6 +30,10 @@
 
 module WorkPackageTypes
   class UpdateFormConfigurationContract < BaseContract
+    include RequiresEnterpriseGuard
+
+    self.enterprise_action = :edit_attribute_groups
+
     attribute :attribute_groups
 
     validate :validate_attribute_group_names

--- a/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
+++ b/spec/contracts/work_package_types/update_form_configuration_contract_spec.rb
@@ -37,75 +37,88 @@ module WorkPackageTypes
 
     subject(:contract) { described_class.new(model, user, options: {}) }
 
-    context "when the user isn't admin" do
-      let(:user) { create(:user) }
-
+    context "without enterprise features enabled" do
       it "the contract is invalid" do
         expect(contract.validate).to be_falsey
       end
 
       it "adds and error to the contract" do
         contract.validate
-        expect(contract.errors.details).to eq(base: [{ error: :error_unauthorized }])
+        expect(contract.errors.details).to eq(base: [{ action: "Edit Attribute Groups", error: :error_enterprise_only }])
       end
     end
 
-    describe "validations" do
-      context "when attribute_groups is present and valid" do
-        let(:valid_group) { ["foo", ["assignee", "responsible"]] }
+    context "with enterprise features enabled", with_ee: %i[edit_attribute_groups] do
+      context "when the user isn't admin" do
+        let(:user) { create(:user) }
 
-        it "is valid" do
-          model.attribute_groups = [valid_group]
+        it "the contract is invalid" do
+          expect(contract.validate).to be_falsey
+        end
 
-          expect(contract.validate).to be_truthy
+        it "adds and error to the contract" do
+          contract.validate
+          expect(contract.errors.details).to eq(base: [{ error: :error_unauthorized }])
         end
       end
 
-      context "when a group has no name" do
-        let(:invalid_group) { ["", ["assignee"]] }
+      describe "validations" do
+        context "when attribute_groups is present and valid" do
+          let(:valid_group) { ["foo", ["assignee", "responsible"]] }
 
-        it "is invalid and adds :group_without_name error" do
-          model.attribute_groups = [invalid_group]
+          it "is valid" do
+            model.attribute_groups = [valid_group]
 
-          expect(contract.validate).to be_falsey
-          expect(contract.errors.details[:attribute_groups]).to include(error: :group_without_name)
+            expect(contract.validate).to be_truthy
+          end
         end
-      end
 
-      context "when there are duplicate group names" do
-        let(:duplicate_group) { ["foo", ["assignee"]] }
+        context "when a group has no name" do
+          let(:invalid_group) { ["", ["assignee"]] }
 
-        it "is invalid and adds :duplicate_group error" do
-          model.attribute_groups = [duplicate_group, duplicate_group]
+          it "is invalid and adds :group_without_name error" do
+            model.attribute_groups = [invalid_group]
 
-          expect(contract.validate).to be_falsey
-          expect(contract.errors.details[:attribute_groups]).to include(error: :duplicate_group, group: "foo")
+            expect(contract.validate).to be_falsey
+            expect(contract.errors.details[:attribute_groups]).to include(error: :group_without_name)
+          end
         end
-      end
 
-      context "when an attribute group contains unknown attributes" do
-        let(:invalid_group) { ["foo", ["unknown_attribute"]] }
+        context "when there are duplicate group names" do
+          let(:duplicate_group) { ["foo", ["assignee"]] }
 
-        it "is invalid and adds an error for the unknown attribute" do
-          model.attribute_groups = [invalid_group]
+          it "is invalid and adds :duplicate_group error" do
+            model.attribute_groups = [duplicate_group, duplicate_group]
 
-          expect(contract.validate).to be_falsey
-          expect(contract.errors.details[:attribute_groups]).to include(
-            error: "Invalid work package attribute used: unknown_attribute"
-          )
+            expect(contract.validate).to be_falsey
+            expect(contract.errors.details[:attribute_groups]).to include(error: :duplicate_group, group: "foo")
+          end
         end
-      end
 
-      context "with invalid query group" do
-        let(:query) { Query.new(name: "Invalid Query", user:) }
-        let(:invalid_query_group) { ["query_group", [query]] }
+        context "when an attribute group contains unknown attributes" do
+          let(:invalid_group) { ["foo", ["unknown_attribute"]] }
 
-        it "is invalid and adds an error for the query group" do
-          model.attribute_groups = [invalid_query_group]
+          it "is invalid and adds an error for the unknown attribute" do
+            model.attribute_groups = [invalid_group]
 
-          expect(contract.validate).to be_falsey
-          expect(contract.errors.details[:attribute_groups])
-            .to include(hash_including(error: :query_invalid, group: "query_group"))
+            expect(contract.validate).to be_falsey
+            expect(contract.errors.details[:attribute_groups]).to include(
+              error: "Invalid work package attribute used: unknown_attribute"
+            )
+          end
+        end
+
+        context "with invalid query group" do
+          let(:query) { Query.new(name: "Invalid Query", user:) }
+          let(:invalid_query_group) { ["query_group", [query]] }
+
+          it "is invalid and adds an error for the query group" do
+            model.attribute_groups = [invalid_query_group]
+
+            expect(contract.validate).to be_falsey
+            expect(contract.errors.details[:attribute_groups])
+              .to include(hash_including(error: :query_invalid, group: "query_group"))
+          end
         end
       end
     end

--- a/spec/controllers/work_package_types/form_configuration_tab_controller_spec.rb
+++ b/spec/controllers/work_package_types/form_configuration_tab_controller_spec.rb
@@ -79,49 +79,59 @@ RSpec.describe WorkPackageTypes::FormConfigurationTabController do
       }
     end
 
-    context "with an unauthorized account" do
-      let(:user) { create(:user) }
+    context "without enterprise feature enabled" do
+      describe "form is not updated" do
+        before { put :update, params: params }
 
-      describe "the access should be restricted" do
-        before { post "update", params: { type_id: "123" } }
-
-        it { expect(response).to have_http_status(:forbidden) }
+        it { expect(response).to have_http_status(:unprocessable_entity) }
       end
     end
 
-    it "updates the work package type" do
-      put :update, params: params
+    context "with enterprise feature enabled", with_ee: %i[edit_attribute_groups] do
+      context "with an unauthorized account" do
+        let(:user) { create(:user) }
 
-      expect(response).to redirect_to(edit_type_form_configuration_path(type))
+        describe "the access should be restricted" do
+          before { post "update", params: { type_id: "123" } }
 
-      type.reload
-      expect(type.attribute_groups.count).to eq(1)
-      expect(type.attribute_groups.first.key).to eql("People")
-    end
-
-    context "with invalid parameters" do
-      let(:params) do
-        {
-          type_id: type.id,
-          type: {
-            attribute_groups: [
-              {
-                type: "attribute",
-                name: "",
-                attributes: [
-                  { key: "assignee", is_cf: nil, is_required: nil, translation: "Assignee" }
-                ],
-                query: nil
-              }
-            ].to_json
-          }
-        }
+          it { expect(response).to have_http_status(:forbidden) }
+        end
       end
 
-      it "renders the edit tab" do
+      it "updates the work package type" do
         put :update, params: params
 
-        expect(response).to render_template(:edit)
+        expect(response).to redirect_to(edit_type_form_configuration_path(type))
+
+        type.reload
+        expect(type.attribute_groups.count).to eq(1)
+        expect(type.attribute_groups.first.key).to eql("People")
+      end
+
+      context "with invalid parameters" do
+        let(:params) do
+          {
+            type_id: type.id,
+            type: {
+              attribute_groups: [
+                {
+                  type: "attribute",
+                  name: "",
+                  attributes: [
+                    { key: "assignee", is_cf: nil, is_required: nil, translation: "Assignee" }
+                  ],
+                  query: nil
+                }
+              ].to_json
+            }
+          }
+        end
+
+        it "renders the edit tab" do
+          put :update, params: params
+
+          expect(response).to render_template(:edit)
+        end
       end
     end
   end

--- a/spec/services/work_package_types/update_service_spec.rb
+++ b/spec/services/work_package_types/update_service_spec.rb
@@ -80,29 +80,39 @@ module WorkPackageTypes
 
       subject(:service) { described_class.new(user:, model:, contract_class:) }
 
-      it "doesn't change the type if no attribute group is passed" do
-        service_result = service.call({})
-        expect(service_result.result).to eq(type)
+      context "without enterprise feature enabled" do
+        it "returns an error" do
+          result = service.call(params)
+          expect(result).to be_failure
+          expect(result.errors.details).to eq(base: [{ action: "Edit Attribute Groups", error: :error_enterprise_only }])
+        end
       end
 
-      it "set the attribute groups to the default value if empty" do
-        allow(type).to receive(:reset_attribute_groups).and_call_original
-        service_result = service.call(attribute_groups: [])
+      context "with enterprise feature enabled", with_ee: %i[edit_attribute_groups] do
+        it "doesn't change the type if no attribute group is passed" do
+          service_result = service.call({})
+          expect(service_result.result).to eq(type)
+        end
 
-        expect(service_result).to be_success
-        expect(type).to have_received(:reset_attribute_groups)
-      end
+        it "set the attribute groups to the default value if empty" do
+          allow(type).to receive(:reset_attribute_groups).and_call_original
+          service_result = service.call(attribute_groups: [])
 
-      it "set the attribute groups to the passed values" do
-        service_result = service.call(params)
+          expect(service_result).to be_success
+          expect(type).to have_received(:reset_attribute_groups)
+        end
 
-        expect(service_result).to be_success
-        group1, groups = *type.reload.attribute_groups
+        it "set the attribute groups to the passed values" do
+          service_result = service.call(params)
 
-        expect(group1.key).to eq("group1")
-        expect(group1.attributes).to contain_exactly(cf1.attribute_name, cf2.attribute_name)
-        expect(groups.key).to eq("groups")
-        expect(groups.attributes).to contain_exactly(cf2.attribute_name)
+          expect(service_result).to be_success
+          group1, groups = *type.reload.attribute_groups
+
+          expect(group1.key).to eq("group1")
+          expect(group1.attributes).to contain_exactly(cf1.attribute_name, cf2.attribute_name)
+          expect(groups.key).to eq("groups")
+          expect(groups.attributes).to contain_exactly(cf2.attribute_name)
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/70503

# What are you trying to accomplish?
- Add Enterprise Check for the form configuration in the backend

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)

---

> [!CAUTION]
> Merge after we released 17.0 as we want to add it to 17.0.1