### PR TITLE
[70792] Calendar widget not visible with Firefox

### DIFF
--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.sass
@@ -1,3 +1,6 @@
+op-wp-calendar
+  height: 100%
+
 .op-wp-calendar
   --fc-border-color: var(--borderColor-default)
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70792

# What are you trying to accomplish?
Allow calendars to span the whole available height and leave it to the container to limit it. Actually, I could not reproduce the original issue, the calendar was correctly shown in Firefox. However, it was weirdly cut after approx. 200px in all browsers even though the widget had more space.

## Screenshots
<img width="735" height="665" alt="Bildschirmfoto 2026-02-03 um 10 25 35" src="https://github.com/user-attachments/assets/861869df-52db-4a9f-8b03-addc142049ca" />
