### PR TITLE
Bug/71901: Fix document connection error on Turbo navigation

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -44,6 +44,7 @@ class BlockNoteElement extends HTMLElement {
   private errorContainer:HTMLDivElement;
   private reactRoot:Root|null = null;
   private stimulusApp:Application|null = null;
+  private renderCallback:((provider?:HocuspocusProvider) => void) | null = null;
 
   constructor() {
     super();
@@ -87,20 +88,26 @@ class BlockNoteElement extends HTMLElement {
 
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
 
-    const render = (provider?:HocuspocusProvider) => {
+    this.renderCallback = (provider?:HocuspocusProvider) => {
       this.reactRoot?.render(
         React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
       );
     };
 
     if (collaborationEnabled) {
-      LiveCollaborationManager.onReady(render);
+      LiveCollaborationManager.onReady(this.renderCallback);
     } else {
-      render();
+      this.renderCallback();
     }
   }
 
   disconnectedCallback() {
+    // Deregister before unmount to prevent stale callbacks firing into a detached element
+    if (this.renderCallback) {
+      LiveCollaborationManager.offReady(this.renderCallback);
+      this.renderCallback = null;
+    }
+
     if (this.reactRoot) {
       this.reactRoot.unmount();
       this.reactRoot = null;

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -51,6 +51,7 @@ export default class extends Controller {
   declare readonly refreshUrlValue:string;
 
   private tokenRefreshService:TokenRefreshService | null = null;
+  private ownedProvider:HocuspocusProvider | null = null;
   private currentToken = '';
   private canUseCachedToken = true;
 
@@ -83,6 +84,7 @@ export default class extends Controller {
     });
 
     LiveCollaborationManager.initializeYjsProvider(provider, ydoc);
+    this.ownedProvider = provider;
 
     if (this.refreshUrlValue && this.tokenExpiresInSecondsValue) {
       // Destroy any existing service to prevent duplicate timers if connect() is called multiple times
@@ -102,6 +104,12 @@ export default class extends Controller {
   disconnect():void {
     this.tokenRefreshService?.destroy();
     this.tokenRefreshService = null;
-    LiveCollaborationManager.destroy();
+
+    // Only destroy if we still own the active provider. During Turbo navigation,
+    // a new controller may have already replaced it — see destroyIfOwner().
+    if (this.ownedProvider) {
+      LiveCollaborationManager.destroyIfOwner(this.ownedProvider);
+      this.ownedProvider = null;
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/live-events.controller.ts
@@ -43,19 +43,27 @@ export default class extends ApplicationController {
   declare readonly popoverTarget:HTMLElement;
 
   private provider:HocuspocusProvider|null = null;
+  private readyCallback:((provider:HocuspocusProvider) => void) | null = null;
   private currentUsers = new Map<number, LiveUser>();
 
   connect() {
-    LiveCollaborationManager.onReady((provider:HocuspocusProvider) => {
+    this.readyCallback = (provider:HocuspocusProvider) => {
       this.provider = provider;
       this.provider.on('awarenessUpdate', this.onAwarenessUpdate);
       this.provider.on('stateless', this.onStateless);
-    });
+    };
+    LiveCollaborationManager.onReady(this.readyCallback);
 
     useDebounce(this, { wait: 1000 });
   }
 
   disconnect() {
+    // Deregister before cleanup to prevent stale callbacks firing into a detached controller
+    if (this.readyCallback) {
+      LiveCollaborationManager.offReady(this.readyCallback);
+      this.readyCallback = null;
+    }
+
     this.currentUsers.clear();
 
     this.provider?.off('awarenessUpdate', this.onAwarenessUpdate);

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -55,10 +55,31 @@ class LiveCollaborationManagerClass {
   }
 
   /**
+   * Conditionally destroys the current collaboration provider if the given provider
+   * instance still owns the shared state.
+   *
+   * During Turbo navigation, the old Stimulus controller's disconnect() fires after the new
+   * controller's connect(). Without an ownership check, the old controller would destroy the
+   * new provider, causing a spurious "connection error" banner.
+   *
+   * @param provider The provider instance requesting destruction; treated as the
+   *                 candidate owner of the current collaboration session.
+   * @returns `true` if the given provider was the current owner and the internal
+   *          provider/doc instances were destroyed; `false` otherwise.
+   */
+  destroyIfOwner(provider:HocuspocusProvider):boolean {
+    if (this.yjsProviderInstance === provider) {
+      this.destroy();
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Cleans up the collaboration provider and Y.Doc instance.
    * This method should be called when a collaboration session is ended
    */
-  destroy():void {
+  private destroy():void {
     this.destroyYjsProvider();
     this.destroyYjsDoc();
 
@@ -90,10 +111,31 @@ class LiveCollaborationManagerClass {
     return this.yjsProviderInstance;
   }
 
+  /**
+   * Registers a listener to be called when the shared YJS provider is ready.
+   *
+   * If a provider is already initialized, the listener is invoked immediately
+   * with the current {@link HocuspocusProvider} instance. Otherwise, the
+   * listener is stored and invoked later once {@link initializeYjsProvider} is called.
+   *
+   * @param listener Callback that receives the ready { @link HocuspocusProvider }
+   *
+   */
   onReady(listener:Listener) {
     this.listeners.push(listener);
     if (this.yjsProviderInstance) {
       listener(this.yjsProviderInstance);
+    }
+  }
+
+  /**
+   * Unregisters a previously registered ready listener.
+   * @param listener The listener function to remove
+   */
+  offReady(listener:Listener):void {
+    const index = this.listeners.indexOf(listener);
+    if (index !== -1) {
+      this.listeners.splice(index, 1);
     }
   }
 }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/71901

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

[wp/71901/activity#comment-1630437](https://community.openproject.org/projects/communicator-stream/work_packages/71901/activity#comment-1630437)

During Turbo page transitions, the old Stimulus controller's `disconnect()` fires after the new controller's `connect()`. The old controller unconditionally called `LiveCollaborationManager.destroy()`, which destroyed the new provider, closed the active WebSocket, and wiped all listeners. The React component then received a disconnect event and showed a spurious "connection error" banner.

# Screenshots

<img width="1831" height="1445" alt="Screenshot 2026-02-13 at 12 29 50 PM" src="https://github.com/user-attachments/assets/9d17e568-1c5c-4e1c-ae18-d6fb8e16b3b9" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->


Fix with ownership-aware lifecycle management:

- ownership bug: ensure `LiveCollaborationManager` doesn't destroy a provider it doesn't own `destroyIfOwner()`
- Add `offReady()` to deregister listeners by reference. Both block-note-element and live-events controller now deregister their `onReady` callbacks on disconnect, preventing stale callbacks from firing into detached DOM elements.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
