### PR TITLE
[70458] Project status button is missing colors in the dropdown

### DIFF
--- a/app/components/op_primer/status_button_component.html.erb
+++ b/app/components/op_primer/status_button_component.html.erb
@@ -11,7 +11,7 @@
 
       @items.each do |option|
         menu.with_item(**option.item_arguments) do |item|
-          item.with_leading_visual_icon(icon: option.icon) if option.icon
+          item.with_leading_visual_icon(icon: option.icon, classes: highlight_class_name(option, :inline)) if option.icon
           item.with_description.with_content(option.description) if option.description
 
           classes = option.colored? ? highlight_class_name(option, :inline) : ""

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -7,11 +7,11 @@
 <% project_phase_color_css %>
 
 <% Meetings::Statuses::AVAILABLE.each do |meeting_status| %>
-  <% resource_color_css("meeting_status", meeting_status) %>
+  <% resource_color_css("meeting_status", meeting_status, inline_foreground: true) %>
 <% end %>
 
 <% Projects::Statuses::AVAILABLE.each do |project_status| %>
-  <% resource_color_css("project_status", project_status) %>
+<% resource_color_css("project_status", project_status, inline_foreground: true) %>
 <% end %>
 
 <% color_css %>

--- a/app/views/highlighting/styles.css.erb
+++ b/app/views/highlighting/styles.css.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% Projects::Statuses::AVAILABLE.each do |project_status| %>
-<% resource_color_css("project_status", project_status, inline_foreground: true) %>
+  <% resource_color_css("project_status", project_status, inline_foreground: true) %>
 <% end %>
 
 <% color_css %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70458

# What are you trying to accomplish?
Set color for icons in status button of projects and meetings

## Screenshots
<img width="420" height="572" alt="Screenshot 2026-02-05 at 15 05 18" src="https://github.com/user-attachments/assets/fd9c18e3-1a8c-4ecc-af31-1819cb98770b" />
<img width="760" height="600" alt="Screenshot 2026-02-05 at 15 05 02" src="https://github.com/user-attachments/assets/e1ae0bd4-3bfc-4b1d-8766-7296150402b7" />
