### PR TITLE
Fix API::Errors::InternalError class

### DIFF
--- a/app/models/query/results/group_by.rb
+++ b/app/models/query/results/group_by.rb
@@ -125,7 +125,7 @@ module ::Query::Results::GroupBy
         ->(list) { list },
         ->(error) do
           msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
-          raise ::API::Errors::InternalError.new(msg)
+          raise ::API::Errors::SafeInternalError.new(msg)
         end
       )
   end

--- a/lib/api/errors/safe_internal_error.rb
+++ b/lib/api/errors/safe_internal_error.rb
@@ -30,37 +30,12 @@
 
 module API
   module Errors
-    # A representation for internal server errors that's safe to be used to wrap unexpected errors received in rescue_from.
-    # It will hide the detailed error message of some exception classes that are known to risk exposing internal details.
-    class InternalError < ErrorBase
+    # A representation for internal server errors that applies no filtering of the error message.
+    # Only use this, if you know that the error message you are passing in is safe to be displayed to the user, as no
+    # filtering of error messages will happen.
+    class SafeInternalError < ErrorBase
       identifier "InternalServerError"
       code 500
-
-      def initialize(error_message = nil, exception:)
-        error = I18n.t("api_v3.errors.code_500")
-
-        if error_message && visible_exception?(exception)
-          error += " #{error_message}"
-        end
-
-        super(error)
-      end
-
-      private
-
-      ##
-      # Hide internal database errors in production
-      def visible_exception?(exception)
-        exception_blocklist.none? do |clz|
-          exception.is_a?(clz)
-        end
-      end
-
-      def exception_blocklist
-        [
-          ActiveRecord::StatementInvalid
-        ]
-      end
     end
   end
 end

--- a/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/item_branch_api.rb
@@ -48,7 +48,7 @@ module API
                   end,
                   ->(error) do
                     msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
-                    raise ::API::Errors::InternalError.new(msg)
+                    raise ::API::Errors::SafeInternalError.new(msg)
                   end
                 )
             end

--- a/lib/api/v3/custom_fields/hierarchy/items_api.rb
+++ b/lib/api/v3/custom_fields/hierarchy/items_api.rb
@@ -78,7 +78,7 @@ module API
                              ->(value) { value },
                              ->(error) do
                                msg = "#{I18n.t('api_v3.errors.code_500')} #{error}"
-                               raise ::API::Errors::InternalError.new(msg)
+                               raise ::API::Errors::SafeInternalError.new(msg)
                              end
                            )
 
@@ -89,7 +89,7 @@ module API
               items = query.results.where(custom_field: @custom_field)
               if items.count != 1
                 msg = "corrupt data found, invalid number of hierarchy roots for custom field"
-                raise ::API::Errors::InternalError.new(msg)
+                raise ::API::Errors::SafeInternalError.new(msg)
               end
 
               items.first

--- a/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
+++ b/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
@@ -100,7 +100,7 @@ module API
                   rescue API::Errors::UnsupportedMediaType => e
                     raise e
                   rescue StandardError => e
-                    raise API::Errors::InternalError.new(e.message)
+                    raise API::Errors::InternalError.new(e.message, exception: e)
                   ensure
                     file.delete
                   end

--- a/modules/storages/app/common/storages/peripherals/storage_error_helper.rb
+++ b/modules/storages/app/common/storages/peripherals/storage_error_helper.rb
@@ -48,7 +48,7 @@ module Storages::Peripherals
       elsif base_errors.include? :forbidden
         fail API::Errors::OutboundRequestForbidden.new(message)
       elsif base_errors.include? :error
-        fail API::Errors::InternalError.new(message)
+        fail API::Errors::SafeInternalError.new(message)
       else
         base_errors
       end
@@ -75,7 +75,7 @@ module Storages::Peripherals
       when :missing_ee_token_for_one_drive
         raise API::Errors::EnterpriseTokenMissing.new
       else
-        raise API::Errors::InternalError.new(error.code)
+        raise API::Errors::SafeInternalError.new(error.code)
       end
     end
   end

--- a/spec/lib/api/errors/internal_error_spec.rb
+++ b/spec/lib/api/errors/internal_error_spec.rb
@@ -28,39 +28,32 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module Errors
-    # A representation for internal server errors that's safe to be used to wrap unexpected errors received in rescue_from.
-    # It will hide the detailed error message of some exception classes that are known to risk exposing internal details.
-    class InternalError < ErrorBase
-      identifier "InternalServerError"
-      code 500
+require "spec_helper"
 
-      def initialize(error_message = nil, exception:)
-        error = I18n.t("api_v3.errors.code_500")
+RSpec.describe API::Errors::InternalError do
+  subject { described_class.new(sensitive_message, exception:) }
 
-        if error_message && visible_exception?(exception)
-          error += " #{error_message}"
-        end
+  let(:sensitive_message) { "This message might contain sensitive information" }
+  let(:exception) { nil }
+  let(:generic_message) { I18n.t("api_v3.errors.code_500") }
 
-        super(error)
-      end
+  context "when the exception is known to be problematic" do
+    let(:exception) { ActiveRecord::StatementInvalid.new }
 
-      private
+    it "hides the sensitive message" do
+      expect(subject.message).to eq(generic_message)
+    end
+  end
 
-      ##
-      # Hide internal database errors in production
-      def visible_exception?(exception)
-        exception_blocklist.none? do |clz|
-          exception.is_a?(clz)
-        end
-      end
+  context "when the exception is something else" do
+    let(:exception) { StandardError.new }
 
-      def exception_blocklist
-        [
-          ActiveRecord::StatementInvalid
-        ]
-      end
+    it "includes the sensitive message" do
+      expect(subject.message).to include(sensitive_message)
+    end
+
+    it "Starts with the generic message" do
+      expect(subject.message).to start_with(generic_message)
     end
   end
 end


### PR DESCRIPTION
This class got broken during what seems to be a
drive-by style-improvement in fbe1215365. That change:

* made it incompatible with frozen strings as error messages
* broke the intended hiding of messages if they came from the wrong class

All of this went by unnoticed, because there were no specs for the InternalError class.

# Ticket
https://community.openproject.org/wp/71444