### PR TITLE
Sync internal fork

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -23,10 +24,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OPENPROJECTCI_GH_LEGAL_TOKEN }}
         with:
-          path-to-signatures: 'contributor-license-agreement/signatures/version1.json'
-          path-to-document: 'https://www.openproject.org/legal/contributor-license-agreement' # e.g. a CLA or a DCO document
+          path-to-signatures: "contributor-license-agreement/signatures/version1.json"
+          path-to-document: "https://www.openproject.org/legal/contributor-license-agreement" # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'main'
+          branch: "main"
           allowlist: >
             Copilot,
             Daten-David,

--- a/.github/workflows/codeql-scan-core.yml
+++ b/.github/workflows/codeql-scan-core.yml
@@ -2,18 +2,19 @@ name: codeql
 
 on:
   push:
-    branches: [ "dev", "release/*", "stable/*" ]
+    branches: ["dev", "release/*", "stable/*"]
   pull_request:
-    branches: [ "dev", "release/*", "stable/*" ]
+    branches: ["dev", "release/*", "stable/*"]
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   schedule:
-    - cron: '32 1 * * 2'
+    - cron: "32 1 * * 2"
 
 jobs:
   analyze:
+    if: github.repository == 'opf/openproject'
     name: Analyze
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     timeout-minutes: 120
     permissions:
       # required for all workflows
@@ -26,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'ruby' ]
+        language: ["javascript-typescript", "ruby"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/create-merge-from-previous-release-branch-pr.yml
+++ b/.github/workflows/create-merge-from-previous-release-branch-pr.yml
@@ -1,48 +1,49 @@
 name: create-merge-from-previous-release-branch
 on:
   push:
-    branches: [ "release/*" ]
+    branches: ["release/*"]
   workflow_dispatch:
 
 permissions: {}
 jobs:
   setup:
+    if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     outputs:
       previous_release_branch: ${{ steps.find_previous_release.outputs.branch }}
       latest_release_branch: ${{ steps.find_latest_release.outputs.branch }}
     steps:
-    - id: find_previous_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-      run: |
-        BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
-          jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -2 | head -1
-        )
-        if [ "$BRANCH" = "" ]; then
-          echo "Invalid release branch found: $BRANCH"
-          exit 1
-        fi
-        echo "Found previous release branch: $BRANCH"
-        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
-    - id: find_latest_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-      run: |
-        BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
-          jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
-        )
-        if [ "$BRANCH" = "" ]; then
-          echo "Invalid release branch found: $BRANCH"
-          exit 1
-        fi
-        
-        echo "Found current release branch: $BRANCH"
-        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+      - id: find_previous_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
+            jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -2 | head -1
+          )
+          if [ "$BRANCH" = "" ]; then
+            echo "Invalid release branch found: $BRANCH"
+            exit 1
+          fi
+          echo "Found previous release branch: $BRANCH"
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+      - id: find_latest_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
+            jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
+          )
+          if [ "$BRANCH" = "" ]; then
+            echo "Invalid release branch found: $BRANCH"
+            exit 1
+          fi
+
+          echo "Found current release branch: $BRANCH"
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
   merge-or-create-pr:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == needs.setup.outputs.previous_release_branch)
     env:
@@ -67,11 +68,11 @@ jobs:
           # Calculate a reasonable date to fetch from (e.g., 6 months ago)
           SINCE_DATE=$(date -d '3 months ago' '+%Y-%m-%d')
           echo "Fetching commits since: $SINCE_DATE"
-          
+
           # Fetch both branches with commits since the calculated date
           git fetch --shallow-since="$SINCE_DATE" origin "$RELEASE_BRANCH" "$PREVIOUS_RELEASE_BRANCH" || {
             echo "Shallow-since fetch failed, trying with depth strategy..."
-            
+
             # Fallback: Use progressive deepening
             git fetch --depth=50 origin "$RELEASE_BRANCH" "$PREVIOUS_RELEASE_BRANCH"
             for depth in 100 200 500 1000; do
@@ -98,7 +99,7 @@ jobs:
           else
             echo "⚠️ Could not find merge-base, operations may be limited"
           fi
-          
+
           echo "Branch $RELEASE_BRANCH has $(git rev-list --count origin/$RELEASE_BRANCH) commits"
           echo "Branch $PREVIOUS_RELEASE_BRANCH has $(git rev-list --count origin/$PREVIOUS_RELEASE_BRANCH) commits"
 

--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -2,7 +2,7 @@ name: create-merge-release-into-dev-pr
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 3 * * *' # Daily at 03:30
+    - cron: "30 3 * * *" # Daily at 03:30
 
 env:
   BASE_BRANCH: dev
@@ -10,25 +10,26 @@ env:
 permissions: {}
 jobs:
   setup:
+    if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     outputs:
       latest_release_branch: ${{ steps.find_latest_release.outputs.branch }}
     steps:
-    - id: find_latest_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-      run: |
-        BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
-          jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
-        )
-        if [ "$BRANCH" = "" ]; then
-          echo "Invalid release branch found: $BRANCH"
-          exit 1
-        fi
+      - id: find_latest_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENPROJECTCI_GH_CORE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
+            jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
+          )
+          if [ "$BRANCH" = "" ]; then
+            echo "Invalid release branch found: $BRANCH"
+            exit 1
+          fi
 
-        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
   merge-or-create-pr:
     env:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,30 +2,31 @@ name: crowdin
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * *' # Daily at 03:00
+    - cron: "0 3 * * *" # Daily at 03:00
 
 permissions: {}
 jobs:
   setup:
+    if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     outputs:
       latest_release_branch: ${{ steps.find_latest_release.outputs.branch }}
     steps:
-    - id: find_latest_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-      run: |
-        BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
-          jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
-        )
-        if [ "$BRANCH" = "" ]; then
-          echo "Invalid release branch found: $BRANCH"
-          exit 1
-        fi
+      - id: find_latest_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          BRANCH=$(curl -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/branches?protected=true | \
+            jq -r '.[].name' | grep '^release/' | sort --version-sort | tail -1
+          )
+          if [ "$BRANCH" = "" ]; then
+            echo "Invalid release branch found: $BRANCH"
+            exit 1
+          fi
 
-        echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
   crowdin:
     permissions:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   compute-inputs:
+    if: github.repository == 'opf/openproject'
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.compute.outputs.tag }}

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -8,12 +8,14 @@ on:
 
 jobs:
   build-dev:
+    if: github.repository == 'opf/openproject'
     uses: ./.github/workflows/docker.yml
     with:
       branch: dev
       tag: dev
     secrets: inherit
   build-release-candidate:
+    if: github.repository == 'opf/openproject'
     # References to release/X.Y and X.Y-rc are being
     # updated from the devkit (UpdateWorkflows step) whenever a new release branch is created
     uses: opf/openproject/.github/workflows/docker.yml@release/17.1

--- a/.github/workflows/sync-internal-fork.yml
+++ b/.github/workflows/sync-internal-fork.yml
@@ -1,0 +1,49 @@
+name: Sync internal fork with main repository
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    # Only run in the private fork, never in the public repo
+    if: github.repository == 'opf/openproject-internal-fork'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/opf/openproject.git
+
+      - name: Fetch upstream
+        run: |
+          git fetch upstream
+
+      - name: Sync dev branch
+        run: |
+          git checkout dev || git checkout -b dev upstream/dev
+          git reset --hard upstream/dev
+          git push origin dev --force
+
+      - name: Sync release/* branches
+        run: |
+          git fetch upstream 'refs/heads/release/*:refs/remotes/upstream/release/*'
+
+          for branch in $(git branch -r | grep 'upstream/release/' | sed 's|upstream/||'); do
+            echo "Syncing $branch..."
+            git checkout "$branch" 2>/dev/null || git checkout -b "$branch" "upstream/$branch"
+            git reset --hard "upstream/$branch"
+            git push origin "$branch" --force
+          done


### PR DESCRIPTION
- Automatically sync `dev` and all `release/*` branches daily into the internal fork
- Restrict all other actions (where it makes sense) to only run in `opf/openproject` not the internal fork.
- Unfortunately, dependabot does not allow conditionals, so we will have to live with it opening PRs on the internal fork