### PR TITLE
Add UI to change MCP configuration

### DIFF
--- a/app/components/mcp_configurations/edit_row_component.rb
+++ b/app/components/mcp_configurations/edit_row_component.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpConfigurations
+  class EditRowComponent < OpPrimer::BorderBoxRowComponent
+    def name
+      render(
+        Primer::Beta::Text.new(
+          font_weight: :bold,
+          data: { test_selector: "mcp-configuration--config-row-name" }
+        )
+      ) { config.identifier.split("/", 2).last }
+    end
+
+    def title
+      render(
+        Primer::Alpha::TextField.new(
+          name: "mcp_configurations[#{config.identifier}][title]",
+          label: McpConfiguration.human_attribute_name(:title),
+          visually_hide_label: true,
+          value: config.title,
+          data: { test_selector: "mcp-configuration--title-input-#{config.identifier}" }
+        )
+      )
+    end
+
+    def description
+      render(
+        Primer::Alpha::TextArea.new(
+          name: "mcp_configurations[#{config.identifier}][description]",
+          label: McpConfiguration.human_attribute_name(:description),
+          visually_hide_label: true,
+          value: config.description,
+          rows: 4,
+          data: { test_selector: "mcp-configuration--description-input-#{config.identifier}" }
+        )
+      )
+    end
+
+    def enabled
+      render(
+        Primer::Alpha::CheckBox.new(
+          name: "mcp_configurations[#{config.identifier}][enabled]",
+          label: McpConfiguration.human_attribute_name(:enabled),
+          visually_hide_label: true,
+          checked: config.enabled,
+          test_selector: "mcp-configuration--enabled-input-#{config.identifier}"
+        )
+      )
+    end
+
+    private
+
+    def config
+      model
+    end
+  end
+end

--- a/app/components/mcp_configurations/edit_table_component.rb
+++ b/app/components/mcp_configurations/edit_table_component.rb
@@ -28,12 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class McpConfiguration < ApplicationRecord
-  SERVER_CONFIGURATION_IDENTIFIER = "mcp_server"
+module McpConfigurations
+  class EditTableComponent < OpPrimer::BorderBoxTableComponent
+    columns :name, :title, :description, :enabled
 
-  class << self
-    def server_config
-      McpConfiguration.find_or_initialize_by(identifier: SERVER_CONFIGURATION_IDENTIFIER)
+    def headers
+      [
+        [:name, { caption: McpConfiguration.human_attribute_name(:name) }],
+        [:title, { caption: McpConfiguration.human_attribute_name(:title) }],
+        [:description, { caption: McpConfiguration.human_attribute_name(:description) }],
+        [:enabled, { caption: McpConfiguration.human_attribute_name(:enabled) }]
+      ]
+    end
+
+    def mobile_title
+      "TODO: Does mobile even make sense?"
+    end
+
+    def row_class
+      EditRowComponent
     end
   end
 end

--- a/app/components/mcp_configurations/multiple_configurations_component.html.erb
+++ b/app/components/mcp_configurations/multiple_configurations_component.html.erb
@@ -1,0 +1,34 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%= primer_form_with(url: multi_update_mcp_configurations_path) do %>
+  <%= render(McpConfigurations::EditTableComponent.new(rows: configurations)) %>
+
+  <%= render(Primer::Beta::Button.new(type: :submit, mt: 3)) { submit_label } %>
+<% end %>

--- a/app/components/mcp_configurations/multiple_configurations_component.rb
+++ b/app/components/mcp_configurations/multiple_configurations_component.rb
@@ -28,12 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class McpConfiguration < ApplicationRecord
-  SERVER_CONFIGURATION_IDENTIFIER = "mcp_server"
+module McpConfigurations
+  class MultipleConfigurationsComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
 
-  class << self
-    def server_config
-      McpConfiguration.find_or_initialize_by(identifier: SERVER_CONFIGURATION_IDENTIFIER)
+    attr_reader :submit_label
+
+    alias_method :configurations, :model
+
+    def initialize(*, submit_label:, **)
+      super(*, **)
+
+      @submit_label = submit_label
     end
   end
 end

--- a/app/controllers/admin/mcp_configurations_controller.rb
+++ b/app/controllers/admin/mcp_configurations_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin
+  class McpConfigurationsController < ::ApplicationController
+    include OpTurbo::ComponentStream
+
+    before_action :require_admin
+
+    menu_item :mcp_configurations
+
+    layout "admin"
+
+    def index
+      @server_config = McpConfiguration.server_config
+      @tool_configs = McpConfiguration.where(identifier: McpTools.tools_by_name.keys)
+
+      @resource_configs = McpConfiguration.where(identifier: McpResources.resources_by_name.keys)
+    end
+
+    def update
+      config = McpConfiguration.find(params[:id])
+      if config.update(mcp_config_params)
+        flash[:notice] = t(".success")
+      else
+        flash[:error] = t(".failure")
+      end
+
+      redirect_to action: :index
+    end
+
+    def multi_update
+      updates = params[:mcp_configurations]
+      updates.transform_values! { |hash| hash.permit(:title, :description, :enabled) }
+
+      updates.each do |identifier, attributes|
+        McpConfiguration.find_by!(identifier:).update!(attributes)
+      end
+
+      flash[:notice] = t(".success")
+      redirect_to action: :index
+    end
+
+    private
+
+    def mcp_config_params
+      params.expect(mcp_configuration: %i[enabled title description])
+    end
+  end
+end

--- a/app/forms/mcp_configurations/server_form.rb
+++ b/app/forms/mcp_configurations/server_form.rb
@@ -28,12 +28,45 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class McpConfiguration < ApplicationRecord
-  SERVER_CONFIGURATION_IDENTIFIER = "mcp_server"
+module McpConfigurations
+  class ServerForm < ApplicationForm
+    include Redmine::I18n
 
-  class << self
-    def server_config
-      McpConfiguration.find_or_initialize_by(identifier: SERVER_CONFIGURATION_IDENTIFIER)
+    form do |f|
+      # TODO: Hide rest of form (and rest of page) when disabled, show when enabled (only after pressing "Update")
+      f.check_box(
+        name: :enabled,
+        label: McpConfiguration.human_attribute_name(:enabled)
+      )
+
+      if server_enabled?
+        f.text_field(
+          name: :title,
+          label: McpConfiguration.human_attribute_name(:title),
+          caption: I18n.t("admin.mcp_configurations.server_form.title_caption"),
+          input_width: :large
+        )
+
+        f.text_area(
+          name: :description,
+          label: McpConfiguration.human_attribute_name(:description),
+          caption: I18n.t("admin.mcp_configurations.server_form.description_caption"),
+          input_width: :large,
+          rows: 4
+        )
+      end
+
+      f.submit(
+        name: :submit,
+        label: I18n.t(:button_update),
+        scheme: :secondary
+      )
+    end
+
+    private
+
+    def server_enabled?
+      model.enabled?
     end
   end
 end

--- a/app/seeders/mcp_configuration_seeder.rb
+++ b/app/seeders/mcp_configuration_seeder.rb
@@ -46,7 +46,7 @@ class McpConfigurationSeeder < Seeder
 
   def seed_server_config
     McpConfiguration.create!(
-      identifier: API::Mcp::CONFIGURATION_IDENTIFIER,
+      identifier: McpConfiguration::SERVER_CONFIGURATION_IDENTIFIER,
       title: Setting.app_title,
       description: "Performs project management tasks on the given installation of OpenProject.",
       enabled: true
@@ -67,7 +67,7 @@ class McpConfigurationSeeder < Seeder
   end
 
   def server_missing?
-    McpConfiguration.where(identifier: API::Mcp::CONFIGURATION_IDENTIFIER).empty?
+    McpConfiguration.where(identifier: McpConfiguration::SERVER_CONFIGURATION_IDENTIFIER).empty?
   end
 
   def tools_missing?

--- a/app/views/admin/mcp_configurations/index.html.erb
+++ b/app/views/admin/mcp_configurations/index.html.erb
@@ -1,0 +1,97 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_administration), t("menus.admin.mcp_configurations") %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t("menus.admin.mcp_configurations") }
+    header.with_description { t(".description") }
+    header.with_breadcrumbs(
+      [{ href: admin_index_path, text: t(:label_administration) },
+       { href: mcp_configurations_path, text: t("menus.admin.ai") },
+       t("menus.admin.mcp_configurations")]
+    )
+  end
+%>
+
+<%= with_enterprise_banner_guard(
+  :mcp_server,
+  variant: :medium,
+  image: "enterprise/scim-api.png" # TODO: Replace
+) do %>
+
+  <%= settings_primer_form_with(model: @server_config, data: { test_selector: "mcp-configuration--server-config-form" }) { |f| render(McpConfigurations::ServerForm.new(f)) } %>
+
+  <% if @server_config.enabled? %>
+    <%=
+      render(Primer::Beta::Subhead.new(mt: 4)) do |component|
+        component.with_heading(tag: :h3) { t(".tools_heading") }
+        component.with_description do
+          link_translate(
+            "admin.mcp_configurations.index.tools_description",
+            links: { docs_url: %i[sysadmin_docs mcp_tools] },
+            external: true
+          )
+        end
+      end
+    %>
+
+    <%=
+      render(
+        McpConfigurations::MultipleConfigurationsComponent.new(
+          @tool_configs,
+          submit_label: t(".tools_submit")
+        )
+      )
+    %>
+
+    <%=
+      render(Primer::Beta::Subhead.new(mt: 4)) do |component|
+        component.with_heading(tag: :h3) { t(".resources_heading") }
+        component.with_description do
+          link_translate(
+            "admin.mcp_configurations.index.resources_description",
+            links: { docs_url: %i[sysadmin_docs mcp_resources] },
+            external: true
+          )
+        end
+      end
+    %>
+
+    <%=
+      render(
+        McpConfigurations::MultipleConfigurationsComponent.new(
+          @resource_configs,
+          submit_label: t(".resources_submit")
+        )
+      )
+    %>
+  <% end %>
+<% end %>

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -129,7 +129,7 @@ Doorkeeper.configure do
   #
   default_scopes :api_v3
 
-  optional_scopes :scim_v2
+  optional_scopes :scim_v2, :mcp
 
   # Change the way client credentials are retrieved from the request object.
   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -476,6 +476,19 @@ Redmine::MenuManager.map :admin_menu do |menu|
             caption: :label_calendars_and_dates,
             icon: "calendar"
 
+  menu.push :ai,
+            { controller: "/admin/mcp_configurations", action: :index },
+            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.mcp_server_active? },
+            caption: I18n.t("menus.admin.ai"),
+            icon: :"sparkle-fill"
+
+  menu.push :mcp_configurations,
+            { controller: "/admin/mcp_configurations", action: :index },
+            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.mcp_server_active? },
+            caption: I18n.t("menus.admin.mcp_configurations"),
+            enterprise_feature: "mcp_server",
+            parent: :ai
+
   menu.push :working_days_and_hours,
             { controller: "/admin/settings/working_days_and_hours_settings", action: :show },
             if: ->(_) { User.current.admin? },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,23 @@ en:
       explanation:
         text: "Individual actions of a user (e.g. updating a work package twice) are aggregated into a single action if their age difference is less than the specified timespan. They will be displayed as a single action within the application. This will also delay notifications by the same amount of time reducing the number of emails being sent and will also affect %{webhook_link} delay."
         link: "webhook"
+    mcp_configurations:
+      index:
+        description: "The model context protocol allows AI agents to provide its users with tools and resources exposed by this OpenProject instance."
+        resources_heading: "Resources"
+        resources_description: "OpenProject implements the following tools. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP resources](docs_url)."
+        resources_submit: "Update resources"
+        tools_heading: "Tools"
+        tools_description: "OpenProject implements the following tools. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP tools](docs_url)."
+        tools_submit: "Update tools"
+      multi_update:
+        success: "MCP configurations were updated successfully."
+      server_form:
+        description_caption: "How the MCP server will be described to other applications who connect to it."
+        title_caption: "A short title shown to applicatons that connect to the MCP server."
+      update:
+        failure: "MCP configuration could not be updated."
+        success: "MCP configuration was updated successfully."
     scim_clients:
       authentication_methods:
         sso: "JWT from identity provider"
@@ -1331,6 +1348,10 @@ en:
         onthefly: "Automatic user creation"
         port: "Port"
         tls_certificate_string: "LDAP server SSL certificate"
+      mcp_configuration:
+        enabled: Enabled
+        title: Title
+        description: Description
       member:
         roles: "Roles"
       notification:
@@ -2566,6 +2587,7 @@ en:
       edit_attribute_groups: Edit Attribute Groups
       gantt_pdf_export: Gantt PDF Export
       ldap_groups: LDAP users and group sync
+      mcp_server: MCP Server
       nextcloud_sso: Single Sign-On for Nextcloud Storage
       one_drive_sharepoint_file_storage: OneDrive/SharePoint File Storage
       placeholder_users: Placeholder Users
@@ -2644,6 +2666,8 @@ en:
       custom_actions:
         title: "Custom actions"
         description: "Custom actions are one-click shortcuts to a set of pre-defined actions that you can make available on certain work packages based on status, role, type or project."
+      mcp_server:
+        description: "Integrate AI agents with your OpenProject instance through MCP."
       nextcloud_sso:
         title: "Single Sign-On for Nextcloud Storage"
         description: "Enable seamless and secure authentication for your Nextcloud storage with Single Sign-On. Simplify access management and enhance user convenience."
@@ -3057,10 +3081,12 @@ en:
 
   menus:
     admin:
-      mail_notification: "Email notifications"
-      mails_and_notifications: "Emails and notifications"
+      ai: "Artificial Intelligence (AI)"
       aggregation: "Aggregation"
       api_and_webhooks: "API and webhooks"
+      mail_notification: "Email notifications"
+      mails_and_notifications: "Emails and notifications"
+      mcp_configurations: "Model Context Protocol (MCP)"
     quick_add:
       label: "Add…"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -612,6 +612,12 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :mcp_configurations, only: %i[index update], controller: "admin/mcp_configurations" do
+      collection do
+        post :multi_update
+      end
+    end
+
     resources :custom_actions, except: :show
 
     namespace :oauth do

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -181,6 +181,10 @@ sysadmin_docs:
     href: https://www.openproject.org/docs/system-admin-guide/users-permissions/roles-permissions/#roles-and-permissions
   ldap:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/ldap-connections/
+  mcp_resources:
+   href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#resources
+  mcp_tools:
+   href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#tools
   oidc:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/
   oidc_acr_values:

--- a/docs/system-admin-guide/integrations/excel-synchronization/README.md
+++ b/docs/system-admin-guide/integrations/excel-synchronization/README.md
@@ -1,7 +1,7 @@
 ---
 sidebar_navigation:
   title: Excel synchronization
-  priority: 599
+  priority: 400
 description: Excel synchronization with OpenProject
 keywords: Excel
 ---

--- a/docs/system-admin-guide/integrations/mcp-server/README.md
+++ b/docs/system-admin-guide/integrations/mcp-server/README.md
@@ -1,0 +1,27 @@
+---
+sidebar_navigation:
+  title: MCP Server
+  priority: 500
+description: Integrate AI agents with your OpenProject instance through MCP.
+keywords: ai llm mcp
+---
+# MCP Server
+
+> [!IMPORTANT]
+> MCP server is an experimental feature that's not yet intended for production usage. It must be enabled on the page for experimental
+> features of your OpenProject instance (found under `/admin/settings/experimental`). Future versions might change this feature in a breaking
+> way, as we still look for user feedback on this feature.
+
+[feature: mcp_server ]
+
+OpenProject allows AI agents and similar tools to integrate through an API called **Model Context Protocol** (MCP).
+
+TODO: Further explanation of use cases
+
+## Configuration
+
+TODO: How to configure the MCP client to connect to OpenProject
+
+## Customization
+
+TODO: What can be customized in the Admin UI

--- a/lib/api/mcp.rb
+++ b/lib/api/mcp.rb
@@ -30,8 +30,6 @@
 
 module API
   class Mcp < ::API::RootAPI
-    CONFIGURATION_IDENTIFIER = "mcp_server"
-
     include ::API::AppsignalAPI
 
     default_format :json
@@ -41,7 +39,7 @@ module API
 
     helpers do
       def server_config
-        @server_config ||= McpConfiguration.find_or_initialize_by(identifier: CONFIGURATION_IDENTIFIER)
+        @server_config ||= McpConfiguration.server_config
       end
     end
 

--- a/spec/features/admin/mcp_configuration_spec.rb
+++ b/spec/features/admin/mcp_configuration_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "MCP configuration page", :js do
+  shared_let(:admin) { create(:admin) }
+  current_user { admin }
+
+  before do
+    # Using the regular seeder here, to have exact/realistic configurations (all tools, etc.)
+    McpConfigurationSeeder.new(nil).seed!
+  end
+
+  context "when the enterprise feature is enabled", with_ee: %i[mcp_server] do
+    context "when MCP server is enabled" do
+      # rubocop:disable Rails/RedundantActiveRecordAllMethod
+      let(:example_tool) { McpConfiguration.find_by(identifier: McpTools.all.first.qualified_name) }
+      let(:example_resource) { McpConfiguration.find_by(identifier: McpResources.all.first.qualified_name) }
+      # rubocop:enable Rails/RedundantActiveRecordAllMethod
+
+      before do
+        McpConfiguration.server_config.update!(enabled: true)
+      end
+
+      it "allows changing server configuration" do
+        visit mcp_configurations_path
+
+        within_test_selector("mcp-configuration--server-config-form") do
+          expect(page).to have_field "Title", with: McpConfiguration.server_config.title
+          expect(page).to have_field "Description", with: McpConfiguration.server_config.description
+
+          fill_in "Title", with: "My custom server title"
+          fill_in "Description", with: "My custom server description is great."
+          click_button "Update"
+
+          wait_for_network_idle
+
+          expect(McpConfiguration.server_config.title).to eq("My custom server title")
+          expect(McpConfiguration.server_config.description).to eq("My custom server description is great.")
+          expect(page).to have_field "Title", with: McpConfiguration.server_config.title
+          expect(page).to have_field "Description", with: McpConfiguration.server_config.description
+        end
+
+        # Page is expected to allow configuration of all tools and resources
+        expect(page).to have_test_selector("mcp-configuration--config-row-name", count: McpTools.all.size + McpResources.all.size)
+
+        within_test_selector("mcp-configuration--server-config-form") do
+          uncheck "Enabled"
+          click_button "Update"
+
+          wait_for_network_idle
+
+          expect(page).to have_field "Enabled"
+          expect(page).to have_no_field "Title"
+          expect(page).to have_no_field "Description"
+        end
+
+        expect(page).to have_no_test_selector("mcp-configuration--config-row-name")
+      end
+
+      it "allows changing tool and resource configuration" do
+        visit mcp_configurations_path
+
+        # only changing this to submit another form afterwards and expect no change to this tool
+        page.find_test_selector("mcp-configuration--title-input-#{example_tool.identifier}").set("My new tool title")
+        page.find_test_selector("mcp-configuration--title-input-#{example_resource.identifier}").set("My new resource title")
+        click_button "Update resources"
+
+        wait_for_network_idle
+
+        expect { example_tool.reload }.not_to change(example_tool, :title)
+        expect { example_resource.reload }.to change(example_resource, :title).to("My new resource title")
+
+        # only changing this to submit another form afterwards and expect no change to this tool
+        page.find_test_selector("mcp-configuration--title-input-#{example_resource.identifier}").set("My other resource title")
+        page.find_test_selector("mcp-configuration--title-input-#{example_tool.identifier}").set("My new tool title")
+        click_button "Update tools"
+
+        wait_for_network_idle
+
+        expect { example_resource.reload }.not_to change(example_resource, :title)
+        expect { example_tool.reload }.to change(example_tool, :title).to("My new tool title")
+      end
+    end
+
+    context "when MCP server is disabled" do
+      before do
+        McpConfiguration.server_config.update!(enabled: false)
+      end
+
+      it "does not show anything, but allows enabling the server" do
+        visit mcp_configurations_path
+
+        expect(page).to have_no_test_selector("mcp-configuration--config-row-name")
+
+        within_test_selector("mcp-configuration--server-config-form") do
+          check "Enabled"
+          click_button "Update"
+
+          wait_for_network_idle
+
+          expect(page).to have_field "Enabled"
+          expect(page).to have_field "Title"
+          expect(page).to have_field "Description"
+        end
+
+        # Page is expected to allow configuration of all tools and resources after enabling again
+        expect(page).to have_test_selector("mcp-configuration--config-row-name", count: McpTools.all.size + McpResources.all.size)
+      end
+    end
+  end
+
+  context "when the enterprise feature is disabled" do
+    it "hides the entire form, but shows an enterprise banner" do
+      visit mcp_configurations_path
+
+      expect(page).to have_enterprise_banner(:corporate)
+
+      expect(page).to have_no_test_selector("mcp-configuration--server-config-form")
+      expect(page).to have_no_test_selector("mcp-configuration--config-row-name")
+    end
+  end
+end

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -31,7 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "Admin menu items",
-               :js do
+               :js,
+               with_flag: { mcp_server: true } do
   shared_let(:user) { create(:admin) }
 
   before do
@@ -46,8 +47,8 @@ RSpec.describe "Admin menu items",
   context "without having any menu items hidden in configuration" do
     it "must display all menu items" do
       expect(page).to have_test_selector("menu-blocks--container")
-      expect(page).to have_test_selector("menu-block", count: 21)
-      expect(page).to have_test_selector("op-menu--item-action", count: 22) # All plus 'overview'
+      expect(page).to have_test_selector("menu-block", count: 22)
+      expect(page).to have_test_selector("op-menu--item-action", count: 23) # All plus 'overview'
     end
   end
 
@@ -57,10 +58,10 @@ RSpec.describe "Admin menu items",
           } do
     it "must not display the hidden menu items and blocks" do
       expect(page).to have_test_selector("menu-blocks--container")
-      expect(page).to have_test_selector("menu-block", count: 20)
+      expect(page).to have_test_selector("menu-block", count: 21)
       expect(page).not_to have_test_selector("menu-block", text: I18n.t(:label_color_plural))
 
-      expect(page).to have_test_selector("op-menu--item-action", count: 21) # All plus 'overview'
+      expect(page).to have_test_selector("op-menu--item-action", count: 22) # All plus 'overview'
       expect(page).not_to have_test_selector("op-menu--item-action", text: I18n.t(:label_color_plural))
     end
   end


### PR DESCRIPTION
So far this configuration wasn't accessible for users at all. This UI allows to disable all tools and resources separately, as well as customizing their textual descriptions.

# Ticket
https://community.openproject.org/wp/68690

# Checklist

* [x] Review UI changes with designer
* [x] Add proper tests