### PR TITLE
[#71859] WP comment is missing text if project initiation request has default settings

### DIFF
--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -100,9 +100,6 @@ module Projects
             label: I18n.t("settings.project_initiation_request.submission.work_package_comment"),
             caption: I18n.t("settings.project_initiation_request.submission.work_package_comment_caption"),
             required: false,
-            value: model.project_creation_wizard_work_package_comment.presence || I18n.t(
-              "settings.project_initiation_request.submission.work_package_comment_default", project_name: model.name
-            ),
             rich_text_options: {
               showAttachments: false,
               editorType: "constrained"

--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -61,6 +61,14 @@ module Projects::CreationWizard
       super.presence || project_creation_wizard_default_status_when_submitted&.id
     end
 
+    def project_creation_wizard_work_package_comment
+      super.presence ||
+        I18n.t(
+          "settings.project_initiation_request.submission.work_package_comment_default",
+          project_name: name
+        )
+    end
+
     def project_creation_wizard_default_work_package_type
       types.first
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/71859

# What are you trying to accomplish?
- Set default value for creation wizard work package comment.

# What approach did you choose and why?
- Override the getter method to always provide the default.
# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
