### PR TITLE
[#70297] Error 500 on Form configuration page after adding a new CF

### DIFF
--- a/frontend/src/app/features/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/features/admin/types/type-form-configuration.component.ts
@@ -108,29 +108,6 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
     this.form = this.element.closest('form')!;
     this.submit = this.form.querySelector('.form-configuration--save')!;
 
-    // In the following we are triggering the form submit ourselves to work around
-    // a firefox shortcoming. But to avoid double submits which are sometimes not canceled fast
-    // enough, we need to memoize whether we have already submitted.
-    let submitted = false;
-
-    this.form.addEventListener('submit', (e) => {
-      if (submitted) { // Cancel if already submitted.
-        e.preventDefault();
-        e.stopPropagation();
-      } else {
-        submitted = true;
-      }
-    });
-
-    // Capture mousedown on button because firefox breaks blur on click
-    this.submit.addEventListener('mousedown', () => {
-      setTimeout(() => {
-        if (!submitted) {
-          this.form.requestSubmit();
-        }
-      }, 50);
-    });
-
     // Capture regular form submit
     this.form.addEventListener('submit', this.eventListeners.typeFormUpdater);
 

--- a/frontend/src/app/features/admin/types/type-form-configuration.component.ts
+++ b/frontend/src/app/features/admin/types/type-form-configuration.component.ts
@@ -1,4 +1,11 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   ExternalRelationQueryConfigurationService,
@@ -32,6 +39,7 @@ export const emptyTypeGroup = '__empty';
 
 @Component({
   selector: 'opce-admin-type-form-configuration',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './type-form-configuration.html',
   providers: [
     TypeBannerService,
@@ -105,8 +113,13 @@ export class TypeFormConfigurationComponent extends UntilDestroyedMixin implemen
     // enough, we need to memoize whether we have already submitted.
     let submitted = false;
 
-    this.form.addEventListener('submit', () => {
-      submitted = true;
+    this.form.addEventListener('submit', (e) => {
+      if (submitted) { // Cancel if already submitted.
+        e.preventDefault();
+        e.stopPropagation();
+      } else {
+        submitted = true;
+      }
     });
 
     // Capture mousedown on button because firefox breaks blur on click

--- a/spec/features/types/form_configuration_spec.rb
+++ b/spec/features/types/form_configuration_spec.rb
@@ -378,4 +378,40 @@ RSpec.describe "form configuration", :js, :selenium do
       dialog.expect_open
     end
   end
+
+  describe "form submission", :js, with_ee: %i[edit_attribute_groups] do
+    # Regression test for double form submission happening on the form configuration page
+    it "only submits the form once (Regression#70297)" do
+      call_count = 0
+      subscription =
+        ActiveSupport::Notifications.subscribe("process_action.action_controller") do |*, payload|
+          payload => { controller:, action: }
+          if controller == "WorkPackageTypes::FormConfigurationTabController" && action == "update"
+            call_count += 1
+          end
+        end
+
+      login_as(admin)
+      visit edit_type_form_configuration_path(type)
+
+      # Wait for form to load
+      form.expect_group("details", "Details")
+
+      # Simulate native mousedown -> mouseup -> click sequence
+      # Including some sleep time to simulate the user actually
+      # holding the mouse button for > 50ms then releasing it.
+      save_button = find(".form-configuration--save")
+
+      save_button.execute_script("this.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))")
+      sleep 0.1
+      save_button.execute_script("this.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))")
+      sleep 0.1
+      save_button.execute_script("this.dispatchEvent(new MouseEvent('click', { bubbles: true }))")
+
+      expect_flash(message: "Successful update.")
+
+      ActiveSupport::Notifications.unsubscribe(subscription)
+      expect(call_count).to eq(1), "Expected 1 form submission but got #{call_count}"
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/70297

# What are you trying to accomplish?
Fix the `PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint` raised when submitting the type form configuration. 

## Screenshots
<details><summary>Before</summary>
<p>

<img width="1182" height="171" alt="image" src="https://github.com/user-attachments/assets/cb842b75-461e-4e43-99d4-b9aaf919e08f" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1231" height="309" alt="image" src="https://github.com/user-attachments/assets/0a775200-7371-462e-82bc-78fb7bad7e93" />


</p>
</details> 

# What approach did you choose and why?
The sporadic nature of the bug, points towards a race conditions, and it happens that we have a bug which submits the configuration form twice upon clicking the save button. Removing the double submission, solves the `PG::UniqueViolation` error.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
