### PR TITLE
(Attempt to) Fix flaky meeting_work_package_outcomes spec

### DIFF
--- a/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
+++ b/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe "Work package meeting outcomes", :js do
             click_on "Add"
           end
 
+          wait_for_network_idle
+
           show_page.in_outcome_component(meeting_agenda_item) do
             expect(page).to have_link(work_package1.subject)
           end
@@ -131,6 +133,8 @@ RSpec.describe "Work package meeting outcomes", :js do
             show_page.select_outcome_action "Remove outcome"
           end
 
+          wait_for_network_idle
+
           expect(page).to have_no_link(work_package1.subject)
           expect { outcome.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
@@ -154,7 +158,9 @@ RSpec.describe "Work package meeting outcomes", :js do
             click_on "Create"
           end
 
-          expect(page).to have_no_dialog(I18n.t(:label_work_package_new))
+          wait_for_network_idle
+
+          expect(page).to have_no_selector(:dialog, I18n.t(:label_work_package_new), wait: 10)
 
           created_wp = WorkPackage.find_by(subject: "New WP from meeting outcome")
           expect(created_wp).to be_present
@@ -179,10 +185,13 @@ RSpec.describe "Work package meeting outcomes", :js do
 
           page.within_dialog(I18n.t(:label_work_package_new)) do
             fill_in "Subject", with: ""
-            click_on "Create"
 
-            expect(page).to have_text("Subject can't be blank")
+            click_on "Create"
           end
+
+          wait_for_network_idle
+
+          expect(page).to have_text("Subject can't be blank")
 
           expect(page).to have_dialog(I18n.t(:label_work_package_new))
           expect(WorkPackage.find_by(subject: "")).to be_nil
@@ -207,7 +216,7 @@ RSpec.describe "Work package meeting outcomes", :js do
             click_on "Cancel"
           end
 
-          expect(page).to have_no_dialog(I18n.t(:label_work_package_new))
+          expect(page).to have_no_selector(:dialog, I18n.t(:label_work_package_new), wait: 10)
           expect(WorkPackage.count).to eq(initial_wp_count)
         end
       end


### PR DESCRIPTION
Flickering spec:
./modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb

Failing run:
https://github.com/opf/openproject/actions/runs/21197707698/job/60977075688

I couldn't see anything obvious, but running the spec multiple times locally resulted in failures and more waits seem to have helped. I'm also not sure why the default 4 second wait isn't enough for closing the dialog, but bumping it up makes the spec pass consistently again.