### PR TITLE
[65130] Disable dates before start date only in range mode

### DIFF
--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -150,7 +150,11 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   }
 
   private computeMinimalSchedulingDate() {
-    this.minimalSchedulingDate = this.startDateValue && this.timezoneService.utcDateToLocalDate(this.startDateValue);
+    if (this.dateMode === 'single') {
+      this.minimalSchedulingDate = null;
+    } else {
+      this.minimalSchedulingDate = this.startDateValue && this.timezoneService.utcDateToLocalDate(this.startDateValue);
+    }
   }
 
   private findDateToJumpTo(dates:Date[]):Date|null {

--- a/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
+++ b/spec/features/work_packages/datepicker/datepicker_follows_relation_spec.rb
@@ -145,5 +145,60 @@ RSpec.describe "Datepicker logic on follow relationships", :js, with_settings: {
         end
       end
     end
+
+    context "if the predecessor has no dates" do
+      before_all do
+        predecessor.update_column(:start_date, nil)
+        predecessor.update_column(:due_date, nil)
+      end
+
+      let!(:follower) do
+        create(:work_package,
+               type:,
+               project:,
+               schedule_manually: false,
+               start_date: nil,
+               due_date: nil)
+      end
+      let!(:relation) { create(:follows_relation, from: follower, to: predecessor) }
+      let(:date_field) { work_packages_page.edit_field(:combinedDate) }
+
+      it "disables the start date and can pick any finish date or duration" do
+        datepicker.expect_start_date("", disabled: true)
+        datepicker.expect_due_date("", disabled: false)
+        datepicker.expect_duration("", disabled: false)
+        datepicker.expect_working_days_only true
+        datepicker.expect_automatic_scheduling_mode
+
+        datepicker.show_date "2024-02-01"
+        datepicker.expect_not_disabled Date.parse("2024-02-01")
+        datepicker.expect_not_disabled Date.parse("2024-02-02")
+        datepicker.expect_disabled Date.parse("2024-02-03") # Saturday is non-working day
+        datepicker.expect_disabled Date.parse("2024-02-04") # Sunday is non-working day
+        datepicker.expect_not_disabled Date.parse("2024-02-05")
+        datepicker.expect_not_disabled Date.parse("2024-02-06")
+        datepicker.expect_not_disabled Date.parse("2024-02-07")
+
+        datepicker.set_date "2024-02-14"
+        # dates before and after the selected date are still selectable
+        datepicker.expect_not_disabled Date.parse("2024-02-01")
+        datepicker.expect_not_disabled Date.parse("2024-02-02")
+        datepicker.expect_not_disabled Date.parse("2024-02-13")
+        datepicker.expect_not_disabled Date.parse("2024-02-14")
+        datepicker.expect_not_disabled Date.parse("2024-02-15")
+        datepicker.expect_not_disabled Date.parse("2024-02-28")
+        datepicker.expect_not_disabled Date.parse("2024-02-29")
+
+        # duration can be set, but it will remove the finish date as start date can't be set
+        datepicker.set_duration 3
+        datepicker.expect_due_date ""
+        datepicker.expect_duration "3"
+
+        # and setting finish date removes the duration too for the same reason
+        datepicker.set_due_date "2024-02-14"
+        datepicker.expect_due_date "2024-02-14"
+        datepicker.expect_duration ""
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/65130

# What are you trying to accomplish?

Fix an issue where an automatically scheduled work package without dates could pick any finish date, but then would be unable to set an earlier finish date.

## Screenshots

See the linked ticket to see an animated gif demonstrating the issue.

# What approach did you choose and why?

Disable dates earlier than start date only when in range mode.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
