### PR TITLE
[#69991] rework work package attachments setting

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -318,7 +318,7 @@ class WorkPackage < ApplicationRecord
   end
 
   def hide_attachments?
-    project&.deactivate_work_package_attachments? || false
+    project&.deactivate_work_package_attachments?
   end
 
   def estimated_hours=(hours)

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -318,11 +318,7 @@ class WorkPackage < ApplicationRecord
   end
 
   def hide_attachments?
-    if project&.deactivate_work_package_attachments.nil?
-      !Setting.show_work_package_attachments
-    else
-      project&.deactivate_work_package_attachments?
-    end
+    project&.deactivate_work_package_attachments? || false
   end
 
   def estimated_hours=(hours)

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -63,6 +63,7 @@ module Projects
       set_default_module_names(attribute_keys.include?("enabled_module_names"))
       set_default_types(attribute_keys.include?("types") || attribute_keys.include?("type_ids"))
       set_default_active_work_package_custom_fields(attribute_keys.include?("work_package_custom_fields"))
+      set_default_show_work_package_attachments(attribute_keys.include?("deactivate_work_package_attachments"))
     end
 
     def set_default_public(provided)
@@ -71,6 +72,10 @@ module Projects
 
     def set_default_module_names(provided)
       model.enabled_module_names = Setting.default_projects_modules if !provided && model.enabled_module_names.empty?
+    end
+
+    def set_default_show_work_package_attachments(provided)
+      model.deactivate_work_package_attachments = !Setting.show_work_package_attachments unless provided
     end
 
     def set_default_types(provided)

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -75,7 +75,7 @@ module Projects
     end
 
     def set_default_show_work_package_attachments(provided)
-      model.deactivate_work_package_attachments = !Setting.show_work_package_attachments unless provided
+      model.deactivate_work_package_attachments = !Setting.show_work_package_attachments? unless provided
     end
 
     def set_default_types(provided)

--- a/db/migrate/20260218095806_apply_work_package_attachment_settings_to_existing_projects.rb
+++ b/db/migrate/20260218095806_apply_work_package_attachment_settings_to_existing_projects.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class ApplyWorkPackageAttachmentSettingsToExistingProjects < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE projects
+      SET settings = jsonb_set(
+        settings,
+        '{deactivate_work_package_attachments}',
+        (SELECT to_jsonb(settings.value::boolean)
+         FROM settings
+         WHERE settings.name = 'show_work_package_attachments')
+      )
+      WHERE NOT (settings ? 'deactivate_work_package_attachments')
+    SQL
+  end
+end

--- a/modules/storages/app/views/storages/project_settings/attachments.html.erb
+++ b/modules/storages/app/views/storages/project_settings/attachments.html.erb
@@ -34,11 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::FlexLayout.new(p: 3)) do |container|
     container.with_row do
-      checked = if @project.deactivate_work_package_attachments.nil?
-                  Setting.show_work_package_attachments
-                else
-                  !@project.deactivate_work_package_attachments
-                end
+      checked = !(@project.deactivate_work_package_attachments || false)
 
       render(
         Primer::Forms::ToggleSwitchForm.new(

--- a/modules/storages/app/views/storages/project_settings/attachments.html.erb
+++ b/modules/storages/app/views/storages/project_settings/attachments.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::FlexLayout.new(p: 3)) do |container|
     container.with_row do
-      checked = !(@project.deactivate_work_package_attachments || false)
+      checked = !@project.deactivate_work_package_attachments
 
       render(
         Primer::Forms::ToggleSwitchForm.new(

--- a/modules/storages/spec/features/hide_attachments_spec.rb
+++ b/modules/storages/spec/features/hide_attachments_spec.rb
@@ -70,36 +70,6 @@ RSpec.describe "Hide attachments", :js do
       wait_for { page }.to have_css('[data-target="toggle-switch.loadingSpinner"][hidden="hidden"] svg', visible: :hidden)
       expect(project.reload).to be_deactivate_work_package_attachments
     end
-
-    context "if Setting.show_work_package_attachments is false", with_settings: { show_work_package_attachments: false } do
-      let(:project) { create(:project) }
-
-      it "renders the toggle as off for project with not set deactivate_work_package_attachments" do
-        expect(project.deactivate_work_package_attachments).to be_nil
-
-        login_as current_user
-
-        visit external_file_storages_project_settings_project_storages_path(project)
-        click_on("Attachments")
-
-        expect(page).to have_css("toggle-switch", text: "Off")
-      end
-    end
-
-    context "if Setting.show_work_package_attachments is true", with_settings: { show_work_package_attachments: true } do
-      let(:project) { create(:project) }
-
-      it "renders the toggle as on for project with not set deactivate_work_package_attachments" do
-        expect(project.deactivate_work_package_attachments).to be_nil
-
-        login_as current_user
-
-        visit external_file_storages_project_settings_project_storages_path(project)
-        click_on("Attachments")
-
-        expect(page).to have_css("toggle-switch", text: "On")
-      end
-    end
   end
 
   describe "OpenProject setting" do
@@ -115,7 +85,7 @@ RSpec.describe "Hide attachments", :js do
       click_on("Save")
 
       # Check db directly to avoid cache being used.
-      expect(Setting.find_by(name: "show_work_package_attachments").value).to be_falsy
+      expect(Setting.find_by(name: "show_work_package_attachments").value).to be_falsey
       expect(page).to have_unchecked_field(checkbox_label)
 
       check(checkbox_label)

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -185,14 +185,14 @@ RSpec.describe WorkPackage do
       context "when project#deactivate_work_package_attachments is false" do
         before { work_package.project.deactivate_work_package_attachments = false }
 
-        it { is_expected.to be_falsy }
+        it { is_expected.to be_falsey }
       end
     end
 
     context "when project is absent" do
       before { work_package.project = nil }
 
-      it { is_expected.to be_falsy }
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -192,13 +192,7 @@ RSpec.describe WorkPackage do
     context "when project is absent" do
       before { work_package.project = nil }
 
-      context "if Setting.show_work_package_attachments is true", with_settings: { show_work_package_attachments: true } do
-        it { is_expected.to be_falsy }
-      end
-
-      context "if Setting.show_work_package_attachments is false", with_settings: { show_work_package_attachments: false } do
-        it { is_expected.to be_truthy }
-      end
+      it { is_expected.to be_falsy }
     end
   end
 

--- a/spec/services/projects/set_attributes_service_spec.rb
+++ b/spec/services/projects/set_attributes_service_spec.rb
@@ -266,6 +266,22 @@ RSpec.describe Projects::SetAttributesService, type: :model do
         end
       end
 
+      describe "work package attachments default value" do
+        context "if global setting is set to show work package attachments",
+                with_settings: { show_work_package_attachments: true } do
+          it "does not deactivate work package attachments" do
+            expect(subject.result.deactivate_work_package_attachments).to be_falsey
+          end
+        end
+
+        context "if global setting is set to hide work package attachments",
+                with_settings: { show_work_package_attachments: false } do
+          it "deactivates work package attachments" do
+            expect(subject.result.deactivate_work_package_attachments).to be_truthy
+          end
+        end
+      end
+
       describe "project status" do
         context "with valid status attributes" do
           let(:status_code) { "on_track" }


### PR DESCRIPTION
# Ticket
[#69991](https://community.openproject.org/work_packages/69991)

# What are you trying to accomplish?
- get rid of weird fallback behaviour, if a project settings was never set
  - e.g. a newly created project would display active wp attachments, if the global setting is set to it
  - after changing the global setting, miraculously the same project shows deactivated wp attachments

# What approach did you choose and why?
- apply global setting to existing projects via migration
- use global setting as default value when creating new projects
- no longer fall back to global settings when looking up values
  - mostly due to the fact, that the global setting is nowhere explained to be used as a fallback. So, there are no surprises.
