### PR TITLE
Docker plugin compile check

### DIFF
--- a/docker/prod/setup/precompile-assets.sh
+++ b/docker/prod/setup/precompile-assets.sh
@@ -2,6 +2,12 @@
 set -euxo pipefail
 
 DOCKER=${DOCKER:-0}
+FORCE_ASSET_RECOMPILE=${FORCE_ASSET_RECOMPILE:-0}
+
+if [ "$FORCE_ASSET_RECOMPILE" = "1" ]; then
+  echo "Forcing asset recompilation by invalidating cached manifests."
+  rm -f config/frontend_assets.manifest.json db/schema_cache.yml
+fi
 
 if [ -f config/frontend_assets.manifest.json ]; then
   echo "Assets have already been precompiled. Reusing."

--- a/docs/installation-and-operations/installation/docker/README.md
+++ b/docs/installation-and-operations/installation/docker/README.md
@@ -407,11 +407,12 @@ COPY Gemfile.plugins /app/
 # RUN npm add npm <package-name>*
 
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
-RUN ./docker/prod/setup/precompile-assets.sh
+RUN FORCE_ASSET_RECOMPILE=1 ./docker/prod/setup/precompile-assets.sh
 ```
 
 The file is based on the normal OpenProject docker image.
 All the Dockerfile does is copy your custom plugins gemfile into the image, install the gems and precompile any new assets.
+The `FORCE_ASSET_RECOMPILE=1` flag ensures plugin frontend assets are rebuilt when extending from an image that already contains precompiled assets.
 
 **slim image**
 
@@ -431,7 +432,7 @@ COPY Gemfile.plugins /app/
 # RUN npm add npm <package-name>*
 
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
-RUN ./docker/prod/setup/precompile-assets.sh
+RUN FORCE_ASSET_RECOMPILE=1 ./docker/prod/setup/precompile-assets.sh
 
 FROM openproject/openproject:17-slim
 

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -300,6 +300,72 @@ ps -ef | grep -F "/usr/bin/memcached" | grep -v grep >/dev/null 2>&1 || {
     docker logs "${VALIDATION_CONTAINER_NAME}" --tail 200 || true
     die "Bundled memcached failed to start in all-in-one image."
   fi
+
+  validate_all_in_one_plugin_inheritance
+}
+
+validate_all_in_one_plugin_inheritance() {
+  local plugin_validation_dir plugin_validation_image
+  plugin_validation_dir="$(mktemp -d)"
+  plugin_validation_image="openproject-validate-plugin-${RANDOM}-${RANDOM}"
+
+  cleanup_plugin_inheritance_validation() {
+    trap - RETURN
+    if [[ -n "${plugin_validation_image:-}" ]]; then
+      docker rmi -f "${plugin_validation_image}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${plugin_validation_dir:-}" ]]; then
+      rm -rf "${plugin_validation_dir}"
+    fi
+  }
+  trap cleanup_plugin_inheritance_validation RETURN
+
+  mkdir -p "${plugin_validation_dir}/openproject-plugin-verification/lib"
+
+  cat > "${plugin_validation_dir}/Gemfile.plugins" <<'RUBY'
+group :opf_plugins do
+  gem "openproject-plugin-verification", path: "/app/vendor/plugins/openproject-plugin-verification"
+end
+RUBY
+
+  cat > "${plugin_validation_dir}/openproject-plugin-verification/openproject-plugin-verification.gemspec" <<'RUBY'
+Gem::Specification.new do |spec|
+  spec.name = "openproject-plugin-verification"
+  spec.version = "0.0.1"
+  spec.summary = "All-in-one image plugin inheritance validation helper"
+  spec.authors = ["OpenProject"]
+  spec.files = Dir["lib/**/*.rb"]
+  spec.require_paths = ["lib"]
+end
+RUBY
+
+  cat > "${plugin_validation_dir}/openproject-plugin-verification/lib/openproject-plugin-verification.rb" <<'RUBY'
+module OpenprojectPluginVerification
+  VERSION = "0.0.1"
+end
+RUBY
+
+  cat > "${plugin_validation_dir}/Dockerfile" <<'DOCKER'
+ARG BASE_IMAGE=openproject/openproject:17
+FROM ${BASE_IMAGE}
+
+COPY openproject-plugin-verification /app/vendor/plugins/openproject-plugin-verification
+COPY Gemfile.plugins /app/
+
+RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
+RUN ./docker/prod/setup/precompile-assets.sh
+DOCKER
+
+  docker build \
+    --build-arg BASE_IMAGE="${IMAGE}" \
+    --tag "${plugin_validation_image}" \
+    "${plugin_validation_dir}"
+
+  docker run --rm --entrypoint sh "${plugin_validation_image}" -lc '
+set -eu
+bundle info openproject-plugin-verification >/dev/null 2>&1
+bundle exec ruby -e "spec = Gem::Specification.find_by_name(\"openproject-plugin-verification\"); abort(\"openproject-plugin-verification gem missing\") unless spec.version.to_s == \"0.0.1\""
+'
 }
 
 case "${TARGET}" in

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -323,6 +323,7 @@ validate_all_in_one_plugin_inheritance() {
   cat > "${plugin_validation_dir}/Gemfile.plugins" <<'RUBY'
 group :opf_plugins do
   gem "openproject-slack", git: "https://github.com/opf/openproject-slack.git", branch: "dev"
+  gem "openproject-proto_plugin", git: "https://github.com/opf/openproject-proto_plugin.git", branch: "dev"
 end
 RUBY
 
@@ -333,7 +334,7 @@ FROM ${BASE_IMAGE}
 COPY Gemfile.plugins /app/
 
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
-RUN ./docker/prod/setup/precompile-assets.sh
+RUN rm -f /app/config/frontend_assets.manifest.json /app/db/schema_cache.yml && ./docker/prod/setup/precompile-assets.sh
 DOCKER
 
   docker build \
@@ -344,6 +345,9 @@ DOCKER
   docker run --rm --entrypoint sh "${plugin_validation_image}" -lc '
 set -eu
 bundle info openproject-slack >/dev/null 2>&1
+bundle info openproject-proto_plugin >/dev/null 2>&1
+grep -q "linked/openproject-proto_plugin/main" /app/frontend/src/app/features/plugins/linked-plugins.module.ts
+grep -R -q "proto_plugin_name" /app/public/assets/frontend
 '
 }
 

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -320,28 +320,9 @@ validate_all_in_one_plugin_inheritance() {
   }
   trap cleanup_plugin_inheritance_validation RETURN
 
-  mkdir -p "${plugin_validation_dir}/openproject-plugin-verification/lib"
-
   cat > "${plugin_validation_dir}/Gemfile.plugins" <<'RUBY'
 group :opf_plugins do
-  gem "openproject-plugin-verification", path: "/app/vendor/plugins/openproject-plugin-verification"
-end
-RUBY
-
-  cat > "${plugin_validation_dir}/openproject-plugin-verification/openproject-plugin-verification.gemspec" <<'RUBY'
-Gem::Specification.new do |spec|
-  spec.name = "openproject-plugin-verification"
-  spec.version = "0.0.1"
-  spec.summary = "All-in-one image plugin inheritance validation helper"
-  spec.authors = ["OpenProject"]
-  spec.files = Dir["lib/**/*.rb"]
-  spec.require_paths = ["lib"]
-end
-RUBY
-
-  cat > "${plugin_validation_dir}/openproject-plugin-verification/lib/openproject-plugin-verification.rb" <<'RUBY'
-module OpenprojectPluginVerification
-  VERSION = "0.0.1"
+  gem "openproject-slack", git: "https://github.com/opf/openproject-slack.git", branch: "dev"
 end
 RUBY
 
@@ -349,7 +330,6 @@ RUBY
 ARG BASE_IMAGE=openproject/openproject:17
 FROM ${BASE_IMAGE}
 
-COPY openproject-plugin-verification /app/vendor/plugins/openproject-plugin-verification
 COPY Gemfile.plugins /app/
 
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
@@ -363,8 +343,7 @@ DOCKER
 
   docker run --rm --entrypoint sh "${plugin_validation_image}" -lc '
 set -eu
-bundle info openproject-plugin-verification >/dev/null 2>&1
-bundle exec ruby -e "spec = Gem::Specification.find_by_name(\"openproject-plugin-verification\"); abort(\"openproject-plugin-verification gem missing\") unless spec.version.to_s == \"0.0.1\""
+bundle info openproject-slack >/dev/null 2>&1
 '
 }
 

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -334,7 +334,7 @@ FROM ${BASE_IMAGE}
 COPY Gemfile.plugins /app/
 
 RUN bundle config unset deployment && bundle install && bundle config set deployment 'true'
-RUN rm -f /app/config/frontend_assets.manifest.json /app/db/schema_cache.yml && ./docker/prod/setup/precompile-assets.sh
+RUN FORCE_ASSET_RECOMPILE=1 ./docker/prod/setup/precompile-assets.sh
 DOCKER
 
   docker build \

--- a/script/ci/docker_validate_image.sh
+++ b/script/ci/docker_validate_image.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-set -x
 
 usage() {
   cat <<'USAGE'


### PR DESCRIPTION
Ensures we can compile custom plugins from an all-in-one docker image. From https://www.openproject.org/docs/installation-and-operations/installation/docker/#openproject-plugins

Note: requires updating the docs to mention the `FORCE_ASSET_RECOMPILE` flag:

```
RUN FORCE_ASSET_RECOMPILE=1 ./docker/prod/setup/precompile-assets.sh
```