### PR TITLE
[#71414] Deleting a Time and Cost report results in an error

### DIFF
--- a/modules/reporting/app/controllers/cost_reports_controller.rb
+++ b/modules/reporting/app/controllers/cost_reports_controller.rb
@@ -190,7 +190,7 @@ class CostReportsController < ApplicationController
     else
       raise ActiveRecord::RecordNotFound
     end
-    redirect_to action: "index", default: 1, id: nil
+    redirect_to action: "index", default: 1, id: nil, status: :see_other
   end
 
   ##

--- a/modules/reporting/config/routes.rb
+++ b/modules/reporting/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       member do
         post :update
         post :rename
+        delete :destroy
       end
     end
   end
@@ -56,6 +57,7 @@ Rails.application.routes.draw do
     member do
       post :update
       post :rename
+      delete :destroy
     end
   end
 end

--- a/modules/reporting/lib/widget/controls/delete.rb
+++ b/modules/reporting/lib/widget/controls/delete.rb
@@ -37,7 +37,11 @@ class Widget::Controls::Delete < Widget::Controls
     popup = content_tag :div, id: "delete_form", style: "display:none", class: "button_form" do
       question = content_tag :p, I18n.t(:label_really_delete_question)
 
-      url_opts = { id: @subject.id }
+      url_opts = if @subject.project
+                   { controller: 'cost_reports', action: 'destroy', id: @subject.id, project_id: @subject.project.id }
+                 else
+                   { controller: 'cost_reports', action: 'destroy', id: @subject.id }
+                 end
       url_opts[request_forgery_protection_token] = form_authenticity_token # if protect_against_forgery?
       opt1 = link_to I18n.t(:button_delete),
                      url_for(url_opts),


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/71414/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
After deleting a Time and Cost report, the user should be redirected back to the Time and Costs overview page instead of the deleted report.

This fixes the 404 error that occurs when OpenProject tries to open a report that no longer exists.

## Screenshots
<img width="1561" height="102" alt="image" src="https://github.com/user-attachments/assets/5cc8af39-589f-4de3-b8bf-2fd7bd512786" />

# What approach did you choose and why?
Modified the CostReportsController to redirect to the overview page (cost_reports_path) after a report is deleted.

This ensures the user stays in the correct context after deletion.

Chose this approach over trying to reload the deleted report because the report no longer exists, and redirecting to the overview is the expected UX.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [✅] Tested major browsers (Chrome, Firefox, Edge, ...)
