### PR TITLE
[#71379] Project initiation request cannot be finished with default setting

### DIFF
--- a/app/contracts/projects/create_artifact_work_package_contract.rb
+++ b/app/contracts/projects/create_artifact_work_package_contract.rb
@@ -69,9 +69,9 @@ module Projects
     end
 
     def validate_assignee_custom_field
-      if project_assignee_custom_field_not_configured?
-        add_error :project_creation_wizard_assignee_custom_field_id, :blank
-      elsif not_allowed_to_read_assignee_custom_field_value?
+      return if project_assignee_custom_field_not_configured?
+
+      if not_allowed_to_read_assignee_custom_field_value?
         add_error assignee_custom_field.attribute_name, :unauthorized
       elsif missing_assignee_custom_field_value?
         add_error assignee_custom_field.attribute_name, :blank

--- a/app/contracts/projects/settings_contract.rb
+++ b/app/contracts/projects/settings_contract.rb
@@ -52,7 +52,6 @@ module Projects
       validate_work_package_type
       validate_status_when_submitted
       validate_assignee_custom_field
-      validate_work_package_comment
       validate_notification_text
     end
 
@@ -78,21 +77,13 @@ module Projects
     end
 
     def validate_assignee_custom_field
-      if model.project_creation_wizard_assignee_custom_field_id.blank?
-        errors.add :project_creation_wizard_assignee_custom_field_id, :blank
-      else
-        valid_custom_field = model.available_custom_fields
-                                  .where(field_format: "user", multi_value: false)
-                                  .exists?(id: model.project_creation_wizard_assignee_custom_field_id)
-        unless valid_custom_field
-          errors.add :project_creation_wizard_assignee_custom_field_id, :inclusion
-        end
-      end
-    end
+      return if model.project_creation_wizard_assignee_custom_field_id.blank?
 
-    def validate_work_package_comment
-      if model.project_creation_wizard_work_package_comment.blank?
-        errors.add :project_creation_wizard_work_package_comment, :blank
+      valid_custom_field = model.available_custom_fields
+                                .where(field_format: "user", multi_value: false)
+                                .exists?(id: model.project_creation_wizard_assignee_custom_field_id)
+      unless valid_custom_field
+        errors.add :project_creation_wizard_assignee_custom_field_id, :inclusion
       end
     end
 

--- a/app/controllers/projects/settings/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/creation_wizard_controller.rb
@@ -109,7 +109,8 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
     error = if @project.project_creation_wizard_default_work_package_type.nil?
               I18n.t("projects.settings.creation_wizard.errors.no_work_package_type")
             elsif @project.project_creation_wizard_default_status_when_submitted.nil?
-              I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted")
+              type = @project.project_creation_wizard_default_work_package_type.name
+              I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted", type:)
             end
 
     if error

--- a/app/controllers/projects/settings/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/creation_wizard_controller.rb
@@ -34,6 +34,7 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
   menu_item :settings_creation_wizard
 
   before_action :check_enterprise_plan, only: :toggle
+  before_action :check_activation_conditions, only: :toggle
 
   def show; end
 
@@ -98,6 +99,22 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
     unless EnterpriseToken.allows_to?(:project_creation_wizard)
       flash[:error] = I18n.t(:notice_requires_enterprise_token)
       redirect_to project_settings_creation_wizard_path(@project, tab: "attributes"), status: :see_other
+    end
+  end
+
+  def check_activation_conditions
+    # Allow disabling even without activation conditions met
+    return if @project.project_creation_wizard_enabled
+
+    error = if @project.project_creation_wizard_default_work_package_type.nil?
+              I18n.t("projects.settings.creation_wizard.errors.no_work_package_type")
+            elsif @project.project_creation_wizard_default_status_when_submitted.nil?
+              I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted")
+            end
+
+    if error
+      flash[:error] = error
+      redirect_to project_settings_creation_wizard_path(@project, tab: params[:tab]), status: :see_other
     end
   end
 

--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -78,7 +78,7 @@ module Projects
             name: :project_creation_wizard_assignee_custom_field_id,
             label: I18n.t("settings.project_initiation_request.submission.assignee"),
             caption: I18n.t("settings.project_initiation_request.submission.assignee_caption_html").html_safe,
-            required: true,
+            required: false,
             input_width: :large,
             autocomplete_options: {
               component: "opce-autocompleter",
@@ -99,7 +99,7 @@ module Projects
             name: :project_creation_wizard_work_package_comment,
             label: I18n.t("settings.project_initiation_request.submission.work_package_comment"),
             caption: I18n.t("settings.project_initiation_request.submission.work_package_comment_caption"),
-            required: true,
+            required: false,
             value: model.project_creation_wizard_work_package_comment.presence || I18n.t(
               "settings.project_initiation_request.submission.work_package_comment_default", project_name: model.name
             ),

--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -60,7 +60,7 @@ module Projects
             input_width: :large
           ) do |list|
             # Statuses of the selected WP type
-            type_id = model.project_creation_wizard_work_package_type_id || model.types.first&.id
+            type_id = model.project_creation_wizard_work_package_type_id
 
             if type_id.present?
               type = Type.find_by(id: type_id)

--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -52,5 +52,21 @@ module Projects::CreationWizard
     def project_creation_wizard_artifact_name
       super.presence || DEFAULT_ARTIFACT_NAME_OPTION
     end
+
+    def project_creation_wizard_work_package_type_id
+      super.presence || project_creation_wizard_default_work_package_type&.id
+    end
+
+    def project_creation_wizard_status_when_submitted_id
+      super.presence || project_creation_wizard_default_status_when_submitted&.id
+    end
+
+    def project_creation_wizard_default_work_package_type
+      types.first
+    end
+
+    def project_creation_wizard_default_status_when_submitted
+      project_creation_wizard_default_work_package_type&.statuses&.first
+    end
   end
 end

--- a/app/services/projects/creation_wizard/create_artifact_work_package_service.rb
+++ b/app/services/projects/creation_wizard/create_artifact_work_package_service.rb
@@ -155,7 +155,7 @@ module Projects::CreationWizard
     end
 
     def assigned_to_id
-      project.custom_value_for(assignee_custom_field).value
+      project.custom_value_for(assignee_custom_field).value if assignee_custom_field
     end
 
     def assignee_custom_field
@@ -182,6 +182,8 @@ module Projects::CreationWizard
     end
 
     def assignee_mention_tag
+      return if assigned_to_id.nil?
+
       principal = Principal.find(assigned_to_id)
 
       ApplicationController.helpers.content_tag(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -672,8 +672,8 @@ en:
         new_label: "New priority"
       creation_wizard:
         errors:
-          no_work_package_type: "Failed to activate project initiation request, at least one active work package type is required in the project."
-          no_status_when_submitted: "Failed to activate project initiation request, the selected work package type needs to have at least one status."
+          no_work_package_type: "Failed to enable project initiation request because it requires at least one active work package type and this project has none. Please add at least one work package type to this project."
+          no_status_when_submitted: "Failed to enable project initiation request because work package type %{type} requires at least one status associated with it. Please enable at least one status workflow for this work package type."
         export:
           description_attachment_export: "The generated artifact will be saved as a PDF attachment to the artifact work package."
           description_file_link_export: "The artifact work package will have a file link to a PDF stored in an external file storage. Requires a working file storage with automatically-managed project folders for this project. At the moment only Nextcloud file storages are supported."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,6 +671,9 @@ en:
       work_package_priorities:
         new_label: "New priority"
       creation_wizard:
+        errors:
+          no_work_package_type: "Failed to activate project initiation request, at least one active work package type is required in the project."
+          no_status_when_submitted: "Failed to activate project initiation request, the selected work package type needs to have at least one status."
         export:
           description_attachment_export: "The generated artifact will be saved as a PDF attachment to the artifact work package."
           description_file_link_export: "The artifact work package will have a file link to a PDF stored in an external file storage. Requires a working file storage with automatically-managed project folders for this project. At the moment only Nextcloud file storages are supported."

--- a/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
+++ b/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
       project.update(project_creation_wizard_work_package_type_id: nil)
     end
 
-    it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
+    it_behaves_like "contract is valid"
   end
 
   context "with unallowed work package type for the project" do
@@ -133,7 +133,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
       project.update(project_creation_wizard_status_when_submitted_id: nil)
     end
 
-    it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :blank
+    it_behaves_like "contract is valid"
   end
 
   context "with unallowed work package status for the type" do
@@ -144,14 +144,6 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
     end
 
     it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :inclusion
-
-    context "with unset work_package_type" do
-      before do
-        project.update(project_creation_wizard_work_package_type_id: nil)
-      end
-
-      it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
-    end
   end
 
   context "with 'Assignee when submitted' not set" do

--- a/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
+++ b/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
       project.update(project_creation_wizard_assignee_custom_field_id: nil)
     end
 
-    it_behaves_like "contract is invalid", project_creation_wizard_assignee_custom_field_id: :blank
+    it_behaves_like "contract is valid"
   end
 
   context "with project attribute pointed by 'Assignee when submitted' not set" do

--- a/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
+++ b/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
@@ -112,10 +112,11 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
 
   context "with unset work package type" do
     before do
-      project.update(project_creation_wizard_work_package_type_id: nil)
+      project.update!(project_creation_wizard_work_package_type_id: nil)
+      project.project_creation_wizard_default_work_package_type.destroy!
     end
 
-    it_behaves_like "contract is valid"
+    it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
   end
 
   context "with unallowed work package type for the project" do
@@ -130,10 +131,11 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
 
   context "with unset work package status" do
     before do
-      project.update(project_creation_wizard_status_when_submitted_id: nil)
+      project.update!(project_creation_wizard_status_when_submitted_id: nil)
+      project.project_creation_wizard_default_status_when_submitted.destroy!
     end
 
-    it_behaves_like "contract is valid"
+    it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :blank
   end
 
   context "with unallowed work package status for the type" do
@@ -144,6 +146,15 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
     end
 
     it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :inclusion
+
+    context "with unset work_package_type" do
+      before do
+        project.update!(project_creation_wizard_work_package_type_id: nil)
+        project.project_creation_wizard_default_work_package_type.destroy!
+      end
+
+      it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
+    end
   end
 
   context "with 'Assignee when submitted' not set" do
@@ -157,7 +168,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
   context "with project attribute pointed by 'Assignee when submitted' not set" do
     before do
       project.send(user_custom_field.attribute_setter, nil)
-      project.save
+      project.save!
     end
 
     it "has invalid contract with :blank error for the assignee custom field" do

--- a/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
+++ b/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::Settings::CreationWizardController do
+  shared_let(:admin) { create(:admin) }
+
+  current_user { admin }
+
+  describe "POST toggle", with_ee: %i[project_creation_wizard] do
+    context "when project has no active work package types" do
+      let(:project) { create(:project, no_types: true, project_creation_wizard_enabled: false) }
+
+      it "does not enable the wizard and shows a flash error" do
+        post :toggle, params: { project_id: project.id }
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to eq(
+          I18n.t("projects.settings.creation_wizard.errors.no_work_package_type")
+        )
+        expect(project.reload.project_creation_wizard_enabled).to be false
+      end
+    end
+
+    context "when the default work package type has no statuses" do
+      let(:project) { create(:project_with_types, project_creation_wizard_enabled: false) }
+
+      it "does not enable the wizard and shows a flash error" do
+        post :toggle, params: { project_id: project.id }
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to eq(
+          I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted")
+        )
+        expect(project.reload.project_creation_wizard_enabled).to be false
+      end
+    end
+
+    context "when activation conditions are met" do
+      let(:type) { create(:type_with_workflow) }
+      let(:project) { create(:project, types: [type], project_creation_wizard_enabled: false) }
+
+      it "enables the wizard" do
+        post :toggle, params: { project_id: project.id }
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to be_nil
+        expect(project.reload.project_creation_wizard_enabled).to be true
+      end
+    end
+
+    context "when disabling the wizard without activation conditions met" do
+      let(:project) { create(:project, no_types: true, project_creation_wizard_enabled: true) }
+
+      it "allows disabling even without types or statuses" do
+        post :toggle, params: { project_id: project.id }
+
+        expect(response).to have_http_status(:redirect)
+        expect(flash[:error]).to be_nil
+        expect(project.reload.project_creation_wizard_enabled).to be false
+      end
+    end
+  end
+end

--- a/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
+++ b/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Projects::Settings::CreationWizardController do
 
         expect(response).to have_http_status(:redirect)
         expect(flash[:error]).to eq(
-          I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted")
+          I18n.t("projects.settings.creation_wizard.errors.no_status_when_submitted",
+                 type: project.project_creation_wizard_default_work_package_type.name)
         )
         expect(project.reload.project_creation_wizard_enabled).to be false
       end

--- a/spec/features/projects/settings/creation_wizard_submission_spec.rb
+++ b/spec/features/projects/settings/creation_wizard_submission_spec.rb
@@ -117,15 +117,6 @@ RSpec.describe "Project creation wizard submission settings", :js do
       expect(page).to have_css(".ck-content", visible: :visible, count: 1)
     end
 
-    it "validates required fields" do
-      submission_page.visit!
-
-      click_button "Save"
-
-      expect(page).to have_text("Assignee when submitted can't be blank.")
-      expect(page).to have_current_path(project_settings_creation_wizard_path(project, tab: "submission"))
-    end
-
     it "only shows single-select user custom fields in assignee dropdown" do
       submission_page.visit!
 

--- a/spec/models/projects/creation_wizard_spec.rb
+++ b/spec/models/projects/creation_wizard_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::CreationWizard do
+  shared_let(:status) { create(:status) }
+  shared_let(:type) { create(:type) }
+  shared_let(:workflow) { create(:workflow, old_status: status, type:) }
+
+  let(:project) { create(:project, types: [type]) }
+
+  describe "#project_creation_wizard_artifact_name" do
+    context "when no value is stored" do
+      it "returns the default artifact name" do
+        expect(project.project_creation_wizard_artifact_name).to eq("project_creation_wizard")
+      end
+    end
+
+    context "when the stored value is nil" do
+      before { project.update_column(:settings, project.settings.merge("project_creation_wizard_artifact_name" => nil)) }
+
+      it "returns the default artifact name" do
+        project.reload
+        expect(project.project_creation_wizard_artifact_name).to eq("project_creation_wizard")
+      end
+    end
+
+    context "when a value is stored" do
+      before { project.project_creation_wizard_artifact_name = "project_initiation_request" }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_artifact_name).to eq("project_initiation_request")
+      end
+    end
+  end
+
+  describe "#project_creation_wizard_work_package_type_id" do
+    context "when no value is stored" do
+      it "returns the id of the first project type" do
+        expect(project.project_creation_wizard_work_package_type_id).to eq(type.id)
+      end
+    end
+
+    context "when the stored value is nil" do
+      before do
+        project.update_column(:settings, project.settings.merge("project_creation_wizard_work_package_type_id" => nil))
+      end
+
+      it "returns the id of the first project type" do
+        project.reload
+        expect(project.project_creation_wizard_work_package_type_id).to eq(type.id)
+      end
+    end
+
+    context "when a value is stored" do
+      let(:other_type) { create(:type) }
+
+      before { project.project_creation_wizard_work_package_type_id = other_type.id }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_work_package_type_id).to eq(other_type.id)
+      end
+    end
+  end
+
+  describe "#project_creation_wizard_status_when_submitted_id" do
+    context "when no value is stored" do
+      it "returns the id of the first status of the first project type" do
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(status.id)
+      end
+    end
+
+    context "when the stored value is nil" do
+      before do
+        project.update_column(:settings,
+                              project.settings.merge("project_creation_wizard_status_when_submitted_id" => nil))
+      end
+
+      it "returns the id of the first status of the first project type" do
+        project.reload
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(status.id)
+      end
+    end
+
+    context "when a value is stored" do
+      let(:other_status) { create(:status) }
+
+      before { project.project_creation_wizard_status_when_submitted_id = other_status.id }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(other_status.id)
+      end
+    end
+  end
+end

--- a/spec/services/projects/creation_wizard/create_artifact_work_package_service_spec.rb
+++ b/spec/services/projects/creation_wizard/create_artifact_work_package_service_spec.rb
@@ -147,6 +147,25 @@ RSpec.describe Projects::CreationWizard::CreateArtifactWorkPackageService do
       expect(artifact_work_package.last_journal.notes).to include(/data-type="user"/)
     end
 
+    context "when 'Assignee when submitted' is not configured" do
+      before do
+        project.update(project_creation_wizard_assignee_custom_field_id: nil)
+      end
+
+      it "creates the artifact work package without an assignee and without a mention in the comment" do
+        result = instance.call
+
+        expect(result.errors.full_messages).to be_empty
+        project = result.result
+
+        artifact_work_package = WorkPackage.find(project.project_creation_wizard_artifact_work_package_id)
+        expect(artifact_work_package.assigned_to).to be_nil
+        expect(artifact_work_package.last_journal.notes).not_to include("<mention")
+        expected_path = Rails.application.routes.url_helpers.project_creation_wizard_path(project)
+        expect(artifact_work_package.last_journal.notes).to include(expected_path)
+      end
+    end
+
     context "when assignee is a group" do
       let(:group) { create(:group, firstname: "test group") }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/71379

# What are you trying to accomplish?
- Inform the user in a meaningful way when the Project Initiation Request settings are incomplete.

# What approach did you choose and why?

- Set default values for PIR settings: `project_creation_wizard_work_package_type_id`, `project_creation_wizard_status_when_submitted_id`.
- Display an error message when activating PIR without a work package type or status.

**Error message when no active types exist in the project:**
<img width="1225" height="777" alt="image" src="https://github.com/user-attachments/assets/ef7c6d65-8578-4146-bc80-0d2ba77745a8" />

**Error message when the selected type has no status associated with:**
<img width="1231" height="739" alt="image" src="https://github.com/user-attachments/assets/891cec28-fbf4-4f71-b373-1d0444f15019" />

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
