### PR TITLE
[69747] Attribute help text do not show up on Project overview on initial page load

### DIFF
--- a/modules/grids/app/components/grids/widgets/project_status.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_status.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     component_wrapper do
       flex_layout do |flex|
         flex.with_row(mb: 3) do
-          render(Projects::StatusButtonComponent.new(project:, user: current_user, hide_help_text: true))
+          render(Projects::StatusButtonComponent.new(project:, user: current_user))
         end
 
         flex.with_row do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69747

# What are you trying to accomplish?
Always show the AttributeHelpText for project status on overview