### PR TITLE
Fix meeting scoping

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/duplicate_in_next_meeting_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/duplicate_in_next_meeting_dialog_component.html.erb
@@ -47,7 +47,8 @@ See COPYRIGHT and LICENSE files for more details.
           Primer::Beta::Button.new(
             tag: :a,
             scheme: :primary,
-            href: duplicate_in_next_meeting_agenda_item_path(
+            href: duplicate_in_next_project_meeting_agenda_item_path(
+              @agenda_item.meeting.project,
               @agenda_item.meeting,
               @agenda_item,
               datetime: @datetime

--- a/modules/meeting/app/components/meeting_agenda_items/item_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component.rb
@@ -100,8 +100,10 @@ module MeetingAgendaItems
           id: @meeting_agenda_item.id,
           "draggable-id": @meeting_agenda_item.id,
           "draggable-type": "agenda-item",
-          "drop-url": drop_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
-                                                    current_occurrence: @current_occurrence)
+          "drop-url": drop_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                            @meeting_agenda_item.meeting,
+                                                            @meeting_agenda_item,
+                                                            current_occurrence: @current_occurrence)
         }
       }
     end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/edit_component.rb
@@ -54,15 +54,16 @@ module MeetingAgendaItems
             meeting_section: @meeting_agenda_item.meeting_section,
             meeting_agenda_item: @meeting_agenda_item,
             method: :put,
-            submit_path: meeting_agenda_item_path(
+            submit_path: project_meeting_agenda_item_path(
+              @meeting_agenda_item.meeting.project,
               @meeting_agenda_item.meeting,
               @meeting_agenda_item,
               format: :turbo_stream,
               current_occurrence: @current_occurrence,
               presentation_mode: @presentation_mode
             ),
-            cancel_path: cancel_edit_meeting_agenda_item_path(
-              @meeting_agenda_item.meeting, @meeting_agenda_item,
+            cancel_path: cancel_edit_project_meeting_agenda_item_path(
+              @meeting_agenda_item.meeting.project, @meeting_agenda_item.meeting, @meeting_agenda_item,
               current_occurrence: @current_occurrence,
               presentation_mode: @presentation_mode
             ),

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -176,8 +176,8 @@ module MeetingAgendaItems
                         tag: :button,
                         content_arguments: outcome_action_data(
                           new_project_meeting_outcome_path(
-                            @meeting_agenda_item.meeting.project,
-                            @meeting_agenda_item.meeting,
+                            @meeting.project,
+                            @meeting,
                             meeting_agenda_item_id: @meeting_agenda_item&.id,
                             kind: :work_package,
                             current_occurrence: @current_occurrence
@@ -216,7 +216,7 @@ module MeetingAgendaItems
       next_meeting_action_item(
         menu,
         label: t(:label_agenda_item_move_to_next),
-        path_helper: :move_to_next_dialog_meeting_agenda_item_path,
+        path_helper: :move_to_next_dialog_project_meeting_agenda_item_path,
         icon: "arrow-right"
       )
     end
@@ -225,12 +225,12 @@ module MeetingAgendaItems
       next_meeting_action_item(
         menu,
         label: t(:label_agenda_item_duplicate_in_next),
-        path_helper: :duplicate_in_next_dialog_meeting_agenda_item_path,
+        path_helper: :duplicate_in_next_dialog_project_meeting_agenda_item_path,
         icon: :duplicate
       )
     end
 
-    def next_meeting_action_item(menu, label:, path_helper:, icon:) # rubocop:disable Metrics/AbcSize
+    def next_meeting_action_item(menu, label:, path_helper:, icon:)
       return unless editable?
       return if in_template?
       return if @series.nil?
@@ -246,8 +246,8 @@ module MeetingAgendaItems
           action: "click->meetings--submit#intercept",
           # TODO let's see if wen can avoid using send here
           href: send(path_helper,
-                     @meeting_agenda_item.meeting.project,
-                     @meeting_agenda_item.meeting,
+                     @meeting.project,
+                     @meeting,
                      @meeting_agenda_item,
                      datetime: next_date.iso8601),
           method: "GET"
@@ -274,8 +274,8 @@ module MeetingAgendaItems
       menu.with_item(label:,
                      scheme: :danger,
                      href: project_meeting_agenda_item_path(
-                       @meeting_agenda_item.meeting.project,
-                       @meeting_agenda_item.meeting,
+                       @meeting.project,
+                       @meeting,
                        @meeting_agenda_item,
                        current_occurrence: @current_occurrence
                      ),
@@ -296,8 +296,8 @@ module MeetingAgendaItems
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
                        href: move_project_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting.project,
-                         @meeting_agenda_item.meeting,
+                         @meeting.project,
+                         @meeting,
                          @meeting_agenda_item,
                          move_to:,
                          current_occurrence: @current_occurrence
@@ -315,8 +315,8 @@ module MeetingAgendaItems
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
                        href: drop_project_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting.project,
-                         @meeting_agenda_item.meeting,
+                         @meeting.project,
+                         @meeting,
                          @meeting_agenda_item,
                          type: :to_backlog,
                          current_occurrence: @current_occurrence
@@ -335,8 +335,8 @@ module MeetingAgendaItems
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
                        href: drop_project_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting.project,
-                         @meeting_agenda_item.meeting,
+                         @meeting.project,
+                         @meeting,
                          @meeting_agenda_item,
                          type: :to_current,
                          current_occurrence: @current_occurrence
@@ -355,8 +355,8 @@ module MeetingAgendaItems
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
                        href: move_to_section_dialog_project_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting.project,
-                         @meeting_agenda_item.meeting,
+                         @meeting.project,
+                         @meeting,
                          @meeting_agenda_item,
                          current_occurrence: @current_occurrence
                        )

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -114,10 +114,11 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_meeting_agenda_item_path(@meeting_agenda_item.meeting,
-                                                           @meeting_agenda_item,
-                                                           presentation_mode: @presentation_mode,
-                                                           current_occurrence: @current_occurrence),
+                       href: edit_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                   @meeting_agenda_item.meeting,
+                                                                   @meeting_agenda_item,
+                                                                   presentation_mode: @presentation_mode,
+                                                                   current_occurrence: @current_occurrence),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :pencil)
@@ -129,8 +130,11 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
-                                                           display_notes_input: true, current_occurrence: @current_occurrence),
+                       href: edit_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                   @meeting_agenda_item.meeting,
+                                                                   @meeting_agenda_item,
+                                                                   display_notes_input: true,
+                                                                   current_occurrence: @current_occurrence),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :note)
@@ -153,10 +157,11 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_write_outcome"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_meeting_outcome_path(@meeting_agenda_item.meeting,
-                                                   meeting_agenda_item_id: @meeting_agenda_item&.id,
-                                                   kind: :information,
-                                                   current_occurrence: @current_occurrence)
+                          new_project_meeting_outcome_path(@meeting_agenda_item.meeting.project,
+                                                           @meeting_agenda_item.meeting,
+                                                           meeting_agenda_item_id: @meeting_agenda_item&.id,
+                                                           kind: :information,
+                                                           current_occurrence: @current_occurrence)
                         ))
     end
 
@@ -164,10 +169,11 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_existing_work_package"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_meeting_outcome_path(@meeting_agenda_item.meeting,
-                                                   meeting_agenda_item_id: @meeting_agenda_item&.id,
-                                                   kind: :work_package,
-                                                   current_occurrence: @current_occurrence)
+                          new_project_meeting_outcome_path(@meeting_agenda_item.meeting.project,
+                                                           @meeting_agenda_item.meeting,
+                                                           meeting_agenda_item_id: @meeting_agenda_item&.id,
+                                                           kind: :work_package,
+                                                           current_occurrence: @current_occurrence)
                         ))
     end
 
@@ -177,8 +183,9 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_work_package_new"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          create_work_package_dialog_meeting_outcomes_path(@meeting,
-                                                                           meeting_agenda_item_id: @meeting_agenda_item.id)
+                          create_work_package_dialog_project_meeting_outcomes_path(@meeting.project,
+                                                                                   @meeting,
+                                                                                   meeting_agenda_item_id: @meeting_agenda_item.id)
                         ))
     end
 
@@ -187,7 +194,7 @@ module MeetingAgendaItems
     end
 
     def copy_action_item(menu)
-      url = meeting_url(@meeting, anchor: "meeting-agenda-item-#{@meeting_agenda_item.id}")
+      url = project_meeting_url(@meeting.project, @meeting, anchor: "meeting-agenda-item-#{@meeting_agenda_item.id}")
       menu.with_item(label: t("meeting.copy.to_clipboard"),
                      tag: :"clipboard-copy",
                      content_arguments: { value: url }) do |item|
@@ -227,12 +234,12 @@ module MeetingAgendaItems
         tag: :button,
         content_arguments: { data: {
           action: "click->meetings--submit#intercept",
-          href: send(
-            path_helper,
-            @meeting_agenda_item.meeting,
-            @meeting_agenda_item,
-            datetime: next_date.iso8601
-          ),
+          # TODO let's see if wen can avoid using send here
+          href: send(path_helper,
+                     @meeting_agenda_item.meeting.project,
+                     @meeting_agenda_item.meeting,
+                     @meeting_agenda_item,
+                     datetime: next_date.iso8601),
           method: "GET"
         } }
       ) do |item|
@@ -256,8 +263,10 @@ module MeetingAgendaItems
       label = @meeting_agenda_item.work_package_id.present? ? wp_agenda_item_delete_label : t(:text_destroy)
       menu.with_item(label:,
                      scheme: :danger,
-                     href: meeting_agenda_item_path(@meeting_agenda_item.meeting, @meeting_agenda_item,
-                                                    current_occurrence: @current_occurrence),
+                     href: project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                            @meeting_agenda_item.meeting,
+                                                            @meeting_agenda_item,
+                                                            current_occurrence: @current_occurrence),
                      form_arguments: {
                        method: :delete, data: { turbo_confirm: t(:text_are_you_sure), "turbo-stream": true }
                      }) do |item|
@@ -274,12 +283,11 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: move_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting,
-                         @meeting_agenda_item,
-                         move_to:,
-                         current_occurrence: @current_occurrence
-                       )
+                       href: move_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                   @meeting_agenda_item.meeting,
+                                                                   @meeting_agenda_item,
+                                                                   move_to:,
+                                                                   current_occurrence: @current_occurrence)
                      } }) do |item|
         item.with_leading_visual_icon(icon:)
       end
@@ -292,12 +300,11 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: drop_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting,
-                         @meeting_agenda_item,
-                         type: :to_backlog,
-                         current_occurrence: @current_occurrence
-                       )
+                       href: drop_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                   @meeting_agenda_item.meeting,
+                                                                   @meeting_agenda_item,
+                                                                   type: :to_backlog,
+                                                                   current_occurrence: @current_occurrence)
                      } }) do |item|
         item.with_leading_visual_icon(icon: "discussion-outdated")
       end
@@ -311,12 +318,11 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: drop_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting,
-                         @meeting_agenda_item,
-                         type: :to_current,
-                         current_occurrence: @current_occurrence
-                       )
+                       href: drop_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                   @meeting_agenda_item.meeting,
+                                                                   @meeting_agenda_item,
+                                                                   type: :to_current,
+                                                                   current_occurrence: @current_occurrence)
                      } }) do |item|
         item.with_leading_visual_icon(icon: "cross-reference")
       end
@@ -330,11 +336,10 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: move_to_section_dialog_meeting_agenda_item_path(
-                         @meeting_agenda_item.meeting,
-                         @meeting_agenda_item,
-                         current_occurrence: @current_occurrence
-                       )
+                       href: move_to_section_dialog_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
+                                                                                     @meeting_agenda_item.meeting,
+                                                                                     @meeting_agenda_item,
+                                                                                     current_occurrence: @current_occurrence)
                      } }) do |item|
         item.with_leading_visual_icon(icon: "op-move")
       end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -191,7 +191,7 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_work_package_new"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          create_work_package_project_meeting_agenda_item_outcomes_path(
+                          create_work_package_dialog_project_meeting_agenda_item_outcomes_path(
                             @meeting.project,
                             @meeting,
                             @meeting_agenda_item

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -216,7 +216,7 @@ module MeetingAgendaItems
       next_meeting_action_item(
         menu,
         label: t(:label_agenda_item_move_to_next),
-        path_helper: :move_to_next_dialog_project_meeting_agenda_item_path,
+        action: :move_to_next,
         icon: "arrow-right"
       )
     end
@@ -225,12 +225,12 @@ module MeetingAgendaItems
       next_meeting_action_item(
         menu,
         label: t(:label_agenda_item_duplicate_in_next),
-        path_helper: :duplicate_in_next_dialog_project_meeting_agenda_item_path,
+        action: :duplicate_in_next,
         icon: :duplicate
       )
     end
 
-    def next_meeting_action_item(menu, label:, path_helper:, icon:)
+    def next_meeting_action_item(menu, label:, action:, icon:)
       return unless editable?
       return if in_template?
       return if @series.nil?
@@ -244,12 +244,7 @@ module MeetingAgendaItems
         tag: :button,
         content_arguments: { data: {
           action: "click->meetings--submit#intercept",
-          # TODO let's see if wen can avoid using send here
-          href: send(path_helper,
-                     @meeting.project,
-                     @meeting,
-                     @meeting_agenda_item,
-                     datetime: next_date.iso8601),
+          href: path_for_next_button(action: action, next_date: next_date),
           method: "GET"
         } }
       ) do |item|
@@ -412,6 +407,21 @@ module MeetingAgendaItems
         @current_occurrence.sections.many?
       else
         @meeting.sections.many?
+      end
+    end
+
+    def path_for_next_button(action:, next_date:)
+      case action
+      when :move_to_next
+        move_to_next_dialog_project_meeting_agenda_item_path(@meeting.project,
+                                                             @meeting,
+                                                             @meeting_agenda_item,
+                                                             datetime: next_date.iso8601)
+      when :duplicate_in_next
+        duplicate_in_next_dialog_project_meeting_agenda_item_path(@meeting.project,
+                                                                  @meeting,
+                                                                  @meeting_agenda_item,
+                                                                  datetime: next_date.iso8601)
       end
     end
   end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -114,11 +114,13 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                   @meeting_agenda_item.meeting,
-                                                                   @meeting_agenda_item,
-                                                                   presentation_mode: @presentation_mode,
-                                                                   current_occurrence: @current_occurrence),
+                       href: edit_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         presentation_mode: @presentation_mode,
+                         current_occurrence: @current_occurrence
+                       ),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :pencil)
@@ -130,11 +132,13 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                   @meeting_agenda_item.meeting,
-                                                                   @meeting_agenda_item,
-                                                                   display_notes_input: true,
-                                                                   current_occurrence: @current_occurrence),
+                       href: edit_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         display_notes_input: true,
+                         current_occurrence: @current_occurrence
+                       ),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :note)
@@ -157,11 +161,13 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_write_outcome"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_project_meeting_outcome_path(@meeting_agenda_item.meeting.project,
-                                                           @meeting_agenda_item.meeting,
-                                                           meeting_agenda_item_id: @meeting_agenda_item&.id,
-                                                           kind: :information,
-                                                           current_occurrence: @current_occurrence)
+                          new_project_meeting_outcome_path(
+                            @meeting_agenda_item.meeting.project,
+                            @meeting_agenda_item.meeting,
+                            meeting_agenda_item_id: @meeting_agenda_item&.id,
+                            kind: :information,
+                            current_occurrence: @current_occurrence
+                          )
                         ))
     end
 
@@ -169,11 +175,13 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_existing_work_package"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_project_meeting_outcome_path(@meeting_agenda_item.meeting.project,
-                                                           @meeting_agenda_item.meeting,
-                                                           meeting_agenda_item_id: @meeting_agenda_item&.id,
-                                                           kind: :work_package,
-                                                           current_occurrence: @current_occurrence)
+                          new_project_meeting_outcome_path(
+                            @meeting_agenda_item.meeting.project,
+                            @meeting_agenda_item.meeting,
+                            meeting_agenda_item_id: @meeting_agenda_item&.id,
+                            kind: :work_package,
+                            current_occurrence: @current_occurrence
+                          )
                         ))
     end
 
@@ -183,9 +191,11 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_work_package_new"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          create_work_package_dialog_project_meeting_outcomes_path(@meeting.project,
-                                                                                   @meeting,
-                                                                                   meeting_agenda_item_id: @meeting_agenda_item.id)
+                          create_work_package_dialog_project_meeting_outcomes_path(
+                            @meeting.project,
+                            @meeting,
+                            meeting_agenda_item_id: @meeting_agenda_item.id
+                          )
                         ))
     end
 
@@ -220,7 +230,7 @@ module MeetingAgendaItems
       )
     end
 
-    def next_meeting_action_item(menu, label:, path_helper:, icon:)
+    def next_meeting_action_item(menu, label:, path_helper:, icon:) # rubocop:disable Metrics/AbcSize
       return unless editable?
       return if in_template?
       return if @series.nil?
@@ -263,10 +273,12 @@ module MeetingAgendaItems
       label = @meeting_agenda_item.work_package_id.present? ? wp_agenda_item_delete_label : t(:text_destroy)
       menu.with_item(label:,
                      scheme: :danger,
-                     href: project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                            @meeting_agenda_item.meeting,
-                                                            @meeting_agenda_item,
-                                                            current_occurrence: @current_occurrence),
+                     href: project_meeting_agenda_item_path(
+                       @meeting_agenda_item.meeting.project,
+                       @meeting_agenda_item.meeting,
+                       @meeting_agenda_item,
+                       current_occurrence: @current_occurrence
+                     ),
                      form_arguments: {
                        method: :delete, data: { turbo_confirm: t(:text_are_you_sure), "turbo-stream": true }
                      }) do |item|
@@ -283,11 +295,13 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: move_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                   @meeting_agenda_item.meeting,
-                                                                   @meeting_agenda_item,
-                                                                   move_to:,
-                                                                   current_occurrence: @current_occurrence)
+                       href: move_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         move_to:,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon:)
       end
@@ -300,11 +314,13 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: drop_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                   @meeting_agenda_item.meeting,
-                                                                   @meeting_agenda_item,
-                                                                   type: :to_backlog,
-                                                                   current_occurrence: @current_occurrence)
+                       href: drop_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         type: :to_backlog,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon: "discussion-outdated")
       end
@@ -318,11 +334,13 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: drop_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                   @meeting_agenda_item.meeting,
-                                                                   @meeting_agenda_item,
-                                                                   type: :to_current,
-                                                                   current_occurrence: @current_occurrence)
+                       href: drop_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         type: :to_current,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon: "cross-reference")
       end
@@ -336,10 +354,12 @@ module MeetingAgendaItems
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: move_to_section_dialog_project_meeting_agenda_item_path(@meeting_agenda_item.meeting.project,
-                                                                                     @meeting_agenda_item.meeting,
-                                                                                     @meeting_agenda_item,
-                                                                                     current_occurrence: @current_occurrence)
+                       href: move_to_section_dialog_project_meeting_agenda_item_path(
+                         @meeting_agenda_item.meeting.project,
+                         @meeting_agenda_item.meeting,
+                         @meeting_agenda_item,
+                         current_occurrence: @current_occurrence
+                       )
                      } }) do |item|
         item.with_leading_visual_icon(icon: "op-move")
       end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -161,10 +161,10 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_write_outcome"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_project_meeting_outcome_path(
+                          new_project_meeting_agenda_item_outcome_path(
                             @meeting_agenda_item.meeting.project,
                             @meeting_agenda_item.meeting,
-                            meeting_agenda_item_id: @meeting_agenda_item&.id,
+                            @meeting_agenda_item,
                             kind: :information,
                             current_occurrence: @current_occurrence
                           )
@@ -175,10 +175,10 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_existing_work_package"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          new_project_meeting_outcome_path(
+                          new_project_meeting_agenda_item_outcome_path(
                             @meeting.project,
                             @meeting,
-                            meeting_agenda_item_id: @meeting_agenda_item&.id,
+                            @meeting_agenda_item,
                             kind: :work_package,
                             current_occurrence: @current_occurrence
                           )
@@ -191,10 +191,10 @@ module MeetingAgendaItems
       submenu.with_item(label: t("label_work_package_new"),
                         tag: :button,
                         content_arguments: outcome_action_data(
-                          create_work_package_dialog_project_meeting_outcomes_path(
+                          create_work_package_project_meeting_agenda_item_outcomes_path(
                             @meeting.project,
                             @meeting,
-                            meeting_agenda_item_id: @meeting_agenda_item.id
+                            @meeting_agenda_item
                           )
                         ))
     end

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_next_meeting_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_next_meeting_dialog_component.html.erb
@@ -34,7 +34,8 @@ See COPYRIGHT and LICENSE files for more details.
       confirm_button_text: I18n.t(:label_agenda_item_move),
       title:,
       form_arguments: {
-        action: move_to_next_meeting_agenda_item_path(
+        action: move_to_next_project_meeting_agenda_item_path(
+          @agenda_item.meeting.project,
           @agenda_item.meeting,
           @agenda_item,
           datetime: @datetime,

--- a/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/move_to_section_form_component.html.erb
@@ -33,7 +33,8 @@ See COPYRIGHT and LICENSE files for more details.
       id: "move-to-section-form",
       model: @agenda_item,
       method: :post,
-      url: move_to_section_meeting_agenda_item_path(
+      url: move_to_section_project_meeting_agenda_item_path(
+        @agenda_item.meeting.project,
         @agenda_item.meeting,
         @agenda_item,
         collapsed: @collapsed

--- a/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_button_component.html.erb
@@ -10,7 +10,7 @@
         label: t("activerecord.models.meeting_agenda_item"),
         tag: :a,
         content_arguments: {
-          href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
+          href: new_project_meeting_agenda_item_path(@meeting.project, @meeting, type: "simple", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
           data: { "turbo-stream": true }
         }
       )
@@ -18,7 +18,7 @@
         label: t("activerecord.models.work_package"),
         tag: :a,
         content_arguments: {
-          href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
+          href: new_project_meeting_agenda_item_path(@meeting.project, @meeting, type: "work_package", meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
           data: { "turbo-stream": true }
         }
       )
@@ -26,10 +26,10 @@
         component.with_item(
           label: t("activerecord.models.meeting_section"),
           tag: :a,
-          href: meeting_sections_path(@meeting),
+          href: project_meeting_sections_path(@meeting.project, @meeting),
           content_arguments: { data: {
             action: "click->meetings--submit#intercept",
-            href: meeting_sections_path(@meeting),
+            href: project_meeting_sections_path(@meeting.project, @meeting),
             method: "POST"
           } }
         )

--- a/modules/meeting/app/components/meeting_agenda_items/new_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/new_component.html.erb
@@ -9,8 +9,18 @@
               meeting_agenda_item: @meeting_agenda_item,
               meeting_section: @meeting_section,
               method: :post,
-              submit_path: meeting_agenda_items_path(@meeting, format: :turbo_stream, current_occurrence: @current_occurrence),
-              cancel_path: cancel_new_meeting_agenda_items_path(@meeting, meeting_section_id: @meeting_section&.id, current_occurrence: @current_occurrence),
+              submit_path: project_meeting_agenda_items_path(
+                @meeting.project,
+                @meeting,
+                format: :turbo_stream,
+                current_occurrence: @current_occurrence
+              ),
+              cancel_path: cancel_new_project_meeting_agenda_items_path(
+                @meeting.project,
+                @meeting,
+                meeting_section_id: @meeting_section&.id,
+                current_occurrence: @current_occurrence
+              ),
               type: @type
             )
           )

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
@@ -3,7 +3,7 @@
     primer_form_with(
       scope: :work_package,
       model: work_package,
-      url: create_work_package_dialog_project_meeting_agenda_item_outcomes_path(
+      url: create_work_package_project_meeting_agenda_item_outcomes_path(
         meeting.project,
         meeting,
         meeting_agenda_item

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
@@ -3,7 +3,11 @@
     primer_form_with(
       scope: :work_package,
       model: work_package,
-      url: create_work_package_meeting_outcomes_path(meeting, meeting_agenda_item_id: meeting_agenda_item.id),
+      url: create_work_package_project_meeting_outcomes_path(
+        meeting.project,
+        meeting,
+        meeting_agenda_item_id: meeting_agenda_item.id
+      ),
       method: :post,
       html: {
         id: "create-work-package-outcome-form"

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
@@ -3,10 +3,10 @@
     primer_form_with(
       scope: :work_package,
       model: work_package,
-      url: create_work_package_project_meeting_outcomes_path(
+      url: create_work_package_dialog_project_meeting_agenda_item_outcomes_path(
         meeting.project,
         meeting,
-        meeting_agenda_item_id: meeting_agenda_item.id
+        meeting_agenda_item
       ),
       method: :post,
       html: {

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/input_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/input_component.rb
@@ -62,23 +62,30 @@ module MeetingAgendaItems::Outcomes
     end
 
     def submit_path
-      if @meeting_outcome.id.present?
-        project_meeting_outcome_path(@meeting.project, @meeting, @meeting_outcome.id, format: :turbo_stream)
+      if @meeting_outcome.persisted?
+        project_meeting_agenda_item_outcome_path(@meeting.project,
+                                                 @meeting,
+                                                 @meeting_agenda_item,
+                                                 @meeting_outcome,
+                                                 format: :turbo_stream)
       else
-        project_meeting_outcomes_path(@meeting.project,
-                                      @meeting,
-                                      meeting_agenda_item_id: @meeting_agenda_item.id,
-                                      format: :turbo_stream)
+        project_meeting_agenda_item_outcomes_path(@meeting.project,
+                                                  @meeting,
+                                                  @meeting_agenda_item,
+                                                  format: :turbo_stream)
       end
     end
 
     def cancel_path
-      if @meeting_outcome.id.present?
-        cancel_edit_project_meeting_outcome_path(@meeting.project, @meeting, @meeting_outcome)
+      if @meeting_outcome.persisted?
+        cancel_edit_project_meeting_agenda_item_outcome_path(@meeting.project,
+                                                             @meeting,
+                                                             @meeting_agenda_item,
+                                                             @meeting_outcome)
       else
-        cancel_new_project_meeting_outcomes_path(@meeting.project,
-                                                 @meeting,
-                                                 meeting_agenda_item_id: @meeting_agenda_item.id)
+        cancel_new_project_meeting_agenda_item_outcomes_path(@meeting.project,
+                                                             @meeting,
+                                                             @meeting_agenda_item)
       end
     end
   end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/input_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/input_component.rb
@@ -63,17 +63,22 @@ module MeetingAgendaItems::Outcomes
 
     def submit_path
       if @meeting_outcome.id.present?
-        meeting_outcome_path(@meeting, @meeting_outcome.id, format: :turbo_stream)
+        project_meeting_outcome_path(@meeting.project, @meeting, @meeting_outcome.id, format: :turbo_stream)
       else
-        meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id, format: :turbo_stream)
+        project_meeting_outcomes_path(@meeting.project,
+                                      @meeting,
+                                      meeting_agenda_item_id: @meeting_agenda_item.id,
+                                      format: :turbo_stream)
       end
     end
 
     def cancel_path
       if @meeting_outcome.id.present?
-        cancel_edit_meeting_outcome_path(@meeting, @meeting_outcome)
+        cancel_edit_project_meeting_outcome_path(@meeting.project, @meeting, @meeting_outcome)
       else
-        cancel_new_meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id)
+        cancel_new_project_meeting_outcomes_path(@meeting.project,
+                                                 @meeting,
+                                                 meeting_agenda_item_id: @meeting_agenda_item.id)
       end
     end
   end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
@@ -25,7 +25,8 @@
           data: {
             "turbo-stream": true,
             action: "click->meetings--submit#intercept",
-            href: new_meeting_outcome_path(
+            href: new_project_meeting_outcome_path(
+              @meeting.project,
               @meeting,
               meeting_agenda_item_id: @meeting_agenda_item.id,
               kind: :work_package
@@ -42,7 +43,8 @@
             data: {
               "turbo-stream": true,
               action: "click->meetings--submit#intercept",
-              href: create_work_package_dialog_meeting_outcomes_path(
+              href: create_work_package_dialog_project_meeting_outcomes_path(
+                @meeting.project,
                 @meeting,
                 meeting_agenda_item_id: @meeting_agenda_item.id
               ),

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
@@ -13,7 +13,12 @@
           data: {
             "turbo-stream": true,
             action: "click->meetings--submit#intercept",
-            href: new_project_meeting_outcome_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id),
+            href: new_project_meeting_agenda_item_outcome_path(
+              @meeting.project,
+              @meeting,
+              @meeting_agenda_item,
+              kind: :information
+            ),
             method: "GET"
           }
         }
@@ -25,10 +30,10 @@
           data: {
             "turbo-stream": true,
             action: "click->meetings--submit#intercept",
-            href: new_project_meeting_outcome_path(
+            href: new_project_meeting_agenda_item_outcome_path(
               @meeting.project,
               @meeting,
-              meeting_agenda_item_id: @meeting_agenda_item.id,
+              @meeting_agenda_item,
               kind: :work_package
             ),
             method: "GET"
@@ -43,10 +48,10 @@
             data: {
               "turbo-stream": true,
               action: "click->meetings--submit#intercept",
-              href: create_work_package_dialog_project_meeting_outcomes_path(
+              href: create_work_package_dialog_project_meeting_agenda_item_outcomes_path(
                 @meeting.project,
                 @meeting,
-                meeting_agenda_item_id: @meeting_agenda_item.id
+                @meeting_agenda_item
               ),
               method: "GET"
             }

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/new_button_component.html.erb
@@ -13,11 +13,7 @@
           data: {
             "turbo-stream": true,
             action: "click->meetings--submit#intercept",
-            href: new_meeting_outcome_path(
-              @meeting,
-              meeting_agenda_item_id: @meeting_agenda_item.id,
-              kind: :information
-            ),
+            href: new_project_meeting_outcome_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id),
             method: "GET"
           }
         }

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.rb
@@ -72,7 +72,12 @@ module MeetingAgendaItems::Outcomes
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
+                       href: edit_project_meeting_agenda_item_outcome_path(
+                         meeting.project,
+                         meeting,
+                         agenda_item,
+                         meeting_outcome
+                       ),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :pencil)
@@ -98,7 +103,12 @@ module MeetingAgendaItems::Outcomes
                      scheme: :danger,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
+                       href: project_meeting_agenda_item_outcome_path(
+                         meeting.project,
+                         meeting,
+                         agenda_item,
+                         meeting_outcome
+                       ),
                        method: "DELETE",
                        confirm_message: t(:text_are_you_sure)
                      } }) do |item|

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.rb
@@ -72,7 +72,7 @@ module MeetingAgendaItems::Outcomes
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: edit_meeting_outcome_path(meeting, meeting_outcome),
+                       href: edit_project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
                        method: "GET"
                      } }) do |item|
         item.with_leading_visual_icon(icon: :pencil)
@@ -98,7 +98,7 @@ module MeetingAgendaItems::Outcomes
                      scheme: :danger,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: meeting_outcome_path(meeting, meeting_outcome),
+                       href: project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
                        method: "DELETE",
                        confirm_message: t(:text_are_you_sure)
                      } }) do |item|

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
@@ -55,12 +55,11 @@ module MeetingAgendaItems::Outcomes
     end
 
     def submit_path
-      project_meeting_outcomes_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id,
-                                                                format: :turbo_stream)
+      project_meeting_agenda_item_outcomes_path(@meeting.project, @meeting, @meeting_agenda_item, format: :turbo_stream)
     end
 
     def cancel_path
-      cancel_new_project_meeting_outcomes_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id)
+      cancel_new_project_meeting_agenda_item_outcomes_path(@meeting.project, @meeting, @meeting_agenda_item)
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_form_component.rb
@@ -55,11 +55,12 @@ module MeetingAgendaItems::Outcomes
     end
 
     def submit_path
-      meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id, format: :turbo_stream)
+      project_meeting_outcomes_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id,
+                                                                format: :turbo_stream)
     end
 
     def cancel_path
-      cancel_new_meeting_outcomes_path(@meeting, meeting_agenda_item_id: @meeting_agenda_item.id)
+      cancel_new_project_meeting_outcomes_path(@meeting.project, @meeting, meeting_agenda_item_id: @meeting_agenda_item.id)
     end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
@@ -84,7 +84,12 @@ module MeetingAgendaItems::Outcomes
                      scheme: :danger,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
+                       href: project_meeting_agenda_item_outcome_path(
+                         meeting.project,
+                         meeting,
+                         agenda_item,
+                         meeting_outcome
+                       ),
                        method: "DELETE",
                        confirm_message: t(:text_are_you_sure)
                      } }) do |item|

--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/work_package_outcome_component.rb
@@ -84,7 +84,7 @@ module MeetingAgendaItems::Outcomes
                      scheme: :danger,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: meeting_outcome_path(meeting, meeting_outcome),
+                       href: project_meeting_outcome_path(meeting.project, meeting, meeting_outcome),
                        method: "DELETE",
                        confirm_message: t(:text_are_you_sure)
                      } }) do |item|

--- a/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/clear_backlog_dialog_component.html.erb
@@ -5,7 +5,11 @@
       confirm_button_text: I18n.t(:label_backlog_clear_button),
       title: I18n.t(:label_backlog_clear),
       form_arguments: {
-        action: clear_backlog_meeting_sections_path(@meeting, current_occurrence: @current_occurrence),
+        action: clear_backlog_project_meeting_sections_path(
+          @meeting.project,
+          @meeting,
+          current_occurrence: @current_occurrence
+        ),
         method: :post
       }
     )

--- a/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/backlogs/header_component.rb
@@ -70,7 +70,9 @@ module MeetingSections
     def clear_action_item(menu)
       menu.with_item(
         label: I18n.t(:label_backlog_clear),
-        href: clear_backlog_dialog_meeting_sections_path(@meeting, current_occurrence: @current_occurrence),
+        href: clear_backlog_dialog_project_meeting_sections_path(@meeting.project,
+                                                                 @meeting,
+                                                                 current_occurrence: @current_occurrence),
         scheme: :danger,
         tag: :a,
         content_arguments: {
@@ -84,8 +86,11 @@ module MeetingSections
     def add_agenda_item_action(menu)
       menu.with_item(
         label: t("label_agenda_item_add", count: 1),
-        href: new_meeting_agenda_item_path(@meeting, type: "simple", meeting_section_id: @backlog.id,
-                                                     current_occurrence: @current_occurrence),
+        href: new_project_meeting_agenda_item_path(@meeting.project,
+                                                   @meeting,
+                                                   type: "simple",
+                                                   meeting_section_id: @backlog.id,
+                                                   current_occurrence: @current_occurrence),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-backlog-add-agenda-item-from-menu" }
         }
@@ -97,8 +102,11 @@ module MeetingSections
     def add_work_package_action(menu)
       menu.with_item(
         label: t("label_agenda_item_work_package_add", count: 1),
-        href: new_meeting_agenda_item_path(@meeting, type: "work_package", meeting_section_id: @backlog.id,
-                                                     current_occurrence: @current_occurrence),
+        href: new_project_meeting_agenda_item_path(@meeting.project,
+                                                   @meeting,
+                                                   type: "work_package",
+                                                   meeting_section_id: @backlog.id,
+                                                   current_occurrence: @current_occurrence),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-backlog-add-work-package-from-menu" }
         }

--- a/modules/meeting/app/components/meeting_sections/header_component.html.erb
+++ b/modules/meeting/app/components/meeting_sections/header_component.html.erb
@@ -44,10 +44,14 @@
       primer_form_with(
         model: @meeting_section,
         method: :put,
-        url: meeting_section_path(@meeting_section.meeting, @meeting_section),
+        url: project_meeting_section_path(@meeting_section.meeting.project, @meeting_section.meeting, @meeting_section),
         data: {
           controller: "meetings--section-form scroll-into-view",
-          "meetings--section-form-cancel-url-value": cancel_edit_meeting_section_path(@meeting_section.meeting, @meeting_section)
+          "meetings--section-form-cancel-url-value": cancel_edit_project_meeting_section_path(
+            @meeting_section.meeting.project,
+            @meeting_section.meeting,
+            @meeting_section
+          )
         }
       ) do |f|
         flex_layout do |editable_title_form|
@@ -66,7 +70,11 @@
                 tag: :button,
                 data: {
                   action: "click->meetings--submit#intercept",
-                  href: cancel_edit_meeting_section_path(@meeting_section.meeting, @meeting_section),
+                  href: cancel_edit_project_meeting_section_path(
+                    @meeting_section.meeting.project,
+                    @meeting_section.meeting,
+                    @meeting_section
+                  ),
                   method: "POST"
                 }
               )

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -105,7 +105,10 @@ module MeetingSections
                      tag: :button,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: move_meeting_section_path(@meeting_section.meeting, @meeting_section, move_to:),
+                       href: move_project_meeting_section_path(@meeting_section.meeting.project,
+                                                               @meeting_section.meeting,
+                                                               @meeting_section,
+                                                               move_to:),
                        test_selector: "meeting-section-move-#{move_to}"
                      } }) do |item|
         item.with_leading_visual_icon(icon:)
@@ -114,7 +117,9 @@ module MeetingSections
 
     def edit_action_item(menu)
       menu.with_item(label: t("label_section_rename"),
-                     href: edit_meeting_section_path(@meeting_section.meeting, @meeting_section),
+                     href: edit_project_meeting_section_path(@meeting_section.meeting.project,
+                                                             @meeting_section.meeting,
+                                                             @meeting_section),
                      content_arguments: {
                        data: { "turbo-stream": true, "test-selector": "meeting-section-edit" }
                      }) do |item|
@@ -125,7 +130,10 @@ module MeetingSections
     def add_agenda_item_action(menu)
       menu.with_item(
         label: t("label_agenda_item_add"),
-        href: new_meeting_agenda_item_path(@meeting_section.meeting, type: "simple", meeting_section_id: @meeting_section&.id),
+        href: new_project_meeting_agenda_item_path(@meeting_section.meeting.project,
+                                                   @meeting_section.meeting,
+                                                   type: "simple",
+                                                   meeting_section_id: @meeting_section&.id),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-section-add-agenda-item-from-menu" }
         }
@@ -137,8 +145,9 @@ module MeetingSections
     def add_work_package_action(menu)
       menu.with_item(
         label: t("label_agenda_item_work_package_add"),
-        href: new_meeting_agenda_item_path(@meeting_section.meeting, type: "work_package",
-                                                                     meeting_section_id: @meeting_section&.id),
+        href: new_project_meeting_agenda_item_path(@meeting_section.meeting.project,
+                                                   @meeting_section.meeting,
+                                                   meeting_section_id: @meeting_section&.id),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-section-add-work-package-from-menu" }
         }
@@ -159,7 +168,9 @@ module MeetingSections
                      scheme: :danger,
                      content_arguments: { data: {
                        action: "click->meetings--submit#intercept",
-                       href: meeting_section_path(@meeting_section.meeting, @meeting_section),
+                       href: project_meeting_section_path(@meeting_section.meeting.project,
+                                                          @meeting_section.meeting,
+                                                          @meeting_section),
                        method: "DELETE",
                        confirm_message: confirm_text,
                        test_selector: "meeting-section-delete"

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -147,6 +147,7 @@ module MeetingSections
         label: t("label_agenda_item_work_package_add"),
         href: new_project_meeting_agenda_item_path(@meeting_section.meeting.project,
                                                    @meeting_section.meeting,
+                                                   type: "work_package",
                                                    meeting_section_id: @meeting_section&.id),
         content_arguments: {
           data: { "turbo-stream": true, "test-selector": "meeting-section-add-work-package-from-menu" }

--- a/modules/meeting/app/components/meeting_sections/show_component.rb
+++ b/modules/meeting/app/components/meeting_sections/show_component.rb
@@ -85,7 +85,7 @@ module MeetingSections
       {
         "draggable-id": @meeting_section.id,
         "draggable-type": "section",
-        "drop-url": drop_meeting_section_path(@meeting, @meeting_section)
+        "drop-url": drop_project_meeting_section_path(@meeting.project, @meeting, @meeting_section)
       }
     end
 

--- a/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
+++ b/modules/meeting/app/components/meetings/exports/modal_dialog_component.html.erb
@@ -18,164 +18,164 @@
           },
           id: MEETING_PDF_EXPORT_FORM_ID
         ) do
-      flex_layout do |modal_body|
-        if OpenProject::FeatureDecisions.minutes_styling_meeting_pdf_active?
-          modal_body.with_row do
-            render(
-              Primer::Alpha::RadioButtonGroup.new(
-                full_width: true,
-                name: "template",
-                label: I18n.t("pdf_generator.dialog.templates.label")
+          flex_layout do |modal_body|
+            if OpenProject::FeatureDecisions.minutes_styling_meeting_pdf_active?
+              modal_body.with_row do
+                render(
+                  Primer::Alpha::RadioButtonGroup.new(
+                    full_width: true,
+                    name: "template",
+                    label: I18n.t("pdf_generator.dialog.templates.label")
+                  )
+                ) do |component|
+                  component.radio_button(
+                    label: I18n.t("meeting.export_pdf_dialog.templates.default.label"),
+                    caption: I18n.t("meeting.export_pdf_dialog.templates.default.caption"),
+                    value: "default",
+                    data: {
+                      "meetings--export--form-name-param": "default",
+                      action: "change->meetings--export--form#templatesChanged"
+                    },
+                    checked: true
+                  )
+                  component.radio_button(
+                    label: I18n.t("meeting.export_pdf_dialog.templates.minutes.label"),
+                    caption: I18n.t("meeting.export_pdf_dialog.templates.minutes.caption"),
+                    value: "minutes",
+                    data: {
+                      "meetings--export--form-name-param": "minutes",
+                      action: "change->meetings--export--form#templatesChanged"
+                    }
+                  )
+                end
+              end
+            end
+            modal_body.with_row(
+              mt: 3,
+              data: {
+                template: "default",
+                "meetings--export--form-target": "inputGroups"
+              },
+              classes: templates_default[:id] == "default" ? nil : "d-none"
+            ) do
+              render(
+                Primer::Alpha::CheckBox.new(
+                  id: "pdf_include_participants",
+                  name: :participants,
+                  checked: true,
+                  label: I18n.t("meeting.export_pdf_dialog.include_participants.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.include_participants.caption"),
+                  visually_hide_label: false
+                )
               )
-            ) do |component|
-              component.radio_button(
-                label: I18n.t("meeting.export_pdf_dialog.templates.default.label"),
-                caption: I18n.t("meeting.export_pdf_dialog.templates.default.caption"),
-                value: "default",
+            end
+            modal_body.with_row(
+              mt: 3,
+              data: {
+                template: "default",
+                "meetings--export--form-target": "inputGroups"
+              },
+              classes: templates_default[:id] == "default" ? nil : "d-none"
+            ) do
+              render(
+                Primer::Alpha::CheckBox.new(
+                  id: "pdf_include_attachments",
+                  name: :attachments,
+                  checked: false,
+                  label: I18n.t("meeting.export_pdf_dialog.include_attachments.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.include_attachments.caption"),
+                  visually_hide_label: false
+                )
+              )
+            end
+            modal_body.with_row(
+              mt: 3,
+              data: {
+                template: "default",
+                "meetings--export--form-target": "inputGroups"
+              },
+              classes: templates_default[:id] == "default" ? nil : "d-none"
+            ) do
+              render(
+                Primer::Alpha::CheckBox.new(
+                  id: "pdf_include_backlog",
+                  name: :backlog,
+                  checked: false,
+                  label: I18n.t("meeting.export_pdf_dialog.include_backlog.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.include_backlog.caption"),
+                  visually_hide_label: false
+                )
+              )
+            end
+            modal_body.with_row(mt: 3) do
+              render(
+                Primer::Alpha::CheckBox.new(
+                  id: "pdf_include_outcomes",
+                  name: :outcomes,
+                  checked: false,
+                  label: I18n.t("meeting.export_pdf_dialog.include_outcomes.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.include_outcomes.caption"),
+                  visually_hide_label: false
+                )
+              )
+            end
+            if OpenProject::FeatureDecisions.minutes_styling_meeting_pdf_active?
+              modal_body.with_row(
                 data: {
-                  "meetings--export--form-name-param": "default",
-                  action: "change->meetings--export--form#templatesChanged"
+                  template: "minutes",
+                  "meetings--export--form-target": "inputGroups"
                 },
-                checked: true
-              )
-              component.radio_button(
-                label: I18n.t("meeting.export_pdf_dialog.templates.minutes.label"),
-                caption: I18n.t("meeting.export_pdf_dialog.templates.minutes.caption"),
-                value: "minutes",
+                classes: templates_default[:id] == "minutes" ? nil : "d-none",
+                mt: 3
+              ) do
+                render Primer::Alpha::TextField.new(
+                  id: "pdf_header_left",
+                  name: :first_page_header_left,
+                  label: I18n.t("meeting.export_pdf_dialog.first_page_header_left.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.first_page_header_left.caption"),
+                  input_width: :large,
+                  visually_hide_label: false,
+                  value: default_first_page_header_left_text
+                )
+              end
+              modal_body.with_row(
                 data: {
-                  "meetings--export--form-name-param": "minutes",
-                  action: "change->meetings--export--form#templatesChanged"
-                }
+                  template: "minutes",
+                  "meetings--export--form-target": "inputGroups"
+                },
+                classes: templates_default[:id] == "minutes" ? nil : "d-none",
+                mt: 3
+              ) do
+                render Primer::Alpha::TextField.new(
+                  id: "pdf_author",
+                  name: :author,
+                  label: I18n.t("meeting.export_pdf_dialog.author.label"),
+                  caption: I18n.t("meeting.export_pdf_dialog.author.caption"),
+                  input_width: :large,
+                  visually_hide_label: false,
+                  value: default_author_text
+                )
+              end
+            end
+            modal_body.with_row(
+              mt: 3,
+              data: {
+                template: "default",
+                "meetings--export--form-target": "inputGroups"
+              }
+            ) do
+              render Primer::Alpha::TextField.new(
+                id: "pdf_footer_text",
+                name: :footer_text,
+                input_width: :large,
+                label: I18n.t("meeting.export_pdf_dialog.footer_text.label"),
+                caption: I18n.t("meeting.export_pdf_dialog.footer_text.caption"),
+                visually_hide_label: false,
+                value: default_footer_text
               )
             end
           end
-        end
-        modal_body.with_row(
-          mt: 3,
-          data: {
-            template: "default",
-            "meetings--export--form-target": "inputGroups"
-          },
-          classes: templates_default[:id] == "default" ? nil : "d-none",
-        ) do
-          render(
-            Primer::Alpha::CheckBox.new(
-              id: "pdf_include_participants",
-              name: :participants,
-              checked: true,
-              label: I18n.t("meeting.export_pdf_dialog.include_participants.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.include_participants.caption"),
-              visually_hide_label: false
-            )
-          )
-        end
-        modal_body.with_row(
-          mt: 3,
-          data: {
-            template: "default",
-            "meetings--export--form-target": "inputGroups"
-          },
-          classes: templates_default[:id] == "default" ? nil : "d-none",
-        ) do
-          render(
-            Primer::Alpha::CheckBox.new(
-              id: "pdf_include_attachments",
-              name: :attachments,
-              checked: false,
-              label: I18n.t("meeting.export_pdf_dialog.include_attachments.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.include_attachments.caption"),
-              visually_hide_label: false
-            )
-          )
-        end
-        modal_body.with_row(
-          mt: 3,
-          data: {
-            template: "default",
-            "meetings--export--form-target": "inputGroups"
-          },
-          classes: templates_default[:id] == "default" ? nil : "d-none",
-        ) do
-          render(
-            Primer::Alpha::CheckBox.new(
-              id: "pdf_include_backlog",
-              name: :backlog,
-              checked: false,
-              label: I18n.t("meeting.export_pdf_dialog.include_backlog.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.include_backlog.caption"),
-              visually_hide_label: false
-            )
-          )
-        end
-        modal_body.with_row(mt: 3) do
-          render(
-            Primer::Alpha::CheckBox.new(
-              id: "pdf_include_outcomes",
-              name: :outcomes,
-              checked: false,
-              label: I18n.t("meeting.export_pdf_dialog.include_outcomes.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.include_outcomes.caption"),
-              visually_hide_label: false
-            )
-          )
-        end
-        if OpenProject::FeatureDecisions.minutes_styling_meeting_pdf_active?
-          modal_body.with_row(
-            data: {
-              template: "minutes",
-              "meetings--export--form-target": "inputGroups"
-            },
-            classes: templates_default[:id] == "minutes" ? nil : "d-none",
-            mt: 3
-          ) do
-            render Primer::Alpha::TextField.new(
-              id: "pdf_header_left",
-              name: :first_page_header_left,
-              label: I18n.t("meeting.export_pdf_dialog.first_page_header_left.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.first_page_header_left.caption"),
-              input_width: :large,
-              visually_hide_label: false,
-              value: default_first_page_header_left_text
-            )
-          end
-          modal_body.with_row(
-            data: {
-              template: "minutes",
-              "meetings--export--form-target": "inputGroups"
-            },
-            classes: templates_default[:id] == "minutes" ? nil : "d-none",
-            mt: 3
-          ) do
-            render Primer::Alpha::TextField.new(
-              id: "pdf_author",
-              name: :author,
-              label: I18n.t("meeting.export_pdf_dialog.author.label"),
-              caption: I18n.t("meeting.export_pdf_dialog.author.caption"),
-              input_width: :large,
-              visually_hide_label: false,
-              value: default_author_text
-            )
-          end
-        end
-        modal_body.with_row(
-          mt: 3,
-          data: {
-            template: "default",
-            "meetings--export--form-target": "inputGroups"
-          }
-        ) do
-          render Primer::Alpha::TextField.new(
-            id: "pdf_footer_text",
-            name: :footer_text,
-            input_width: :large,
-            label: I18n.t("meeting.export_pdf_dialog.footer_text.label"),
-            caption: I18n.t("meeting.export_pdf_dialog.footer_text.caption"),
-            visually_hide_label: false,
-            value: default_footer_text
-          )
-        end
-      end
-    end %>
+        end %>
   <% end %>
   <% dialog.with_footer do %>
     <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": MODAL_ID })) { I18n.t(:button_cancel) } %>

--- a/modules/meeting/app/components/meetings/participants/add_user_form_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/add_user_form_component.html.erb
@@ -2,7 +2,7 @@
   component_wrapper do
     primer_form_with(
       model: MeetingParticipant.new(meeting: @meeting),
-      url: meeting_participants_path(@meeting)
+      url: project_meeting_participants_path(@meeting.project, @meeting)
     ) do |form|
       grid_layout("meeting-participant-form", tag: :div) do |grid|
         grid.with_area(:participant) do

--- a/modules/meeting/app/components/meetings/participants/attended_toggle_button_component.rb
+++ b/modules/meeting/app/components/meetings/participants/attended_toggle_button_component.rb
@@ -46,7 +46,7 @@ module Meetings
       render(
         Primer::Beta::Button.new(
           tag: :a,
-          href: toggle_attendance_meeting_participant_path(@meeting, @participant),
+          href: toggle_attendance_project_meeting_participant_path(@meeting.project, @meeting, @participant),
           data: {
             turbo_method: :post,
             test_selector: "attendance_button_#{@participant.user_id}"

--- a/modules/meeting/app/components/meetings/participants/box_header_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_header_component.html.erb
@@ -17,7 +17,7 @@
           Primer::Beta::Button.new(
             tag: :a,
             scheme: :invisible,
-            href: mark_all_attended_meeting_participants_path(@meeting),
+            href: mark_all_attended_project_meeting_participants_path(@meeting.project, @meeting),
             align_self: :center,
             data: { "turbo-method": :post }
           )

--- a/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
@@ -14,12 +14,21 @@
       row.with_column(flex: 1, flex_layout: true, ml: 3) do |column|
         column.with_row do
           render(
+<<<<<<< HEAD
             Primer::Beta::Link.new(
               href: user_path(@participant.user),
               underline: false,
               font_weight: :bold,
               test_selector: "participant_user_link_#{@participant.user_id}",
               classes: "meeting-participant-user-link",
+=======
+            Primer::Beta::IconButton.new(
+              scheme: :invisible,
+              tag: :a,
+              href: project_meeting_participant_path(@meeting.project, @meeting, @participant),
+              icon: :x,
+              aria: { label: I18n.t("meeting.participants.label.remove_participant") },
+>>>>>>> c23896ad3c4 (Refactor meeting routes)
               data: {
                 "hover-card-url" => hover_card_user_path(@participant.user),
                 "hover-card-trigger-target" => "trigger"

--- a/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
@@ -55,7 +55,7 @@
               Primer::Beta::IconButton.new(
                 scheme: :invisible,
                 tag: :a,
-                href: meeting_participant_path(@meeting, @participant),
+                href: project_meeting_participant_path(@meeting.project, @meeting, @participant),
                 icon: :x,
                 aria: { label: I18n.t("meeting.participants.label.remove_participant") },
                 data: {

--- a/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
@@ -14,21 +14,12 @@
       row.with_column(flex: 1, flex_layout: true, ml: 3) do |column|
         column.with_row do
           render(
-<<<<<<< HEAD
             Primer::Beta::Link.new(
               href: user_path(@participant.user),
               underline: false,
               font_weight: :bold,
               test_selector: "participant_user_link_#{@participant.user_id}",
               classes: "meeting-participant-user-link",
-=======
-            Primer::Beta::IconButton.new(
-              scheme: :invisible,
-              tag: :a,
-              href: project_meeting_participant_path(@meeting.project, @meeting, @participant),
-              icon: :x,
-              aria: { label: I18n.t("meeting.participants.label.remove_participant") },
->>>>>>> c23896ad3c4 (Refactor meeting routes)
               data: {
                 "hover-card-url" => hover_card_user_path(@participant.user),
                 "hover-card-trigger-target" => "trigger"

--- a/modules/meeting/app/components/meetings/presentation_mode/show_component.html.erb
+++ b/modules/meeting/app/components/meetings/presentation_mode/show_component.html.erb
@@ -9,7 +9,7 @@
           meeting_agenda_item_id: current_item.id,
           started_at: started_at_param
         ),
-        poll_for_changes_interval_value: check_for_updates_interval,
+        poll_for_changes_interval_value: check_for_updates_interval
       }
     ) do %>
   <%= content_tag :div,
@@ -24,17 +24,17 @@
 
     <%= render(border_box_container(test_selector: "meeting-presentation-agenda-item")) do |container| %>
       <%= render MeetingAgendaItems::ItemComponent.new(
-        container:,
-        meeting_agenda_item: current_item,
-        presentation_mode: true
-      ) %>
+            container:,
+            meeting_agenda_item: current_item,
+            presentation_mode: true
+          ) %>
     <% end %>
   <% end %>
 
   <%= render Meetings::PresentationMode::FooterComponent.new(
-    meeting: meeting,
-    sorted_agenda_item_ids: @agenda_item_ids,
-    current_item: current_item,
-    started_at: @started_at
-  ) %>
+        meeting: meeting,
+        sorted_agenda_item_ids: @agenda_item_ids,
+        current_item: current_item,
+        started_at: @started_at
+      ) %>
 <% end %>

--- a/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/details_component.html.erb
@@ -143,7 +143,7 @@
                       scheme: :link,
                       underline: false,
                       tag: :a,
-                      href: manage_participants_dialog_meeting_participants_path(@meeting),
+                      href: manage_participants_dialog_project_meeting_participants_path(@meeting.project, @meeting),
                       classes: "hide-when-print",
                       data: { controller: "async-dialog" }
                     )

--- a/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
+++ b/modules/meeting/app/components/meetings/side_panel/participants_component.html.erb
@@ -13,7 +13,7 @@
           icon: :gear,
           scheme: :invisible,
           tag: :a,
-          href: manage_participants_dialog_meeting_participants_path(@meeting),
+          href: manage_participants_dialog_project_meeting_participants_path(@meeting.project, @meeting),
           classes: "hide-when-print",
           data: { controller: "async-dialog" },
           "aria-label": I18n.t("meeting.participants.label.manage_participants"),
@@ -40,7 +40,7 @@
                   underline: false,
                   font_weight: :bold,
                   tag: :a,
-                  href: manage_participants_dialog_meeting_participants_path(@meeting),
+                  href: manage_participants_dialog_project_meeting_participants_path(@meeting.project, @meeting),
                   classes: "hide-when-print",
                   data: { controller: "async-dialog" }
                 )

--- a/modules/meeting/app/components/recurring_meetings/table_header_component.html.erb
+++ b/modules/meeting/app/components/recurring_meetings/table_header_component.html.erb
@@ -38,12 +38,14 @@ See COPYRIGHT and LICENSE files for more details.
 
           if @planned
             container.with_column do
-              render(Primer::Beta::Button.new(
-                       tag: :a,
-                       mobile_label: I18n.t("recurring_meeting.template.label_view_template"),
-                       side: :medium,
-                       href: meeting_path(@meeting.template)
-                     )) do |button|
+              render(
+                Primer::Beta::Button.new(
+                  tag: :a,
+                  mobile_label: I18n.t("recurring_meeting.template.label_view_template"),
+                  side: :medium,
+                  href: meeting_path(@meeting.template)
+                )
+              ) do |button|
                 button.with_leading_visual_icon(icon: :pencil)
                 I18n.t("recurring_meeting.template.label_edit_template")
               end

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.html.erb
@@ -4,7 +4,7 @@
       id: "add-work-package-to-meeting-form",
       model: @meeting_agenda_item,
       method: :post,
-      url: work_package_meeting_agenda_items_path(@work_package),
+      url: project_work_package_meeting_agenda_items_path(@work_package.project, @work_package),
       data: data_attributes
     ) do |f|
       flex_layout(mb: 3) do |flex|

--- a/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/add_work_package_to_meeting_form_component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -47,7 +48,10 @@ module WorkPackageMeetingsTab
       {
         controller: "refresh-on-form-changes",
         "refresh-on-form-changes-target": "form",
-        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_work_package_meeting_agenda_items_path(@work_package)
+        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_project_work_package_meeting_agenda_items_path(
+          @work_package.project,
+          @work_package
+        )
       }
     end
   end

--- a/modules/meeting/app/components/work_package_meetings_tab/heading_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/heading_component.html.erb
@@ -9,7 +9,7 @@
           render(
             Primer::Beta::Button.new(
               tag: :a,
-              href: dialog_work_package_meeting_agenda_items_path(@work_package),
+              href: dialog_project_work_package_meeting_agenda_items_path(@work_package.project, @work_package),
               data: { controller: "async-dialog" },
               test_selector: "op-add-work-package-to-meeting-dialog-trigger"
             )

--- a/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
@@ -20,7 +20,8 @@
             end
             component.with_tab(
               selected: @direction == :past,
-              href: work_package_meetings_tab_index_path(
+              href: project_work_package_meetings_tab_index_path(
+                @work_package.project,
                 @work_package,
                 direction: :past
               )

--- a/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/index_component.html.erb
@@ -9,7 +9,8 @@
           render(Primer::Alpha::TabNav.new(label: "label")) do |component|
             component.with_tab(
               selected: @direction == :upcoming,
-              href: work_package_meetings_tab_index_path(
+              href: project_work_package_meetings_tab_index_path(
+                @work_package.project,
                 @work_package,
                 direction: :upcoming
               )

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -34,6 +34,8 @@ class MeetingAgendaItemsController < ApplicationController
   include OpTurbo::FlashStreamHelper
   include Meetings::AgendaComponentStreams
 
+  load_and_authorize_with_permission_in_project :manage_agendas
+
   before_action :set_meeting
   before_action :set_agenda_item_type, only: %i[new create]
   before_action :set_meeting_agenda_item,
@@ -41,7 +43,6 @@ class MeetingAgendaItemsController < ApplicationController
   before_action :set_current_occurrence,
                 :set_presentation_mode,
                 only: %i[new cancel_new edit cancel_edit create update destroy drop move move_to_section_dialog]
-  before_action :authorize
   before_action :check_recurring_meeting_param, only: %i[move_to_next_meeting duplicate_in_next_meeting]
   before_action :assign_drop_params, only: %i[drop]
 
@@ -231,7 +232,7 @@ class MeetingAgendaItemsController < ApplicationController
     )
   end
 
-  def move_to_next_meeting # rubocop:disable Metrics/AbcSize
+  def move_to_next_meeting
     next_occurrence = init_next_meeting_occurrence
     return if next_occurrence.nil?
 
@@ -322,8 +323,7 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def set_meeting
-    @meeting = Meeting.visible.find(params[:meeting_id])
-    @project = @meeting.project # required for authorization via before_action
+    @meeting = @project.meetings.visible.find(params[:meeting_id])
   end
 
   # In case we updated the meeting as part of the service flow

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -36,15 +36,14 @@ class MeetingOutcomesController < ApplicationController
   authorize_with_permission :add_work_packages, only: %i[create_work_package_dialog create_work_package]
 
   before_action :set_meeting
-  before_action :set_meeting_agenda_item, except: %i[edit cancel_edit update destroy]
+  before_action :set_meeting_agenda_item
   before_action :set_meeting_outcome, except: %i[new cancel_new create create_work_package_dialog create_work_package]
 
   def new
     update_meeting_metadata_via_turbo_stream
 
     if @meeting.in_progress? && !@meeting_agenda_item.in_backlog?
-      kind = params[:kind].to_sym
-      component = build_outcome_form_component(kind)
+      component = build_outcome_form_component
 
       replace_via_turbo_stream(
         component:,
@@ -183,7 +182,7 @@ class MeetingOutcomesController < ApplicationController
   end
 
   def set_meeting_agenda_item
-    @meeting_agenda_item = @meeting.agenda_items.find(params[:meeting_agenda_item_id])
+    @meeting_agenda_item = @meeting.agenda_items.find(params[:agenda_item_id])
   end
 
   def set_meeting_outcome
@@ -197,8 +196,12 @@ class MeetingOutcomesController < ApplicationController
                        end
   end
 
-  def build_outcome_form_component(kind)
-    component_class = kind == :work_package ? MeetingAgendaItems::Outcomes::WorkPackageFormComponent : MeetingAgendaItems::Outcomes::InputComponent
+  def build_outcome_form_component
+    component_class = if params[:kind] == "work_package"
+                        MeetingAgendaItems::Outcomes::WorkPackageFormComponent
+                      else
+                        MeetingAgendaItems::Outcomes::InputComponent
+                      end
 
     component_class.new(
       meeting: @meeting,

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -32,13 +32,12 @@ class MeetingOutcomesController < ApplicationController
   include OpTurbo::ComponentStream
   include Meetings::AgendaComponentStreams
 
+  load_and_authorize_with_permission_in_project :manage_outcomes
+  authorize_with_permission :add_work_packages, only: %i[create_work_package_dialog create_work_package]
+
   before_action :set_meeting
   before_action :set_meeting_agenda_item, except: %i[edit cancel_edit update destroy]
   before_action :set_meeting_outcome, except: %i[new cancel_new create create_work_package_dialog create_work_package]
-  before_action :authorize_global, only: %i[new create]
-  before_action :authorize, except: %i[new create create_work_package_dialog create_work_package]
-
-  authorize_with_permission :add_work_packages, only: %i[create_work_package_dialog create_work_package]
 
   def new
     update_meeting_metadata_via_turbo_stream
@@ -180,8 +179,7 @@ class MeetingOutcomesController < ApplicationController
   private
 
   def set_meeting
-    @meeting = Meeting.visible.find(params[:meeting_id])
-    @project = @meeting.project # required for authorization via before_action
+    @meeting = @project.meetings.visible.find(params[:meeting_id])
   end
 
   def set_meeting_agenda_item

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -33,7 +33,8 @@ class MeetingParticipantsController < ApplicationController
   include OpTurbo::FlashStreamHelper
   include Meetings::AgendaComponentStreams
 
-  before_action :authorize
+  load_and_authorize_with_permission_in_project :edit_meetings
+
   before_action :set_meeting
   before_action :set_participant, only: %i[toggle_attendance destroy]
 
@@ -94,7 +95,7 @@ class MeetingParticipantsController < ApplicationController
   private
 
   def set_meeting
-    @meeting = Meeting.visible.find(params[:meeting_id])
+    @meeting = @project.meetings.visible.find(params[:meeting_id])
   end
 
   def set_participant
@@ -114,9 +115,9 @@ class MeetingParticipantsController < ApplicationController
       .new(user: User.current)
       .call(meeting: @meeting, user_id: user_id, invited: true, attended: false)
       .on_failure do |call|
-      call.errors.full_messages.each do |msg|
-        @meeting.errors.add(:base, msg)
-      end
+        call.errors.full_messages.each do |msg|
+          @meeting.errors.add(:base, msg)
+        end
     end
   end
 end

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -33,7 +33,7 @@ class MeetingSectionsController < ApplicationController
   include OpTurbo::ComponentStream
   include Meetings::AgendaComponentStreams
 
-  load_and_authorize_with_permission_in_project :edit_meetings
+  load_and_authorize_with_permission_in_project :manage_agendas
 
   before_action :set_meeting
   before_action :set_meeting_section,

--- a/modules/meeting/app/controllers/meeting_sections_controller.rb
+++ b/modules/meeting/app/controllers/meeting_sections_controller.rb
@@ -33,12 +33,13 @@ class MeetingSectionsController < ApplicationController
   include OpTurbo::ComponentStream
   include Meetings::AgendaComponentStreams
 
+  load_and_authorize_with_permission_in_project :edit_meetings
+
   before_action :set_meeting
   before_action :set_meeting_section,
                 except: %i[create clear_backlog clear_backlog_dialog]
   before_action :set_collapsed_state, only: %i[create cancel_edit destroy]
   before_action :set_current_occurrence, only: %i[clear_backlog clear_backlog_dialog]
-  before_action :authorize
 
   def edit
     if @meeting_section.editable?
@@ -204,8 +205,7 @@ class MeetingSectionsController < ApplicationController
   private
 
   def set_meeting
-    @meeting = Meeting.visible.find(params[:meeting_id])
-    @project = @meeting.project # required for authorization via before_action
+    @meeting = @project.meetings.visible.find(params[:meeting_id])
   end
 
   # In case we updated the meeting as part of the service flow
@@ -223,10 +223,7 @@ class MeetingSectionsController < ApplicationController
   end
 
   def set_current_occurrence
-    @current_occurrence = @project
-      .meetings
-      .visible
-      .find_by(id: params[:current_occurrence])
+    @current_occurrence = @project.meetings.visible.find_by(id: params[:current_occurrence])
   end
 
   def set_collapsed_state
@@ -234,9 +231,7 @@ class MeetingSectionsController < ApplicationController
   end
 
   def meeting_section_params
-    params
-      .require(:meeting_section)
-      .permit(:title)
+    params.expect({ meeting_section: [:title] })
   end
 
   def generic_call_failure_response(call)

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -183,9 +183,9 @@ class RecurringMeetingsController < ApplicationController
       init_next_occurrence_job(@first_occurrence)
       deliver_invitation_mails
 
-      flash[:success] = I18n.t("recurring_meeting.occurrence.first_created")
+      flash.now[:success] = I18n.t("recurring_meeting.occurrence.first_created")
     else
-      flash[:error] = call.message
+      flash.now[:error] = call.message
     end
 
     respond_to do |format|
@@ -289,7 +289,7 @@ class RecurringMeetingsController < ApplicationController
     end
   end
 
-  def upcoming_meetings(count:)
+  def upcoming_meetings(count:) # rubocop:disable Metrics/AbcSize
     opened = @recurring_meeting
       .upcoming_instantiated_meetings
       .index_by(&:start_time)

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -81,6 +81,10 @@ class RecurringMeetingsController < ApplicationController
     )
   end
 
+  def edit
+    redirect_to controller: "meetings", action: "show", id: @recurring_meeting.template, status: :see_other
+  end
+
   def create # rubocop:disable Metrics/AbcSize
     call = ::RecurringMeetings::CreateService
       .new(user: current_user)
@@ -110,10 +114,6 @@ class RecurringMeetingsController < ApplicationController
     end
   end
 
-  def edit
-    redirect_to controller: "meetings", action: "show", id: @recurring_meeting.template, status: :see_other
-  end
-
   def update
     call = ::RecurringMeetings::UpdateService
       .new(model: @recurring_meeting, user: current_user)
@@ -121,7 +121,7 @@ class RecurringMeetingsController < ApplicationController
 
     if call.success?
       fallback_location = project_recurring_meeting_path(@project, call.result)
-      redirect_back(fallback_location:, status: :see_other, turbo: false)
+      redirect_back_or_to(fallback_location, status: :see_other, turbo: false)
     else
       respond_to do |format|
         format.turbo_stream do
@@ -225,7 +225,7 @@ class RecurringMeetingsController < ApplicationController
     result
       .on_failure { |call| render_500(message: call.message) }
       .on_success do |call|
-      send_data call.result, filename: filename_for_content_disposition("#{filename}.ics")
+        send_data call.result, filename: filename_for_content_disposition("#{filename}.ics")
     end
   end
 
@@ -265,11 +265,11 @@ class RecurringMeetingsController < ApplicationController
       .participants
       .invited
       .find_each do |participant|
-      MeetingSeriesMailer.invited(
-        @recurring_meeting,
-        participant.user,
-        User.current
-      ).deliver_later
+        MeetingSeriesMailer.invited(
+          @recurring_meeting,
+          participant.user,
+          User.current
+        ).deliver_later
     end
   end
 
@@ -280,12 +280,12 @@ class RecurringMeetingsController < ApplicationController
       .participants
       .invited
       .find_each do |participant|
-      MeetingMailer
-        .invited(
-          meeting,
-          participant.user,
-          User.current
-        ).deliver_later
+        MeetingMailer
+          .invited(
+            meeting,
+            participant.user,
+            User.current
+          ).deliver_later
     end
   end
 

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -7,7 +7,7 @@ class RecurringMeetingsController < ApplicationController
   include OpTurbo::FlashStreamHelper
 
   before_action :load_and_authorize_in_optional_project
-  before_action :find_meeting, except: %i[index new create]
+  before_action :find_recurring_meeting, except: %i[index new create]
 
   before_action :get_scheduled_meeting, only: %i[delete_scheduled_dialog destroy_scheduled]
   before_action :redirect_to_project, only: %i[show]
@@ -19,14 +19,7 @@ class RecurringMeetingsController < ApplicationController
   menu_item :meetings
 
   def index
-    results =
-      if @project
-        RecurringMeeting.visible.where(project_id: @project.id)
-      else
-        RecurringMeeting.visible
-      end
-
-    @recurring_meetings = show_more_pagination(results, limit: params[:limit])
+    @recurring_meetings = show_more_pagination(visible_recurring_meetings_scope, limit: params[:limit])
 
     respond_to do |format|
       format.html do
@@ -337,8 +330,16 @@ class RecurringMeetingsController < ApplicationController
     render_400 unless @scheduled_meeting.meeting_id.nil?
   end
 
-  def find_meeting
-    @recurring_meeting = RecurringMeeting.visible.find(params[:id])
+  def visible_recurring_meetings_scope
+    if @project
+      @project.recurring_meetings.visible
+    else
+      RecurringMeeting.visible
+    end
+  end
+
+  def find_recurring_meeting
+    @recurring_meeting = visible_recurring_meetings_scope.find(params[:id])
   end
 
   def convert_params

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -121,7 +121,8 @@ class WorkPackageMeetingsTabController < ApplicationController
   end
 
   def meeting_for(meeting_id)
-    @project.meetings.allowed_to(User.current, :manage_agendas).find(meeting_id)
+    # TODO: Should this be scoped to the project?
+    Meeting.visible.find(meeting_id)
   end
 
   def add_work_package_to_meeting_params

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -32,8 +32,9 @@ class WorkPackageMeetingsTabController < ApplicationController
   include OpTurbo::ComponentStream
   include Meetings::WorkPackageMeetingsTabComponentStreams
 
+  load_and_authorize_with_permission_in_project :view_work_packages
+
   before_action :set_work_package
-  before_action :authorize_global
 
   def index
     direction = params[:direction]&.to_sym || :upcoming # default to upcoming
@@ -91,7 +92,7 @@ class WorkPackageMeetingsTabController < ApplicationController
 
   def refresh_form
     @meeting_agenda_item = MeetingAgendaItem.new(
-      meeting: Meeting.find(params[:meeting_agenda_item][:meeting_id]),
+      meeting: meeting_for(params[:meeting_agenda_item][:meeting_id]),
       notes: params[:meeting_agenda_item][:notes]
     )
 
@@ -116,8 +117,11 @@ class WorkPackageMeetingsTabController < ApplicationController
   private
 
   def set_work_package
-    @work_package = WorkPackage.visible.find(params[:work_package_id])
-    @project = @work_package.project # required for authorization via before_action
+    @work_package = @project.work_packages.visible.find(params[:work_package_id])
+  end
+
+  def meeting_for(meeting_id)
+    @project.meetings.allowed_to(User.current, :manage_agendas).find(meeting_id)
   end
 
   def add_work_package_to_meeting_params

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -72,10 +72,17 @@ class Meeting < ApplicationRecord
     order("#{Meeting.table_name}.title ASC")
       .includes({ participants: :user }, :author)
   }
+
   scope :visible, ->(*args) {
     includes(:project)
       .references(:projects)
       .merge(Project.allowed_to(args.first || User.current, :view_meetings))
+  }
+
+  scope :allowed_to, ->(user, permission) {
+    includes(:project)
+      .references(:projects)
+      .merge(Project.allowed_to(user, permission))
   }
 
   scope :participated_by, ->(user) {

--- a/modules/meeting/app/views/meeting_mailer/cancelled.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/cancelled.html.erb
@@ -30,13 +30,17 @@ See COPYRIGHT and LICENSE files for more details.
 <%
   summary =
     if @meeting.recurring?
-      I18n.t("meeting.email.cancelled.summary_occurrence",
-             title: @meeting.title,
-             actor: @actor)
+      I18n.t(
+        "meeting.email.cancelled.summary_occurrence",
+        title: @meeting.title,
+        actor: @actor
+      )
     else
-      I18n.t("meeting.email.cancelled.summary",
-             title: @meeting.title,
-             actor: @actor)
+      I18n.t(
+        "meeting.email.cancelled.summary",
+        title: @meeting.title,
+        actor: @actor
+      )
     end
 %>
 

--- a/modules/meeting/app/views/meeting_mailer/invited.html.erb
+++ b/modules/meeting/app/views/meeting_mailer/invited.html.erb
@@ -109,6 +109,6 @@ See COPYRIGHT and LICENSE files for more details.
     <%= link_to I18n.t(:"meeting.email.open_meeting_link"),
                 meeting_url(@meeting),
                 target: "_blank",
-                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;" %>
+                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;", rel: "noopener" %>
   <% end %>
 <% end %>

--- a/modules/meeting/app/views/meeting_series_mailer/invited.html.erb
+++ b/modules/meeting/app/views/meeting_series_mailer/invited.html.erb
@@ -110,6 +110,6 @@ See COPYRIGHT and LICENSE files for more details.
     <%= link_to I18n.t(:label_view_meeting_series),
                 recurring_meeting_url(@series),
                 target: "_blank",
-                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;" %>
+                style: "color: #333333; text-decoration: none; font-size: 14px;white-space: nowrap;", rel: "noopener" %>
   <% end %>
 <% end %>

--- a/modules/meeting/app/views/recurring_meetings/new.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/new.html.erb
@@ -33,9 +33,9 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_breadcrumbs(
       [
         ({ href: project_overview_path(@project.id), text: @project.name } if @project.present?),
-         { href: @project.present? ? project_recurring_meetings_path(@project.id) : recurring_meetings_path,
-           text: I18n.t(:label_meeting_plural) },
-         t(:label_recurring_meeting_new)
+        { href: @project.present? ? project_recurring_meetings_path(@project.id) : recurring_meetings_path,
+          text: I18n.t(:label_meeting_plural) },
+        t(:label_recurring_meeting_new)
       ].compact
     )
   end

--- a/modules/meeting/app/views/recurring_meetings/show.html.erb
+++ b/modules/meeting/app/views/recurring_meetings/show.html.erb
@@ -37,13 +37,13 @@ See COPYRIGHT and LICENSE files for more details.
 <% else -%>
   <% if @direction == "past" -%>
     <%= render RecurringMeetings::TableComponent.new(
-      recurring_meeting: @recurring_meeting,
-      rows: @meetings,
-      current_project: @project,
-      count: @count,
-      direction: @direction,
-      max_count: @max_count
-    ) %>
+          recurring_meeting: @recurring_meeting,
+          rows: @meetings,
+          current_project: @project,
+          count: @count,
+          direction: @direction,
+          max_count: @max_count
+        ) %>
   <% else -%>
     <%= render partial: "show_upcoming" %>
   <% end -%>

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -162,37 +162,6 @@ Rails.application.routes.draw do
       end
     end
 
-    resource :agenda, controller: "meeting_agendas", only: [:update] do
-      member do
-        get :history
-        get :diff
-        put :close
-        put :open
-        post :preview
-      end
-
-      resources :versions, only: [:show],
-                           controller: "meeting_agendas"
-    end
-
-    resource :contents, controller: "meeting_contents", only: %i[show update] do
-      member do
-        get :history
-        get :diff
-      end
-    end
-
-    resource :minutes, controller: "meeting_minutes", only: [:update] do
-      member do
-        get :history
-        get :diff
-        post :preview
-      end
-
-      resources :versions, only: [:show],
-                           controller: "meeting_minutes"
-    end
-
     member do
       get "/:tab" => "meetings#show", :constraints => { tab: /(agenda|minutes)/ }, :as => "tab"
     end

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -29,8 +29,33 @@
 #++
 
 Rails.application.routes.draw do
+  # Global route to show recurring meetings over all projects and create form from the global view
+  resources :recurring_meetings, only: %i[index show new create] do
+    collection do
+      get :humanize_schedule, controller: "recurring_meetings/schedule", action: :humanize_schedule
+    end
+  end
+
+  # Global route to show meetings over all projects and create form from the global view
+  resources :meetings, only: %i[index show new create] do
+    collection do
+      get :new_dialog
+      get "menu" => "meetings/menus#show"
+      get :fetch_timezone
+
+      get "ical/:token", controller: "meetings/ical", action: :index, as: "ical_feed"
+    end
+  end
+
+  # All other routes are project scoped for correct permission handling
   resources :projects, only: %i[] do
     resources :meetings do
+      collection do
+        get :new_dialog
+        get "menu" => "meetings/menus#show"
+        get :fetch_timezone
+      end
+
       member do
         get :copy
         get :check_for_updates
@@ -48,12 +73,6 @@ Rails.application.routes.draw do
         post :toggle_notifications
         get :exit_draft_mode_dialog
         post :exit_draft_mode
-      end
-
-      collection do
-        get :new_dialog
-        get "menu" => "meetings/menus#show"
-        get :fetch_timezone
       end
 
       resources :agenda_items, controller: "meeting_agenda_items" do
@@ -80,6 +99,7 @@ Rails.application.routes.draw do
           post :clear_backlog
           get :clear_backlog_dialog
         end
+
         member do
           post :cancel_edit
           put :drop
@@ -104,6 +124,7 @@ Rails.application.routes.draw do
           get :manage_participants_dialog
           post :mark_all_attended
         end
+
         member do
           post :toggle_attendance
         end
@@ -141,28 +162,13 @@ Rails.application.routes.draw do
         end
       end
     end
+
     resources :meeting_agenda_items, only: %i[] do
       collection do
         get :dialog, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting_dialog
         post :create, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting
         get :refresh_form, controller: "work_package_meetings_tab", action: :refresh_form
       end
-    end
-  end
-
-  resources :recurring_meetings, only: %i[index show new create] do
-    collection do
-      get :humanize_schedule, controller: "recurring_meetings/schedule", action: :humanize_schedule
-    end
-  end
-
-  resources :meetings, only: %i[index show new create] do
-    collection do
-      get :new_dialog
-      get "menu" => "meetings/menus#show"
-      get :fetch_timezone
-
-      get "ical/:token", controller: "meetings/ical", action: :index, as: "ical_feed"
     end
   end
 end

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -77,7 +77,6 @@ Rails.application.routes.draw do
 
       resources :agenda_items, controller: "meeting_agenda_items" do
         collection do
-          get :new, action: :new, as: :new
           get :cancel_new
         end
 
@@ -93,7 +92,7 @@ Rails.application.routes.draw do
           post :move_to_section
         end
 
-        resources :outcomes, controller: "meeting_outcomes" do
+        resources :outcomes, controller: "meeting_outcomes", except: %i[index show] do
           collection do
             get :cancel_new
             get :create_work_package_dialog

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -92,6 +92,18 @@ Rails.application.routes.draw do
           put :move_to_section_dialog
           post :move_to_section
         end
+
+        resources :outcomes, controller: "meeting_outcomes" do
+          collection do
+            get :cancel_new
+            get :create_work_package_dialog
+            post :create_work_package
+          end
+
+          member do
+            get :cancel_edit
+          end
+        end
       end
 
       resources :sections, controller: "meeting_sections" do
@@ -104,18 +116,6 @@ Rails.application.routes.draw do
           post :cancel_edit
           put :drop
           put :move
-        end
-      end
-
-      resources :outcomes, controller: "meeting_outcomes" do
-        collection do
-          get :new, action: :new, as: :new
-          get :cancel_new
-          get :create_work_package_dialog
-          post :create_work_package
-        end
-        member do
-          get :cancel_edit
         end
       end
 

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -151,22 +151,22 @@ Rails.application.routes.draw do
         get :end_series_dialog
       end
     end
-  end
 
-  resources :work_packages, only: %i[] do
-    resources :meetings, only: %i[] do
-      collection do
-        resources :tab, only: %i[index], controller: "work_package_meetings_tab", as: "meetings_tab" do
-          get :count, on: :collection
+    resources :work_packages, only: %i[] do
+      resources :meetings, only: %i[] do
+        collection do
+          resources :tab, only: %i[index], controller: "work_package_meetings_tab", as: "meetings_tab" do
+            get :count, on: :collection
+          end
         end
       end
-    end
 
-    resources :meeting_agenda_items, only: %i[] do
-      collection do
-        get :dialog, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting_dialog
-        post :create, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting
-        get :refresh_form, controller: "work_package_meetings_tab", action: :refresh_form
+      resources :meeting_agenda_items, only: %i[] do
+        collection do
+          get :dialog, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting_dialog
+          post :create, controller: "work_package_meetings_tab", action: :add_work_package_to_meeting
+          get :refresh_form, controller: "work_package_meetings_tab", action: :refresh_form
+        end
       end
     end
   end

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -31,12 +31,29 @@
 Rails.application.routes.draw do
   resources :projects, only: %i[] do
     resources :meetings do
+      member do
+        get :copy
+        get :check_for_updates
+        get :cancel_edit
+        get :download_ics
+        put :update_title
+        get :details_dialog
+        put :update_details
+        put :change_state
+        post :notify
+        get :history
+        get :delete_dialog
+        get :generate_pdf_dialog
+        get :toggle_notifications_dialog
+        post :toggle_notifications
+        get :exit_draft_mode_dialog
+        post :exit_draft_mode
+      end
+
       collection do
         get :new_dialog
         get "menu" => "meetings/menus#show"
         get :fetch_timezone
-
-        get "ical/:token", controller: "meetings/ical", action: :index, as: "ical_feed"
       end
 
       resources :agenda_items, controller: "meeting_agenda_items" do
@@ -44,6 +61,7 @@ Rails.application.routes.draw do
           get :new, action: :new, as: :new
           get :cancel_new
         end
+
         member do
           get :cancel_edit
           put :drop
@@ -56,6 +74,7 @@ Rails.application.routes.draw do
           post :move_to_section
         end
       end
+
       resources :sections, controller: "meeting_sections" do
         collection do
           post :clear_backlog
@@ -67,6 +86,7 @@ Rails.application.routes.draw do
           put :move
         end
       end
+
       resources :outcomes, controller: "meeting_outcomes" do
         collection do
           get :new, action: :new, as: :new
@@ -78,6 +98,7 @@ Rails.application.routes.draw do
           get :cancel_edit
         end
       end
+
       resources :participants, controller: "meeting_participants" do
         collection do
           get :manage_participants_dialog
@@ -88,35 +109,11 @@ Rails.application.routes.draw do
         end
       end
 
-      resource :agenda, controller: "meeting_agendas", only: [:update] do
-        member do
-          get :history
-          get :diff
-          put :close
-          put :open
-          post :preview
+      resource :presentation, only: %i[show edit], controller: "meeting_presentation" do
+        collection do
+          get :check_for_updates
+          post :start
         end
-
-        resources :versions, only: [:show],
-                             controller: "meeting_agendas"
-      end
-
-      resource :contents, controller: "meeting_contents", only: %i[show update] do
-        member do
-          get :history
-          get :diff
-        end
-      end
-
-      resource :minutes, controller: "meeting_minutes", only: [:update] do
-        member do
-          get :history
-          get :diff
-          post :preview
-        end
-
-        resources :versions, only: [:show],
-                             controller: "meeting_minutes"
       end
     end
 

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -34,34 +34,89 @@ Rails.application.routes.draw do
       collection do
         get :new_dialog
         get "menu" => "meetings/menus#show"
+        get :fetch_timezone
+
+        get "ical/:token", controller: "meetings/ical", action: :index, as: "ical_feed"
       end
 
-      member do
-        get :copy
-        get :check_for_updates
-        get :cancel_edit
-        get :download_ics
-        put :update_title
-        get :details_dialog
-        put :update_details
-        put :change_state
-        post :notify
-        get :history
-        get :delete_dialog
-        get :generate_pdf_dialog
-        get :toggle_notifications_dialog
-        post :toggle_notifications
-        get :exit_draft_mode_dialog
-        post :exit_draft_mode
-      end
-
-      resource :presentation,
-               only: %i[show edit],
-               controller: "meeting_presentation" do
+      resources :agenda_items, controller: "meeting_agenda_items" do
         collection do
-          get :check_for_updates
-          post :start
+          get :new, action: :new, as: :new
+          get :cancel_new
         end
+        member do
+          get :cancel_edit
+          put :drop
+          put :move
+          get :move_to_next_dialog, action: :move_to_next_meeting_dialog
+          post :move_to_next, action: :move_to_next_meeting
+          get :duplicate_in_next_dialog, action: :duplicate_in_next_meeting_dialog
+          post :duplicate_in_next, action: :duplicate_in_next_meeting
+          put :move_to_section_dialog
+          post :move_to_section
+        end
+      end
+      resources :sections, controller: "meeting_sections" do
+        collection do
+          post :clear_backlog
+          get :clear_backlog_dialog
+        end
+        member do
+          post :cancel_edit
+          put :drop
+          put :move
+        end
+      end
+      resources :outcomes, controller: "meeting_outcomes" do
+        collection do
+          get :new, action: :new, as: :new
+          get :cancel_new
+          get :create_work_package_dialog
+          post :create_work_package
+        end
+        member do
+          get :cancel_edit
+        end
+      end
+      resources :participants, controller: "meeting_participants" do
+        collection do
+          get :manage_participants_dialog
+          post :mark_all_attended
+        end
+        member do
+          post :toggle_attendance
+        end
+      end
+
+      resource :agenda, controller: "meeting_agendas", only: [:update] do
+        member do
+          get :history
+          get :diff
+          put :close
+          put :open
+          post :preview
+        end
+
+        resources :versions, only: [:show],
+                             controller: "meeting_agendas"
+      end
+
+      resource :contents, controller: "meeting_contents", only: %i[show update] do
+        member do
+          get :history
+          get :diff
+        end
+      end
+
+      resource :minutes, controller: "meeting_minutes", only: [:update] do
+        member do
+          get :history
+          get :diff
+          post :preview
+        end
+
+        resources :versions, only: [:show],
+                             controller: "meeting_minutes"
       end
     end
 
@@ -111,59 +166,6 @@ Rails.application.routes.draw do
       get :fetch_timezone
 
       get "ical/:token", controller: "meetings/ical", action: :index, as: "ical_feed"
-    end
-
-    resources :agenda_items, controller: "meeting_agenda_items" do
-      collection do
-        get :new, action: :new, as: :new
-        get :cancel_new
-      end
-      member do
-        get :cancel_edit
-        put :drop
-        put :move
-        get :move_to_next_dialog, action: :move_to_next_meeting_dialog
-        post :move_to_next, action: :move_to_next_meeting
-        get :duplicate_in_next_dialog, action: :duplicate_in_next_meeting_dialog
-        post :duplicate_in_next, action: :duplicate_in_next_meeting
-        put :move_to_section_dialog
-        post :move_to_section
-      end
-    end
-    resources :sections, controller: "meeting_sections" do
-      collection do
-        post :clear_backlog
-        get :clear_backlog_dialog
-      end
-      member do
-        post :cancel_edit
-        put :drop
-        put :move
-      end
-    end
-    resources :outcomes, controller: "meeting_outcomes" do
-      collection do
-        get :new, action: :new, as: :new
-        get :cancel_new
-        get :create_work_package_dialog
-        post :create_work_package
-      end
-      member do
-        get :cancel_edit
-      end
-    end
-    resources :participants, controller: "meeting_participants" do
-      collection do
-        get :manage_participants_dialog
-        post :mark_all_attended
-      end
-      member do
-        post :toggle_attendance
-      end
-    end
-
-    member do
-      get "/:tab" => "meetings#show", :constraints => { tab: /(agenda|minutes)/ }, :as => "tab"
     end
   end
 end

--- a/modules/meeting/frontend/module/main.ts
+++ b/modules/meeting/frontend/module/main.ts
@@ -67,7 +67,7 @@ export function workPackageMeetingsCount(
       throttleTime(1000),
       switchMap(() => {
         return http
-          .get(`${pathHelperService.workPackagePath(workPackage.id as string)}/meetings/tab/count`)
+          .get(`${pathHelperService.projectWorkPackagePath(workPackage.project.id as string, workPackage.id as string)}/meetings/tab/count`)
           .pipe(
             map((res:{ count:number }) => res.count),
           );

--- a/modules/meeting/frontend/module/meetings-tab/meetings-tab.component.ts
+++ b/modules/meeting/frontend/module/meetings-tab/meetings-tab.component.ts
@@ -49,6 +49,6 @@ export class MeetingsTabComponent implements OnInit, TabComponent {
   ) {}
 
   ngOnInit():void {
-    this.turboFrameSrc = `${this.PathHelper.staticBase}/work_packages/${this.workPackage.id}/meetings/tab`;
+    this.turboFrameSrc = `${this.PathHelper.projectWorkPackagePath(this.workPackage.project.id as string, this.workPackage.id as string)}/meetings/tab`;
   }
 }

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Open the Meetings tab",
            member_with_roles: { project => role })
   end
 
-  let(:meetings_tab) { Pages::MeetingsTab.new(work_package.id) }
+  let(:meetings_tab) { Pages::MeetingsTab.new(project_id: project.id, work_package_id: work_package.id) }
 
   let(:tabs) { Components::WorkPackages::Tabs.new(work_package) }
   let(:meetings_tab_element) { find(".op-tab-row--link_selected", text: "MEETINGS") }

--- a/modules/meeting/spec/requests/meeting_participants_spec.rb
+++ b/modules/meeting/spec/requests/meeting_participants_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "MeetingParticipants requests",
     let(:base_params) do
       {
         meeting_id: meeting.id,
+        project_id: project.id,
         meeting_participant: {
           user_id: []
         }
@@ -62,7 +63,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "creates a single participant" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.to change { meeting.participants.count }.by(1)
 
         expect(response).to have_http_status(:ok)
@@ -75,7 +76,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "sends notification email" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
           perform_enqueued_jobs
         end.to change { ActionMailer::Base.deliveries.size }.by(1)
       end
@@ -92,7 +93,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "creates multiple participants" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.to change { meeting.participants.count }.by(2)
 
         expect(response).to have_http_status(:ok)
@@ -114,7 +115,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "creates participants for users with meeting permissions" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.to change { meeting.participants.count }.by(1)
 
         expect(response).to have_http_status(:ok)
@@ -124,7 +125,7 @@ RSpec.describe "MeetingParticipants requests",
       end
 
       it "adds errors for users without meeting permissions" do
-        post meeting_participants_path(meeting), params: params, as: :turbo_stream
+        post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include "User #{user_without_meeting_permissions.name} is not a valid participant."
@@ -146,14 +147,14 @@ RSpec.describe "MeetingParticipants requests",
 
       it "does not create participants for users not in project" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.not_to change { meeting.participants.count }
 
         expect(response).to have_http_status(:ok)
       end
 
       it "adds appropriate errors" do
-        post meeting_participants_path(meeting), params: params, as: :turbo_stream
+        post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
 
         expect(response.body).to include "User #{user_not_in_project.name} is not a valid participant."
 
@@ -167,7 +168,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "does not create any participants" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.not_to change { meeting.participants.count }
 
         expect(response).to have_http_status(:ok)
@@ -179,7 +180,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "handles nil gracefully" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.not_to change { meeting.participants.count }
 
         expect(response).to have_http_status(:ok)
@@ -197,7 +198,7 @@ RSpec.describe "MeetingParticipants requests",
 
       it "creates participants for valid users only" do
         expect do
-          post meeting_participants_path(meeting), params: params, as: :turbo_stream
+          post project_meeting_participants_path(project, meeting), params: params, as: :turbo_stream
         end.to change { meeting.participants.count }.by(1)
 
         expect(response).to have_http_status(:ok)
@@ -214,7 +215,7 @@ RSpec.describe "MeetingParticipants requests",
     let!(:participant2) { create(:meeting_participant, meeting:, user: user_with_meeting_permissions2, attended: false) }
 
     it "marks all participants as attended" do
-      post mark_all_attended_meeting_participants_path(meeting), as: :turbo_stream
+      post mark_all_attended_project_meeting_participants_path(project, meeting), as: :turbo_stream
 
       expect(response).to have_http_status(:ok)
       expect(participant1.reload.attended).to be true
@@ -227,7 +228,7 @@ RSpec.describe "MeetingParticipants requests",
 
     it "toggles attendance status" do
       expect do
-        post toggle_attendance_meeting_participant_path(meeting, participant), as: :turbo_stream
+        post toggle_attendance_project_meeting_participant_path(project, meeting, participant), as: :turbo_stream
       end.to change { participant.reload.attended }.from(false).to(true)
 
       expect(response).to have_http_status(:ok)
@@ -239,7 +240,7 @@ RSpec.describe "MeetingParticipants requests",
 
     it "removes the participant" do
       expect do
-        delete meeting_participant_path(meeting, participant), as: :turbo_stream
+        delete project_meeting_participant_path(project, meeting, participant), as: :turbo_stream
       end.to change { meeting.participants.count }.by(-1)
 
       expect(response).to have_http_status(:ok)
@@ -248,7 +249,7 @@ RSpec.describe "MeetingParticipants requests",
 
   describe "GET /meetings/:meeting_id/participants/manage_participants_dialog" do
     it "responds with the manage participants dialog" do
-      get manage_participants_dialog_meeting_participants_path(meeting), as: :turbo_stream
+      get manage_participants_dialog_project_meeting_participants_path(project, meeting), as: :turbo_stream
 
       expect(response).to have_http_status(:ok)
     end

--- a/modules/meeting/spec/requests/meeting_sections_spec.rb
+++ b/modules/meeting/spec/requests/meeting_sections_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Meeting sections requests",
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
       it "returns 404" do
-        get edit_meeting_section_path(other_meeting, other_section)
+        get edit_project_meeting_section_path(other_meeting.project, other_meeting, other_section)
 
         expect(response).to have_http_status(:not_found)
       end
@@ -61,7 +61,7 @@ RSpec.describe "Meeting sections requests",
       let(:other_meeting) { create(:meeting, project: other_project) }
 
       it "returns 404" do
-        post meeting_sections_path(other_meeting)
+        post project_meeting_sections_path(other_meeting.project, other_meeting)
 
         expect(response).to have_http_status(:not_found)
       end
@@ -75,7 +75,7 @@ RSpec.describe "Meeting sections requests",
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
       it "returns 404" do
-        put meeting_section_path(other_meeting, other_section),
+        put project_meeting_section_path(other_meeting.project, other_meeting, other_section),
             params: { meeting_section: { title: "New title" } }
 
         expect(response).to have_http_status(:not_found)
@@ -90,7 +90,7 @@ RSpec.describe "Meeting sections requests",
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
       it "returns 404" do
-        delete meeting_section_path(other_meeting, other_section)
+        delete project_meeting_section_path(other_meeting.project, other_meeting, other_section)
 
         expect(response).to have_http_status(:not_found)
       end

--- a/modules/meeting/spec/requests/meeting_sections_spec.rb
+++ b/modules/meeting/spec/requests/meeting_sections_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe "Meeting sections requests",
       let(:other_meeting) { create(:meeting, project: other_project) }
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
-      it "returns 404" do
+      it "returns 403" do
         get edit_project_meeting_section_path(other_meeting.project, other_meeting, other_section)
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -60,10 +60,10 @@ RSpec.describe "Meeting sections requests",
       let(:other_project) { create(:project, enabled_module_names: %i[meetings]) }
       let(:other_meeting) { create(:meeting, project: other_project) }
 
-      it "returns 404" do
+      it "returns 403" do
         post project_meeting_sections_path(other_meeting.project, other_meeting)
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -74,11 +74,11 @@ RSpec.describe "Meeting sections requests",
       let(:other_meeting) { create(:meeting, project: other_project) }
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
-      it "returns 404" do
+      it "returns 403" do
         put project_meeting_section_path(other_meeting.project, other_meeting, other_section),
             params: { meeting_section: { title: "New title" } }
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
@@ -89,10 +89,10 @@ RSpec.describe "Meeting sections requests",
       let(:other_meeting) { create(:meeting, project: other_project) }
       let(:other_section) { create(:meeting_section, meeting: other_meeting) }
 
-      it "returns 404" do
+      it "returns 403" do
         delete project_meeting_section_path(other_meeting.project, other_meeting, other_section)
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -701,7 +701,7 @@ module Pages::Meetings
           add_section_link = find_link("Section")
           url = add_section_link[:href]
 
-          expect(URI.parse(url).path).to eq(meeting_sections_path(meeting))
+          expect(URI.parse(url).path).to eq(project_meeting_sections_path(meeting.project, meeting))
         end
       end
     end

--- a/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
+++ b/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -32,15 +33,16 @@ require "support/pages/page"
 
 module Pages
   class MeetingsTab < Page
-    attr_reader :work_package_id
+    attr_reader :work_package_id, :project_id
 
-    def initialize(work_package_id)
+    def initialize(project_id:, work_package_id:)
       super()
       @work_package_id = work_package_id
+      @project_id = project_id
     end
 
     def path
-      "/work_packages/#{work_package_id}/tabs/meetings"
+      "/projects/#{project_id}/work_packages/#{work_package_id}/tabs/meetings"
     end
 
     def expect_tab_present


### PR DESCRIPTION
# Ticket
- https://community.openproject.org/projects/openproject/work_packages/70962
- https://community.openproject.org/projects/openproject/work_packages/70903
- 
# What are you trying to accomplish?
- Move all routes that modify meeting resource routes into the `/projects/:slug/meetings` scope to have all automatic permission checks executed properly.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
