### PR TITLE
Fall back to default attachment store

### DIFF
--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -31,6 +31,7 @@
 module Projects::CreationWizard
   ARTIFACT_NAME_OPTIONS = %w[project_creation_wizard project_initiation_request project_mandate].freeze
   DEFAULT_ARTIFACT_NAME_OPTION = "project_creation_wizard"
+  DEFAULT_ARTIFACT_EXPORT_TYPE = "attachment"
 
   extend ActiveSupport::Concern
 
@@ -44,7 +45,7 @@ module Projects::CreationWizard
     store_attribute :settings, :project_creation_wizard_notification_text, :string
     store_attribute :settings, :project_creation_wizard_work_package_comment, :string
     store_attribute :settings, :project_creation_wizard_artifact_work_package_id, :integer
-    store_attribute :settings, :project_creation_wizard_artifact_export_type, :string, default: "attachment"
+    store_attribute :settings, :project_creation_wizard_artifact_export_type, :string
     store_attribute :settings, :project_creation_wizard_artifact_export_storage, :string
 
     # The store_attribute default cannot be used here, because the default is not returned
@@ -55,6 +56,10 @@ module Projects::CreationWizard
 
     def project_creation_wizard_work_package_type_id
       super.presence || project_creation_wizard_default_work_package_type&.id
+    end
+
+    def project_creation_wizard_artifact_export_type
+      super.presence || DEFAULT_ARTIFACT_EXPORT_TYPE
     end
 
     def project_creation_wizard_status_when_submitted_id


### PR DESCRIPTION
For older PIR settings, there was no default attachment_type set. We should use the same pattern as for other settings here for consistency