### PR TITLE
[#71325, #71327] Drag and drop fixes

### DIFF
--- a/app/components/admin/enumerations/index_component.rb
+++ b/app/components/admin/enumerations/index_component.rb
@@ -52,7 +52,7 @@ module Admin
       def drop_target_config
         {
           generic_drag_and_drop_target: "container",
-          "target-container-accessor": "& > ul",
+          "target-container-accessor": ":scope > ul",
           "target-allowed-drag-type": "enumeration"
         }
       end

--- a/app/components/admin/enumerations/index_component.rb
+++ b/app/components/admin/enumerations/index_component.rb
@@ -51,7 +51,7 @@ module Admin
 
       def drop_target_config
         {
-          "is-drag-and-drop-target": true,
+          generic_drag_and_drop_target: "container",
           "target-container-accessor": "& > ul",
           "target-allowed-drag-type": "enumeration"
         }

--- a/app/components/admin/enumerations/item_component.html.erb
+++ b/app/components/admin/enumerations/item_component.html.erb
@@ -3,7 +3,7 @@
     flex_layout(align_items: :center, justify_content: :space_between) do |enumeration_container|
       enumeration_container.with_column(flex_layout: true) do |enumeration_info|
         enumeration_info.with_column(mr: 2) do
-          render(Primer::OpenProject::DragHandle.new(draggable: true))
+          render(Primer::OpenProject::DragHandle.new)
         end
 
         if colored?

--- a/app/components/settings/project_custom_field_sections/index_component.rb
+++ b/app/components/settings/project_custom_field_sections/index_component.rb
@@ -59,7 +59,7 @@ module Settings
 
       def drop_target_config
         {
-          "is-drag-and-drop-target": true,
+          generic_drag_and_drop_target: "container",
           "target-allowed-drag-type": "section" # the type of dragged items which are allowed to be dropped in this target
         }
       end

--- a/app/components/settings/project_custom_field_sections/show_component.rb
+++ b/app/components/settings/project_custom_field_sections/show_component.rb
@@ -56,7 +56,7 @@ module Settings
 
       def drag_and_drop_target_config
         {
-          "is-drag-and-drop-target": true,
+          generic_drag_and_drop_target: "container",
           "target-container-accessor": ".Box > ul", # the accessor of the container that contains the drag and drop items
           "target-id": @project_custom_field_section.id, # the id of the target
           "target-allowed-drag-type": "custom-field" # the type of dragged items which are allowed to be dropped in this target

--- a/app/components/settings/project_phase_definitions/index_component.rb
+++ b/app/components/settings/project_phase_definitions/index_component.rb
@@ -48,7 +48,7 @@ module Settings
       def drop_target_config
         {
           generic_drag_and_drop_target: "container",
-          "target-container-accessor": "& > ul",
+          "target-container-accessor": ":scope > ul",
           "target-allowed-drag-type": "life-cycle-step-definition"
         }
       end

--- a/app/components/settings/project_phase_definitions/index_component.rb
+++ b/app/components/settings/project_phase_definitions/index_component.rb
@@ -47,7 +47,7 @@ module Settings
 
       def drop_target_config
         {
-          "is-drag-and-drop-target": true,
+          generic_drag_and_drop_target: "container",
           "target-container-accessor": "& > ul",
           "target-allowed-drag-type": "life-cycle-step-definition"
         }

--- a/app/components/work_package_types/export_template_list_component.rb
+++ b/app/components/work_package_types/export_template_list_component.rb
@@ -49,7 +49,7 @@ module WorkPackageTypes
     def drag_and_drop_target_config
       {
         generic_drag_and_drop_target: "container",
-        "target-container-accessor": "& > ul",
+        "target-container-accessor": ":scope > ul",
         "target-allowed-drag-type": "template",
         test_selector: "pdf-export-template-rows"
       }

--- a/app/components/work_package_types/export_template_list_component.rb
+++ b/app/components/work_package_types/export_template_list_component.rb
@@ -48,7 +48,7 @@ module WorkPackageTypes
 
     def drag_and_drop_target_config
       {
-        "is-drag-and-drop-target": true,
+        generic_drag_and_drop_target: "container",
         "target-container-accessor": "& > ul",
         "target-allowed-drag-type": "template",
         test_selector: "pdf-export-template-rows"

--- a/app/components/work_package_types/export_template_row_component.html.erb
+++ b/app/components/work_package_types/export_template_row_component.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
   component_wrapper do
     flex_layout(align_items: :center) do |item_information|
       item_information.with_column(mr: 2) do
-        render(Primer::OpenProject::DragHandle.new(draggable: true))
+        render(Primer::OpenProject::DragHandle.new)
       end
       item_information.with_column(flex: 1, flex_layout: true) do |title_container|
         title_container.with_column(pt: 1, mr: 2) do

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -28,11 +28,12 @@
  * ++
  */
 
-import * as Turbo from '@hotwired/turbo';
 import { Controller } from '@hotwired/stimulus';
-import dragula, { Drake } from 'dragula';
+import * as Turbo from '@hotwired/turbo';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
+import dragula, { Drake } from 'dragula';
 import { useMeta } from 'stimulus-use';
+import invariant from 'tiny-invariant';
 
 interface TargetConfig {
   container:Element;
@@ -41,32 +42,61 @@ interface TargetConfig {
 }
 
 export default class GenericDragAndDropController extends Controller {
+  static targets = ['container'];
+
+  containerTargets:HTMLElement[];
+
   static metaNames = ['csrf-token'];
   declare readonly csrfToken:string;
 
-  drake:Drake|undefined;
-  targetConfigs:TargetConfig[];
-
-  containerTargets:Element[];
-
-  observer:MutationObserver|null = null;
+  private drake:Drake|null = null;
+  private containers:HTMLElement[] = [];
+  private targetConfigs:TargetConfig[] = [];
 
   connect() {
     useMeta(this, { suffix: false });
+
+    this.drake?.destroy();
     this.initDrake();
-    this.startMutationObserver();
+  }
+
+  disconnect() {
+    this.drake?.destroy();
+    this.drake = null;
+  }
+
+  containerTargetConnected(target:HTMLElement) {
+    const container = this.resolveContainerElement(target);
+    const targetConfig:TargetConfig = {
+      container,
+      allowedDragType: target.getAttribute('data-target-allowed-drag-type'),
+      targetId: target.getAttribute('data-target-id'),
+    };
+
+    // we need to save the targetConfigs separately as we need to pass the pure container elements to drake
+    // but need the configuration of the targets when dropping elements
+    this.targetConfigs.push(targetConfig);
+    this.containers.push(container);
+  }
+
+  containerTargetDisconnected(target:HTMLElement) {
+    const container = this.resolveContainerElement(target);
+    const index = this.containers.indexOf(container);
+    if (index !== -1) {
+      this.containers.splice(index, 1);
+      this.targetConfigs.splice(index, 1);
+    }
+  }
+
+  cancel() {
+    this.drake?.cancel(true);
   }
 
   initDrake() {
-    this.setContainerTargetsAndConfigs();
-
-    // reinit drake if it already exists
-    if (this.drake) {
-      this.drake.destroy();
-    }
-
+    // Note: dragula stores a reference to this.containers, so mutations
+    // from containerTargetConnected/Disconnected automatically propagate
     this.drake = dragula(
-      this.containerTargets,
+      this.containers,
       {
         moves: (_el, _source, handle, _sibling) => !!handle?.classList.contains('octicon-grabber'),
         accepts: (el:Element, target:Element, source:Element, sibling:Element) => this.accepts(el, target, source, sibling),
@@ -90,46 +120,6 @@ export default class GenericDragAndDropController extends Controller {
         },
       );
     });
-  }
-
-  reInitDrakeContainers() {
-    this.setContainerTargetsAndConfigs();
-    if (this.drake) {
-      this.drake.containers = this.containerTargets;
-    }
-  }
-
-  setContainerTargetsAndConfigs():void {
-    const rawTargets = Array.from(
-      this.element.querySelectorAll('[data-is-drag-and-drop-target="true"]'),
-    );
-    this.targetConfigs = [];
-    let processedTargets:Element[] = [];
-
-    rawTargets.forEach((target:Element) => {
-      const targetConfig:TargetConfig = {
-        container: target,
-        allowedDragType: target.getAttribute('data-target-allowed-drag-type'),
-        targetId: target.getAttribute('data-target-id'),
-      };
-
-      // if the target has a container accessor, use that as the container instead of the element itself
-      // we need this e.g. in Primer's borderbox component as we cannot add required data attributes to the ul element there
-      const containerAccessor = target.getAttribute('data-target-container-accessor');
-
-      if (containerAccessor) {
-        target = target.querySelector(containerAccessor)!;
-        targetConfig.container = target;
-      }
-
-      // we need to save the targetConfigs separately as we need to pass the pure container elements to drake
-      // but need the configuration of the targets when dropping elements
-      this.targetConfigs.push(targetConfig);
-
-      processedTargets = processedTargets.concat(target);
-    });
-
-    this.containerTargets = processedTargets;
   }
 
   accepts(el:Element, target:Element, _source:Element|null, _sibling:Element|null) {
@@ -169,17 +159,7 @@ export default class GenericDragAndDropController extends Controller {
       }
     }
 
-    if (this.drake) {
-      this.drake.cancel(true); // necessary to prevent "copying" behaviour
-    }
-  }
-
-  disconnect() {
-    if (this.drake) {
-      this.drake.destroy();
-    }
-
-    this.stopMutationObserver();
+    this.cancel();
   }
 
   protected buildData(el:Element, target:Element):FormData {
@@ -205,32 +185,15 @@ export default class GenericDragAndDropController extends Controller {
     return data;
   }
 
-  private startMutationObserver() {
-    this.observer = new MutationObserver((mutations) => {
-      const addedNodes = mutations
-        .filter((mutation:MutationRecord) => mutation.type === 'childList')
-        .map((mutation:MutationRecord) => Array.from(mutation.addedNodes))
-        .reduce((acc, val) => acc.concat(val), []);
-
-      const newTarget = addedNodes.some((node) =>
-        node instanceof Element
-        && node.matches('[data-is-drag-and-drop-target="true"], [data-is-drag-and-drop-target="true"] *'));
-
-      if (newTarget) {
-        this.reInitDrakeContainers();
-      }
-    });
-
-    this.observer.observe(this.element, {
-      childList: true,
-      subtree: true,
-    });
-  }
-
-  private stopMutationObserver() {
-    if (this.observer) {
-      this.observer.disconnect();
-      this.observer = null;
+  // if the target has a container accessor, use that as the container instead of the element itself
+  // we need this e.g. in Primer's borderbox component as we cannot add required data attributes to the ul element there
+  private resolveContainerElement(target:HTMLElement):HTMLElement {
+    const accessor = target.getAttribute('data-target-container-accessor');
+    if (!accessor) {
+      return target;
     }
+    const container = target.querySelector<HTMLElement>(accessor);
+    invariant(container, `Expected container element matching "${accessor}"`);
+    return container;
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -49,6 +49,9 @@ export default class GenericDragAndDropController extends Controller {
   static metaNames = ['csrf-token'];
   declare readonly csrfToken:string;
 
+  static values = { handleSelector: { type: String, default: '.DragHandle' } };
+  declare readonly handleSelectorValue:string;
+
   private drake:Drake|null = null;
   private containers:HTMLElement[] = [];
   private targetConfigs:TargetConfig[] = [];
@@ -98,11 +101,19 @@ export default class GenericDragAndDropController extends Controller {
     this.drake = dragula(
       this.containers,
       {
-        moves: (_el, _source, handle, _sibling) => !!handle?.classList.contains('octicon-grabber'),
+        moves: (_el, _source, handle, _sibling) => !!handle && !!handle.closest(this.handleSelectorValue),
         accepts: (el:Element, target:Element, source:Element, sibling:Element) => this.accepts(el, target, source, sibling),
         revertOnSpill: true, // enable reverting of elements if they are dropped outside of a valid target
       },
     )
+      .on('drag', (el) => {
+        const handle = el.querySelector(this.handleSelectorValue)!;
+        handle.setAttribute('aria-pressed', 'true');
+      })
+      .on('dragend', (el) => {
+        const handle = el.querySelector(this.handleSelectorValue)!;
+        handle.setAttribute('aria-pressed', 'false');
+       })
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       .on('drop', this.drop.bind(this));
 

--- a/frontend/src/stimulus/controllers/dynamic/meetings/drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/drag-and-drop.controller.ts
@@ -44,9 +44,7 @@ export default class extends GenericDragAndDropController {
   override async drop(el:Element, target:Element, source:Element|null, sibling:Element|null) {
     if (hasUnsavedChanges()) {
       if (!window.confirm(I18n.t('js.text_are_you_sure_to_cancel'))) {
-        if (this.drake) {
-          this.drake.cancel(true);
-        }
+        this.cancel();
         return;
       }
     }

--- a/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/item_component.html.erb
@@ -32,7 +32,7 @@
 <%= component_wrapper do
       grid_layout("op-documents-types-list--item", tag: :div, align_items: :center) do |grid|
         grid.with_area(:"drag-handle", tag: :div, classes: "hide-when-print") do
-          render(Primer::OpenProject::DragHandle.new(draggable: true))
+          render(Primer::OpenProject::DragHandle.new)
         end
 
         grid.with_area(:name, tag: :div, classes: "ellipsis") do

--- a/modules/meeting/app/components/meeting_agenda_items/list_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/list_component.rb
@@ -50,7 +50,7 @@ module MeetingAgendaItems
 
     def drop_target_config
       {
-        "is-drag-and-drop-target": true,
+        meetings__drag_and_drop_target: "container",
         "target-allowed-drag-type": "section" # the type of dragged items which are allowed to be dropped in this target
       }
     end

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -57,7 +57,7 @@ module MeetingSections
 
     def drag_and_drop_target_config
       {
-        "is-drag-and-drop-target": true,
+        meetings__drag_and_drop_target: "container",
         "target-container-accessor": ".Box > ul", # the accessor of the container that contains the drag and drop items
         "target-id": @meeting_section.id, # the id of the target
         "target-allowed-drag-type": "custom-field" # the type of dragged items which are allowed to be dropped in this target

--- a/modules/meeting/app/components/meeting_sections/header_component.rb
+++ b/modules/meeting/app/components/meeting_sections/header_component.rb
@@ -55,15 +55,6 @@ module MeetingSections
       }
     end
 
-    def drag_and_drop_target_config
-      {
-        meetings__drag_and_drop_target: "container",
-        "target-container-accessor": ".Box > ul", # the accessor of the container that contains the drag and drop items
-        "target-id": @meeting_section.id, # the id of the target
-        "target-allowed-drag-type": "custom-field" # the type of dragged items which are allowed to be dropped in this target
-      }
-    end
-
     def editable?
       @meeting_section.editable? && User.current.allowed_in_project?(:manage_agendas, @meeting_section.project)
     end

--- a/modules/meeting/app/components/meeting_sections/show_component.rb
+++ b/modules/meeting/app/components/meeting_sections/show_component.rb
@@ -91,7 +91,7 @@ module MeetingSections
 
     def drag_and_drop_target_config
       {
-        "is-drag-and-drop-target": true,
+        meetings__drag_and_drop_target: "container",
         "target-container-accessor": ".Box > ul", # the accessor of the container that contains the drag and drop items
         "target-id": @meeting_section.id, # the id of the target
         "target-allowed-drag-type": "agenda-item" # the type of dragged items which are allowed to be dropped in this target


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/71325
https://community.openproject.org/wp/71327

# What are you trying to accomplish?

**WP 71325**

Improves `GenericDragAndDropController`'s interop with Turbo's partial page updates: although not reproducible in current production code, list items are sometimes no longer draggable after a partial page update.

**WP 71327**

Fixes an issue where the drag handle doesn't actually drag if clicked in the wrong place.
Removes `draggable="true"` which enables HTMl5 Drag and Drop API, conflicting with our Dragula-based implementaiton.
Updates drag handle detection to use `closest()` for more reliable matching.

## Screenshots

There should be no visual changes.

# What approach did you choose and why?

This patch attempts to handle page changes "idiomatically" via Stimulus lifecycle callbacks rather than a hand-rolled `MutationObserver`-based implementation.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
