### PR TITLE
[58458] Replace ajax loading indicator with Primer component

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -182,7 +182,11 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% end %>
   </div>
-  <div id="ajax-indicator" style="display:none;"><span><%= t(:label_loading) %></span></div>
+  <%= render Primer::Beta::Spinner.new(
+        size: :large,
+        hidden: true,
+        wrapper_arguments: { id: "global-loading-indicator", position: :absolute }
+      ) %>
 </div>
 <%# Properly decides main menu expanded state and width before its drawn. Fixes flickering side menu
         where menu is first expanded, then being collapsed in angular. %>

--- a/frontend/src/global_styles/content/_global_loading_indicator.sass
+++ b/frontend/src/global_styles/content/_global_loading_indicator.sass
@@ -26,44 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-/***** Ajax indicator *****
-
-#ajax-indicator
-  position: absolute
-  /* fixed not supported by IE
-  background-color: #eee
-  border: 1px solid #bbb
-  top: 35%
-  left: 40%
-  width: 20%
-  font-weight: var(--base-text-weight-bold)
-  text-align: center
-  padding: 0.6em
-  z-index: 100
-  opacity: 0.5
-
-html > body #ajax-indicator
-  position: fixed
-
-#ajax-indicator span, .ajax-indicator
-  background-position: 0% 40%
-  background-repeat: no-repeat
-  background-image: url('../../assets/images/loading.gif')
-
-.ajax_appended_information.loading .ajax-indicator
-  padding-left: 22px
-  display: block
-  width: 0
-  margin-left: auto
-  margin-right: auto
-  white-space: nowrap
-
-/***** Ajax indicator *****
-
-// FIXME: find out which values actually apply
-#ajax-indicator
-  position: absolute
-  /* fixed not supported by IE
-  background-color: #d9d9d9
-  border: 1px solid #8f8f8f
-  opacity: 0.7
+/***** Global loading indicator *****
+#global-loading-indicator
+  top: 50%
+  left: 50%

--- a/frontend/src/global_styles/content/_index.sass
+++ b/frontend/src/global_styles/content/_index.sass
@@ -45,7 +45,7 @@
 @import principal-list
 @import progress_bar
 @import form_error_messages
-@import ajax_indicator
+@import global_loading_indicator
 @import tooltips
 @import scrollable_tabs
 @import tabs

--- a/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/filter/filters-form.controller.ts
@@ -32,6 +32,10 @@
 import { Controller } from '@hotwired/stimulus';
 import { renderStreamMessage } from '@hotwired/turbo';
 import { debounce } from 'lodash';
+import {
+  hideElement,
+  showElement,
+} from 'core-app/shared/helpers/dom-helpers';
 
 interface PrimerTextFieldElement extends HTMLElement {
   inputElement:HTMLInputElement;
@@ -398,8 +402,8 @@ export default class FiltersFormController extends Controller {
     // Remove the page parameter when changing filters, so that pagination resets
     params.delete('page');
     params.set('filters', newFilters);
-    const ajaxIndicator = document.querySelector<HTMLElement>('#ajax-indicator')!;
-    ajaxIndicator.style.display = '';
+    const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator')!;
+    showElement(loadingIndicator);
 
     const pathName = this.urlPathNameValue || window.location.pathname;
     const url = `${pathName}?${params.toString()}`;
@@ -413,11 +417,11 @@ export default class FiltersFormController extends Controller {
         .then((response:Response) => response.text())
         .then((html:string) => {
           renderStreamMessage(html);
-          ajaxIndicator.style.display = 'none';
+          hideElement(loadingIndicator);
         })
         .catch((error:Error) => {
           console.error('Error:', error);
-          ajaxIndicator.style.display = 'none';
+          hideElement(loadingIndicator);
         });
     } else {
       window.location.href = url;

--- a/frontend/src/stimulus/helpers/request-helpers.ts
+++ b/frontend/src/stimulus/helpers/request-helpers.ts
@@ -34,16 +34,16 @@ import invariant from 'tiny-invariant';
 
 export function post(url:string|URL, options?:Options) {
   const request = new FetchRequest('post', url, options);
-  return withAjaxIndicator(request.perform());
+  return withLoadingIndicator(request.perform());
 }
 
-function withAjaxIndicator(request:Promise<FetchResponse>) {
-  const ajaxIndicator = document.querySelector<HTMLElement>('#ajax-indicator');
-  invariant(ajaxIndicator, 'Expected an Element with id ajax-indicator to be present');
-  showElement(ajaxIndicator);
+function withLoadingIndicator(request:Promise<FetchResponse>) {
+  const loadingIndicator = document.querySelector<HTMLElement>('#global-loading-indicator');
+  invariant(loadingIndicator, 'Expected an Element with id global-loading-indicator to be present');
+  showElement(loadingIndicator);
 
   return request.then((response) => {
-    hideElement(ajaxIndicator);
+    hideElement(loadingIndicator);
     return response;
   });
 }

--- a/modules/reporting/spec/features/support/pages/cost_report_page.rb
+++ b/modules/reporting/spec/features/support/pages/cost_report_page.rb
@@ -81,7 +81,7 @@ module Pages
 
     def wait_for_page_to_reload
       wait_for_network_idle
-      expect(page).to have_no_css("#ajax-indicator")
+      expect(page).to have_no_css("#global-loading-indicator")
     end
 
     def path


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/58458
https://community.openproject.org/wp/68625

# What are you trying to accomplish?
Replace old ajax loading indicator with Primer spinner

## Screenshots
**Before**
<img width="1396" height="585" alt="Bildschirmfoto 2026-02-04 um 10 42 35" src="https://github.com/user-attachments/assets/68483fb4-af4b-4264-a9e5-a878cc4846e5" />

**After**
<img width="1178" height="515" alt="Bildschirmfoto 2026-02-04 um 10 47 21" src="https://github.com/user-attachments/assets/b0bc6b42-8021-42c1-8cfd-01a09e08f4a0" />


# What approach did you choose and why?
This is a pragmatic fix to replace the existing old loading indicator with a Primer component. The best solution is always a skeleton in place indicating the expected content. However, this requires more effort while this was an 30min fix and is already an improvement.
