### PR TITLE
Add `member_wih_roles` and `member_with_permissions` attributes to project factories

### DIFF
--- a/spec/factories/principal_factory.rb
+++ b/spec/factories/principal_factory.rb
@@ -33,14 +33,14 @@ FactoryBot.define do
     transient do
       # example:
       #   member_with_permissions: {
-      #     project => [:view_work_packages]
+      #     project => :view_work_packages
       #     work_package => [:view_work_packages, :edit_work_packages]
       #   }
       member_with_permissions { {} }
 
       # example:
       #   member_wih_roles: {
-      #     project => [role1],
+      #     project => role1,
       #     work_package => [role2, role3]
       #   }
       member_with_roles { {} }
@@ -81,15 +81,15 @@ FactoryBot.define do
         auth_provider = AuthProvider.find_by(slug:) || create(:oidc_provider, slug:)
         principal.user_auth_provider_links.create!(auth_provider:, external_id:)
       end
-      evaluator.member_with_permissions.each do |object, permissions|
+      evaluator.member_with_permissions.each do |object, permission_or_permissions|
         if object.is_a?(Project)
-          role = create(:project_role, permissions:)
+          role = create(:project_role, permissions: Array(permission_or_permissions))
           create(:member, principal:, project: object, roles: [role])
         elsif Member.can_be_member_of?(object)
           project = object.respond_to?(:project) ? object.project : nil
           role_factory = :"#{object.model_name.element}_role"
 
-          role = create(role_factory, permissions:)
+          role = create(role_factory, permissions: Array(permission_or_permissions))
           create(:member, principal:, entity: object, project:, roles: [role])
         end
       end
@@ -111,7 +111,7 @@ FactoryBot.define do
       end
 
       if evaluator.global_roles.present?
-        create(:global_member, principal:, roles: evaluator.global_roles)
+        create(:global_member, principal:, roles: Array(evaluator.global_roles))
       end
     end
   end

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -30,10 +30,55 @@
 
 FactoryBot.define do
   factory :project, parent: :workspace do
+    transient do
+      # example:
+      #   member_with_permissions: {
+      #     user => [:view_work_packages]
+      #     other_user => [:view_work_packages, :edit_work_packages]
+      #   }
+      member_with_permissions { {} }
+
+      # example:
+      #   member_wih_roles: {
+      #     user => [role1],
+      #     other_user => [role2, role3]
+      #   }
+      member_with_roles { {} }
+    end
+
     workspace_type { "project" }
 
     sequence(:name) { |n| "My Project No. #{n}" }
     sequence(:identifier) { |n| "myproject_no_#{n}" }
+
+    callback(:after_build) do |_project, evaluator|
+      is_build_strategy = evaluator.instance_eval { @build_strategy.is_a? FactoryBot::Strategy::Build }
+      uses_member_association = evaluator.member_with_permissions.present? || evaluator.member_with_roles.present?
+      if is_build_strategy && uses_member_association
+        raise ArgumentError,
+              "Use create(...) with principals and member_with_permissions, member_with_roles traits."
+      end
+    end
+
+    callback(:after_stub) do |_project, evaluator|
+      uses_member_association = evaluator.member_with_permissions.present? || evaluator.member_with_roles.present?
+      if uses_member_association
+        raise ArgumentError,
+              "To create memberships, you either need to use create(...) or use the `mock_permissions_for` " \
+              "helper on the stubbed models"
+      end
+    end
+
+    callback(:after_create) do |project, evaluator|
+      evaluator.member_with_permissions.each do |principal, permissions|
+        role = create(:project_role, permissions:)
+        create(:member, principal:, project: project, roles: [role])
+      end
+
+      evaluator.member_with_roles.each do |principal, role_or_roles|
+        create(:member, principal:, project: project, roles: Array(role_or_roles))
+      end
+    end
 
     factory :public_project do
       public { true } # Remark: public defaults to true

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -33,14 +33,14 @@ FactoryBot.define do
     transient do
       # example:
       #   member_with_permissions: {
-      #     user => [:view_work_packages]
+      #     user => :view_work_packages
       #     other_user => [:view_work_packages, :edit_work_packages]
       #   }
       member_with_permissions { {} }
 
       # example:
       #   member_wih_roles: {
-      #     user => [role1],
+      #     user => role1,
       #     other_user => [role2, role3]
       #   }
       member_with_roles { {} }
@@ -70,8 +70,8 @@ FactoryBot.define do
     end
 
     callback(:after_create) do |project, evaluator|
-      evaluator.member_with_permissions.each do |principal, permissions|
-        role = create(:project_role, permissions:)
+      evaluator.member_with_permissions.each do |principal, permission_or_permissions|
+        role = create(:project_role, permissions: Array(permission_or_permissions))
         create(:member, principal:, project: project, roles: [role])
       end
 


### PR DESCRIPTION
We already had `member_with_roles` and `member_with_permissions` on the factories for principals

https://github.com/opf/openproject/blob/c746629c516ca9d09c9dee4657d5928ae54f9e2f/spec/factories/principal_factory.rb#L34-L46

This PR adds the analogue functionality to project factories as well. I have already a few times erroneously wanted to use them and got errors, so here they are.