### PR TITLE
Remove unused options in work package helper

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -36,116 +36,27 @@ module WorkPackagesHelper
   # Examples:
   #
   #   link_to_work_package(package)                            # => Defect #6: This is the subject
-  #   link_to_work_package(package, all_link: true)            # => Defect #6: This is the subject (everything within the link)
-  #   link_to_work_package(package, truncate: 9)               # => Defect #6: This i...
-  #   link_to_work_package(package, subject: false)            # => Defect #6
-  #   link_to_work_package(package, type: false)               # => #6: This is the subject
-  #   link_to_work_package(package, project: true)             # => Foo - Defect #6
-  #   link_to_work_package(package, id_only: true)             # => #6
-  #   link_to_work_package(package, subject_only: true)        # => This is the subject (as link)
-  #   link_to_work_package(package, status: true)              # => #6 New (if #id => true)
-  def link_to_work_package(package, options = {})
-    if options[:subject_only]
-      options.merge!(type: false,
-                     subject: true,
-                     id: false,
-                     all_link: true)
-    elsif options[:id_only]
-      options.merge!(type: false,
-                     subject: false,
-                     id: true,
-                     all_link: true)
-    else
-      options.reverse_merge!(type: true,
-                             subject: true,
-                             id: true)
+  #   link_to_work_package(package, link_subject: true)        # => Defect #6: This is the subject (everything within the link)
+  #   link_to_work_package(package, display_project: true)     # => Foo - Defect #6: This is the subject
+  def link_to_work_package(work_package, display_project: false, link_subject: false) # rubocop:disable Metrics/AbcSize
+    output = "".html_safe
+    output << "#{work_package.project} - " if display_project && work_package.project_id
+
+    link = link_to(work_package_path(work_package),
+                   title: work_package.subject,
+                   class: link_to_work_package_css_classes(work_package)) do
+      link_parts = []
+      link_parts << work_package.type.to_s if work_package.type_id
+      link_parts << "##{work_package.id}:"
+      link_parts << content_tag(:span, I18n.t(:label_closed_work_packages), class: "sr-only") if work_package.closed?
+      link_parts << work_package.subject if link_subject
+
+      safe_join(link_parts, " ")
     end
 
-    parts = { prefix: [],
-              hidden_link: [],
-              link: [],
-              suffix: [],
-              title: [],
-              css_class: link_to_work_package_css_classes(package, options) }
-
-    # Prefix part
-
-    parts[:prefix] << package.project.to_s if options[:project]
-
-    # Link part
-
-    parts[:link] << h(options[:before_text].to_s) if options[:before_text]
-
-    parts[:link] << h(package.type.to_s) if options[:type]
-
-    parts[:link] << "##{h(package.id)}" if options[:id]
-
-    parts[:link] << h(package.status).to_s if options[:id] && options[:status] && package.status_id
-
-    # Hidden link part
-
-    if package.closed? && !options[:no_hidden]
-      parts[:hidden_link] << content_tag(:span,
-                                         I18n.t(:label_closed_work_packages),
-                                         class: "sr-only")
-    end
-
-    # Suffix part
-
-    if options[:subject]
-      subject = if options[:subject]
-                  subject = package.subject
-                  if options[:truncate]
-                    subject = truncate(subject, length: options[:truncate])
-                  end
-
-                  subject
-                end
-
-      parts[:suffix] << h(subject)
-    end
-
-    # title part
-
-    parts[:title] << (options[:title].nil? ? package.subject : options[:title])
-
-    # combining
-
-    prefix = parts[:prefix].join(" ")
-    suffix = parts[:suffix].join(" ")
-    link = parts[:link].join(" ").strip
-    hidden_link = parts[:hidden_link].join
-    title = parts[:title].join(" ")
-    css_class = parts[:css_class].join(" ")
-
-    # Determine path or url
-    work_package_link =
-      if options.fetch(:only_path, true)
-        work_package_path(package)
-      else
-        work_package_url(package)
-      end
-
-    if options[:all_link]
-      link_text = [prefix, link].reject(&:empty?).join(" - ")
-      link_text = [link_text, suffix].reject(&:empty?).join(": ")
-      link_text = [hidden_link, link_text].reject(&:empty?).join
-
-      link_to(link_text.html_safe,
-              work_package_link,
-              title:,
-              class: css_class)
-    else
-      link_text = [hidden_link, link].reject(&:empty?).join
-
-      html_link = link_to(link_text.html_safe,
-                          work_package_link,
-                          title:,
-                          class: css_class)
-
-      [[prefix, html_link].reject(&:empty?).join(" - "),
-       suffix].reject(&:empty?).join(": ")
-    end.html_safe
+    output << link
+    output << " #{work_package.subject}" unless link_subject
+    output
   end
 
   def work_package_list(work_packages, &)
@@ -176,7 +87,7 @@ module WorkPackagesHelper
     "#{start_date} - #{due_date}"
   end
 
-  def send_notification_option(checked = false)
+  def send_notification_option(checked: false)
     content_tag(:label, for: "send_notification", class: "form--label-with-check-box") do
       (content_tag "span", class: "form--check-box-container" do
         boxes = hidden_field_tag("send_notification", "0", id: nil)
@@ -220,10 +131,10 @@ module WorkPackagesHelper
 
   def work_packages_columns_options
     @work_packages_columns_options ||= Query
-                                         .new
-                                         .displayable_columns
-                                         .sort_by(&:caption)
-                                         .map { |column| { name: column.caption, id: column.name.to_s } }
+      .new
+      .displayable_columns
+      .sort_by(&:caption)
+      .map { |column| { name: column.caption, id: column.name.to_s } }
   end
 
   def selected_work_packages_columns_options
@@ -232,13 +143,14 @@ module WorkPackagesHelper
   end
 
   def protected_work_packages_columns_options
+    protected_columns = %w[id subject]
     work_packages_columns_options
-      .select { |column| column[:id] == "id" || column[:id] == "subject" }
+      .select { |column| protected_columns.include?(column[:id]) }
   end
 
   private
 
-  def truncated_work_package_description(work_package, lines = 3)
+  def truncated_work_package_description(work_package, lines = 3) # rubocop:disable Metrics/AbcSize
     description_lines = work_package.description.to_s.lines.to_a[0, lines]
 
     if description_lines[lines - 1] && work_package.description.to_s.lines.to_a.size > lines
@@ -261,24 +173,9 @@ module WorkPackagesHelper
     end
   end
 
-  def info_user_attributes(work_package)
-    responsible = if work_package.responsible_id.present?
-                    "<span class='label'>#{WorkPackage.human_attribute_name(:responsible)}:</span> " +
-                      h(work_package.responsible.name).to_s
-                  end
-
-    assignee = if work_package.assigned_to_id.present?
-                 "<span class='label'>#{WorkPackage.human_attribute_name(:assigned_to)}:</span> " +
-                   h(work_package.assigned_to.name).to_s
-               end
-
-    [responsible, assignee].compact.join("<br>").html_safe
-  end
-
-  def link_to_work_package_css_classes(package, options)
+  def link_to_work_package_css_classes(package)
     classes = ["work_package"]
     classes << "closed" if package.closed?
-    classes << options[:class].to_s
 
     classes
   end

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -66,7 +66,7 @@ See COPYRIGHT and LICENSE files for more details.
             <div>
               <ul>
                 <%- issues.each do |issue| -%>
-                  <li><%= link_to_work_package(issue, project: (@project != issue.project)) %></li>
+                  <li><%= link_to_work_package(issue, display_project: (@project != issue.project)) %></li>
                 <%- end -%>
               </ul>
             </div>

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -161,7 +161,7 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
     if related_work_package
       I18n.t(
         "journals.cause_descriptions.#{cause['type']}",
-        link: html? ? link_to_work_package(related_work_package, all_link: true) : "##{related_work_package.id}"
+        link: html? ? link_to_work_package(related_work_package, link_subject: true) : "##{related_work_package.id}"
       )
 
     else

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -125,7 +125,7 @@ module OpenProject
         link_to(project_name, project_path_or_url(project, options), html_options)
       else
         project_name
-      end.html_safe
+      end
     end
 
     # Like #link_to_user, but will render a Primer link instead of a regular link.

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe WorkPackagesHelper do
 
     describe "without parameters" do
       it "returns a link to the work package with type and id as the text if type is set" do
-        link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id}$")
+        link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id}:$")
         expect(helper.link_to_work_package(stub_work_package)).to have_css(
           "a[href='#{work_package_path(stub_work_package)}']", text: link_text
         )
@@ -59,55 +59,19 @@ RSpec.describe WorkPackagesHelper do
       it "prepends an invisible closed information if the work package is closed" do
         stub_work_package.status = closed_status
 
-        expect(helper.link_to_work_package(stub_work_package)).to have_css("a span.sr-only", text: "closed")
-      end
-
-      it "omits the invisible closed information if told so even though the work package is closed" do
-        stub_work_package.status = closed_status
-
-        expect(helper.link_to_work_package(stub_work_package, no_hidden: true))
-          .to have_no_css("a span.sr-only", text: "closed")
+        result = helper.link_to_work_package(stub_work_package)
+        # The hidden span should be inside the link
+        expect(result).to have_css("a span.sr-only", text: "closed")
       end
     end
 
-    describe "with the all_link option provided" do
+    describe "with the link_subject option provided" do
       it "returns a link to the work package with the type, id, and subject as the text" do
         link_text = Regexp.new("^#{stub_type} ##{stub_work_package.id}: #{stub_work_package.subject}$")
         expect(helper.link_to_work_package(stub_work_package,
-                                           all_link: true)).to have_css(
+                                           link_subject: true)).to have_css(
                                              "a[href='#{work_package_path(stub_work_package)}']", text: link_text
                                            )
-      end
-    end
-
-    describe "when truncating" do
-      it "truncates the subject if the subject is longer than the specified amount" do
-        stub_work_package.subject = "12345678"
-
-        text = Regexp.new("1234...$")
-        expect(helper.link_to_work_package(stub_work_package, truncate: 7)).to have_text(text)
-      end
-
-      it "does not truncate the subject if the subject is shorter than the specified amount" do
-        stub_work_package.subject = "1234567"
-
-        text = Regexp.new("1234567$")
-        expect(helper.link_to_work_package(stub_work_package, truncate: 7)).to have_text(text)
-      end
-    end
-
-    describe "when omitting the subject" do
-      it "omits the subject" do
-        expect(helper.link_to_work_package(stub_work_package, subject: false)).to have_no_text(stub_work_package.subject)
-      end
-    end
-
-    describe "when omitting the type" do
-      it "omits the type" do
-        link_text = Regexp.new("^##{stub_work_package.id}$")
-        expect(helper.link_to_work_package(stub_work_package,
-                                           type: false)).to have_css("a[href='#{work_package_path(stub_work_package)}']",
-                                                                     text: link_text)
       end
     end
 
@@ -119,43 +83,11 @@ RSpec.describe WorkPackagesHelper do
       end
 
       it "prepends the project if parameter set to true" do
-        expect(helper.link_to_work_package(stub_work_package, project: true)).to have_text(text)
+        expect(helper.link_to_work_package(stub_work_package, display_project: true)).to have_text(text)
       end
 
       it "does not include the project name if the parameter is missing/false" do
         expect(helper.link_to_work_package(stub_work_package)).to have_no_text(text)
-      end
-    end
-
-    describe "when only wanting the id" do
-      it "returns a link with the id as text only" do
-        link_text = Regexp.new("^##{stub_work_package.id}$")
-        expect(helper.link_to_work_package(stub_work_package,
-                                           id_only: true)).to have_css("a[href='#{work_package_path(stub_work_package)}']",
-                                                                       text: link_text)
-      end
-
-      it "does not have the subject as text" do
-        expect(helper.link_to_work_package(stub_work_package, id_only: true)).to have_no_text(stub_work_package.subject)
-      end
-    end
-
-    describe "when only wanting the subject" do
-      it "returns a link with the subject as text" do
-        link_text = Regexp.new("^#{stub_work_package.subject}$")
-        expect(helper.link_to_work_package(stub_work_package,
-                                           subject_only: true)).to have_css(
-                                             "a[href='#{work_package_path(stub_work_package)}']", text: link_text
-                                           )
-      end
-    end
-
-    describe "with the status displayed" do
-      it "returns a link with the status name contained in the text" do
-        link_text = Regexp.new("^#{stub_type.name} ##{stub_work_package.id} #{stub_work_package.status}$")
-        expect(helper.link_to_work_package(stub_work_package,
-                                           status: true)).to have_css("a[href='#{work_package_path(stub_work_package)}']",
-                                                                      text: link_text)
       end
     end
   end

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
   shared_let(:work_package) { create(:work_package) }
   let(:instance) { described_class.new(build(:work_package_journal)) }
   let(:work_package_html_link) do
-    link_to_work_package(work_package, all_link: true)
+    link_to_work_package(work_package, link_subject: true)
   end
   let(:work_package_raw_link) { "##{work_package.id}" }
 


### PR DESCRIPTION
The `link_to_work_package` was super convoluted, and 90% of these options were not used anywhere. Simplify the method and remove unused options.
https://community.openproject.org/projects/openproject/work_packages/70567/activity?query_id=5722