### PR TITLE
increase robustness of wizard pages in case of disabled fields only page

### DIFF
--- a/app/forms/projects/wizard/custom_fields_form.rb
+++ b/app/forms/projects/wizard/custom_fields_form.rb
@@ -33,6 +33,11 @@ module Projects
       include ::CustomFields::CustomFieldRendering
 
       form do |custom_fields_form|
+        # This placeholder is relevant in cases where no custom fields are rendered at all or all
+        # custom fields rendered are disabled. Without it, the form might be completely empty and
+        # the controller would complain about a missing parameter namespace expected by the ActionController::Parameters.
+        custom_fields_form.hidden(name: "_placeholder", value: "")
+
         render_custom_fields(form: custom_fields_form)
       end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/71384

# What are you trying to accomplish?

Avoid the browser not sending a `project` parameter scope in case only disabled fields are displayed on a project wizard page.

