### PR TITLE
[#70560] PDF export with custom uploaded font fails with some storage configurations (S3)

### DIFF
--- a/app/models/exports/pdf/common/view.rb
+++ b/app/models/exports/pdf/common/view.rb
@@ -59,19 +59,25 @@ class Exports::PDF::Common::View
   end
 
   def self.valid_custom_font?
-    CustomStyle.current.present? &&
-      CustomStyle.current.export_font_regular.present? &&
-      CustomStyle.current.export_font_regular.local_file.present?
+    cs = CustomStyle.current
+    return false if cs.blank?
+
+    valid_custom_font_cut?(cs.export_font_regular) &&
+      valid_optional_custom_font_cut?(cs.export_font_bold) &&
+      valid_optional_custom_font_cut?(cs.export_font_italic) &&
+      valid_optional_custom_font_cut?(cs.export_font_bold_italic)
+    # Something in the remote storage failed. Log, but do not stop PDF generation
   rescue StandardError => e
-    Rails.logger.error "Failed to access custom PDF font file: #{e}"
-    false # Fallback to default fonts
+    Rails.logger.error "Failed to apply custom PDF font to export: #{e.message}:\n#{e.backtrace.join("\n")}"
+    false
   end
 
   def self.valid_custom_font_cut?(cut)
     cut.present? && cut.local_file.present?
-  rescue StandardError => e
-    Rails.logger.error "Failed to access custom PDF font file: #{e}"
-    false # Fallback to default fonts
+  end
+
+  def self.valid_optional_custom_font_cut?(cut)
+    cut.blank? || cut.local_file.present?
   end
 
   def options
@@ -124,9 +130,6 @@ class Exports::PDF::Common::View
 
   def font_or_default(cut, default)
     cut.present? && cut.local_file.present? ? cut.local_file : default
-  rescue StandardError => e
-    Rails.logger.error "Failed to access custom PDF font file: #{e}"
-    default
   end
 
   def custom_font_files


### PR DESCRIPTION
backport PDF custom font handling from dev to 17.0 branch
