### PR TITLE
[#70609] If user cancels a meeting that is currently happening, the meeting disappears from list  

### DIFF
--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -297,11 +297,16 @@ class RecurringMeetingsController < ApplicationController
     # Include ongoing scheduled occurrences by setting a start time in the past
     from_time = Time.current - @recurring_meeting.template.duration.hours
 
-    planned = @recurring_meeting
-      .scheduled_occurrences(limit: count + opened.count, from_time:)
+    # Get +1 scheduled_occurrences in case there is an ongoing cancelled occurrence
+    scheduled_times = @recurring_meeting
+      .scheduled_occurrences(limit: count + 1, from_time:)
       .reject { |start_time| opened.include?(start_time) }
+
+    has_ongoing = scheduled_times.any? { |start_time| start_time < Time.current }
+
+    planned = scheduled_times
       .map { |start_time| cancelled[start_time] || scheduled_meeting(start_time) }
-      .first([count, 0].max)
+      .first([(count + (has_ongoing ? 1 : 0)), 0].max)
 
     [opened.values.sort_by(&:start_time), planned]
   end

--- a/modules/meeting/app/controllers/recurring_meetings_controller.rb
+++ b/modules/meeting/app/controllers/recurring_meetings_controller.rb
@@ -293,8 +293,12 @@ class RecurringMeetingsController < ApplicationController
 
     # Planned meetings consist of scheduled occurrences and cancelled meetings
     # Open meetings are removed from the scheduled occurrences as they are displayed separately
+
+    # Include ongoing scheduled occurrences by setting a start time in the past
+    from_time = Time.current - @recurring_meeting.template.duration.hours
+
     planned = @recurring_meeting
-      .scheduled_occurrences(limit: count + opened.count)
+      .scheduled_occurrences(limit: count + opened.count, from_time:)
       .reject { |start_time| opened.include?(start_time) }
       .map { |start_time| cancelled[start_time] || scheduled_meeting(start_time) }
       .first([count, 0].max)

--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -238,8 +238,8 @@ class RecurringMeeting < ApplicationRecord
       .intersect?(%w[frequency start_date start_time start_time_hour iterations interval end_after end_date location])
   end
 
-  def scheduled_occurrences(limit:)
-    schedule.next_occurrences(limit, Time.current)
+  def scheduled_occurrences(limit:, from_time: Time.current)
+    schedule.next_occurrences(limit, from_time)
   end
 
   def first_occurrence
@@ -315,9 +315,10 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def upcoming_cancelled_meetings
+    # Include ongoing cancelled meetings by setting a start time in the past
     scheduled_meetings
-      .upcoming
       .cancelled
+      .where(start_time: (Time.current - template.duration.hours)..)
       .order(start_time: :asc)
   end
 

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
@@ -325,13 +325,13 @@ RSpec.describe "Recurring meetings show",
     let!(:ongoing_instance) do
       create :meeting,
              recurring_meeting:,
-             start_time: Time.zone.today + 10.hours - 10.minutes
+             start_time: Time.zone.today + 10.hours
     end
     let!(:ongoing) do
       create :scheduled_meeting,
              recurring_meeting:,
              meeting: ongoing_instance,
-             start_time: Time.zone.today + 10.hours - 10.minutes
+             start_time: Time.zone.today + 10.hours
     end
 
     it "shows the correct number of next occurrences (Regression #61194)" do

--- a/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
+++ b/modules/meeting/spec/requests/recurring_meetings/recurring_meetings_show_spec.rb
@@ -346,6 +346,41 @@ RSpec.describe "Recurring meetings show",
     end
   end
 
+  context "with a cancelled ongoing meeting" do
+    let(:recurring_meeting) do
+      create :recurring_meeting,
+             project:,
+             author: user,
+             start_time: Time.zone.today + 10.hours,
+             frequency: "daily",
+             end_after: "iterations",
+             iterations: 5
+    end
+
+    let!(:cancelled_ongoing) do
+      create :scheduled_meeting,
+             recurring_meeting:,
+             start_time: Time.zone.today + 10.hours,
+             cancelled: true
+    end
+
+    it "shows the cancelled ongoing meeting in the planned section (Bug #70609)" do
+      travel_to(Time.zone.today + 10.hours + 1.minute) do
+        get project_recurring_meeting_path(project, recurring_meeting)
+      end
+
+      cancelled_meeting_time = format_time(cancelled_ongoing.start_time)
+
+      planned = page.find("[data-test-selector='planned-table']")
+      expect(planned).to have_text cancelled_meeting_time
+      expect(planned).to have_row("Cancelled")
+
+      (1..4).each do |date|
+        expect(planned).to have_text format_time(Time.zone.today + date.days + 10.hours)
+      end
+    end
+  end
+
   context "when user has no permissions to access" do
     let(:current_user) { create(:user) }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/70609

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Update `scheduled_occurrences` to allow it to get occurrences from a past time (current time - template duration), which allows the "ongoing" cancelled occurrence to show up
- Update the controller code to allow that occurrence to actually show up (adjusting counts where necessary, etc)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
