### PR TITLE
Rework authorization with clearer load_and_authorize_with_permission_in_project

### DIFF
--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -33,7 +33,14 @@
 module Accounts::Authorization
   extend ActiveSupport::Concern
 
-  METHODS_ENFORCING_AUTHORIZATION = %i[require_admin authorize authorize_global load_and_authorize_in_optional_project].freeze
+  METHODS_ENFORCING_AUTHORIZATION = %i[
+    require_admin
+    authorize
+    authorize_global
+    authorize_with_global_permission
+    load_and_authorize_in_optional_project
+    load_and_authorize_with_permission_in_project
+  ].freeze
 
   included do
     class_attribute :authorization_ensured,
@@ -86,13 +93,14 @@ module Accounts::Authorization
   # * a parameter-like Hash (eg. { controller: '/projects', action: 'edit' })
   # * a permission Symbol (eg. :edit_project)
   def do_authorize(action, global: false) # rubocop:disable Metrics/PerceivedComplexity
-    is_authorized = if global
-                      User.current.allowed_based_on_permission_context?(action)
-                    else
-                      User.current.allowed_based_on_permission_context?(action,
-                                                                        project: @project || @projects,
-                                                                        entity: @work_package || @work_packages)
-                    end
+    is_authorized =
+      if global
+        User.current.allowed_based_on_permission_context?(action)
+      else
+        User.current.allowed_based_on_permission_context?(action,
+                                                          project: @project || @projects,
+                                                          entity: @work_package || @work_packages)
+      end
 
     unless is_authorized
       if @project&.archived?
@@ -206,14 +214,16 @@ module Accounts::Authorization
       end
     end
 
-    # Find a project based on params[:project_id]
-    # and authorize on a given permission
-    def load_and_authorize_with_permission_in_optional_project(permission, **args)
+    def authorize_with_global_permission(permission, **args)
+      authorize_with_permission(permission, global: true, **args)
+    end
+
+    def load_and_authorize_with_permission_in_project(permission, **args)
       authorization_checked_by_default_action(**args.slice(:only, :except))
 
       before_action(**args) do
-        @project = Project.find(params[:project_id]) if params[:project_id].present?
-        do_authorize(permission, global: params[:project_id].blank?)
+        @project = Project.find(params[:project_id])
+        do_authorize(permission, global: false)
       end
     end
   end

--- a/app/controllers/projects/creation_wizard_controller.rb
+++ b/app/controllers/projects/creation_wizard_controller.rb
@@ -31,8 +31,7 @@
 class Projects::CreationWizardController < ApplicationController
   include OpTurbo::ComponentStream
 
-  before_action :find_project_by_project_id
-  load_and_authorize_with_permission_in_optional_project :edit_project_attributes
+  load_and_authorize_with_permission_in_project :edit_project_attributes
   before_action :load_sections_and_fields, only: %i[show update]
   before_action :find_current_section, only: %i[show update]
 

--- a/modules/meeting/app/controllers/meeting_presentation_controller.rb
+++ b/modules/meeting/app/controllers/meeting_presentation_controller.rb
@@ -33,15 +33,14 @@ class MeetingPresentationController < ApplicationController
   include Meetings::AgendaComponentStreams
   include Meetings::PresentationComponentStreams
 
-  before_action :check_feature_flag
+  load_and_authorize_with_permission_in_project :view_meetings
 
   before_action :find_meeting
+  before_action :check_feature_flag
   before_action :check_presentable
   before_action :determine_current_id
   before_action :set_started_at
   before_action :find_agenda_item, only: [:check_for_updates]
-
-  load_and_authorize_with_permission_in_optional_project :view_meetings
 
   layout "meetings/presentation"
 
@@ -66,8 +65,7 @@ class MeetingPresentationController < ApplicationController
   private
 
   def find_meeting
-    @meeting = Meeting.find(params[:meeting_id])
-    @project = @meeting.project
+    @meeting = @project.meetings.visible.find(params[:meeting_id])
   end
 
   def find_agenda_item

--- a/spec/controllers/concerns/authorization_spec.rb
+++ b/spec/controllers/concerns/authorization_spec.rb
@@ -167,19 +167,42 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
     it_behaves_like "is prevented", :index
   end
 
-  context "with authorization checked with load_and_authorize_with_permission_in_optional_project" do
+  context "with authorization checked with authorize_with_global_permission" do
     controller do
       include Accounts::Authorization
       include controller_setup
 
-      load_and_authorize_with_permission_in_optional_project :view_project
+      authorize_with_global_permission :view_project
 
       def do_authorize(*)
         true
       end
     end
 
-    it "loads the project if present" do
+    it "does not load the project and calls global authorization" do
+      allow(controller).to receive(:do_authorize)
+      allow(Project).to receive(:find)
+
+      get :index, params: { project_id: "1" }
+
+      expect(Project).not_to have_received(:find)
+      expect(controller).to have_received(:do_authorize).with(:view_project, global: true)
+    end
+  end
+
+  context "with authorization checked with load_and_authorize_with_permission_in_project" do
+    controller do
+      include Accounts::Authorization
+      include controller_setup
+
+      load_and_authorize_with_permission_in_project :view_project
+
+      def do_authorize(*)
+        true
+      end
+    end
+
+    it "loads the project and calls project authorization" do
       allow(controller).to receive(:do_authorize)
       allow(Project).to receive(:find)
 
@@ -189,42 +212,14 @@ RSpec.describe ApplicationController, "enforcement of authorization" do # ruboco
       expect(controller).to have_received(:do_authorize).with(:view_project, global: false)
     end
 
-    it "uses the global call if not present" do
+    it "renders 404 if project_id is missing" do
       allow(controller).to receive(:do_authorize)
-      allow(Project).to receive(:find)
 
       get :index
 
-      expect(Project).not_to have_received(:find)
-      expect(controller).to have_received(:do_authorize).with(:view_project, global: true)
+      expect(response).to have_http_status :not_found
+      expect(controller).not_to have_received(:do_authorize)
     end
-  end
-
-  context "with authorization checked on single action with load_and_authorize_with_permission_in_optional_project" do
-    controller do
-      include Accounts::Authorization
-      include controller_setup
-
-      load_and_authorize_with_permission_in_optional_project :view_project, only: %i[test]
-
-      def test
-        render plain: "OK"
-      end
-
-      def do_authorize(*)
-        true
-      end
-    end
-
-    before do
-      @routes.draw do # rubocop:disable RSpec/InstanceVariable
-        get "/anonymous/index"
-        get "/anonymous/test"
-      end
-    end
-
-    it_behaves_like "succeeds", :test
-    it_behaves_like "is prevented", :index
   end
 
   context "with authorization checked with load_and_authorize_in_optional_project" do


### PR DESCRIPTION
For permission-based checks, `load_and_authorize_with_permission_in_optional_project` never makes sense, as you specify a project permission