### PR TITLE
Allow to use regular API Keys for MCP requests

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -59,7 +59,7 @@ OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope
 end
 
 OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope::MCP_SCOPE, { store: false }) do |_|
-  %i[oauth jwt_oidc]
+  %i[oauth jwt_oidc user_basic_auth basic_auth_failure]
 end
 
 Rails.application.configure do |app|

--- a/spec/requests/api/v3/support/mcp_examples.rb
+++ b/spec/requests/api/v3/support/mcp_examples.rb
@@ -174,4 +174,10 @@ RSpec.shared_examples_for "MCP unauthenticated response" do
     subject
     expect(last_response.headers["WWW-Authenticate"]).to be_present
   end
+
+  it "indicates resource_metadata in the WWW-Authenticate header" do
+    subject
+    keys = last_response.headers["WWW-Authenticate"].split.select { |s| s.include?("=") }.map { |s| s.split("=").first }
+    expect(keys).to include("resource_metadata")
+  end
 end

--- a/spec/requests/mcp/tools_list_spec.rb
+++ b/spec/requests/mcp/tools_list_spec.rb
@@ -69,14 +69,28 @@ RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
       expect(tool.fetch("description")).to eq(tool_config.description)
     end
 
-    context "when not passing a Bearer token" do
+    context "when not passing a token" do
       subject do
+        # TODO: It's actually a hack that we expect clients to provide this header for proper WWW-Authenticate responses
+        # Regular clients will never see the extended WWW-Authenticate headers with resource_metadata hints
         header "X-Authentication-Scheme", "Bearer"
         header "Content-Type", "application/json"
         post "/mcp", request_body.to_json
       end
 
       it_behaves_like "MCP unauthenticated response"
+    end
+
+    context "when passing an API key via Basic auth" do
+      subject do
+        header "Authorization", "Basic #{Base64.encode64("apikey:#{apikey.plain_value}")}"
+        header "Content-Type", "application/json"
+        post "/mcp", request_body.to_json
+      end
+
+      let(:apikey) { create(:api_token) }
+
+      it_behaves_like "MCP result response"
     end
 
     context "when passing a Bearer token with a wrong scope" do


### PR DESCRIPTION
Some clients, such as Claude code require dynamic client registration for their regular workflow. However, they allow to fallback to static HTTP headers for authentication.

This approach allows to construct the corresponding header for Basic authentication and add it to Claude.

# Ticket
Backport into 17.1 experimental features for https://community.openproject.org/wp/71147