### PR TITLE
[#70490] Account for optional parentheses when fixing "is empty", "is not" custom field baseline filters

### DIFF
--- a/app/models/journable/historic_active_record_relation.rb
+++ b/app/models/journable/historic_active_record_relation.rb
@@ -201,7 +201,7 @@ class Journable::HistoricActiveRecordRelation < ActiveRecord::Relation
     # Replace all occurrences of `custom_values.value` within the WHERE clause.
     # This handles operators like "is empty" which generate multiple references:
     # e.g. `WHERE custom_values.value IS NULL OR custom_values.value = ''`
-    predicate.gsub!(/WHERE #{Regexp.escape(custom_values)}\.value.*/) do |match|
+    predicate.gsub!(/WHERE.*#{Regexp.escape(custom_values)}\.value.*/) do |match|
       match.gsub!("#{custom_values}.value", "#{customizable_journals}.value")
     end
   end

--- a/spec/models/journable/historic_active_record_relation_spec.rb
+++ b/spec/models/journable/historic_active_record_relation_spec.rb
@@ -258,20 +258,39 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
           end
         end
 
-        context "with the 'is empty' operator" do
+        context "with 'is empty' on list field and 'is not' on hierarchy field (Regression#70490)",
+                with_ee: [:custom_field_hierarchies] do
           let(:list_custom_field) do
             create(:list_wp_custom_field,
                    name: "List CF",
                    types: project.types,
                    projects: [project])
           end
-          let!(:wednesday_list_cf_journal) do
-            create(:journal_customizable_journal, journal: wednesday_journal, custom_field: list_custom_field, value: "1")
+          let(:hierarchy_custom_field) do
+            create(:hierarchy_wp_custom_field,
+                   name: "Hierarchy CF",
+                   types: project.types,
+                   projects: [project])
           end
-          let!(:work_package_without_cf) do
+
+          let!(:wednesday_list_cf_journal) do
+            create(:journal_customizable_journal,
+                   journal: wednesday_journal,
+                   custom_field: list_custom_field,
+                   value: "1")
+          end
+          let!(:wednesday_hierarchy_cf_journal) do
+            create(:journal_customizable_journal,
+                   journal: wednesday_journal,
+                   custom_field: hierarchy_custom_field,
+                   value: "1")
+          end
+
+          let!(:work_package_matching) do
             create(:work_package, project:, journals: { monday => {}, wednesday => {}, friday => {} })
           end
-          let(:filter) do
+
+          let(:is_empty_filter) do
             Queries::WorkPackages::Filter::CustomFieldFilter.create!(
               name: list_custom_field.column_name,
               context: build_stubbed(:query, project:),
@@ -279,7 +298,15 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
               values: []
             )
           end
-          let(:relation) { WorkPackage.where(filter.where) }
+          let(:is_not_filter) do
+            Queries::WorkPackages::Filter::CustomFieldFilter.create!(
+              name: hierarchy_custom_field.column_name,
+              context: build_stubbed(:query, project:),
+              operator: "!",
+              values: ["1"]
+            )
+          end
+          let(:relation) { WorkPackage.where("(#{is_empty_filter.where}) AND (#{is_not_filter.where})") }
           let(:historic_relation) { relation.at_timestamp(wednesday) }
 
           it "transforms the expression to join the customizable_journals with correct value substitutions" do
@@ -290,13 +317,18 @@ RSpec.describe Journable::HistoricActiveRecordRelation do
                   customizable_journals.journal_id = work_packages.journal_id
                   AND customizable_journals.custom_field_id = #{list_custom_field.id}
                 SQL
-              expect(subject_sql).to include "customizable_journals.value IS NULL"
+              expect(subject_sql)
+                .to include <<~SQL.squish
+                  JOIN customizable_journals ON
+                  customizable_journals.journal_id = work_packages.journal_id
+                  AND customizable_journals.custom_field_id = #{hierarchy_custom_field.id}
+                SQL
               expect(subject_sql).not_to include "custom_values.value"
             end
           end
 
-          it "returns work packages without the custom field value at the timestamp" do
-            expect(subject).to include work_package_without_cf
+          it "returns only work packages matching both filters at the timestamp" do
+            expect(subject).to include work_package_matching
             expect(subject).not_to include work_package
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/70490


# What are you trying to accomplish?
The previous fix was missing the option where the conditions are wrapped in parentheses.

# What approach did you choose and why?
Update the regex to match conditions with or without parentheses.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
