### PR TITLE
add bin/migrate to migrate given dump to latest OpenProject version

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+## Takes a given OpenProject database dump (>= OpenProject 10) and migrates it to the latest version.
+
+DUMP_FILE="$1"
+POSTGRES_CONTAINER=op-migrate-pg17
+OUTPUT_BUFFER=$(mktemp)
+
+if [ -z $DUMP_FILE ]; then
+  echo "Please provide a valid path to an OpenProject database dump file."
+fi
+
+dump() {
+  docker exec op10 bash -c 'pg_dump -d $DATABASE_URL'
+}
+
+# Function to be called on exit, whether regular or on error
+cleanup() {
+  echo "Cleaning up..."
+
+  docker stop $POSTGRES_CONTAINER
+
+  rm $OUTPUT_BUFFER
+
+  echo "done"
+}
+
+# Set up the trap to call cleanup on exit or error
+trap cleanup EXIT
+
+echo "Starting database..."
+docker run --rm -d --name $POSTGRES_CONTAINER -e POSTGRES_PASSWORD=postgres -p 5017:5432 postgres:17 &>/dev/null
+
+SECONDS=0
+while ! docker logs --since 5m op-migrate-pg17 2>1 | grep 'database system is ready to accept connections' &> /dev/null; do
+  echo "... waiting for database to start"
+  sleep 3
+
+  if [ $SECONDS -gt 10 ]; then
+    >&2 echo "Error: database hasn't started"
+    docker logs $POSTGRES_CONTAINER
+
+    exit 1
+  fi
+done
+
+DB_IP=$(docker inspect $POSTGRES_CONTAINER | grep IPAddress | cut -d: -f2 | tr -d '"' | tr -d ',' | tr -d ' ')
+
+echo "Database started under $DB_IP"
+
+docker exec -i $POSTGRES_CONTAINER su - postgres -c 'psql -c "CREATE DATABASE openproject;"'
+
+echo -e "\nRestoring dump"
+cat $DUMP_FILE | sed 's/OWNER TO openproject/OWNER TO postgres/g' | docker exec -u 999 -i $POSTGRES_CONTAINER bash -c 'psql -d openproject'
+
+SCHEMA_VERSION=$(echo "psql -qtd openproject -c \"select MAX(version) from schema_migrations where version like '2020%';\"" | docker exec -u 999 -i $POSTGRES_CONTAINER bash -)
+
+if [ -z "$SCHEMA_VERSION" ]; then
+  >&2 echo "Your OpenProject version is older than version 10. Please use script/migrate/migrate-from-pre-8.sh to migrate to a more recent state first."
+  exit 1
+fi
+
+echo -e "\nImported database"
+
+OP_VERSION=15
+
+while [ $? -eq 0 ]; do
+  echo "Looking for next OpenProject version..."
+
+  if ! docker pull openproject/openproject:$OP_VERSION &> $OUTPUT_BUFFER; then
+    if cat $OUTPUT_BUFFER | grep "not found" &>/dev/null; then
+      echo "Migration complete." # no next OP image found, meaning we just migrated the latest version
+
+      break
+    else
+      echo "Failed pulling OpenProject $OP_VERSION"
+
+      exit 1
+    fi
+  fi
+
+  echo -e "\nMigrating to OpenProject $OP_VERSION..."
+
+  docker run --rm -e DATABASE_URL="postgresql://postgres:postgres@$DB_IP:5432/openproject" -i openproject/openproject:$OP_VERSION bundle exec rake db:migrate
+
+  if [ $? -gt 0 ]; then
+    >&2 echo "Migration to OpenProject $OP_VERSION failed (see error above)"
+    exit 1
+  fi
+
+  OP_VERSION=$((OP_VERSION + 1))
+done
+
+echo "Dumping migrated (OpenProject $((OP_VERSION - 1))) database..."
+
+MIGRATED_FILE=$(echo $DUMP_FILE | sed -r 's/\.(sql|pgdump)/-migrated.sql/')
+
+docker exec -u 999 -i $POSTGRES_CONTAINER pg_dump -d openproject -x -O | gzip > $MIGRATED_FILE
+
+echo "Dump saved under $MIGRATED_FILE"

--- a/bin/migrate
+++ b/bin/migrate
@@ -2,12 +2,15 @@
 
 ## Takes a given OpenProject database dump (>= OpenProject 10) and migrates it to the latest version.
 
+GREEN='\033[0;32m'
+NC='\033[0m'
+
 DUMP_FILE="$1"
 POSTGRES_CONTAINER=op-migrate-pg17
 OUTPUT_BUFFER=$(mktemp)
 
 if [ -z $DUMP_FILE ]; then
-  echo "Please provide a valid path to an OpenProject database dump file."
+  echo -e "${GREEN}Please provide a valid path to an OpenProject database dump file.${NC}"
 fi
 
 dump() {
@@ -29,7 +32,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Starting database..."
-docker run --rm -d --name $POSTGRES_CONTAINER -e POSTGRES_PASSWORD=postgres -p 5017:5432 postgres:17 &>/dev/null
+docker run --rm -d --name $POSTGRES_CONTAINER -e POSTGRES_PASSWORD=postgres postgres:17 &>/dev/null
 
 SECONDS=0
 while ! docker logs --since 5m op-migrate-pg17 2>1 | grep 'database system is ready to accept connections' &> /dev/null; do
@@ -48,7 +51,12 @@ DB_IP=$(docker inspect $POSTGRES_CONTAINER | grep IPAddress | cut -d: -f2 | tr -
 
 echo "Database started under $DB_IP"
 
+# create database to import dump into
 docker exec -i $POSTGRES_CONTAINER su - postgres -c 'psql -c "CREATE DATABASE openproject;"'
+# create extensions used by OpenProject
+#   this may have to be updated when new extensions are added
+#   yes, the migrations SHOULD take care of it, and yet some fail if these are not already present when migrating dumps even as recent as v16
+docker exec -i $POSTGRES_CONTAINER su - postgres -c 'psql -d openproject -c "CREATE EXTENSION IF NOT EXISTS btree_gist WITH SCHEMA pg_catalog; CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA pg_catalog; CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA pg_catalog;"'
 
 echo -e "\nRestoring dump"
 cat $DUMP_FILE | sed 's/OWNER TO openproject/OWNER TO postgres/g' | docker exec -u 999 -i $POSTGRES_CONTAINER bash -c 'psql -d openproject'
@@ -64,12 +72,14 @@ echo -e "\nImported database"
 
 OP_VERSION=15
 
-while [ $? -eq 0 ]; do
-  echo "Looking for next OpenProject version..."
+set -o pipefail # we want exit codes to make it through tee too
 
-  if ! docker pull openproject/openproject:$OP_VERSION &> $OUTPUT_BUFFER; then
+while [ $? -eq 0 ]; do
+  echo -e "Looking for next OpenProject version...\n"
+
+  if ! docker pull openproject/openproject:$OP_VERSION 2>&1 | tee $OUTPUT_BUFFER; then
     if cat $OUTPUT_BUFFER | grep "not found" &>/dev/null; then
-      echo "Migration complete." # no next OP image found, meaning we just migrated the latest version
+      echo -e "\nNo newer OpenProject version found. Migration complete." # no next OP image found, meaning we just migrated the latest version
 
       break
     else
@@ -81,11 +91,15 @@ while [ $? -eq 0 ]; do
 
   echo -e "\nMigrating to OpenProject $OP_VERSION..."
 
-  docker run --rm -e DATABASE_URL="postgresql://postgres:postgres@$DB_IP:5432/openproject" -i openproject/openproject:$OP_VERSION bundle exec rake db:migrate
+  docker run --rm -e DATABASE_URL="postgresql://postgres:postgres@$DB_IP:5432/openproject" -i openproject/openproject:$OP_VERSION bundle exec rake db:migrate 2>&1 | tee $OUTPUT_BUFFER
 
   if [ $? -gt 0 ]; then
-    >&2 echo "Migration to OpenProject $OP_VERSION failed (see error above)"
-    exit 1
+    if cat $OUTPUT_BUFFER | grep 'PG::DuplicateTable: ERROR:  relation "work_packages" already exists' &>/dev/null; then
+      >&2 echo -e "\nWarning: Migration to OpenProject $OP_VERSION failed likely because the dump is already beyond that version. Trying next version."
+    else
+      >&2 echo -e "\nMigration to OpenProject $OP_VERSION failed (see error above)"
+      exit 1
+    fi
   fi
 
   OP_VERSION=$((OP_VERSION + 1))
@@ -97,4 +111,4 @@ MIGRATED_FILE=$(echo $DUMP_FILE | sed -r 's/\.(sql|pgdump)/-migrated.sql/')
 
 docker exec -u 999 -i $POSTGRES_CONTAINER pg_dump -d openproject -x -O | gzip > $MIGRATED_FILE
 
-echo "Dump saved under $MIGRATED_FILE"
+echo -e "\n${GREEN}Dump saved under ${MIGRATED_FILE}${NC}\n"

--- a/bin/migrate
+++ b/bin/migrate
@@ -6,11 +6,27 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 
 DUMP_FILE="$1"
+NEW_SCHEMA_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--change-schema-name)
+      NEW_SCHEMA_NAME="$2"
+      shift 2
+      ;;
+    *)
+      DUMP_FILE="$1"
+      shift
+      ;;
+  esac
+done
+
 POSTGRES_CONTAINER=op-migrate-pg17
 OUTPUT_BUFFER=$(mktemp)
 
 if [ -z $DUMP_FILE ]; then
-  echo -e "${GREEN}Please provide a valid path to an OpenProject database dump file.${NC}"
+  echo -e "Usage: bin/migrate [-n|--change-schema-name NAME] openproject.sql"
+  exit 1
 fi
 
 dump() {
@@ -104,6 +120,11 @@ while [ $? -eq 0 ]; do
 
   OP_VERSION=$((OP_VERSION + 1))
 done
+
+if [ -n "$NEW_SCHEMA_NAME" ]; then
+  echo -e "\nChanging schema name to '${NEW_SCHEMA_NAME}'...\n"
+  docker exec -i $POSTGRES_CONTAINER su - postgres -c "psql -d openproject -c 'ALTER SCHEMA public RENAME TO \"${NEW_SCHEMA_NAME}\"'"
+fi
 
 echo "Dumping migrated (OpenProject $((OP_VERSION - 1))) database..."
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -5,13 +5,17 @@
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-DUMP_FILE="$1"
+DUMP_FILE=""
 NEW_SCHEMA_NAME=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -n|--change-schema-name)
       NEW_SCHEMA_NAME="$2"
+      shift 2
+      ;;
+    -f|--format)
+      DUMP_FORMAT="$2"
       shift 2
       ;;
     *)
@@ -24,8 +28,8 @@ done
 POSTGRES_CONTAINER=op-migrate-pg17
 OUTPUT_BUFFER=$(mktemp)
 
-if [ -z $DUMP_FILE ]; then
-  echo -e "Usage: bin/migrate [-n|--change-schema-name NAME] openproject.sql"
+if [ -z "$DUMP_FILE" ]; then
+  echo -e "Usage: bin/migrate [-n|--change-schema-name NAME] [-f|--format sql|pgdump] openproject.sql"
   exit 1
 fi
 
@@ -128,8 +132,12 @@ fi
 
 echo "Dumping migrated (OpenProject $((OP_VERSION - 1))) database..."
 
-MIGRATED_FILE=$(echo $DUMP_FILE | sed -r 's/\.(sql|pgdump)/-migrated.sql/')
-
-docker exec -u 999 -i $POSTGRES_CONTAINER pg_dump -d openproject -x -O | gzip > $MIGRATED_FILE
+if [ "$DUMP_FORMAT" = "pgdump" ]; then
+  MIGRATED_FILE=$(echo $DUMP_FILE | sed -r 's/\.(sql|pgdump)/-migrated.pgdump/')
+  docker exec -u 999 -i $POSTGRES_CONTAINER pg_dump -d openproject -Fc -x -O > $MIGRATED_FILE
+else
+  MIGRATED_FILE=$(echo $DUMP_FILE | sed -r 's/\.(sql|pgdump)/-migrated.sql.gz/')
+  docker exec -u 999 -i $POSTGRES_CONTAINER pg_dump -d openproject -x -O | gzip > $MIGRATED_FILE
+fi
 
 echo -e "\n${GREEN}Dump saved under ${MIGRATED_FILE}${NC}\n"

--- a/bin/migrate
+++ b/bin/migrate
@@ -109,6 +109,8 @@ while [ $? -eq 0 ]; do
     fi
   fi
 
+  SECONDS_SINCE_EPOCH=$(date +%s)
+
   echo -e "\nMigrating to OpenProject $OP_VERSION..."
 
   docker run --rm -e DATABASE_URL="postgresql://postgres:postgres@$DB_IP:5432/openproject" -i openproject/openproject:$OP_VERSION bundle exec rake db:migrate 2>&1 | tee $OUTPUT_BUFFER
@@ -119,6 +121,18 @@ while [ $? -eq 0 ]; do
     else
       >&2 echo -e "\nMigration to OpenProject $OP_VERSION failed (see error above)"
       exit 1
+    fi
+  else
+    echo -e "\nPerforming migration background jobs if any have been enqueued...\n"
+
+    # performing any new background jobs enqueued by the migration above
+    docker run --rm -e OPENPROJECT_DISABLE__SECRET_KEY_BASE__CHECK=true -e DATABASE_URL="postgresql://postgres:postgres@$DB_IP:5432/openproject" -i openproject/openproject:$OP_VERSION bundle exec rails runner "GoodJob::Job.where(performed_at: nil).where('created_at > ?', Time.zone.at($SECONDS_SINCE_EPOCH)).find_each { it.perform lock_id: 1 }" 2>&1 | tee $OUTPUT_BUFFER
+
+    if [ $? -gt 0 ]; then
+      >&2 echo -e "\The execution of some background jobs failed. See output above."
+      exit 1
+    else
+      echo -e "\nFinished background jobs. Moving on.\n"
     fi
   fi
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -51,7 +51,7 @@ echo "Starting database..."
 docker run --rm -d --name $POSTGRES_CONTAINER -e POSTGRES_PASSWORD=postgres postgres:17 &>/dev/null
 
 SECONDS=0
-while ! docker logs --since 5m op-migrate-pg17 2>1 | grep 'database system is ready to accept connections' &> /dev/null; do
+while ! docker logs --since 5m op-migrate-pg17 2>&1 | grep 'database system is ready to accept connections' &> /dev/null; do
   echo "... waiting for database to start"
   sleep 3
 

--- a/docs/installation-and-operations/operation/upgrading/README.md
+++ b/docs/installation-and-operations/operation/upgrading/README.md
@@ -8,7 +8,7 @@ sidebar_navigation:
 
 > **Note**: We strongly recommend that you have backed up your installation before upgrading OpenProject to a newer version, especially when performing multiple upgrades at once. Please follow the [backup](../backing-up) instructions.
 
-> **Note**: OpenProject supports migrating from one major version to the next. That means that migrating from a version X (and any of its minor and patch level) to version X+1 (and any of its minor and patch level) is supported. Migrating to X+2 however cannot be done directly but requires to install X+1 in between.
+> **Note**: OpenProject supports migrating from one major version to the next. That means that migrating from a version X (and any of its minor and patch level) to version X+1 (and any of its minor and patch level) is supported. Migrating to X+2 however cannot be done directly but requires to install X+1 in between. Please refer to the [Step-wise database migration script](#step-wise-database-migration-script) section for an easy way to do this.
 
 | Topic                                                        | Content                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
@@ -267,3 +267,67 @@ rm -rf /opt/openproject/frontend/node_modules
 OpenProject 8.0. has removed Textile, all previous content is migrated to GFM Markdown using [pandoc](https://pandoc.org). This will happen automatically during the migration run. A recent pandoc version will be downloaded by OpenProject.
 
 For more information, please visit [this separate guide](../../misc/textile-migration).
+
+## Step-wise database migration script
+
+For migrating database dumps from OpenProject version 10 or later to the current version, you can use the [`bin/migrate`](../../../../bin/migrate) script. This script automates the process of restoring a database dump and sequentially applying migrations through each OpenProject version until the latest version is reached.
+
+### Prerequisites
+
+- Docker installed and running
+- Docker Hub access (to pull OpenProject images)
+- A database dump file from OpenProject 10.x or later (in `.sql` or `.pgdump` format)
+
+### Usage
+
+```shell
+./bin/migrate [OPTIONS] <dump-file>
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-n, --change-schema-name NAME` | Change the PostgreSQL schema name to `NAME` before dumping the migrated database. Default schema is `public`. |
+| `-f, --format FORMAT` | Output format for the migrated dump. Options: `sql` (default, gzipped), `pgdump` (custom/binary format). |
+
+### Examples
+
+Migrate a database dump to the latest version:
+
+```shell
+./bin/migrate openproject-10.5.sql
+```
+
+Migrate and output in PostgreSQL custom format:
+
+```shell
+./bin/migrate -f pgdump openproject-10.5.sql
+```
+
+Migrate and change the schema name to `custom_schema`:
+
+```shell
+./bin/migrate -n custom_schema openproject-10.5.sql
+```
+
+Migrate with both custom format and schema name:
+
+```shell
+./bin/migrate -f pgdump -n custom_schema openproject-10.5.sql
+```
+
+### Output
+
+The script creates a new file with the migrated database dump. The output filename is derived from the input filename:
+
+- For SQL format (default): `{input}-migrated.sql.gz` (gzipped)
+- For pgdump format: `{input}-migrated.pgdump`
+
+### Notes
+
+- The script requires a dump from OpenProject 10.x or later. For older versions, use `script/migrate/migrate-from-pre-8.sh` first.
+- The script starts a temporary PostgreSQL 17 container for the migration process.
+- Each OpenProject version's Docker image is pulled on demand during migration.
+- The migration process may take significant time depending on the size of your database and the number of versions to migrate through.
+- The script automatically cleans up the temporary container and files on exit.

--- a/docs/installation-and-operations/operation/upgrading/README.md
+++ b/docs/installation-and-operations/operation/upgrading/README.md
@@ -276,7 +276,7 @@ For migrating database dumps from OpenProject version 10 or later to the current
 
 - Docker installed and running
 - Docker Hub access (to pull OpenProject images)
-- A database dump file from OpenProject 10.x or later (in `.sql` or `.pgdump` format)
+- A database dump file from OpenProject 10.x or later in `.sql` plain text format
 
 ### Usage
 


### PR DESCRIPTION
Adds a helper script to perform a step-wise migration of a given OpenProject dump with the only dependency being **bash** and **docker**.

- [x] migrate in major version steps starting from OpenProject 15
- [x] allow text (.sql)
- [x] or custom (.pgdump)
- [x] check schema versions to check at which version to start, a version hint in the db would be quite useful here
- [x] execute background jobs enqueued by migrations 
- [x] add docs

An exemplary run would look as follows.

```
bin/migrate .../openproject.sql 
Starting database...
... waiting for database to start
Database started under 172.17.0.3
CREATE DATABASE
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION

Restoring dump
SET
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
CREATE COLLATION
CREATE EXTENSION
COMMENT
SET
SET
CREATE TABLE
CREATE SEQUENCE
ALTER SEQUENCE
CREATE TABLE
CREATE TABLE
CREATE SEQUENCE
ALTER SEQUENCE
CREATE TABLE

[...]

Imported database
Looking for next OpenProject version...

15: Pulling from openproject/openproject
Digest: sha256:d9f71d33f3fa2b2059c4c8e3978a4cccd5044437d9023b2be284aca83a17e717
Status: Image is up to date for openproject/openproject:15
docker.io/openproject/openproject:15

Migrating to OpenProject 15...
-----> Setting PGVERSION=13 PGBIN=/usr/lib/postgresql/13/bin PGCONF_FILE=/etc/postgresql/13/main/postgresql.conf
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/schema_cache.rb:129:in 'block in ActiveRecord::ConnectionAdapters::SchemaReflection#load_cache': Ignoring db/schema_cache.yml because it has expired. The current schema version is 20251103123548, but the one in the schema cache file is 20250402083709. (StructuredWarnings::StandardWarning)
/app/vendor/bundle/ruby/3.4.0/gems/grape-2.3.0/lib/grape/util/registry.rb:10:in 'Grape::Util::Registry#register': json is already registered with class Bim::Bcf::API::ErrorFormatter::Json (StructuredWarnings::StandardWarning)
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/schema_cache.rb:129:in 'block in ActiveRecord::ConnectionAdapters::SchemaReflection#load_cache': Ignoring db/schema_cache.yml because it has expired. The current schema version is 20251103123548, but the one in the schema cache file is 20250402083709. (StructuredWarnings::StandardWarning)
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PG::DuplicateTable: ERROR:  relation "work_packages" already exists
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in 'PG::Connection#exec'

[...]

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateTable: ERROR:  relation "work_packages" already exists (ActiveRecord::StatementInvalid)

[...]

Caused by:
PG::DuplicateTable: ERROR:  relation "work_packages" already exists (PG::DuplicateTable)

[...]

/usr/local/bundle/bin/bundle:25:in 'Kernel#load'
/usr/local/bundle/bin/bundle:25:in '<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
I, [2026-07-29T09:43:54.828168 #1]  INFO -- : Increasing database pool size to 17 to match max threads
W, [2026-07-29T09:43:55.851065 #1]  WARN -- : 127.0.0.1:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:43:55.957553 #1]  WARN -- : 127.0.0.1:11211 failed (count: 1) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:43:55.957592 #1]  WARN -- : 127.0.0.1:11211 is down
I, [2026-07-29T09:43:58.694795 #1]  INFO -- : Migrating to ToV710AggregatedMigrations (10000000000000)
== 10000000000000 ToV710AggregatedMigrations: migrating =======================
-- create_table("work_packages", {id: :integer, bulk: true})

Warning: Migration to OpenProject 15 failed likely because the dump is already beyond that version. Trying next version.
Looking for next OpenProject version...

16: Pulling from openproject/openproject
Digest: sha256:eb08fa636184f737af2cd31b2ef1706cb9b35bf7bc2cfe2c4e065e1dd461a74e
Status: Image is up to date for openproject/openproject:16
docker.io/openproject/openproject:16

Migrating to OpenProject 16...
-----> Setting PGVERSION=17 PGBIN=/usr/lib/postgresql/17/bin PGCONF_FILE=/etc/postgresql/17/main/postgresql.conf
/app/vendor/bundle/ruby/3.4.0/gems/activerecord-8.0.3/lib/active_record/connection_adapters/schema_cache.rb:129:in 'block in ActiveRecord::ConnectionAdapters::SchemaReflection#load_cache': Ignoring db/schema_cache.yml because it has expired. The current schema version is 20251103123548, but the one in the schema cache file is 20260313120000. (StructuredWarnings::StandardWarning)
I, [2026-07-29T09:44:10.136181 #1]  INFO -- : Increasing database pool size to 17 to match max threads
W, [2026-07-29T09:44:11.204851 #1]  WARN -- : 127.0.0.1:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:44:11.312445 #1]  WARN -- : 127.0.0.1:11211 failed (count: 1) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:44:11.312484 #1]  WARN -- : 127.0.0.1:11211 is down
I, [2026-07-29T09:44:14.270401 #1]  INFO -- : Migrating to StripControlCharactersFromCustomFieldNames (20260313120000)
== 20260313120000 StripControlCharactersFromCustomFieldNames: migrating =======
-- execute("UPDATE custom_fields SET name = regexp_replace(name, E'[\\x01-\\x1F\\x7F]', '', 'g') WHERE name ~ E'[\\x01-\\x1F\\x7F]'")
   -> 0.0014s
== 20260313120000 StripControlCharactersFromCustomFieldNames: migrated (0.0015s) 

Looking for next OpenProject version...

17: Pulling from openproject/openproject
Digest: sha256:027281d63686e64059d2f5592ca643a0f6208cfdebe66486b51e152008ffc4d4
Status: Image is up to date for openproject/openproject:17
docker.io/openproject/openproject:17

Migrating to OpenProject 17...
-----> Setting PGVERSION=17 PGBIN=/usr/lib/postgresql/17/bin PGCONF_FILE=/etc/postgresql/17/main/postgresql.conf
/app/vendor/bundle/ruby/4.0.0/gems/activerecord-8.1.3/lib/active_record/connection_adapters/schema_cache.rb:129:in 'block in ActiveRecord::ConnectionAdapters::SchemaReflection#load_cache': Ignoring db/schema_cache.yml because it has expired. The current schema version is 20260313120000, but the one in the schema cache file is 20260706065400. (StructuredWarnings::StandardWarning)
/app/vendor/bundle/ruby/4.0.0/gems/activerecord-8.1.3/lib/active_record/connection_adapters/schema_cache.rb:129:in 'block in ActiveRecord::ConnectionAdapters::SchemaReflection#load_cache': Ignoring db/schema_cache.yml because it has expired. The current schema version is 20260313120000, but the one in the schema cache file is 20260706065400. (StructuredWarnings::StandardWarning)
I, [2026-07-29T09:44:25.167661 #1]  INFO -- : Increasing database pool size to 17 to match max threads
W, [2026-07-29T09:44:26.015127 #1]  WARN -- : 127.0.0.1:11211 failed (count: 0) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:44:26.121609 #1]  WARN -- : 127.0.0.1:11211 failed (count: 1) Errno::ECONNREFUSED: Connection refused - connect(2) for "127.0.0.1" port 11211
W, [2026-07-29T09:44:26.121644 #1]  WARN -- : 127.0.0.1:11211 is down
I, [2026-07-29T09:44:28.755972 #1]  INFO -- : Migrating to AggregatedMigrations (1000016)
== 1000016 AggregatedMigrations: migrating ====================================
== 1000016 AggregatedMigrations: migrated (0.0056s) ===========================

I, [2026-07-29T09:44:28.907246 #1]  INFO -- : Migrating to AggregatedMeetingMigrations (1003016)
== 1003016 AggregatedMeetingMigrations: migrating =============================
== 1003016 AggregatedMeetingMigrations: migrated (0.0013s) ====================

I, [2026-07-29T09:44:28.970168 #1]  INFO -- : Migrating to AggregatedCostsMigrations (1009016)
== 1009016 AggregatedCostsMigrations: migrating ===============================
== 1009016 AggregatedCostsMigrations: migrated (0.0009s) ======================

I, [2026-07-29T09:44:29.032123 #1]  INFO -- : Migrating to AggregatedStoragesMigrations (1017016)
== 1017016 AggregatedStoragesMigrations: migrating ============================
== 1017016 AggregatedStoragesMigrations: migrated (0.0127s) ===================

[...]

I, [2026-07-29T09:44:32.781526 #1]  INFO -- : Migrating to RemoveDeletedUserMeetingParticipants (20260706065400)
== 20260706065400 RemoveDeletedUserMeetingParticipants: migrating =============
-- execute("DELETE FROM meeting_participant_journals USING users WHERE meeting_participant_journals.user_id = users.id AND users.type = 'DeletedUser'")
   -> 0.0006s
-- execute("DELETE FROM meeting_participants USING users WHERE meeting_participants.user_id = users.id AND users.type = 'DeletedUser'")
   -> 0.0003s
== 20260706065400 RemoveDeletedUserMeetingParticipants: migrated (0.0011s) ====

Looking for next OpenProject version...

Error response from daemon: failed to resolve reference "docker.io/openproject/openproject:18": docker.io/openproject/openproject:18: not found

No newer OpenProject version found. Migration complete.
Dumping migrated (OpenProject 17) database...

Dump saved under .../openproject-migrated.sql.gz

Cleaning up...
op-migrate-pg17
done
```