### PR TITLE
adapt specs for pdf content type

### DIFF
--- a/modules/reporting/spec/features/export_timesheet_spec.rb
+++ b/modules/reporting/spec/features/export_timesheet_spec.rb
@@ -30,6 +30,8 @@ require_relative "../spec_helper"
 require_relative "support/pages/cost_report_page"
 
 RSpec.describe "Timesheet PDF export", :js do
+  include PDFExportSpecUtils
+
   shared_let(:project) { create(:project) }
   shared_let(:user) { create(:admin) }
   shared_let(:cost_type) { create(:cost_type, name: "Post-war", unit: "cap", unit_plural: "caps") }
@@ -55,7 +57,7 @@ RSpec.describe "Timesheet PDF export", :js do
 
     # Switching to that tab and checking that the content is a PDF
     within_window new_window do
-      expect(page.source).to have_css("[type='application/pdf']")
+      expect_current_url_to_be_pdf
     end
   end
 end

--- a/spec/features/projects/export_spec.rb
+++ b/spec/features/projects/export_spec.rb
@@ -31,6 +31,8 @@
 require "spec_helper"
 
 RSpec.describe "project export", :js do
+  include PDFExportSpecUtils
+
   shared_let(:important_project) { create(:project, name: "Important schedule plan", description: "Important description") }
   shared_let(:party_project) { create(:project, name: "Christmas party", description: "Christmas description") }
   shared_let(:user) do
@@ -193,7 +195,7 @@ RSpec.describe "project export", :js do
       end
 
       within_window new_window do
-        expect(page.source).to have_css("[type='application/pdf']")
+        expect_current_url_to_be_pdf
       end
     end
   end

--- a/spec/support/work_packages/pdf_export.rb
+++ b/spec/support/work_packages/pdf_export.rb
@@ -15,4 +15,10 @@ module PDFExportSpecUtils
     end
     WorkPackage.human_attribute_name(column_name)
   end
+
+  def expect_current_url_to_be_pdf
+    uri = URI.parse(page.current_url)
+    response = Net::HTTP.get_response(uri)
+    expect(response["Content-Type"]).to include("application/pdf")
+  end
 end


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Chrome has been migrating its built-in PDF viewer from GuestView (separate WebContents with an <embed> element) to OOPIF (Out-of-Process Iframe). Chrome 145 appears to be where this became the default.

