### PR TITLE
Only return projects from search_projects MCP tool

### DIFF
--- a/app/services/mcp_tools/search_projects.rb
+++ b/app/services/mcp_tools/search_projects.rb
@@ -65,7 +65,7 @@ module McpTools
     )
 
     def call(page: nil, **filters)
-      filtered = apply_filters(Project.visible, filters)
+      filtered = apply_filters(Project.project.visible, filters)
       projects = apply_pagination(filtered, page)
 
       {

--- a/docs/api/apiv3/components/schemas/portfolio_model.yml
+++ b/docs/api/apiv3/components/schemas/portfolio_model.yml
@@ -42,10 +42,6 @@ properties:
     required:
       - self
       - categories
-      - types
-      - versions
-      - memberships
-      - workPackages
     properties:
       update:
         allOf:

--- a/docs/api/apiv3/components/schemas/program_model.yml
+++ b/docs/api/apiv3/components/schemas/program_model.yml
@@ -42,10 +42,6 @@ properties:
     required:
       - self
       - categories
-      - types
-      - versions
-      - memberships
-      - workPackages
     properties:
       update:
         allOf:

--- a/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/projects/project_representer_rendering_spec.rb
@@ -133,6 +133,10 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
       context "for a portfolio" do
         let(:project) { build_stubbed(:portfolio) }
 
+        it "fulfills the documented schema" do
+          expect(generated).to match_json_schema.from_docs("portfolio_model")
+        end
+
         it_behaves_like "property", :_type do
           let(:value) { "Portfolio" }
         end
@@ -140,6 +144,10 @@ RSpec.describe API::V3::Projects::ProjectRepresenter, "rendering" do
 
       context "for a program" do
         let(:project) { build_stubbed(:program) }
+
+        it "fulfills the documented schema" do
+          expect(generated).to match_json_schema.from_docs("program_model")
+        end
 
         it_behaves_like "property", :_type do
           let(:value) { "Program" }

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
 
   let!(:project_a) { create(:project, identifier: "abc", name: "The ABC Project", status_code: :on_track) }
   let!(:project_b) { create(:project, identifier: "def", name: "The DEF Project", status_code: :off_track) }
+  let!(:portfolio) { create(:portfolio, identifier: "ghi", name: "The unrelated Portfolio", status_code: :on_track) }
 
   let(:server_config) { create(:mcp_configuration, identifier: "mcp_server") }
   let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name) }


### PR DESCRIPTION
Right now it's completely possible to request a portfolio as `/api/v3/projects/:id`. For all intents and purposes the response looks like it should fulfill the project schema, but that limited the _type to Project.

In our MCP API (where clients and server validate the schema of responses), this led to an issue.

Going forward, I am wondering, whether it should be expected that the `search_projects` MCP tool (and internally `Project.visible`) should be returning non-projects at all. But right now, this seems to be what it is.