### PR TITLE
Allow to configure MCP tool responses

### DIFF
--- a/app/controllers/admin/mcp_configurations_controller.rb
+++ b/app/controllers/admin/mcp_configurations_controller.rb
@@ -48,6 +48,7 @@ module Admin
     def update
       config = McpConfiguration.find(params[:id])
       if config.update(mcp_config_params)
+        update_tool_response_format
         flash[:notice] = t(".success")
       else
         flash[:error] = t(".failure")
@@ -72,6 +73,17 @@ module Admin
 
     def mcp_config_params
       params.expect(mcp_configuration: %i[enabled title description])
+    end
+
+    def update_tool_response_format
+      return if tool_response_format_param.nil?
+      return unless McpTools::Base::RESPONSE_FORMATS.include?(tool_response_format_param.to_sym)
+
+      Setting.mcp_tool_response_format = tool_response_format_param
+    end
+
+    def tool_response_format_param
+      params.dig(:mcp_configuration, :tool_response_format)
     end
   end
 end

--- a/app/forms/mcp_configurations/server_form.rb
+++ b/app/forms/mcp_configurations/server_form.rb
@@ -33,7 +33,6 @@ module McpConfigurations
     include Redmine::I18n
 
     form do |f|
-      # TODO: Hide rest of form (and rest of page) when disabled, show when enabled (only after pressing "Update")
       f.check_box(
         name: :enabled,
         label: McpConfiguration.human_attribute_name(:enabled)
@@ -54,6 +53,32 @@ module McpConfigurations
           input_width: :large,
           rows: 4
         )
+
+        f.radio_button_group(
+          name: :tool_response_format,
+          label: I18n.t("admin.mcp_configurations.server_form.tool_response_format")
+        ) do |radios|
+          radios.radio_button(
+            value: :full,
+            checked: current_response_format?(:full),
+            label: I18n.t("admin.mcp_configurations.server_form.tool_response_format_full_label"),
+            caption: I18n.t("admin.mcp_configurations.server_form.tool_response_format_full_caption")
+          )
+
+          radios.radio_button(
+            value: :structured_only,
+            checked: current_response_format?(:structured_only),
+            label: I18n.t("admin.mcp_configurations.server_form.tool_response_format_structured_only_label"),
+            caption: I18n.t("admin.mcp_configurations.server_form.tool_response_format_structured_only_caption")
+          )
+
+          radios.radio_button(
+            value: :content_only,
+            checked: current_response_format?(:content_only),
+            label: I18n.t("admin.mcp_configurations.server_form.tool_response_format_content_only_label"),
+            caption: I18n.t("admin.mcp_configurations.server_form.tool_response_format_content_only_caption")
+          )
+        end
       end
 
       f.submit(
@@ -67,6 +92,14 @@ module McpConfigurations
 
     def server_enabled?
       model.enabled?
+    end
+
+    def tool_response_format
+      Setting.mcp_tool_response_format
+    end
+
+    def current_response_format?(format)
+      format == tool_response_format
     end
   end
 end

--- a/app/services/mcp_tools/base.rb
+++ b/app/services/mcp_tools/base.rb
@@ -30,6 +30,8 @@
 
 module McpTools
   class Base
+    RESPONSE_FORMATS = %i[full content_only structured_only].freeze
+
     class << self
       def qualified_name
         "tools/#{name}"
@@ -176,7 +178,7 @@ module McpTools
         validate_root_output_schema!(@tool_context.output_schema)
       end
 
-      format_result(result)
+      format_response(result)
     end
 
     private
@@ -186,8 +188,18 @@ module McpTools
       raise NotImplemented, "#{self.class} needs to implement #call method"
     end
 
-    def format_result(result)
-      MCP::Tool::Response.new([{ type: "text", text: result.to_json }], structured_content: result)
+    def format_response(result)
+      plain = render_plain_content? ? format_content(result) : []
+      structured_content = render_structured_content? ? format_structured_content(result) : nil
+      MCP::Tool::Response.new(plain, **{ structured_content: }.compact)
+    end
+
+    def format_content(result)
+      [{ type: "text", text: result.to_json }]
+    end
+
+    def format_structured_content(result)
+      result
     end
 
     def current_user
@@ -199,6 +211,14 @@ module McpTools
       return if root_type == "object"
 
       raise "MCP tools must respond with a JSON object as the root element. #{self.class} responds in #{root_type}."
+    end
+
+    def render_plain_content?
+      %i[full content_only].include?(Setting.mcp_tool_response_format)
+    end
+
+    def render_structured_content?
+      %i[full structured_only].include?(Setting.mcp_tool_response_format)
     end
 
     # Usable by tool implementations. Takes a scope and filters it according to the passed params.

--- a/app/services/mcp_tools/resource_proxy_tool.rb
+++ b/app/services/mcp_tools/resource_proxy_tool.rb
@@ -54,11 +54,8 @@ module McpTools
       McpResources.read_resource_content(self.class.resource.uri, resources_considered: McpResources.all)
     end
 
-    def format_result(content)
-      MCP::Tool::Response.new(
-        [{ type: "resource", resource: McpResources.format_json_resource(self.class.resource.uri, content) }],
-        structured_content: content
-      )
+    def format_content(result)
+      [{ type: "resource", resource: McpResources.format_json_resource(self.class.resource.uri, result) }]
     end
   end
 end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -757,6 +757,12 @@ module Settings
         allowed: %w[danish dutch english finnish french german hungarian
                     italian norwegian portuguese romanian russian simple spanish swedish turkish]
       },
+      mcp_tool_response_format: {
+        default: :full,
+        format: :symbol,
+        allowed: -> { McpTools::Base::RESPONSE_FORMATS },
+        description: "How to format responses for MCP tools. Using values other than full may improve language model performance."
+      },
       migration_check_on_exceptions: {
         description: "Check for missing migrations in internal errors",
         default: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,19 @@ en:
       server_form:
         description_caption: "How the MCP server will be described to other applications who connect to it."
         title_caption: "A short title shown to applications that connect to the MCP server."
+        tool_response_format: "Tool response format"
+        tool_response_format_content_only_label: "Content only"
+        tool_response_format_content_only_caption: >
+          Choose this if MCP clients connecting to this instance do not support structured content.
+          Tool responses will only contain plain text content and leave out the structured version.
+        tool_response_format_full_label: "Full"
+        tool_response_format_full_caption: >
+          The most compatible option. Tool responses will include both regular and structured content, allowing MCP clients to choose which format they want to read.
+          This may increase the number of tokens that the language model has to process, potentially increasing cost and decreasing performance.
+        tool_response_format_structured_only_label: "Structured content only"
+        tool_response_format_structured_only_caption: >
+          Choose this if you are certain that MCP clients connecting to this instance support structured content.
+          Tool responses will only include structured content and leave out its text representation.
       update:
         failure: "MCP configuration could not be updated."
         success: "MCP configuration was updated successfully."

--- a/spec/requests/api/v3/support/mcp_examples.rb
+++ b/spec/requests/api/v3/support/mcp_examples.rb
@@ -68,7 +68,7 @@ RSpec.shared_examples_for "MCP response with structured content" do
           properties: {
             isError: { type: "boolean" },
             content: { type: "array" },
-            structuredContent: { type: ["object", "array"] }
+            structuredContent: { type: ["object"] }
           }
         }
       }
@@ -179,5 +179,91 @@ RSpec.shared_examples_for "MCP unauthenticated response" do
     subject
     keys = last_response.headers["WWW-Authenticate"].split.select { |s| s.include?("=") }.map { |s| s.split("=").first }
     expect(keys).to include("resource_metadata")
+  end
+end
+
+RSpec.shared_examples_for "MCP text tool" do
+  it_behaves_like "MCP response with structured content"
+
+  it "also includes text content" do
+    subject
+    content = parsed_results.fetch("content").first
+    expect(content).not_to be_nil
+    expect(content.fetch("type")).to eq("text")
+  end
+
+  context "when setting tool response format to structured_only", with_config: { mcp_tool_response_format: :structured_only } do
+    it_behaves_like "MCP response with structured content"
+
+    it "includes no content" do
+      subject
+      content = parsed_results.fetch("content").first
+      expect(content).to be_nil
+    end
+  end
+
+  context "when setting tool response format to content_only", with_config: { mcp_tool_response_format: :content_only } do
+    it_behaves_like "MCP result response"
+
+    it "includes text content" do
+      subject
+      content = parsed_results.fetch("content").first
+      expect(content).not_to be_nil
+      expect(content.fetch("type")).to eq("text")
+    end
+
+    it "includes no structured content" do
+      subject
+      expect(parsed_results.key?("structuredContent")).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+    end
+  end
+
+  context "when the tool is disabled via configuration" do
+    let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
+
+    it_behaves_like "MCP error response"
+  end
+end
+
+RSpec.shared_examples_for "MCP embedded resource tool" do
+  it_behaves_like "MCP response with structured content"
+
+  it "also includes resource content" do
+    subject
+    content = parsed_results.fetch("content").first
+    expect(content).not_to be_nil
+    expect(content.fetch("type")).to eq("resource")
+  end
+
+  context "when setting tool response format to structured_only", with_config: { mcp_tool_response_format: :structured_only } do
+    it_behaves_like "MCP response with structured content"
+
+    it "includes no content" do
+      subject
+      content = parsed_results.fetch("content").first
+      expect(content).to be_nil
+    end
+  end
+
+  context "when setting tool response format to content_only", with_config: { mcp_tool_response_format: :content_only } do
+    it_behaves_like "MCP result response"
+
+    it "includes resource content" do
+      subject
+      content = parsed_results.fetch("content").first
+      expect(content).not_to be_nil
+      expect(content.fetch("type")).to eq("resource")
+    end
+
+    it "includes no structured content" do
+      subject
+      expect(parsed_results.key?("structuredContent")).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+    end
+  end
+
+  context "when the tool is disabled via configuration" do
+    let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
+
+    it_behaves_like "MCP error response"
   end
 end

--- a/spec/requests/mcp/mcp_tools/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_tools/current_user_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe McpTools::CurrentUser, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP embedded resource tool"
 
     it "responds with a properly formatted user" do
       subject
@@ -72,12 +72,6 @@ RSpec.describe McpTools::CurrentUser, with_flag: { mcp_server: true } do
     it "responds with the current user" do
       subject
       expect(parsed_results.dig("structuredContent", "id")).to eq(user.id)
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe McpTools::ListStatuses, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP embedded resource tool"
 
     it "finds all statuses" do
       subject
@@ -77,12 +77,6 @@ RSpec.describe McpTools::ListStatuses, with_flag: { mcp_server: true } do
     it "responds with properly formatted statuses" do
       subject
       expect(parsed_results.fetch("structuredContent").to_json).to match_json_schema.from_docs("status_collection_model")
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
 
     context "when lacking permission to see statuses" do

--- a/spec/requests/mcp/mcp_tools/list_types_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_types_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe McpTools::ListTypes, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP embedded resource tool"
 
     it "finds all types" do
       subject
@@ -77,12 +77,6 @@ RSpec.describe McpTools::ListTypes, with_flag: { mcp_server: true } do
     it "responds with properly formatted types" do
       subject
       expect(parsed_results.fetch("structuredContent").to_json).to match_json_schema.from_docs("types_model")
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
 
     context "when lacking permission to see types" do

--- a/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe McpTools::SearchPortfolios, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all portfolios without filters" do
       subject
@@ -189,12 +189,6 @@ RSpec.describe McpTools::SearchPortfolios, with_flag: { mcp_server: true } do
         subject
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/mcp_tools/search_programs_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_programs_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe McpTools::SearchPrograms, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all programs without filters" do
       subject
@@ -189,12 +189,6 @@ RSpec.describe McpTools::SearchPrograms, with_flag: { mcp_server: true } do
         subject
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all projects without filters" do
       subject
@@ -188,12 +188,6 @@ RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
         subject
         expect(parsed_results.dig("structuredContent", "items")).to be_empty
       end
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/mcp_tools/search_users_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_users_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe McpTools::SearchUsers, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all users without filters" do
       subject
@@ -170,12 +170,6 @@ RSpec.describe McpTools::SearchUsers, with_flag: { mcp_server: true } do
           expect(parsed_results.dig("structuredContent", "items").size).to eq(overspilling_users)
         end
       end
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
   end
 

--- a/spec/requests/mcp/mcp_tools/search_versions_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_versions_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe McpTools::SearchVersions, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all versions without filters" do
       subject

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe McpTools::SearchWorkPackages, with_flag: { mcp_server: true } do
   end
 
   context "when the mcp_server enterprise feature is enabled", with_ee: %i[mcp_server] do
-    it_behaves_like "MCP response with structured content"
+    it_behaves_like "MCP text tool"
 
     it "finds all work packages without filters" do
       subject
@@ -261,12 +261,6 @@ RSpec.describe McpTools::SearchWorkPackages, with_flag: { mcp_server: true } do
         subject
         expect(result_items).to be_empty
       end
-    end
-
-    context "when the tool is disabled via configuration" do
-      let(:tool_config) { create(:mcp_configuration, identifier: described_class.qualified_name, enabled: false) }
-
-      it_behaves_like "MCP error response"
     end
 
     describe "pagination" do


### PR DESCRIPTION
This is an effort to give administrators more control over the volume of data returned. While we don't want to limit the actually useful part of the data, we suspect that some MCP clients might pass both the content and the structured content to the language model. Thus we allow admins to configure which one will be generated.

# Ticket
https://community.openproject.org/wp/71978