### PR TITLE
Fix/71345/meeting reopen

### DIFF
--- a/modules/meeting/app/components/meetings/index/form_component.html.erb
+++ b/modules/meeting/app/components/meetings/index/form_component.html.erb
@@ -86,8 +86,7 @@
               end
 
               frequency_row.with_column(
-                flex: 1,
-                hidden: @meeting.frequency_working_days?
+                flex: 1
               ) do
                 flex_layout do |end_after|
                   end_after.with_row(

--- a/modules/meeting/app/contracts/recurring_meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/recurring_meetings/update_contract.rb
@@ -55,6 +55,9 @@ module RecurringMeetings
     end
 
     def all_instantiated_meetings_covered
+      # Don't run coverage call when model itself is invalid
+      # as that might lead to unexpected errors
+      return if model.errors.any?
       return if model.end_after_never?
       return unless model.reschedule_required?
 

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -358,5 +358,19 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
         )
       end
     end
+
+    context "when changing end_after to iterations without providing iterations count" do
+      let(:params) do
+        {
+          end_after: "iterations",
+          iterations: nil
+        }
+      end
+
+      it "fails validation without raising an exception" do
+        expect(service_result).not_to be_success
+        expect(service_result.errors.messages[:iterations]).to include("is not a number.")
+      end
+    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/71345/activity

When trying to reopen a meeting, the iterations value was hidden and resulted in being saved as nil, which triggers an error in the `UpdateContract#all_instantiated_meetings_covered`. This method should not validate when the model itself is invalid