### PR TITLE
bug/70362 Revoke session-bound OAuth tokens on user logout

### DIFF
--- a/app/services/oauth/revoke_session_tokens_service.rb
+++ b/app/services/oauth/revoke_session_tokens_service.rb
@@ -29,22 +29,14 @@
 #++
 
 module OAuth
-  class RevokeSessionTokensService < BaseServices::BaseCallable
-    def initialize(user:)
-      super()
-      @user = user
-    end
-
-    def perform
+  class RevokeSessionTokensService
+    def self.call(user)
       application_uids = SessionBoundApplicationRegistry.registered_uids
-      return ServiceResult.success if application_uids.empty?
 
       applications = Doorkeeper::Application.where(uid: application_uids)
       applications.each do |app|
-        Doorkeeper::Application.revoke_tokens_and_grants_for(app.id, @user)
+        Doorkeeper::Application.revoke_tokens_and_grants_for(app.id, user)
       end
-
-      ServiceResult.success
     end
   end
 end

--- a/app/services/oauth/revoke_session_tokens_service.rb
+++ b/app/services/oauth/revoke_session_tokens_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OAuth
+  class RevokeSessionTokensService < BaseServices::BaseCallable
+    def initialize(user:)
+      super()
+      @user = user
+    end
+
+    def perform
+      application_uids = SessionBoundApplicationRegistry.registered_uids
+      return ServiceResult.success if application_uids.empty?
+
+      applications = Doorkeeper::Application.where(uid: application_uids)
+      applications.each do |app|
+        Doorkeeper::Application.revoke_tokens_and_grants_for(app.id, @user)
+      end
+
+      ServiceResult.success
+    end
+  end
+end

--- a/app/services/oauth/session_bound_application_registry.rb
+++ b/app/services/oauth/session_bound_application_registry.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OAuth
+  class SessionBoundApplicationRegistry
+    class << self
+      def register(application_uid)
+        registered_uids << application_uid
+      end
+
+      def registered_uids
+        @registered_uids ||= Set.new
+      end
+
+      def reset!
+        @registered_uids = Set.new
+      end
+    end
+  end
+end

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -47,6 +47,8 @@ module Users
         remove_matching_autologin_token! user
       end
 
+      revoke_session_bound_oauth_tokens!(user)
+
       controller.reset_session
 
       User.current = User.anonymous
@@ -70,6 +72,12 @@ module Users
       Token::AutoLogin
         .where(user:)
         .find_by_plaintext_value(value)&.destroy
+    end
+
+    def revoke_session_bound_oauth_tokens!(user)
+      OAuth::RevokeSessionTokensService.new(user:).call
+    rescue StandardError => e
+      OpenProject.logger.warn { "Failed to revoke session-bound OAuth tokens for user ##{user.id}: #{e.message}" }
     end
   end
 end

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -75,9 +75,7 @@ module Users
     end
 
     def revoke_session_bound_oauth_tokens!(user)
-      OAuth::RevokeSessionTokensService.new(user:).call
-    rescue StandardError => e
-      OpenProject.logger.warn { "Failed to revoke session-bound OAuth tokens for user ##{user.id}: #{e.message}" }
+      OAuth::RevokeSessionTokensService.call(user)
     end
   end
 end

--- a/app/services/users/logout_service.rb
+++ b/app/services/users/logout_service.rb
@@ -43,11 +43,10 @@ module Users
       if OpenProject::Configuration.drop_old_sessions_on_logout?
         remove_all_autologin_tokens! user
         remove_all_sessions! user
+        revoke_session_bound_oauth_tokens!(user)
       else
         remove_matching_autologin_token! user
       end
-
-      revoke_session_bound_oauth_tokens!(user)
 
       controller.reset_session
 

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -130,5 +130,11 @@ module OpenProject::Documents
 
     # Add documents to allowed search params
     additional_permitted_attributes search: %i(documents)
+
+    config.to_prepare do
+      ::OAuth::SessionBoundApplicationRegistry.register(
+        ::Documents::OAuth::EnsureApplicationService::APPLICATION_UID
+      )
+    end
   end
 end

--- a/spec/services/oauth/revoke_session_tokens_service_spec.rb
+++ b/spec/services/oauth/revoke_session_tokens_service_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OAuth::RevokeSessionTokensService do
+  subject(:service_call) { described_class.new(user:).call }
+
+  let(:user) { create(:user) }
+
+  after do
+    OAuth::SessionBoundApplicationRegistry.reset!
+  end
+
+  describe "#call" do
+    context "when no applications are registered" do
+      it "returns success" do
+        result = service_call
+
+        expect(result).to be_success
+      end
+    end
+
+    context "when a registered application does not exist in the database" do
+      before do
+        OAuth::SessionBoundApplicationRegistry.register("non_existent_app")
+      end
+
+      it "returns success" do
+        result = service_call
+
+        expect(result).to be_success
+      end
+    end
+
+    context "when a registered application exists" do
+      let!(:application) do
+        create(:oauth_application, uid: "test_session_bound_app")
+      end
+
+      before do
+        OAuth::SessionBoundApplicationRegistry.register("test_session_bound_app")
+      end
+
+      context "with no tokens for the user" do
+        it "returns success" do
+          result = service_call
+
+          expect(result).to be_success
+        end
+      end
+
+      context "with tokens for the user" do
+        let!(:token1) do
+          application.access_tokens.create!(
+            resource_owner_id: user.id,
+            scopes: "api_v3",
+            expires_in: 24.hours.to_i
+          )
+        end
+
+        let!(:token2) do
+          application.access_tokens.create!(
+            resource_owner_id: user.id,
+            scopes: "api_v3",
+            expires_in: 24.hours.to_i
+          )
+        end
+
+        it "revokes all tokens for the user" do
+          expect { service_call }
+            .to change { token1.reload.revoked? }.from(false).to(true)
+            .and change { token2.reload.revoked? }.from(false).to(true)
+        end
+
+        it "returns success" do
+          result = service_call
+
+          expect(result).to be_success
+        end
+      end
+
+      context "with tokens for other users" do
+        let(:other_user) { create(:user) }
+
+        let!(:user_token) do
+          application.access_tokens.create!(
+            resource_owner_id: user.id,
+            scopes: "api_v3",
+            expires_in: 24.hours.to_i
+          )
+        end
+
+        let!(:other_user_token) do
+          application.access_tokens.create!(
+            resource_owner_id: other_user.id,
+            scopes: "api_v3",
+            expires_in: 24.hours.to_i
+          )
+        end
+
+        it "only revokes tokens for the specified user" do
+          service_call
+
+          expect(user_token.reload).to be_revoked
+          expect(other_user_token.reload).not_to be_revoked
+        end
+      end
+    end
+
+    context "with multiple registered applications" do
+      let!(:app1) { create(:oauth_application, uid: "app_1") }
+      let!(:app2) { create(:oauth_application, uid: "app_2") }
+      let!(:unregistered_app) { create(:oauth_application, uid: "unregistered_app") }
+
+      let!(:app1_token) do
+        app1.access_tokens.create!(
+          resource_owner_id: user.id,
+          scopes: "api_v3",
+          expires_in: 24.hours.to_i
+        )
+      end
+
+      let!(:app2_token) do
+        app2.access_tokens.create!(
+          resource_owner_id: user.id,
+          scopes: "api_v3",
+          expires_in: 24.hours.to_i
+        )
+      end
+
+      let!(:unregistered_app_token) do
+        unregistered_app.access_tokens.create!(
+          resource_owner_id: user.id,
+          scopes: "api_v3",
+          expires_in: 24.hours.to_i
+        )
+      end
+
+      before do
+        OAuth::SessionBoundApplicationRegistry.register("app_1")
+        OAuth::SessionBoundApplicationRegistry.register("app_2")
+      end
+
+      it "revokes tokens for all registered applications" do
+        service_call
+
+        expect(app1_token.reload).to be_revoked
+        expect(app2_token.reload).to be_revoked
+      end
+
+      it "does not revoke tokens for unregistered applications" do
+        service_call
+
+        expect(unregistered_app_token.reload).not_to be_revoked
+      end
+    end
+  end
+end

--- a/spec/services/oauth/revoke_session_tokens_service_spec.rb
+++ b/spec/services/oauth/revoke_session_tokens_service_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe OAuth::RevokeSessionTokensService do
-  subject(:service_call) { described_class.new(user:).call }
+  subject(:service_call) { described_class.call(user) }
 
   let(:user) { create(:user) }
 
@@ -39,12 +39,12 @@ RSpec.describe OAuth::RevokeSessionTokensService do
     OAuth::SessionBoundApplicationRegistry.reset!
   end
 
-  describe "#call" do
+  describe ".call" do
     context "when no applications are registered" do
-      it "returns success" do
+      it "passes through" do
         result = service_call
 
-        expect(result).to be_success
+        expect(result).to be_empty
       end
     end
 
@@ -53,10 +53,10 @@ RSpec.describe OAuth::RevokeSessionTokensService do
         OAuth::SessionBoundApplicationRegistry.register("non_existent_app")
       end
 
-      it "returns success" do
+      it "passes through" do
         result = service_call
 
-        expect(result).to be_success
+        expect(result).to be_empty
       end
     end
 
@@ -70,10 +70,10 @@ RSpec.describe OAuth::RevokeSessionTokensService do
       end
 
       context "with no tokens for the user" do
-        it "returns success" do
+        it "passes through" do
           result = service_call
 
-          expect(result).to be_success
+          expect(result).to contain_exactly(application)
         end
       end
 
@@ -98,12 +98,6 @@ RSpec.describe OAuth::RevokeSessionTokensService do
           expect { service_call }
             .to change { token1.reload.revoked? }.from(false).to(true)
             .and change { token2.reload.revoked? }.from(false).to(true)
-        end
-
-        it "returns success" do
-          result = service_call
-
-          expect(result).to be_success
         end
       end
 

--- a/spec/services/oauth/session_bound_application_registry_spec.rb
+++ b/spec/services/oauth/session_bound_application_registry_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OAuth::SessionBoundApplicationRegistry do
+  before do
+    described_class.reset!
+  end
+
+  describe ".register" do
+    it "adds an application UID to the registry" do
+      described_class.register("test_app_uid")
+
+      expect(described_class.registered_uids).to include("test_app_uid")
+    end
+
+    it "does not add duplicates" do
+      described_class.register("test_app_uid")
+      described_class.register("test_app_uid")
+
+      expect(described_class.registered_uids.size).to eq(1)
+    end
+  end
+
+  describe ".registered_uids" do
+    it "returns an empty set by default" do
+      expect(described_class.registered_uids).to be_empty
+      expect(described_class.registered_uids).to be_a(Set)
+    end
+
+    it "returns all registered UIDs" do
+      described_class.register("app_1")
+      described_class.register("app_2")
+
+      expect(described_class.registered_uids).to contain_exactly("app_1", "app_2")
+    end
+  end
+
+  describe ".reset!" do
+    it "clears all registered UIDs" do
+      described_class.register("test_app_uid")
+
+      described_class.reset!
+
+      expect(described_class.registered_uids).to be_empty
+    end
+  end
+end

--- a/spec/services/users/logout_service_spec.rb
+++ b/spec/services/users/logout_service_spec.rb
@@ -93,6 +93,44 @@ RSpec.describe Users::LogoutService, type: :model do
       end
     end
 
+    context "with session-bound OAuth tokens" do
+      let!(:application) { create(:oauth_application, uid: "test_session_app") }
+      let!(:token) do
+        application.access_tokens.create!(
+          resource_owner_id: user.id,
+          scopes: "api_v3",
+          expires_in: 24.hours.to_i
+        )
+      end
+
+      before do
+        OAuth::SessionBoundApplicationRegistry.register("test_session_app")
+      end
+
+      after do
+        OAuth::SessionBoundApplicationRegistry.reset!
+      end
+
+      it "revokes session-bound OAuth tokens" do
+        expect { subject }.to change { token.reload.revoked? }.from(false).to(true)
+      end
+
+      context "when token revocation fails" do
+        before do
+          allow_any_instance_of(OAuth::RevokeSessionTokensService) # rubocop:disable RSpec/AnyInstance
+            .to receive(:call)
+            .and_raise(StandardError, "DB error")
+          allow(OpenProject.logger).to receive(:warn)
+        end
+
+        it "logs a warning and completes logout" do
+          expect { subject }.not_to raise_error
+          expect(User.current).to eq User.anonymous
+          expect(OpenProject.logger).to have_received(:warn)
+        end
+      end
+    end
+
     context "when config is disabled",
             with_config: { drop_old_sessions_on_logout: false } do
       it "destroys none of the existing sessions" do

--- a/spec/services/users/logout_service_spec.rb
+++ b/spec/services/users/logout_service_spec.rb
@@ -91,28 +91,28 @@ RSpec.describe Users::LogoutService, type: :model do
           expect(Token::AutoLogin.where(user_id: user.id)).to be_empty
         end
       end
-    end
 
-    context "with session-bound OAuth tokens" do
-      let!(:application) { create(:oauth_application, uid: "test_session_app") }
-      let!(:token) do
-        application.access_tokens.create!(
-          resource_owner_id: user.id,
-          scopes: "api_v3",
-          expires_in: 24.hours.to_i
-        )
-      end
+      describe "session-bound OAuth tokens" do
+        let!(:application) { create(:oauth_application, uid: "test_session_app") }
+        let!(:oauth_token) do
+          application.access_tokens.create!(
+            resource_owner_id: user.id,
+            scopes: "api_v3",
+            expires_in: 24.hours.to_i
+          )
+        end
 
-      before do
-        OAuth::SessionBoundApplicationRegistry.register("test_session_app")
-      end
+        before do
+          OAuth::SessionBoundApplicationRegistry.register("test_session_app")
+        end
 
-      after do
-        OAuth::SessionBoundApplicationRegistry.reset!
-      end
+        after do
+          OAuth::SessionBoundApplicationRegistry.reset!
+        end
 
-      it "revokes session-bound OAuth tokens" do
-        expect { subject }.to change { token.reload.revoked? }.from(false).to(true)
+        it "revokes session-bound OAuth tokens" do
+          expect { subject }.to change { oauth_token.reload.revoked? }.from(false).to(true)
+        end
       end
     end
 

--- a/spec/services/users/logout_service_spec.rb
+++ b/spec/services/users/logout_service_spec.rb
@@ -114,21 +114,6 @@ RSpec.describe Users::LogoutService, type: :model do
       it "revokes session-bound OAuth tokens" do
         expect { subject }.to change { token.reload.revoked? }.from(false).to(true)
       end
-
-      context "when token revocation fails" do
-        before do
-          allow_any_instance_of(OAuth::RevokeSessionTokensService) # rubocop:disable RSpec/AnyInstance
-            .to receive(:call)
-            .and_raise(StandardError, "DB error")
-          allow(OpenProject.logger).to receive(:warn)
-        end
-
-        it "logs a warning and completes logout" do
-          expect { subject }.not_to raise_error
-          expect(User.current).to eq User.anonymous
-          expect(OpenProject.logger).to have_received(:warn)
-        end
-      end
     end
 
     context "when config is disabled",


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/70362

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

When a user signs out, their OAuth tokens for session-bound applications (like Documents collaborative editing) are now revoked. This prevents other browser tabs from continuing to access real-time features after logout.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Introduces a generic registry pattern where modules can register their OAuth applications as session-bound, making them eligible for automatic token revocation on logout.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
