### PR TITLE
Forbid last remaining admin to delete themselves

### DIFF
--- a/app/components/users/edit_page_header_component.html.erb
+++ b/app/components/users/edit_page_header_component.html.erb
@@ -80,7 +80,7 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
 
-      if Setting.users_deletable_by_admins?
+      if Users::DeleteContract.deletion_allowed?(@user, User.current)
         header.with_action_button(
           tag: :a,
           scheme: :danger,

--- a/app/contracts/users/delete_contract.rb
+++ b/app/contracts/users/delete_contract.rb
@@ -40,6 +40,8 @@ module Users
     # @param user [User] User to be deleted.
     # @param actor [User] User who wants to delete the given user.
     def self.deletion_allowed?(user, actor)
+      return false if user.admin? && User.admin.active.where.not(id: user.id).empty?
+
       if actor == user
         Setting.users_deletable_by_self?
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -226,9 +226,13 @@ class UsersController < ApplicationController
     # true if the user deletes him/herself
     self_delete = (@user == User.current)
 
-    Users::DeleteService.new(model: @user, user: User.current).call
+    result = Users::DeleteService.new(model: @user, user: User.current).call
 
-    flash[:notice] = I18n.t("account.deletion_pending")
+    if result.success?
+      flash[:notice] = I18n.t("account.deletion_pending")
+    else
+      flash[:error] = result.errors.full_messages.join(", ")
+    end
 
     respond_to do |format|
       format.html do
@@ -283,7 +287,12 @@ class UsersController < ApplicationController
   end
 
   def check_if_deletion_allowed
-    render_404 unless Users::DeleteContract.deletion_allowed? @user, User.current
+    return if Users::DeleteContract.deletion_allowed?(@user, User.current)
+
+    render_error_flash_message_via_turbo_stream(message: I18n.t("user.error_cannot_delete_user"))
+    respond_with_turbo_streams(status: :not_found) do |format|
+      format.html { render_404 }
+    end
   end
 
   def my_or_admin_layout

--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -37,7 +37,7 @@ See COPYRIGHT and LICENSE files for more details.
        t(:label_account)]
     )
 
-    if Setting.users_deletable_by_self?
+    if Users::DeleteContract.deletion_allowed?(@user, User.current)
       header.with_action_button(
         tag: :a,
         scheme: :danger,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5203,6 +5203,7 @@ en:
     text_change_disabled_for_ldap_login: "The name and email is set by LDAP and can thus not be changed."
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
+    error_cannot_delete_user: "User cannot be deleted"
 
   version_status_closed: "closed"
   version_status_locked: "locked"

--- a/spec/contracts/users/delete_contract_spec.rb
+++ b/spec/contracts/users/delete_contract_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe Users::DeleteContract do
+  include_context "ModelContract shared context"
+
+  let(:user) { create(:user) }
+  let(:contract) { described_class.new(user, current_user) }
+
+  context "when self deletion is allowed", with_settings: { users_deletable_by_self: true } do
+    context "when user is the current user" do
+      let(:current_user) { user }
+
+      it_behaves_like "contract is valid"
+    end
+
+    context "when user is not the current user" do
+      let(:current_user) { create(:user) }
+
+      it_behaves_like "contract is invalid"
+    end
+
+    context "when the only admin tries to delete itself" do
+      let(:user) { create(:admin) }
+      let(:current_user) { user }
+
+      it_behaves_like "contract is invalid"
+    end
+
+    context "when the last active admin tries to delete itself" do
+      let!(:other_admin) { create(:admin, status: :locked) }
+      let(:user) { create(:admin) }
+      let(:current_user) { user }
+
+      it_behaves_like "contract is invalid"
+    end
+
+    context "when one of many admins tries to delete itself" do
+      let!(:other_admin) { create(:admin) }
+      let(:user) { create(:admin) }
+      let(:current_user) { user }
+
+      it_behaves_like "contract is valid"
+    end
+  end
+
+  context "when self deletion is not allowed", with_settings: { users_deletable_by_self: false } do
+    context "when user is the current user" do
+      let(:current_user) { user }
+
+      it_behaves_like "contract is invalid"
+    end
+  end
+
+  context "when deletion by admins is allowed", with_settings: { users_deletable_by_admins: true } do
+    context "when current user is an admin" do
+      let(:current_user) { create(:admin) }
+
+      it_behaves_like "contract is valid"
+
+      context "and deleted user is also an admin" do
+        let(:user) { create(:admin) }
+
+        it_behaves_like "contract is valid"
+      end
+    end
+
+    context "when current user is not an admin" do
+      let(:current_user) { create(:user, global_permissions: [:manage_user]) }
+
+      it_behaves_like "contract is invalid"
+    end
+
+    context "when the only admin tries to delete itself" do
+      let(:user) { create(:admin) }
+      let(:current_user) { user }
+
+      it_behaves_like "contract is invalid"
+    end
+  end
+
+  include_examples "contract reuses the model errors" do
+    let(:current_user) { build_stubbed(:admin) }
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/71980/activity

# What are you trying to accomplish?
- Prevent the only administrator in the instance to be deleted
- Additionally: Consistently use the Contract to determine if we want to show the delete button.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
