### PR TITLE
[#71351] Teach Single/Range Date Picker support for `placeholder` text

### DIFF
--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.html
@@ -13,6 +13,7 @@
     [attr.name]="name"
     [required]="required"
     [disabled]="disabled"
+    [placeholder]="placeholder"
     [ngModel]="stringValue"
     (ngModelChange)="changeValueFromInputDebounced($event)"
     (focus)="showDatePicker()"
@@ -29,6 +30,7 @@
     name="{{ name }}-start"
     [required]="required"
     [disabled]="disabled"
+    [placeholder]="placeholder"
     [ngModel]="value[0] || ''"
     (ngModelChange)="changeValueFromInputDebounced([$event, value[1] || ''])"
     />
@@ -42,6 +44,7 @@
     name="{{ name }}-end"
     [required]="required"
     [disabled]="disabled"
+    [placeholder]="placeholder"
     [ngModel]="value[1] || ''"
     (ngModelChange)="changeValueFromInputDebounced([value[0] || '', $event])"
     />

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -111,6 +111,8 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
 
   @Input() disabled = false;
 
+  @Input() placeholder = '';
+
   @Input() minimalDate:Date|null = null;
 
   @Input() inputClassNames = '';

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.html
@@ -14,6 +14,7 @@
     [attr.name]="name"
     [required]="required"
     [disabled]="disabled"
+    [placeholder]="placeholder"
     (input)="changeValueFromInput($event.target.value)"
     (focus)="showDatePicker()"
     (click)="sentCalendarToTopLayer()"
@@ -34,6 +35,7 @@
     [attr.name]="name"
     [required]="required"
     [disabled]="disabled"
+    [placeholder]="placeholder"
     [ngModel]="value"
     (ngModelChange)="changeValueFromInput($event)"
     />

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -89,6 +89,8 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
 
   @Input() disabled = false;
 
+  @Input() placeholder = '';
+
   @Input() minimalDate:Date|null = null;
 
   @Input() inputClassNames = '';

--- a/lib/primer/open_project/forms/date_picker.html.erb
+++ b/lib/primer/open_project/forms/date_picker.html.erb
@@ -45,7 +45,8 @@ See COPYRIGHT and LICENSE files for more details.
                                   name: @datepicker_options.fetch(:name) { builder.field_name(@input.name) },
                                   value: @datepicker_options.fetch(:value) { @input.input_arguments[:value] || builder.object&.send(@input.name) },
                                   inputClassNames: @datepicker_options.fetch(:class) { @input.input_arguments[:class] },
-                                  dataAction: @datepicker_options.fetch(:data, {}).fetch(:action, nil)
+                                  dataAction: @datepicker_options.fetch(:data, {}).fetch(:action, nil),
+                                  placeholder: @input.input_arguments.fetch(:placeholder, "")
                                 ) %>
     <% end %>
   <% end %>

--- a/lib/primer/open_project/forms/dsl/single_date_picker_input.rb
+++ b/lib/primer/open_project/forms/dsl/single_date_picker_input.rb
@@ -35,7 +35,7 @@ module Primer
         class SingleDatePickerInput < Primer::Forms::Dsl::TextFieldInput
           attr_reader :datepicker_options
 
-          def initialize(name:, label:, datepicker_options:, **system_arguments)
+          def initialize(name:, label:, datepicker_options: {}, **system_arguments)
             @datepicker_options = derive_datepicker_options(datepicker_options)
 
             super(name:, label:, **system_arguments)

--- a/modules/backlogs/app/forms/backlogs/backlog_header_form.rb
+++ b/modules/backlogs/app/forms/backlogs/backlog_header_form.rb
@@ -48,16 +48,14 @@ module Backlogs
           label: attribute_name(:start_date),
           placeholder: attribute_name(:start_date),
           visually_hide_label: true,
-          leading_visual: { icon: :calendar },
-          datepicker_options: {}
+          leading_visual: { icon: :calendar }
         )
         dates.single_date_picker(
           name: :effective_date,
           label: attribute_name(:effective_date),
           placeholder: attribute_name(:effective_date),
           visually_hide_label: true,
-          leading_visual: { icon: :calendar },
-          datepicker_options: {}
+          leading_visual: { icon: :calendar }
         )
       end
 

--- a/spec/lib/primer/open_project/forms/date_picker_spec.rb
+++ b/spec/lib/primer/open_project/forms/date_picker_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Primer::OpenProject::Forms::DatePicker, type: :forms do
+  include ViewComponent::TestHelpers
+
+  let(:model) { build_stubbed(:comment) }
+
+  describe "single date picker" do
+    def render_form
+      render_in_view_context(model) do |model|
+        primer_form_with(url: "/foo", model:) do |f|
+          render_inline_form(f) do |form|
+            form.single_date_picker(
+              name: :some_date,
+              label: "Some date",
+              placeholder: "Pick a date",
+              datepicker_options: { value: "" }
+            )
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "renders the label" do
+      expect(rendered_form).to have_element :label
+    end
+
+    it "renders the single date picker angular component" do
+      expect(rendered_form).to have_element "opce-basic-single-date-picker"
+    end
+
+    it "passes placeholder as a data attribute" do
+      expect(rendered_form).to have_element "opce-basic-single-date-picker",
+                                            "data-placeholder": "Pick a date".to_json
+    end
+  end
+
+  describe "without placeholder" do
+    def render_form
+      render_in_view_context(model) do |model|
+        primer_form_with(url: "/foo", model:) do |f|
+          render_inline_form(f) do |form|
+            form.single_date_picker(
+              name: :some_date,
+              label: "Some date",
+              datepicker_options: { value: "" }
+            )
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "defaults placeholder to an empty string" do
+      expect(rendered_form).to have_element "opce-basic-single-date-picker",
+                                            "data-placeholder": "".to_json
+    end
+  end
+
+  describe "range date picker" do
+    def render_form
+      render_in_view_context(model) do |model|
+        primer_form_with(url: "/foo", model:) do |f|
+          render_inline_form(f) do |form|
+            form.range_date_picker(
+              name: :some_date,
+              label: "Some date",
+              placeholder: "Pick a range",
+              datepicker_options: { value: "" }
+            )
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "renders the range date picker angular component" do
+      expect(rendered_form).to have_element "opce-range-date-picker"
+    end
+
+    it "passes placeholder as a data attribute" do
+      expect(rendered_form).to have_element "opce-range-date-picker",
+                                            "data-placeholder": "Pick a range".to_json
+    end
+  end
+end

--- a/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
+++ b/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
@@ -226,14 +226,14 @@ RSpec.describe Primer::OpenProject::Forms::Dsl::InputMethods, type: :forms do
     end
 
     describe "#single_date_picker" do
-      let(:field_group) { form_dsl.single_date_picker(name:, label:, datepicker_options: {}, **options) }
+      let(:field_group) { form_dsl.single_date_picker(name:, label:, **options) }
 
       include_examples "input class", Primer::OpenProject::Forms::Dsl::SingleDatePickerInput
       it_behaves_like "supporting help texts"
     end
 
     describe "#range_date_picker" do
-      let(:field_group) { form_dsl.range_date_picker(name:, label:, datepicker_options: {}, **options) }
+      let(:field_group) { form_dsl.range_date_picker(name:, label:, **options) }
 
       include_examples "input class", Primer::OpenProject::Forms::Dsl::RangeDatePickerInput
       it_behaves_like "supporting help texts"


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is based off #21723**. Please review/merge that PR first. 

# Ticket

https://community.openproject.org/work_packages/71351

# What are you trying to accomplish?

- Updates Angular `OpBasicSingleDatePickerComponent` and `OpBasicRangeDatePickerComponent`s to support passing a `placeholder` value.
- Updates Primer Form inputs to pass `placeholder` as a date attribute.
- Additionally, this PR makes `SingleDatePickerInput`'s `datepicker_options` param optional.

## Screenshots

| Before | After |
|--------|--------|
| <img width="609" height="145" alt="Screenshot 2026-02-08 at 16 30 59" src="https://github.com/user-attachments/assets/098bc92b-9961-41e1-8626-7053c04b6c6e" /> | <img width="607" height="137" alt="Screenshot 2026-02-08 at 16 30 18" src="https://github.com/user-attachments/assets/f73da599-d09c-480c-bca1-56efa747d07d" />|

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
