### PR TITLE
[#67224] Add a new Outcome type that links a work package as an outcome  

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -72,6 +72,7 @@ class WorkPackage < ApplicationRecord
   has_and_belongs_to_many :github_pull_requests # rubocop:disable Rails/HasAndBelongsToMany
 
   has_many :meeting_agenda_items, dependent: :nullify
+  has_many :meeting_outcomes, dependent: :nullify
   # The MeetingAgendaItem has a default order, but the ordered field is not part of the select
   # that retrieves the meetings, hence we need to remove the order.
   has_many :meetings, -> { unscope(:order).distinct }, through: :meeting_agenda_items, source: :meeting

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -138,16 +138,32 @@ module MeetingAgendaItems
     end
 
     def add_outcome_action_item(menu)
-      menu.with_item(label: t("label_agenda_item_add_outcome"),
-                     tag: :button,
-                     content_arguments: { data: {
-                       action: "click->meetings--submit#intercept",
-                       href: new_meeting_outcome_path(@meeting_agenda_item.meeting,
-                                                      meeting_agenda_item_id: @meeting_agenda_item&.id,
-                                                      current_occurrence: @current_occurrence),
-                       method: "GET"
-                     } }) do |item|
-        item.with_leading_visual_icon(icon: :plus)
+      menu.with_sub_menu_item(label: t("label_agenda_item_add_outcome")) do |submenu|
+        submenu.with_leading_visual_icon(icon: :plus)
+
+        with_item_group(submenu) do
+          submenu.with_item(label: t("label_write_outcome"),
+                            tag: :button,
+                            content_arguments: { data: {
+                              action: "click->meetings--submit#intercept",
+                              href: new_meeting_outcome_path(@meeting_agenda_item.meeting,
+                                                             meeting_agenda_item_id: @meeting_agenda_item&.id,
+                                                             kind: :information,
+                                                             current_occurrence: @current_occurrence),
+                              method: "GET"
+                            } })
+
+          submenu.with_item(label: t("label_existing_work_package"),
+                            tag: :button,
+                            content_arguments: { data: {
+                              action: "click->meetings--submit#intercept",
+                              href: new_meeting_outcome_path(@meeting_agenda_item.meeting,
+                                                             meeting_agenda_item_id: @meeting_agenda_item&.id,
+                                                             kind: :work_package,
+                                                             current_occurrence: @current_occurrence),
+                              method: "GET"
+                            } })
+        end
       end
     end
 

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
@@ -19,7 +19,7 @@
         }
       )
       component.with_item(
-        label: t(:label_add_work_package),
+        label: t(:label_existing_work_package),
         tag: :a,
         content_arguments: {
           data: {

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
@@ -1,19 +1,35 @@
 <%=
-  component_wrapper(style: "position: relative") do
-    render(
-      Primer::Beta::Button.new(
-        scheme: :secondary,
-        tag: :button,
-        classes: "hide-when-print",
-        data: {
-          action: "click->meetings--submit#intercept",
-          href: new_meeting_outcome_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id),
-          method: "GET"
+  component_wrapper do
+    render(Primer::Alpha::ActionMenu.new(classes: "hide-when-print")) do |component|
+      component.with_show_button(scheme: :secondary) do |button|
+        button.with_leading_visual_icon(icon: :plus)
+        button.with_trailing_visual_icon(icon: "triangle-down")
+        t(:label_agenda_outcome)
+      end
+      component.with_item(
+        label: t(:label_write_outcome),
+        tag: :a,
+        content_arguments: {
+          data: {
+            "turbo-stream": true,
+            action: "click->meetings--submit#intercept",
+            href: new_meeting_outcome_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id, kind: :information),
+            method: "GET"
+          }
         }
       )
-    ) do |button|
-      button.with_leading_visual_icon(icon: :plus)
-      t(:label_agenda_outcome)
+      component.with_item(
+        label: t(:label_add_work_package),
+        tag: :a,
+        content_arguments: {
+          data: {
+            "turbo-stream": true,
+            action: "click->meetings--submit#intercept",
+            href: new_meeting_outcome_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id, kind: :work_package),
+            method: "GET"
+          }
+        }
+      )
     end
   end
 %>

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.html.erb
@@ -1,0 +1,52 @@
+<%=
+  component_wrapper do
+    primer_form_with(
+      model: @meeting_outcome,
+      method: :post,
+      url: submit_path,
+      namespace: "form_#{wrapper_uniq_by}",
+      data: { action: "submit->meetings--submit#interceptOutcomeFormSubmission" },
+      class: "meeting-agenda-item-outcome-form"
+    ) do |f|
+      flex_layout(tag: :div) do |flex|
+        flex.with_row(mb: 2) do
+          render_inline_form(f) do |form|
+            form.work_package_autocompleter(
+              name: :work_package_id,
+              label: WorkPackage.model_name.human,
+              visually_hide_label: false,
+              autocomplete_options: {
+                id: "op-agenda-item-outcome-wp-autocomplete",
+                openDirectly: true,
+                focusDirectly: true
+              }
+            )
+          end
+        end
+
+        flex.with_row do
+          flex_layout(justify_content: :flex_end) do |row|
+            row.with_column(mr: 2) do
+              render(
+                Primer::Beta::Button.new(
+                  scheme: :secondary,
+                  tag: :a,
+                  href: cancel_path,
+                  data: { "turbo-stream": true }
+                )
+              ) { t("button_cancel") }
+            end
+            row.with_column do
+              render(
+                Primer::Beta::Button.new(
+                  scheme: :primary,
+                  type: :submit
+                )
+              ) { t("button_add") }
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.html.erb
@@ -17,6 +17,9 @@
               visually_hide_label: false,
               autocomplete_options: {
                 id: "op-agenda-item-outcome-wp-autocomplete",
+                data: {
+                  "test-selector": "op-agenda-item-outcome-wp-autocomplete"
+                },
                 openDirectly: true,
                 focusDirectly: true
               }

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
@@ -27,34 +27,39 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-class MeetingOutcome < ApplicationRecord
-  belongs_to :meeting_agenda_item, touch: true
-  belongs_to :work_package, optional: true
-  belongs_to :author, class_name: "User", optional: true
 
-  enum :kind, {
-    information: 0,
-    decision: 1,
-    work_package: 2
-  }.freeze, suffix: true, default: "information"
+module MeetingAgendaItems::Outcomes
+  class WorkPackageFormComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
 
-  validates :meeting_agenda_item, presence: true
-  validates :notes, presence: { if: -> { information_kind? } }
-  validates :work_package, presence: { if: -> { work_package_kind? } }
+    def initialize(meeting:, meeting_agenda_item:, meeting_outcome: nil)
+      super
+      @meeting = meeting
+      @meeting_agenda_item = meeting_agenda_item
+      @meeting_outcome = meeting_outcome || build_meeting_outcome
+      @project_id = @meeting.project.id
+    end
 
-  def editable?
-    meeting_agenda_item.meeting.in_progress?
-  end
+    private
 
-  def linked_work_package?
-    work_package_kind? && work_package.present?
-  end
+    def wrapper_uniq_by
+      @meeting_agenda_item.id
+    end
 
-  def visible_work_package?
-    linked_work_package? && work_package.visible?(User.current)
-  end
+    def build_meeting_outcome
+      MeetingOutcome.new(
+        meeting_agenda_item: @meeting_agenda_item,
+        kind: :work_package
+      )
+    end
 
-  def deleted_work_package?
-    persisted? && work_package_kind? && work_package_id_was.nil?
+    def submit_path
+      meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id, format: :turbo_stream)
+    end
+
+    def cancel_path
+      cancel_new_meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id)
+    end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.html.erb
@@ -1,0 +1,63 @@
+<%=
+  component_wrapper do
+    render(OpPrimer::InsetBoxComponent.new(border: false, classes: "outcome-container")) do
+      grid_layout("op-meeting-outcome-notes", tag: :div, id: "outcome-#{@meeting_outcome.id}") do |grid|
+        grid.with_area(:title, tag: :span, classes: "title") do
+          if multiple_outcomes?
+            render(Primer::Beta::Heading.new(tag: :h5)) { "#{t(:label_agenda_outcome)} #{@index + 1}" }
+          else
+            render(Primer::Beta::Heading.new(tag: :h5)) { t(:label_agenda_outcome) }
+          end
+        end
+
+        grid.with_area(:content, tag: :div) do
+          render(Primer::Box.new(classes: "op-uc-container", mt: 1, pb: 0)) do
+            if @meeting_outcome.visible_work_package?
+              flex_layout(direction: :column, gap: 2) do |flex|
+                flex.with_row do
+                  render(WorkPackages::InfoLineComponent.new(work_package: @meeting_outcome.work_package))
+                end
+                flex.with_row do
+                  render(
+                    Primer::Beta::Link.new(
+                      href: work_package_path(@meeting_outcome.work_package),
+                      font_size: :normal,
+                      font_weight: :bold
+                    )
+                  ) { @meeting_outcome.work_package.subject }
+                end
+              end
+            elsif @meeting_outcome.linked_work_package?
+              render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+                I18n.t(:label_agenda_item_undisclosed_wp, id: @meeting_outcome.work_package_id)
+              end
+            elsif @meeting_outcome.deleted_work_package?
+              render(Primer::Beta::Text.new(tag: :s, font_size: :small, color: :danger)) do
+                I18n.t(:label_agenda_item_deleted_wp)
+              end
+            end
+          end
+        end
+
+        grid.with_area(:actions, tag: :div, justify_self: :end, classes: "hide-when-print") do
+          render(Primer::Alpha::ActionMenu.new) do |menu|
+            menu.with_show_button(
+              icon: "kebab-horizontal",
+              "aria-label": t(:label_agenda_outcome_actions),
+              scheme: :invisible,
+              ml: 2,
+              test_selector: "op-meeting-outcome-actions"
+            )
+            with_item_group(menu) do
+              copy_action_item(menu)
+            end
+
+            with_item_group(menu) do
+              delete_action_item(menu)
+            end
+          end
+        end
+      end
+    end
+  end
+%>

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module MeetingAgendaItems::Outcomes
+  class WorkPackageOutcomeComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :meeting_outcome, :agenda_item, :meeting, :index
+
+    def initialize(meeting_outcome:, index:)
+      super
+
+      @meeting_outcome = meeting_outcome
+      @agenda_item = meeting_outcome.meeting_agenda_item
+      @meeting = @agenda_item.meeting
+      @index = index
+    end
+
+    private
+
+    def wrapper_uniq_by
+      @meeting_outcome.id
+    end
+
+    def multiple_outcomes?
+      agenda_item.outcomes.size > 1
+    end
+
+    def edit_enabled?
+      meeting.in_progress? &&
+        User.current.allowed_in_project?(:manage_outcomes, meeting.project) &&
+        !agenda_item.in_backlog?
+    end
+
+    def in_backlog?
+      agenda_item.meeting_section.backlog?
+    end
+
+    def copy_action_item(menu)
+      return if in_backlog?
+
+      url = meeting_url(meeting, anchor: "outcome-#{meeting_outcome.id}")
+      menu.with_item(label: t("button_copy_link_to_clipboard"),
+                     tag: :"clipboard-copy",
+                     content_arguments: { value: url }) do |item|
+        item.with_leading_visual_icon(icon: :copy)
+      end
+    end
+
+    def delete_action_item(menu)
+      return unless edit_enabled?
+
+      menu.with_item(label: t("label_agenda_outcome_delete"),
+                     tag: :button,
+                     scheme: :danger,
+                     content_arguments: { data: {
+                       action: "click->meetings--submit#intercept",
+                       href: meeting_outcome_path(meeting, meeting_outcome),
+                       method: "DELETE",
+                       confirm_message: t(:text_are_you_sure)
+                     } }) do |item|
+        item.with_leading_visual_icon(icon: :trash)
+      end
+    end
+  end
+end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/wrapper_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/wrapper_component.html.erb
@@ -3,7 +3,11 @@
     flex_layout(pt: 2, classes: "gap-2") do |flex|
       outcomes.each.with_index do |outcome, i|
         flex.with_row do
-          render(MeetingAgendaItems::Outcomes::OutcomeComponent.new(meeting_outcome: outcome, index: i))
+          if outcome.work_package_kind?
+            render(MeetingAgendaItems::Outcomes::WorkPackageOutcomeComponent.new(meeting_outcome: outcome, index: i))
+          else
+            render(MeetingAgendaItems::Outcomes::OutcomeComponent.new(meeting_outcome: outcome, index: i))
+          end
         end
       end
 

--- a/modules/meeting/app/contracts/meeting_outcomes/base_contract.rb
+++ b/modules/meeting/app/contracts/meeting_outcomes/base_contract.rb
@@ -41,5 +41,17 @@ module MeetingOutcomes
 
     attribute :notes
     attribute :kind
+
+    validate :validate_work_package_visible
+
+    private
+
+    def validate_work_package_visible
+      return if model.work_package_id.blank?
+
+      unless WorkPackage.visible(user).exists?(id: model.work_package_id)
+        errors.add :work_package, :error_not_found
+      end
+    end
   end
 end

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -88,7 +88,7 @@ class MeetingOutcomesController < ApplicationController
     if call.success?
       update_outcomes_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item)
     else
-      render_base_error_in_flash_message_via_turbo_stream(call.errors)
+      render_error_flash_message_via_turbo_stream(message: call.errors.full_messages.join("\n"))
     end
 
     update_meeting_metadata_via_turbo_stream
@@ -114,7 +114,7 @@ class MeetingOutcomesController < ApplicationController
     if call.success?
       update_outcomes_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item)
     else
-      render_base_error_in_flash_message_via_turbo_stream(call.errors)
+      render_error_flash_message_via_turbo_stream(message: call.errors.full_messages.join("\n"))
     end
 
     update_meeting_metadata_via_turbo_stream
@@ -132,7 +132,7 @@ class MeetingOutcomesController < ApplicationController
       update_outcomes_via_turbo_stream(meeting_agenda_item: @meeting_agenda_item)
       update_header_component_via_turbo_stream
     else
-      render_base_error_in_flash_message_via_turbo_stream(call.errors)
+      render_error_flash_message_via_turbo_stream(message: call.errors.full_messages.join("\n"))
     end
 
     update_meeting_metadata_via_turbo_stream

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -42,27 +42,13 @@ class MeetingOutcomesController < ApplicationController
     update_meeting_metadata_via_turbo_stream
 
     if @meeting.in_progress? && !@meeting_agenda_item.in_backlog?
-      @kind = params[:kind]&.to_sym || :information
-
-      component = if @kind == :work_package
-                    MeetingAgendaItems::Outcomes::WorkPackageFormComponent.new(
-                      meeting: @meeting,
-                      meeting_agenda_item: @meeting_agenda_item,
-                      meeting_outcome: @meeting_agenda_item.outcomes.new
-                    )
-                  else
-                    MeetingAgendaItems::Outcomes::InputComponent.new(
-                      meeting: @meeting,
-                      meeting_agenda_item: @meeting_agenda_item,
-                      meeting_outcome: @meeting_agenda_item.outcomes.new
-                    )
-                  end
+      kind = params[:kind].to_sym
+      component = build_outcome_form_component(kind)
 
       replace_via_turbo_stream(
         component:,
         target: MeetingAgendaItems::Outcomes::NewButtonComponent.component_id(@meeting_agenda_item)
       )
-
     else
       render_error_flash_message_via_turbo_stream(message: t("text_outcome_cannot_be_added"))
     end
@@ -93,23 +79,9 @@ class MeetingOutcomesController < ApplicationController
   end
 
   def create
-    call = if params[:meeting_outcome][:work_package_id].present?
-             ::MeetingOutcomes::CreateService
-               .new(user: current_user)
-               .call(
-                 meeting_agenda_item: @meeting_agenda_item,
-                 work_package_id: params[:meeting_outcome][:work_package_id],
-                 kind: :work_package
-               )
-           else
-             ::MeetingOutcomes::CreateService
-               .new(user: current_user)
-               .call(
-                 meeting_agenda_item: @meeting_agenda_item,
-                 notes: params[:meeting_outcome][:notes],
-                 kind: :information
-               )
-           end
+    call = ::MeetingOutcomes::CreateService
+             .new(user: current_user)
+             .call(create_outcome_params)
 
     @meeting_outcome = call.result
 
@@ -120,7 +92,6 @@ class MeetingOutcomesController < ApplicationController
     end
 
     update_meeting_metadata_via_turbo_stream
-
     respond_with_turbo_streams
   end
 
@@ -182,5 +153,31 @@ class MeetingOutcomesController < ApplicationController
 
   def set_meeting_outcome
     @meeting_outcome = MeetingOutcome.find(params[:id])
+  end
+
+  def build_outcome_form_component(kind)
+    component_class = kind == :work_package ? MeetingAgendaItems::Outcomes::WorkPackageFormComponent : MeetingAgendaItems::Outcomes::InputComponent
+
+    component_class.new(
+      meeting: @meeting,
+      meeting_agenda_item: @meeting_agenda_item,
+      meeting_outcome: @meeting_agenda_item.outcomes.new
+    )
+  end
+
+  def create_outcome_params
+    if params[:meeting_outcome][:work_package_id].present?
+      {
+        meeting_agenda_item: @meeting_agenda_item,
+        work_package_id: params[:meeting_outcome][:work_package_id],
+        kind: :work_package
+      }
+    else
+      {
+        meeting_agenda_item: @meeting_agenda_item,
+        notes: params[:meeting_outcome][:notes],
+        kind: :information
+      }
+    end
   end
 end

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -42,9 +42,24 @@ class MeetingOutcomesController < ApplicationController
     update_meeting_metadata_via_turbo_stream
 
     if @meeting.in_progress? && !@meeting_agenda_item.in_backlog?
+      @kind = params[:kind]&.to_sym || :information
+
+      component = if @kind == :work_package
+                    MeetingAgendaItems::Outcomes::WorkPackageFormComponent.new(
+                      meeting: @meeting,
+                      meeting_agenda_item: @meeting_agenda_item,
+                      meeting_outcome: @meeting_agenda_item.outcomes.new
+                    )
+                  else
+                    MeetingAgendaItems::Outcomes::InputComponent.new(
+                      meeting: @meeting,
+                      meeting_agenda_item: @meeting_agenda_item,
+                      meeting_outcome: @meeting_agenda_item.outcomes.new
+                    )
+                  end
+
       replace_via_turbo_stream(
-        component: MeetingAgendaItems::Outcomes::InputComponent.new(meeting: @meeting, meeting_agenda_item: @meeting_agenda_item,
-                                                                    meeting_outcome: @meeting_agenda_item.outcomes.new),
+        component:,
         target: MeetingAgendaItems::Outcomes::NewButtonComponent.component_id(@meeting_agenda_item)
       )
 
@@ -78,12 +93,23 @@ class MeetingOutcomesController < ApplicationController
   end
 
   def create
-    call = ::MeetingOutcomes::CreateService
-             .new(user: current_user)
-             .call(
-               meeting_agenda_item: @meeting_agenda_item,
-               notes: params[:meeting_outcome][:notes]
-             )
+    call = if params[:meeting_outcome][:work_package_id].present?
+             ::MeetingOutcomes::CreateService
+               .new(user: current_user)
+               .call(
+                 meeting_agenda_item: @meeting_agenda_item,
+                 work_package_id: params[:meeting_outcome][:work_package_id],
+                 kind: :work_package
+               )
+           else
+             ::MeetingOutcomes::CreateService
+               .new(user: current_user)
+               .call(
+                 meeting_agenda_item: @meeting_agenda_item,
+                 notes: params[:meeting_outcome][:notes],
+                 kind: :information
+               )
+           end
 
     @meeting_outcome = call.result
 

--- a/modules/meeting/app/services/meeting_outcomes/set_attributes_service.rb
+++ b/modules/meeting/app/services/meeting_outcomes/set_attributes_service.rb
@@ -30,9 +30,27 @@
 
 module MeetingOutcomes
   class SetAttributesService < ::BaseServices::SetAttributes
+    def set_attributes(params)
+      super
+
+      set_work_package_and_kind(params)
+    end
+
     def set_default_attributes(_params)
       model.change_by_system do
         model.author = user
+      end
+    end
+
+    private
+
+    def set_work_package_and_kind(params)
+      if params[:work_package_id].present?
+        model.work_package_id = params[:work_package_id]
+        model.kind = params[:kind]
+      elsif params[:notes].present?
+        model.notes = params[:notes]
+        model.kind = params[:kind]
       end
     end
   end

--- a/modules/meeting/app/services/meeting_outcomes/set_attributes_service.rb
+++ b/modules/meeting/app/services/meeting_outcomes/set_attributes_service.rb
@@ -44,13 +44,13 @@ module MeetingOutcomes
 
     private
 
-    def set_work_package_and_kind(params)
+    def set_work_package_and_kind(params) # rubocop:disable Metrics/AbcSize
       if params[:work_package_id].present?
         model.work_package_id = params[:work_package_id]
         model.kind = params[:kind]
       elsif params[:notes].present?
         model.notes = params[:notes]
-        model.kind = params[:kind]
+        model.kind = params[:kind] if model.new_record?
       end
     end
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -595,6 +595,8 @@ en:
   label_agenda_outcome_actions: "Agenda outcome actions"
   label_agenda_outcome_edit: "Edit outcome"
   label_agenda_outcome_delete: "Remove outcome"
+  label_write_outcome: "Write outcome"
+  label_add_work_package: "Add work package"
   text_outcome_not_editable_anymore: "This outcome is not editable anymore."
   text_outcome_cannot_be_added: "An outcome can no longer be added."
 

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -596,7 +596,7 @@ en:
   label_agenda_outcome_edit: "Edit outcome"
   label_agenda_outcome_delete: "Remove outcome"
   label_write_outcome: "Write outcome"
-  label_add_work_package: "Add work package"
+  label_existing_work_package: "Existing work package"
   text_outcome_not_editable_anymore: "This outcome is not editable anymore."
   text_outcome_cannot_be_added: "An outcome can no longer be added."
 

--- a/modules/meeting/spec/contracts/meeting_outcomes/create_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_outcomes/create_contract_spec.rb
@@ -85,6 +85,40 @@ RSpec.describe MeetingOutcomes::CreateContract do
 
       it_behaves_like "contract is invalid", base: I18n.t(:text_outcome_not_editable_anymore)
     end
+
+    context "when work_package_id is set" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_meetings manage_outcomes view_work_packages] })
+      end
+      let(:other_project) { create(:project) }
+      let(:work_package) { create(:work_package, project:) }
+      let(:other_work_package) { create(:work_package, project: other_project) }
+      let(:outcome) { build(:meeting_outcome, meeting_agenda_item:, work_package:, kind: :work_package) }
+
+      before do
+        meeting.update_column(:state, :in_progress)
+      end
+
+      context "when user can view the work package" do
+        it_behaves_like "contract is valid"
+      end
+
+      context "when user cannot view the work package" do
+        let(:outcome) { build(:meeting_outcome, meeting_agenda_item:, work_package: other_work_package, kind: :work_package) }
+
+        it_behaves_like "contract is invalid", work_package: :error_not_found
+      end
+
+      context "when the referenced work package doesn't exist" do
+        let(:outcome) { build(:meeting_outcome, meeting_agenda_item:, work_package: nil, kind: :work_package) }
+
+        before do
+          outcome.work_package_id = 999999
+        end
+
+        it_behaves_like "contract is invalid", work_package: %i[blank error_not_found]
+      end
+    end
   end
 
   context "without permission" do

--- a/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
+++ b/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require_relative "../support/pages/meetings/show"
+
+RSpec.describe "Meeting outcomes work package linking", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings work_package_tracking]) }
+  shared_let(:user) do
+    create :user,
+           lastname: "First",
+           preferences: { time_zone: "Etc/UTC" },
+           member_with_permissions: { project => %i[view_meetings manage_agendas manage_outcomes view_work_packages] }
+  end
+  shared_let(:meeting) do
+    create :meeting,
+           project:,
+           start_time: "2024-12-31T13:30:00Z",
+           duration: 1.5,
+           author: user
+  end
+  shared_let(:meeting_agenda_item) { create(:meeting_agenda_item, meeting:) }
+  shared_let(:work_package1) do
+    create(:work_package,
+           project:,
+           subject: "Important task")
+  end
+  shared_let(:work_package2) do
+    create(:work_package,
+           project:,
+           subject: "Another task")
+  end
+
+  let(:current_user) { user }
+  let(:state) { :in_progress }
+  let(:show_page) { Pages::Meetings::Show.new(meeting) }
+
+  before do
+    meeting.update!(state:)
+    login_as current_user
+  end
+
+  context "when a user has the necessary permissions" do
+    context "when the meeting is 'in progress'" do
+      it "shows a dropdown with two outcome options" do
+        show_page.visit!
+
+        within("#meeting-agenda-items-outcomes-new-button-component-#{meeting_agenda_item.id}") do
+          click_on "Outcome"
+
+          expect(page).to have_text("Write outcome")
+          expect(page).to have_text("Existing work package")
+        end
+      end
+
+      it "can link an existing work package as an outcome" do
+        show_page.visit!
+
+        item = MeetingAgendaItem.find(meeting_agenda_item.id)
+
+        within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+          click_on "Outcome"
+        end
+        page.find("a", text: "Existing work package", wait: 3).click
+
+        expect(page).to have_css("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}")
+        select_autocomplete(find_test_selector("op-agenda-item-outcome-wp-autocomplete"),
+                            query: "Important",
+                            results_selector: "body")
+        within("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}") do
+          click_on "Add"
+        end
+
+        show_page.in_outcome_component(item) do
+          expect(page).to have_text(work_package1.type.name)
+          expect(page).to have_text("##{work_package1.id}")
+          expect(page).to have_text(work_package1.status.name)
+          expect(page).to have_link(work_package1.subject)
+        end
+      end
+
+      it "can delete a work package outcome" do
+        outcome = create(:meeting_outcome,
+                         meeting_agenda_item:,
+                         work_package: work_package1,
+                         kind: :work_package)
+
+        show_page.visit!
+
+        item = MeetingAgendaItem.find(meeting_agenda_item.id)
+
+        show_page.in_outcome_component(item) do
+          expect(page).to have_text(work_package1.subject)
+          show_page.select_outcome_action "Remove outcome"
+        end
+
+        expect(page).to have_no_text(work_package1.subject)
+        expect { outcome.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "can create both text and work package outcomes for the same agenda item" do
+        show_page.visit!
+
+        item = MeetingAgendaItem.find(meeting_agenda_item.id)
+
+        within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+          click_on "Outcome"
+        end
+        page.find("a", text: "Write outcome", wait: 3).click
+
+        field = TextEditorField.new(page, "Outcome", selector: test_selector("meeting-outcome-input-for-#{item.id}"))
+        field.expect_active!
+        field.set_value "This is a text outcome"
+        click_on "Save"
+
+        show_page.in_outcome_component(item) do
+          show_page.expect_outcome "This is a text outcome"
+        end
+
+        within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+          click_on "Outcome"
+        end
+        page.find("a", text: "Existing work package", wait: 3).click
+
+        select_autocomplete(find_test_selector("op-agenda-item-outcome-wp-autocomplete"),
+                            query: "Another",
+                            results_selector: "body")
+
+        within("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}") do
+          click_on "Add"
+        end
+
+        show_page.in_outcome_component(item) do
+          show_page.expect_outcome "This is a text outcome"
+          expect(page).to have_link(work_package2.subject)
+
+          expect(page).to have_text("Outcome 1")
+          expect(page).to have_text("Outcome 2")
+        end
+      end
+
+      it "can cancel adding a work package outcome" do
+        show_page.visit!
+
+        item = MeetingAgendaItem.find(meeting_agenda_item.id)
+
+        within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+          click_on "Outcome"
+        end
+        page.find("a", text: "Existing work package", wait: 3).click
+
+        expect(page).to have_css("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}")
+
+        # Close the autocompleter dropdown that opens automatically
+        page.find("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id} .ng-input input").send_keys(:escape)
+
+        within("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}") do
+          click_on "Cancel"
+        end
+
+        # Form should be hidden, button should be back
+        expect(page).to have_no_css("#meeting-agenda-items-outcomes-work-package-form-component-#{item.id}")
+        expect(page).to have_css("#meeting-agenda-items-outcomes-new-button-component-#{item.id}")
+      end
+    end
+  end
+
+  context "when the work package is from another project" do
+    let!(:other_project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
+    let!(:other_wp) { create(:work_package, project: other_project, author: user, subject: "Private work package") }
+    let!(:role) { create(:project_role, permissions: %w[view_work_packages]) }
+    let!(:membership) { create(:member, principal: user, project: other_project, roles: [role]) }
+    let!(:other_user) do
+      create(:user,
+             lastname: "Other",
+             member_with_permissions: { project => %i[view_meetings] })
+    end
+    let!(:outcome) do
+      create(:meeting_outcome,
+             meeting_agenda_item:,
+             work_package: other_wp,
+             kind: :work_package)
+    end
+
+    it "shows undisclosed message for users without access" do
+      show_page.visit!
+
+      show_page.in_outcome_component(meeting_agenda_item) do
+        expect(page).to have_text("Private work package")
+      end
+
+      login_as(other_user)
+
+      show_page.visit!
+
+      show_page.in_outcome_component(meeting_agenda_item) do
+        expect(page).to have_no_text("Private work package")
+        expect(page).to have_text(I18n.t(:label_agenda_item_undisclosed_wp, id: other_wp.id))
+      end
+    end
+  end
+
+  context "when the linked work package is deleted" do
+    let!(:work_package_to_delete) { create(:work_package, project:, subject: "To be deleted") }
+    let!(:outcome) do
+      create(:meeting_outcome,
+             meeting_agenda_item:,
+             work_package: work_package_to_delete,
+             kind: :work_package)
+    end
+
+    it "shows deleted work package message after deletion" do
+      show_page.visit!
+
+      show_page.in_outcome_component(meeting_agenda_item) do
+        expect(page).to have_text("To be deleted")
+      end
+
+      work_package_to_delete.destroy!
+      show_page.visit!
+
+      show_page.in_outcome_component(meeting_agenda_item) do
+        expect(page).to have_no_text("To be deleted")
+        expect(page).to have_text(I18n.t(:label_agenda_item_deleted_wp))
+      end
+    end
+  end
+
+  context "when the meeting is not in progress" do
+    let(:state) { :open }
+    let(:outcome) do
+      create(:meeting_outcome,
+             meeting_agenda_item:,
+             work_package: work_package1,
+             kind: :work_package)
+    end
+
+    before do
+      outcome
+      show_page.visit!
+    end
+
+    it "can view work package outcomes but not add or edit them" do
+      show_page.in_outcome_component(meeting_agenda_item) do
+        expect(page).to have_text(work_package1.subject)
+      end
+
+      show_page.expect_no_outcome_button
+
+      show_page.expect_no_outcome_actions
+    end
+  end
+end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -235,6 +235,8 @@ module Pages::Meetings
       open_menu(item) do
         if action.downcase.include?("move")
           click_on "Move"
+        elsif action.downcase.include?("outcome")
+          click_on "Add outcome"
         end
         click_on action
       end
@@ -325,15 +327,21 @@ module Pages::Meetings
     end
 
     def add_outcome(item, &)
-      page.within("#meeting-agenda-items-outcomes-wrapper-component-#{item.id}") do
-        click_link_or_button "Outcome"
+      page.within("#meeting-agenda-items-outcomes-new-button-component-#{item.id}") do
+        click_on "Outcome"
       end
+      expect(page).to have_text("Write outcome", wait: 2)
+      page.find("a", text: "Write outcome").click
       expect_outcome_form(item)
       page.within("#meeting-agenda-items-outcomes-input-component-#{item.id}", &)
     end
 
     def add_outcome_from_menu(item, &)
-      select_action item, "Add outcome"
+      open_menu(item) do
+        click_on "Add outcome"
+        expect(page).to have_text("Write outcome", wait: 2)
+        click_on "Write outcome"
+      end
       expect_outcome_form(item)
       page.within("#meeting-agenda-items-outcomes-input-component-#{item.id}", &)
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67224

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
- Allow linking an existing work package as an outcome

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
- Create new outcome and outcome form components to deal with outcomes of kind `work_package`
- Reorganize the '+ Outcome' button and agenda item menu options to allow creating outcomes of both types

# Merge checklist

- [x] Added/updated tests
