### PR TITLE
rename status boards to kanban boards

### DIFF
--- a/modules/boards/config/locales/en.yml
+++ b/modules/boards/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
       action: "Action board (%{attribute})"
     board_type_attributes:
       assignee: Assignee
-      status: Status
+      status: Kanban
       version: Version
       subproject: Subproject
       subtasks: Parent-child

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Custom field filter in boards",
     board_index.visit!
 
     # Create new board
-    board_page = board_index.create_board action: "Status"
+    board_page = board_index.create_board action: "Kanban"
 
     # expect lists of default status
     board_page.expect_list "Open"

--- a/modules/boards/spec/features/action_boards/status_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_board_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Status action board",
       board_index.visit!
 
       # Create new board
-      board_page = board_index.create_board action: "Status"
+      board_page = board_index.create_board action: "Kanban"
 
       # expect lists of default status
       board_page.expect_list "Open"
@@ -116,7 +116,7 @@ RSpec.describe "Status action board",
       board_index.visit!
 
       # Create new board
-      board_page = board_index.create_board action: "Status"
+      board_page = board_index.create_board action: "Kanban"
 
       board_page.add_list option: "Whatever"
       board_page.expect_list "Whatever"
@@ -158,7 +158,7 @@ RSpec.describe "Status action board",
 
       # Create new board
       board_page = board_index.create_board title: "My Status Board",
-                                            action: "Status"
+                                            action: "Kanban"
 
       # expect lists of default status
       board_page.expect_list "Open"
@@ -312,7 +312,7 @@ RSpec.describe "Status action board",
       board_index.visit!
 
       # Create new board
-      board_page = board_index.create_board action: "Status"
+      board_page = board_index.create_board action: "Kanban"
 
       # expect lists of default status
       board_page.expect_list "Open"
@@ -320,7 +320,7 @@ RSpec.describe "Status action board",
 
       board_index.visit!
       # Create another status board
-      second_board_page = board_index.create_board action: "Status", via_toolbar: false
+      second_board_page = board_index.create_board action: "Kanban", via_toolbar: false
 
       # Expect only one list with the default status
       second_board_page.expect_list "Open"

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Status action board",
     board_index.visit!
 
     # Create new board
-    board_page = board_index.create_board action: "Status"
+    board_page = board_index.create_board action: "Kanban"
 
     # expect lists of default status
     board_page.expect_list "Open"

--- a/modules/boards/spec/features/board_conflicts_spec.rb
+++ b/modules/boards/spec/features/board_conflicts_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Board remote changes resolution", :js, with_ee: %i[board_view] d
     board_index.visit!
 
     # Create new board
-    board_page = board_index.create_board action: "Status"
+    board_page = board_index.create_board action: "Kanban"
 
     # expect lists of default status
     board_page.expect_list "Open"

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Work Package boards spec", :js, :selenium, with_ee: %i[board_vie
   it "navigates from boards to the WP full view and back" do
     board_index.visit!
 
-    board_page = board_index.create_board action: "Status"
+    board_page = board_index.create_board action: "Kanban"
 
     # See the work packages
     board_page.expect_query "Open", editable: false

--- a/modules/boards/spec/features/boards_global_create_spec.rb
+++ b/modules/boards/spec/features/boards_global_create_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Boards",
         expect(page).to have_enterprise_banner
         expect(page).to have_selector(:radio_button, "Basic")
 
-        %w[Status Assignee Version Subproject Parent-child].each do |restricted_board_type|
+        %w[Kanban Assignee Version Subproject Parent-child].each do |restricted_board_type|
           expect(page).to have_selector(:radio_button, restricted_board_type, disabled: true)
         end
       end
@@ -85,7 +85,7 @@ RSpec.describe "Boards",
 
         context 'when creating a "Status" board' do
           before do
-            new_board_page.set_board_type "Status"
+            new_board_page.set_board_type "Kanban"
             new_board_page.click_on_submit
 
             wait_for_reload

--- a/modules/boards/spec/features/boards_sorting_spec.rb
+++ b/modules/boards/spec/features/boards_sorting_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Work Package boards sorting spec",
     query_menu.expect_item "My Action Board"
 
     board_page = board_index.create_board title: "My Status Board",
-                                          action: "Status"
+                                          action: "Kanban"
     board_page.back_to_index
 
     board_index.expect_boards_listed "My Status Board",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/70911

# What are you trying to accomplish?

Use the name "Kanban" for status boards.

## Screenshots

<img width="530" height="241" alt="image" src="https://github.com/user-attachments/assets/09c39a48-f147-4372-9065-45c1a3d80ed6" />

# Merge checklist

- [x] Added/updated tests
