### PR TITLE
Rename rest_api_enabled to api_tokens_enabled

### DIFF
--- a/app/components/my/access_token/api_tokens_section_component.rb
+++ b/app/components/my/access_token/api_tokens_section_component.rb
@@ -56,7 +56,7 @@ module My
 
       def token_available?
         case token_type.to_s
-        when "Token::API" then Setting.rest_api_enabled?
+        when "Token::API" then Setting.api_tokens_enabled?
         when "Token::ICalMeeting" then Setting.ical_enabled?
         when "Token::RSS" then Setting.feeds_enabled?
         else raise ArgumentError, "Unknown token type: #{token_type}"

--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -101,7 +101,7 @@ module Accounts::CurrentUser
   end
 
   def current_api_key_user
-    return unless Setting.rest_api_enabled? && api_request?
+    return unless Setting.api_tokens_enabled? && api_request?
 
     key = api_key_from_request
 

--- a/app/controllers/my/access_tokens_controller.rb
+++ b/app/controllers/my/access_tokens_controller.rb
@@ -172,7 +172,7 @@ module My
     helper_method :has_tokens?
 
     def has_tokens?
-      Setting.feeds_enabled? || Setting.rest_api_enabled? || current_user.ical_tokens.any?
+      Setting.feeds_enabled? || Setting.api_tokens_enabled? || current_user.ical_tokens.any?
     end
 
     def set_api_token

--- a/app/forms/admin/settings/api_settings_form.rb
+++ b/app/forms/admin/settings/api_settings_form.rb
@@ -48,7 +48,7 @@ module Admin
       end
 
       settings_form do |sf|
-        sf.check_box(name: :rest_api_enabled)
+        sf.check_box(name: :api_tokens_enabled, caption: I18n.t(:setting_api_tokens_enabled_caption))
 
         sf.text_field(
           name: :apiv3_max_page_size,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -448,7 +448,7 @@ class User < Principal
   end
 
   def self.find_by_api_key(key)
-    return nil unless Setting.rest_api_enabled?
+    return nil unless Setting.api_tokens_enabled?
 
     token = Token::API.find_by_plaintext_value(key)
 

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -126,6 +126,13 @@ module Settings
         default: :quarantine,
         allowed: %i[quarantine delete]
       },
+      api_tokens_enabled: {
+        default: true,
+        description: "Decide whether users can create personal API tokens in their account settings",
+        # Keeping old name only for backwards-compatibility, can be removed in OpenProject 18.0
+        env_alias: "OPENPROJECT_REST__API__ENABLED",
+        format: :boolean
+      },
       auth_source_sso: {
         description: "Configuration for Header-based Single Sign-On",
         format: :hash,
@@ -968,9 +975,6 @@ module Settings
       },
       repository_truncate_at: {
         default: 500
-      },
-      rest_api_enabled: {
-        default: true
       },
       scm: {
         format: :hash,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4571,6 +4571,10 @@ en:
   setting_smtp_password: "SMTP password"
   setting_smtp_domain: "SMTP HELO domain"
   setting_activity_days_default: "Days displayed on project activity"
+  setting_api_tokens_enabled: "Enable API tokens"
+  setting_api_tokens_enabled_caption: >
+    Decide whether users can create personal API tokens in their account settings. These tokens can be used to access the different
+    APIs of OpenProject, such as APIv3 and MCP.
   setting_app_subtitle: "Application subtitle"
   setting_app_title: "Application title"
   setting_attachment_max_size: "Attachment max. size"
@@ -4685,7 +4689,6 @@ en:
   setting_repository_checkout_text: "Checkout instruction text"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
   setting_repository_truncate_at: "Maximum number of files displayed in the repository browser"
-  setting_rest_api_enabled: "Enable REST web service"
   setting_self_registration: "Self-registration"
   setting_self_registration_caption: >
     Choose the self-registration mechanism for users. Be careful with the setting you choose, as some

--- a/db/migrate/20260212133700_rename_setting_rest_api_enabled.rb
+++ b/db/migrate/20260212133700_rename_setting_rest_api_enabled.rb
@@ -23,40 +23,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "warden/basic_auth"
+require_relative "migration_utils/setting_renamer"
 
-module OpenProject
-  module Authentication
-    module Strategies
-      module Warden
-        ##
-        # Allows users to authenticate using their API key via basic auth.
-        # Note that in order for a user to be able to generate one
-        # `Setting.api_tokens_enabled` has to be `true`.
-        #
-        # The basic auth credentials are expected to contain the literal 'apikey'
-        # as the user name and the API key as the password.
-        class UserBasicAuth < ::Warden::Strategies::BasicAuth
-          def self.user
-            "apikey"
-          end
+class RenameSettingRestAPIEnabled < ActiveRecord::Migration[8.0]
+  def up
+    ::Migration::MigrationUtils::SettingRenamer.rename(:rest_api_enabled, :api_tokens_enabled)
+  end
 
-          def valid?
-            OpenProject::Configuration.apiv3_enable_basic_auth? &&
-            super &&
-            username == self.class.user
-          end
-
-          def authenticate_user(_, api_key)
-            User.find_by_api_key api_key
-          end
-        end
-      end
-    end
+  def down
+    ::Migration::MigrationUtils::SettingRenamer.rename(:api_tokens_enabled, :rest_api_enabled)
   end
 end

--- a/docs/system-admin-guide/api-and-webhooks/README.md
+++ b/docs/system-admin-guide/api-and-webhooks/README.md
@@ -13,9 +13,12 @@ Navigate to **Administration → API and webhooks**.
 
 ## API
 
+<!-- TODO: Replace screenshot with new version -->
 ![API settings in OpenProject administration](openproject_system_admin_guide_api.png)
 
-Here, you can manage the **REST web service** to selectively control whether foreign applications may access your OpenProject API endpoints from within the browser. This setting allows users to access the OpenProject API using an API token created from the users "Account settings" page. You can set the **maximum page size** the API will respond with. It will not be possible to perform API requests that return more values on a single page. You can also enable **write access to read-only attributes**, which will allow administrators to write static read-only attributes during creation, such as *createdAt* and *author*. 
+Here, you can manage whether users can create personal API tokens, this setting allows users to access the OpenProject APIs using an API token created from the user's "Account settings" page.
+You can set the **maximum page size** the API will respond with. It will not be possible to perform API requests that return more values on a single page.
+You can also enable **write access to read-only attributes**, which will allow administrators to write static read-only attributes during creation, such as *createdAt* and *author*. This can be useful during data imports.
 
 ### Documentation
 

--- a/lib_static/open_project/authentication/strategies/warden/user_api_token.rb
+++ b/lib_static/open_project/authentication/strategies/warden/user_api_token.rb
@@ -35,12 +35,12 @@ module OpenProject
         ##
         # Allows users to authenticate using their API key as a Bearer token.
         # Note that in order for a user to be able to generate one
-        # `Setting.rest_api_enabled` has to be `1`.
+        # `Setting.api_tokens_enabled` has to be `1`.
         class UserAPIToken < ::Warden::Strategies::Base
           include FailWithHeader
 
           def valid?
-            return false unless Setting.rest_api_enabled?
+            return false unless Setting.api_tokens_enabled?
 
             @access_token = ::Doorkeeper::OAuth::Token.from_bearer_authorization(
               ::Doorkeeper::Grape::AuthorizationDecorator.new(request)

--- a/spec/constants/settings/definition_spec.rb
+++ b/spec/constants/settings/definition_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe Settings::Definition, :settings_reset do
 
       it "overriding boolean configuration from ENV will cast the value",
          with_env: { "OPENPROJECT_REST__API__ENABLED" => "0" } do
-        reset(:rest_api_enabled)
-        expect(all[:rest_api_enabled].value).to be false
+        reset(:api_tokens_enabled)
+        expect(all[:api_tokens_enabled].value).to be false
       end
 
       it "overriding symbol configuration having allowed values from ENV will cast the value before validation check",

--- a/spec/features/users/my/access_tokens_spec.rb
+++ b/spec/features/users/my/access_tokens_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "my access tokens", :js do
   end
 
   describe "API tokens" do
-    context "when API access is disabled via global settings", with_settings: { rest_api_enabled: false } do
+    context "when API tokens are disabled via global setting", with_settings: { api_tokens_enabled: false } do
       it "shows notice about disabled token" do
         visit my_access_tokens_path
 
@@ -57,7 +57,7 @@ RSpec.describe "my access tokens", :js do
       end
     end
 
-    context "when API access is enabled via global settings", with_settings: { rest_api_enabled: true } do
+    context "when API tokens are enabled via global setting", with_settings: { api_tokens_enabled: true } do
       it "API tokens can be generated and revoked" do
         visit my_access_tokens_path
 

--- a/spec/forms/admin/settings/api_settings_form_spec.rb
+++ b/spec/forms/admin/settings/api_settings_form_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe Admin::Settings::APISettingsForm, type: :forms do
   end
 
   it "renders", :aggregate_failures do
-    expect(rendered_form).to have_field "Enable REST web service", type: :checkbox do |field|
-      expect(field["name"]).to eq "settings[rest_api_enabled]"
+    expect(rendered_form).to have_field "Enable API tokens", type: :checkbox do |field|
+      expect(field["name"]).to eq "settings[api_tokens_enabled]"
     end
 
     expect(rendered_form).to have_field "Maximum API page size", type: :number do |field|


### PR DESCRIPTION
The name of this setting was pretty outdated by now. It might have disabled the entire API in the past, but that time is long gone. By now the APIv3 can't be disabled at all and OpenProject would fall apart if it was disabled.

The only thing that this setting changes, is whether users can create an access token in their account settings and whether tokens created this way are accepted by OpenProject. So naming and description have been adapted accordingly.

# Ticket
https://community.openproject.org/wp/71886