### PR TITLE
fix accidental inclusion of slim-bim digest in slim tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -294,7 +294,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v6
         with:
-          name: digests-${{ inputs.tag }}-${{ matrix.target }}-${{ matrix.digest }}
+          name: digests-${{ inputs.tag }}-${{ matrix.target }}--${{ matrix.digest }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -310,7 +310,7 @@ jobs:
       - name: Merge digests
         uses: actions/upload-artifact/merge@v6
         with:
-          pattern: "digests-${{ inputs.tag }}-${{ matrix.target }}-${{ matrix.digest }}*"
+          pattern: "digests-${{ inputs.tag }}-${{ matrix.target }}--*"
           overwrite: true
           name: "merged-digests-${{ inputs.tag }}-${{ matrix.target }}-${{ github.run_number }}-${{ github.run_attempt }}"
       - name: Download digests


### PR DESCRIPTION
WP [#70980](https://community.openproject.org/projects/openproject/work_packages/70980/activity)

Tested successfully in [this build](https://github.com/opf/openproject/actions/runs/21291013052) where the `slim` tag ends up with 2 digests (the correct ones) as expected.