### PR TITLE
[71144] WP type drop-down is cut off on mobile

### DIFF
--- a/frontend/src/global_styles/layout/work_packages/_full_view.sass
+++ b/frontend/src/global_styles/layout/work_packages/_full_view.sass
@@ -136,7 +136,6 @@
 @media only screen and (max-width: $breakpoint-md)
   .work-packages--subject-type-row
     flex-wrap: wrap
-    overflow: hidden
 
 #work-packages-index
   .op-uc-link_permalink


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71144

# What are you trying to accomplish?
Allow overflow in the mobile WP subject row. Due to the wrap, the subject will actually never overflow, but the type selector will once opened

## Screenshots

<img width="472" height="689" alt="Bildschirmfoto 2026-02-03 um 11 10 25" src="https://github.com/user-attachments/assets/4237956e-4fc1-4fb1-acdb-8d08cd0224ca" />
