### PR TITLE
[#70242] Meeting template shows 'Duplicate' menu point with empty action list  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.html.erb
@@ -75,7 +75,7 @@
             add_outcome_action_items(menu) if add_outcome_action?
           end
 
-          if editable? && !presentation_mode?
+          if editable? && !presentation_mode? && has_move_actions?
             with_item_group(menu) do
               menu.with_sub_menu_item(label: I18n.t("label_agenda_item_move")) do |submenu|
                 submenu.with_leading_visual_icon(icon: :"op-arrow-in")
@@ -97,10 +97,12 @@
               end
             end
 
-            with_item_group(menu) do
-              menu.with_sub_menu_item(label: I18n.t("label_agenda_item_duplicate")) do |submenu|
-                submenu.with_leading_visual_icon(icon: :duplicate)
-                with_item_group(submenu) { duplicate_in_next_meeting_action_item(submenu) }
+            if has_next_occurrence?
+              with_item_group(menu) do
+                menu.with_sub_menu_item(label: I18n.t("label_agenda_item_duplicate")) do |submenu|
+                  submenu.with_leading_visual_icon(icon: :duplicate)
+                  with_item_group(submenu) { duplicate_in_next_meeting_action_item(submenu) }
+                end
               end
             end
           end

--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -231,13 +231,9 @@ module MeetingAgendaItems
     end
 
     def next_meeting_action_item(menu, label:, action:, icon:)
-      return unless editable?
-      return if in_template?
-      return if @series.nil?
+      return unless has_next_occurrence?
 
-      from_time = @meeting.start_time.past? ? Time.current : @meeting.start_time
-      next_date = @series.next_occurrence(from_time:)
-      return if next_date.nil?
+      next_date = @series.next_occurrence(from_time: next_occurrence_from_time)
 
       menu.with_item(
         label:,
@@ -250,6 +246,30 @@ module MeetingAgendaItems
       ) do |item|
         item.with_leading_visual_icon(icon:)
       end
+    end
+
+    def has_next_occurrence?
+      return false unless editable?
+      return false if in_template?
+      return false if @series.nil?
+
+      next_date = @series.next_occurrence(from_time: next_occurrence_from_time)
+      next_date.present?
+    end
+
+    def next_occurrence_from_time
+      @meeting.start_time.past? ? Time.current : @meeting.start_time
+    end
+
+    def has_move_actions?
+      return false unless editable?
+
+      return true unless first? && last?
+      return true if many_sections?
+      return true if !in_template? || in_backlog?
+      return true if has_next_occurrence?
+
+      false
     end
 
     def move_actions(menu)
@@ -395,12 +415,6 @@ module MeetingAgendaItems
     def in_section?
       true
     end
-
-    # def visible_sections?
-    #   return true if @meeting.templated?
-    #
-    #   @meeting.sections.many?
-    # end
 
     def many_sections?
       if @meeting_agenda_item.in_backlog? && @current_occurrence.present?

--- a/modules/meeting/spec/components/meeting_agenda_items/item_component/show_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/item_component/show_component_spec.rb
@@ -89,4 +89,60 @@ RSpec.describe MeetingAgendaItems::ItemComponent::ShowComponent, type: :componen
       end
     end
   end
+
+  describe "duplicate action visibility (Bugs #70242, #70287)" do
+    let(:series) do
+      create(:recurring_meeting,
+             project:,
+             start_time: 1.week.from_now,
+             frequency: "weekly",
+             end_after: "specific_date",
+             end_date: 2.weeks.from_now.to_date,
+             author: user)
+    end
+    let(:meeting_section) { create(:meeting_section, meeting:) }
+    let(:meeting_agenda_item) { create(:meeting_agenda_item, meeting:, meeting_section:, title: "Test item") }
+
+    subject(:rendered_component) do
+      render_inline(described_class.new(meeting_agenda_item:))
+    end
+
+    context "when viewing a template" do
+      let(:meeting) { series.template }
+
+      it "does not show the duplicate submenu" do
+        expect(rendered_component).to have_no_text(I18n.t("label_agenda_item_duplicate"))
+      end
+    end
+
+    context "when viewing the last occurrence of a series" do
+      let(:meeting) do
+        create(:meeting,
+               project:,
+               recurring_meeting: series,
+               start_time: 2.weeks.from_now,
+               author: user)
+      end
+
+      it "does not show the duplicate submenu" do
+        expect(series.next_occurrence(from_time: meeting.start_time)).to be_nil
+        expect(rendered_component).to have_no_text(I18n.t("label_agenda_item_duplicate"))
+      end
+    end
+
+    context "when viewing an occurrence with future occurrences" do
+      let(:meeting) do
+        create(:meeting,
+               project:,
+               recurring_meeting: series,
+               start_time: 1.week.from_now,
+               author: user)
+      end
+
+      it "shows the duplicate submenu" do
+        expect(series.next_occurrence(from_time: meeting.start_time)).to be_present
+        expect(rendered_component).to have_text(I18n.t("label_agenda_item_duplicate"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70242
https://community.openproject.org/work_packages/70287


<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add the same checks for "Duplicate in next meeting" that are used for "Move to next meeting"
- Also hide the "Move" menu item unless any move actions are actually possible

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
