### PR TITLE
[chore] use explicit swiftshader GL for chrome testing

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -11,12 +11,15 @@ RUN apt-get update -qq && \
   apt-get install -y wget gnupg lsb-release curl && \
   wget --quiet -O- https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgrsql.gpg - && \
   echo "deb [signed-by=/usr/share/keyrings/postgrsql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg  main" > /etc/apt/sources.list.d/pgdg.list
-# Temporarily use a mirror for Chrome until the official one no longer has issues with xeokit. Can be tested by running
-# rspec ./modules/bim/spec/features/bcf/create_spec.rb:107 after switching to the official package source.
-ENV CHROME_SOURCE_URL="https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_142.0.7444.134-1_amd64.deb"
-RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && wget --no-verbose -O $f $CHROME_SOURCE_URL && \
-  apt-get update -qq && apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr && \
-  rm -f "$f" && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/postgresql && find /usr/share/locale/* -maxdepth 0 -type d ! -name 'en' -exec rm -rf {} \;
+ENV CHROME_SOURCE_URL="https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb"
+RUN --mount=type=cache,target=/var/cache/apt export f="/tmp/chrome.deb" && \
+  wget --no-verbose -O $f $CHROME_SOURCE_URL && \
+  apt-get update -qq && \
+  apt-get install -y "$f" postgresql-$PGVERSION postgresql-client-$PGVERSION time imagemagick default-jre-headless firefox-esr && \
+  rm -f "$f" && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/postgresql && \
+  find /usr/share/locale/* -maxdepth 0 -type d ! -name 'en' -exec rm -rf {} \;
 
 RUN curl -L https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -o - | tar xJf - -C /usr/local --strip=1 && node --version
 

--- a/spec/support/browsers/chrome.rb
+++ b/spec/support/browsers/chrome.rb
@@ -26,9 +26,13 @@ def register_chrome(language, name: :"chrome_#{language}", headless: "new", over
     options.add_argument("--disable-dev-shm-usage")
     options.add_argument("--disable-smooth-scrolling")
     # Software GPU to avoid the dreaded "[ERROR] [Canvas '__0']: Failed to get a
-    # WebGL context" error for tests using xeokit, adapted from answers of
-    # https://stackoverflow.com/q/70948512/177665 and
+    # WebGL context" error for tests using xeokit. The automatic fallback to SwiftShader
+    # was disabled in January 2026, so that we now have to enable the fallback manually in
+    # the test environment.
+    # See https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md
     options.add_argument("--use-gl=angle")
+    options.add_argument("--use-angle=swiftshader-webgl")
+    options.add_argument("--enable-unsafe-swiftshader")
     # Disable "Select your search engine screen"
     options.add_argument("--disable-search-engine-choice-screen")
 

--- a/spec/support/cuprite_setup.rb
+++ b/spec/support/cuprite_setup.rb
@@ -97,7 +97,15 @@ def register_better_cuprite(language, name: :"better_cuprite_#{language}")
       "disable-backgrounding-occluded-windows": nil,
       # This disables non-foreground tabs from getting a lower process priority.
       # Useful for parallel test runs.
-      "disable-renderer-backgrounding": nil
+      "disable-renderer-backgrounding": nil,
+      # Software GPU to avoid the dreaded "[ERROR] [Canvas '__0']: Failed to get a
+      # WebGL context" error for tests using xeokit. The automatic fallback to SwiftShader
+      # was disabled in January 2026, so that we now have to enable the fallback manually in
+      # the test environment.
+      # See https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md
+      "use-gl": "angle",
+      "use-angle": "swiftshader-webgl",
+      "enable-unsafe-swiftshader": true
     }
 
     if ENV["OPENPROJECT_TESTING_AUTO_DEVTOOLS"].present?


### PR DESCRIPTION
# What are you trying to accomplish?

- enable xeokit browser tests locally in docker
- resetting chrome download mirror for CI testing images

## What was happening

See https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md

The automatic fallback to swiftshader was deprecated and now must be enabled manually.