### PR TITLE
[#70334] Align the project dropdown active project close button vertically

### DIFF
--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -110,7 +110,8 @@
 
     &-remove
       margin-left: $spot-spacing-0_5
-      font-size: 0.75rem
+      display: flex
+      align-self: center
 
     &-action_disabled &-title
       opacity: 0.5

--- a/frontend/src/app/spot/styles/sass/components/list.sass
+++ b/frontend/src/app/spot/styles/sass/components/list.sass
@@ -110,6 +110,7 @@
 
     &-remove
       margin-left: $spot-spacing-0_5
+      font-size: 0.75rem
 
     &-action_disabled &-title
       opacity: 0.5


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/70334

# What are you trying to accomplish?
Fix vertical alignment issue of the project close button in the project dropdown.

## Screenshots
Before
<img width="111" height="40" alt="image" src="https://github.com/user-attachments/assets/66b73fed-c97f-4788-876e-f897a573c090" />

After
<img width="97" height="45" alt="image" src="https://github.com/user-attachments/assets/a80d34de-7c21-4b6c-ab46-950d4c43b77f" />

# What approach did you choose and why?
Change the font size of the close button, so it aligns with the Project name and other icons

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
