### PR TITLE
Use custom field available in project check

### DIFF
--- a/lib/api/v3/custom_options/custom_options_api.rb
+++ b/lib/api/v3/custom_options/custom_options_api.rb
@@ -42,7 +42,7 @@ module API
                 when WorkPackageCustomField
                   authorized_work_package_option(custom_option)
                 when ProjectCustomField
-                  authorize_in_any_project(%i[view_project]) { raise API::Errors::NotFound }
+                  authorized_project_custom_option(custom_option)
                 when TimeEntryCustomField
                   authorize_in_any_work_package(:log_own_time) do
                     authorize_in_any_project(:log_time) do
@@ -63,6 +63,15 @@ module API
                   .exists?(custom_fields: { id: custom_option.custom_field_id })
 
                 unless allowed
+                  raise API::Errors::NotFound
+                end
+              end
+
+              def authorized_project_custom_option(custom_option)
+                unless Project
+                  .visible(current_user)
+                  .joins(:project_custom_field_project_mappings)
+                  .exists?(project_custom_field_project_mappings: { custom_field_id: custom_option.custom_field_id })
                   raise API::Errors::NotFound
                 end
               end

--- a/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
+++ b/spec/requests/api/v3/custom_options/custom_options_resource_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "API v3 Custom Options resource", :aggregate_failures do
     end
 
     describe "ProjectCustomField" do
-      shared_let(:custom_field) { create(:list_project_custom_field) }
+      shared_let(:custom_field) { create(:list_project_custom_field, projects: [project]) }
       shared_let(:custom_option) { create(:custom_option, custom_field:) }
 
       context "when being allowed" do
@@ -137,6 +137,20 @@ RSpec.describe "API v3 Custom Options resource", :aggregate_failures do
           expect(response.body)
             .to be_json_eql(custom_option.value.to_json)
                   .at_path("value")
+        end
+      end
+
+      context "when custom field is not activated in a visible project" do
+        shared_let(:other_project) { create(:project) }
+        shared_let(:other_custom_field) { create(:list_project_custom_field, projects: [other_project]) }
+        shared_let(:other_custom_option) { create(:custom_option, custom_field: other_custom_field) }
+
+        let(:permissions) { [:view_project] }
+        let(:path) { api_v3_paths.custom_option other_custom_option.id }
+
+        it "is 404" do
+          expect(subject.status)
+            .to be(404)
         end
       end
 


### PR DESCRIPTION
Use Project.visible check on custom option availability, and allow not disclosing a project name in a query representer