### PR TITLE
[#65634] Phase definitions: increase header container height

### DIFF
--- a/app/components/settings/project_phase_definitions/index_component.html.erb
+++ b/app/components/settings/project_phase_definitions/index_component.html.erb
@@ -73,9 +73,9 @@ See COPYRIGHT and LICENSE files for more details.
 
       flex.with_row do
         render(border_box_container(mb: 3, data: drop_target_config)) do |component|
-          component.with_header(font_weight: :bold, py: 2) do
+          component.with_header(font_weight: :bold) do
             flex_layout(justify_content: :space_between, align_items: :center) do |header_container|
-              header_container.with_column(py: 2) do
+              header_container.with_column do
                 render(Primer::Beta::Text.new(font_weight: :bold)) do
                   I18n.t("settings.project_phase_definitions.section_header")
                 end

--- a/app/components/settings/project_phase_definitions/index_component.html.erb
+++ b/app/components/settings/project_phase_definitions/index_component.html.erb
@@ -31,10 +31,12 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper do
     flex_layout(data: wrapper_data_attributes) do |flex|
       flex.with_row do
-        render EnterpriseEdition::BannerComponent.new(:customize_life_cycle,
-                                                      variant: :medium,
-                                                      image: "enterprise/project-lifecycle.png",
-                                                      mb: 3)
+        render EnterpriseEdition::BannerComponent.new(
+          :customize_life_cycle,
+          variant: :medium,
+          image: "enterprise/project-lifecycle.png",
+          mb: 3
+        )
       end
 
       if allowed_to_customize_life_cycle?
@@ -56,11 +58,13 @@ See COPYRIGHT and LICENSE files for more details.
               }
             )
 
-            subheader.with_action_button(scheme: :primary,
-                                         leading_icon: :plus,
-                                         label: I18n.t("settings.project_phase_definitions.label_add_description"),
-                                         tag: :a,
-                                         href: new_admin_settings_project_phase_definition_path) do
+            subheader.with_action_button(
+              scheme: :primary,
+              leading_icon: :plus,
+              label: I18n.t("settings.project_phase_definitions.label_add_description"),
+              tag: :a,
+              href: new_admin_settings_project_phase_definition_path
+            ) do
               I18n.t("settings.project_phase_definitions.label_add")
             end
           end
@@ -71,7 +75,7 @@ See COPYRIGHT and LICENSE files for more details.
         render(border_box_container(mb: 3, data: drop_target_config)) do |component|
           component.with_header(font_weight: :bold, py: 2) do
             flex_layout(justify_content: :space_between, align_items: :center) do |header_container|
-              header_container.with_column do
+              header_container.with_column(py: 2) do
                 render(Primer::Beta::Text.new(font_weight: :bold)) do
                   I18n.t("settings.project_phase_definitions.section_header")
                 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/65634

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Adjust the header row height so that it matches the height we use in other places. This header row is still a bit smaller than the project attributes one – but this is due to the fact that the project attributes header also includes additional components (a drag field for drag and drop and a list selector) that add to the height.

Had to perform some unrelated formatting to satisfy the linter.

## Screenshots

Before:
<img width="564" height="620" alt="image" src="https://github.com/user-attachments/assets/7156541e-a6b3-46fb-87e1-9438dfa3f6d4" />


After:
<img width="564" height="620" alt="image" src="https://github.com/user-attachments/assets/b54b8223-4ba4-497e-a319-e4e02ed34915" />


