### PR TITLE
Fix slow tests when checking date visible in date picker

### DIFF
--- a/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
+++ b/spec/features/projects/life_cycle/overview_page/dialog/update_spec.rb
@@ -281,6 +281,7 @@ RSpec.describe "Edit project phases on project overview page", :js do
         # The earliest enabled date should be after initiating date's finish date
         initiating_finish_date_succesor = initiating_finish_date + 1.day
 
+        datepicker.show_date(initiating_finish_date)
         datepicker.expect_not_disabled(initiating_finish_date)
         datepicker.expect_not_disabled(initiating_finish_date_succesor)
 
@@ -300,6 +301,7 @@ RSpec.describe "Edit project phases on project overview page", :js do
         dialog.expect_input("Finish date", value: "")
         dialog.expect_input("Duration", value: "", disabled: true)
 
+        datepicker.show_date(initiating_finish_date)
         datepicker.expect_disabled(initiating_finish_date)
         datepicker.expect_not_disabled(initiating_finish_date_succesor)
 

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -181,7 +181,6 @@ module Components
     ##
     # Expect the given date to be visible and a non-working day
     def expect_non_working(date)
-      ensure_date_is_displayed(date) unless displays_date?(date)
       label = date.strftime("%B %-d, %Y")
       expect(page).to have_css(".flatpickr-day.flatpickr-non-working-day[aria-label='#{label}']")
     end
@@ -189,7 +188,6 @@ module Components
     ##
     # Expect the given date to be visible and a working day
     def expect_working(date)
-      ensure_date_is_displayed(date) unless displays_date?(date)
       label = date.strftime("%B %-d, %Y")
       expect(page).to have_css(".flatpickr-day:not(.flatpickr-non-working-day)[aria-label='#{label}']")
     end
@@ -197,7 +195,6 @@ module Components
     ##
     # Expect the given date to be visible and disabled
     def expect_disabled(date)
-      ensure_date_is_displayed(date) unless displays_date?(date)
       label = date.strftime("%B %-d, %Y")
       expect(page).to have_css(".flatpickr-day.flatpickr-disabled[aria-label='#{label}']," \
                                ".flatpickr-day.flatpickr-non-working-day[aria-label='#{label}']")
@@ -206,7 +203,6 @@ module Components
     ##
     # Expect the given date to be visible and enabled
     def expect_not_disabled(date)
-      ensure_date_is_displayed(date) unless displays_date?(date)
       label = date.strftime("%B %-d, %Y")
       expect(page).to have_css(".flatpickr-day:not(.flatpickr-disabled):not(.flatpickr-non-working-day)[aria-label='#{label}']")
     end
@@ -220,11 +216,6 @@ module Components
     def has_previous_month_toggle?
       expect_visible
       page.has_css?(".flatpickr-prev-month", wait: 0)
-    end
-
-    def ensure_date_is_displayed(date)
-      select_year(date.year)
-      select_month(date.month)
     end
 
     protected

--- a/spec/support/components/datepicker/datepicker.rb
+++ b/spec/support/components/datepicker/datepicker.rb
@@ -5,6 +5,7 @@ module Components
     include Capybara::DSL
     include Capybara::RSpecMatchers
     include RSpec::Matchers
+
     attr_reader :context_selector
 
     ##
@@ -211,12 +212,14 @@ module Components
     end
 
     def displays_date?(date)
+      expect_visible
       label = date.strftime("%B %-d, %Y")
-      page.has_css?(".flatpickr-day.flatpickr-disabled[aria-label='#{label}']")
+      page.has_css?(".flatpickr-day[aria-label='#{label}']", wait: 0)
     end
 
     def has_previous_month_toggle?
-      page.has_css?(".flatpickr-prev-month")
+      expect_visible
+      page.has_css?(".flatpickr-prev-month", wait: 0)
     end
 
     def ensure_date_is_displayed(date)

--- a/spec/support/shared/ferrum_patches.rb
+++ b/spec/support/shared/ferrum_patches.rb
@@ -52,7 +52,7 @@ module Ferrum
       main_frame_id = @traffic.first&.request&.frame_id
       current_navigation = @traffic.reverse.find { |conn| conn.navigation_request?(main_frame_id) }
       current_traffic = @traffic.filter do |exchange|
-        next unless exchange.request
+        next unless exchange.request && current_navigation
 
         exchange.request.loader_id == current_navigation.request.loader_id
       end


### PR DESCRIPTION
# Ticket

None

# What are you trying to accomplish?

Fix some unnecessary waiting in feature tests involving date picker.

# What approach did you choose and why?

941096114cb introduced `Components::Datepicker#displays_date?(date)` to check if a date is visible in the date picker before doing some assertions on it. Then 84bbf8d5495 doubled down on it by calling it inside each `#expect_non_working(date)`, `#expect_working(date)`, `#expect_disabled(date)`, `#expect_not_disabled(date)` methods.

The problem is that `#displays_date?(date)` uses `has_css?` so it returns immediately if the check is positive, but waits for 3 seconds for the date to become visible if it's not yet. It's missing a `wait: 0`. And the css selector is wrong to: it searches for `.flatpickr-day.flatpickr-disabled` instead of `.flatpickr-day`, so it was returning false when the date was visible and enabled.

This commit fixes the problem by:
- Adding `wait: 0` to `has_css?`
- Changing the css selector to `.flatpickr-day`
- Add some `#expect_visible` calls to be sure the date picker is visible before doing assertions with `wait: 0`

And same for `#has_previous_month_toggle?`: it missed a `wait: 0` for the same reasons.

This makes for instance the 2 specs in `spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb:84` run in 11 seconds instead of 1 minute 27 seconds.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
