### PR TITLE
[#71945] Error in meeting PDF exports if cover image file storage is broken (S3)

### DIFF
--- a/app/models/exports/pdf/components/cover.rb
+++ b/app/models/exports/pdf/components/cover.rb
@@ -185,11 +185,17 @@ module Exports::PDF::Components::Cover
     [image_obj, image_info, image_opts, height]
   end
 
-  def custom_cover_image
+  def custom_cover_image_file
     return unless CustomStyle.current.present? &&
-      CustomStyle.current.export_cover.present? && CustomStyle.current.export_cover.local_file.present?
+                  CustomStyle.current.export_cover.present? && CustomStyle.current.export_cover.local_file.present?
 
-    image_file = CustomStyle.current.export_cover.local_file.path
+    CustomStyle.current.export_cover.local_file.path
+  end
+
+  def custom_cover_image
+    image_file = custom_cover_image_file
+    return unless image_file
+
     content_type = OpenProject::ContentTypeDetector.new(image_file).detect
     return unless pdf_embeddable?(content_type)
 

--- a/app/models/exports/pdf/components/cover.rb
+++ b/app/models/exports/pdf/components/cover.rb
@@ -194,6 +194,9 @@ module Exports::PDF::Components::Cover
     return unless pdf_embeddable?(content_type)
 
     image_file
+  rescue StandardError => e
+    Rails.logger.error "Failed to access custom PDF cover file: #{e}"
+    nil # Fallback to default cover
   end
 
   def write_background_image


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/71945

# What are you trying to accomplish?

This is another occurrence of the same bug in the outdated dependency gem carrierwave (which we cannot immediately update)

see 
[#70560](https://community.openproject.org/work_packages/70560) [#69625](https://community.openproject.org/work_packages/69625) [#67626](https://community.openproject.org/work_packages/67626) [#67642](https://community.openproject.org/work_packages/67642) [#57612](https://community.openproject.org/work_packages/57612) [#44939](https://community.openproject.org/work_packages/44939)

# What approach did you choose and why?
As the PDF export nor the exporting user can not directly do something about this, catch and log the error
