### PR TITLE
Fix wrong helptext

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4709,7 +4709,7 @@ en:
         <strong>Note:</strong> Unless you also disable password logins, with this option enabled,
         users can still log in internally by visiting the <code>%{internal_path}</code> login page.
       remapping_existing_users_hint: >
-        If enabled, allows any configured identity provider to login existing users based on their email address,
+        If enabled, allows any configured identity provider to login existing users based on their username,
         even if the user never signed in through that provider before. This can be useful when migrating the OpenProject instance
         to a new SSO provider, but is not recommended when using a provider that is not trusted by all users of your instance.
     attachments:


### PR DESCRIPTION
The helptext indicated that the email address was relevant for matching users. However, in fact it's the username that is relevant for this.

# Ticket
https://community.openproject.org/wp/70389