### PR TITLE
Fix handling of external link warnings in mails, and add more flexible parsing

### DIFF
--- a/app/controllers/external_link_warning_controller.rb
+++ b/app/controllers/external_link_warning_controller.rb
@@ -63,11 +63,11 @@ class ExternalLinkWarningController < ApplicationController
   def parse_url(url)
     return nil if url.blank?
 
-    uri = URI.parse(url)
-    return url if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+    uri = Addressable::URI.parse(url)
+    return url if %w[http https].include?(uri.scheme&.downcase)
 
     nil
-  rescue URI::InvalidURIError
+  rescue Addressable::URI::InvalidURIError
     nil
   end
 end

--- a/lib/open_project/text_formatting/filters/external_link_capture_filter.rb
+++ b/lib/open_project/text_formatting/filters/external_link_capture_filter.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+module OpenProject::TextFormatting
+  module Filters
+    class ExternalLinkCaptureFilter < HTML::Pipeline::Filter
+      include OpenProject::StaticRouting::UrlHelpers
+
+      def call
+        return doc unless applicable?
+
+        doc.css("a[href]").each do |node|
+          url = node["href"]
+          next if internal_link?(url)
+
+          node["href"] = external_redirect(url:)
+          node["target"] = "_blank"
+        end
+
+        doc
+      end
+
+      def applicable?
+        Setting.capture_external_links? && EnterpriseToken.allows_to?(:capture_external_links)
+      end
+
+      private
+
+      def external_redirect(url:)
+        url_helpers.external_redirect_url(url:)
+      end
+
+      def internal_link?(href)
+        return true if href.blank?
+        return true if href.start_with?("#", "/")
+
+        # Only capture HTTP/HTTPS links, allow all other schemes (mailto, tel, ical, custom protocols, etc.)
+        return true unless href.start_with?("http", "https")
+
+        # Check if it's an internal link
+        internal_url = "#{Setting.protocol}://#{Setting.host_name}"
+        return true if href.start_with?(internal_url)
+
+        # Additional host names check
+        Setting.additional_host_names.each do |additional_host|
+          additional_url = "#{Setting.protocol}://#{additional_host}"
+          return true if href.start_with?(additional_url)
+        end
+
+        false
+      end
+
+      def url_helpers
+        @url_helpers ||= OpenProject::StaticRouting::StaticUrlHelpers.new
+      end
+    end
+  end
+end

--- a/lib/open_project/text_formatting/formats/markdown/formatter.rb
+++ b/lib/open_project/text_formatting/formats/markdown/formatter.rb
@@ -58,6 +58,7 @@ module OpenProject::TextFormatting::Formats::Markdown
         OpenProject::TextFormatting::Filters::AutolinkCustomProtocolsFilter,
         OpenProject::TextFormatting::Filters::RelativeLinkFilter,
         OpenProject::TextFormatting::Filters::LinkAttributeFilter,
+        OpenProject::TextFormatting::Filters::ExternalLinkCaptureFilter,
         OpenProject::TextFormatting::Filters::FigureWrappedFilter,
         OpenProject::TextFormatting::Filters::BemCssFilter
       ]

--- a/spec/controllers/external_link_warning_controller_spec.rb
+++ b/spec/controllers/external_link_warning_controller_spec.rb
@@ -73,6 +73,19 @@ RSpec.describe ExternalLinkWarningController do
       end
     end
 
+    context "with a percent-encoded unicode URL" do
+      before do
+        allow(Setting).to receive(:capture_external_links?).and_return(false)
+      end
+
+      it "handles URLs with percent-encoded UTF-8 characters" do
+        encoded_url = CGI.escape("https://example.com?ünicode=1")
+        get :show, params: { url: encoded_url }
+
+        expect(response).to redirect_to("https://example.com?ünicode=1")
+      end
+    end
+
     context "with an invalid URL" do
       it "redirects to home when URL is blank" do
         get :show, params: { url: "" }

--- a/spec/features/external_link_capture_spec.rb
+++ b/spec/features/external_link_capture_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "External link capture", :js, :selenium do
 
       visit project_wiki_path(project, wiki_page)
 
-      link = page.find('a[href^="/external_redirect?url="]')
+      link = page.find('a[href*="/external_redirect?url="]')
       new_window = window_opened_by { link.click }
 
       within_window new_window do

--- a/spec/lib/open_project/text_formatting/filters/external_link_capture_filter_spec.rb
+++ b/spec/lib/open_project/text_formatting/filters/external_link_capture_filter_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::TextFormatting::Filters::ExternalLinkCaptureFilter do
+  let(:filter) { described_class.new(html, context) }
+  let(:context) { {} }
+  let(:html) { "" }
+
+  describe "#call" do
+    context "when capture_external_links is disabled" do
+      before do
+        allow(Setting).to receive(:capture_external_links?).and_return(false)
+      end
+
+      it "does not modify external links" do
+        html = '<a href="https://example.com">External</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="https://example.com"')
+      end
+    end
+
+    context "when capture_external_links is enabled",
+            with_ee: %i[capture_external_links],
+            with_settings: {
+              capture_external_links: true,
+              host_name: "localhost:3000",
+              https: false
+            } do
+      it "redirects external HTTP links" do
+        html = '<a href="https://example.com">External</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="http://localhost:3000/external_redirect?url=')
+        expect(result.to_html).to include(CGI.escape("https://example.com"))
+      end
+
+      it "redirects external HTTPS links" do
+        html = '<a href="https://example.org">External</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="http://localhost:3000/external_redirect?url=')
+        expect(result.to_html).to include(CGI.escape("https://example.org"))
+      end
+
+      it "does not redirect relative links" do
+        html = '<a href="/work_packages">Internal</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="/work_packages"')
+      end
+
+      it "does not redirect anchor links" do
+        html = '<a href="#section">Anchor</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="#section"')
+      end
+
+      it "does not redirect mailto links" do
+        html = '<a href="mailto:test@example.com">Email</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="mailto:test@example.com"')
+      end
+
+      it "does not redirect tel links" do
+        html = '<a href="tel:+1234567890">Phone</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="tel:+1234567890"')
+      end
+
+      it "does not redirect ical links" do
+        html = '<a href="webcal://example.com/calendar.ics">Calendar</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="webcal://example.com/calendar.ics"')
+      end
+
+      it "does not redirect custom protocol links" do
+        html = '<a href="vscode://file/path/to/file">VS Code</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="vscode://file/path/to/file"')
+      end
+
+      it "does not redirect file protocol links" do
+        html = '<a href="file:///path/to/file">File</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="file:///path/to/file"')
+      end
+
+      it "does not redirect internal links" do
+        html = '<a href="http://localhost:3000/work_packages">Internal</a>'
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include('href="http://localhost:3000/work_packages"')
+      end
+
+      context "with additional host names", with_settings: { additional_host_names: ["example.local"] } do
+        it "does not redirect links from additional host names" do
+          html = '<a href="http://example.local/work_packages">Internal</a>'
+          filter = described_class.new(html, context)
+          result = filter.call
+
+          expect(result.to_html).to include('href="http://example.local/work_packages"')
+        end
+      end
+
+      it "handles multiple links in the same document" do
+        html = <<~HTML
+          <p>Visit <a href="https://example.com">Example</a> or <a href="https://test.org">Test</a></p>
+        HTML
+        filter = described_class.new(html, context)
+        result = filter.call
+
+        expect(result.to_html).to include(CGI.escape("https://example.com"))
+        expect(result.to_html).to include(CGI.escape("https://test.org"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/71907

https://community.openproject.org/projects/openproject/work_packages/71931

This PR restores the format_text pipeline for external links, as this initially caused caching issues. Since then, we always rewrite the link, and deal with the setting in the controller. This made this point mute. The JS handler is still needed for flows not going through MD pipeline