### PR TITLE
Bug/71111 external link capture not working in documents

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -42,7 +42,7 @@ import OpBlockNoteContainer from '../react/OpBlockNoteContainer';
 
 class BlockNoteElement extends HTMLElement {
   private stimulusRoot:HTMLDivElement;
-  private mount:HTMLDivElement;
+  private editorMount:HTMLDivElement;
   private errorContainer:HTMLDivElement;
   private reactRoot:Root|null = null;
   private stimulusApp:Application|null = null;
@@ -52,7 +52,7 @@ class BlockNoteElement extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: 'open' });
 
-    // Wrapper div as Stimulus root so both errorContainer and mount are in scope
+    // Wrapper div as Stimulus root so both errorContainer and editorMount are in scope
     this.stimulusRoot = document.createElement('div');
 
     // Container for connection error/recovery messages (rendered by React via fetchConnectionTemplate)
@@ -61,15 +61,15 @@ class BlockNoteElement extends HTMLElement {
     this.errorContainer.dataset.controller = 'flash';
     this.errorContainer.dataset.flashAutohideValue = 'true';
 
-    this.mount = document.createElement('div');
-    this.mount.dataset.controller = 'external-links';
+    this.editorMount = document.createElement('div');
+    this.editorMount.dataset.controller = 'external-links';
     const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
     if (browserSpecificClasses.length > 0) {
-      this.mount.classList.add(...browserSpecificClasses);
+      this.editorMount.classList.add(...browserSpecificClasses);
     }
 
     this.stimulusRoot.appendChild(this.errorContainer);
-    this.stimulusRoot.appendChild(this.mount);
+    this.stimulusRoot.appendChild(this.editorMount);
     shadowRoot.appendChild(this.stimulusRoot);
 
     const blockNoteStylesheetUrl = this.getAttribute('blocknote-stylesheet-url');
@@ -96,7 +96,7 @@ class BlockNoteElement extends HTMLElement {
     this.stimulusApp.register('external-links', ExternalLinksController);
 
     // Initialize React application within shadow DOM
-    this.reactRoot = createRoot(this.mount);
+    this.reactRoot = createRoot(this.editorMount);
 
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
 
@@ -128,7 +128,7 @@ class BlockNoteElement extends HTMLElement {
   private BlockNoteReactContainer = (hocuspocusProvider?:HocuspocusProvider) => {
     return React.createElement(
       ShadowDomWrapper,
-      { target: this.mount },
+      { target: this.editorMount },
       React.createElement(
         OpBlockNoteContainer,
         {

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -58,6 +58,12 @@ class BlockNoteElement extends HTMLElement {
     if (browserSpecificClasses.length > 0) {
       this.stimulusRoot.classList.add(...browserSpecificClasses);
     }
+    // Clone the blank-target link description into the shadow DOM
+    // so aria-describedby references resolve for links inside the editor
+    const blankLinkDesc = document.getElementById('open-blank-target-link-description');
+    if (blankLinkDesc) {
+      this.stimulusRoot.appendChild(blankLinkDesc.cloneNode(true));
+    }
 
     // Container for connection error/recovery messages (rendered by React via fetchConnectionTemplate)
     this.errorContainer = document.createElement('div');

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -31,6 +31,7 @@
 import { User } from '@blocknote/core/comments';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Application } from '@hotwired/stimulus';
+import ExternalLinksController from 'core-stimulus/controllers/external-links.controller';
 import FlashController from 'core-stimulus/controllers/flash.controller';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { ShadowDomWrapper } from 'op-blocknote-extensions';
@@ -40,6 +41,7 @@ import { createRoot } from 'react-dom/client';
 import OpBlockNoteContainer from '../react/OpBlockNoteContainer';
 
 class BlockNoteElement extends HTMLElement {
+  private stimulusRoot:HTMLDivElement;
   private mount:HTMLDivElement;
   private errorContainer:HTMLDivElement;
   private reactRoot:Root|null = null;
@@ -50,6 +52,9 @@ class BlockNoteElement extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: 'open' });
 
+    // Wrapper div as Stimulus root so both errorContainer and mount are in scope
+    this.stimulusRoot = document.createElement('div');
+
     // Container for connection error/recovery messages (rendered by React via fetchConnectionTemplate)
     this.errorContainer = document.createElement('div');
     this.errorContainer.id = 'documents-show-edit-view-connection-error-notice-component';
@@ -57,13 +62,15 @@ class BlockNoteElement extends HTMLElement {
     this.errorContainer.dataset.flashAutohideValue = 'true';
 
     this.mount = document.createElement('div');
+    this.mount.dataset.controller = 'external-links';
     const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
     if (browserSpecificClasses.length > 0) {
       this.mount.classList.add(...browserSpecificClasses);
     }
 
-    shadowRoot.appendChild(this.errorContainer);
-    shadowRoot.appendChild(this.mount);
+    this.stimulusRoot.appendChild(this.errorContainer);
+    this.stimulusRoot.appendChild(this.mount);
+    shadowRoot.appendChild(this.stimulusRoot);
 
     const blockNoteStylesheetUrl = this.getAttribute('blocknote-stylesheet-url');
     if (blockNoteStylesheetUrl) {
@@ -84,8 +91,9 @@ class BlockNoteElement extends HTMLElement {
 
   connectedCallback() {
     // Initialize Stimulus application within shadow DOM
-    this.stimulusApp = Application.start(this.errorContainer);
+    this.stimulusApp = Application.start(this.stimulusRoot);
     this.stimulusApp.register('flash', FlashController);
+    this.stimulusApp.register('external-links', ExternalLinksController);
 
     // Initialize React application within shadow DOM
     this.reactRoot = createRoot(this.mount);

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -54,6 +54,10 @@ class BlockNoteElement extends HTMLElement {
 
     // Wrapper div as Stimulus root so both errorContainer and editorMount are in scope
     this.stimulusRoot = document.createElement('div');
+    const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
+    if (browserSpecificClasses.length > 0) {
+      this.stimulusRoot.classList.add(...browserSpecificClasses);
+    }
 
     // Container for connection error/recovery messages (rendered by React via fetchConnectionTemplate)
     this.errorContainer = document.createElement('div');
@@ -63,10 +67,6 @@ class BlockNoteElement extends HTMLElement {
 
     this.editorMount = document.createElement('div');
     this.editorMount.dataset.controller = 'external-links';
-    const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
-    if (browserSpecificClasses.length > 0) {
-      this.editorMount.classList.add(...browserSpecificClasses);
-    }
 
     this.stimulusRoot.appendChild(this.errorContainer);
     this.stimulusRoot.appendChild(this.editorMount);

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -74,7 +74,7 @@ export default class ExternalLinksController extends ApplicationController {
     useMutation(this, { attributes: true, childList: true, subtree: true, attributeFilter: ['target', 'href'] });
 
     // Initial pass: handle existing external links (accessibility)
-    document.querySelectorAll<HTMLAnchorElement>(LINK_QUERY).forEach((link)=>{
+    this.element.querySelectorAll<HTMLAnchorElement>(LINK_QUERY).forEach((link)=>{
       if (!shouldProcessLink(link)) return;
 
       if (isLinkBlank(link)) updateBlankLink(link);


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/work_packages/71111

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Capture external links within the shadow DOM. Continues: #21844

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="2062" height="787" alt="Screenshot 2026-02-17 at 11 47 04 AM" src="https://github.com/user-attachments/assets/e2d53a25-0501-4402-ba73-f191bd6ed202" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Register the ExternalLinksController inside the shadow DOM instantiated on a new wrapping stimulusRoot ancestor node.

Its initial link scan used `document.querySelectorAll` which cannot cross shadow DOM boundaries. Hence, scope the link query to `this.element` instead so it works both globally (on `<body>`) and inside shadow DOM.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
