### PR TITLE
Implementation/71253 migrate and rework sprint permissions

### DIFF
--- a/app/contracts/work_packages/base_contract.rb
+++ b/app/contracts/work_packages/base_contract.rb
@@ -46,8 +46,9 @@ module WorkPackages
     attribute :type_id
     attribute :priority_id
     attribute :category_id
+    # TODO: manage_sprint_items can be removed once the sprint_id is in place.
     attribute :version_id,
-              permission: :assign_versions do
+              permission: %i(assign_versions manage_sprint_items) do
       validate_version_is_assignable
     end
 

--- a/app/contracts/work_packages/update_contract.rb
+++ b/app/contracts/work_packages/update_contract.rb
@@ -33,7 +33,8 @@ module WorkPackages
     include UnchangedProject
 
     attribute :lock_version,
-              permission: %i[edit_work_packages change_work_package_status assign_versions manage_subtasks move_work_packages] do
+              permission: %i[edit_work_packages change_work_package_status assign_versions manage_sprint_items manage_subtasks
+                             move_work_packages] do
       if model.lock_version.nil? || model.lock_version_changed?
         errors.add :base, :error_conflict
       end
@@ -60,6 +61,7 @@ module WorkPackages
       with_unchanged_project_id do
         next if allowed_in_work_package?(:edit_work_packages) ||
                 allowed_in_project?(:assign_versions) ||
+                allowed_in_project?(:manage_sprint_items) ||
                 allowed_in_project?(:change_work_package_status) ||
                 allowed_in_project?(:manage_subtasks) ||
                 allowed_in_project?(:move_work_packages)

--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/migrate/migration_utils/permission_renamer")
+require Rails.root.join("db/migrate/migration_utils/permission_adder")
+
+class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
+  def up
+    ::Migration::MigrationUtils::PermissionRenamer.rename("view_master_backlog", "view_sprints")
+
+    ::Migration::MigrationUtils::PermissionAdder.add(:view_taskboards, :view_sprints)
+    RolePermission.delete_by(permission: "view_taskboards")
+
+    ::Migration::MigrationUtils::PermissionAdder.add(:manage_versions, :create_sprints)
+    ::Migration::MigrationUtils::PermissionAdder.add(:select_done_statuses, :create_sprints)
+    ::Migration::MigrationUtils::PermissionAdder.add(:update_sprints, :create_sprints)
+
+    RolePermission.delete_by(permission: %w(update_sprints select_done_statuses))
+
+    ::Migration::MigrationUtils::PermissionAdder.add(:assign_versions, :manage_sprint_items)
+    ::Migration::MigrationUtils::PermissionAdder.add(:add_work_packages, :manage_sprint_items)
+    ::Migration::MigrationUtils::PermissionAdder.add(:edit_work_packages, :manage_sprint_items)
+
+    RolePermission.delete_by(permission: %w(assign_versions))
+  end
+
+  def down
+    ::Migration::MigrationUtils::PermissionAdder.add(:view_sprints, :view_taskboards, force: true)
+    ::Migration::MigrationUtils::PermissionRenamer.rename("view_sprints", "view_master_backlog")
+
+    # Note: Some roles might receive extra permissions on the way down because,
+    # we need to add back all the roles that have been merged on the way up.
+    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :manage_versions)
+    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :select_done_statuses, force: true)
+    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :update_sprints, force: true)
+
+    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :assign_versions)
+    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :add_work_packages)
+    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :edit_work_packages)
+
+    # Remove new permissions that were added during up
+    RolePermission.delete_by(permission: %w(create_sprints manage_sprint_items))
+  end
+end

--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -5,8 +5,11 @@ require Rails.root.join("db/migrate/migration_utils/permission_adder")
 
 class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
   def up
-    ::Migration::MigrationUtils::PermissionRenamer.rename("view_master_backlog", "view_sprints")
+    ::Migration::MigrationUtils::PermissionRenamer.rename(:view_master_backlog, :view_sprints)
 
+    # TODO: This could also use the PermissionRenamer.rename, but since that method is using an
+    # SQL update query, we can potentially end up having duplicate permissions defined,
+    # if a user has both view_master_backlog and view_taskboards.
     ::Migration::MigrationUtils::PermissionAdder.add(:view_taskboards, :view_sprints)
     RolePermission.delete_by(permission: "view_taskboards")
 
@@ -19,8 +22,6 @@ class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
     ::Migration::MigrationUtils::PermissionAdder.add(:assign_versions, :manage_sprint_items)
     ::Migration::MigrationUtils::PermissionAdder.add(:add_work_packages, :manage_sprint_items)
     ::Migration::MigrationUtils::PermissionAdder.add(:edit_work_packages, :manage_sprint_items)
-
-    RolePermission.delete_by(permission: %w(assign_versions))
   end
 
   def down

--- a/db/migrate/migration_utils/permission_renamer.rb
+++ b/db/migrate/migration_utils/permission_renamer.rb
@@ -32,6 +32,14 @@ module Migration
   module MigrationUtils
     class PermissionRenamer
       class << self
+        # TODO: Rewrite this method to consider already existing permissions, in order to avoid
+        # duplicates. It can be rewritten to use the PermissionAdder, which already avoids adding
+        # duplicates:
+        #   def rename(from, to, force: false)
+        #     ::Migration::MigrationUtils::PermissionAdder.add(from, to, force:)
+        #     RolePermission.delete_by(permission: from)
+        #   end
+
         def rename(from, to)
           ActiveRecord::Base.connection.execute <<-SQL.squish
           UPDATE #{role_permissions_table}

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -657,7 +657,8 @@ module API
           @current_user_update_allowed =
             current_user.allowed_in_work_package?(:edit_work_packages, represented) ||
               current_user.allowed_in_project?(:change_work_package_status, represented.project) ||
-              current_user.allowed_in_project?(:assign_versions, represented.project)
+              current_user.allowed_in_project?(:assign_versions, represented.project) ||
+              current_user.allowed_in_project?(:manage_sprint_items, represented.project)
         end
 
         def view_time_entries_allowed?

--- a/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
       tooltip_direction: :se
     )
 
-    if user_allowed?(:update_sprints)
+    if user_allowed?(:create_sprints)
       menu.with_item(
         label: t(".action_menu.edit_sprint"),
         href: edit_name_backlogs_project_sprint_path(project, sprint),
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:add_work_packages)
+    if user_allowed?(:manage_sprint_items)
       menu.with_item(
         label: t(".action_menu.new_story"),
         href: new_project_work_packages_dialog_path(
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:update_sprints) || user_allowed?(:add_work_packages)
+    if user_allowed?(:create_sprints) || user_allowed?(:manage_sprint_items)
       menu.with_divider
     end
 
@@ -73,7 +73,7 @@ See COPYRIGHT and LICENSE files for more details.
     end
 
     if backlog.sprint_backlog?
-      if user_allowed?(:view_taskboards)
+      if user_allowed?(:view_sprints)
         menu.with_item(
           label: t(".action_menu.task_board"),
           tag: :a,

--- a/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
@@ -73,14 +73,12 @@ See COPYRIGHT and LICENSE files for more details.
     end
 
     if backlog.sprint_backlog?
-      if user_allowed?(:view_sprints)
-        menu.with_item(
-          label: t(".action_menu.task_board"),
-          tag: :a,
-          href: backlogs_project_sprint_taskboard_path(project, sprint)
-        ) do |item|
-          item.with_leading_visual_icon(icon: :"op-view-cards")
-        end
+      menu.with_item(
+        label: t(".action_menu.task_board"),
+        tag: :a,
+        href: backlogs_project_sprint_taskboard_path(project, sprint)
+      ) do |item|
+        item.with_leading_visual_icon(icon: :"op-view-cards")
       end
 
       menu.with_item(

--- a/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
@@ -103,7 +103,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:manage_versions)
+    if user_allowed?(:create_sprints)
       menu.with_item(
         label: t(".action_menu.properties"),
         tag: :a,

--- a/modules/backlogs/app/seeders/common.yml
+++ b/modules/backlogs/app/seeders/common.yml
@@ -31,7 +31,6 @@ modules_permissions:
   - role: :default_role_member
     add:
     - :view_sprints
-    - :create_sprints
     - :manage_sprint_items
   - role: :default_role_reader
     add:

--- a/modules/backlogs/app/seeders/common.yml
+++ b/modules/backlogs/app/seeders/common.yml
@@ -30,9 +30,9 @@ modules_permissions:
   backlogs:
   - role: :default_role_member
     add:
-    - :view_master_backlog
-    - :view_taskboards
+    - :view_sprints
+    - :create_sprints
+    - :manage_sprint_items
   - role: :default_role_reader
     add:
-    - :view_master_backlog
-    - :view_taskboards
+    - :view_sprints

--- a/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
@@ -5,7 +5,7 @@
         blankslate.with_visual_icon(icon: :versions)
         blankslate.with_heading(tag: :h2).with_content(t(:backlogs_empty_title))
 
-        if current_user.allowed_in_project?(:manage_versions, @project)
+        if current_user.allowed_in_project?(:create_sprints, @project)
           blankslate.with_description_content(t(:backlogs_empty_action_text))
         end
       end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -155,11 +155,11 @@ en:
   label_sprint_new: "New sprint"
   label_task_board: "Task board"
 
+  permission_view_sprints: "View sprints"
   permission_create_sprints: "Create sprints"
-  permission_view_master_backlog: "View master backlog"
-  permission_view_taskboards: "View taskboards"
-  permission_select_done_statuses: "Select done statuses"
-  permission_update_sprints: "Update sprints"
+  permission_start_complete_sprint: "Start/complete sprint"
+  permission_manage_sprint_items: "Manage sprint items"
+  permission_share_sprint: "Share sprint"
 
   project_module_backlogs: "Backlogs"
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -75,7 +75,8 @@ module OpenProject::Backlogs
                      rb_taskboards: :show,
                      rb_tasks: %i[index show],
                      rb_impediments: %i[index show] },
-                   permissible_on: :project
+                   permissible_on: :project,
+                   dependencies: :view_work_packages
 
         permission :create_sprints,
                    { rb_sprints: %i[new_dialog refresh_form create edit_name update],

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -103,7 +103,7 @@ module OpenProject::Backlogs
                    {},
                    permissible_on: :project,
                    require: :member,
-                   dependencies: %i[create_sprints],
+                   dependencies: :create_sprints,
                    visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
       end
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -59,57 +59,49 @@ module OpenProject::Backlogs
         end
 
         OpenProject::AccessControl.permission(:edit_work_packages).tap do |edit|
-          edit.controller_actions << "rb_stories/move"
-          edit.controller_actions << "rb_stories/reorder"
           edit.controller_actions << "rb_tasks/update"
           edit.controller_actions << "rb_impediments/update"
         end
       end
 
       project_module :backlogs, dependencies: :work_package_tracking do
-        # Master backlog permissions
-        permission :view_master_backlog,
+        permission :view_sprints,
                    { rb_master_backlogs: %i[index details],
                      rb_sprints: %i[index show show_name],
                      rb_wikis: :show,
                      rb_stories: %i[index show],
                      rb_queries: :show,
-                     rb_burndown_charts: :show },
-                   permissible_on: :project
-
-        permission :view_taskboards,
-                   { rb_taskboards: :show,
-                     rb_sprints: :show,
-                     rb_stories: :show,
+                     rb_burndown_charts: :show,
+                     rb_taskboards: :show,
                      rb_tasks: %i[index show],
-                     rb_impediments: %i[index show],
-                     rb_wikis: :show,
-                     rb_burndown_charts: :show },
+                     rb_impediments: %i[index show] },
                    permissible_on: :project
-
-        permission :select_done_statuses,
-                   {
-                     "projects/settings/backlogs": %i[show update rebuild_positions]
-                   },
-                   permissible_on: :project,
-                   require: :member
-
-        # Sprint permissions
-        # :show_sprints and :list_sprints are implicit in :view_master_backlog permission
-        permission :update_sprints,
-                   {
-                     rb_sprints: %i[edit_name update],
-                     rb_wikis: %i[edit update]
-                   },
-                   permissible_on: :project,
-                   require: :member
 
         permission :create_sprints,
-                   {
-                     rb_sprints: %i[new_dialog create refresh_form]
-                   },
+                   { rb_sprints: %i[new_dialog refresh_form create edit_name update],
+                     rb_wikis: %i[edit update],
+                     "projects/settings/backlogs": %i[show update rebuild_positions] },
                    permissible_on: :project,
-                   require: :member
+                   require: :member,
+                   dependencies: :view_sprints
+
+        permission :start_complete_sprint,
+                   {},
+                   permissible_on: :project,
+                   require: :member,
+                   dependencies: :view_sprints
+
+        permission :manage_sprint_items,
+                   { rb_stories: %i[move reorder] },
+                   permissible_on: :project,
+                   require: :member,
+                   dependencies: %i[view_sprints add_work_packages edit_work_packages]
+
+        permission :share_sprint,
+                   {},
+                   permissible_on: :project,
+                   require: :member,
+                   dependencies: %i[create_sprints]
       end
 
       menu :project_menu,

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -90,7 +90,8 @@ module OpenProject::Backlogs
                    {},
                    permissible_on: :project,
                    require: :member,
-                   dependencies: :view_sprints
+                   dependencies: :view_sprints,
+                   visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
 
         permission :manage_sprint_items,
                    { rb_stories: %i[move reorder] },
@@ -102,7 +103,8 @@ module OpenProject::Backlogs
                    {},
                    permissible_on: :project,
                    require: :member,
-                   dependencies: %i[create_sprints]
+                   dependencies: %i[create_sprints],
+                   visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
       end
 
       menu :project_menu,

--- a/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
   end
 
   describe "permission-based items" do
-    context "with :update_sprints permission" do
-      let(:permissions) { %i[view_master_backlog update_sprints] }
+    context "with :create_sprints permission" do
+      let(:permissions) { %i[view_sprints create_sprints] }
 
       it "shows Edit item with pencil icon" do
         render_component
@@ -71,8 +71,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "without :update_sprints permission" do
-      let(:permissions) { [:view_master_backlog] }
+    context "without :create_sprints permission" do
+      let(:permissions) { [:view_sprints] }
 
       it "does not show Edit item" do
         render_component
@@ -81,8 +81,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "with :add_work_packages permission" do
-      let(:permissions) { %i[view_master_backlog add_work_packages] }
+    context "with :manage_sprint_items permission" do
+      let(:permissions) { %i[view_sprints manage_sprint_items] }
 
       it "shows Add new story item with compose icon" do
         render_component
@@ -92,8 +92,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "without :add_work_packages permission" do
-      let(:permissions) { [:view_master_backlog] }
+    context "without :manage_sprint_items permission" do
+      let(:permissions) { [:view_sprints] }
 
       it "does not show Add new story item" do
         render_component
@@ -103,7 +103,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
     end
 
     context "with :manage_versions permission" do
-      let(:permissions) { %i[view_master_backlog manage_versions] }
+      let(:permissions) { %i[view_sprints manage_versions] }
 
       it "shows Properties item with gear icon" do
         render_component
@@ -114,7 +114,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
     end
 
     context "without :manage_versions permission" do
-      let(:permissions) { [:view_master_backlog] }
+      let(:permissions) { [:view_sprints] }
 
       it "does not show Properties item" do
         render_component
@@ -123,8 +123,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "with :view_taskboards permission" do
-      let(:permissions) { %i[view_master_backlog view_taskboards] }
+    context "with :view_sprints permission" do
+      let(:permissions) { %i[view_sprints] }
 
       it "shows Task board item" do
         render_component
@@ -133,8 +133,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "without :view_taskboards permission" do
-      let(:permissions) { [:view_master_backlog] }
+    context "without :view_sprints permission" do
+      let(:permissions) { [] }
 
       it "does not show Task board item" do
         render_component
@@ -145,7 +145,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
   end
 
   describe "always-visible items" do
-    let(:permissions) { [:view_master_backlog] }
+    let(:permissions) { [:view_sprints] }
 
     it "shows Stories/Tasks link" do
       render_component
@@ -182,7 +182,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
 
   describe "module-based items" do
     context "when wiki module is enabled" do
-      let(:permissions) { [:view_master_backlog] }
+      let(:permissions) { [:view_sprints] }
       let(:project) { create(:project, types: [type_feature, type_task], enabled_module_names: %w[backlogs wiki]) }
 
       it "shows Wiki item" do
@@ -194,7 +194,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
     end
 
     context "when wiki module is disabled" do
-      let(:permissions) { [:view_master_backlog] }
+      let(:permissions) { [:view_sprints] }
       let(:project) { create(:project, types: [type_feature, type_task], enabled_module_names: %w[backlogs]) }
 
       it "does not show Wiki item" do

--- a/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
@@ -59,28 +59,6 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
   end
 
   describe "permission-based items" do
-    context "with :create_sprints permission" do
-      let(:permissions) { %i[view_sprints create_sprints] }
-
-      it "shows Edit item with pencil icon" do
-        render_component
-
-        expect(page).to have_css("action-menu")
-        expect(page).to have_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
-        expect(page).to have_octicon(:pencil)
-      end
-    end
-
-    context "without :create_sprints permission" do
-      let(:permissions) { [:view_sprints] }
-
-      it "does not show Edit item" do
-        render_component
-
-        expect(page).to have_no_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
-      end
-    end
-
     context "with :manage_sprint_items permission" do
       let(:permissions) { %i[view_sprints manage_sprint_items] }
 
@@ -102,8 +80,8 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       end
     end
 
-    context "with :manage_versions permission" do
-      let(:permissions) { %i[view_sprints manage_versions] }
+    context "with :create_sprints permission" do
+      let(:permissions) { %i[view_sprints create_sprints] }
 
       it "shows Properties item with gear icon" do
         render_component
@@ -111,15 +89,29 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
         expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.properties"))
         expect(page).to have_octicon(:gear)
       end
+
+      it "shows Edit item with pencil icon" do
+        render_component
+
+        expect(page).to have_css("action-menu")
+        expect(page).to have_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
+        expect(page).to have_octicon(:pencil)
+      end
     end
 
-    context "without :manage_versions permission" do
+    context "without :create_sprints permission" do
       let(:permissions) { [:view_sprints] }
 
       it "does not show Properties item" do
         render_component
 
         expect(page).to have_no_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.properties"))
+      end
+
+      it "does not show Edit item" do
+        render_component
+
+        expect(page).to have_no_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
       end
     end
 

--- a/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
@@ -124,16 +124,6 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
         expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.task_board"))
       end
     end
-
-    context "without :view_sprints permission" do
-      let(:permissions) { [] }
-
-      it "does not show Task board item" do
-        render_component
-
-        expect(page).to have_no_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.task_board"))
-      end
-    end
   end
 
   describe "always-visible items" do

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RbSprintsController do
     shared_let(:type_feature) { create(:type_feature) }
     shared_let(:type_task) { create(:type_task) }
 
-    let(:all_permissions) { %i[view_master_backlog view_work_packages create_sprints] }
+    let(:all_permissions) { %i[view_sprints view_work_packages create_sprints] }
     let(:permissions) { all_permissions }
     let(:user) do
       create(:user, member_with_permissions: { project => permissions })

--- a/modules/backlogs/spec/controllers/rb_taskboards_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_taskboards_controller_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe RbTaskboardsController do
+  shared_let(:type_feature) { create(:type_feature) }
+  shared_let(:type_task) { create(:type_task) }
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  let(:permissions) { [] }
+  let(:project) { create(:project, member_with_permissions: { user => permissions }) }
+  let(:status)  { create(:status, name: "status 1", is_default: true) }
+  let(:sprint)  { create(:sprint, project:) }
+  let(:story)   { create(:story, status:, version: sprint, project:) }
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+      .and_return({ "story_types" => [type_feature.id], "task_type" => type_task.id })
+  end
+
+  describe "GET show" do
+    before do
+      get :show, params: { project_id: project.identifier, sprint_id: sprint.id }
+    end
+
+    it "performs that request" do
+      expect(response).to be_successful
+      expect(response).to render_template :show
+    end
+
+    context "as a member with view_sprints permission" do
+      let(:user) { create(:user) }
+      let(:permissions) { %i[view_sprints view_work_packages] }
+
+      it "grants access" do
+        expect(response).to be_successful
+        expect(response).to render_template :show
+      end
+    end
+
+    context "as a member without view_sprints permission" do
+      let(:user) { create(:user) }
+      let(:permissions) { [:view_project] }
+
+      it "denies access" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "as a non-member" do
+      current_user { create(:user) }
+
+      it "denies access" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe "Backlogs context menu", :js do
   shared_let(:user) do
     create(:user,
            member_with_permissions: { project => %i[add_work_packages
-                                                    view_master_backlog
-                                                    view_taskboards
+                                                    view_sprints
                                                     view_work_packages] })
   end
   shared_let(:sprint) do
@@ -146,9 +145,9 @@ RSpec.describe "Backlogs context menu", :js do
     end
   end
 
-  context "when the user does not have view_taskboards permission" do
+  context "when the user does not have view_sprints permission" do
     before do
-      RolePermission.where(permission: "view_taskboards").delete_all
+      RolePermission.where(permission: "view_sprints").delete_all
     end
 
     it 'does not display the "Task board" menu entry' do

--- a/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
@@ -146,18 +146,6 @@ RSpec.describe "Backlogs context menu", :js do
     end
   end
 
-  context "when the user does not have view_sprints permission" do
-    before do
-      RolePermission.where(permission: "view_sprints").delete_all
-    end
-
-    it 'does not display the "Task board" menu entry' do
-      within_backlog_context_menu do |menu|
-        expect(menu).to have_no_selector :menuitem, "Task board"
-      end
-    end
-  end
-
   context "when the wiki module is not enabled" do
     before do
       project.enabled_module_names -= ["wiki"]

--- a/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/context_menu_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe "Backlogs context menu", :js do
     create(:user,
            member_with_permissions: { project => %i[add_work_packages
                                                     view_sprints
-                                                    view_work_packages] })
+                                                    view_work_packages
+                                                    manage_sprint_items] })
   end
   shared_let(:sprint) do
     create(:version,
@@ -133,9 +134,9 @@ RSpec.describe "Backlogs context menu", :js do
     end
   end
 
-  context "when the user does not have add_work_packages permission" do
+  context "when the user does not have manage_sprint_items permission" do
     before do
-      RolePermission.where(permission: "add_work_packages").delete_all
+      RolePermission.where(permission: "manage_sprint_items").delete_all
     end
 
     it 'does not display the "New story" menu entry' do

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Backlogs", :js do
   let(:user) do
     create(:user,
            member_with_permissions: { project => %i(add_work_packages
-                                                    view_master_backlog
+                                                    view_sprints
                                                     view_work_packages
                                                     assign_versions) })
   end

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Backlogs", :js do
            member_with_permissions: { project => %i(add_work_packages
                                                     view_sprints
                                                     view_work_packages
-                                                    assign_versions) })
+                                                    manage_sprint_items) })
   end
   let(:project) { create(:project) }
 

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -52,13 +52,14 @@ RSpec.describe "Backlogs in backlog view", :js do
     create(:project_role,
            permissions: %i(
              view_project
-             view_master_backlog
+             view_sprints
+             create_sprints
+             manage_sprint_items
              add_work_packages
              view_work_packages
              edit_work_packages
              manage_subtasks
              manage_versions
-             update_sprints
              assign_versions
            ))
   end

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -51,16 +51,16 @@ RSpec.describe "Backlogs in backlog view", :js do
   let(:role) do
     create(:project_role,
            permissions: %i(
-            view_project
-            view_sprints
-            create_sprints
-            manage_sprint_items
-            add_work_packages
-            view_work_packages
-            edit_work_packages
-            manage_subtasks
-            manage_versions
-          ))
+             view_project
+             view_sprints
+             create_sprints
+             manage_sprint_items
+             add_work_packages
+             view_work_packages
+             edit_work_packages
+             manage_subtasks
+             manage_versions
+           ))
   end
   let!(:current_user) do
     create(:user,

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -51,17 +51,16 @@ RSpec.describe "Backlogs in backlog view", :js do
   let(:role) do
     create(:project_role,
            permissions: %i(
-             view_project
-             view_sprints
-             create_sprints
-             manage_sprint_items
-             add_work_packages
-             view_work_packages
-             edit_work_packages
-             manage_subtasks
-             manage_versions
-             assign_versions
-           ))
+            view_project
+            view_sprints
+            create_sprints
+            manage_sprint_items
+            add_work_packages
+            view_work_packages
+            edit_work_packages
+            manage_subtasks
+            manage_versions
+          ))
   end
   let!(:current_user) do
     create(:user,

--- a/modules/backlogs/spec/features/empty_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/empty_backlogs_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Empty backlogs project",
   end
 
   context "as regular member" do
-    let(:role) { create(:project_role, permissions: %i(view_master_backlog)) }
+    let(:role) { create(:project_role, permissions: %i(view_sprints)) }
     let(:current_user) { create(:user, member_with_roles: { project => role }) }
 
     it "shows a blankslate without description" do

--- a/modules/backlogs/spec/features/impediments_spec.rb
+++ b/modules/backlogs/spec/features/impediments_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Impediments on taskboard", :js,
   end
   let(:role) do
     create(:project_role,
-           permissions: %i(view_taskboards
+           permissions: %i(view_sprints
                            add_work_packages
                            view_work_packages
                            edit_work_packages

--- a/modules/backlogs/spec/features/impediments_spec.rb
+++ b/modules/backlogs/spec/features/impediments_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Impediments on taskboard", :js,
                            view_work_packages
                            edit_work_packages
                            manage_subtasks
-                           assign_versions
+                           manage_sprint_items
                            work_package_assigned))
   end
   let!(:current_user) do

--- a/modules/backlogs/spec/features/resolved_status_spec.rb
+++ b/modules/backlogs/spec/features/resolved_status_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Resolved status" do
   let!(:status) { create(:status, is_default: true) }
   let(:role) do
     create(:project_role,
-           permissions: %i[select_done_statuses])
+           permissions: %i[create_sprints view_sprints])
   end
   let!(:current_user) do
     create(:user,

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -33,7 +33,7 @@ require_relative "../../support/pages/backlogs"
 
 RSpec.describe "Create", :js do
   let(:project) { create(:project) }
-  let(:all_permissions) { %i[view_master_backlog view_work_packages create_sprints] }
+  let(:all_permissions) { %i[view_sprints view_work_packages create_sprints] }
   let(:permissions) { all_permissions }
   let(:user) do
     create(:user, member_with_permissions: { project => permissions })

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -52,7 +52,8 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
   end
   let(:role) do
     create(:project_role,
-           permissions: %i(view_master_backlog
+           permissions: %i(view_sprints
+                           manage_sprint_items
                            add_work_packages
                            view_work_packages
                            edit_work_packages

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
                            add_work_packages
                            view_work_packages
                            edit_work_packages
-                           manage_subtasks
-                           assign_versions))
+                           manage_subtasks))
   end
   let!(:current_user) do
     create(:user,

--- a/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
+++ b/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Tasks on taskboard", :js,
   end
   let(:role) do
     create(:project_role,
-           permissions: %i(view_taskboards
+           permissions: %i(view_sprints
                            add_work_packages
                            view_work_packages
                            edit_work_packages

--- a/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
+++ b/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Tasks on taskboard", :js,
                            view_work_packages
                            edit_work_packages
                            manage_subtasks
-                           assign_versions
+                           manage_sprint_items
                            work_package_assigned))
   end
   let!(:current_user) do

--- a/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::AccessControl, "Backlogs module permissions" do # rubocop:disable RSpec/SpecFilePathFormat
+  describe "view_sprints" do
+    subject { described_class.permission(:view_sprints) }
+
+    it "depends on view_work_packages" do
+      expect(subject.dependencies).to contain_exactly(:view_work_packages)
+    end
+  end
+
+  describe "create_sprints" do
+    subject { described_class.permission(:create_sprints) }
+
+    it "depends on view_sprints" do
+      expect(subject.dependencies).to contain_exactly(:view_sprints)
+    end
+  end
+
+  describe "manage_sprint_items" do
+    subject { described_class.permission(:manage_sprint_items) }
+
+    it "depends on view_sprints, add_work_packages, and edit_work_packages" do
+      expect(subject.dependencies).to contain_exactly(:view_sprints, :add_work_packages, :edit_work_packages)
+    end
+  end
+
+  describe "start_complete_sprint" do
+    subject { described_class.permission(:start_complete_sprint) }
+
+    it "depends on view_sprints" do
+      expect(subject.dependencies).to contain_exactly(:view_sprints)
+    end
+
+    context "when scrum_projects feature flag is active", with_flag: { scrum_projects: true } do
+      it { is_expected.to be_visible }
+    end
+
+    context "when scrum_projects feature flag is inactive", with_flag: { scrum_projects: false } do
+      it { is_expected.to be_hidden }
+    end
+  end
+
+  describe "share_sprint" do
+    subject { described_class.permission(:share_sprint) }
+
+    it "depends on create_sprints" do
+      expect(subject.dependencies).to contain_exactly(:create_sprints)
+    end
+
+    context "when scrum_projects feature flag is active", with_flag: { scrum_projects: true } do
+      it { is_expected.to be_visible }
+    end
+
+    context "when scrum_projects feature flag is inactive", with_flag: { scrum_projects: false } do
+      it { is_expected.to be_hidden }
+    end
+  end
+end

--- a/modules/backlogs/spec/services/impediments/create_services_spec.rb
+++ b/modules/backlogs/spec/services/impediments/create_services_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Impediments::CreateService do
   let(:impediment_subject) { "Impediment A" }
 
   let(:user) { create(:user) }
-  let(:role) { create(:project_role, permissions: %i(add_work_packages assign_versions work_package_assigned)) }
+  let(:role) { create(:project_role, permissions: %i(add_work_packages manage_sprint_items work_package_assigned)) }
   let(:type_feature) { create(:type_feature) }
   let(:type_task) { create(:type_task) }
   let(:priority) { create(:priority, is_default: true) }

--- a/modules/backlogs/spec/services/stories/create_service_spec.rb
+++ b/modules/backlogs/spec/services/stories/create_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Stories::CreateService, type: :model do
   let(:type_feature) { create(:type_feature) }
 
   let(:user) do
-    create(:user, member_with_permissions: { project => %i(add_work_packages manage_subtasks assign_versions) })
+    create(:user, member_with_permissions: { project => %i(add_work_packages manage_subtasks manage_sprint_items) })
   end
 
   let(:instance) do

--- a/modules/backlogs/spec/views/rb_master_backlogs/index.html.erb_spec.rb
+++ b/modules/backlogs/spec/views/rb_master_backlogs/index.html.erb_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "rb_master_backlogs/index" do
   let(:user) { create(:user) }
   let(:role_allowed) do
     create(:project_role,
-           permissions: %i[view_master_backlog view_taskboards])
+           permissions: %i[view_sprints])
   end
   let(:statuses) do
     [create(:status, is_default: true),

--- a/spec/contracts/work_packages/update_contract_spec.rb
+++ b/spec/contracts/work_packages/update_contract_spec.rb
@@ -384,9 +384,21 @@ RSpec.describe WorkPackages::UpdateContract do
     context "for a user having only the assign_versions permission" do
       let(:permissions) { %i[assign_versions] }
 
-      it "includes all attributes except version_id" do
+      it "includes version_id only" do
         expect(subject)
-          .to include("version_id", "version")
+          .to include("version_id", "version", "lock_version_id", "lock_version")
+
+        expect(subject)
+          .not_to include("subject", "start_date", "description")
+      end
+    end
+
+    context "for a user having only the manage_sprint_items permission" do
+      let(:permissions) { %i[manage_sprint_items] }
+
+      it "includes version_id only" do
+        expect(subject)
+          .to include("version_id", "version", "lock_version_id", "lock_version")
 
         expect(subject)
           .not_to include("subject", "start_date", "description")

--- a/spec/features/work_packages/edit_on_assign_version_permission_spec.rb
+++ b/spec/features/work_packages/edit_on_assign_version_permission_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "edit work package", :js do
            lastname: "Guy",
            member_with_permissions: { project => permissions })
   end
-  let(:permissions) { %i[view_work_packages assign_versions] }
+  let(:permissions) { %i[view_work_packages manage_sprint_items assign_versions] }
 
   let(:cf_all) do
     create(:work_package_custom_field, is_for_all: true, field_format: "text")
@@ -43,7 +43,21 @@ RSpec.describe "edit work package", :js do
 
   context "as a user having only the assign_versions permission" do
     it "can only change the version" do
-      wp_page.update_attributes version: version.name
+      wp_page.fill_in_attributes version: version.name
+
+      wp_page.expect_toast(message: "Successful update")
+      wp_page.expect_attributes version: version.name
+
+      subject_field = wp_page.work_package_field("subject")
+      subject_field.expect_read_only
+    end
+  end
+
+  context "as a user having only the manage_sprint_items permission" do
+    let(:permissions) { %i[view_work_packages manage_sprint_items] }
+
+    it "can only change the version" do
+      wp_page.fill_in_attributes version: version.name
 
       wp_page.expect_toast(message: "Successful update")
       wp_page.expect_attributes version: version.name

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -490,6 +490,20 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
         end
       end
 
+      context "when user lacks edit permission but has manage_sprint_items" do
+        let(:permissions) { all_permissions - [:edit_work_packages] + [:manage_sprint_items] }
+
+        it_behaves_like "has an untitled link" do
+          let(:link) { "update" }
+          let(:href) { api_v3_paths.work_package_form(work_package.id) }
+        end
+
+        it_behaves_like "has an untitled link" do
+          let(:link) { "updateImmediately" }
+          let(:href) { api_v3_paths.work_package(work_package.id) }
+        end
+      end
+
       context "when user lacks edit permission but has change_work_package_status" do
         let(:permissions) { all_permissions - [:edit_work_packages] + [:change_work_package_status] }
 

--- a/spec/migrations/migrate_backlogs_permissions_spec.rb
+++ b/spec/migrations/migrate_backlogs_permissions_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20260212145213_migrate_backlogs_permissions")
+
+RSpec.describe MigrateBacklogsPermissions, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  let!(:empty_role) { create(:project_role) }
+  # Using add_public_permissions: false to keep permission sets minimal.
+  let!(:backlog_viewer_role) do
+    create(:project_role, permissions: %i[view_master_backlog], add_public_permissions: false)
+  end
+  let!(:taskboard_viewer_role) do
+    create(:project_role, permissions: %i[view_taskboards], add_public_permissions: false)
+  end
+  let(:member_role_permissions) do
+    %i[view_master_backlog view_taskboards add_work_packages
+       edit_work_packages assign_versions].to_set
+  end
+  let(:migrated_member_role_permissions) do
+    %i[add_work_packages edit_work_packages view_sprints manage_sprint_items].to_set
+  end
+  let!(:member_role) do
+    create(:project_role, permissions: member_role_permissions, add_public_permissions: false)
+  end
+  let(:manager_role_permissions) do
+    %i[view_master_backlog view_taskboards manage_versions select_done_statuses
+       update_sprints assign_versions add_work_packages edit_work_packages].to_set
+  end
+  let(:migrated_manager_role_permissions) do
+    %i[manage_versions add_work_packages edit_work_packages
+       view_sprints create_sprints manage_sprint_items].to_set
+  end
+  let!(:manager_role) do
+    create(:project_role, permissions: manager_role_permissions, add_public_permissions: false)
+  end
+
+  describe "migrating up" do
+    it "does not add any permissions to a role without backlogs permissions" do
+      expect { migrate }.not_to change { empty_role.reload.permissions }
+    end
+
+    it "migrates manager_role permissions correctly" do
+      expect { migrate }
+        .to change { manager_role.reload.permissions.to_set }
+        .from(manager_role_permissions)
+        .to(migrated_manager_role_permissions)
+    end
+
+    it "migrates backlog_viewer_role permissions correctly" do
+      expect { migrate }
+        .to change { backlog_viewer_role.reload.permissions }
+        .from(%i[view_master_backlog])
+        .to(%i[view_sprints])
+    end
+
+    it "migrates taskboard_viewer_role permissions correctly" do
+      expect { migrate }
+        .to change { taskboard_viewer_role.reload.permissions }
+        .from(%i[view_taskboards])
+        .to(%i[view_sprints])
+    end
+
+    it "migrates member_role permissions correctly" do
+      expect { migrate }
+        .to change { member_role.reload.permissions.to_set }
+        .from(member_role_permissions)
+        .to(migrated_member_role_permissions)
+    end
+
+    it "does not duplicate view_sprints when role had both view_master_backlog and view_taskboards" do
+      migrate
+      expect(manager_role.reload.role_permissions.where(permission: "view_sprints").count).to eq(1)
+    end
+
+    it "does not duplicate create_sprints when role has multiple source permissions" do
+      migrate
+      expect(manager_role.reload.role_permissions.where(permission: "create_sprints").count).to eq(1)
+    end
+
+    it "does not duplicate manage_sprint_items when role has multiple source permissions" do
+      migrate
+      expect(manager_role.reload.role_permissions.where(permission: "manage_sprint_items").count).to eq(1)
+    end
+  end
+
+  describe "migrating down" do
+    subject(:rollback) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) } }
+
+    before { migrate }
+
+    it "reverts backlog_viewer_role permissions" do
+      expect { rollback }
+        .to change { backlog_viewer_role.reload.permissions.to_set }
+        .from(%i[view_sprints].to_set)
+        .to(%i[view_taskboards view_master_backlog].to_set)
+    end
+
+    it "reverts manager_role permissions" do
+      expect { rollback }
+        .to change { manager_role.reload.permissions.to_set }
+        .from(migrated_manager_role_permissions)
+        .to(manager_role_permissions)
+    end
+
+    it "reverts member_role permissions" do
+      expect { rollback }
+        .to change { member_role.reload.permissions.to_set }
+        .from(migrated_member_role_permissions)
+        .to(member_role_permissions)
+    end
+  end
+end

--- a/spec/migrations/migrate_backlogs_permissions_spec.rb
+++ b/spec/migrations/migrate_backlogs_permissions_spec.rb
@@ -44,21 +44,21 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
   end
   let(:member_role_permissions) do
     %i[view_master_backlog view_taskboards add_work_packages
-       edit_work_packages assign_versions].to_set
+       edit_work_packages assign_versions]
   end
   let(:migrated_member_role_permissions) do
-    %i[add_work_packages edit_work_packages view_sprints manage_sprint_items].to_set
+    %i[add_work_packages edit_work_packages assign_versions view_sprints manage_sprint_items]
   end
   let!(:member_role) do
     create(:project_role, permissions: member_role_permissions, add_public_permissions: false)
   end
   let(:manager_role_permissions) do
     %i[view_master_backlog view_taskboards manage_versions select_done_statuses
-       update_sprints assign_versions add_work_packages edit_work_packages].to_set
+       update_sprints assign_versions add_work_packages edit_work_packages]
   end
   let(:migrated_manager_role_permissions) do
-    %i[manage_versions add_work_packages edit_work_packages
-       view_sprints create_sprints manage_sprint_items].to_set
+    %i[manage_versions add_work_packages edit_work_packages assign_versions
+       view_sprints create_sprints manage_sprint_items]
   end
   let!(:manager_role) do
     create(:project_role, permissions: manager_role_permissions, add_public_permissions: false)
@@ -71,30 +71,30 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
 
     it "migrates manager_role permissions correctly" do
       expect { migrate }
-        .to change { manager_role.reload.permissions.to_set }
-        .from(manager_role_permissions)
-        .to(migrated_manager_role_permissions)
+        .to change { manager_role.reload.permissions }
+        .from(match_array(manager_role_permissions))
+        .to(match_array(migrated_manager_role_permissions))
     end
 
     it "migrates backlog_viewer_role permissions correctly" do
       expect { migrate }
         .to change { backlog_viewer_role.reload.permissions }
-        .from(%i[view_master_backlog])
-        .to(%i[view_sprints])
+        .from(match_array(%i[view_master_backlog]))
+        .to(match_array(%i[view_sprints]))
     end
 
     it "migrates taskboard_viewer_role permissions correctly" do
       expect { migrate }
         .to change { taskboard_viewer_role.reload.permissions }
-        .from(%i[view_taskboards])
-        .to(%i[view_sprints])
+        .from(match_array(%i[view_taskboards]))
+        .to(match_array(%i[view_sprints]))
     end
 
     it "migrates member_role permissions correctly" do
       expect { migrate }
-        .to change { member_role.reload.permissions.to_set }
-        .from(member_role_permissions)
-        .to(migrated_member_role_permissions)
+        .to change { member_role.reload.permissions }
+        .from(match_array(member_role_permissions))
+        .to(match_array(migrated_member_role_permissions))
     end
 
     it "does not duplicate view_sprints when role had both view_master_backlog and view_taskboards" do
@@ -120,23 +120,23 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
 
     it "reverts backlog_viewer_role permissions" do
       expect { rollback }
-        .to change { backlog_viewer_role.reload.permissions.to_set }
-        .from(%i[view_sprints].to_set)
-        .to(%i[view_taskboards view_master_backlog].to_set)
+        .to change { backlog_viewer_role.reload.permissions }
+        .from(match_array(%i[view_sprints]))
+        .to(match_array(%i[view_taskboards view_master_backlog]))
     end
 
     it "reverts manager_role permissions" do
       expect { rollback }
-        .to change { manager_role.reload.permissions.to_set }
-        .from(migrated_manager_role_permissions)
-        .to(manager_role_permissions)
+        .to change { manager_role.reload.permissions }
+        .from(match_array(migrated_manager_role_permissions))
+        .to(match_array(manager_role_permissions))
     end
 
     it "reverts member_role permissions" do
       expect { rollback }
-        .to change { member_role.reload.permissions.to_set }
-        .from(migrated_member_role_permissions)
-        .to(member_role_permissions)
+        .to change { member_role.reload.permissions }
+        .from(match_array(migrated_member_role_permissions))
+        .to(match_array(member_role_permissions))
     end
   end
 end

--- a/spec/seeders/root_seeder_standard_edition_spec.rb
+++ b/spec/seeders/root_seeder_standard_edition_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe RootSeeder,
       member_role = root_seeder.seed_data.find_reference(:default_role_member)
       expect(member_role.permissions).to include(
         :view_work_packages, # from common basic data
-        :view_taskboards, # from backlogs module
+        :view_sprints, # from backlogs module
         :show_board_views, # from board module
         :view_documents, # from documents module
         :view_budgets, # from costs module


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71253

# What are you trying to accomplish?
- Introduce the new sprint permissions, View sprints, Create sprints, Start/Complete sprints, Manage sprint items, Share sprints.

# What approach did you choose and why?
- Introduce the new roles inside the backlogs module.
- Hide newly introduced roles behind a feature flag.
- Migrate old backlog roles to the sprint roles.
# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
