### PR TITLE
Attempt to fix flaky Backlogs feature specs

### DIFF
--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -29,7 +29,7 @@
 require "spec_helper"
 require_relative "../../support/pages/backlogs"
 
-RSpec.describe "Backlogs", :js, :selenium, driver: :firefox_de do # using FF due to regression #64158
+RSpec.describe "Backlogs", :js do
   let(:story_type) do
     create(:type_feature)
   end

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -133,19 +133,16 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
   let(:backlogs_page) { Pages::Backlogs.new(project) }
 
   before do
-    login_as current_user
-
     Setting.plugin_openproject_backlogs = {
       "story_types" => [story.id.to_s, other_story.id.to_s],
       "task_type" => task.id.to_s
     }
+
+    login_as current_user
+    backlogs_page.visit!
   end
 
-  it "displays stories which are editable via details view" do
-    backlogs_page.visit!
-
-    # All stories are visible in their sprint/backlog
-    # but non stories are not displayed
+  it "displays stories in correct order, calculates velocity, and allows editing story points" do
     backlogs_page
       .expect_story_in_sprint(sprint_story1, sprint)
 
@@ -179,15 +176,17 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
       .edit_story_in_details_view(sprint_story2, subject: "Updated story", story_points: 3)
 
     backlogs_page.expect_velocity(sprint, 8)
+  end
 
-    # Assigning the story to the backlog will move it to the backlog
+  it "moves story from sprint to backlog when version is changed via details view" do
     backlogs_page
       .edit_story_in_details_view(sprint_story1, version: backlog)
 
     backlogs_page.expect_story_not_in_sprint(sprint_story1, sprint)
     backlogs_page.expect_story_in_sprint(sprint_story1, backlog)
+  end
 
-    # Changing type to TASK will remove the item from the list
+  it "removes story from sprint when type is changed to non-story type via details view" do
     backlogs_page
       .edit_story_in_details_view(sprint_story2, type: task.name)
 

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_relative "../support/pages/backlogs"
 
-RSpec.describe "Stories in backlog", :js, :selenium, :settings_reset do
+RSpec.describe "Stories in backlog", :js, :settings_reset do
   let!(:project) do
     create(:project,
            types: [story, task, other_story],

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -91,10 +91,6 @@ module Pages
     def edit_story_in_details_view(story, **attributes)
       click_in_story_menu(story, "Open details view")
 
-      wait_for { find("turbo-frame#content-bodyRight")[:complete] }.to be_truthy
-
-      expect(page).to have_current_path details_backlogs_project_backlogs_path(story.project, story)
-
       alter_attributes_in_details_view(story, **attributes)
     end
 
@@ -194,6 +190,8 @@ module Pages
       details_view = Pages::PrimerizedSplitWorkPackage.new(story)
       details_view.expect_tab :overview
       details_view.expect_subject
+
+      expect(page).to have_current_path details_backlogs_project_backlogs_path(story.project, story)
 
       yield details_view
     end


### PR DESCRIPTION
# Ticket

N/A


# What are you trying to accomplish?

Fix flaky spec `modules/backlogs/spec/features/stories_in_backlog_spec.rb:144` which was failing in https://github.com/opf/openproject/actions/runs/21831004728/job/62989007830


# What approach did you choose and why?

- Moved the “details view” current-path assertion into the shared `within_details_view` helper and removed a turbo-frame complete wait.
- Updated Backlogs feature specs to run with the default `:js` driver (Cuprite) by removing `:selenium` / explicit Firefox driver metadata.
- Refactored/renamed Backlogs stories feature scenarios into clearer, separate examples.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
