### PR TITLE
Refactor installation uuid to use new persist_on_first_read

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -80,8 +80,6 @@ class Setting < ApplicationRecord
     end
 
     def create_setting_accessors(name)
-      return if [:installation_uuid].include?(name.to_sym)
-
       # Defines getter and setter for each setting
       # Then setting values can be read using: Setting.some_setting_name
       # or set using Setting.some_setting_name = "some value"
@@ -221,28 +219,6 @@ class Setting < ApplicationRecord
   # Check whether a setting was defined
   def self.exists?(name)
     Settings::Definition[name].present?
-  end
-
-  def self.installation_uuid
-    if settings_table_exists_yet?
-      # we avoid the default getters and setters since the cache messes things up
-      setting = find_or_initialize_by(name: "installation_uuid")
-      if setting.value.blank?
-        setting.value = generate_installation_uuid
-        setting.save!
-      end
-      setting.value
-    else
-      "unknown"
-    end
-  end
-
-  def self.generate_installation_uuid
-    if Rails.env.test?
-      "test"
-    else
-      SecureRandom.uuid
-    end
   end
 
   %i[emails_header emails_footer].each do |mail|

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -657,7 +657,11 @@ module Settings
       },
       installation_uuid: {
         format: :string,
-        default: nil
+        default: -> { SecureRandom.uuid },
+        persist_on_first_read: true,
+        default_by_env: {
+          test: "test_uuid"
+        }
       },
       internal_password_confirmation: {
         description: "Require password confirmations for certain administrative actions",

--- a/spec/helpers/security_badge_helper_spec.rb
+++ b/spec/helpers/security_badge_helper_spec.rb
@@ -32,17 +32,12 @@ require "spec_helper"
 
 RSpec.describe SecurityBadgeHelper do
   describe "#security_badge_url" do
-    before do
-      # can't use with_settings since Setting.installation_uuid has a custom implementation
-      allow(Setting).to receive(:installation_uuid).and_return "abcd1234"
-    end
-
     it "generates a URL with the release API path and the details of the installation" do
       uri = URI.parse(helper.security_badge_url)
       query = Rack::Utils.parse_nested_query(uri.query)
       expect(uri.host).to eq("releases.openproject.com")
       expect(query.keys).to contain_exactly("uuid", "type", "version", "db", "lang", "ee")
-      expect(query["uuid"]).to eq("abcd1234")
+      expect(query["uuid"]).to eq("test_uuid")
       expect(query["version"]).to eq(OpenProject::VERSION.to_semver)
       expect(query["type"]).to eq("manual")
       expect(query["ee"]).to eq("false")

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -267,53 +267,6 @@ RSpec.describe Setting do
     end
   end
 
-  describe ".installation_uuid" do
-    after do
-      described_class.find_by(name: "installation_uuid")&.destroy
-    end
-
-    it "returns unknown if the settings table isn't available yet" do
-      allow(described_class)
-        .to receive(:settings_table_exists_yet?)
-        .and_return(false)
-      expect(described_class.installation_uuid).to eq("unknown")
-    end
-
-    context "with settings table ready" do
-      it "resets the value if blank" do
-        described_class.create!(name: "installation_uuid", value: "")
-        expect(described_class.installation_uuid).not_to be_blank
-      end
-
-      it "returns the existing value if any" do
-        # can't use with_settings since described_class.installation_uuid has a custom implementation
-        allow(described_class).to receive(:installation_uuid).and_return "abcd1234"
-
-        expect(described_class.installation_uuid).to eq("abcd1234")
-      end
-
-      context "with no existing value" do
-        context "in test environment" do
-          before do
-            expect(Rails.env).to receive(:test?).and_return(true)
-          end
-
-          it "returns 'test' as the UUID" do
-            expect(described_class.installation_uuid).to eq("test")
-          end
-        end
-
-        it "returns a random UUID" do
-          expect(Rails.env).to receive(:test?).and_return(false)
-          installation_uuid = described_class.installation_uuid
-          expect(installation_uuid).not_to eq("test")
-          expect(installation_uuid.size).to eq(36)
-          expect(described_class.installation_uuid).to eq(installation_uuid)
-        end
-      end
-    end
-  end
-
   # Check that when reading certain setting values that they get overwritten if needed.
   describe "filter saved settings" do
     it "returns the value for 'work_package_list_default_highlighting_mode' without changing it" do


### PR DESCRIPTION
We introduced `persist_on_first_read` for a similar pattern that installation_uuid has. Generate a setting in DB on first read. we can reuse it and remove complexity

https://community.openproject.org/work_packages/71634