### PR TITLE
Bump hocuspocus release to include arm64/v8 build platforms

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -113,7 +113,7 @@ ENV PGDATA=/var/openproject/pgdata
 COPY --from=openproject/gosu /go/bin/gosu /usr/local/bin/gosu
 RUN chmod +x /usr/local/bin/gosu && gosu nobody true
 
-COPY --from=openproject/hocuspocus:release-ccd9c565 --chown=$APP_USER:$APP_USER /app /opt/hocuspocus
+COPY --from=openproject/hocuspocus:release-38128805 --chown=$APP_USER:$APP_USER /app /opt/hocuspocus
 
 RUN ./docker/prod/setup/postinstall-onprem.sh && \
   ln -s /app/docker/prod/setup/.irbrc /root/


### PR DESCRIPTION
https://community.openproject.org/wp/705107

See: https://github.com/opf/op-blocknote-hocuspocus/pull/31


* https://hub.docker.com/r/openproject/hocuspocus/tags
* https://github.com/opf/op-blocknote-hocuspocus/actions/runs/20990839489/job/60335705962

<img width="570" height="467" alt="Screenshot 2026-01-14 at 1 42 38 PM" src="https://github.com/user-attachments/assets/15efae02-0fcf-4db0-9b91-25888c89d34c" />
