### PR TITLE
[69491] Scroll bar overlaps input fields on PIR

### DIFF
--- a/app/components/projects/wizard/page_component.sass
+++ b/app/components/projects/wizard/page_component.sass
@@ -32,8 +32,10 @@
   min-height: 0
   grid-template-areas: "sidebar main help"
   grid-template-columns: 300px 1fr 350px
-  gap: var(--base-size-16, 1rem)
   overflow: hidden
+
+  &--main
+    padding: 0 var(--base-size-16, 1rem)
 
   &--sidebar,
   &--help


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69491

# What are you trying to accomplish?
Add padding instead of gap to avoid that the scrollbar overlaps the actual content

## Screenshots
<img width="1498" height="564" alt="Bildschirmfoto 2026-02-05 um 08 39 41 1" src="https://github.com/user-attachments/assets/bbef3693-890e-4aac-99ad-e7582aa59491" />

