### PR TITLE
correctly handle multi value cases on journal changes comparison

### DIFF
--- a/app/services/journals/create_service/customizable.rb
+++ b/app/services/journals/create_service/customizable.rb
@@ -68,24 +68,36 @@ class Journals::CreateService
     def changes_sql
       sanitize(<<~SQL.squish, journable_id:, customized_type: journable_class_name)
         SELECT
-          max_journals.journable_id
+          :journable_id AS JOURNABLE_ID
         FROM
-          max_journals
-        LEFT OUTER JOIN
-          customizable_journals
-        ON
-          customizable_journals.journal_id = max_journals.id
+          (
+            SELECT
+               custom_field_id,
+               ARRAY_AGG(#{normalize_newlines_sql('custom_values.value')} ORDER BY value) AS value
+            FROM
+             custom_values
+            WHERE
+              custom_values.customized_id = :journable_id
+              AND custom_values.customized_type = :customized_type
+              AND custom_values.value != ''
+            GROUP BY
+              custom_field_id
+          ) current_values
         FULL JOIN
-          (SELECT *
-           FROM custom_values
-           WHERE custom_values.customized_id = :journable_id AND custom_values.customized_type = :customized_type) custom_values
-        ON
-          custom_values.custom_field_id = customizable_journals.custom_field_id
+          (
+            SELECT
+              custom_field_id,
+              ARRAY_AGG(#{normalize_newlines_sql('customizable_journals.value')} ORDER BY value) AS value
+            FROM
+              customizable_journals
+            WHERE
+              journal_id IN (SELECT id FROM max_journals)
+            GROUP BY
+              custom_field_id
+          ) journal_values
+        ON current_values.custom_field_id = journal_values.custom_field_id
         WHERE
-          (custom_values.value IS NULL AND customizable_journals.value IS NOT NULL)
-          OR (customizable_journals.value IS NULL AND custom_values.value IS NOT NULL AND custom_values.value != '')
-          OR (#{normalize_newlines_sql('customizable_journals.value')} !=
-              #{normalize_newlines_sql('custom_values.value')})
+          current_values.value IS DISTINCT FROM journal_values.value
       SQL
     end
   end

--- a/spec/factories/work_package_factory.rb
+++ b/spec/factories/work_package_factory.rb
@@ -118,9 +118,13 @@ FactoryBot.define do
                               .symbolize_keys
                               .merge(attributes)
 
+          # Does not yet support overwriting the custom values via the provided attributes.
+          work_package_cv_attributes = work_package.custom_values.map { it.attributes.slice("custom_field_id", "value") }
+
           create(:work_package_journal,
                  **journal_attributes,
-                 data: build(:journal_work_package_journal, data_attributes))
+                 data: build(:journal_work_package_journal, data_attributes),
+                 customizable_journals: work_package_cv_attributes.map { build(:journal_customizable_journal, it) })
         end
 
         work_package.journals.reload

--- a/spec/models/work_package/work_package_acts_as_journalized_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_journalized_spec.rb
@@ -444,123 +444,134 @@ RSpec.describe WorkPackage do
       end
     end
 
-    context "on custom value changes", with_settings: { journal_aggregation_time_minutes: 0 } do
-      let(:custom_field) { create(:work_package_custom_field) }
-      let(:custom_value) do
-        build(:custom_value,
-              value: "false",
-              custom_field:)
-      end
-
-      let(:custom_field_id) { "custom_fields_#{custom_value.custom_field_id}" }
-
-      shared_let(:journable) do
-        create(:work_package)
-      end
-
-      shared_context "for work package with custom value" do
-        before do
+    context "on custom value changes" do
+      # The explicit id is needed so that the accessors ('custom_field_1') can be used
+      shared_let(:custom_field) do
+        create(:boolean_wp_custom_field, id: 1) do |custom_field|
           project.work_package_custom_fields << custom_field
           type.custom_fields << custom_field
-          journable.reload
-          journable.custom_values << custom_value
-          journable.save!
         end
       end
 
-      context "for new custom value" do
-        include_context "for work package with custom value"
+      context "when setting a custom value" do
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 journals: {
+                   1.day.ago => { user: }
+                 })
+        end
 
-        subject { journable.last_journal.details }
-
-        it { is_expected.to have_key custom_field_id }
-
-        it { expect(subject[custom_field_id]).to eq([nil, custom_value.value]) }
+        include_examples "journaled values for",
+                         new_values_set: {
+                           "custom_field_1" => true
+                         },
+                         expected_values: {
+                           "custom_fields_1" => [nil, "t"]
+                         },
+                         expect_new_journal: true
       end
 
-      context "for custom value modified" do
-        include_context "for work package with custom value"
-
-        let(:modified_custom_value) do
-          create(:work_package_custom_value,
-                 value: "true",
-                 custom_field:)
+      context "when modifying a custom value" do
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 custom_field_1: false,
+                 journals: {
+                   1.day.ago => { user: }
+                 })
         end
 
-        before do
-          journable.custom_values = [modified_custom_value]
-          journable.save!
-        end
-
-        subject { journable.last_journal.details }
-
-        it { is_expected.to have_key custom_field_id }
-
-        it { expect(subject[custom_field_id]).to eq([custom_value.value.to_s, modified_custom_value.value.to_s]) }
+        include_examples "journaled values for",
+                         new_values_set: {
+                           "custom_field_1" => true
+                         },
+                         expected_values: {
+                           "custom_fields_1" => %w[f t]
+                         },
+                         expect_new_journal: true
       end
 
-      context "when work package saved w/o change" do
-        include_context "for work package with custom value"
-
-        let(:unmodified_custom_value) do
-          create(:work_package_custom_value,
-                 value: "false",
-                 custom_field:)
+      context "when a custom value is removed" do
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 custom_field_1: false,
+                 journals: {
+                   1.day.ago => { user: }
+                 })
         end
 
-        before do
-          journable.custom_values = [unmodified_custom_value]
-        end
-
-        it { expect { journable.save! }.not_to change(Journal, :count) }
-
-        it "does not set an upper bound to the already existing journal" do
-          journable.save!
-          expect(journable.last_journal.validity_period.end)
-            .to be_nil
-        end
+        include_examples "journaled values for",
+                         new_values_set: {
+                           "custom_field_1" => nil
+                         },
+                         expected_values: {
+                           "custom_fields_1" => ["f", nil]
+                         },
+                         expect_new_journal: true
       end
 
-      context "when custom value removed" do
-        include_context "for work package with custom value"
-
-        before do
-          journable.custom_values.delete(custom_value)
-          journable.save!
+      context "when nothing changed" do
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 custom_field_1: false,
+                 journals: {
+                   5.days.ago => { user: }
+                 })
         end
 
-        subject { journable.last_journal.details }
-
-        it { is_expected.to have_key custom_field_id }
-
-        it { expect(subject[custom_field_id]).to eq([custom_value.value, nil]) }
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
       end
 
-      context "when custom value did not exist before" do
-        let(:custom_field) do
-          create(:work_package_custom_field,
-                 is_required: false,
-                 field_format: "list",
-                 possible_values: ["", "1", "2", "3", "4", "5", "6", "7"])
-        end
-        let(:custom_value) do
-          create(:custom_value,
-                 value: "",
-                 customized: journable,
-                 custom_field:)
-        end
-
-        describe "empty values are recognized as unchanged" do
-          include_context "for work package with custom value"
-
-          it { expect(journable.last_journal.customizable_journals).to be_empty }
+      context "when nothing changed and a custom field is added after work package creation" do
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 journals: {
+                   5.days.ago => { user: }
+                 }) do
+            create(:boolean_wp_custom_field, id: 2) do |cf|
+              project.work_package_custom_fields << cf
+              type.custom_fields << cf
+            end
+          end
         end
 
-        describe "empty values handled as non existing" do
-          include_context "for work package with custom value"
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
+      end
 
-          it { expect(journable.last_journal.customizable_journals.count).to eq(0) }
+      context "when nothing changed and the work package has multiple values for the same custom field" do
+        shared_let(:list_cf) do
+          create(:list_wp_custom_field, id: 2, possible_values: %w[A B C D]) do |cf|
+            project.work_package_custom_fields << cf
+            type.custom_fields << cf
+          end
         end
+
+        shared_let(:journable) do
+          create(:work_package,
+                 project:,
+                 type:,
+                 custom_field_1: true,
+                 custom_field_2: [list_cf.custom_options.find_by(value: "A"),
+                                  list_cf.custom_options.find_by(value: "D")],
+                 journals: {
+                   5.days.ago => { user: },
+                   4.days.ago => { user:, notes: "First comment" }
+                 })
+        end
+
+        include_examples "no journaled value changes for",
+                         new_values_set: {}
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/59360

# What is changed?

if a journable has a multi select custom field and has more than two values selected for it, the SQL used to compare the current state with the journaled state falsely identified the custom field values as having changed even if there were no changes.

The reason for this was that the SQL compared each value of the custom field individually against all the other values. If there are more than one value, it would always find a value it was unequal to. 

By aggregating all the values of a custom field in a deterministic order the comparison is now handled with all the values of a custom field as a set. 

# Merge checklist

- [x] Added/updated tests