### PR TITLE
Maintenance: use slim base image to reduce attack surface

### DIFF
--- a/bin/build-docker-aio
+++ b/bin/build-docker-aio
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t openproject/openproject:$(git rev-parse --abbrev-ref HEAD | tr '/' '-') --build-arg DEBIAN_BASE=bookworm -f docker/prod/Dockerfile .
+

--- a/bin/build-docker-slim
+++ b/bin/build-docker-slim
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t openproject/openproject:$(git rev-parse --abbrev-ref HEAD | tr '/' '-')-slim --build-arg BIM_SUPPORT=false --target slim -f docker/prod/Dockerfile .
+

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_BASE="trixie"
 # Add SBOM scan context for intermediate steps
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
 ARG BUILDKIT_SBOM_SCAN_STAGE=true
-FROM ruby:${RUBY_VERSION}-${DEBIAN_BASE} AS base
+FROM ruby:${RUBY_VERSION}-slim-${DEBIAN_BASE} AS base
 LABEL maintainer="operations@openproject.com"
 
 ARG NODE_VERSION="22.21.0"

--- a/docker/prod/setup/preinstall-common.sh
+++ b/docker/prod/setup/preinstall-common.sh
@@ -29,6 +29,7 @@ apt-get upgrade -y
 
 apt-get install -yq --no-install-recommends \
 	curl \
+	wget \
 	file \
 	gnupg2 \
 	lsb-release
@@ -51,7 +52,9 @@ apt-get install -yq --no-install-recommends \
 	imagemagick \
 	libclang-dev \
 	libjemalloc2 \
-	git
+	git \
+	build-essential \
+	libyaml-dev \
 
 for version in $PGVERSION_CHOICES ; do
 	apt-get install -yq --no-install-recommends postgresql-client-$version


### PR DESCRIPTION
This reduces the number of vulnerabilities in the OpenProject images further by using the slim ruby image as its base rather than the default one.

This removes unused dependencies (such as mariadb and openexr) adding unnecessary vulnerabilities.