### PR TITLE
fix: correct "Podppzycje" typo in Polish translation

### DIFF
--- a/config/locales/crowdin/pl.yml
+++ b/config/locales/crowdin/pl.yml
@@ -3689,7 +3689,7 @@ pl:
   label_subproject: "Podprojekt"
   label_subproject_new: "Nowy podprojekt"
   label_subproject_plural: "Podprojekty"
-  label_subitems: "Podppzycje"
+  label_subitems: "Podpozycje"
   label_subtask_plural: "Zadania podrzędne"
   label_summary: "Podsumowanie"
   label_system: "System"

--- a/modules/grids/config/locales/crowdin/js-pl.yml
+++ b/modules/grids/config/locales/crowdin/js-pl.yml
@@ -30,7 +30,7 @@ pl:
         project_status_beta:
           title: 'Status (BETA)'
         subprojects:
-          title: 'Podppzycje'
+          title: 'Podpozycje'
         project_favorites:
           title: 'Ulubione projekty'
           no_results: 'Obecnie nie masz żadnych ulubionych projektów. Kliknij ikonę gwiazdki na pulpicie nawigacyjnym projektu, aby dodać go do ulubionych.'

--- a/modules/grids/config/locales/crowdin/pl.yml
+++ b/modules/grids/config/locales/crowdin/pl.yml
@@ -5,7 +5,7 @@ pl:
       empty: "Ten widżet jest obecnie pusty."
       not_available: "Ten widżet jest niedostępny."
       subitems:
-        title: "Podppzycje"
+        title: "Podpozycje"
         no_results: "Nie ma żadnych widocznych elementów podrzędnych."
         view_all_subitems: "Wyświetl wszystkie podppzycje"
         button_text: "Podelement"


### PR DESCRIPTION
# Ticket

## What are you trying to accomplish?

Fix a typo in the Polish UI labels by correcting "Podppzycje" to "Podpozycje" to ensure proper spelling and improve UI text quality.

I corrected the typo directly in the localization file.
This is a minimal, low-risk change limited to i18n content, with no impact on logic or behavior. No alternative approaches were necessary.

Merge checklist

 - [ ] Added/updated tests (not applicable – text-only change)
 - [ ] Added/updated documentation in Lookbook (not applicable)
 - [ ] Tested major browsers (not applicable – no UI behavior change)