### PR TITLE
[#69713] PDF export of the project initiation request: long titles take too much space

### DIFF
--- a/app/models/project/pdf_export/project_initiation/standard.yml
+++ b/app/models/project/pdf_export/project_initiation/standard.yml
@@ -57,7 +57,7 @@ cover:
     margin_top: 30
     no_border: true
     color: "008080"
-    size: 32
+    size: 30
   footer:
     margin_bottom: 20
     size: 12


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/69713

# What are you trying to accomplish?
With the full 255 characters of a project title, the title hardly fits on the cover page.

# What approach did you choose and why?
Reduce the font size a bit

