### PR TITLE
Build hocuspocus as pre-step to docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -51,7 +51,7 @@ jobs:
 
   build-hocuspocus:
     needs: compute-inputs
-    uses: opf/hocuspocus/.github/workflows/docker-build.yml@dev
+    uses: opf/op-blocknote-hocuspocus/.github/workflows/docker-build.yml@dev
     with:
       ref: refs/tags/${{ needs.compute-inputs.outputs.tag }}
       tags: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       tag: ${{ steps.compute.outputs.tag }}
       branch: ${{ steps.compute.outputs.branch }}
+      version: ${{ steps.compute.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,11 +42,25 @@ jobs:
             BRANCH_REF="dev"
           fi
 
+          # version strips the v prefix (v17.1.0 => 17.1.0) for hocuspocus docker tags
+          VERSION="${TAG_REF#v}"
+
           echo "branch=$BRANCH_REF" | tee -a "$GITHUB_OUTPUT"
           echo "tag=$TAG_REF" | tee -a "$GITHUB_OUTPUT"
+          echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+
+  build-hocuspocus:
+    needs: compute-inputs
+    uses: opf/hocuspocus/.github/workflows/docker-build.yml@dev
+    with:
+      ref: refs/tags/${{ needs.compute-inputs.outputs.tag }}
+      tags: |
+        openproject/hocuspocus:latest
+        openproject/hocuspocus:${{ needs.compute-inputs.outputs.version }}
+    secrets: inherit
 
   build:
-    needs: compute-inputs
+    needs: [compute-inputs, build-hocuspocus]
     uses: ./.github/workflows/docker.yml
     with:
       branch: ${{ needs.compute-inputs.outputs.branch }}


### PR DESCRIPTION
Trigger hocuspocus tagged builds before we build OpenProject X.Y.Z docker images. This is because the release will pin the hocuspocus deployment in https://github.com/opf/openproject/blob/dev/docker/prod/Dockerfile#L116

related
https://github.com/opf/op-blocknote-hocuspocus/pull/50