### PR TITLE
[#67226] Display in the meeting tab of a WorkPackage that the WP is the outcome of a meeting  

### DIFF
--- a/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
@@ -32,6 +32,7 @@
         flex.with_row do
           render(
             WorkPackageMeetingsTab::ListComponent.new(
+              work_package: @work_package,
               agenda_items_grouped_by_meeting: @agenda_items_grouped_by_meeting,
               direction: @direction
             )

--- a/modules/meeting/app/components/work_package_meetings_tab/list_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/list_component.html.erb
@@ -5,7 +5,7 @@
         flex.with_row(mt: 3) do
           render(
             WorkPackageMeetingsTab::MeetingComponent.new(
-              meeting:, meeting_agenda_items:
+              work_package: @work_package, meeting:, meeting_agenda_items:
             )
           )
         end

--- a/modules/meeting/app/components/work_package_meetings_tab/list_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/list_component.rb
@@ -32,9 +32,10 @@ module WorkPackageMeetingsTab
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(agenda_items_grouped_by_meeting:, direction:)
+    def initialize(work_package:, agenda_items_grouped_by_meeting:, direction:)
       super
 
+      @work_package = work_package
       @agenda_items_grouped_by_meeting = agenda_items_grouped_by_meeting
       @direction = direction
     end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
@@ -10,11 +10,12 @@
       end
     end
 
-    if @meeting_agenda_item.outcomes.exists?
-      outcome = @meeting_agenda_item.outcomes.information_kind.last
+    outcomes = @meeting_agenda_item.outcomes.information_kind.to_a
+    outcomes.each_with_index do |outcome, index|
       flex.with_row do
         render(OpPrimer::InsetBoxComponent.new(border: false, mt: 2, classes: "outcome-container")) do
-          concat render(Primer::Beta::Heading.new(tag: :h5)) { t(:label_agenda_outcome) }
+          heading = outcomes.size > 1 ? "#{t(:label_agenda_outcome)} #{index + 1}" : t(:label_agenda_outcome)
+          concat render(Primer::Beta::Heading.new(tag: :h5)) { heading }
           concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
         end
       end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
@@ -8,7 +8,7 @@
 
     if work_package_is_agenda_item?
       flex.with_row do
-        render(Primer::Beta::Text.new(color: @meeting_agenda_item.notes.present? ? nil : :subtle)) do
+        render(Primer::Beta::Text.new(color: @meeting_agenda_item.notes.present? ? :default : :subtle)) do
           if @meeting_agenda_item.notes.present?
             ::OpenProject::TextFormatting::Renderer.format_text(@meeting_agenda_item.notes)
           else
@@ -23,8 +23,7 @@
       outcomes.each_with_index do |outcome, index|
         flex.with_row do
           render(OpPrimer::InsetBoxComponent.new(border: false, mt: 2, classes: "outcome-container")) do
-            heading = outcomes.size > 1 ? "#{t(:label_agenda_outcome)} #{index + 1}" : t(:label_agenda_outcome)
-            concat render(Primer::Beta::Heading.new(tag: :h5)) { heading }
+            concat render(Primer::Beta::Heading.new(tag: :h5)) { outcome_heading(outcomes, index) }
             concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
           end
         end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
@@ -1,22 +1,32 @@
 <%=
   flex_layout do |flex|
-    flex.with_row do
-      render(Primer::Beta::Text.new(color: @meeting_agenda_item.notes.present? ? nil : :subtle)) do
-        if @meeting_agenda_item.notes.present?
-          ::OpenProject::TextFormatting::Renderer.format_text(@meeting_agenda_item.notes)
-        else
-          t("text_agenda_item_no_notes")
+    if !work_package_is_agenda_item?
+      flex.with_row do
+        render(Primer::Beta::Label.new(scheme: :accent)) { t(:label_added_as_outcome) }
+      end
+    end
+
+    if work_package_is_agenda_item?
+      flex.with_row do
+        render(Primer::Beta::Text.new(color: @meeting_agenda_item.notes.present? ? nil : :subtle)) do
+          if @meeting_agenda_item.notes.present?
+            ::OpenProject::TextFormatting::Renderer.format_text(@meeting_agenda_item.notes)
+          else
+            t("text_agenda_item_no_notes")
+          end
         end
       end
     end
 
-    outcomes = @meeting_agenda_item.outcomes.information_kind.to_a
-    outcomes.each_with_index do |outcome, index|
-      flex.with_row do
-        render(OpPrimer::InsetBoxComponent.new(border: false, mt: 2, classes: "outcome-container")) do
-          heading = outcomes.size > 1 ? "#{t(:label_agenda_outcome)} #{index + 1}" : t(:label_agenda_outcome)
-          concat render(Primer::Beta::Heading.new(tag: :h5)) { heading }
-          concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
+    if work_package_is_agenda_item?
+      outcomes = @meeting_agenda_item.outcomes.to_a
+      outcomes.each_with_index do |outcome, index|
+        flex.with_row do
+          render(OpPrimer::InsetBoxComponent.new(border: false, mt: 2, classes: "outcome-container")) do
+            heading = outcomes.size > 1 ? "#{t(:label_agenda_outcome)} #{index + 1}" : t(:label_agenda_outcome)
+            concat render(Primer::Beta::Heading.new(tag: :h5)) { heading }
+            concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
+          end
         end
       end
     end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
@@ -42,5 +42,12 @@ module WorkPackageMeetingsTab
     def work_package_is_agenda_item?
       @meeting_agenda_item.work_package_id == @work_package.id
     end
+
+    def outcome_heading(outcomes, index)
+      heading = t(:label_agenda_outcome)
+      heading += " #{index + 1}" if outcomes.size > 1
+
+      heading
+    end
   end
 end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
@@ -32,10 +32,15 @@ module WorkPackageMeetingsTab
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting_agenda_item:)
+    def initialize(work_package:, meeting_agenda_item:)
       super
 
+      @work_package = work_package
       @meeting_agenda_item = meeting_agenda_item
+    end
+
+    def work_package_is_agenda_item?
+      @meeting_agenda_item.work_package_id == @work_package.id
     end
   end
 end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_component.html.erb
@@ -26,7 +26,7 @@
     end
     @meeting_agenda_items.each do |meeting_agenda_item|
       border_box.with_row do
-        render(WorkPackageMeetingsTab::MeetingAgendaItemComponent.new(meeting_agenda_item:))
+        render(WorkPackageMeetingsTab::MeetingAgendaItemComponent.new(work_package: @work_package, meeting_agenda_item:))
       end
     end
   end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_component.rb
@@ -32,9 +32,10 @@ module WorkPackageMeetingsTab
     include ApplicationHelper
     include OpPrimer::ComponentHelpers
 
-    def initialize(meeting:, meeting_agenda_items:)
+    def initialize(work_package:, meeting:, meeting_agenda_items:)
       super
 
+      @work_package = work_package
       @meeting = meeting
       @meeting_agenda_items = meeting_agenda_items
     end

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -164,10 +164,12 @@ class WorkPackageMeetingsTabController < ApplicationController
   end
 
   def agenda_items_linked_to_work_package
-    MeetingAgendaItem.where(
-      "meeting_agenda_items.work_package_id = :wp_id OR meeting_agenda_items.id IN (SELECT meeting_agenda_item_id FROM meeting_outcomes WHERE meeting_outcomes.work_package_id = :wp_id)", # rubocop:disable Layout/LineLength
-      wp_id: @work_package.id
-    )
+    MeetingAgendaItem.where(<<~SQL.squish, wp_id: @work_package.id)
+      meeting_agenda_items.work_package_id = :wp_id OR
+      meeting_agenda_items.id IN (
+        SELECT meeting_agenda_item_id FROM meeting_outcomes WHERE meeting_outcomes.work_package_id = :wp_id
+      )
+    SQL
   end
 
   def sort_clause(direction)

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -53,7 +53,9 @@ class WorkPackageMeetingsTabController < ApplicationController
   end
 
   def count
-    count = Meeting.visible.not_templated.where(id: @work_package.meetings.select(:id)).count
+    count = Meeting.visible.not_templated
+      .where(id: agenda_items_linked_to_work_package.select(:meeting_id))
+      .count
     render json: { count: }
   end
 
@@ -152,14 +154,20 @@ class WorkPackageMeetingsTabController < ApplicationController
   end
 
   def get_agenda_items_of_work_package(direction)
-    agenda_items = MeetingAgendaItem
-        .includes(:meeting)
+    agenda_items = agenda_items_linked_to_work_package
+        .includes(:meeting, :outcomes)
         .where(meeting_id: Meeting.not_templated.visible(current_user))
-        .where(work_package_id: @work_package.id)
         .order(sort_clause(direction))
 
     comparison = direction == :past ? "<" : ">="
     agenda_items.where("meetings.start_time + (interval '1 hour' * meetings.duration) #{comparison} ?", Time.zone.now)
+  end
+
+  def agenda_items_linked_to_work_package
+    MeetingAgendaItem.where(
+      "meeting_agenda_items.work_package_id = :wp_id OR meeting_agenda_items.id IN (SELECT meeting_agenda_item_id FROM meeting_outcomes WHERE meeting_outcomes.work_package_id = :wp_id)", # rubocop:disable Layout/LineLength
+      wp_id: @work_package.id
+    )
   end
 
   def sort_clause(direction)

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -592,6 +592,7 @@ en:
   label_agenda_outcome_actions: "Agenda outcome actions"
   label_agenda_outcome_edit: "Edit outcome"
   label_agenda_outcome_delete: "Remove outcome"
+  label_added_as_outcome: "Added as outcome"
   label_write_outcome: "Write outcome"
   label_existing_work_package: "Existing work package"
   text_outcome_not_editable_anymore: "This outcome is not editable anymore."

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -290,6 +290,33 @@ RSpec.describe "Open the Meetings tab",
       end
     end
 
+    context "when the work_package is linked as an outcome" do
+      let!(:meeting) { create(:meeting, project:) }
+      let!(:other_work_package) { create(:work_package, project:, subject: "Different work package") }
+
+      let!(:meeting_agenda_item) do
+        create(:meeting_agenda_item, meeting:, work_package: other_work_package, notes: "Discussing something else")
+      end
+
+      let!(:outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, work_package:, kind: :work_package)
+      end
+
+      it "shows the meeting with 'Added as outcome' label" do
+        work_package_page.visit!
+        switch_to_meetings_tab
+
+        meetings_tab.expect_upcoming_counter_to_be(1)
+
+        page.within_test_selector("op-meeting-container-#{meeting.id}") do
+          expect(page).to have_content(meeting.title)
+          expect(page).to have_content(I18n.t(:label_added_as_outcome))
+
+          expect(page).to have_no_content(meeting_agenda_item.notes)
+        end
+      end
+    end
+
     context "when the work_package was already referenced in past meetings" do
       let!(:first_past_meeting) { create(:meeting, project:, start_time: Date.yesterday - 11.hours) }
       let!(:second_past_meeting) { create(:meeting, project:, start_time: Date.yesterday - 10.hours) }

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "Open the Meetings tab",
       end
     end
 
-    context "when the work_package is referenced and has an outcome" do
+    context "when the work_package is referenced and has a single outcome" do
       let!(:meeting) { create(:meeting, project:) }
 
       let!(:meeting_agenda_item) do
@@ -286,6 +286,37 @@ RSpec.describe "Open the Meetings tab",
         page.within_test_selector("op-meeting-container-#{meeting.id}") do
           expect(page).to have_content(meeting_agenda_item.notes)
           expect(page).to have_content(outcome.notes)
+        end
+      end
+    end
+
+    context "when the work_package is referenced and has multiple outcomes" do
+      let!(:meeting) { create(:meeting, project:) }
+
+      let!(:meeting_agenda_item) do
+        create(:meeting_agenda_item, meeting:, work_package:, notes: "Discussion notes")
+      end
+
+      let!(:first_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, notes: "First decision")
+      end
+
+      let!(:second_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, notes: "Second decision")
+      end
+
+      it "shows all outcomes with numbered headings" do
+        work_package_page.visit!
+        switch_to_meetings_tab
+
+        meetings_tab.expect_upcoming_counter_to_be(1)
+
+        page.within_test_selector("op-meeting-container-#{meeting.id}") do
+          expect(page).to have_content(meeting_agenda_item.notes)
+          expect(page).to have_content(first_outcome.notes)
+          expect(page).to have_content(second_outcome.notes)
+          expect(page).to have_content("#{I18n.t(:label_agenda_outcome)} 1")
+          expect(page).to have_content("#{I18n.t(:label_agenda_outcome)} 2")
         end
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/67226
https://community.openproject.org/work_packages/70779

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Display meetings associated with a work package not only via agenda items, but also via outcomes in the work package meetings tab

# Merge checklist

- [x] Added/updated tests
