### PR TITLE
Move generation of WWW-header into format block

### DIFF
--- a/app/controllers/concerns/accounts/current_user.rb
+++ b/app/controllers/concerns/accounts/current_user.rb
@@ -168,12 +168,8 @@ module Accounts::CurrentUser
           redirect_to main_app.signin_path(back_url: login_back_url)
         end
 
-        auth_header = OpenProject::Authentication::WWWAuthenticate.response_header
-
         format.any(:xml, :js, :json, :turbo_stream) do
-          head :unauthorized,
-               "X-Reason" => "login needed",
-               "WWW-Authenticate" => auth_header
+          head :unauthorized, "WWW-Authenticate" => OpenProject::Authentication::WWWAuthenticate.response_header
         end
 
         format.all { head :not_acceptable }


### PR DESCRIPTION
This way, the header is only generated when it's needed and not on every request.

# Ticket
Discovered when looking into https://community.openproject.org/wp/71964

The root cause of the linked WP was rather missing configuration that was probably also a cause for problems before. This has been fixed indepdendently.

This fix here just ensures that the generation of the header only happens when necessary and the corresponding bug can only be triggered, when the header would be sent (not on other requests).