### PR TITLE
Feature/71882 display pir configuration errors on the settings page and the new project page

### DIFF
--- a/app/components/projects/new_component.html.erb
+++ b/app/components/projects/new_component.html.erb
@@ -35,6 +35,19 @@ See COPYRIGHT and LICENSE files for more details.
       html: { id: "project-create-form" }
     ) do |f|
       flex_layout do |container|
+        if template_configuration_missing
+          container.with_row(mb: 3, **step_2_display) do
+            render(
+              Primer::Alpha::Banner.new(
+                scheme: :warning,
+                icon: :alert,
+                dismiss_scheme: :none,
+                test_selector: "op-project-misconfigured-warning"
+              )
+            ) { template_configuration_error }
+          end
+        end
+
         container.with_row(mb: 3, **step_2_display) do
           render(
             Primer::Forms::FormList.new(

--- a/app/components/projects/new_component.rb
+++ b/app/components/projects/new_component.rb
@@ -34,7 +34,7 @@ module Projects
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
 
-    options :project, :template, :step
+    options :project, :template, :step, :template_configuration_missing
 
     def step_2_display
       { display: :none } unless step == 2
@@ -42,6 +42,17 @@ module Projects
 
     def step_3_display
       { display: :none } unless step == 3
+    end
+
+    def template_configuration_error
+      if User.current.allowed_in_project?(:edit_project, template)
+        I18n.t(
+          "projects.copy.pir_configuration.warning_html",
+          settings_url: helpers.project_settings_creation_wizard_path(template)
+        ).html_safe
+      else
+        I18n.t("projects.copy.pir_configuration.contact_admin")
+      end
     end
 
     def workspaces_path

--- a/app/components/projects/project_creation_footer_component.rb
+++ b/app/components/projects/project_creation_footer_component.rb
@@ -32,12 +32,13 @@ module Projects
   class ProjectCreationFooterComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    def initialize(form_identifier:, project:, template:, current_step:, cancel_href:)
+    def initialize(form_identifier:, project:, template:, current_step:, cancel_href:, submit_disabled: false)
       @form_identifier = form_identifier
       @project = project
       @template = template
       @current_step = current_step
       @cancel_href = cancel_href
+      @submit_disabled = submit_disabled
 
       super
     end
@@ -53,7 +54,7 @@ module Projects
       end
     end
 
-    attr_reader :form_identifier, :project, :template, :current_step, :cancel_href
+    attr_reader :form_identifier, :project, :template, :current_step, :cancel_href, :submit_disabled
 
     private
 
@@ -72,7 +73,8 @@ module Projects
       {
         form: form_identifier,
         name: "finish",
-        value: "true"
+        value: "true",
+        disabled: submit_disabled
       }
     end
 

--- a/app/components/projects/settings/creation_wizard/page_header_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/page_header_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
       if configuration_incomplete?
         concat render(
           Primer::Alpha::Banner.new(
-            scheme: :warning,
+            scheme: :danger,
             icon: :alert,
             mt: 3,
             dismiss_scheme: :none,

--- a/app/components/projects/settings/creation_wizard/page_header_component.html.erb
+++ b/app/components/projects/settings/creation_wizard/page_header_component.html.erb
@@ -30,7 +30,21 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render Primer::OpenProject::PageHeader.new do |header|
     header.with_title { I18n.t("settings.project_initiation_request.name.options.project_initiation_request") }
-    header.with_description { I18n.t("settings.project_initiation_request.header_description") }
+    header.with_description do
+      concat I18n.t("settings.project_initiation_request.header_description")
+
+      if configuration_incomplete?
+        concat render(
+          Primer::Alpha::Banner.new(
+            scheme: :warning,
+            icon: :alert,
+            mt: 3,
+            dismiss_scheme: :none,
+            test_selector: "op-creation-wizard-configuration-warning"
+          )
+        ) { configuration_warning_message }
+      end
+    end
     header.with_breadcrumbs(
       [{ href: project_overview_path(@project.id), text: @project.name },
        { href: project_settings_general_path(@project.id), text: I18n.t("label_project_settings") },

--- a/app/components/projects/settings/creation_wizard/page_header_component.rb
+++ b/app/components/projects/settings/creation_wizard/page_header_component.rb
@@ -31,11 +31,30 @@
 class Projects::Settings::CreationWizard::PageHeaderComponent < ApplicationComponent
   include OpPrimer::ComponentHelpers
 
-  def initialize(project:)
+  def initialize(project:, validation_result: nil)
     super
 
     @project = project
+    @validation_result = validation_result
   end
 
-  attr_reader :project
+  attr_reader :project, :validation_result
+
+  def configuration_incomplete?
+    @project.project_creation_wizard_enabled && validation_result&.failure?
+  end
+
+  def missing_field_names
+    validation_result.errors.attribute_names
+                     .reject { |attr| attr == :base }
+                     .map { |attr| Project.human_attribute_name(attr) }
+  end
+
+  def configuration_warning_message
+    heading = content_tag(:strong, I18n.t("projects.settings.creation_wizard.configuration_incomplete_warning"))
+    items = safe_join(missing_field_names.map { |name| content_tag(:li, name) })
+    list = content_tag(:ul, items, class: "pl-4 mb-0 mt-1")
+
+    safe_join([heading, list])
+  end
 end

--- a/app/contracts/projects/settings_contract.rb
+++ b/app/contracts/projects/settings_contract.rb
@@ -104,7 +104,8 @@ module Projects
     end
 
     def updating_submission_settings?
-      has_changed_setting?("project_creation_wizard_assignee_custom_field_id") ||
+      options[:validate_all] ||
+        has_changed_setting?("project_creation_wizard_assignee_custom_field_id") ||
         has_changed_setting?("project_creation_wizard_work_package_type_id") ||
         has_changed_setting?("project_creation_wizard_status_when_submitted_id") ||
         has_changed_setting?("project_creation_wizard_send_confirmation_email") ||

--- a/app/controllers/projects/settings/creation_wizard_controller.rb
+++ b/app/controllers/projects/settings/creation_wizard_controller.rb
@@ -35,7 +35,15 @@ class Projects::Settings::CreationWizardController < Projects::SettingsControlle
 
   before_action :check_enterprise_plan, only: :toggle
 
-  def show; end
+  def show
+    # Check whether the creation wizard is configured correctly.
+    @validation_result = Projects::SetAttributesService.new(
+      model: @project,
+      user: current_user,
+      contract_class: Projects::SettingsContract,
+      contract_options: { validate_all: true }
+    ).call
+  end
 
   def disable_dialog
     respond_with_dialog Projects::Settings::CreationWizard::DisableDialogComponent.new(

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -42,6 +42,7 @@ class ProjectsController < ApplicationController
   before_action :require_admin, only: %i[destroy destroy_info]
   before_action :find_optional_parent, only: :new
   before_action :find_optional_template, only: %i[new create]
+  before_action :block_creation_if_template_misconfigured, only: :create
 
   no_authorization_required! :index
 
@@ -192,10 +193,7 @@ class ProjectsController < ApplicationController
 
   def new_from_template
     params[:step] = 2
-    @new_project = Projects::CopyService
-      .new(user: current_user, source: @template, contract_options: { validate_model: false })
-      .call(target_project_params: params.permit(:parent_id).to_h, attributes_only: true)
-      .result
+    @new_project = build_project_from_template(params.permit(:parent_id).to_h)
 
     render layout: layout_for_new
   end
@@ -240,9 +238,9 @@ class ProjectsController < ApplicationController
       redirect_to job_status_path(job.job_id)
     else
       @new_project = service_call.result
-      params[:step] = 2
-      flash.now[:error] = I18n.t(:notice_unsuccessful_create_with_reason, reason: service_call.message)
-      render action: :new, status: :unprocessable_entity, layout: "no_menu"
+      render_template_error(
+        I18n.t(:notice_unsuccessful_create_with_reason, reason: service_call.message)
+      )
     end
   end
 
@@ -252,6 +250,26 @@ class ProjectsController < ApplicationController
     step_2_is_valid = !attributes_with_error.intersect?(second_step_attributes)
 
     params[:step] = step_2_is_valid ? 3 : 2
+  end
+
+  def block_creation_if_template_misconfigured
+    return unless @template_configuration_missing
+
+    @new_project = build_project_from_template(permitted_params.new_project.to_h)
+    render_template_error(I18n.t("projects.copy.pir_configuration.creation_blocked"))
+  end
+
+  def build_project_from_template(target_params = {})
+    Projects::CopyService
+      .new(user: current_user, source: @template, contract_options: { validate_model: false })
+      .call(target_project_params: target_params, attributes_only: true)
+      .result
+  end
+
+  def render_template_error(message)
+    params[:step] = 2
+    flash.now[:error] = message
+    render action: :new, status: :unprocessable_entity, layout: "no_menu"
   end
 
   def clear_custom_field_errors!(project)
@@ -277,6 +295,19 @@ class ProjectsController < ApplicationController
       .workspace_type(params[:workspace_type])
       .visible(current_user)
       .find_by(id: template_id)
+
+    check_template_configuration(@template) if @template&.project_creation_wizard_enabled?
+  end
+
+  def check_template_configuration(template)
+    result = Projects::SetAttributesService.new(
+      model: template,
+      user: current_user,
+      contract_class: Projects::SettingsContract,
+      contract_options: { validate_all: true }
+    ).call
+
+    @template_configuration_missing = result.failure?
   end
 
   # Parent projects MAY define templates for subitems to be used

--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -60,7 +60,7 @@ module Projects
             input_width: :large
           ) do |list|
             # Statuses of the selected WP type
-            type_id = model.project_creation_wizard_work_package_type_id || model.types.first&.id
+            type_id = model.project_creation_wizard_work_package_type_id
 
             if type_id.present?
               type = Type.find_by(id: type_id)

--- a/app/forms/projects/settings/creation_wizard/submission_form.rb
+++ b/app/forms/projects/settings/creation_wizard/submission_form.rb
@@ -100,9 +100,6 @@ module Projects
             label: I18n.t("settings.project_initiation_request.submission.work_package_comment"),
             caption: I18n.t("settings.project_initiation_request.submission.work_package_comment_caption"),
             required: true,
-            value: model.project_creation_wizard_work_package_comment.presence || I18n.t(
-              "settings.project_initiation_request.submission.work_package_comment_default", project_name: model.name
-            ),
             rich_text_options: {
               showAttachments: false,
               editorType: "constrained"

--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -52,5 +52,21 @@ module Projects::CreationWizard
     def project_creation_wizard_artifact_name
       super.presence || DEFAULT_ARTIFACT_NAME_OPTION
     end
+
+    def project_creation_wizard_work_package_type_id
+      super.presence || project_creation_wizard_default_work_package_type&.id
+    end
+
+    def project_creation_wizard_status_when_submitted_id
+      super.presence || project_creation_wizard_default_status_when_submitted&.id
+    end
+
+    def project_creation_wizard_default_work_package_type
+      types.first
+    end
+
+    def project_creation_wizard_default_status_when_submitted
+      project_creation_wizard_default_work_package_type&.statuses&.first
+    end
   end
 end

--- a/app/models/projects/creation_wizard.rb
+++ b/app/models/projects/creation_wizard.rb
@@ -61,6 +61,13 @@ module Projects::CreationWizard
       super.presence || project_creation_wizard_default_status_when_submitted&.id
     end
 
+    def project_creation_wizard_work_package_comment
+      super.presence || I18n.t(
+        "settings.project_initiation_request.submission.work_package_comment_default",
+        project_name: name
+      )
+    end
+
     def project_creation_wizard_default_work_package_type
       types.first
     end

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -68,7 +68,8 @@ See COPYRIGHT and LICENSE files for more details.
           render Projects::NewComponent.new(
             project: @new_project,
             template: @template,
-            step: 2
+            step: 2,
+            template_configuration_missing: @template_configuration_missing
           )
         %>
       <% when 3 %>
@@ -89,7 +90,8 @@ See COPYRIGHT and LICENSE files for more details.
           project: @new_project,
           template: @template,
           current_step: params.fetch(:step, 1).to_i,
-          cancel_href:
+          cancel_href:,
+          submit_disabled: @template_configuration_missing
         )
       end
     %>

--- a/app/views/projects/settings/creation_wizard/show.html.erb
+++ b/app/views/projects/settings/creation_wizard/show.html.erb
@@ -27,7 +27,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render Projects::Settings::CreationWizard::PageHeaderComponent.new(project: @project) %>
+<%= render Projects::Settings::CreationWizard::PageHeaderComponent.new(
+      project: @project,
+      validation_result: @validation_result
+    ) %>
 
 <% if @project.project_creation_wizard_enabled %>
   <% tab = params[:tab] || "name" %>
@@ -42,9 +45,11 @@ See COPYRIGHT and LICENSE files for more details.
     <%= render partial: "export" %>
   <% end %>
 <% else %>
-  <% with_enterprise_banner_guard(:project_creation_wizard,
-                                  variant: :large,
-                                  image: "enterprise/project-creation-wizard.png") do %>
+  <% with_enterprise_banner_guard(
+       :project_creation_wizard,
+       variant: :large,
+       image: "enterprise/project-creation-wizard.png"
+     ) do %>
     <%= render Projects::Settings::CreationWizard::BlankSlateComponent.new(project: @project) %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -681,7 +681,7 @@ en:
           label_file_link_export: "Upload file to external file storage and add file link to work package"
           pdf_file_storage: "PDF file storage"
           unavailable: "unavailable"
-        configuration_incomplete_warning: "The project initiation request configuration is not complete. The following fields need to be configured:"
+        configuration_incomplete_warning: "The configuration is incomplete! The project initiation request will not function correctly unless the following fields are set:"
         label_request_submission: "Request submission"
         project_attributes_description: >
           Select which project attributes should be included in the project initiation request.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -681,6 +681,7 @@ en:
           label_file_link_export: "Upload file to external file storage and add file link to work package"
           pdf_file_storage: "PDF file storage"
           unavailable: "unavailable"
+        configuration_incomplete_warning: "The project initiation request configuration is not complete. The following fields need to be configured:"
         label_request_submission: "Request submission"
         project_attributes_description: >
           Select which project attributes should be included in the project initiation request.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,6 +537,13 @@ en:
   projects:
     copy:
       # Contains custom strings for options when copying a project that cannot be found elsewhere.
+      pir_configuration:
+        creation_blocked: >-
+          The project cannot be created from the chosen template because the project initiation request is not configured correctly.
+        warning_html: >-
+          The chosen template has project initiation request enabled, but it is missing configuration. Please visit the template's <a href="%{settings_url}" target="_blank">project initiation request settings</a> to complete the setup.
+        contact_admin: >-
+          The chosen template has project initiation request enabled, but it is missing configuration. Please contact an administrator to complete the setup.
       members: "Project members"
       overviews: "Project overview"
       queries: "Work packages: saved views"
@@ -681,7 +688,7 @@ en:
           label_file_link_export: "Upload file to external file storage and add file link to work package"
           pdf_file_storage: "PDF file storage"
           unavailable: "unavailable"
-        configuration_incomplete_warning: "The configuration is incomplete! The project initiation request will not function correctly unless the following fields are set:"
+        configuration_incomplete_warning: "The configuration is incomplete! The project initiation request will not work unless the following fields are set:"
         label_request_submission: "Request submission"
         project_attributes_description: >
           Select which project attributes should be included in the project initiation request.

--- a/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
+++ b/spec/contracts/projects/create_artifact_work_package_contract_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
       project.update(project_creation_wizard_work_package_type_id: nil)
     end
 
-    it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
+    it_behaves_like "contract is valid"
   end
 
   context "with unallowed work package type for the project" do
@@ -133,7 +133,7 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
       project.update(project_creation_wizard_status_when_submitted_id: nil)
     end
 
-    it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :blank
+    it_behaves_like "contract is valid"
   end
 
   context "with unallowed work package status for the type" do
@@ -144,14 +144,6 @@ RSpec.describe Projects::CreateArtifactWorkPackageContract, :check_errors_i18n d
     end
 
     it_behaves_like "contract is invalid", project_creation_wizard_status_when_submitted_id: :inclusion
-
-    context "with unset work_package_type" do
-      before do
-        project.update(project_creation_wizard_work_package_type_id: nil)
-      end
-
-      it_behaves_like "contract is invalid", project_creation_wizard_work_package_type_id: :blank
-    end
   end
 
   context "with 'Assignee when submitted' not set" do

--- a/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
+++ b/spec/controllers/projects/settings/creation_wizard_controller_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::Settings::CreationWizardController do
+  shared_let(:user) { create(:admin) }
+  let(:set_attributes_service) { instance_double(Projects::SetAttributesService, call: service_result) }
+
+  current_user { user }
+
+  describe "GET #show" do
+    let(:project) { build_stubbed(:project) }
+
+    before do
+      allow(Project)
+        .to receive(:find)
+              .with(project.identifier)
+              .and_return(project)
+
+      allow(Projects::SetAttributesService)
+        .to receive(:new)
+              .with(
+                model: project,
+                user:,
+                contract_class: Projects::SettingsContract,
+                contract_options: { validate_all: true }
+              )
+              .and_return(set_attributes_service)
+
+      get :show, params: { project_id: project.identifier }
+    end
+
+    context "when the service returns a successful validation result" do
+      let(:service_result) { ServiceResult.success(result: project) }
+
+      it "renders the show template and assigns the validation result", :aggregate_failures do
+        expect(response).to be_successful
+        expect(assigns(:validation_result)).to eq(service_result)
+      end
+    end
+
+    context "when the service returns a failed validation result" do
+      let(:service_result) do
+        ServiceResult.failure(result: project, errors: project.errors).tap do |result|
+          result.errors.add(:project_creation_wizard_work_package_type_id, :blank)
+          result.errors.add(:project_creation_wizard_assignee_custom_field_id, :blank)
+        end
+      end
+
+      it "still renders the show template successfully", :aggregate_failures do
+        expect(response).to be_successful
+        expect(assigns(:validation_result)).to eq(service_result)
+        expect(assigns(:validation_result)).to be_failure
+      end
+    end
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -440,6 +440,47 @@ RSpec.describe ProjectsController do
         end
       end
     end
+
+    describe "block_creation_if_template_misconfigured" do
+      context "when template has wizard enabled and is misconfigured" do
+        let(:workspace_type) { "project" }
+        let(:template) { create(:template_project, project_creation_wizard_enabled: true, workspace_type:) }
+
+        before do
+          set_attrs_service = instance_double(
+            Projects::SetAttributesService,
+            call: ServiceResult.failure(result: template)
+          )
+
+          allow(Projects::SetAttributesService)
+            .to receive(:new)
+                  .with(model: template, user: admin,
+                        contract_class: Projects::SettingsContract,
+                        contract_options: { validate_all: true })
+                  .and_return(set_attrs_service)
+
+          new_project = Project.new(name: "New Project")
+          copy_service = instance_double(
+            Projects::CopyService,
+            call: ServiceResult.success(result: new_project)
+          )
+
+          allow(Projects::CopyService)
+            .to receive(:new)
+                  .with(user: admin, source: template, contract_options: { validate_model: false })
+                  .and_return(copy_service)
+
+          post :create, params: { template_id: template.id, workspace_type:, project: { name: "New Project" } }
+        end
+
+        it "blocks creation and renders new with an error", :aggregate_failures do
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to render_template "new"
+          expect(flash[:error]).to eq I18n.t("projects.copy.pir_configuration.creation_blocked")
+          expect(controller.params[:step].to_i).to eq 2
+        end
+      end
+    end
   end
 
   describe "#index" do

--- a/spec/models/projects/creation_wizard_spec.rb
+++ b/spec/models/projects/creation_wizard_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Projects::CreationWizard do
+  shared_let(:status) { create(:status) }
+  shared_let(:type) { create(:type) }
+  shared_let(:workflow) { create(:workflow, old_status: status, type:) }
+
+  let(:project) { create(:project, types: [type]) }
+
+  describe "#project_creation_wizard_artifact_name" do
+    context "when no value is stored" do
+      it "returns the default artifact name" do
+        expect(project.project_creation_wizard_artifact_name).to eq("project_creation_wizard")
+      end
+    end
+
+    context "when the stored value is nil" do
+      before { project.update_column(:settings, project.settings.merge("project_creation_wizard_artifact_name" => nil)) }
+
+      it "returns the default artifact name" do
+        project.reload
+        expect(project.project_creation_wizard_artifact_name).to eq("project_creation_wizard")
+      end
+    end
+
+    context "when a value is stored" do
+      before { project.project_creation_wizard_artifact_name = "project_initiation_request" }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_artifact_name).to eq("project_initiation_request")
+      end
+    end
+  end
+
+  describe "#project_creation_wizard_work_package_type_id" do
+    context "when no value is stored" do
+      it "returns the id of the first project type" do
+        expect(project.project_creation_wizard_work_package_type_id).to eq(type.id)
+      end
+    end
+
+    context "when the stored value is nil" do
+      before do
+        project.update_column(:settings, project.settings.merge("project_creation_wizard_work_package_type_id" => nil))
+      end
+
+      it "returns the id of the first project type" do
+        project.reload
+        expect(project.project_creation_wizard_work_package_type_id).to eq(type.id)
+      end
+    end
+
+    context "when a value is stored" do
+      let(:other_type) { create(:type) }
+
+      before { project.project_creation_wizard_work_package_type_id = other_type.id }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_work_package_type_id).to eq(other_type.id)
+      end
+    end
+  end
+
+  describe "#project_creation_wizard_status_when_submitted_id" do
+    context "when no value is stored" do
+      it "returns the id of the first status of the first project type" do
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(status.id)
+      end
+    end
+
+    context "when the stored value is nil" do
+      before do
+        project.update_column(:settings,
+                              project.settings.merge("project_creation_wizard_status_when_submitted_id" => nil))
+      end
+
+      it "returns the id of the first status of the first project type" do
+        project.reload
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(status.id)
+      end
+    end
+
+    context "when a value is stored" do
+      let(:other_status) { create(:status) }
+
+      before { project.project_creation_wizard_status_when_submitted_id = other_status.id }
+
+      it "returns the stored value" do
+        expect(project.project_creation_wizard_status_when_submitted_id).to eq(other_status.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71882

# What are you trying to accomplish?
- Inform the user and administrator in a meaningful way when the Project Initiation Request settings are incomplete.

# What approach did you choose and why?
- [X] Display an error message in the Project Initiation Request settings if the configuration is not complete.
<details><summary>Screenshot of PIR settings</summary>
<p>

<img width="2460" height="1474" alt="image" src="https://github.com/user-attachments/assets/d3b5a618-e04a-42f5-b523-905f5ba18c06" />


</p>
</details> 

- [X] Display a warning message and prevent project creation if the chosen template's configuration is not complete.
<details><summary>Screenshot of template warning</summary>
<p>

<img width="2462" height="1478" alt="image" src="https://github.com/user-attachments/assets/3194c1e5-8e10-4030-88e4-084fabd48224" />


</p>
</details> 

<details><summary>Screenshot of the error message upon submission.</summary>
<p>

<img width="2464" height="1474" alt="image" src="https://github.com/user-attachments/assets/35c5acd6-5ac7-4ab1-9765-c78e418c735c" />


</p>
</details> 

- [ ] Display the User Project Attribute select field in the PIR settings when the **Assignee when submitted** has the User Project Attribute chosen. Additionally also validate the presence of a chosen user in the User Project Attribute.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
