### PR TITLE
Code maintenance/71902 simplify and standardize permission checks in controllers

### DIFF
--- a/app/contracts/attachments/delete_contract.rb
+++ b/app/contracts/attachments/delete_contract.rb
@@ -30,7 +30,7 @@
 
 module Attachments
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       model.deletable?(user)
     }
   end

--- a/app/contracts/delete_contract.rb
+++ b/app/contracts/delete_contract.rb
@@ -37,6 +37,30 @@ class DeleteContract < ModelContract
 
       @delete_permission
     end
+
+    def allowed?(user:, model:, action:)
+      case action
+      when :delete
+        delete_allowed?(user: user, model: model)
+      else
+        raise ArgumentError, "Unknown action #{action}"
+      end
+    end
+
+    def delete_allowed?(user:, model:)
+      permission = delete_permission
+
+      case permission
+      when :admin
+        user.admin? && user.active?
+      when Proc
+        instance_exec(&permission)
+      when Symbol
+        model.project && user.allowed_in_project?(permission, model.project)
+      else
+        raise ArgumentError, "#{self.class} used without delete_permission. Set a  Proc, or project-based permission symbol"
+      end
+    end
   end
 
   validate :user_allowed
@@ -54,17 +78,6 @@ class DeleteContract < ModelContract
   end
 
   def authorized?
-    permission = self.class.delete_permission
-
-    case permission
-    when :admin
-      user.admin? && user.active?
-    when Proc
-      instance_exec(&permission)
-    when Symbol
-      model.project && user.allowed_in_project?(permission, model.project)
-    else
-      raise ArgumentError, "#{self.class} used without delete_permission. Set a  Proc, or project-based permission symbol"
-    end
+    self.class.delete_allowed?(user: user, model: model)
   end
 end

--- a/app/contracts/emoji_reactions/delete_contract.rb
+++ b/app/contracts/emoji_reactions/delete_contract.rb
@@ -30,7 +30,7 @@
 
 module EmojiReactions
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       # The user can delete the reaction if they created it
       model.user_id == user.id
     }

--- a/app/contracts/oauth/applications/delete_contract.rb
+++ b/app/contracts/oauth/applications/delete_contract.rb
@@ -31,7 +31,7 @@
 module OAuth
   module Applications
     class DeleteContract < ::DeleteContract
-      delete_permission -> { !model.builtin? && user.admin? }
+      delete_permission ->(user:, model:) { !model.builtin? && user.admin? }
     end
   end
 end

--- a/app/contracts/placeholder_users/delete_contract.rb
+++ b/app/contracts/placeholder_users/delete_contract.rb
@@ -30,9 +30,7 @@
 
 module PlaceholderUsers
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
-      self.class.deletion_allowed?(model, user)
-    }
+    delete_permission ->(user:, model:) { deletion_allowed?(model, user) }
 
     ##
     # Checks if a given placeholder user may be deleted by a user.

--- a/app/contracts/project_queries/delete_contract.rb
+++ b/app/contracts/project_queries/delete_contract.rb
@@ -30,6 +30,6 @@
 
 module ProjectQueries
   class DeleteContract < ::DeleteContract
-    delete_permission -> { user == model.user }
+    delete_permission ->(user:, model:) { user == model.user }
   end
 end

--- a/app/contracts/relations/delete_contract.rb
+++ b/app/contracts/relations/delete_contract.rb
@@ -30,7 +30,7 @@
 
 module Relations
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       user.allowed_in_work_package?(:manage_work_package_relations, model.from) &&
         user.allowed_in_work_package?(:manage_work_package_relations, model.to)
     }

--- a/app/contracts/reminders/delete_contract.rb
+++ b/app/contracts/reminders/delete_contract.rb
@@ -30,7 +30,7 @@
 
 module Reminders
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       # The user can delete the reminder if they created it
       model.creator_id == user.id
     }

--- a/app/contracts/shares/project_queries/delete_contract.rb
+++ b/app/contracts/shares/project_queries/delete_contract.rb
@@ -33,7 +33,7 @@ module Shares
     class DeleteContract < Shares::DeleteContract
       # DeleteContract has its own permission check and does not care about the role class,
       # so we do not need to include the BaseExtension here.
-      delete_permission -> { model.entity.editable? }
+      delete_permission ->(model:, **_kwargs) { model.entity.editable? }
     end
   end
 end

--- a/app/contracts/users/delete_contract.rb
+++ b/app/contracts/users/delete_contract.rb
@@ -30,9 +30,7 @@
 
 module Users
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
-      self.class.deletion_allowed?(model, user)
-    }
+    delete_permission ->(user:, model:) { deletion_allowed?(model, user) }
 
     ##
     # Checks if a given user may be deleted by another one.

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -112,6 +112,10 @@ module Accounts::Authorization
     is_authorized
   end
 
+  def authorization_check(contract_class:, action:, model:)
+    render_403 unless contract_class.allowed?(model:, action:, user: current_user)
+  end
+
   def require_admin
     return unless require_login
 

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -113,7 +113,10 @@ module Accounts::Authorization
   end
 
   def authorization_check(contract_class:, action:, model:)
-    render_403 unless contract_class.allowed?(model:, action:, user: current_user)
+    return true if contract_class.allowed?(model:, action:, user: current_user)
+
+    render_403
+    false
   end
 
   def require_admin

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -112,8 +112,9 @@ module Accounts::Authorization
     is_authorized
   end
 
-  def authorization_check(action:, scope: nil) # rubocop:disable Naming/PredicateMethod
-    return true if OpenProject::ActionAuthorizer.allowed?(action, user: current_user, scope:)
+  def authorization_check(action:, scope: nil, model: nil) # rubocop:disable Naming/PredicateMethod
+    # TODO: throw argument error if both scope and model are nil
+    return true if OpenProject::ActionAuthorizer.allowed?(action, on: model, user: current_user, scope:)
 
     render_403
     false

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -112,11 +112,10 @@ module Accounts::Authorization
     is_authorized
   end
 
-  def authorization_check(action:, scope: nil, model: nil) # rubocop:disable Naming/PredicateMethod
-    return true if OpenProject::ActionAuthorizer.allowed?(action, on: model, user: current_user, scope:)
+  def authorization_check(action:, on: nil, scope: nil)
+    return true if OpenProject::ActionAuthorizer.allowed?(action, on:, user: current_user, scope:)
 
-    render_403
-    false
+    render_403 and false
   end
 
   def require_admin

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -112,8 +112,8 @@ module Accounts::Authorization
     is_authorized
   end
 
-  def authorization_check(contract_class:, action:, model:)
-    return true if contract_class.allowed?(model:, action:, user: current_user)
+  def authorization_check(action:, scope: nil) # rubocop:disable Naming/PredicateMethod
+    return true if OpenProject::ActionAuthorizer.allowed?(action, user: current_user, scope:)
 
     render_403
     false

--- a/app/controllers/concerns/accounts/authorization.rb
+++ b/app/controllers/concerns/accounts/authorization.rb
@@ -113,7 +113,6 @@ module Accounts::Authorization
   end
 
   def authorization_check(action:, scope: nil, model: nil) # rubocop:disable Naming/PredicateMethod
-    # TODO: throw argument error if both scope and model are nil
     return true if OpenProject::ActionAuthorizer.allowed?(action, on: model, user: current_user, scope:)
 
     render_403

--- a/lib/open_project/action_authorizer.rb
+++ b/lib/open_project/action_authorizer.rb
@@ -30,6 +30,18 @@
 
 module OpenProject
   class ActionAuthorizer
+    module Registrable
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def register_action_authorization(action, method:)
+          on = module_parent.name.singularize.to_sym
+
+          OpenProject::ActionAuthorizer.register(action, on:, contract: self, method:)
+        end
+      end
+    end
+
     class << self
       def register(action, on:, contract:, method:)
         registry[on.to_s.to_sym][action] = [contract, method]

--- a/lib/open_project/action_authorizer.rb
+++ b/lib/open_project/action_authorizer.rb
@@ -28,47 +28,42 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DeleteContract < ModelContract
-  class << self
-    def delete_permission(permission = nil)
-      if permission
-        @delete_permission = permission
+module OpenProject
+  class ActionAuthorizer
+    class << self
+      def register(name, scope:, contract:, method:)
+        registry[scope.to_s.to_sym][name] = [contract, method]
       end
 
-      @delete_permission
-    end
+      def allowed?(name, user:, scope: nil)
+        entry = find_check(name, scope.class) || find_check(name, nil)
 
-    def delete_allowed?(user:, scope:)
-      permission = delete_permission
+        unless entry
+          scope_desc = scope.nil? ? "nil" : scope.class.name
+          raise ArgumentError, "No authorization check registered for '#{name}' with scope #{scope_desc}"
+        end
 
-      case permission
-      when :admin
-        user.admin? && user.active?
-      when Proc
-        permission.call(user:, model: scope)
-      when Symbol
-        scope.project && user.allowed_in_project?(permission, scope.project)
-      else
-        raise ArgumentError, "#{self.class} used without delete_permission. Set a  Proc, or project-based permission symbol"
+        contract, method = entry
+        contract.to_s.constantize.public_send(method, user:, scope:)
+      end
+
+      def reset!
+        @registry = {}
+      end
+
+      private
+
+      def registry
+        @registry ||= Hash.new { |h, k| h[k] = {} }
+      end
+
+      def find_check(name, scope)
+        return registry[:''][name] if scope.nil?
+
+        check = registry[scope.to_s.to_sym][name]
+
+        check || find_check(name, scope.superclass)
       end
     end
-  end
-
-  validate :user_allowed
-
-  def user_allowed
-    unless authorized?
-      errors.add :base, :error_unauthorized
-    end
-  end
-
-  protected
-
-  def validate_model?
-    false
-  end
-
-  def authorized?
-    self.class.delete_allowed?(user:, scope: model)
   end
 end

--- a/lib/open_project/action_authorizer.rb
+++ b/lib/open_project/action_authorizer.rb
@@ -31,17 +31,24 @@
 module OpenProject
   class ActionAuthorizer
     class << self
-      def register(name, scope:, contract:, method:)
-        registry[scope.to_s.to_sym][name] = [contract, method]
+      def register(action, on:, contract:, method:)
+        registry[on.to_s.to_sym][action] = [contract, method]
       end
 
-      def allowed?(name, user:, scope: nil)
-        entry = find_check(name, scope.class) || find_check(name, nil)
+      # TODO: check if on is really optional.
+      def allowed?(action, user:, on: nil, scope: nil)
+        on = determine_on(on, scope)
+        raise ArgumentError, "Either on or scope needs to be provided." unless on
 
-        unless entry
-          scope_desc = scope.nil? ? "nil" : scope.class.name
-          raise ArgumentError, "No authorization check registered for '#{name}' with scope #{scope_desc}"
+        entry = find_check(action, on)
+
+        # TODO: Check for whether eager loading is active
+        if entry.nil? && Rails.env.local?
+          eager_load_contracts_for(on)
+          entry = find_check(action, on)
         end
+
+        raise ArgumentError, "No authorization check registered for ':#{action}' on the model #{on}." unless entry
 
         contract, method = entry
         contract.to_s.constantize.public_send(method, user:, scope:)
@@ -49,6 +56,7 @@ module OpenProject
 
       def reset!
         @registry = {}
+        @loaded_namespaces = Set.new
       end
 
       private
@@ -57,12 +65,30 @@ module OpenProject
         @registry ||= Hash.new { |h, k| h[k] = {} }
       end
 
-      def find_check(name, scope)
-        return registry[:''][name] if scope.nil?
+      def loaded_namespaces
+        @loaded_namespaces ||= Set.new
+      end
 
-        check = registry[scope.to_s.to_sym][name]
+      def determine_on(on, scope)
+        if on.is_a?(Class)
+          on.to_s.to_sym
+        elsif scope.is_a?(ActiveRecord::Base)
+          scope.class.to_s.to_sym
+        end
+      end
 
-        check || find_check(name, scope.superclass)
+      def find_check(action, on)
+        registry[on][action]
+      end
+
+      def eager_load_contracts_for(on)
+        namespace = on.to_s.pluralize.safe_constantize
+
+        return if namespace.nil? || loaded_namespaces.include?(namespace)
+
+        loaded_namespaces << namespace
+        # TODO: check if contracts can be identified so that only those are loaded and not all of e.g Meetings
+        Rails.autoloaders.each { |loader| loader.eager_load_namespace(namespace) }
       end
     end
   end

--- a/modules/costs/app/contracts/time_entries/delete_contract.rb
+++ b/modules/costs/app/contracts/time_entries/delete_contract.rb
@@ -28,7 +28,7 @@
 
 module TimeEntries
   class DeleteContract < ::DeleteContract
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       edit_all = user.allowed_in_project?(:edit_time_entries, model.project)
       edit_own = if model.entity.is_a?(WorkPackage)
                    user.allowed_in_work_package?(:edit_own_time_entries, model.entity)

--- a/modules/grids/app/contracts/grids/delete_contract.rb
+++ b/modules/grids/app/contracts/grids/delete_contract.rb
@@ -30,6 +30,6 @@ require "grids/base_contract"
 
 module Grids
   class DeleteContract < ::DeleteContract
-    delete_permission -> { model.user_deletable? && Grids::Configuration.writable?(model, user) }
+    delete_permission ->(user:, model:) { model.user_deletable? && Grids::Configuration.writable?(model, user) }
   end
 end

--- a/modules/meeting/app/contracts/meeting_outcomes/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_outcomes/delete_contract.rb
@@ -32,7 +32,7 @@ module MeetingOutcomes
   class DeleteContract < ::DeleteContract
     include EditableItem
 
-    delete_permission -> {
+    delete_permission ->(user:, model:) {
       user.allowed_in_project?(:manage_outcomes, model.meeting_agenda_item.project)
     }
   end

--- a/modules/meeting/app/contracts/meeting_participants/delete_contract.rb
+++ b/modules/meeting/app/contracts/meeting_participants/delete_contract.rb
@@ -30,6 +30,6 @@
 
 module MeetingParticipants
   class DeleteContract < ::DeleteContract
-    delete_permission -> { user.allowed_in_project?(:edit_meetings, model.meeting.project) }
+    delete_permission ->(user:, model:) { user.allowed_in_project?(:edit_meetings, model.meeting.project) }
   end
 end

--- a/modules/meeting/app/contracts/meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/meetings/create_contract.rb
@@ -36,12 +36,41 @@ module Meetings
     validate :user_allowed_to_add
     validate :recurring_meeting_visible
 
+    class << self
+      def allowed?(user:, model:, action:)
+        case action
+        when :create
+          create_allowed?(user:, project: model)
+        when :copy
+          create_allowed?(user:, project: model.project)
+        when :new
+          new_allowed?(user:, project: model)
+        else
+          raise ArgumentError, "Unknown action #{action}"
+        end
+      end
+
+      def create_allowed?(user:, project:)
+        return false if project.nil?
+
+        user.allowed_in_project?(:create_meetings, project)
+      end
+
+      def new_allowed?(user:, project:)
+        if project.nil?
+          user.allowed_in_any_project?(:create_meetings)
+        else
+          user.allowed_in_project?(:create_meetings, project)
+        end
+      end
+    end
+
     private
 
     def user_allowed_to_add
       return if model.project.nil?
 
-      unless user.allowed_in_project?(:create_meetings, model.project)
+      unless self.class.create_allowed?(user: user, project: model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/contracts/meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/meetings/create_contract.rb
@@ -30,6 +30,8 @@
 
 module Meetings
   class CreateContract < BaseContract
+    include OpenProject::ActionAuthorizer::Registrable
+
     attribute :recurring_meeting_id
     attribute :uid
 
@@ -56,9 +58,9 @@ module Meetings
       end
     end
 
-    OpenProject::ActionAuthorizer.register(:new, on: :Meeting, contract: self, method: :new_allowed?)
-    OpenProject::ActionAuthorizer.register(:create, on: :Meeting, contract: self, method: :create_allowed?)
-    OpenProject::ActionAuthorizer.register(:copy, on: :Meeting, contract: self, method: :copy_allowed?)
+    register_action_authorization :new, method: :new_allowed?
+    register_action_authorization :create, method: :create_allowed?
+    register_action_authorization :copy, method: :copy_allowed?
 
     private
 

--- a/modules/meeting/app/contracts/meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/meetings/create_contract.rb
@@ -56,6 +56,10 @@ module Meetings
       end
     end
 
+    OpenProject::ActionAuthorizer.register(:new, on: :Meeting, contract: self, method: :new_allowed?)
+    OpenProject::ActionAuthorizer.register(:create, on: :Meeting, contract: self, method: :create_allowed?)
+    OpenProject::ActionAuthorizer.register(:copy, on: :Meeting, contract: self, method: :copy_allowed?)
+
     private
 
     def user_allowed_to_add

--- a/modules/meeting/app/contracts/meetings/create_contract.rb
+++ b/modules/meeting/app/contracts/meetings/create_contract.rb
@@ -37,31 +37,22 @@ module Meetings
     validate :recurring_meeting_visible
 
     class << self
-      def allowed?(user:, model:, action:)
-        case action
-        when :create
-          create_allowed?(user:, project: model)
-        when :copy
-          create_allowed?(user:, project: model.project)
-        when :new
-          new_allowed?(user:, project: model)
-        else
-          raise ArgumentError, "Unknown action #{action}"
-        end
+      def create_allowed?(user:, scope:)
+        return false if scope.nil?
+
+        user.allowed_in_project?(:create_meetings, scope)
       end
 
-      def create_allowed?(user:, project:)
-        return false if project.nil?
-
-        user.allowed_in_project?(:create_meetings, project)
-      end
-
-      def new_allowed?(user:, project:)
-        if project.nil?
+      def new_allowed?(user:, scope:)
+        if scope.nil?
           user.allowed_in_any_project?(:create_meetings)
         else
-          user.allowed_in_project?(:create_meetings, project)
+          user.allowed_in_project?(:create_meetings, scope)
         end
+      end
+
+      def copy_allowed?(user:, scope:)
+        create_allowed?(user:, scope: scope.project)
       end
     end
 
@@ -70,7 +61,7 @@ module Meetings
     def user_allowed_to_add
       return if model.project.nil?
 
-      unless self.class.create_allowed?(user: user, project: model.project)
+      unless self.class.create_allowed?(user: user, scope: model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/meeting/app/contracts/meetings/delete_contract.rb
+++ b/modules/meeting/app/contracts/meetings/delete_contract.rb
@@ -30,5 +30,7 @@
 module Meetings
   class DeleteContract < ::DeleteContract
     delete_permission :delete_meetings
+
+    OpenProject::ActionAuthorizer.register(:delete, on: :Meeting, contract: self, method: :delete_allowed?)
   end
 end

--- a/modules/meeting/app/contracts/meetings/delete_contract.rb
+++ b/modules/meeting/app/contracts/meetings/delete_contract.rb
@@ -29,8 +29,10 @@
 
 module Meetings
   class DeleteContract < ::DeleteContract
+    include OpenProject::ActionAuthorizer::Registrable
+
     delete_permission :delete_meetings
 
-    OpenProject::ActionAuthorizer.register(:delete, on: :Meeting, contract: self, method: :delete_allowed?)
+    register_action_authorization :delete, method: :delete_allowed?
   end
 end

--- a/modules/meeting/app/contracts/meetings/show_contract.rb
+++ b/modules/meeting/app/contracts/meetings/show_contract.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,58 +26,33 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class DeleteContract < ModelContract
-  class << self
-    def delete_permission(permission = nil)
-      if permission
-        @delete_permission = permission
+module Meetings
+  class ShowContract < ::BaseContract
+    class << self
+      def allowed?(user:, model:, action:)
+        case action
+        when :show
+          show_allowed?(user:, model:)
+        when :index
+          index_allowed?(user:, model:)
+        else
+          raise ArgumentError, "Unknown action #{action}"
+        end
       end
 
-      @delete_permission
-    end
+      def show_allowed?(user:, model:)
+        user.allowed_in_project?(:view_meetings, model.project)
+      end
 
-    def allowed?(user:, model:, action:)
-      case action
-      when :delete
-        delete_allowed?(user:, model:)
-      else
-        raise ArgumentError, "Unknown action #{action}"
+      def index_allowed?(user:, model:)
+        if model.present?
+          user.allowed_in_project?(:view_meetings, model)
+        else
+          user.allowed_globally?(:view_meetings)
+        end
       end
     end
-
-    def delete_allowed?(user:, model:)
-      permission = delete_permission
-
-      case permission
-      when :admin
-        user.admin? && user.active?
-      when Proc
-        permission.call(user:, model:)
-      when Symbol
-        model.project && user.allowed_in_project?(permission, model.project)
-      else
-        raise ArgumentError, "#{self.class} used without delete_permission. Set a  Proc, or project-based permission symbol"
-      end
-    end
-  end
-
-  validate :user_allowed
-
-  def user_allowed
-    unless authorized?
-      errors.add :base, :error_unauthorized
-    end
-  end
-
-  protected
-
-  def validate_model?
-    false
-  end
-
-  def authorized?
-    self.class.delete_allowed?(user:, model:)
   end
 end

--- a/modules/meeting/app/contracts/meetings/show_contract.rb
+++ b/modules/meeting/app/contracts/meetings/show_contract.rb
@@ -30,6 +30,8 @@
 
 module Meetings
   class ShowContract < ::BaseContract
+    include OpenProject::ActionAuthorizer::Registrable
+
     class << self
       def show_allowed?(user:, scope:)
         user.allowed_in_project?(:view_meetings, scope.project)
@@ -44,7 +46,7 @@ module Meetings
       end
     end
 
-    OpenProject::ActionAuthorizer.register(:show, on: :Meeting, contract: self, method: :show_allowed?)
-    OpenProject::ActionAuthorizer.register(:index, on: :Meeting, contract: self, method: :index_allowed?)
+    register_action_authorization :show, method: :show_allowed?
+    register_action_authorization :index, method: :index_allowed?
   end
 end

--- a/modules/meeting/app/contracts/meetings/show_contract.rb
+++ b/modules/meeting/app/contracts/meetings/show_contract.rb
@@ -43,5 +43,8 @@ module Meetings
         end
       end
     end
+
+    OpenProject::ActionAuthorizer.register(:show, on: :Meeting, contract: self, method: :show_allowed?)
+    OpenProject::ActionAuthorizer.register(:index, on: :Meeting, contract: self, method: :index_allowed?)
   end
 end

--- a/modules/meeting/app/contracts/meetings/show_contract.rb
+++ b/modules/meeting/app/contracts/meetings/show_contract.rb
@@ -31,24 +31,13 @@
 module Meetings
   class ShowContract < ::BaseContract
     class << self
-      def allowed?(user:, model:, action:)
-        case action
-        when :show
-          show_allowed?(user:, model:)
-        when :index
-          index_allowed?(user:, model:)
-        else
-          raise ArgumentError, "Unknown action #{action}"
-        end
+      def show_allowed?(user:, scope:)
+        user.allowed_in_project?(:view_meetings, scope.project)
       end
 
-      def show_allowed?(user:, model:)
-        user.allowed_in_project?(:view_meetings, model.project)
-      end
-
-      def index_allowed?(user:, model:)
-        if model.present?
-          user.allowed_in_project?(:view_meetings, model)
+      def index_allowed?(user:, scope:)
+        if scope.present?
+          user.allowed_in_project?(:view_meetings, scope)
         else
           user.allowed_globally?(:view_meetings)
         end

--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -30,6 +30,7 @@
 
 module Meetings
   class UpdateContract < BaseContract
+    include OpenProject::ActionAuthorizer::Registrable
     include Redmine::I18n
 
     validate :user_allowed_to_edit
@@ -47,8 +48,8 @@ module Meetings
       end
     end
 
-    OpenProject::ActionAuthorizer.register(:update, on: :Meeting, contract: self, method: :update_allowed?)
-    OpenProject::ActionAuthorizer.register(:edit, on: :Meeting, contract: self, method: :update_allowed?)
+    register_action_authorization :update, method: :update_allowed?
+    register_action_authorization :edit, method: :update_allowed?
 
     def user_allowed_to_edit
       errors.add(:base, :error_unauthorized) unless self.class.update_allowed?(user:, scope: model)

--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -41,10 +41,23 @@ module Meetings
       end
     end
 
-    def user_allowed_to_edit
-      unless user.allowed_in_project?(:edit_meetings, model.project)
-        errors.add :base, :error_unauthorized
+    class << self
+      def allowed?(user:, model:, action:)
+        case action
+        when :update
+          update_allowed?(user:, model:)
+        else
+          raise ArgumentError, "Unknown action #{action}"
+        end
       end
+
+      def update_allowed?(user:, model:)
+        user.allowed_in_project?(:edit_meetings, model.project)
+      end
+    end
+
+    def user_allowed_to_edit
+      errors.add(:base, :error_unauthorized) unless self.class.update_allowed?(user:, model:)
     end
 
     def valid_rescheduling_date # rubocop:disable Metrics/AbcSize

--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -47,6 +47,9 @@ module Meetings
       end
     end
 
+    OpenProject::ActionAuthorizer.register(:update, on: :Meeting, contract: self, method: :update_allowed?)
+    OpenProject::ActionAuthorizer.register(:edit, on: :Meeting, contract: self, method: :update_allowed?)
+
     def user_allowed_to_edit
       errors.add(:base, :error_unauthorized) unless self.class.update_allowed?(user:, scope: model)
     end

--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -42,22 +42,13 @@ module Meetings
     end
 
     class << self
-      def allowed?(user:, model:, action:)
-        case action
-        when :update
-          update_allowed?(user:, model:)
-        else
-          raise ArgumentError, "Unknown action #{action}"
-        end
-      end
-
-      def update_allowed?(user:, model:)
-        user.allowed_in_project?(:edit_meetings, model.project)
+      def update_allowed?(user:, scope:)
+        user.allowed_in_project?(:edit_meetings, scope.project)
       end
     end
 
     def user_allowed_to_edit
-      errors.add(:base, :error_unauthorized) unless self.class.update_allowed?(user:, model:)
+      errors.add(:base, :error_unauthorized) unless self.class.update_allowed?(user:, scope: model)
     end
 
     def valid_rescheduling_date # rubocop:disable Metrics/AbcSize

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -207,6 +207,8 @@ class MeetingsController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
+    authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
+
     recurring = @meeting.recurring_meeting
 
     # rubocop:disable Rails/ActionControllerFlashBeforeRender

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -56,6 +56,8 @@ class MeetingsController < ApplicationController
   menu_item :new_meeting, only: %i[new create]
 
   def index
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @project, action: :index)
+
     load_meetings
 
     render "index",
@@ -67,6 +69,8 @@ class MeetingsController < ApplicationController
   end
 
   def show
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+
     respond_to do |format|
       format.pdf { export_pdf }
       format.html do
@@ -81,6 +85,8 @@ class MeetingsController < ApplicationController
   end
 
   def check_for_updates
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+
     if params[:reference] == @meeting.changed_hash
       head :no_content
     else
@@ -88,9 +94,19 @@ class MeetingsController < ApplicationController
     end
   end
 
-  def new; end
+  def new
+    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :new)
+
+    respond_to do |format|
+      format.html do
+        render :new
+      end
+    end
+  end
 
   def edit
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     respond_to do |format|
       format.turbo_stream do
         update_header_component_via_turbo_stream(state: :edit)
@@ -104,6 +120,10 @@ class MeetingsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
+    return unless authorization_check(contract_class: Meetings::CreateContract,
+                                      model: @project || Project.find_by(id: @converted_params["project_id"]),
+                                      action: :create)
+
     call =
       if @copy_from
         ::Meetings::CopyService
@@ -153,6 +173,8 @@ class MeetingsController < ApplicationController
   end
 
   def new_dialog
+    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :new)
+
     respond_with_dialog Meetings::Index::DialogComponent.new(
       meeting: @meeting,
       project: @project
@@ -164,6 +186,8 @@ class MeetingsController < ApplicationController
   end
 
   def copy
+    return unless authorization_check(contract_class: Meetings::CreateContract, model: @meeting, action: :copy)
+
     copy_from = @meeting
     call = ::Meetings::CopyService
       .new(user: current_user, model: copy_from)
@@ -186,6 +210,8 @@ class MeetingsController < ApplicationController
   end
 
   def delete_dialog
+    return unless authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
+
     respond_with_dialog Meetings::DeleteDialogComponent.new(
       meeting: @meeting,
       back_url: params[:back_url]
@@ -193,6 +219,8 @@ class MeetingsController < ApplicationController
   end
 
   def update
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     call = ::Meetings::UpdateService
       .new(user: current_user, model: @meeting)
       .call(@converted_params)
@@ -207,7 +235,7 @@ class MeetingsController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
-    authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
+    return unless authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
 
     recurring = @meeting.recurring_meeting
 
@@ -227,6 +255,8 @@ class MeetingsController < ApplicationController
   end
 
   def history
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+
     @events = get_events
   rescue ActiveRecord::RecordNotFound => e
     op_handle_warning "Failed to find all resources in activities: #{e.message}"
@@ -234,14 +264,20 @@ class MeetingsController < ApplicationController
   end
 
   def cancel_edit
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     update_header_component_via_turbo_stream(state: :show)
 
     respond_with_turbo_streams
   end
 
-  def details_dialog; end
+  def details_dialog
+    nil unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+  end
 
   def update_title
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     @meeting.update(title: meeting_params[:title])
 
     if @meeting.errors.any?
@@ -254,6 +290,8 @@ class MeetingsController < ApplicationController
   end
 
   def update_details
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     call = ::Meetings::UpdateService
       .new(user: current_user, model: @meeting)
       .call(meeting_params)
@@ -273,6 +311,8 @@ class MeetingsController < ApplicationController
   end
 
   def change_state
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+
     case params[:state]
     when "open"
       @meeting.open!
@@ -293,6 +333,8 @@ class MeetingsController < ApplicationController
   end
 
   def download_ics
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+
     ::Meetings::ICalService
       .new(user: current_user, meeting: @meeting)
       .call
@@ -303,12 +345,16 @@ class MeetingsController < ApplicationController
   end
 
   def notify
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+
     handle_notification(type: :notify)
 
     redirect_to action: :show, id: @meeting
   end
 
   def fetch_timezone
+    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :create)
+
     return unless timezone_params.keys.count == 2
 
     User.execute_as(User.current) do
@@ -324,6 +370,8 @@ class MeetingsController < ApplicationController
   end
 
   def generate_pdf_dialog
+    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+
     respond_with_dialog Meetings::Exports::ModalDialogComponent.new(
       meeting: @meeting,
       project: @project
@@ -331,10 +379,14 @@ class MeetingsController < ApplicationController
   end
 
   def toggle_notifications_dialog
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+
     respond_with_dialog Meetings::SidePanel::ToggleNotificationsDialogComponent.new(@meeting)
   end
 
   def toggle_notifications
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+
     @meeting.toggle!(:notify)
 
     # Reload to get the updated value
@@ -355,10 +407,14 @@ class MeetingsController < ApplicationController
   end
 
   def exit_draft_mode_dialog
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+
     respond_with_dialog Meetings::ExitDraftModeDialogComponent.new(meeting: @meeting)
   end
 
   def exit_draft_mode
+    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+
     call = ::Meetings::UpdateService
              .new(user: current_user, model: @meeting)
              .call({ state: "open", notify: meeting_params[:notify] == "1" })

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -56,7 +56,7 @@ class MeetingsController < ApplicationController
   menu_item :new_meeting, only: %i[new create]
 
   def index
-    return unless authorization_check(action: :index_meetings, scope: @project)
+    return unless authorization_check(action: :index, scope: @project, model: Meeting)
 
     load_meetings
 
@@ -95,7 +95,7 @@ class MeetingsController < ApplicationController
   end
 
   def new
-    return unless authorization_check(action: :new_meeting, scope: @project)
+    return unless authorization_check(action: :new, scope: @project, model: Meeting)
 
     respond_to do |format|
       format.html do
@@ -120,8 +120,9 @@ class MeetingsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    return unless authorization_check(action: :create_meeting,
-                                      scope: @project || Project.find_by(id: @converted_params["project_id"]))
+    return unless authorization_check(action: :create,
+                                      scope: @project || Project.find_by(id: @converted_params["project_id"]),
+                                      model: Meeting)
 
     call =
       if @copy_from
@@ -172,7 +173,7 @@ class MeetingsController < ApplicationController
   end
 
   def new_dialog
-    return unless authorization_check(action: :new_meeting, scope: @project)
+    return unless authorization_check(action: :new, scope: @project, model: Meeting)
 
     respond_with_dialog Meetings::Index::DialogComponent.new(
       meeting: @meeting,
@@ -352,7 +353,7 @@ class MeetingsController < ApplicationController
   end
 
   def fetch_timezone
-    return unless authorization_check(action: :create_meeting, scope: @project)
+    return unless authorization_check(action: :create, scope: @project, model: Meeting)
 
     return unless timezone_params.keys.count == 2
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -56,7 +56,7 @@ class MeetingsController < ApplicationController
   menu_item :new_meeting, only: %i[new create]
 
   def index
-    return unless authorization_check(action: :index, scope: @project, model: Meeting)
+    return unless authorization_check(action: :index, scope: @project, on: Meeting)
 
     load_meetings
 
@@ -95,7 +95,7 @@ class MeetingsController < ApplicationController
   end
 
   def new
-    return unless authorization_check(action: :new, scope: @project, model: Meeting)
+    return unless authorization_check(action: :new, scope: @project, on: Meeting)
 
     respond_to do |format|
       format.html do
@@ -122,7 +122,7 @@ class MeetingsController < ApplicationController
   def create # rubocop:disable Metrics/AbcSize
     return unless authorization_check(action: :create,
                                       scope: @project || Project.find_by(id: @converted_params["project_id"]),
-                                      model: Meeting)
+                                      on: Meeting)
 
     call =
       if @copy_from
@@ -173,7 +173,7 @@ class MeetingsController < ApplicationController
   end
 
   def new_dialog
-    return unless authorization_check(action: :new, scope: @project, model: Meeting)
+    return unless authorization_check(action: :new, scope: @project, on: Meeting)
 
     respond_with_dialog Meetings::Index::DialogComponent.new(
       meeting: @meeting,
@@ -353,7 +353,7 @@ class MeetingsController < ApplicationController
   end
 
   def fetch_timezone
-    return unless authorization_check(action: :create, scope: @project, model: Meeting)
+    return unless authorization_check(action: :create, scope: @project, on: Meeting)
 
     return unless timezone_params.keys.count == 2
 

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -56,7 +56,7 @@ class MeetingsController < ApplicationController
   menu_item :new_meeting, only: %i[new create]
 
   def index
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @project, action: :index)
+    return unless authorization_check(action: :index_meetings, scope: @project)
 
     load_meetings
 
@@ -69,7 +69,7 @@ class MeetingsController < ApplicationController
   end
 
   def show
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+    return unless authorization_check(action: :show, scope: @meeting)
 
     respond_to do |format|
       format.pdf { export_pdf }
@@ -85,7 +85,7 @@ class MeetingsController < ApplicationController
   end
 
   def check_for_updates
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+    return unless authorization_check(action: :show, scope: @meeting)
 
     if params[:reference] == @meeting.changed_hash
       head :no_content
@@ -95,7 +95,7 @@ class MeetingsController < ApplicationController
   end
 
   def new
-    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :new)
+    return unless authorization_check(action: :new_meeting, scope: @project)
 
     respond_to do |format|
       format.html do
@@ -105,7 +105,7 @@ class MeetingsController < ApplicationController
   end
 
   def edit
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     respond_to do |format|
       format.turbo_stream do
@@ -120,9 +120,8 @@ class MeetingsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    return unless authorization_check(contract_class: Meetings::CreateContract,
-                                      model: @project || Project.find_by(id: @converted_params["project_id"]),
-                                      action: :create)
+    return unless authorization_check(action: :create_meeting,
+                                      scope: @project || Project.find_by(id: @converted_params["project_id"]))
 
     call =
       if @copy_from
@@ -173,7 +172,7 @@ class MeetingsController < ApplicationController
   end
 
   def new_dialog
-    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :new)
+    return unless authorization_check(action: :new_meeting, scope: @project)
 
     respond_with_dialog Meetings::Index::DialogComponent.new(
       meeting: @meeting,
@@ -186,7 +185,7 @@ class MeetingsController < ApplicationController
   end
 
   def copy
-    return unless authorization_check(contract_class: Meetings::CreateContract, model: @meeting, action: :copy)
+    return unless authorization_check(action: :copy, scope: @meeting)
 
     copy_from = @meeting
     call = ::Meetings::CopyService
@@ -210,7 +209,7 @@ class MeetingsController < ApplicationController
   end
 
   def delete_dialog
-    return unless authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
+    return unless authorization_check(action: :delete, scope: @meeting)
 
     respond_with_dialog Meetings::DeleteDialogComponent.new(
       meeting: @meeting,
@@ -219,7 +218,7 @@ class MeetingsController < ApplicationController
   end
 
   def update
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :update, scope: @meeting)
 
     call = ::Meetings::UpdateService
       .new(user: current_user, model: @meeting)
@@ -235,7 +234,7 @@ class MeetingsController < ApplicationController
   end
 
   def destroy # rubocop:disable Metrics/AbcSize
-    return unless authorization_check(contract_class: Meetings::DeleteContract, model: @meeting, action: :delete)
+    return unless authorization_check(action: :delete, scope: @meeting)
 
     recurring = @meeting.recurring_meeting
 
@@ -255,7 +254,7 @@ class MeetingsController < ApplicationController
   end
 
   def history
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+    return unless authorization_check(action: :show, scope: @meeting)
 
     @events = get_events
   rescue ActiveRecord::RecordNotFound => e
@@ -264,7 +263,7 @@ class MeetingsController < ApplicationController
   end
 
   def cancel_edit
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     update_header_component_via_turbo_stream(state: :show)
 
@@ -272,11 +271,11 @@ class MeetingsController < ApplicationController
   end
 
   def details_dialog
-    nil unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    authorization_check(action: :edit, scope: @meeting)
   end
 
   def update_title
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     @meeting.update(title: meeting_params[:title])
 
@@ -290,7 +289,7 @@ class MeetingsController < ApplicationController
   end
 
   def update_details
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     call = ::Meetings::UpdateService
       .new(user: current_user, model: @meeting)
@@ -311,7 +310,7 @@ class MeetingsController < ApplicationController
   end
 
   def change_state
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :update)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     case params[:state]
     when "open"
@@ -333,7 +332,7 @@ class MeetingsController < ApplicationController
   end
 
   def download_ics
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+    return unless authorization_check(action: :show, scope: @meeting)
 
     ::Meetings::ICalService
       .new(user: current_user, meeting: @meeting)
@@ -345,7 +344,7 @@ class MeetingsController < ApplicationController
   end
 
   def notify
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     handle_notification(type: :notify)
 
@@ -353,7 +352,7 @@ class MeetingsController < ApplicationController
   end
 
   def fetch_timezone
-    return unless authorization_check(contract_class: Meetings::CreateContract, model: @project, action: :create)
+    return unless authorization_check(action: :create_meeting, scope: @project)
 
     return unless timezone_params.keys.count == 2
 
@@ -370,7 +369,7 @@ class MeetingsController < ApplicationController
   end
 
   def generate_pdf_dialog
-    return unless authorization_check(contract_class: Meetings::ShowContract, model: @meeting, action: :show)
+    return unless authorization_check(action: :show, scope: @meeting)
 
     respond_with_dialog Meetings::Exports::ModalDialogComponent.new(
       meeting: @meeting,
@@ -379,13 +378,13 @@ class MeetingsController < ApplicationController
   end
 
   def toggle_notifications_dialog
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     respond_with_dialog Meetings::SidePanel::ToggleNotificationsDialogComponent.new(@meeting)
   end
 
   def toggle_notifications
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     @meeting.toggle!(:notify)
 
@@ -407,13 +406,13 @@ class MeetingsController < ApplicationController
   end
 
   def exit_draft_mode_dialog
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     respond_with_dialog Meetings::ExitDraftModeDialogComponent.new(meeting: @meeting)
   end
 
   def exit_draft_mode
-    return unless authorization_check(contract_class: Meetings::UpdateContract, model: @meeting, action: :edit)
+    return unless authorization_check(action: :edit, scope: @meeting)
 
     call = ::Meetings::UpdateService
              .new(user: current_user, model: @meeting)

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -192,6 +192,42 @@ module OpenProject::Meeting
       ::Exports::Register.register do
         single(::Meeting, Meetings::Exporter)
       end
+
+      OpenProject::ActionAuthorizer.register(:new_meeting,
+                                             scope: nil,
+                                             contract: :"Meetings::CreateContract",
+                                             method: :new_allowed?)
+      OpenProject::ActionAuthorizer.register(:create_meeting,
+                                             scope: :Project,
+                                             contract: :"Meetings::CreateContract",
+                                             method: :create_allowed?)
+      OpenProject::ActionAuthorizer.register(:copy,
+                                             scope: :Meeting,
+                                             contract: :"Meetings::CreateContract",
+                                             method: :copy_allowed?)
+
+      OpenProject::ActionAuthorizer.register(:update,
+                                             scope: :Meeting,
+                                             contract: :"Meetings::UpdateContract",
+                                             method: :update_allowed?)
+      OpenProject::ActionAuthorizer.register(:edit,
+                                             scope: :Meeting,
+                                             contract: :"Meetings::UpdateContract",
+                                             method: :update_allowed?)
+
+      OpenProject::ActionAuthorizer.register(:show,
+                                             scope: :Meeting,
+                                             contract: :"Meetings::ShowContract",
+                                             method: :show_allowed?)
+      OpenProject::ActionAuthorizer.register(:index_meetings,
+                                             scope: nil,
+                                             contract: :"Meetings::ShowContract",
+                                             method: :index_allowed?)
+
+      OpenProject::ActionAuthorizer.register(:delete,
+                                             scope: :Meeting,
+                                             contract: :"Meetings::DeleteContract",
+                                             method: :delete_allowed?)
     end
 
     add_api_path :meetings do

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -49,7 +49,7 @@ module OpenProject::Meeting
                      work_package_meetings_tab: %i[index count],
                      recurring_meetings: %i[index show new create download_ics]
                    },
-                   permissible_on: :project
+                   permissible_on: %i[project global]
         permission :create_meetings,
                    {
                      meetings: %i[new create copy new_dialog fetch_timezone],

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -193,41 +193,6 @@ module OpenProject::Meeting
         single(::Meeting, Meetings::Exporter)
       end
 
-      OpenProject::ActionAuthorizer.register(:new_meeting,
-                                             scope: nil,
-                                             contract: :"Meetings::CreateContract",
-                                             method: :new_allowed?)
-      OpenProject::ActionAuthorizer.register(:create_meeting,
-                                             scope: :Project,
-                                             contract: :"Meetings::CreateContract",
-                                             method: :create_allowed?)
-      OpenProject::ActionAuthorizer.register(:copy,
-                                             scope: :Meeting,
-                                             contract: :"Meetings::CreateContract",
-                                             method: :copy_allowed?)
-
-      OpenProject::ActionAuthorizer.register(:update,
-                                             scope: :Meeting,
-                                             contract: :"Meetings::UpdateContract",
-                                             method: :update_allowed?)
-      OpenProject::ActionAuthorizer.register(:edit,
-                                             scope: :Meeting,
-                                             contract: :"Meetings::UpdateContract",
-                                             method: :update_allowed?)
-
-      OpenProject::ActionAuthorizer.register(:show,
-                                             scope: :Meeting,
-                                             contract: :"Meetings::ShowContract",
-                                             method: :show_allowed?)
-      OpenProject::ActionAuthorizer.register(:index_meetings,
-                                             scope: nil,
-                                             contract: :"Meetings::ShowContract",
-                                             method: :index_allowed?)
-
-      OpenProject::ActionAuthorizer.register(:delete,
-                                             scope: :Meeting,
-                                             contract: :"Meetings::DeleteContract",
-                                             method: :delete_allowed?)
     end
 
     add_api_path :meetings do

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -192,7 +192,6 @@ module OpenProject::Meeting
       ::Exports::Register.register do
         single(::Meeting, Meetings::Exporter)
       end
-
     end
 
     add_api_path :meetings do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/71902

# What are you trying to accomplish?

Run permission checks on explicit model objects (e.g. meetings) rather than on routes. The checks are centralized in the contracts which are already the place for checking permissions for edit, update and delete but are not used for show, index and non standard HTTP actions (e.g. toggle). 

This is less intended to be an actual code improvement to be merged but rather a starting point for discussions about the patterns introduced.

Introduced concepts:
 
* [Contracts have class methods that can be called to check permissions](https://github.com/opf/openproject/pull/21973/changes#diff-613e4cd48f3e0cb14ac04b93f9f9579df3ff49f4f1fd68cc95d2a630a5519f2bR42-R58). Those follow the pattern `xyz_allowed?` and take the user to check on as well as the scope to check as parameters. A scope might then be e.g. the meeting instance to be updated/deleted but could also be the project a new meeting is to be created on.  
* [ShowContracts are introduced](https://github.com/opf/openproject/pull/21973/changes#diff-755f4113610eafe0241168474b80342e028e6b3b209e335be67a58d8dbedf103R32-R47) to cover show and index actions. These might just as well be different contracts but so far, the need for splitting them up wasn't pressing.
* [Contracts register to a central authority](https://github.com/opf/openproject/pull/21973/changes#diff-613e4cd48f3e0cb14ac04b93f9f9579df3ff49f4f1fd68cc95d2a630a5519f2bR61-R63) explaining on what action they are responsible for the permission check and which method to call in this case.
* The [controller checks first](https://github.com/opf/openproject/pull/21973/changes#diff-88b66b9a0141ca37ae48cf523c43a8d913d2db320f303b3c54dbbe1c50f347b7R59-R88) if an action is allowed and will return 403 if it doesn't. The check is rather simple to call and doesn't require knowing the contract and method to check since the central authority distributes the call. It requires knowing the action's name. This should be standardized by convention to make it easy to remember. 


