### PR TITLE
Fix grammar errors in docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ keywords: help, documentation
 
 Get started with installing and upgrading OpenProject using [our Installation Guide starting point](./installation-and-operations/).
 
-The guides [packaged](./installation-and-operations/installation/packaged) and [Docker-based](./installation-and-operations/installation/docker) installations are provided.
+The guides for [packaged](./installation-and-operations/installation/packaged) and [Docker-based](./installation-and-operations/installation/docker) installations are provided.
 
 ## Upgrading
 
@@ -24,7 +24,7 @@ The guides for [upgrading](./installation-and-operations/operation/upgrading) ar
 
 ## Operation
 
-* [Backing up you installation](./installation-and-operations/operation/backing-up)
+* [Backing up your installation](./installation-and-operations/operation/backing-up)
 * [Alter configuration of OpenProject](./installation-and-operations/configuration)
 * [Manual repository integration for Git and Subversion](./installation-and-operations/configuration/repositories)
 * [Configure incoming mails](./installation-and-operations/configuration/incoming-emails)


### PR DESCRIPTION
Fixed two grammatical errors in docs/README.md to improve documentation clarity and professionalism.

# Ticket
N/A - Minor documentation grammar fixes

# What are you trying to accomplish?
Corrected grammatical errors in the docs/README.md file to improve documentation quality and readability.

**Changes made:**
1. Operation section: "Backing up you installation" → "Backing up your installation"
2. Installation section: "The guides [packaged]..." → "The guides for [packaged]..."

Both changes fix grammatical errors that affected the professional quality of the documentation.

## Screenshots
N/A - Text-only changes

# What approach did you choose and why?
Straightforward grammar corrections:
1. Changed "you" to "your" - clear possessive pronoun error
2. Added "for" after "The guides" - improves sentence structure and consistency with similar lines in the document

These are simple fixes with no alternative approaches needed, as the errors are objective grammatical mistakes.

# Merge checklist
- [x] Added/updated tests - N/A for documentation grammar fixes
- [x] Added/updated documentation in Lookbook (patterns, previews, etc) - N/A, this IS the documentation
- [x] Tested major browsers (Chrome, Firefox, Edge, ...) - N/A for text-only documentation changes