### PR TITLE
Update dev hocuspocus compose image version and env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,15 @@ FE_PORT=4200
 OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__URL=ws://localhost:1234
 OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__SECRET=secret12345
 
+# Hocuspocus (collaborative editing) - docker dev development
+# OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__URL=wss://hocuspocus.local
+# OPENPROJECT_COLLABORATIVE__EDITING__HOCUSPOCUS__SECRET=secret12345
+
 # Default TLD for docker dev stack (e.g. when set to "local", services will be openproject.local, nextcloud.local, etc.)
 OPENPROJECT_DOCKER_DEV_TLD=local
 
 # Use this variables to configure hostnames for frontend and backend, e.g. to enable HTTPS in docker development setup
+# For docker development: openproject.local and localhost for "local" development
 OPENPROJECT_DEV_HOST=localhost
 OPENPROJECT_DEV_URL=http://${OPENPROJECT_DEV_HOST}:${FE_PORT}
 

--- a/docker/dev/hocuspocus/docker-compose.yml
+++ b/docker/dev/hocuspocus/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   hocuspocus:
     # In case of MacOS you need to specify the platform in your `docker/dev/hocuspocus/docker-compose.override.yml`:
     # platform: linux/amd64
-    image:  openproject/hocuspocus:latest
+    image:  openproject/hocuspocus:dev-latest
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.hocuspocus.rule=Host(`hocuspocus.${OPENPROJECT_DOCKER_DEV_TLD:-local}`)"
@@ -14,7 +14,6 @@ services:
     networks:
       - gateway
     environment:
-      - ALLOWED_DOMAINS=openproject.${OPENPROJECT_DOCKER_DEV_TLD:-local},localhost
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - SECRET=secret12345
 networks:


### PR DESCRIPTION
- [x] Remove deprecated `ALLOWED_DOMAINS`
- [x] Point to `openproject/hocuspocus:dev-lates` by default