### PR TITLE
[#71038] WP meeting outcome is not displayed in WP meetings tab + outcome order is off  

### DIFF
--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.html.erb
@@ -24,7 +24,11 @@
         flex.with_row do
           render(OpPrimer::InsetBoxComponent.new(border: false, mt: 2, classes: "outcome-container")) do
             concat render(Primer::Beta::Heading.new(tag: :h5)) { outcome_heading(outcomes, index) }
-            concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
+            if outcome.work_package_kind?
+              work_package_outcome_text(outcome)
+            else
+              concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) { format_text(outcome, :notes) }
+            end
           end
         end
       end

--- a/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
+++ b/modules/meeting/app/components/work_package_meetings_tab/meeting_agenda_item_component.rb
@@ -49,5 +49,34 @@ module WorkPackageMeetingsTab
 
       heading
     end
+
+    def work_package_outcome_text(outcome) # rubocop:disable Metrics/AbcSize
+      if outcome.visible_work_package?
+        concat render(Primer::Box.new(classes: "op-uc-container", pb: 0, mt: 1)) {
+          flex_layout do |flex|
+            flex.with_row do
+              render(WorkPackages::InfoLineComponent.new(work_package: outcome.work_package))
+            end
+            flex.with_row do
+              render(
+                Primer::Beta::Link.new(
+                  href: work_package_path(outcome.work_package),
+                  font_size: :normal,
+                  font_weight: :bold
+                )
+              ) { outcome.work_package.subject }
+            end
+          end
+        }
+      elsif outcome.linked_work_package?
+        concat render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) {
+          I18n.t(:label_agenda_item_undisclosed_wp, id: outcome.work_package_id)
+        }
+      elsif outcome.deleted_work_package?
+        concat render(Primer::Beta::Text.new(font_size: :small, color: :danger, tag: :s)) {
+          I18n.t(:label_agenda_item_deleted_wp)
+        }
+      end
+    end
   end
 end

--- a/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
+++ b/modules/meeting/app/controllers/work_package_meetings_tab_controller.rb
@@ -160,7 +160,8 @@ class WorkPackageMeetingsTabController < ApplicationController
 
   def get_agenda_items_of_work_package(direction)
     agenda_items = agenda_items_linked_to_work_package
-        .includes(:meeting, :outcomes)
+        .includes(:meeting)
+        .preload(:outcomes)
         .where(meeting_id: Meeting.not_templated.visible(current_user))
         .order(sort_clause(direction))
 

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -305,6 +305,10 @@ RSpec.describe "Open the Meetings tab",
         create(:meeting_outcome, meeting_agenda_item:, notes: "Second decision")
       end
 
+      let!(:third_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, notes: "Third decision")
+      end
+
       it "shows all outcomes with numbered headings" do
         work_package_page.visit!
         switch_to_meetings_tab
@@ -317,6 +321,23 @@ RSpec.describe "Open the Meetings tab",
           expect(page).to have_content(second_outcome.notes)
           expect(page).to have_content("#{I18n.t(:label_agenda_outcome)} 1")
           expect(page).to have_content("#{I18n.t(:label_agenda_outcome)} 2")
+          expect(page).to have_content("#{I18n.t(:label_agenda_outcome)} 3")
+        end
+      end
+
+      it "displays outcomes in ascending order of their ids" do
+        work_package_page.visit!
+        switch_to_meetings_tab
+
+        meetings_tab.expect_upcoming_counter_to_be(1)
+
+        page.within_test_selector("op-meeting-container-#{meeting.id}") do
+          outcome_containers = page.all(".outcome-container")
+
+          expect(outcome_containers.size).to eq(3)
+          expect(outcome_containers[0]).to have_content(first_outcome.notes)
+          expect(outcome_containers[1]).to have_content(second_outcome.notes)
+          expect(outcome_containers[2]).to have_content(third_outcome.notes)
         end
       end
     end

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -348,6 +348,35 @@ RSpec.describe "Open the Meetings tab",
       end
     end
 
+    context "when another work_package is linked as an outcome to this work_package's agenda item" do
+      let!(:meeting) { create(:meeting, project:) }
+      let!(:outcome_work_package) { create(:work_package, project:, subject: "Linked as outcome WP") }
+
+      let!(:meeting_agenda_item) do
+        create(:meeting_agenda_item, meeting:, work_package:, notes: "WP agenda item")
+      end
+
+      let!(:work_package_outcome) do
+        create(:meeting_outcome, meeting_agenda_item:, work_package: outcome_work_package, kind: :work_package)
+      end
+
+      it "shows the other work package as an outcome in the list (Bug #71038)" do
+        work_package_page.visit!
+        switch_to_meetings_tab
+
+        meetings_tab.expect_upcoming_counter_to_be(1)
+
+        page.within_test_selector("op-meeting-container-#{meeting.id}") do
+          expect(page).to have_content(meeting.title)
+          expect(page).to have_content(I18n.t(:label_agenda_outcome))
+          expect(page).to have_content(meeting_agenda_item.notes)
+          expect(page).to have_content(outcome_work_package.subject)
+
+          expect(page).to have_no_content(I18n.t(:label_added_as_outcome))
+        end
+      end
+    end
+
     context "when the work_package was already referenced in past meetings" do
       let!(:first_past_meeting) { create(:meeting, project:, start_time: Date.yesterday - 11.hours) }
       let!(:second_past_meeting) { create(:meeting, project:, start_time: Date.yesterday - 10.hours) }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/71038

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Render work package outcomes correctly when added as an outcome for another work package
- Fix the order of outcomes in the work package meetings tab to match the order of outcomes in the meeting

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
