### PR TITLE
Documents: zooming in issue on iOS

### DIFF
--- a/app/forms/concerns/browser_aware.rb
+++ b/app/forms/concerns/browser_aware.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module BrowserAware
+  extend ActiveSupport::Concern
+
+  included do
+    include BrowserHelper
+  end
+
+  # N.B. This is an inelegant, and very likely brittle solution.
+  #
+  # The Browser gem uses `helper_method(:browser)` to declare a
+  # controller method as a helper. This helper is available in classic
+  # Rails views, but since upgrading to ViewComponent 4.0, no longer
+  # works with Primer Forms.
+  def browser
+    @view_context.controller.send(:browser)
+  end
+end

--- a/app/forms/projects/life_cycle/form.rb
+++ b/app/forms/projects/life_cycle/form.rb
@@ -29,6 +29,8 @@
 #++
 module Projects::LifeCycle
   class Form < ApplicationForm
+    include BrowserAware
+
     form do |f|
       f.group(layout: :horizontal) do |horizontal_form|
         start_date_input(horizontal_form)
@@ -151,16 +153,6 @@ module Projects::LifeCycle
 
     def placeholder
       browser.device.mobile? ? "yyyy-mm-dd" : nil
-    end
-
-    # N.B. This is an inelegant, and very likely brittle solution.
-    #
-    # The Browser gem uses `helper_method(:browser)` to declare a
-    # controller method as a helper. This helper is available in classic
-    # Rails views, but since upgrading to ViewComponent 4.0, no longer
-    # works with Primer Forms.
-    def browser
-      @view_context.controller.send(:browser)
     end
   end
 end

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -55,7 +55,12 @@ class BlockNoteElement extends HTMLElement {
     this.errorContainer.id = 'documents-show-edit-view-connection-error-notice-component';
     this.errorContainer.dataset.controller = 'flash';
     this.errorContainer.dataset.flashAutohideValue = 'true';
+
     this.mount = document.createElement('div');
+    const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
+    if (browserSpecificClasses.length > 0) {
+      this.mount.classList.add(...browserSpecificClasses);
+    }
 
     shadowRoot.appendChild(this.errorContainer);
     shadowRoot.appendChild(this.mount);

--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -70,5 +70,6 @@
     select,
     textarea,
     input,
-    .op-uc-container.op-uc-container_editing
+    .op-uc-container.op-uc-container_editing,
+    .block-note-editor-container > .bn-editor
       font-size: 16px !important

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -41,6 +41,7 @@
       "attachments-collection-key": attachments_collection_key,
       "blocknote-stylesheet-url": blocknote_stylesheet_url,
       "shadow-dom-stylesheet-url": shadow_dom_stylesheet_url,
+      "browser-specific-classes": browser_specific_classes.join(" "),
       "data-test-selector": "blocknote-document-description"
     )
   )

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -35,7 +35,7 @@ module Primer
       class BlockNoteEditor < Primer::Forms::BaseComponent
         include ::OpenProject::StaticRouting::UrlHelpers
         include FrontendAssetHelper
-        include BrowserHelper
+        include BrowserAware
 
         attr_reader :input,
                     :value,
@@ -64,16 +64,6 @@ module Primer
           @shadow_dom_stylesheet_url = variable_asset_path("styles.css")
 
           @collaboration_enabled = true
-        end
-
-        # N.B. This is an inelegant, and very likely brittle solution.
-        #
-        # The Browser gem uses `helper_method(:browser)` to declare a
-        # controller method as a helper. This helper is available in classic
-        # Rails views, but since upgrading to ViewComponent 4.0, no longer
-        # works with Primer Forms.
-        def browser
-          @view_context.controller.send(:browser)
         end
       end
     end

--- a/lib/primer/open_project/forms/block_note_editor.rb
+++ b/lib/primer/open_project/forms/block_note_editor.rb
@@ -35,6 +35,7 @@ module Primer
       class BlockNoteEditor < Primer::Forms::BaseComponent
         include ::OpenProject::StaticRouting::UrlHelpers
         include FrontendAssetHelper
+        include BrowserHelper
 
         attr_reader :input,
                     :value,
@@ -63,6 +64,16 @@ module Primer
           @shadow_dom_stylesheet_url = variable_asset_path("styles.css")
 
           @collaboration_enabled = true
+        end
+
+        # N.B. This is an inelegant, and very likely brittle solution.
+        #
+        # The Browser gem uses `helper_method(:browser)` to declare a
+        # controller method as a helper. This helper is available in classic
+        # Rails views, but since upgrading to ViewComponent 4.0, no longer
+        # works with Primer Forms.
+        def browser
+          @view_context.controller.send(:browser)
         end
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/71023

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Include blocknote editor in the special rules for iOS safari, to prevent auto-zooming

https://stackoverflow.com/a/6394497/8900797

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

https://github.com/user-attachments/assets/3fd2cbfc-84c4-4ec0-813d-d3e8e36cd821

https://github.com/user-attachments/assets/22ba7b23-09a1-4066-bebd-5da1112278b7

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The browser specific classes exist in `<body>` (light DOM) while `.block-note-editor-container` is inside the shadow tree- we now include them in the shadow dom root node as well.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
