### PR TITLE
[#70007] Project list: project name is not centered

### DIFF
--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -161,7 +161,7 @@ module Projects
         workspace_type_badge
       ].compact_blank
 
-      safe_join(content)
+      content_tag(:div, safe_join(content), class: "projects-table--name")
     end
 
     def hierarchy_icon

--- a/frontend/src/global_styles/content/_projects_list.sass
+++ b/frontend/src/global_styles/content/_projects_list.sass
@@ -75,17 +75,19 @@ $content-padding: 10px
       color: var(--fgColor-muted)
 
   td.name
-    .projects-table--name-text
-      @include text-shortener
-      white-space: nowrap
+    > .projects-table--name
+        display: flex
+        gap: var(--base-size-8, 8px)
 
-    .projects-table--name-description
-      @extend %autocomplete-description
+        > .projects-table--name-text
+            @include text-shortener
+            white-space: nowrap
+
+        > .projects-table--name-description
+            @extend %autocomplete-description
 
   td.project--hierarchy
     white-space: nowrap
-    display: flex
-    gap: var(--base-size-8, 8px)
 
   @for $i from 1 through 9
     tr.idnt-#{$i} td.project--hierarchy


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/70007

# What are you trying to accomplish?
Center the project list name column vertically.

## Screenshots
<details><summary>Before</summary>
<p>

<img width="587" height="183" alt="image" src="https://github.com/user-attachments/assets/8b980956-e2b6-468b-9b6a-e0a391fa3bbc" />

</p>
</details> 


<details><summary>After</summary>
<p>

<img width="522" height="149" alt="image" src="https://github.com/user-attachments/assets/8588be79-1907-4d4d-aab6-65a29cc301c1" />



</p>
</details> 


# What approach did you choose and why?
The flex layout put on the table row was breaking the height of the row, so I introduced a container div and applied flex styling on it instead of the table row.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
