### PR TITLE
[#70490] Using "is empty" or "is not" on custom field breaks baseline query

### DIFF
--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -198,7 +198,12 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
 
     predicate.gsub! "AND #{custom_values}.custom_field_id =",
                     "AND #{customizable_journals}.custom_field_id ="
-    predicate.gsub! "WHERE #{custom_values}.value", "WHERE #{customizable_journals}.value"
+    # Replace all occurrences of `custom_values.value` within the WHERE clause.
+    # This handles operators like "is empty" which generate multiple references:
+    # e.g. `WHERE custom_values.value IS NULL OR custom_values.value = ''`
+    predicate.gsub!(/WHERE #{Regexp.escape(custom_values)}\.value.*/) do |match|
+      match.gsub!("#{custom_values}.value", "#{customizable_journals}.value")
+    end
   end
 
   # Add a timestamp condition: Select the work package journals that are the

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -257,6 +257,49 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
             expect(subject).not_to include work_package
           end
         end
+
+        context "with the 'is empty' operator" do
+          let(:list_custom_field) do
+            create(:list_wp_custom_field,
+                   name: "List CF",
+                   types: project.types,
+                   projects: [project])
+          end
+          let!(:wednesday_list_cf_journal) do
+            create(:journal_customizable_journal, journal: wednesday_journal, custom_field: list_custom_field, value: "1")
+          end
+          let!(:work_package_without_cf) do
+            create(:work_package, project:, journals: { monday => {}, wednesday => {}, friday => {} })
+          end
+          let(:filter) do
+            Queries::WorkPackages::Filter::CustomFieldFilter.create!(
+              name: list_custom_field.column_name,
+              context: build_stubbed(:query, project:),
+              operator: "!*",
+              values: []
+            )
+          end
+          let(:relation) { WorkPackage.where(filter.where) }
+          let(:historic_relation) { relation.at_timestamp(wednesday) }
+
+          it "transforms the expression to join the customizable_journals with correct value substitutions" do
+            subject.to_sql.squish.tap do |subject_sql|
+              expect(subject_sql)
+                .to include <<~SQL.squish
+                  JOIN customizable_journals ON
+                  customizable_journals.journal_id = work_packages.journal_id
+                  AND customizable_journals.custom_field_id = #{list_custom_field.id}
+                SQL
+              expect(subject_sql).to include "customizable_journals.value IS NULL"
+              expect(subject_sql).not_to include "custom_values.value"
+            end
+          end
+
+          it "returns work packages without the custom field value at the timestamp" do
+            expect(subject).to include work_package_without_cf
+            expect(subject).not_to include work_package
+          end
+        end
       end
 
       describe "when searching for two custom fields (concatenated into string as Query#results does)" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/70490

# What are you trying to accomplish?
Fix the error when a query has a custom field condition like "is empty".

# What approach did you choose and why?

The issue lies in the `Journable::HistoricActiveRecordRelation#substitute_custom_values_join_in_predicate` method. In case of using filter conditions such as "is empty", the generated where clause contains multiple values like `WHERE custom_values.value IS NULL OR custom_values.value = ''`. The substitute logic is changed replace multiple occurrences of the `custom_values.value` field, which was not happening before.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
