### PR TITLE
[#70541] Fix tests that broke with the shadow dom changes

### DIFF
--- a/modules/documents/spec/features/attachment_upload_spec.rb
+++ b/modules/documents/spec/features/attachment_upload_spec.rb
@@ -155,15 +155,12 @@ RSpec.describe "Upload attachment to documents",
 
   shared_examples "can upload an image in BlockNote" do
     it "is possible to upload attachments from the editor" do
-      pending("handling tests with shadow dom")
       expect(page).to have_no_css("img[alt='image.png']")
       editor.open_add_image_dialog
 
       expect do
-        attach_file(image_fixture.path, make_visible: true) do
-          find(:button, text: "Upload image").click
-        end
-        expect(page).to have_css("img[alt='image.png'][src*='/api/v3/attachments/']")
+        editor.attach_file(image_fixture.path)
+        expect(editor.element).to have_css("img[alt='image.png'][src*='/api/v3/attachments/']")
       end.to change { document.attachments.count }.by(1)
     end
   end
@@ -172,15 +169,12 @@ RSpec.describe "Upload attachment to documents",
     context "with an incompatible attachment allowlist",
             with_settings: { attachment_whitelist: %w[image/jpg] } do
       it "shows a nice error" do
-        pending("handling tests with shadow dom")
         editor.open_add_image_dialog
         expect do
-          attach_file(image_fixture.path, make_visible: true) do
-            find(:button, text: "Upload image").click
-          end
+          editor.attach_file(image_fixture.path)
           expect(page).to have_content I18n.t("activerecord.errors.models.attachment.attributes.content_type.not_allowlisted",
                                               value: "image/png")
-          expect(page).to have_no_css("img[alt='image.png']")
+          expect(editor.element).to have_no_css("img[alt='image.png']")
         end.not_to change { document.attachments.count }
       end
     end

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -30,7 +30,7 @@
 
 require "rails_helper"
 
-RSpec.describe "BlockNote editor rendering", :js, with_settings: { real_time_text_collaboration_enabled: true } do
+RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { real_time_text_collaboration_enabled: true } do
   let(:admin) { create(:admin) }
   let(:type) { create(:document_type, :experimental) }
   let(:document) { create(:document, type:) }
@@ -68,11 +68,10 @@ RSpec.describe "BlockNote editor rendering", :js, with_settings: { real_time_tex
   end
 
   it "renders the BlockNote editor with custom menu entries for work package linking" do
-    pending("handling tests with shadow dom")
     visit document_path(document)
 
     expect(page).to have_test_selector("blocknote-document-description")
-    editor.fill_in_with_content("/openproject")
-    expect(page).to have_content("Link to existing work package")
+    editor.fill_in("/openproject")
+    expect(editor.content).to have_content("Link existing work package")
   end
 end

--- a/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
+++ b/modules/documents/spec/features/documents/project/show_edit_document_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe "Show/Edit Document View",
 
     aggregate_failures "can edit document content" do
       editor = FormFields::Primerized::BlockNoteEditorInput.new
-      editor.fill_in_with_content("This is the new **content**.")
+      editor.fill_in("This is the new **content**.")
 
-      expect(editor.text).to include("This is the new **content**.")
+      expect(editor.element).to have_content("This is the new content.") # bold is applied
     end
   end
 

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -5,28 +5,27 @@ module FormFields
     class BlockNoteEditorInput
       include Capybara::DSL
 
-      def open_add_image_dialog
-        send_keys_to_editor("/image")
-        send_keys_to_editor(:enter)
-      end
-
       def open_command_dialog
         send_keys_to_editor("/")
       end
 
-      def fill_in_with_content(content)
+      def open_add_image_dialog
+        send_keys_to_editor("/image")
+        send_keys(:enter)
+      end
+
+      def fill_in(content)
         send_keys_to_editor(content)
       end
 
-      def text
-        page.evaluate_script(<<~JS)
-          document.querySelector('op-block-note')
-            .shadowRoot.querySelector('div[role="textbox"]')
-            .textContent;
-        JS
+      def attach_file(path)
+        input = shadow_root.find("input[type='file']", visible: false)
+        input.attach_file(path, make_visible: true)
       end
 
       def content
+        # capybara does not yet support getting content directly
+        # on shadow roots
         page.evaluate_script(<<~JS)
           document.querySelector('op-block-note')
             .shadowRoot
@@ -34,23 +33,20 @@ module FormFields
         JS
       end
 
+      def shadow_root
+        page.find("op-block-note").shadow_root
+      end
+
+      def element
+        shadow_root.find("div[role='textbox']")
+      end
+
       private
 
+      # Attention: This only works with selenium, not with cuprite,
+      # as cuprite does not support shadow dom (yet).
       def send_keys_to_editor(keys)
-        page.execute_script(<<~JS, keys.to_s)
-          const editor = document.querySelector('op-block-note')
-            .shadowRoot.querySelector('div[role="textbox"]');
-
-          editor.focus();
-
-          const text = arguments[0];
-          if (text === 'enter') {
-            editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
-          } else {
-            document.execCommand('insertText', false, text);
-            editor.dispatchEvent(new Event('change', {bubbles: true}));
-          }
-        JS
+        element.send_keys(keys)
       end
     end
   end


### PR DESCRIPTION
https://community.openproject.org/work_packages/70541

With capybara, you can not select elements within the shadow dom directly. You always have to:
1. Select the element that hosts the shadow dom
2. Call `shadow_root` on this element
3. Select from there

Unfortunately, capybara's `within` does not work with the shadow dom, so you have to do this every time.

Also, this only works with selenium, not with cuprite. Cuprite does not yet support the shadow dom enough.

