### PR TITLE
Append ICS as separate mail part, and set publish for subscriptions

### DIFF
--- a/modules/meeting/app/mailers/concerns/calendar_attachment.rb
+++ b/modules/meeting/app/mailers/concerns/calendar_attachment.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CalendarAttachment
+  extend ActiveSupport::Concern
+
+  private
+
+  # Adds a downloadable .ics attachment for manual import
+  #
+  # @param ics_content [String] the ICS calendar content
+  # @param cancelled [Boolean] whether this is a cancellation (uses CANCEL method) or invitation (REQUEST)
+  def add_calendar_attachment(ics_content, cancelled:)
+    method = cancelled ? "CANCEL" : "REQUEST"
+
+    # Add as downloadable attachment for clients that prefer downloading
+    attachments["meeting.ics"] = {
+      mime_type: "text/calendar; method=#{method}; charset=UTF-8",
+      content: ics_content
+    }
+  end
+
+  # Adds the calendar content as a text/calendar MIME part to enable
+  # calendar interaction buttons in email clients (Outlook, Apple Mail, Thunderbird)
+  #
+  # @param message [Mail::Message] the mail message to attach calendar to
+  # @param ics_content [String] the ICS calendar content
+  # @param cancelled [Boolean] whether this is a cancellation (uses CANCEL method) or invitation (REQUEST)
+  def add_calendar_part(message, ics_content, cancelled:)
+    method = cancelled ? "CANCEL" : "REQUEST"
+
+    calendar_part = Mail::Part.new do
+      content_type "text/calendar; method=#{method}; charset=UTF-8"
+      body ics_content
+    end
+
+    wrapper = message.parts.find { |p| p.content_type&.start_with?("multipart/alternative") } || message
+    wrapper.add_part(calendar_part)
+  end
+end

--- a/modules/meeting/app/mailers/meeting_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_mailer.rb
@@ -29,6 +29,8 @@
 #++
 
 class MeetingMailer < UserMailer
+  include CalendarAttachment
+
   def invited(meeting, user, actor)
     @actor = actor
     @meeting = meeting
@@ -152,12 +154,17 @@ class MeetingMailer < UserMailer
       call = ics_service_call(meeting, user, **args)
 
       call.on_success do
-        attachments["meeting.ics"] = {
-          mime_type: "text/calendar; method=REQUEST; charset=UTF-8",
-          content: call.result
-        }
+        ics_content = call.result
+        cancelled = args[:cancelled] || false
 
-        yield
+        # The attachment has to be added before the mail is created
+        add_calendar_attachment(ics_content, cancelled:)
+
+        message = yield
+
+        add_calendar_part(message, ics_content, cancelled:)
+
+        message
       end
 
       call.on_failure do
@@ -184,7 +191,5 @@ class MeetingMailer < UserMailer
 
   def set_headers(meeting)
     open_project_headers "Project" => meeting.project.identifier, "Meeting-Id" => meeting.id
-    headers["Content-Type"] = 'text/calendar; charset=utf-8; method="PUBLISH"; name="meeting.ics"'
-    headers["Content-Transfer-Encoding"] = "8bit"
   end
 end

--- a/modules/meeting/app/mailers/meeting_series_mailer.rb
+++ b/modules/meeting/app/mailers/meeting_series_mailer.rb
@@ -29,6 +29,8 @@
 #++
 
 class MeetingSeriesMailer < UserMailer
+  include CalendarAttachment
+
   def invited(series, user, actor)
     @actor = actor
     @series = series
@@ -90,16 +92,23 @@ class MeetingSeriesMailer < UserMailer
 
   private
 
-  def with_attached_ics(series, user)
+  def with_attached_ics(series, user, cancelled: false)
     User.execute_as(user) do
       call = ::RecurringMeetings::ICalService
-        .new(user:, series: series)
-        .generate_series
+        .new(user:, series:)
+        .generate_series(cancelled:)
 
       call.on_success do
-        attachments["meeting.ics"] = call.result
+        ics_content = call.result
 
-        yield
+        # The attachment has to be added before the mail is created
+        add_calendar_attachment(ics_content, cancelled:)
+
+        message = yield
+
+        add_calendar_part(message, ics_content, cancelled:)
+
+        message
       end
 
       call.on_failure do
@@ -110,7 +119,5 @@ class MeetingSeriesMailer < UserMailer
 
   def set_headers(series)
     open_project_headers "Project" => series.project.identifier, "Meeting-Id" => series.id
-    headers["Content-Type"] = 'text/calendar; charset=utf-8; method="PUBLISH"; name="meeting.ics"'
-    headers["Content-Transfer-Encoding"] = "8bit"
   end
 end

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -52,6 +52,9 @@ module AllMeetings
           calendar.add_series_event(recurring_meeting:, cancelled: false)
         end
 
+        # Set PUBLISH method for subscription feeds (informational, no RSVP expected)
+        calendar.publish
+
         ServiceResult.success(result: calendar.to_ical)
       end
     rescue StandardError => e

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -34,6 +34,8 @@ module Meetings
   class IcalendarBuilder
     attr_reader :builder_internal_timezone, :calendar, :all_times, :calendar_generated_for_user
 
+    delegate :publish, to: :calendar
+
     def initialize(timezone:, user: User.current)
       @calendar_generated_for_user = user
       @builder_internal_timezone = timezone

--- a/modules/meeting/spec/mailers/meeting_mailer_spec.rb
+++ b/modules/meeting/spec/mailers/meeting_mailer_spec.rb
@@ -273,6 +273,55 @@ RSpec.describe MeetingMailer do
       end
     end
 
+    describe "calendar MIME part for email client integration" do
+      def find_calendar_part(message)
+        message.all_parts.find { |p| p.content_type&.include?("text/calendar") && !p.content_disposition&.include?("attachment") }
+      end
+
+      it "includes a text/calendar part with REQUEST method" do
+        calendar_part = find_calendar_part(mail)
+
+        expect(calendar_part).to be_present
+        expect(calendar_part.content_type).to include("text/calendar")
+        expect(calendar_part.content_type).to include("method=REQUEST")
+      end
+
+      it "includes the ICS content in the calendar part" do
+        calendar_part = find_calendar_part(mail)
+
+        expect(calendar_part.body.decoded).to include("BEGIN:VCALENDAR")
+        expect(calendar_part.body.decoded).to include("METHOD:REQUEST")
+        expect(calendar_part.body.decoded).to include("Important meeting")
+      end
+
+      it "also includes the ICS as a downloadable attachment" do
+        attachment = mail.attachments["meeting.ics"]
+
+        expect(attachment).to be_present
+        expect(attachment.content_type).to include("text/calendar")
+        expect(attachment.body.decoded).to include("BEGIN:VCALENDAR")
+      end
+
+      context "when the meeting is cancelled" do
+        let(:mail) { described_class.cancelled(meeting, author, author) }
+
+        it "includes a text/calendar part with CANCEL method" do
+          calendar_part = find_calendar_part(mail)
+
+          expect(calendar_part).to be_present
+          expect(calendar_part.content_type).to include("text/calendar")
+          expect(calendar_part.content_type).to include("method=CANCEL")
+        end
+
+        it "includes the ICS content with CANCEL method" do
+          calendar_part = find_calendar_part(mail)
+
+          expect(calendar_part.body.decoded).to include("BEGIN:VCALENDAR")
+          expect(calendar_part.body.decoded).to include("METHOD:CANCEL")
+        end
+      end
+    end
+
     context "with a recipient with another time zone" do
       let!(:preference) { watcher1.pref.update(time_zone: "Asia/Tokyo") }
       let(:mail) { described_class.icalendar_notification(meeting, watcher1, author) }


### PR DESCRIPTION
Additionally to adding the ICS file as a plain attachment, adding it as a second part with "text/calendar; method=REQUEST; charset=UTF-8" (or method=CANCEL when cancelled), more mail clients will pick this up.

At the same time, the ICS subscription calendar was not set to publish, showing invites as tentative/pending