### PR TITLE
Always respond in Bearer method for WWW-Authenticate header

### DIFF
--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -168,7 +168,7 @@ module Accounts::CurrentUser
           redirect_to main_app.signin_path(back_url: login_back_url)
         end
 
-        auth_header = OpenProject::Authentication::WWWAuthenticate.response_header(request_headers: request.headers)
+        auth_header = OpenProject::Authentication::WWWAuthenticate.response_header
 
         format.any(:xml, :js, :json, :turbo_stream) do
           head :unauthorized,

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -30,20 +30,14 @@
 
 namespace = OpenProject::Authentication::Strategies::Warden
 
-strategies = [
-  [:basic_auth_failure, namespace::BasicAuthFailure,  "Basic"],
-  [:global_basic_auth,  namespace::GlobalBasicAuth,   "Basic"],
-  [:user_basic_auth,    namespace::UserBasicAuth,     "Basic"],
-  [:user_api_token,     namespace::UserAPIToken,      "Bearer"],
-  [:oauth,              namespace::DoorkeeperOAuth,   "Bearer"],
-  [:anonymous_fallback, namespace::AnonymousFallback, "Basic"],
-  [:jwt_oidc,           namespace::JwtOidc,           "Bearer"],
-  [:session,            namespace::Session,           "Session"]
-]
-
-strategies.each do |name, clazz, auth_scheme|
-  OpenProject::Authentication.add_strategy(name, clazz, auth_scheme)
-end
+OpenProject::Authentication.add_strategy(:basic_auth_failure, namespace::BasicAuthFailure,  "Basic")
+OpenProject::Authentication.add_strategy(:global_basic_auth,  namespace::GlobalBasicAuth,   "Basic")
+OpenProject::Authentication.add_strategy(:user_basic_auth,    namespace::UserBasicAuth,     "Basic")
+OpenProject::Authentication.add_strategy(:user_api_token,     namespace::UserAPIToken,      "Bearer")
+OpenProject::Authentication.add_strategy(:oauth,              namespace::DoorkeeperOAuth,   "Bearer")
+OpenProject::Authentication.add_strategy(:anonymous_fallback, namespace::AnonymousFallback, "Basic")
+OpenProject::Authentication.add_strategy(:jwt_oidc,           namespace::JwtOidc,           "Bearer")
+OpenProject::Authentication.add_strategy(:session,            namespace::Session,           "Session")
 
 OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope::API_V3, { store: false }) do |_|
   %i[global_basic_auth

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -32,9 +32,7 @@ export class TurboRequestsService {
       init.signal = controller.signal;
     }
 
-    const defaultHeaders:{'X-Authentication-Scheme':string, 'X-CSRF-Token'?:string} = {
-      'X-Authentication-Scheme': 'Session',
-    };
+    const defaultHeaders:{'X-CSRF-Token'?:string} = {};
     if(init.method && !(init.method === 'GET' || init.method === 'HEAD')) {
       defaultHeaders['X-CSRF-Token'] = getMetaContent('csrf-token');
     }

--- a/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
@@ -32,9 +32,7 @@ export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   private handleAuthenticatedRequest(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
     const csrfToken = getMetaContent('csrf-token');
 
-    let newHeaders = req.headers
-      .set('X-Authentication-Scheme', 'Session')
-      .set('X-Requested-With', 'XMLHttpRequest');
+    let newHeaders = req.headers.set('X-Requested-With', 'XMLHttpRequest');
 
     if (csrfToken) {
       newHeaders = newHeaders.set('X-CSRF-TOKEN', csrfToken);

--- a/frontend/src/react/helpers/connection-template-fetcher.ts
+++ b/frontend/src/react/helpers/connection-template-fetcher.ts
@@ -80,7 +80,6 @@ export async function fetchConnectionTemplate(
       method: 'GET',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
-        'X-Authentication-Scheme': 'Session',
       },
     });
 

--- a/frontend/src/stimulus/controllers/async-dialog.controller.ts
+++ b/frontend/src/stimulus/controllers/async-dialog.controller.ts
@@ -61,7 +61,6 @@ export default class AsyncDialogController extends ApplicationController {
       method: this.method,
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
-        'X-Authentication-Scheme': 'Session',
       },
     }).then((response) => {
       const contentType = response.headers.get('Content-Type') ?? '';

--- a/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
@@ -119,7 +119,6 @@ export default class extends ApplicationController {
       method: 'GET',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
-        'X-Authentication-Scheme': 'Session',
       },
     })
       .then((response:Response) => {

--- a/frontend/src/stimulus/controllers/dynamic/forum-messages.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/forum-messages.controller.ts
@@ -53,7 +53,6 @@ export default class ForumMessagesController extends Controller {
     void fetch(href, {
       headers: {
         Accept: 'application/json',
-        'X-Authentication-Scheme': 'Session',
       },
     })
       .then((response) => response.json())

--- a/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
+++ b/frontend/src/stimulus/controllers/require-password-confirmation.controller.ts
@@ -91,7 +91,6 @@ export default class RequirePasswordConfirmationController extends ApplicationCo
       method: 'GET',
       headers: {
         Accept: 'text/vnd.turbo-stream.html',
-        'X-Authentication-Scheme': 'Session',
       },
     }).then((response) => {
       const contentType = response.headers.get('Content-Type') ?? '';

--- a/frontend/src/stimulus/services/documents/token-refresh.service.ts
+++ b/frontend/src/stimulus/services/documents/token-refresh.service.ts
@@ -120,7 +120,6 @@ export class TokenRefreshService {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-Token': getMetaContent('csrf-token'),
-        'X-Authentication-Scheme': 'Session',
       },
       credentials: 'same-origin',
     });

--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -31,7 +31,6 @@ export function addTurboEventListeners() {
     const headers = event.detail.fetchOptions.headers as Record<string, string>;
     headers['Turbo-Referrer'] = window.location.href;
     headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
-    headers['X-Authentication-Scheme'] = 'Session';
   });
 
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -279,8 +279,7 @@ module API
 
     def self.auth_headers
       lambda do
-        header = OpenProject::Authentication::WWWAuthenticate
-                   .response_header(scope: authentication_scope, request_headers: env)
+        header = OpenProject::Authentication::WWWAuthenticate.response_header(scope: authentication_scope)
 
         { "WWW-Authenticate" => header }
       end

--- a/lib_static/open_project/authentication.rb
+++ b/lib_static/open_project/authentication.rb
@@ -240,20 +240,6 @@ module OpenProject
     module WWWAuthenticate
       module_function
 
-      def pick_auth_scheme(supported_schemes, default_scheme, request_headers = {})
-        req_scheme = request_headers["HTTP_X_AUTHENTICATION_SCHEME"]
-
-        if supported_schemes.include? req_scheme
-          req_scheme
-        else
-          default_scheme
-        end
-      end
-
-      def default_auth_scheme
-        "Basic"
-      end
-
       def default_realm
         "OpenProject API"
       end
@@ -262,34 +248,16 @@ module OpenProject
         Manager.scope_config(scope).realm || default_realm
       end
 
-      def response_header(
-        default_auth_scheme: self.default_auth_scheme,
-        scope: nil,
-        request_headers: {},
-        error: nil,
-        error_description: nil
-      )
-        scheme = pick_auth_scheme(auth_schemes(scope),
-                                  default_auth_scheme,
-                                  request_headers)
+      def response_header(scope: nil, error: nil, error_description: nil)
+        header = %{Bearer realm="#{scope_realm(scope)}", resource_metadata="#{resource_metadata}"}
+        header << %{, scope="#{escape_string scope}"} if scope
 
-        header = %{#{scheme} realm="#{scope_realm(scope)}"}
-        if scheme == "Bearer"
-          header << %{, resource_metadata="#{resource_metadata}"}
-          header << %{, scope="#{escape_string scope}"} if scope
+        if error
+          header << %{, error="#{escape_string error}"}
+          header << %{, error_description="#{escape_string error_description}"} if error_description
         end
 
-        header << %{, error="#{escape_string error}"}                         if error
-        header << %{, error_description="#{escape_string error_description}"} if error && error_description
         header
-      end
-
-      def auth_schemes(scope)
-        strategies = Array(Manager.scope_config(scope).strategies)
-
-        Manager.auth_schemes
-          .select { |_, info| scope.nil? or info.strategies.intersect?(strategies) }
-          .keys
       end
 
       def escape_string(string)
@@ -301,13 +269,15 @@ module OpenProject
       end
     end
 
+    # Prepended to the warden basic auth strategy, so when a client already tries to use Basic auth (but fails), they
+    # will receive a Basic WWW-Authenticate header.
     module AuthHeaders
       include WWWAuthenticate
 
       # #scope available from Warden::Strategies::BasicAuth
 
       def auth_scheme
-        pick_auth_scheme auth_schemes(scope), default_auth_scheme, env
+        "Basic"
       end
 
       def realm

--- a/lib_static/open_project/authentication/failure_app.rb
+++ b/lib_static/open_project/authentication/failure_app.rb
@@ -75,8 +75,7 @@ module OpenProject
       end
 
       def unauthorized_header(env)
-        header = OpenProject::Authentication::WWWAuthenticate
-          .response_header(scope: scope(env), request_headers: env)
+        header = OpenProject::Authentication::WWWAuthenticate.response_header(scope: scope(env))
 
         { "WWW-Authenticate" => header }
       end

--- a/lib_static/open_project/authentication/strategies/warden/fail_with_header.rb
+++ b/lib_static/open_project/authentication/strategies/warden/fail_with_header.rb
@@ -36,7 +36,6 @@ module OpenProject
           def fail_with_header!(error:, error_description: nil)
             headers(
               "WWW-Authenticate" => OpenProject::Authentication::WWWAuthenticate.response_header(
-                default_auth_scheme: "Bearer",
                 scope:,
                 error:,
                 error_description:

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -187,6 +187,9 @@ RSpec.describe "API V3 Authentication" do
       let(:token) { create(:oauth_access_token, resource_owner: nil, application:) }
       let(:application) { create(:oauth_application) }
       let(:oauth_access_token) { token.plaintext_token }
+      let(:expected_www_auth_header) do
+        %{Bearer realm="OpenProject API", #{resource_metadata}, scope="api_v3"}
+      end
 
       # Note: This is just caused by DoorkeeperOauth rejecting to handle this case and auth falling through to basic auth
       # more specific examples can be found at spec/requests/oauth/client_credentials_flow_spec.rb
@@ -194,10 +197,7 @@ RSpec.describe "API V3 Authentication" do
 
       it "returns unauthorized" do
         expect(last_response).to have_http_status :unauthorized
-
-        # Note: This is just caused by DoorkeeperOauth rejecting to handle this case and auth falling through to basic auth
-        # more specific examples can be found at spec/requests/oauth/client_credentials_flow_spec.rb
-        expect(last_response.header["WWW-Authenticate"]).to eq('Basic realm="OpenProject API"')
+        expect(last_response.header["WWW-Authenticate"]).to eq(expected_www_auth_header)
         expect(JSON.parse(last_response.body)).to eq(error_response_body)
       end
 
@@ -332,7 +332,7 @@ RSpec.describe "API V3 Authentication" do
           end
 
           it "returns the WWW-Authenticate header" do
-            expect(last_response.header["WWW-Authenticate"]).to include 'Basic realm="OpenProject API"'
+            expect(last_response.header["WWW-Authenticate"]).to include 'Bearer realm="OpenProject API"'
           end
         end
 
@@ -383,34 +383,7 @@ RSpec.describe "API V3 Authentication" do
 
           it "returns the WWW-Authenticate header" do
             expect(last_response.header["WWW-Authenticate"])
-              .to include 'Basic realm="OpenProject API"'
-          end
-        end
-
-        context 'with invalid credentials an X-Authentication-Scheme "Session"' do
-          let(:expected_message) { "You did not provide the correct credentials." }
-
-          before do
-            set_basic_auth_header(username, password.reverse)
-            header "X-Authentication-Scheme", "Session"
-            get resource
-          end
-
-          it "returns 401 unauthorized" do
-            expect(last_response).to have_http_status :unauthorized
-          end
-
-          it "returns the correct JSON response" do
-            expect(JSON.parse(last_response.body)).to eq error_response_body
-          end
-
-          it "returns the correct content type header" do
-            expect(last_response.headers["Content-Type"]).to eq "application/hal+json; charset=utf-8"
-          end
-
-          it "returns the WWW-Authenticate header" do
-            expect(last_response.header["WWW-Authenticate"])
-              .to include 'Session realm="OpenProject API"'
+              .to include 'Bearer realm="OpenProject API"'
           end
         end
 

--- a/spec/requests/mcp/mcp_resources/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/current_user_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::CurrentUser, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/project_spec.rb
+++ b/spec/requests/mcp/mcp_resources/project_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::Project, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/status_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_list_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::StatusList, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/status_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::Status, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/type_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_list_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::TypeList, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/type_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::Type, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/user_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::User, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/version_spec.rb
+++ b/spec/requests/mcp/mcp_resources/version_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::Version, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_resources/work_package_spec.rb
+++ b/spec/requests/mcp/mcp_resources/work_package_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpResources::WorkPackage, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_tools/current_user_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::CurrentUser, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::ListStatuses, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/list_types_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_types_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::ListTypes, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/search_users_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_users_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::SearchUsers, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe McpTools::SearchWorkPackages, with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end

--- a/spec/requests/mcp/resource_templates_list_spec.rb
+++ b/spec/requests/mcp/resource_templates_list_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe "MCP resources/templates/list", with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end
@@ -87,7 +86,6 @@ RSpec.describe "MCP resources/templates/list", with_flag: { mcp_server: true } d
 
     context "when not passing a Bearer token" do
       subject do
-        header "X-Authentication-Scheme", "Bearer"
         header "Content-Type", "application/json"
         post "/mcp", request_body.to_json
       end

--- a/spec/requests/mcp/resources_list_spec.rb
+++ b/spec/requests/mcp/resources_list_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe "MCP resources/list", with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end
@@ -87,7 +86,6 @@ RSpec.describe "MCP resources/list", with_flag: { mcp_server: true } do
 
     context "when not passing a Bearer token" do
       subject do
-        header "X-Authentication-Scheme", "Bearer"
         header "Content-Type", "application/json"
         post "/mcp", request_body.to_json
       end

--- a/spec/requests/mcp/tools_list_spec.rb
+++ b/spec/requests/mcp/tools_list_spec.rb
@@ -33,7 +33,6 @@ require "spec_helper"
 RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
-    header "X-Authentication-Scheme", "Bearer"
     header "Content-Type", "application/json"
     post "/mcp", request_body.to_json
   end
@@ -71,9 +70,6 @@ RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
 
     context "when not passing a token" do
       subject do
-        # TODO: It's actually a hack that we expect clients to provide this header for proper WWW-Authenticate responses
-        # Regular clients will never see the extended WWW-Authenticate headers with resource_metadata hints
-        header "X-Authentication-Scheme", "Bearer"
         header "Content-Type", "application/json"
         post "/mcp", request_body.to_json
       end


### PR DESCRIPTION
The intention of this change is to always respond in the metadata-rich version of the header that indicates things like the required scope and the URL of the resource_metadata endpoint, which was previously hidden and only visible if clients used a non-standard HTTP request header.

semantically it's probably the preferable version of the header by now anyways, because:

* all APIs accept some kind of Bearer token, not all of them accept Basic auth
* Even API tokens can now be passed as Bearer tokens

Practically the Basic auth header also caused unintended browser pop-ups when the frontend code didn't include the correct request header to avoid the Basic auth offer, this now can't happen anymore, since the Basic auth version of the header is only returned, if the client actively tried to authenticate through Basic auth.

# Ticket
https://community.openproject.org/wp/71419

# Alternatives considered

**Alternative 1: Only change the default, but keep auth scheme selection logic**

This solution was dismissed, because it would keep the code as complex as it was before without any perceivable benefit. The `X-Authentication-Scheme` header has never been documented anywhere and our code does not seem to rely on the server responding in `WWW-Authenticate: Session ...` at all. As far as I can tell, the primary purpose of this header was to "get rid" of the basic auth pop ups in the browser. Thus simplification seemed like the preferable choice.

**Alternative 2: Return multiple WWW-Authenticate headers**

I honestly considered this option for being semantically most correct. As far as I can tell (and I would've needed to investigate this further before implementing), it's perfectly legal to include the `WWW-Authenticate` header more than once, i.e. one header per supported scheme.

However, this solution would've even increased the complexity of the implementation and might still have required us to suppress the Basic auth response in some cases. In the end this didn't seem worth it, even though I'd still consider it, if there's a need to not skip a supported auth method.