### PR TITLE
[70497] On mobile, global search result box shows a lot of white space

### DIFF
--- a/frontend/src/app/core/global_search/input/global-search-input-mobile.component.sass
+++ b/frontend/src/app/core/global_search/input/global-search-input-mobile.component.sass
@@ -21,7 +21,8 @@ $search-input-height-mobile: 36px
           right: 0
 
         .ng-select-bottom
-          height: calc(100vh - #{var(--header-height)})
+          height: auto
+          max-height: calc(100vh - #{var(--header-height)})
           overflow-y: auto
           margin: 0
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70497

# What are you trying to accomplish?
Prevent the global search dropdown from taking full viewport height on mobile
when only few results are shown.

## Screenshots
<img width="320" height="622" alt="Screenshot 2026-02-03 at 09 12 39" src="https://github.com/user-attachments/assets/24d3e54c-ec06-40e9-a0de-c07f2c48306c" />

# What approach did you choose and why?
Use max-height instead of a fixed height so the dropdown grows naturally
with its content and only becomes scrollable once it exceeds the viewport.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
