### PR TITLE
[#67536] BlockNote: sort OpenProject work packages by ID

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^20.1.1",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.20/op-blocknote-extensions-0.0.20.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.21/op-blocknote-extensions-0.0.21.tgz",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
         "react": "^19.2.0",
@@ -18327,9 +18327,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.20",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.20/op-blocknote-extensions-0.0.20.tgz",
-      "integrity": "sha512-0x2hv5N6cUaYwTJWN29vtMU/DIyUrCalenqR+dE4S58ohQwWXQ3zJMnAHQmkeluCw/PdmtjxiNMbajGJxXVoyg==",
+      "version": "0.0.21",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.21/op-blocknote-extensions-0.0.21.tgz",
+      "integrity": "sha512-Jrkc+JF6IHfaG2e+uOfkqc07HcyH94PhYaf4dff68drWQ19+A9UPeocURbMjuBo+xd7/czHqVpNKiKdTm0mbsA==",
       "dependencies": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",
@@ -36083,8 +36083,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.20/op-blocknote-extensions-0.0.20.tgz",
-      "integrity": "sha512-0x2hv5N6cUaYwTJWN29vtMU/DIyUrCalenqR+dE4S58ohQwWXQ3zJMnAHQmkeluCw/PdmtjxiNMbajGJxXVoyg==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.21/op-blocknote-extensions-0.0.21.tgz",
+      "integrity": "sha512-Jrkc+JF6IHfaG2e+uOfkqc07HcyH94PhYaf4dff68drWQ19+A9UPeocURbMjuBo+xd7/czHqVpNKiKdTm0mbsA==",
       "requires": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^20.1.1",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.20/op-blocknote-extensions-0.0.20.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.21/op-blocknote-extensions-0.0.21.tgz",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",
     "react": "^19.2.0",


### PR DESCRIPTION
https://community.openproject.org/work_packages/67536

The actual fix is done in version 0.0.21 of op-blocknote-extensions, so this just updates to the fixed version.

This should go into 17.0.1