### PR TITLE
Remove manage_overview permission checks in code

### DIFF
--- a/modules/grids/spec/controllers/grids/overviews_controller_spec.rb
+++ b/modules/grids/spec/controllers/grids/overviews_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Overviews::OverviewsController do
 
   before do
     mock_permissions_for(current_user) do |mock|
-      mock.allow_in_project *permissions, :view_news, :manage_overview, project:
+      mock.allow_in_project *permissions, :view_news, :manage_dashboards, project:
     end
 
     login_as current_user

--- a/modules/overviews/config/locales/en.yml
+++ b/modules/overviews/config/locales/en.yml
@@ -2,5 +2,4 @@ en:
   overviews:
     label_home: "%{workspace_type} home"
     label_dashboard: "Dashboard"
-    label_overview: 'Overview'
-  permission_manage_overview: 'Manage overview page'
+    label_overview: "Overview"

--- a/modules/overviews/lib/overviews/engine.rb
+++ b/modules/overviews/lib/overviews/engine.rb
@@ -92,12 +92,8 @@ module Overviews
 
         OpenProject::AccessControl.map do |ac_map|
           ac_map.project_module nil do |map|
-            map.permission :manage_overview,
-                           { "overviews/overviews": %i[show] },
-                           permissible_on: :project,
-                           require: :member
             map.permission :manage_dashboards,
-                           { "overviews/overviews": %i[dashboard] },
+                           { "overviews/overviews": %i[show dashboard] },
                            permissible_on: :project,
                            require: :member
           end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/70793/activity

References #20045 

# What are you trying to accomplish?
- In #20045 we have renamed the `manage_overviews` permission to `manage_dashboards`
- We have still left the `manage_overviews` permission in code but it did not do anything.
- We have received a report that the overview page (which is now a dashboard) can be managed with just the `manage_dashboards` permission, I think this is intended behavior, but it is confusing.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
