### PR TITLE
Fix: allow openproject app protocol in csp

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -47,7 +47,7 @@ Rails.application.config.after_initialize do
       frame_src << OpenProject::Configuration[:security_badge_url] if OpenProject::Configuration[:security_badge_displayed]
 
       # Default src
-      default_src = %w('self') # rubocop:disable Lint/PercentStringArray
+      default_src = %w('self' openprojectapp:) # rubocop:disable Lint/PercentStringArray
 
       # Attachment uploaders
       default_src += OpenProject::Configuration.remote_storage_hosts


### PR DESCRIPTION
Currently authorising the OpenProject app may not work due to the CSP blocking the redirect to the app protocol. This ought to fix that.

WP [#70966](https://community.openproject.org/projects/openproject/work_packages/70966/activity)