### PR TITLE
[#71101] move pagination logic to tools base class

### DIFF
--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -35,6 +35,10 @@ module McpTools
         "tools/#{name}"
       end
 
+      def page_size
+        100
+      end
+
       def default_title(title = nil)
         @default_title = title if title.present?
 
@@ -54,7 +58,16 @@ module McpTools
       end
 
       def input_schema(schema = nil)
-        @input_schema = schema if schema.present?
+        if schema.present?
+          page = {
+            type: "number",
+            default: 1,
+            description: "Page number for pagination. If no page is defined, the first result set is returned. " \
+                         "To get the rest of the results, use a page number of 2 or higher."
+          }
+
+          @input_schema = schema.deep_merge({ properties: { page: } })
+        end
 
         @input_schema
       end
@@ -180,15 +193,20 @@ module McpTools
     # Filtering happens based on the filters defined for the tool, see .filter.
     def apply_filters(scope, params)
       params.each do |name, value|
-        filter_proc = filter_proc_for(name)
+        filter_proc = self.class.filters[name]
+        return scope unless filter_proc
+
         scope = filter_proc.call(scope, value)
       end
 
       scope
     end
 
-    def filter_proc_for(name)
-      self.class.filters[name] || raise(ArgumentError, "Don't know how to handle filter argument called #{name}")
+    def apply_pagination(scope, query)
+      page = query[:page] || 1
+      page_size = self.class.page_size
+
+      scope.offset((page - 1) * page_size).limit(page_size)
     end
   end
 end

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -57,10 +57,12 @@ module McpTools
         @name
       end
 
-      def pagination_enabled?(enabled = nil)
-        @pagination_enabled = enabled if enabled.present?
-
+      def pagination_enabled?
         @pagination_enabled || false
+      end
+
+      def enable_pagination
+        @pagination_enabled = true
       end
 
       def input_schema(schema = nil)

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -57,16 +57,26 @@ module McpTools
         @name
       end
 
+      def pagination_enabled?(enabled = nil)
+        @pagination_enabled = enabled if enabled.present?
+
+        @pagination_enabled || false
+      end
+
       def input_schema(schema = nil)
         if schema.present?
-          page = {
-            type: "number",
-            default: 1,
-            description: "Page number for pagination. If no page is defined, the first result set is returned. " \
-                         "To get the rest of the results, use a page number of 2 or higher."
-          }
+          if pagination_enabled?
+            page = {
+              type: "number",
+              default: 1,
+              description: "Page number for pagination. If no page is defined, the first result set is returned. " \
+                           "To get the rest of the results, use a page number of 2 or higher."
+            }
 
-          @input_schema = schema.deep_merge({ properties: { page: } })
+            @input_schema = schema.deep_merge({ properties: { page: } })
+          else
+            @input_schema = schema
+          end
         end
 
         @input_schema
@@ -193,20 +203,24 @@ module McpTools
     # Filtering happens based on the filters defined for the tool, see .filter.
     def apply_filters(scope, params)
       params.each do |name, value|
-        filter_proc = self.class.filters[name]
-        return scope unless filter_proc
-
+        filter_proc = filter_proc_for(name)
         scope = filter_proc.call(scope, value)
       end
 
       scope
     end
 
-    def apply_pagination(scope, query)
-      page = query[:page] || 1
+    def filter_proc_for(name)
+      self.class.filters[name] || raise(ArgumentError, "Don't know how to handle filter argument called #{name}")
+    end
+
+    def apply_pagination(scope, page)
+      return scope unless self.class.pagination_enabled?
+
+      page_number = page || 1
       page_size = self.class.page_size
 
-      scope.offset((page - 1) * page_size).limit(page_size)
+      scope.offset((page_number - 1) * page_size).limit(page_size)
     end
   end
 end

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -30,17 +30,11 @@
 
 module McpTools
   class SearchProjects < Base
-    class << self
-      def page_size
-        100
-      end
-    end
-
     default_title "Search projects"
     default_description "Search projects matching all of the passed input parameters. " \
                         "Parameters not passed are ignored. Results are limited to a maximum " \
                         "of #{page_size} projects. To get the rest of the results, call the tool again with a" \
-                        "page number of 1 or higher."
+                        "page number of 2 or higher."
 
     name "search_projects"
     annotations read_only: true, idempotent: true, destructive: false
@@ -54,12 +48,7 @@ module McpTools
       properties: {
         name: { type: "string", description: "Name of the project. Accepts partial project names, not case-sensitive." },
         identifier: { type: "string", description: "Project indentifier. Case-sensitive, matching exactly." },
-        status_code: { type: "string", enum: Project.status_codes.keys, description: "The project status." },
-        page: {
-          type: "number",
-          description: "Page number for pagination. If no page is defined, the first result set is returned. " \
-                       "To get the rest of the results, use a page number of 1 or higher."
-        }
+        status_code: { type: "string", enum: Project.status_codes.keys, description: "The project status." }
       }
     )
 
@@ -74,12 +63,12 @@ module McpTools
       }
     )
 
-    def call(page: 0, **filters)
-      page_size = self.class.page_size
-      projects = apply_filters(Project.visible.offset(page * page_size).limit(page_size), filters)
+    def call(**query)
+      filtered = apply_filters(Project.visible, query)
+      paginated = apply_pagination(filtered, query)
 
       {
-        items: projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
+        items: paginated.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
       }
     end
   end

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -38,7 +38,7 @@ module McpTools
 
     name "search_projects"
     annotations read_only: true, idempotent: true, destructive: false
-    pagination_enabled? true
+    enable_pagination
 
     filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
     filter :identifier

--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -38,6 +38,7 @@ module McpTools
 
     name "search_projects"
     annotations read_only: true, idempotent: true, destructive: false
+    pagination_enabled? true
 
     filter :name, filter_class: Queries::Projects::Filters::NameFilter, operator: "~"
     filter :identifier
@@ -63,12 +64,12 @@ module McpTools
       }
     )
 
-    def call(**query)
-      filtered = apply_filters(Project.visible, query)
-      paginated = apply_pagination(filtered, query)
+    def call(page: nil, **filters)
+      filtered = apply_filters(Project.visible, filters)
+      projects = apply_pagination(filtered, page)
 
       {
-        items: paginated.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
+        items: projects.map { |p| API::V3::Projects::ProjectRepresenter.create(p, current_user:) }
       }
     end
   end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -39,7 +39,7 @@ module McpTools
 
     name "search_work_packages"
     annotations read_only: true, idempotent: true, destructive: false
-    pagination_enabled? true
+    enable_pagination
 
     # We can't use subclasses of WorkPackageFilter as filter_class, because they overwrite apply_to badly and rely on using
     # an instantiated Query to be used.

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -39,6 +39,7 @@ module McpTools
 
     name "search_work_packages"
     annotations read_only: true, idempotent: true, destructive: false
+    pagination_enabled? true
 
     # We can't use subclasses of WorkPackageFilter as filter_class, because they overwrite apply_to badly and rely on using
     # an instantiated Query to be used.
@@ -54,7 +55,7 @@ module McpTools
     input_schema(
       properties: {
         assigned_to_id: {
-          type: ["number", "null"],
+          type: %w[number null],
           description: "The ID of the user or group that is assigned to this work package. " \
                        "Pass null to search for work packages without an assignee."
         },
@@ -68,7 +69,7 @@ module McpTools
         },
         type_id: { type: "number", description: "The ID of the work package's type." },
         version_id: {
-          type: ["number", "null"],
+          type: %w[number null],
           description: "The ID of the work package's version. Pass null to search for work packages without a version."
         }
       }
@@ -85,12 +86,12 @@ module McpTools
       }
     )
 
-    def call(**query)
-      filtered = apply_filters(WorkPackage.visible, query)
-      paginated = apply_pagination(filtered, query)
+    def call(page: nil, **filters)
+      filtered = apply_filters(WorkPackage.visible, filters)
+      work_packages = apply_pagination(filtered, page)
 
       {
-        items: paginated.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) }
+        items: work_packages.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) }
       }
     end
   end

--- a/app/services/mcp_tools/search_work_packages.rb
+++ b/app/services/mcp_tools/search_work_packages.rb
@@ -30,12 +30,12 @@
 
 module McpTools
   class SearchWorkPackages < Base
-    # TODO: The mcp gem does not support pagination, so we only limit the number of results for now
-    MAX_SIZE = 100
-
     default_title "Search work packages"
     default_description "Search work packages matching all of the passed input parameters. " \
-                        "Parameters not passed are ignored. Results are limited to a maximum of #{MAX_SIZE} work packages."
+                        "Parameters not passed are ignored. Results are limited to a maximum " \
+                        "of #{page_size} work packages. To get the rest of the results, call the tool again with a" \
+                        "page number of 2 or higher."
+
 
     name "search_work_packages"
     annotations read_only: true, idempotent: true, destructive: false
@@ -86,10 +86,11 @@ module McpTools
     )
 
     def call(**query)
-      work_packages = apply_filters(WorkPackage.visible.limit(MAX_SIZE), query)
+      filtered = apply_filters(WorkPackage.visible, query)
+      paginated = apply_pagination(filtered, query)
 
       {
-        items: work_packages.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) }
+        items: paginated.map { |wp| API::V3::WorkPackages::WorkPackageRepresenter.create(wp, current_user:) }
       }
     end
   end

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
       end
 
       context "if another page is requested" do
-        let(:call_args) { { name: "Death Star", page: 1 } }
+        let(:call_args) { { name: "Death Star", page: 2 } }
 
         it "returns the requested page" do
           subject

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -269,6 +269,39 @@ RSpec.describe McpTools::SearchWorkPackages, with_flag: { mcp_server: true } do
 
       it_behaves_like "MCP error response"
     end
+
+    describe "pagination" do
+      let(:page_size) { 10 }
+      let(:overspilling_work_packages) { 5 }
+      let(:work_packages_count) { page_size + overspilling_work_packages }
+      let(:call_args) { { subject: "Stormtrooper" } }
+
+      before do
+        allow(described_class).to receive(:page_size).and_return(page_size)
+
+        work_packages_count.times do |idx|
+          create(:work_package,
+                 project:,
+                 type:,
+                 status:,
+                 subject: "Send Stormtrooper squad No. #{idx} to Jedi temple on Coruscant")
+        end
+      end
+
+      it "returns only results up to the page size" do
+        subject
+        expect(parsed_results.dig("structuredContent", "items").count).to eq(page_size)
+      end
+
+      context "if another page is requested" do
+        let(:call_args) { { subject: "Stormtrooper", page: 2 } }
+
+        it "returns the requested page" do
+          subject
+          expect(parsed_results.dig("structuredContent", "items").count).to eq(overspilling_work_packages)
+        end
+      end
+    end
   end
 
   context "when the mcp_server enterprise feature is disabled" do


### PR DESCRIPTION
# Ticket
[#71101](https://community.openproject.org/work_packages/71101)

# What are you trying to accomplish?
- improve acceptance for MCP clients
- add pagination to search work packages

# What approach did you choose and why?
- set default page to 1
- add method in base class to be called in tool's `call` method