### PR TITLE
Ensure full page reload after 2FA submission

### DIFF
--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/enter_backup_code.html.erb
@@ -1,6 +1,12 @@
 <% html_title t(:field_otp) %>
 <div id="login-form" class="form -bordered">
-  <%= styled_form_tag({ action: :verify_backup_code }, { autocomplete: "off", id: "submit_backup_code" }) do %>
+  <%= styled_form_tag(
+        { action: :verify_backup_code },
+        autocomplete: "off",
+        id: "submit_backup_code",
+        data: {
+          turbo: false
+        }) do %>
     <h2><%= t "two_factor_authentication.login.enter_backup_code_title" %></h2>
     <p><%= I18n.t("two_factor_authentication.login.enter_backup_code_text") %></p>
     <hr class="form--separator">

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/authentication/request_otp.html.erb
@@ -8,7 +8,9 @@
   <%= styled_form_tag(
         { action: :confirm_otp },
         id: "submit_otp",
-        autocomplete: "off", data: {
+        autocomplete: "off",
+        data: {
+          turbo: false,
           challenge_url: url_for(action: :webauthn_challenge, format: :json),
           device_type: @used_device.class.device_type,
           action: "submit->two-factor-authentication#onVerifyDevice"
@@ -66,7 +68,13 @@
     data-two-factor-authentication-target="resendOptions"
     hidden>
     <% if resend_supported %>
-      <%= styled_form_tag({ action: :retry }, autocomplete: "off", id: "resend_otp") do %>
+      <%= styled_form_tag(
+            { action: :retry },
+            autocomplete: "off",
+            id: "resend_otp",
+            data: {
+              turbo: false
+            }) do %>
         <%= hidden_field_tag "use_device", @service.device.id %>
         <hr>
         <div class="resend-header"><%= t(:text_send_otp_again) %></div>
@@ -89,7 +97,11 @@
         <% @active_devices.each do |device| %>
           <% next if device.id == @used_device.id %>
           <li>
-            <%= form_tag({ action: :retry }, method: :post, data: { turbo: false }) do %>
+            <%= form_tag(
+                  { action: :retry },
+                  method: :post,
+                  data: { turbo: false }
+                ) do %>
               <%= hidden_field_tag "use_device", device.id %>
               <%= submit_tag device.redacted_identifier, class: "button--link" %>
             <% end %>

--- a/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
+++ b/modules/two_factor_authentication/app/views/two_factor_authentication/two_factor_devices/confirm.html.erb
@@ -1,6 +1,13 @@
 <% html_title(t(:label_my_account), t("two_factor_authentication.devices.confirm_device")) -%>
 
-<%= styled_form_tag(confirm_path, method: :post, id: "login-form", class: "form -bordered", autocomplete: "off") do %>
+<%= styled_form_tag(confirm_path,
+                    method: :post,
+                    id: "login-form",
+                    class: "form -bordered",
+                    autocomplete: "off",
+                    data: {
+                      turbo: false
+                    }) do %>
   <h2><%= t("two_factor_authentication.devices.confirm_device") %></h2>
   <p><%= t("two_factor_authentication.devices.text_confirm_to_complete_html", identifier: @device.identifier) %></p>
   <hr class="form--separator">


### PR DESCRIPTION
For OAuth grants, we need to output appends for the form-action CSP, otherwise posting will be prevented by CSP. For 2FA enabled accounts, we redirect the user first to the 2FA flow before returning to the grant, which fails when the request is made with turbo

WP [#70966](https://community.openproject.org/projects/openproject/work_packages/70966/activity)