### PR TITLE
[#70560] PDF export with custom uploaded logo/fonts fails with some storage configurations (S3)

### DIFF
--- a/app/models/exports/pdf/common/logo.rb
+++ b/app/models/exports/pdf/common/logo.rb
@@ -38,7 +38,7 @@ module Exports::PDF::Common::Logo
     custom_logo_image_filename || Rails.root.join("app/assets/images/logo_openproject.png")
   end
 
-  def custom_logo_image_filename
+  def custom_logo_image_filename # rubocop:disable Metrics/AbcSize
     return unless CustomStyle.current.present? &&
       CustomStyle.current.export_logo.present? && CustomStyle.current.export_logo.local_file.present?
 
@@ -47,5 +47,8 @@ module Exports::PDF::Common::Logo
     return unless pdf_embeddable?(content_type)
 
     image_file
+  rescue StandardError => e
+    Rails.logger.error "Failed to access custom PDF logo file: #{e}"
+    nil # Fallback to default logo
   end
 end

--- a/app/models/exports/pdf/common/view.rb
+++ b/app/models/exports/pdf/common/view.rb
@@ -62,10 +62,16 @@ class Exports::PDF::Common::View
     CustomStyle.current.present? &&
       CustomStyle.current.export_font_regular.present? &&
       CustomStyle.current.export_font_regular.local_file.present?
+  rescue StandardError => e
+    Rails.logger.error "Failed to access custom PDF font file: #{e}"
+    false # Fallback to default fonts
   end
 
   def self.valid_custom_font_cut?(cut)
     cut.present? && cut.local_file.present?
+  rescue StandardError => e
+    Rails.logger.error "Failed to access custom PDF font file: #{e}"
+    false # Fallback to default fonts
   end
 
   def options
@@ -118,6 +124,9 @@ class Exports::PDF::Common::View
 
   def font_or_default(cut, default)
     cut.present? && cut.local_file.present? ? cut.local_file : default
+  rescue StandardError => e
+    Rails.logger.error "Failed to access custom PDF font file: #{e}"
+    default
   end
 
   def custom_font_files


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/70560

This is another occurrence of the same bug in the outdated dependency gem carrierwave (which we cannot immediately update)

see [#69625](https://community.openproject.org/work_packages/69625) [#67626](https://community.openproject.org/work_packages/67626) [#67642](https://community.openproject.org/work_packages/67642) [#57612](https://community.openproject.org/work_packages/57612) [#44939](https://community.openproject.org/work_packages/44939)

# What approach did you choose and why?

Catch and log the error, let the PDF export proceed with the default logo/fonts
