### PR TITLE
Harmonize capitilisation on Access tokens page

### DIFF
--- a/app/views/my/access_tokens/_icalendar_tokens_section.html.erb
+++ b/app/views/my/access_tokens/_icalendar_tokens_section.html.erb
@@ -31,18 +31,18 @@ See COPYRIGHT and LICENSE files for more details.
 
 <div id="icalendar-token-section" class="mb-4">
   <%= render(Primer::Beta::Subhead.new) do |component|
-    component.with_heading(tag: :h3, size: :medium) do
-      t("my_account.access_tokens.ical.title")
-    end
-    component.with_description do
-      link_translate(
-        "my_account.access_tokens.ical.text_hint_link",
-        links: {
-          docs_url: %i[user_guide access_tokens]
-        }
-      )
-    end
-  end %>
+        component.with_heading(tag: :h3, size: :medium) do
+          t("my_account.access_tokens.ical.title")
+        end
+        component.with_description do
+          link_translate(
+            "my_account.access_tokens.ical.text_hint_link",
+            links: {
+              docs_url: %i[user_guide calendar subscribe]
+            }
+          )
+        end
+      end %>
   <% if Setting.ical_enabled? %>
     <%= render(My::AccessToken::ICal::TableComponent.new(rows: ical_tokens_grouped_by_query.values.flatten)) %>
   <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3113,7 +3113,7 @@ en:
         text_hint: "API tokens allow third-party applications to communicate with this OpenProject instance via REST APIs."
         static_token_name: "API token"
         disabled_text: "API tokens are not enabled by the administrator. Please contact your administrator to use this feature."
-        add_button: "API Token"
+        add_button: "API token"
       ical:
         blank_description: "To add an iCalendar token, subscribe to a new or existing calendar from within the Calendar module of a project. You must have the necessary permissions."
         blank_title: "No iCalendar token"
@@ -3141,7 +3141,7 @@ en:
         removed: "OAuth client token successfully removed"
         unknown_integration: "Unknown"
       token/rss:
-        add_button: "RSS Token"
+        add_button: "RSS token"
         blank_description: "There is no RSS token yet. You can create one using the button below."
         blank_title: "No RSS token"
         title: "RSS"

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -225,8 +225,9 @@ user_guides:
   href: https://www.openproject.org/docs/user-guide/
   label: homescreen.links.user_guides
 user_guide:
-  access_tokens:
-    href: https://www.openproject.org/docs/user-guide/account-settings/#access-tokens
+  calendar:
+    subscribe:
+      href: https://www.openproject.org/docs/user-guide/calendar/#subscribe-to-a-calendar
 webinar_videos:
   href: https://www.youtube.com/watch?v=un6zCm8_FT4
 website:

--- a/spec/features/users/my/access_tokens_spec.rb
+++ b/spec/features/users/my/access_tokens_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "my access tokens", :js do
         expect(page).to have_no_content("API tokens are not enabled by the administrator.")
 
         within "#api-token-component" do
-          expect(page).to have_test_selector("api-token-add", text: "API Token")
+          expect(page).to have_test_selector("api-token-add", text: "API token")
           find_test_selector("api-token-add").click
         end
 
@@ -86,7 +86,7 @@ RSpec.describe "my access tokens", :js do
 
         # multiple API tokens can be created
         within "#api-token-component" do
-          expect(page).to have_test_selector("api-token-add", text: "API Token")
+          expect(page).to have_test_selector("api-token-add", text: "API token")
         end
 
         # revoke API token
@@ -106,7 +106,7 @@ RSpec.describe "my access tokens", :js do
           expect(page).to have_no_content("Testing Token")
 
           # API token can be created again
-          expect(page).to have_test_selector("api-token-add", text: "API Token")
+          expect(page).to have_test_selector("api-token-add", text: "API token")
         end
       end
     end
@@ -119,19 +119,19 @@ RSpec.describe "my access tokens", :js do
 
         within "#rss-token-component" do
           expect(page).to have_content("RSS tokens are not enabled by the administrator.")
-          expect(page).not_to have_test_selector("rss-token-add", text: "RSS Token")
+          expect(page).not_to have_test_selector("rss-token-add", text: "RSS token")
         end
       end
     end
 
     context "when RSS access is enabled via global settings", with_settings: { feeds_enabled: true } do
-      it "in Access Tokens they can generate and revoke their RSS key" do
+      it "in Access tokens they can generate and revoke their RSS key" do
         visit my_access_tokens_path
 
         expect(page).to have_no_content("RSS tokens are not enabled by the administrator.")
 
         within "#rss-token-component" do
-          expect(page).to have_test_selector("rss-token-add", text: "RSS Token")
+          expect(page).to have_test_selector("rss-token-add", text: "RSS token")
           find_test_selector("rss-token-add").click
         end
 
@@ -142,7 +142,7 @@ RSpec.describe "my access tokens", :js do
 
         # only one RSS token can be created
         within "#rss-token-component" do
-          expect(page).not_to have_test_selector("rss-token-add", text: "RSS Token")
+          expect(page).not_to have_test_selector("rss-token-add", text: "RSS token")
         end
 
         # revoke RSS token
@@ -159,7 +159,7 @@ RSpec.describe "my access tokens", :js do
 
         # RSS token can be created again
         within "#rss-token-component" do
-          expect(page).to have_test_selector("rss-token-add", text: "RSS Token")
+          expect(page).to have_test_selector("rss-token-add", text: "RSS token")
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/design-system/work_packages/65411/activity#comment-1623725
https://community.openproject.org/projects/design-system/work_packages/65411/activity#comment-1623746

* Rename "Token" to "token"
* Change URL of link in description of iCal Block