### PR TITLE
[#70540] Support work package outcomes in the PDF exports  

### DIFF
--- a/modules/meeting/app/workers/meetings/pdf/common/agenda.rb
+++ b/modules/meeting/app/workers/meetings/pdf/common/agenda.rb
@@ -81,17 +81,53 @@ module Meetings::PDF::Common::Agenda
   end
 
   def write_outcomes(agenda_item)
-    outcomes = agenda_item
-                 .outcomes
-                 .all
-                 .reject { |outcome| outcome.notes.blank? }
+    outcomes = agenda_item.outcomes.to_a
     outcomes.each_with_index do |outcome, index|
       pdf.indent(styles.outcome_indent) do
         write_optional_page_break
         write_outcome_title(index, outcomes.size > 1)
-        write_outcome_notes(outcome.notes)
+        if outcome.work_package_kind?
+          write_work_package_outcome(outcome)
+        elsif outcome.notes.present?
+          write_outcome_notes(outcome.notes)
+        end
       end
     end
+  end
+
+  def write_work_package_outcome(outcome)
+    with_vertical_margin(styles.outcome_work_package_margin) do
+      if outcome.visible_work_package?
+        write_visible_work_package_outcome(outcome.work_package)
+      elsif outcome.linked_work_package?
+        write_undisclosed_work_package_outcome(outcome.work_package_id)
+      elsif outcome.deleted_work_package?
+        write_deleted_work_package_outcome
+      end
+    end
+  end
+
+  def write_visible_work_package_outcome(work_package)
+    href = url_helpers.work_package_url(work_package)
+    link_text = "#{work_package.type.name} ##{work_package.id} #{work_package.subject}"
+    status_text = " (#{work_package.status.name})"
+    base_style = styles.outcome_work_package
+    pdf.formatted_text([
+                         base_style.merge({ text: link_text, link: href, styles: [:underline] }),
+                         base_style.merge({ text: status_text })
+                       ])
+  end
+
+  def write_undisclosed_work_package_outcome(work_package_id)
+    pdf.formatted_text([
+                         { text: I18n.t(:label_agenda_item_undisclosed_wp, id: work_package_id) }
+                       ], styles.outcome_work_package)
+  end
+
+  def write_deleted_work_package_outcome
+    pdf.formatted_text([
+                         { text: I18n.t(:label_agenda_item_deleted_wp) }
+                       ], styles.outcome_work_package)
   end
 
   def write_outcome_title(index, multiple_outcomes)

--- a/modules/meeting/app/workers/meetings/pdf/common/styles.rb
+++ b/modules/meeting/app/workers/meetings/pdf/common/styles.rb
@@ -92,6 +92,14 @@ module Meetings::PDF::Common::Styles
       @styles.dig(:outcome, :indent).presence || 15
     end
 
+    def outcome_work_package
+      resolve_font(@styles.dig(:outcome, :work_package))
+    end
+
+    def outcome_work_package_margin
+      resolve_margin(@styles.dig(:outcome, :work_package))
+    end
+
     def agenda_item_title
       resolve_font(@styles.dig(:agenda_item, :title))
     end

--- a/modules/meeting/app/workers/meetings/pdf/default/schema.json
+++ b/modules/meeting/app/workers/meetings/pdf/default/schema.json
@@ -1452,6 +1452,19 @@
             }
           ]
         },
+        "work_package": {
+          "type": "object",
+          "title": "Agenda item outcome work package",
+          "description": "Styling for work package outcomes",
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
         "indent": {
           "title": "Indent width",
           "description": "Indent for agenda item notes",

--- a/modules/meeting/app/workers/meetings/pdf/default/standard.yml
+++ b/modules/meeting/app/workers/meetings/pdf/default/standard.yml
@@ -243,8 +243,11 @@ outcome:
     styles: [ "bold" ]
     margin_top: 5
     margin_bottom: 5
+  work_package:
+    size: 10
+    margin_bottom: 3
   markdown_margin:
-    margin_bottom: 8
+    margin_bottom: 3
   markdown:
     font:
       size: 10

--- a/modules/meeting/app/workers/meetings/pdf/minutes/schema.json
+++ b/modules/meeting/app/workers/meetings/pdf/minutes/schema.json
@@ -1408,6 +1408,19 @@
             }
           ]
         },
+        "work_package": {
+          "type": "object",
+          "title": "Agenda item outcome work package",
+          "description": "Styling for work package outcomes",
+          "allOf": [
+            {
+              "$ref": "#/$defs/font"
+            },
+            {
+              "$ref": "#/$defs/margin"
+            }
+          ]
+        },
         "indent": {
           "title": "Indent width",
           "description": "Indent for agenda item notes",

--- a/modules/meeting/app/workers/meetings/pdf/minutes/standard.yml
+++ b/modules/meeting/app/workers/meetings/pdf/minutes/standard.yml
@@ -257,6 +257,9 @@ outcome:
     styles: [ "bold" ]
     margin_top: 5
     margin_bottom: 5
+  work_package:
+    size: 10
+    margin_bottom: 5
   markdown_margin:
     margin_bottom: 8
   markdown:

--- a/modules/meeting/spec/workers/meetings/pdf/default/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/pdf/default/exporter_spec.rb
@@ -308,4 +308,124 @@ RSpec.describe Meetings::PDF::Default::Exporter do
       end
     end
   end
+
+  context "with a meeting with work package outcomes" do
+    let(:meeting) do
+      create(:meeting, author: user, project:, title: "Meeting with WP outcomes", location: "Somewhere", state: :closed)
+    end
+    let(:type_task) { create(:type_task) }
+    let(:status) { create(:status, is_default: true, name: "In Progress") }
+    let(:outcome_work_package) { create(:work_package, project:, status:, subject: "Outcome WP", type: type_task) }
+    let(:meeting_section) { create(:meeting_section, meeting:, title: "Section with outcomes") }
+    let(:meeting_agenda_item) do
+      create(:meeting_agenda_item, meeting_section:, duration_in_minutes: 15, title: "Agenda Item", presenter: user,
+                                   notes: "Agenda item notes")
+    end
+
+    before do
+      User.current = user
+      meeting_agenda_item
+    end
+
+    context "with a visible work package outcome" do
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: outcome_work_package, notes: nil)
+      end
+      let(:options) do
+        { participants: "0", outcomes: "1" }
+      end
+
+      before do
+        wp_outcome
+      end
+
+      it "renders the work package outcome with type, id, subject and status" do
+        expected_document = [
+          *expected_cover_page,
+          *meeting_head,
+
+          "Section with outcomes", "  ", "15 mins",
+          "Agenda Item", "  ", "15 mins", "  ", "Export User",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Task", "##{outcome_work_package.id}", "Outcome WP", " (In Progress)",
+
+          "1", # Page number
+          export_time_formatted,
+          project.name
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+
+    context "with a hidden work package outcome" do
+      let!(:secret_project) { create(:project, members: [other_user]) }
+      let(:secret_work_package) { create(:work_package, project: secret_project) }
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: secret_work_package, notes: nil)
+      end
+      let(:options) do
+        { participants: "0", outcomes: "1" }
+      end
+
+      before do
+        secret_work_package
+        wp_outcome
+      end
+
+      it "renders the undisclosed work package message" do
+        expected_document = [
+          *expected_cover_page,
+          *meeting_head,
+
+          "Section with outcomes", "  ", "15 mins",
+          "Agenda Item", "  ", "15 mins", "  ", "Export User",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Work package ##{secret_work_package.id} not visible",
+
+          "1", # Page number
+          export_time_formatted,
+          project.name
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+
+    context "with a deleted work package outcome" do
+      let!(:deleted_wp) { create(:work_package, project:) }
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: deleted_wp, notes: nil)
+      end
+      let(:options) do
+        { participants: "0", outcomes: "1" }
+      end
+
+      before do
+        wp_outcome
+        deleted_wp.destroy!
+      end
+
+      it "renders the deleted work package message" do
+        expected_document = [
+          *expected_cover_page,
+          *meeting_head,
+
+          "Section with outcomes", "  ", "15 mins",
+          "Agenda Item", "  ", "15 mins", "  ", "Export User",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Deleted work package reference",
+
+          "1", # Page number
+          export_time_formatted,
+          project.name
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+  end
 end

--- a/modules/meeting/spec/workers/meetings/pdf/minutes/exporter_spec.rb
+++ b/modules/meeting/spec/workers/meetings/pdf/minutes/exporter_spec.rb
@@ -304,4 +304,112 @@ RSpec.describe Meetings::PDF::Minutes::Exporter do
       end
     end
   end
+
+  context "with a meeting with work package outcomes" do
+    let(:type_task) { create(:type_task) }
+    let(:status) { create(:status, is_default: true, name: "In Progress") }
+    let(:outcome_work_package) { create(:work_package, project:, status:, subject: "Outcome WP", type: type_task) }
+    let(:meeting_section) { create(:meeting_section, meeting:, title: "Section with outcomes") }
+    let(:meeting_agenda_item) do
+      create(:meeting_agenda_item, meeting_section:, duration_in_minutes: 15, title: "Agenda Item", presenter: user,
+                                   notes: "Agenda item notes")
+    end
+
+    before do
+      User.current = user
+      meeting_agenda_item
+    end
+
+    context "with a visible work package outcome" do
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: outcome_work_package, notes: nil)
+      end
+      let(:options) do
+        default_options.merge(outcomes: "1")
+      end
+
+      before do
+        wp_outcome
+      end
+
+      it "renders the work package outcome with type, id, subject and status" do
+        expected_document = [
+          meeting.title,
+          *meeting_info,
+          *meeting_info_custom,
+          "1. Section with outcomes", "  ", "15 mins",
+          "1.1. Agenda Item",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Task", "##{outcome_work_package.id}", "Outcome WP", " (In Progress)",
+          *expected_header_footer
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+
+    context "with a hidden work package outcome" do
+      let!(:secret_project) { create(:project, members: [other_user]) }
+      let(:secret_work_package) { create(:work_package, project: secret_project) }
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: secret_work_package, notes: nil)
+      end
+      let(:options) do
+        default_options.merge(outcomes: "1")
+      end
+
+      before do
+        secret_work_package
+        wp_outcome
+      end
+
+      it "renders the undisclosed work package message" do
+        expected_document = [
+          meeting.title,
+          *meeting_info,
+          *meeting_info_custom,
+          "1. Section with outcomes", "  ", "15 mins",
+          "1.1. Agenda Item",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Work package ##{secret_work_package.id} not visible",
+          *expected_header_footer
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+
+    context "with a deleted work package outcome" do
+      let!(:deleted_wp) { create(:work_package, project:) }
+      let(:wp_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, kind: :work_package, work_package: deleted_wp, notes: nil)
+      end
+      let(:options) do
+        default_options.merge(outcomes: "1")
+      end
+
+      before do
+        wp_outcome
+        deleted_wp.destroy!
+      end
+
+      it "renders the deleted work package message" do
+        expected_document = [
+          meeting.title,
+          *meeting_info,
+          *meeting_info_custom,
+          "1. Section with outcomes", "  ", "15 mins",
+          "1.1. Agenda Item",
+          "Agenda item notes",
+          "✓   Outcome",
+          "Deleted work package reference",
+          *expected_header_footer
+        ].join(" ")
+
+        expect(subject).to eq expected_document
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70540

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Render work package outcomes in both PDF exports
- Adjust margins to make the layout more uniform

# Note
The final layout might still need adjustments, but we can do that fine tuning separately when the design team has a bit more capacity. This PR already makes it a bit more consistent than before

# Merge checklist

- [x] Added/updated tests
