### PR TITLE
Show links to manage user status for users with manage_user permission

### DIFF
--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -78,12 +78,15 @@ module Users
       [status_link].compact
     end
 
-    def status_link
+    def status_link # rubocop:disable Metrics/AbcSize
       # Don't show for current user
       return if user.id == table.current_user.id
 
-      # Don't show if non-admin
-      return unless table.current_user.admin?
+      # Don't show if you don't have the permission
+      return unless table.current_user.allowed_globally?(:manage_user)
+
+      # Don't show when affected user is an admin and current user is not
+      return if user.admin? && !table.current_user.admin?
 
       helpers.change_user_status_links user
     end

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -78,17 +78,24 @@ module Users
       [status_link].compact
     end
 
-    def status_link # rubocop:disable Metrics/AbcSize
-      # Don't show for current user
-      return if user.id == table.current_user.id
-
-      # Don't show if you don't have the permission
-      return unless table.current_user.allowed_globally?(:manage_user)
-
-      # Don't show when affected user is an admin and current user is not
-      return if user.admin? && !table.current_user.admin?
+    def status_link
+      return if user_is_current_user?
+      return unless current_user_allowed_to_manage_users?
+      return if user_is_admin_and_current_user_is_no_admin?
 
       helpers.change_user_status_links user
+    end
+
+    def user_is_current_user?
+      user.id == table.current_user.id
+    end
+
+    def current_user_allowed_to_manage_users?
+      table.current_user.allowed_globally?(:manage_user)
+    end
+
+    def user_is_admin_and_current_user_is_no_admin?
+      user.admin? && !table.current_user.admin?
     end
 
     def column_css_class(column)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -157,6 +157,14 @@ class UsersController < ApplicationController
   def change_status # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     if @user.id == current_user.id
       # user is not allowed to change own status
+      flash[:error] = I18n.t("user.error_status_change_self")
+      redirect_back_or_default({ action: "edit", id: @user })
+      return
+    end
+
+    if @user.admin? && !current_user.admin?
+      # non-admin users are not allowed to change admin status
+      flash[:error] = I18n.t("user.error_admin_change_on_non_admin")
       redirect_back_or_default({ action: "edit", id: @user })
       return
     end
@@ -167,23 +175,28 @@ class UsersController < ApplicationController
       return redirect_back_or_default({ action: "edit", id: @user })
     end
 
+    activated_account = false
+
     if params[:unlock]
       @user.failed_login_count = 0
       @user.activate
+      activated_account = true
     elsif params[:lock]
       @user.lock
     elsif params[:activate]
       @user.activate
+      activated_account = true
     end
-    # Was the account activated? (do it before User#save clears the change)
-    was_activated = (@user.status_change == %w[registered active])
 
-    if params[:activate] && @user.missing_authentication_method?
+    # Was the account activated? (do it before User#save clears the change)
+    should_deliver_activation_mail = (@user.status_change == %w[registered active])
+
+    if activated_account && @user.missing_authentication_method?
       flash[:error] = I18n.t("user.error_status_change_failed",
                              errors: I18n.t(:notice_user_missing_authentication_method))
     elsif @user.save
       flash[:notice] = I18n.t(:notice_successful_update)
-      if was_activated
+      if should_deliver_activation_mail
         UserMailer.account_activated(@user).deliver_later
       end
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5113,6 +5113,8 @@ en:
       other: "locked temporarily (%{count} failed login attempts)"
     confirm_status_change: "You are about to change the status of '%{name}'. Are you sure you want to continue?"
     deleted: "Deleted user"
+    error_status_change_self: "You cannot change your own user status."
+    error_admin_change_on_non_admin: "Only administrators can change the status of administrator users."
     error_status_change_failed: "Changing the user status failed due to the following errors: %{errors}"
     invite: Invite user via email
     invited: invited

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -33,6 +33,14 @@ require "work_package"
 
 RSpec.describe UsersController do
   shared_let(:admin) { create(:admin) }
+  shared_let(:user_manager) do
+    create(:user,
+           login: "user-manager",
+           mail: "user-manager@example.com",
+           firstname: "User",
+           lastname: "Manager",
+           global_permissions: %i[view_all_principals manage_user])
+  end
   shared_let(:anonymous) { User.anonymous }
 
   shared_let(:user_password) { "bob!" * 4 }
@@ -411,7 +419,7 @@ RSpec.describe UsersController do
   end
 
   describe "#change_status", with_settings: { available_languages: %w[en de], bcc_recipients: 1 } do
-    let(:acting_user) { admin }
+    let(:acting_user) { user_manager }
     let(:affected_user) { registered_user }
 
     let!(:registered_user) do
@@ -442,7 +450,7 @@ RSpec.describe UsersController do
       end
 
       context "when trying to modifiy yourself" do
-        let(:affected_user) { admin }
+        let(:affected_user) { acting_user }
 
         it "does not allow changing own status" do
           subject
@@ -452,15 +460,28 @@ RSpec.describe UsersController do
         end
       end
 
-      context "when trying to modify an admin as non-admin" do
-        let(:acting_user) { create(:user, global_permissions: %i[view_all_principals manage_user]) }
+      context "when trying to modify an admin" do
         let(:affected_user) { create(:admin) }
 
-        it "does not allow changing the status of an admin" do
-          subject
+        context "as non-admin" do
+          it "does not allow changing the status of an admin" do
+            subject
 
-          expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
-          expect(response).to redirect_to(action: :edit)
+            expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
+            expect(response).to redirect_to(action: :edit)
+          end
+        end
+
+        context "as admin" do
+          let(:acting_user) { admin }
+
+          it "allows changing the status of an admin" do
+            subject
+
+            affected_user.reload
+
+            expect(affected_user).to be_locked
+          end
         end
       end
     end
@@ -513,7 +534,7 @@ RSpec.describe UsersController do
       end
 
       context "when trying to modifiy yourself" do
-        let(:affected_user) { admin }
+        let(:affected_user) { acting_user }
 
         it "does not allow changing own status" do
           subject
@@ -567,7 +588,7 @@ RSpec.describe UsersController do
       end
 
       context "when trying to modifiy yourself" do
-        let(:affected_user) { admin }
+        let(:affected_user) { acting_user }
 
         it "does not allow changing own status" do
           subject
@@ -577,15 +598,28 @@ RSpec.describe UsersController do
         end
       end
 
-      context "when trying to modify an admin as non-admin" do
-        let(:acting_user) { create(:user, global_permissions: %i[view_all_principals manage_user]) }
+      context "when trying to modify an admin" do
         let(:affected_user) { create(:admin) }
 
-        it "does not allow changing the status of an admin" do
-          subject
+        context "as non-admin" do
+          it "does not allow changing the status of an admin" do
+            subject
 
-          expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
-          expect(response).to redirect_to(action: :edit)
+            expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
+            expect(response).to redirect_to(action: :edit)
+          end
+        end
+
+        context "as admin" do
+          let(:acting_user) { admin }
+
+          it "allows changing the status of an admin" do
+            subject
+
+            affected_user.reload
+
+            expect(affected_user).to be_active
+          end
         end
       end
 
@@ -613,7 +647,7 @@ RSpec.describe UsersController do
 
         it "shows the user limit reached error and recommends to upgrade" do
           subject
-          expect(flash[:error]).to match /Adding additional users will exceed the current limit.*upgrade/i
+          expect(flash[:error]).to match(/Adding additional users will exceed the current limit./i)
         end
 
         it "does not activate the user" do
@@ -642,7 +676,7 @@ RSpec.describe UsersController do
     end
 
     it "assigns users" do
-      expect(assigns(:users)).to contain_exactly(user, admin)
+      expect(assigns(:users)).to contain_exactly(user, admin, user_manager)
     end
 
     context "with a name filter" do
@@ -669,7 +703,7 @@ RSpec.describe UsersController do
       let!(:deleted_user) { create(:user_marked_for_deletion) }
 
       it "does not include this user to the users list" do
-        expect(assigns(:users)).to contain_exactly(user, admin)
+        expect(assigns(:users)).to contain_exactly(user, admin, user_manager)
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -410,37 +410,153 @@ RSpec.describe UsersController do
     end
   end
 
-  describe "#change_status",
-           with_settings: {
-             available_languages: %w[en de],
-             bcc_recipients: 1
-           } do
+  describe "#change_status", with_settings: { available_languages: %w[en de], bcc_recipients: 1 } do
+    let(:acting_user) { admin }
+    let(:affected_user) { registered_user }
+
+    let!(:registered_user) do
+      create(:user, status: User.statuses[:registered], language: "de")
+    end
+
+    subject do
+      as_logged_in_user acting_user do
+        post :change_status,
+             params: {
+               id: affected_user.id,
+               **status_params
+             }
+      end
+    end
+
+    describe "WHEN locking a user" do
+      let(:status_params) do
+        { lock: "1" }
+      end
+
+      it "locks the user" do
+        subject
+
+        affected_user.reload
+
+        expect(affected_user).to be_locked
+      end
+
+      context "when trying to modifiy yourself" do
+        let(:affected_user) { admin }
+
+        it "does not allow changing own status" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_status_change_self"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
+      context "when trying to modify an admin as non-admin" do
+        let(:acting_user) { create(:user, global_permissions: %i[view_all_principals manage_user]) }
+        let(:affected_user) { create(:admin) }
+
+        it "does not allow changing the status of an admin" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+    end
+
+    describe "WHEN unlocking a locked user" do
+      before do
+        registered_user.lock
+      end
+
+      let(:status_params) do
+        { unlock: "1" }
+      end
+
+      it "activates and unlocks the user" do
+        subject
+
+        affected_user.reload
+
+        expect(affected_user).to be_active
+        expect(affected_user).not_to be_locked
+      end
+
+      it "resets failed login attempts" do
+        affected_user.update(failed_login_count: 3)
+
+        expect do
+          subject
+          affected_user.reload
+        end.to change(affected_user, :failed_login_count).to(0)
+      end
+
+      context "when the user does not have an authentication method" do
+        before do
+          UserPassword.where(user_id: affected_user.id).delete_all
+          UserAuthProviderLink.where(user_id: affected_user.id).delete_all
+          affected_user.update(ldap_auth_source_id: nil)
+        end
+
+        it "does not activate or unlock the user and shows an error" do
+          subject
+
+          affected_user.reload
+          expect(affected_user).not_to be_active
+          expect(affected_user).to be_locked
+
+          expect(flash[:error]).to eq(I18n.t("user.error_status_change_failed",
+                                             errors: I18n.t(:notice_user_missing_authentication_method)))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
+      context "when trying to modifiy yourself" do
+        let(:affected_user) { admin }
+
+        it "does not allow changing own status" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_status_change_self"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
+      context "when trying to modify an admin as non-admin" do
+        let(:acting_user) { create(:user, global_permissions: %i[view_all_principals manage_user]) }
+        let(:affected_user) { create(:admin) }
+
+        it "does not allow changing the status of an admin" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+    end
+
     describe "WHEN activating a registered user" do
-      let!(:registered_user) do
-        create(:user, status: User.statuses[:registered],
-                      language: "de")
+      let(:status_params) do
+        { activate: "1" }
       end
 
       let(:user_limit_reached) { false }
 
       before do
         allow(OpenProject::Enterprise).to receive(:user_limit_reached?).and_return(user_limit_reached)
-
-        as_logged_in_user admin do
-          post :change_status,
-               params: {
-                 id: registered_user.id,
-                 user: { status: User.statuses[:active] },
-                 activate: "1"
-               }
-        end
       end
 
       it "activates the user" do
-        assert registered_user.reload.active?
+        subject
+
+        affected_user.reload
+        expect(affected_user).to be_active
       end
 
       it "sends an email to the correct user in the correct language" do
+        subject
+
         perform_enqueued_jobs
         mail = ActionMailer::Base.deliveries.last
         expect(mail).not_to be_nil
@@ -450,14 +566,58 @@ RSpec.describe UsersController do
         end
       end
 
+      context "when trying to modifiy yourself" do
+        let(:affected_user) { admin }
+
+        it "does not allow changing own status" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_status_change_self"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
+      context "when trying to modify an admin as non-admin" do
+        let(:acting_user) { create(:user, global_permissions: %i[view_all_principals manage_user]) }
+        let(:affected_user) { create(:admin) }
+
+        it "does not allow changing the status of an admin" do
+          subject
+
+          expect(flash[:error]).to eq(I18n.t("user.error_admin_change_on_non_admin"))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
+      context "when the user does not have an authentication method" do
+        before do
+          UserPassword.where(user_id: registered_user.id).delete_all
+          UserAuthProviderLink.where(user_id: registered_user.id).delete_all
+          registered_user.update(ldap_auth_source_id: nil)
+        end
+
+        it "does not activate the user and shows an error" do
+          subject
+
+          affected_user.reload
+          expect(affected_user).not_to be_active
+
+          expect(flash[:error]).to eq(I18n.t("user.error_status_change_failed",
+                                             errors: I18n.t(:notice_user_missing_authentication_method)))
+          expect(response).to redirect_to(action: :edit)
+        end
+      end
+
       context "with user limit reached" do
         let(:user_limit_reached) { true }
 
         it "shows the user limit reached error and recommends to upgrade" do
+          subject
           expect(flash[:error]).to match /Adding additional users will exceed the current limit.*upgrade/i
         end
 
         it "does not activate the user" do
+          subject
           expect(registered_user.reload).not_to be_active
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/70796/activity

# What are you trying to accomplish?
- Show links to lock/unlock/activate users for user managers with the `manage_user` permission
- Add tests that verify that the actions work as intended


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
