### PR TITLE
display cf type in page title

### DIFF
--- a/app/components/admin/custom_fields/edit_form_header_component.html.erb
+++ b/app/components/admin/custom_fields/edit_form_header_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new(test_selector: "custom-fields--page-header")) do |header|
     header.with_title { page_title }
 
-    header.with_breadcrumbs(breadcrumbs_items)
+    header.with_breadcrumbs(breadcrumbs_items, selected_item_font_weight: :normal)
 
     helpers.render_tab_header_nav(header, tabs, test_selector: :custom_field_detail_header)
   end

--- a/app/components/admin/custom_fields/edit_form_header_component.html.erb
+++ b/app/components/admin/custom_fields/edit_form_header_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::OpenProject::PageHeader.new(test_selector: "custom-fields--page-header")) do |header|
-    header.with_title { @custom_field.attribute_in_database("name") }
+    header.with_title { page_title }
 
     header.with_breadcrumbs(breadcrumbs_items)
 

--- a/app/components/admin/custom_fields/edit_form_header_component.rb
+++ b/app/components/admin/custom_fields/edit_form_header_component.rb
@@ -76,6 +76,11 @@ module Admin
 
       private
 
+      def page_title
+        concat @custom_field.attribute_in_database("name")
+        concat render(Primer::Beta::Text.new(color: :muted)) { " (#{helpers.label_for_custom_field_format(@custom_field.field_format)})" }
+      end
+
       def breadcrumbs_items
         [{ href: admin_index_path, text: t(:label_administration) },
          { href: custom_fields_path, text: t(:label_custom_field_plural) },

--- a/app/components/admin/custom_fields/edit_form_header_component.rb
+++ b/app/components/admin/custom_fields/edit_form_header_component.rb
@@ -82,10 +82,13 @@ module Admin
       end
 
       def breadcrumbs_items
-        [{ href: admin_index_path, text: t(:label_administration) },
-         { href: custom_fields_path, text: t(:label_custom_field_plural) },
-         { href: custom_fields_path(tab: @custom_field.type), text: I18n.t(@custom_field.type_name) },
-         @custom_field.attribute_in_database("name")]
+        [
+          { href: admin_index_path, text: t(:label_administration) },
+          { href: custom_fields_path, text: t(:label_custom_field_plural) },
+          { href: custom_fields_path(tab: @custom_field.type), text: I18n.t(@custom_field.type_name) },
+          helpers.nested_breadcrumb_element(helpers.label_for_custom_field_format(model.field_format),
+                                            @custom_field.attribute_in_database("name"))
+        ]
       end
     end
   end

--- a/app/components/settings/project_custom_fields/edit_form_header_component.html.erb
+++ b/app/components/settings/project_custom_fields/edit_form_header_component.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title { page_title }
     header.with_description { t("settings.project_attributes.edit.description") } unless hide_description?
-    header.with_breadcrumbs(breadcrumbs_items)
+    header.with_breadcrumbs(breadcrumbs_items, selected_item_font_weight: :normal)
 
     helpers.render_tab_header_nav(header, tabs, test_selector: :project_attribute_detail_header)
   end

--- a/app/components/settings/project_custom_fields/edit_form_header_component.html.erb
+++ b/app/components/settings/project_custom_fields/edit_form_header_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { @custom_field.attribute_in_database("name") }
+    header.with_title { page_title }
     header.with_description { t("settings.project_attributes.edit.description") } unless hide_description?
     header.with_breadcrumbs(breadcrumbs_items)
 

--- a/app/components/settings/project_custom_fields/edit_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/edit_form_header_component.rb
@@ -78,6 +78,11 @@ module Settings
         tabs
       end
 
+      def page_title
+        concat @custom_field.attribute_in_database("name")
+        concat render(Primer::Beta::Text.new(color: :muted)) { " (#{helpers.label_for_custom_field_format(@custom_field.field_format)})" }
+      end
+
       def breadcrumbs_items
         [{ href: admin_index_path, text: t("label_administration") },
          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },

--- a/app/components/settings/project_custom_fields/edit_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/edit_form_header_component.rb
@@ -84,10 +84,13 @@ module Settings
       end
 
       def breadcrumbs_items
-        [{ href: admin_index_path, text: t("label_administration") },
-         { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
-         { href: admin_settings_project_custom_fields_path, text: t("settings.project_attributes.heading") },
-         @custom_field.attribute_in_database("name")]
+        [
+          { href: admin_index_path, text: t("label_administration") },
+          { href: admin_settings_project_custom_fields_path, text: t("label_project_plural") },
+          { href: admin_settings_project_custom_fields_path, text: t("settings.project_attributes.heading") },
+          helpers.nested_breadcrumb_element(helpers.label_for_custom_field_format(@custom_field.field_format),
+                                            @custom_field.attribute_in_database("name"))
+        ]
       end
 
       def hide_description?

--- a/app/components/settings/project_custom_fields/new_form_header_component.html.erb
+++ b/app/components/settings/project_custom_fields/new_form_header_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
-    header.with_title { t("settings.project_attributes.new.heading") }
+    header.with_title { page_title }
     header.with_description { t("settings.project_attributes.new.description") } unless hide_description?
     header.with_breadcrumbs(breadcrumb_items, selected_item_font_weight: :normal)
   end

--- a/app/components/settings/project_custom_fields/new_form_header_component.rb
+++ b/app/components/settings/project_custom_fields/new_form_header_component.rb
@@ -31,6 +31,11 @@
 module Settings
   module ProjectCustomFields
     class NewFormHeaderComponent < ApplicationComponent
+      def page_title
+        concat t("settings.project_attributes.new.heading")
+        concat render(Primer::Beta::Text.new(color: :muted)) { " (#{helpers.label_for_custom_field_format(model.field_format)})" }
+      end
+
       def breadcrumb_items
         [
           { href: admin_index_path, text: t("label_administration") },

--- a/app/views/custom_fields/new.html.erb
+++ b/app/views/custom_fields/new.html.erb
@@ -31,7 +31,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   render(Primer::OpenProject::PageHeader.new(test_selector: "custom-fields--page-header")) do |header|
-    header.with_title { t(:label_custom_field_new) }
+    header.with_title do
+      concat t(:label_custom_field_new)
+      concat render(Primer::Beta::Text.new(color: :muted)) { " (#{label_for_custom_field_format(@custom_field.field_format)})" }
+    end
     header.with_breadcrumbs(
       [{ href: admin_index_path, text: t(:label_administration) },
        { href: custom_fields_path, text: t(:label_custom_field_plural) },


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/68524

# What are you trying to accomplish?

Display the field format in the title of:
* The custom field
  * new form
  * edit form
* The project attribute 
  * new form
  * edit form

## Screenshots

<img width="556" height="151" alt="image" src="https://github.com/user-attachments/assets/ef824fe5-59e8-4e79-9a69-440486eeed17" />


# Merge checklist

- No tests added because the changes are trivial
