### PR TITLE
[70614] Documents module is missing meaningfull html title

### DIFF
--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -29,6 +29,8 @@
   ++#
 %>
 
+<% html_title(t(:label_document_plural), @document.title) %>
+
 <% if @document.collaborative? %>
   <% if Setting.real_time_text_collaboration_enabled? %>
     <%=


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70614

# What are you trying to accomplish?
Add correct html title to Documents module


