### PR TITLE
[#70585] Images are broken on moved meeting agenda item

### DIFF
--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -304,7 +304,7 @@ class MeetingAgendaItemsController < ApplicationController
 
     ::MeetingAgendaItems::CreateService
       .new(user: current_user)
-      .call(attributes)
+      .call(attributes, source_meeting_id: @meeting_agenda_item.meeting_id)
   end
 
   def init_next_meeting_occurrence

--- a/modules/meeting/app/services/meeting_agenda_items/concerns/copy_attachments.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/concerns/copy_attachments.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,32 +29,41 @@
 #++
 
 module MeetingAgendaItems
-  class CreateService < ::BaseServices::Create
-    include AfterPerformHook
-    include Concerns::CopyAttachments
+  module Concerns
+    module CopyAttachments
+      private
 
-    alias_method :original_after_perform, :after_perform
+      def copy_attachments_from_meeting(agenda_item, source_meeting_id)
+        return if agenda_item.notes.blank?
+        return if agenda_item.meeting_id == source_meeting_id
 
-    def call(params, source_meeting_id: nil)
-      @source_meeting_id = source_meeting_id
-      super(params)
-    end
+        source_meeting = Meeting.find(source_meeting_id)
+        source_meeting.attachments.each do |attachment|
+          next unless agenda_item.notes.include?("/attachments/#{attachment.id}/")
 
-    def after_perform(call)
-      # The reload is required because, the time slot calculations are changing the
-      # `start_time`, `end_time` attributes and they should be available for rendering.
-      call.result.reload
-      original_after_perform(call)
+          copy_attachment(attachment, agenda_item.meeting, agenda_item)
+        end
+      end
 
-      copy_attachments_from_source(call.result) if call.success?
+      def copy_attachment(source_attachment, target_meeting, agenda_item)
+        copy = Attachment.new(
+          source_attachment
+            .dup
+            .attributes
+            .except("file")
+            .merge("author_id" => user.id, "container_id" => target_meeting.id)
+        )
 
-      call
-    end
+        source_attachment.file.copy_to(copy)
+        copy.save!
 
-    private
+        updated_notes = agenda_item.notes.gsub(
+          "/api/v3/attachments/#{source_attachment.id}/content",
+          "/api/v3/attachments/#{copy.id}/content"
+        )
 
-    def copy_attachments_from_source(agenda_item)
-      copy_attachments_from_meeting(agenda_item, @source_meeting_id) if @source_meeting_id.present?
+        agenda_item.update!(notes: updated_notes)
+      end
     end
   end
 end

--- a/modules/meeting/app/services/meeting_agenda_items/update_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/update_service.rb
@@ -31,6 +31,7 @@
 module MeetingAgendaItems
   class UpdateService < ::BaseServices::Update
     include AfterPerformHook
+    include Concerns::CopyAttachments
 
     alias_method :original_after_perform, :after_perform
 
@@ -45,42 +46,9 @@ module MeetingAgendaItems
     def after_perform(call)
       original_after_perform(call)
 
-      if call.success? && @old_meeting_id != call.result.meeting_id
-        copy_attachments_to_new_meeting(call.result, @old_meeting_id)
-      end
+      copy_attachments_from_meeting(call.result, @old_meeting_id) if call.success?
 
       call
-    end
-
-    def copy_attachments_to_new_meeting(agenda_item, old_meeting_id)
-      return if agenda_item.notes.blank?
-
-      old_meeting = Meeting.find(old_meeting_id)
-      old_meeting.attachments.each do |attachment|
-        next unless agenda_item.notes.include?("/attachments/#{attachment.id}/")
-
-        copy_attachment(attachment, agenda_item.meeting, agenda_item)
-      end
-    end
-
-    def copy_attachment(source_attachment, target_meeting, agenda_item)
-      copy = Attachment.new(
-        source_attachment
-          .dup
-          .attributes
-          .except("file")
-          .merge("author_id" => user.id, "container_id" => target_meeting.id)
-      )
-
-      source_attachment.file.copy_to(copy)
-      copy.save!
-
-      updated_notes = agenda_item.notes.gsub(
-        "/api/v3/attachments/#{source_attachment.id}/content",
-        "/api/v3/attachments/#{copy.id}/content"
-      )
-
-      agenda_item.update!(notes: updated_notes)
     end
   end
 end

--- a/modules/meeting/app/services/meeting_agenda_items/update_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/update_service.rb
@@ -32,6 +32,8 @@ module MeetingAgendaItems
   class UpdateService < ::BaseServices::Update
     include AfterPerformHook
 
+    alias_method :original_after_perform, :after_perform
+
     private
 
     def before_perform(params)
@@ -41,7 +43,7 @@ module MeetingAgendaItems
     end
 
     def after_perform(call)
-      super
+      original_after_perform(call)
 
       if call.success? && @old_meeting_id != call.result.meeting_id
         copy_attachments_to_new_meeting(call.result, @old_meeting_id)

--- a/modules/meeting/app/services/meeting_agenda_items/update_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/update_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,5 +31,54 @@
 module MeetingAgendaItems
   class UpdateService < ::BaseServices::Update
     include AfterPerformHook
+
+    private
+
+    def before_perform(params)
+      @old_meeting_id = model.meeting_id if model.persisted?
+
+      super
+    end
+
+    def after_perform(call)
+      super
+
+      if call.success? && @old_meeting_id != call.result.meeting_id
+        copy_attachments_to_new_meeting(call.result, @old_meeting_id)
+      end
+
+      call
+    end
+
+    def copy_attachments_to_new_meeting(agenda_item, old_meeting_id)
+      return if agenda_item.notes.blank?
+
+      old_meeting = Meeting.find(old_meeting_id)
+      old_meeting.attachments.each do |attachment|
+        next unless agenda_item.notes.include?("/attachments/#{attachment.id}/")
+
+        copy_attachment(attachment, agenda_item.meeting, agenda_item)
+      end
+    end
+
+    def copy_attachment(source_attachment, target_meeting, agenda_item)
+      copy = Attachment.new(
+        source_attachment
+          .dup
+          .attributes
+          .except("file")
+          .merge("author_id" => user.id, "container_id" => target_meeting.id)
+      )
+
+      source_attachment.file.copy_to(copy)
+      copy.save!
+
+      updated_notes = agenda_item.notes.gsub(
+        "/api/v3/attachments/#{source_attachment.id}/content",
+        "/api/v3/attachments/#{copy.id}/content"
+      )
+
+      agenda_item.update!(notes: updated_notes)
+    end
   end
 end

--- a/modules/meeting/spec/services/meeting_agenda_items/create_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_agenda_items/create_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe MeetingAgendaItems::CreateService do
+  let(:user) { create(:user, member_with_permissions: { project => %i[view_meetings manage_agendas] }) }
+  let(:project) { create(:project) }
+  let(:meeting_a) { create(:meeting, project:) }
+  let(:meeting_b) { create(:meeting, project:) }
+  let(:source_meeting_id) { meeting_a.id }
+
+  subject(:service_call) { described_class.new(user:).call(params, source_meeting_id: source_meeting_id) }
+
+  describe "duplicating agenda item to a different meeting" do
+    context "when agenda item has attachments referenced in notes" do
+      let!(:attachment) do
+        create(:attachment, container: meeting_a, filename: "test.png", author: user)
+      end
+      let(:params) do
+        {
+          meeting_id: meeting_b.id,
+          title: "Duplicated item",
+          notes: "Here is an image: ![test](/api/v3/attachments/#{attachment.id}/content)"
+        }
+      end
+
+      it "copies the attachment to the new meeting" do
+        expect { service_call }.to change { meeting_b.attachments.count }.by(1)
+      end
+
+      it "updates the notes to reference the new attachment" do
+        service_call
+        created_item = service_call.result
+
+        new_attachment = Attachment.last
+
+        expect(created_item.notes).not_to include("/api/v3/attachments/#{attachment.id}/content")
+        expect(created_item.notes).to include("/api/v3/attachments/#{new_attachment.id}/content")
+      end
+    end
+
+    context "when agenda item has no attachments" do
+      let(:params) do
+        {
+          meeting_id: meeting_b.id,
+          title: "Item without attachments",
+          notes: "Just text"
+        }
+      end
+
+      it "does not create any attachments" do
+        expect { service_call }.not_to change(Attachment, :count)
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/services/meeting_agenda_items/update_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_agenda_items/update_service_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe MeetingAgendaItems::UpdateService do
+  let(:user) { create(:user, member_with_permissions: { project => %i[view_meetings manage_agendas] }) }
+  let(:project) { create(:project) }
+  let(:meeting_a) { create(:meeting, project:) }
+  let(:meeting_b) { create(:meeting, project:) }
+  let(:agenda_item) { create(:meeting_agenda_item, meeting: meeting_a) }
+
+  subject(:service_call) { described_class.new(user:, model: agenda_item).call(params) }
+
+  describe "moving agenda item to a different meeting" do
+    context "when agenda item has attachments referenced in notes" do
+      let!(:attachment) do
+        create(:attachment, container: meeting_a, filename: "test.png", author: user)
+      end
+      let(:params) do
+        {
+          meeting_id: meeting_b.id,
+          meeting_section: nil
+        }
+      end
+      let(:initial_notes) { "Here is an image: ![test](/api/v3/attachments/#{attachment.id}/content)" }
+
+      before do
+        agenda_item.update_column(:notes, initial_notes)
+      end
+
+      it "copies the attachment to the new meeting" do
+        expect { service_call }.to change { meeting_b.attachments.count }.by(1)
+      end
+
+      it "updates the notes to reference the new attachment" do
+        service_call
+        agenda_item.reload
+
+        new_attachment = Attachment.last
+
+        expect(agenda_item.notes).not_to include("/api/v3/attachments/#{attachment.id}/content")
+        expect(agenda_item.notes).to include("/api/v3/attachments/#{new_attachment.id}/content")
+      end
+    end
+
+    context "when agenda item has no attachments" do
+      let(:params) { { meeting_id: meeting_b.id, meeting_section: nil } }
+
+      before do
+        agenda_item.update_column(:notes, "Just text")
+      end
+
+      it "does not create any attachments" do
+        expect { service_call }.not_to change(Attachment, :count)
+      end
+    end
+
+    context "when meeting does not change" do
+      let!(:attachment) do
+        create(:attachment, container: meeting_a, filename: "test.png", author: user)
+      end
+      let(:params) { { title: "Updated title" } }
+
+      before do
+        agenda_item.update_column(:notes, "Here is an image: ![test](/api/v3/attachments/#{attachment.id}/content)")
+      end
+
+      it "does not copy attachments" do
+        expect { service_call }.not_to change(Attachment, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70585

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Copy attachments over to the new meeting when agenda items with attachments are moved or duplicated as part of the create and update services
- This ensures no broken images when the original meeting and attachments are destroyed

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
