### PR TITLE
[70100] project attributes have a border on mobile fields 

### DIFF
--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -383,8 +383,6 @@ $scrollbar-size: 10px
   display: inline-block
   width: 100%
   padding: var(--base-size-4, 4px) !important
-  @media (hover: none) and (pointer: coarse)
-    border-color: var(--borderColor-default) !important
   @media (hover: hover)
     &:hover
       border-color: var(--borderColor-default) !important


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70100

# What are you trying to accomplish?
 Remove border from mobile style of project attributes

## Screenshots

<img width="192" height="477" alt="Bildschirmfoto 2026-02-05 um 08 52 17" src="https://github.com/user-attachments/assets/be3f4612-90ad-48b5-8676-9b1631aa1981" />
