### PR TITLE
Try improving journal create service

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -198,11 +198,18 @@ module Journals
     # used as the values returned by the overall SQL statement so that an AR instance can be instantiated with it.
     #
     def create_journal_sql(predecessor, notes, internal, cause)
-      journal_modifications = journal_modification_sql(predecessor, notes, internal, cause)
-      relation_modifications = relation_modifications_sql(predecessor, notes, cause)
-
-      journal_cte_clauses = [journal_modifications]
-      journal_cte_clauses << relation_modifications if relation_modifications.any?
+      journal_cte_clauses = [
+        select_max_journal_cte_clause,
+        select_changes_cte_clause,
+        cleanup_predecessor_data_cte_clause(predecessor, notes, cause),
+        touch_journable_cte_clause(notes, cause),
+        fetch_time_cte_clause,
+        insert_data_cte_clause(notes, cause),
+        update_predecessor_cte_clause(predecessor, notes, cause),
+        update_or_insert_journal_cte_clause(predecessor, notes, internal, cause),
+        *associations.map { cleanup_predecessor_association_cte_clause(it, predecessor, notes, cause) },
+        *associations.map { insert_association_cte_clause(it) }
+      ].compact_blank
 
       <<~SQL
         WITH #{journal_cte_clauses.join(',')}
@@ -210,70 +217,34 @@ module Journals
       SQL
     end
 
-    def journal_modification_sql(predecessor, notes, internal, cause)
-      <<~SQL
-        max_journals AS (
-          #{select_max_journal_sql}
-        ), changes AS (
-          #{select_changed_sql}
-        ), cleanup_predecessor_data AS (
-          #{cleanup_predecessor_data_sql(predecessor, notes, cause)}
-        ), touch_journable AS (
-          #{touch_journable_sql(notes, cause)}
-        ), fetch_time AS (
-          #{fetch_time_sql}
-        ), insert_data AS (
-          #{insert_data_sql(notes, cause)}
-        ), update_predecessor AS (
-          #{update_predecessor_sql(predecessor, notes, cause)}
-        ), inserted_journal AS (
-          #{update_or_insert_journal_sql(predecessor, notes, internal, cause)}
-        )
-      SQL
-    end
-
-    def relation_modifications_sql(predecessor, notes, cause)
-      associations.map do |association|
-        association_modifications_sql(association, predecessor, notes, cause)
-      end
-    end
-
-    def association_modifications_sql(association, predecessor, notes, cause)
-      <<~SQL
-        cleanup_predecessor_#{association.name} AS (
-          #{association.cleanup_predecessor(predecessor, notes, cause)}
-        ), insert_#{association.name} AS (
-          #{association.insert_sql}
-        )
-      SQL
-    end
-
-    def select_max_journal_sql
+    def select_max_journal_cte_clause
       sanitize(<<~SQL, journable_id:, journable_type:)
-        SELECT
-          :journable_id journable_id,
-          :journable_type journable_type,
-          updated_at,
-          COALESCE(journals.version, fallback.version) AS version,
-          COALESCE(journals.id, 0) id,
-          COALESCE(journals.data_id, 0) data_id
-        FROM
-          journals
-        RIGHT OUTER JOIN
-          (SELECT 0 AS version) fallback
-        ON
-          journals.journable_id = :journable_id
-          AND journals.journable_type = :journable_type
-          AND journals.version IN (
-            SELECT MAX(version)
-            FROM journals
-            WHERE journable_id = :journable_id
-            AND journable_type = :journable_type
-          )
+        max_journals AS (
+          SELECT
+            :journable_id journable_id,
+            :journable_type journable_type,
+            updated_at,
+            COALESCE(journals.version, fallback.version) AS version,
+            COALESCE(journals.id, 0) id,
+            COALESCE(journals.data_id, 0) data_id
+          FROM
+            journals
+          RIGHT OUTER JOIN
+            (SELECT 0 AS version) fallback
+          ON
+            journals.journable_id = :journable_id
+            AND journals.journable_type = :journable_type
+            AND journals.version IN (
+              SELECT MAX(version)
+              FROM journals
+              WHERE journable_id = :journable_id
+              AND journable_type = :journable_type
+            )
+        )
       SQL
     end
 
-    def select_changed_sql
+    def select_changes_cte_clause
       sql = <<~SQL
         SELECT
            *
@@ -290,16 +261,27 @@ module Journals
         SQL
       end
 
-      sql
+      <<~SQL
+        changes AS (
+          #{sql}
+        )
+      SQL
     end
 
-    def cleanup_predecessor_data_sql(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              data_table_name,
-                              :id,
-                              :data_id)
+    def cleanup_predecessor_data_cte_clause(predecessor, notes, cause)
+      return unless predecessor
+
+      sql = cleanup_predecessor_for(predecessor,
+                                    notes,
+                                    cause,
+                                    data_table_name,
+                                    :id,
+                                    :data_id)
+      <<~SQL
+        cleanup_predecessor_data AS (
+          #{sql}
+        )
+      SQL
     end
 
     # Updates the updated_at timestamp of the journable.
@@ -312,25 +294,26 @@ module Journals
     # Therefore, this is only carried out if:
     # * if there are changes or a note or a cause
     # * AND the journable doesn't already have a newer timestamp than the most recent journal
-    def touch_journable_sql(notes, cause)
+    def touch_journable_cte_clause(notes, cause)
       if journable.class.aaj_options[:timestamp].to_sym == :updated_at
-        sql = <<~SQL
-          UPDATE
-            #{journable_table_name}
-          SET
-            updated_at = statement_timestamp()
-          WHERE
-            id = :id
-            #{only_on_changed_or_forced_condition_sql(notes, cause)}
-            AND NOT updated_at > (SELECT updated_at FROM max_journals)
-          RETURNING updated_at
+        sanitize(<<~SQL, id: journable.id)
+          touch_journable AS (
+            UPDATE
+              #{journable_table_name}
+            SET
+              updated_at = statement_timestamp()
+            WHERE
+              id = :id
+              #{only_on_changed_or_forced_condition_sql(notes, cause)}
+              AND NOT updated_at > (SELECT updated_at FROM max_journals)
+            RETURNING updated_at
+          )
         SQL
-
-        sanitize(sql,
-                 id: journable.id)
       else
         <<~SQL
-          SELECT NULL::timestamp with time zone AS updated_at
+          touch_journable AS (
+            SELECT NULL::timestamp with time zone AS updated_at
+          )
         SQL
       end
     end
@@ -339,26 +322,30 @@ module Journals
     # * setting the created_at and updated_at timestamps of the newly created journal
     # * setting the updated_at timestamp on an updated (aggregated with) journal
     # * setting the validity_period (upper bound) of the preceding journal.
-    def fetch_time_sql
+    def fetch_time_cte_clause
       sanitize(<<~SQL, journable_timestamp:)
-        SELECT COALESCE((SELECT updated_at FROM touch_journable), :journable_timestamp) AS updated_at
+        fetch_time AS (
+          SELECT COALESCE((SELECT updated_at FROM touch_journable), :journable_timestamp) AS updated_at
+        )
       SQL
     end
 
-    def insert_data_sql(notes, cause)
+    def insert_data_cte_clause(notes, cause)
       sanitize(<<~SQL, journable_id:)
-        INSERT INTO
-          #{data_table_name} (
-            #{data_sink_columns}
-          )
-        SELECT
-          #{data_source_columns}
-        FROM #{journable_table_name}
-        #{journable_data_sql_addition}
-        WHERE
-          #{journable_table_name}.id = :journable_id
-          #{only_on_changed_or_forced_condition_sql(notes, cause)}
-        RETURNING *
+        insert_data AS (
+          INSERT INTO
+            #{data_table_name} (
+              #{data_sink_columns}
+            )
+          SELECT
+            #{data_source_columns}
+          FROM #{journable_table_name}
+          #{journable_data_sql_addition}
+          WHERE
+            #{journable_table_name}.id = :journable_id
+            #{only_on_changed_or_forced_condition_sql(notes, cause)}
+          RETURNING *
+        )
       SQL
     end
 
@@ -367,29 +354,31 @@ module Journals
     # If there is a predecessor (meaning we are aggregating/updating an existing journal), nothing is done.
     # In that case, the preceding journal is the one we are currently aggregating with so it will still remain
     # the most recent one.
-    def update_predecessor_sql(predecessor, notes, cause)
-      return "SELECT 1" if predecessor.present?
+    def update_predecessor_cte_clause(predecessor, notes, cause)
+      return if predecessor.present?
 
       <<~SQL
-        UPDATE
-          journals
-        SET
-          validity_period = tstzrange(lower(validity_period), (SELECT updated_at FROM fetch_time), '[)')
-        WHERE
-          id = (SELECT id from max_journals)
-          #{only_on_changed_or_forced_condition_sql(notes, cause)}
+        update_predecessor AS (
+          UPDATE
+            journals
+          SET
+            validity_period = tstzrange(lower(validity_period), (SELECT updated_at FROM fetch_time), '[)')
+          WHERE
+            id = (SELECT id from max_journals)
+            #{only_on_changed_or_forced_condition_sql(notes, cause)}
+        )
       SQL
     end
 
-    def update_or_insert_journal_sql(predecessor, notes, internal, cause)
+    def update_or_insert_journal_cte_clause(predecessor, notes, internal, cause)
       if predecessor
-        update_journal_sql(predecessor, notes, cause)
+        update_journal_cte_clause(predecessor, notes, cause)
       else
-        insert_journal_sql(notes, internal, cause)
+        insert_journal_cte_clause(notes, internal, cause)
       end
     end
 
-    def update_journal_sql(predecessor, notes, cause)
+    def update_journal_cte_clause(predecessor, notes, cause)
       # If there is a predecessor, we don't want to create a new one, we simply rewrite it.
       # The original data of that predecessor (data e.g. work_package_journals, customizable_journals, attachable_journals)
       # has been deleted before but the notes need to be taken over and the timestamps updated as if the
@@ -401,18 +390,20 @@ module Journals
       # In case there is no change at all, the journal will not need to be modified. But even
       # without a change, having notes or a cause will require to have the journal written.
       sql = <<~SQL
-        UPDATE
-          journals
-        SET
-          notes = :notes,
-          updated_at = (SELECT updated_at FROM fetch_time),
-          data_id = insert_data.id,
-          cause = :cause
-        FROM insert_data
-        WHERE journals.id = :predecessor_id
-        #{only_on_changed_or_forced_condition_sql(notes, cause)}
-        RETURNING
-          journals.*
+        inserted_journal AS (
+          UPDATE
+            journals
+          SET
+            notes = :notes,
+            updated_at = (SELECT updated_at FROM fetch_time),
+            data_id = insert_data.id,
+            cause = :cause
+          FROM insert_data
+          WHERE journals.id = :predecessor_id
+          #{only_on_changed_or_forced_condition_sql(notes, cause)}
+          RETURNING
+            journals.*
+        )
       SQL
 
       sanitize(sql,
@@ -421,38 +412,40 @@ module Journals
                cause: cause_sql(cause))
     end
 
-    def insert_journal_sql(notes, internal, cause)
+    def insert_journal_cte_clause(notes, internal, cause)
       sql = <<~SQL
-        INSERT INTO
-          journals (
-            journable_id,
-            journable_type,
-            version,
-            user_id,
-            notes,
-            restricted,
-            created_at,
-            updated_at,
-            data_id,
-            data_type,
-            cause,
-            validity_period
-          )
-        SELECT
-          :journable_id,
-          :journable_type,
-          COALESCE(max_journals.version, 0) + 1,
-          :user_id,
-          :notes,
-          :restricted,
-          (SELECT updated_at FROM fetch_time),
-          (SELECT updated_at FROM fetch_time),
-          insert_data.id,
-          :data_type,
-          :cause,
-          tstzrange((SELECT updated_at FROM fetch_time), NULL)
-        FROM max_journals, insert_data
-        RETURNING *
+        inserted_journal AS (
+          INSERT INTO
+            journals (
+              journable_id,
+              journable_type,
+              version,
+              user_id,
+              notes,
+              restricted,
+              created_at,
+              updated_at,
+              data_id,
+              data_type,
+              cause,
+              validity_period
+            )
+          SELECT
+            :journable_id,
+            :journable_type,
+            COALESCE(max_journals.version, 0) + 1,
+            :user_id,
+            :notes,
+            :restricted,
+            (SELECT updated_at FROM fetch_time),
+            (SELECT updated_at FROM fetch_time),
+            insert_data.id,
+            :data_type,
+            :cause,
+            tstzrange((SELECT updated_at FROM fetch_time), NULL)
+          FROM max_journals, insert_data
+          RETURNING *
+        )
       SQL
 
       sanitize(sql,
@@ -463,6 +456,24 @@ module Journals
                journable_type:,
                user_id: user.id,
                data_type: journable.class.journal_class.name)
+    end
+
+    def cleanup_predecessor_association_cte_clause(association, predecessor, notes, cause)
+      return unless predecessor
+
+      <<~SQL
+        cleanup_predecessor_#{association.name} AS (
+          #{association.cleanup_predecessor(predecessor, notes, cause)}
+        )
+      SQL
+    end
+
+    def insert_association_cte_clause(association)
+      <<~SQL
+        insert_#{association.name} AS (
+          #{association.insert_sql}
+        )
+      SQL
     end
 
     def changes_data_sql

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -146,10 +146,10 @@ module Journals
     #   aggregated with)
     # * OR a predecessor is replaced
     #
-    # If a change has been identified (not for a note or a cause) and a predecessor to aggregate with exists, the predecessor's
-    # data is stripped. this is done by the CTEs 'cleanup_predecessor_data' and the ones for the associated data,
-    # 'cleanup_predecessor_XYZ' (where XYZ is e.g. attachable or customizable). If no predecessor exists,
-    # a noop SQL statement is run instead.
+    # If a change has been identified (not for a note or a cause) and a predecessor to aggregate with exists, the
+    # predecessor's data is removed. This is done by the CTEs 'delete_predecessor_data' for the journable and
+    # by 'delete_predecessor_XYZ' for the associated data, where XYZ is e.g. attachable, customizable, etc.
+    # If no predecessor exists, these CTEs are skipped.
     # To strip the information from the journal, the data record (e.g. from work_packages_journals) as well as the
     # associated data information is removed. The journal itself is kept and will later on have its
     # updated_at and possibly its notes property updated.
@@ -201,13 +201,13 @@ module Journals
       journal_cte_clauses = [
         select_max_journal_cte_clause,
         select_changes_cte_clause,
-        cleanup_predecessor_data_cte_clause(predecessor, notes, cause),
+        delete_predecessor_data_cte_clause(predecessor, notes, cause),
         touch_journable_cte_clause(notes, cause),
-        fetch_time_cte_clause,
+        select_fetch_time_cte_clause,
         insert_data_cte_clause(notes, cause),
         update_predecessor_cte_clause(predecessor, notes, cause),
         update_or_insert_journal_cte_clause(predecessor, notes, internal, cause),
-        *associations.map { cleanup_predecessor_association_cte_clause(it, predecessor, notes, cause) },
+        *associations.map { delete_predecessor_association_cte_clause(it, predecessor, notes, cause) },
         *associations.map { insert_association_cte_clause(it) }
       ].compact_blank
 
@@ -268,17 +268,17 @@ module Journals
       SQL
     end
 
-    def cleanup_predecessor_data_cte_clause(predecessor, notes, cause)
+    def delete_predecessor_data_cte_clause(predecessor, notes, cause)
       return unless predecessor
 
-      sql = cleanup_predecessor_for(predecessor,
-                                    notes,
-                                    cause,
-                                    data_table_name,
-                                    :id,
-                                    :data_id)
+      sql = delete_predecessor_for(predecessor,
+                                   notes,
+                                   cause,
+                                   data_table_name,
+                                   :id,
+                                   :data_id)
       <<~SQL
-        cleanup_predecessor_data AS (
+        delete_predecessor_data AS (
           #{sql}
         )
       SQL
@@ -322,7 +322,7 @@ module Journals
     # * setting the created_at and updated_at timestamps of the newly created journal
     # * setting the updated_at timestamp on an updated (aggregated with) journal
     # * setting the validity_period (upper bound) of the preceding journal.
-    def fetch_time_cte_clause
+    def select_fetch_time_cte_clause
       sanitize(<<~SQL, journable_timestamp:)
         fetch_time AS (
           SELECT COALESCE((SELECT updated_at FROM touch_journable), :journable_timestamp) AS updated_at
@@ -458,12 +458,12 @@ module Journals
                data_type: journable.class.journal_class.name)
     end
 
-    def cleanup_predecessor_association_cte_clause(association, predecessor, notes, cause)
+    def delete_predecessor_association_cte_clause(association, predecessor, notes, cause)
       return unless predecessor
 
       <<~SQL
-        cleanup_predecessor_#{association.name} AS (
-          #{association.cleanup_predecessor(predecessor, notes, cause)}
+        delete_predecessor_#{association.name} AS (
+          #{association.delete_predecessor(predecessor, notes, cause)}
         )
       SQL
     end

--- a/app/services/journals/create_service/agenda_itemable.rb
+++ b/app/services/journals/create_service/agenda_itemable.rb
@@ -34,13 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:agenda_items)
     end
 
-    def cleanup_predecessor(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              "meeting_agenda_item_journals",
-                              :journal_id,
-                              :id)
+    def delete_predecessor(predecessor, notes, cause)
+      delete_predecessor_for(predecessor,
+                             notes,
+                             cause,
+                             "meeting_agenda_item_journals",
+                             :journal_id,
+                             :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/attachable.rb
+++ b/app/services/journals/create_service/attachable.rb
@@ -34,13 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:attachable?)
     end
 
-    def cleanup_predecessor(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              "attachable_journals",
-                              :journal_id,
-                              :id)
+    def delete_predecessor(predecessor, notes, cause)
+      delete_predecessor_for(predecessor,
+                             notes,
+                             cause,
+                             "attachable_journals",
+                             :journal_id,
+                             :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/customizable.rb
+++ b/app/services/journals/create_service/customizable.rb
@@ -34,13 +34,13 @@ class Journals::CreateService
       journable.customizable?
     end
 
-    def cleanup_predecessor(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              "customizable_journals",
-                              :journal_id,
-                              :id)
+    def delete_predecessor(predecessor, notes, cause)
+      delete_predecessor_for(predecessor,
+                             notes,
+                             cause,
+                             "customizable_journals",
+                             :journal_id,
+                             :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/helpers.rb
+++ b/app/services/journals/create_service/helpers.rb
@@ -39,7 +39,7 @@ class Journals::CreateService
 
     def journable_class_name = journable.class.base_class.name
 
-    def cleanup_predecessor_for(predecessor, notes, cause, table_name, column, referenced_id)
+    def delete_predecessor_for(predecessor, notes, cause, table_name, column, referenced_id)
       return "SELECT 1" unless predecessor
 
       sanitize(<<~SQL.squish, column => predecessor.send(referenced_id))

--- a/app/services/journals/create_service/project_phase.rb
+++ b/app/services/journals/create_service/project_phase.rb
@@ -34,13 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:phases)
     end
 
-    def cleanup_predecessor(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              "project_phase_journals",
-                              :journal_id,
-                              :id)
+    def delete_predecessor(predecessor, notes, cause)
+      delete_predecessor_for(predecessor,
+                             notes,
+                             cause,
+                             "project_phase_journals",
+                             :journal_id,
+                             :id)
     end
 
     def insert_sql

--- a/app/services/journals/create_service/storable.rb
+++ b/app/services/journals/create_service/storable.rb
@@ -34,13 +34,13 @@ class Journals::CreateService
       journable.respond_to?(:file_links)
     end
 
-    def cleanup_predecessor(predecessor, notes, cause)
-      cleanup_predecessor_for(predecessor,
-                              notes,
-                              cause,
-                              "storages_file_links_journals",
-                              :journal_id,
-                              :id)
+    def delete_predecessor(predecessor, notes, cause)
+      delete_predecessor_for(predecessor,
+                             notes,
+                             cause,
+                             "storages_file_links_journals",
+                             :journal_id,
+                             :id)
     end
 
     def insert_sql


### PR DESCRIPTION
@ulferts 
While reviewing https://github.com/opf/openproject/pull/21590, I forgot that I wrote some other comments while reviewing.

Here they are:

> I find the name `predecessor` confusing. I assume that's the preceding journal, but no that's actually the **aggregatable** preceding journal. Once you know it, you know it, but before tracing how this variable is set and finding out well that's just confusing.
> 
> `relation_modifications_sql` could be renamed `associations_modifications_sql` as it does a `associations.map { association_modifications_sql() }` internally.
> 
> `cleanup_predecessor_data` could be renamed `delete_aggregatable_predecessor_data` or anything else that has the word `delete` in it. `cleanup` makes me think that data is normalized. No it's just deleted if outdated.
> 
> `create_journal_sql` contains 2 cte(s): `journal_modifications` and `relation_modifications`. `relation_modifications` is added only if not nil.
> I don't get why this is done in two different methods and not generalized. It could be one big `cte_clauses` array, compacted and joined.
> This could avoid having noop CTEs like `SELECT 1` for `cleanup_predecessor_data` CTE: simply return `nil`.

And I gave it a try. I did not rename `predecessor` into something else because I was not too sure about it.

I replaced the methods returning sql to return the cte directly, so that they can return `nil` and be filtered out. This also allows executing them more easily when being in a binding.irg session.
I prefixed method names with an actual sql command name (`insert`, `select`, `update`, `delete`) except for `touch`.

Two things I considered but did not actually do and for which I'd like to have you opinion:
- rename `#update_or_insert_journal_cte_clause` method and `inserted_journal` CTE as `#upsert_journal_cte_clause` and `upsert_journal`. Because I don't like that `#update_journal_cte_clause` returns a CTE named `inserted_journal`.
- rename `fetch_time` CTE as `journal_timestamp` because fetch_time is what it does but does not really describe what it is, and I'd prefer it to describe what it is.

