### PR TITLE
bug/71888 Spurious CSP errors with Hocuspocus integration due to URL scheme misconfiguration

### DIFF
--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
@@ -47,7 +47,7 @@
           required: true,
           input_width: :large,
           caption: I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.caption"),
-          **hocuspocus_url_validation_attributes
+          validation_message: validation_message_for(:collaborative_editing_hocuspocus_url)
         )
 
         form.text_field(

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
@@ -35,8 +35,14 @@
       render_inline_settings_form(f) do |form|
         form.html_content do
           if some_unwritable_settings?
-            render(Primer::Alpha::Banner.new(icon: :info)) do
-              I18n.t("documents.admin.collaboration_settings.banner.#{none_writable_settings? ? 'none_writable' : 'some_unwritable'}")
+            if invalid_hocuspocus_url?
+              render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert)) do
+                I18n.t("documents.admin.collaboration_settings.banner.invalid_env_url")
+              end
+            else
+              render(Primer::Alpha::Banner.new(icon: :info)) do
+                I18n.t("documents.admin.collaboration_settings.banner.#{none_writable_settings? ? 'none_writable' : 'some_unwritable'}")
+              end
             end
           end
         end

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.html.erb
@@ -35,14 +35,8 @@
       render_inline_settings_form(f) do |form|
         form.html_content do
           if some_unwritable_settings?
-            if invalid_hocuspocus_url?
-              render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert)) do
-                I18n.t("documents.admin.collaboration_settings.banner.invalid_env_url")
-              end
-            else
-              render(Primer::Alpha::Banner.new(icon: :info)) do
-                I18n.t("documents.admin.collaboration_settings.banner.#{none_writable_settings? ? 'none_writable' : 'some_unwritable'}")
-              end
+            render(Primer::Alpha::Banner.new(icon: :info)) do
+              I18n.t("documents.admin.collaboration_settings.banner.#{none_writable_settings? ? 'none_writable' : 'some_unwritable'}")
             end
           end
         end
@@ -52,7 +46,8 @@
           label: I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.label"),
           required: true,
           input_width: :large,
-          caption: I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.caption")
+          caption: I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.caption"),
+          **hocuspocus_url_validation_attributes
         )
 
         form.text_field(

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
@@ -37,6 +37,11 @@ module Documents
 
         delegate :writable_setting?, to: :helpers
 
+        def initialize(errors: nil)
+          super()
+          @errors = errors
+        end
+
         def none_writable_settings?
           settings.none? { writable_setting?(it) }
         end
@@ -45,11 +50,11 @@ module Documents
           settings.any? { !writable_setting?(it) }
         end
 
-        def hocuspocus_url_validation_attributes
-          {}.tap do |options|
-            if invalid_hocuspocus_url?
-              options[:validation_message] = I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.invalid_scheme")
-            end
+        def validation_message_for(attribute)
+          if attribute == :collaborative_editing_hocuspocus_url && (@errors&.include?(attribute) || invalid_hocuspocus_url?)
+            I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.invalid_scheme")
+          elsif @errors&.include?(attribute)
+            @errors.full_messages_for(attribute).to_sentence
           end
         end
 

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
@@ -45,6 +45,14 @@ module Documents
           settings.any? { !writable_setting?(it) }
         end
 
+        def invalid_hocuspocus_url?
+          return false if Setting.collaborative_editing_hocuspocus_url.blank?
+
+          !Documents::Admin::Settings::CollaborationServerSettingsParamsContract.valid_hocuspocus_url?(
+            Setting.collaborative_editing_hocuspocus_url
+          )
+        end
+
         private
 
         def settings

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
@@ -45,15 +45,28 @@ module Documents
           settings.any? { !writable_setting?(it) }
         end
 
-        def invalid_hocuspocus_url?
-          return false if Setting.collaborative_editing_hocuspocus_url.blank?
-
-          !Documents::Admin::Settings::CollaborationServerSettingsParamsContract.valid_hocuspocus_url?(
-            Setting.collaborative_editing_hocuspocus_url
-          )
+        def hocuspocus_url_validation_attributes
+          {}.tap do |options|
+            if invalid_hocuspocus_url?
+              options[:validation_message] = I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.invalid_scheme")
+            end
+          end
         end
 
         private
+
+        def invalid_hocuspocus_url?
+          return false if Setting.collaborative_editing_hocuspocus_url.blank?
+
+          !valid_hocuspocus_url?(Setting.collaborative_editing_hocuspocus_url)
+        end
+
+        def valid_hocuspocus_url?(url)
+          uri = URI.parse(url)
+          uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
+        rescue URI::InvalidURIError
+          false
+        end
 
         def settings
           %i[collaborative_editing_hocuspocus_url

--- a/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
+++ b/modules/documents/app/components/documents/admin/collaboration_settings/settings_form_component.rb
@@ -63,10 +63,10 @@ module Documents
         def invalid_hocuspocus_url?
           return false if Setting.collaborative_editing_hocuspocus_url.blank?
 
-          !valid_hocuspocus_url?(Setting.collaborative_editing_hocuspocus_url)
+          !websocket_url?(Setting.collaborative_editing_hocuspocus_url)
         end
 
-        def valid_hocuspocus_url?(url)
+        def websocket_url?(url)
           uri = URI.parse(url)
           uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
         rescue URI::InvalidURIError

--- a/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
+++ b/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
@@ -47,17 +47,18 @@ module Documents
         def validate_collaborative_editing_hocuspocus_url
           url = params[:collaborative_editing_hocuspocus_url]
           return if url.blank?
+          return if websocket_url?(url)
 
-          uri = URI.parse(url)
-          unless uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
-            errors.add :collaborative_editing_hocuspocus_url, :invalid_url_scheme,
-                       allowed_schemes: allowed_protocols.join(", ")
-          end
-        rescue URI::InvalidURIError
-          errors.add :collaborative_editing_hocuspocus_url, :invalid_url
+          errors.add :collaborative_editing_hocuspocus_url, :invalid,
+                     message: I18n.t("documents.admin.collaboration_settings.hocuspocus_server_url.invalid_scheme")
         end
 
-        def allowed_protocols = %w[ws wss]
+        def websocket_url?(url)
+          uri = URI.parse(url)
+          uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
+        rescue URI::InvalidURIError
+          false
+        end
       end
     end
   end

--- a/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
+++ b/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
@@ -36,6 +36,15 @@ module Documents
 
         validate :validate_collaborative_editing_hocuspocus_url
 
+        def self.valid_hocuspocus_url?(url)
+          return false if url.blank?
+
+          uri = URI.parse(url)
+          uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
+        rescue URI::InvalidURIError
+          false
+        end
+
         # Expose the param value as a method so that ActiveModel::Errors#full_messages
         # can resolve the attribute without hitting Disposable::Twin's method_missing.
         def collaborative_editing_hocuspocus_url
@@ -47,14 +56,17 @@ module Documents
         def validate_collaborative_editing_hocuspocus_url
           url = params[:collaborative_editing_hocuspocus_url]
           return if url.blank?
+          return if self.class.valid_hocuspocus_url?(url)
 
-          uri = URI.parse(url)
-          unless uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
-            errors.add :collaborative_editing_hocuspocus_url, :invalid_url_scheme,
-                       allowed_schemes: allowed_protocols.join(", ")
+          error_type = begin
+            URI.parse(url)
+            :invalid_url_scheme
+          rescue URI::InvalidURIError
+            :invalid_url
           end
-        rescue URI::InvalidURIError
-          errors.add :collaborative_editing_hocuspocus_url, :invalid_url
+
+          options = error_type == :invalid_url_scheme ? { allowed_schemes: allowed_protocols.join(", ") } : {}
+          errors.add :collaborative_editing_hocuspocus_url, error_type, **options
         end
 
         def allowed_protocols = %w[ws wss]

--- a/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
+++ b/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
@@ -31,51 +31,33 @@
 module Documents
   module Admin
     module Settings
-      class DocumentCollaborationSettingsController < ::Admin::SettingsController
-        include OpTurbo::ComponentStream
+      class CollaborationServerSettingsParamsContract < ::ParamsContract
+        include RequiresAdminGuard
 
-        menu_item :document_collaboration_settings
+        validate :validate_collaborative_editing_hocuspocus_url
 
-        def create
-          toggle_collaboration(enabled: true)
-        end
-
-        def delete_dialog
-          respond_with_dialog Documents::Admin::CollaborationSettings::DisableTextCollaborationDialogComponent.new
-        end
-
-        def destroy
-          toggle_collaboration(enabled: false)
+        # Expose the param value as a method so that ActiveModel::Errors#full_messages
+        # can resolve the attribute without hitting Disposable::Twin's method_missing.
+        def collaborative_editing_hocuspocus_url
+          params[:collaborative_editing_hocuspocus_url]
         end
 
         private
 
-        def update_service
-          Documents::Admin::Settings::CollaborationServerSettingsUpdateService
-        end
+        def validate_collaborative_editing_hocuspocus_url
+          url = params[:collaborative_editing_hocuspocus_url]
+          return if url.blank?
 
-        def toggle_collaboration(enabled:)
-          call = update_service
-            .new(user: current_user)
-            .call(real_time_text_collaboration_enabled: enabled.to_s)
-
-          if call.success?
-            flash[:notice] = I18n.t(success_key_for(enabled))
-          else
-            flash[:error] = call.errors.full_messages.to_sentence
+          uri = URI.parse(url)
+          unless uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
+            errors.add :collaborative_editing_hocuspocus_url, :invalid_url_scheme,
+                       allowed_schemes: allowed_protocols.join(", ")
           end
-
-          redirect_to action: :show
+        rescue URI::InvalidURIError
+          errors.add :collaborative_editing_hocuspocus_url, :invalid_url
         end
 
-        def success_key_for(enabled)
-          base = "documents.admin"
-          if enabled
-            "#{base}.enable_text_collaboration.success"
-          else
-            "#{base}.disable_text_collaboration_dialog.success"
-          end
-        end
+        def allowed_protocols = %w[ws wss]
       end
     end
   end

--- a/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
+++ b/modules/documents/app/contracts/documents/admin/settings/collaboration_server_settings_params_contract.rb
@@ -36,15 +36,6 @@ module Documents
 
         validate :validate_collaborative_editing_hocuspocus_url
 
-        def self.valid_hocuspocus_url?(url)
-          return false if url.blank?
-
-          uri = URI.parse(url)
-          uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
-        rescue URI::InvalidURIError
-          false
-        end
-
         # Expose the param value as a method so that ActiveModel::Errors#full_messages
         # can resolve the attribute without hitting Disposable::Twin's method_missing.
         def collaborative_editing_hocuspocus_url
@@ -56,17 +47,14 @@ module Documents
         def validate_collaborative_editing_hocuspocus_url
           url = params[:collaborative_editing_hocuspocus_url]
           return if url.blank?
-          return if self.class.valid_hocuspocus_url?(url)
 
-          error_type = begin
-            URI.parse(url)
-            :invalid_url_scheme
-          rescue URI::InvalidURIError
-            :invalid_url
+          uri = URI.parse(url)
+          unless uri.is_a?(URI::WS) || uri.is_a?(URI::WSS)
+            errors.add :collaborative_editing_hocuspocus_url, :invalid_url_scheme,
+                       allowed_schemes: allowed_protocols.join(", ")
           end
-
-          options = error_type == :invalid_url_scheme ? { allowed_schemes: allowed_protocols.join(", ") } : {}
-          errors.add :collaborative_editing_hocuspocus_url, error_type, **options
+        rescue URI::InvalidURIError
+          errors.add :collaborative_editing_hocuspocus_url, :invalid_url
         end
 
         def allowed_protocols = %w[ws wss]

--- a/modules/documents/app/controllers/documents/admin/settings/document_collaboration_settings_controller.rb
+++ b/modules/documents/app/controllers/documents/admin/settings/document_collaboration_settings_controller.rb
@@ -50,6 +50,11 @@ module Documents
 
         private
 
+        def failure_callback(call)
+          @errors = call.errors
+          render :show, status: :unprocessable_entity
+        end
+
         def update_service
           Documents::Admin::Settings::CollaborationServerSettingsUpdateService
         end

--- a/modules/documents/app/services/documents/admin/settings/collaboration_server_settings_update_service.rb
+++ b/modules/documents/app/services/documents/admin/settings/collaboration_server_settings_update_service.rb
@@ -31,50 +31,12 @@
 module Documents
   module Admin
     module Settings
-      class DocumentCollaborationSettingsController < ::Admin::SettingsController
-        include OpTurbo::ComponentStream
-
-        menu_item :document_collaboration_settings
-
-        def create
-          toggle_collaboration(enabled: true)
-        end
-
-        def delete_dialog
-          respond_with_dialog Documents::Admin::CollaborationSettings::DisableTextCollaborationDialogComponent.new
-        end
-
-        def destroy
-          toggle_collaboration(enabled: false)
-        end
-
-        private
-
-        def update_service
-          Documents::Admin::Settings::CollaborationServerSettingsUpdateService
-        end
-
-        def toggle_collaboration(enabled:)
-          call = update_service
-            .new(user: current_user)
-            .call(real_time_text_collaboration_enabled: enabled.to_s)
-
-          if call.success?
-            flash[:notice] = I18n.t(success_key_for(enabled))
-          else
-            flash[:error] = call.errors.full_messages.to_sentence
-          end
-
-          redirect_to action: :show
-        end
-
-        def success_key_for(enabled)
-          base = "documents.admin"
-          if enabled
-            "#{base}.enable_text_collaboration.success"
-          else
-            "#{base}.disable_text_collaboration_dialog.success"
-          end
+      class CollaborationServerSettingsUpdateService < ::Settings::UpdateService
+        def validate_params
+          contract = CollaborationServerSettingsParamsContract.new(model, user, params:)
+          ServiceResult.new success: contract.valid?,
+                            errors: contract.errors,
+                            result: model
         end
       end
     end

--- a/modules/documents/app/views/documents/admin/settings/document_collaboration_settings/show.html.erb
+++ b/modules/documents/app/views/documents/admin/settings/document_collaboration_settings/show.html.erb
@@ -33,4 +33,4 @@
 
 <%= render(Documents::Admin::CollaborationSettings::PageHeaderComponent.new) %>
 
-<%= render(Documents::Admin::CollaborationSettings::SettingsFormComponent.new) %>
+<%= render(Documents::Admin::CollaborationSettings::SettingsFormComponent.new(errors: @errors)) %>

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -149,6 +149,7 @@ en:
         banner:
           none_writable: These values are configured via environment variables and cannot be edited here.
           some_unwritable: Some values are configured via environment variables and cannot be edited here.
+          invalid_env_url: The Hocuspocus server URL is configured via an environment variable but uses an unsupported protocol. Only ws:// and wss:// are allowed.
         hocuspocus_server_url:
           label: "Hocuspocus server URL"
           caption: "The address of a working Hocuspocus server."

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
     name: "OpenProject Documents"
     description: "An OpenProject plugin to allow creation of documents in projects."
 
+  attributes:
+    collaborative_editing_hocuspocus_url: "Hocuspocus server URL"
+
   activerecord:
     errors:
       models:

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -149,10 +149,10 @@ en:
         banner:
           none_writable: These values are configured via environment variables and cannot be edited here.
           some_unwritable: Some values are configured via environment variables and cannot be edited here.
-          invalid_env_url: The Hocuspocus server URL is configured via an environment variable but uses an unsupported protocol. Only ws:// and wss:// are allowed.
         hocuspocus_server_url:
           label: "Hocuspocus server URL"
           caption: "The address of a working Hocuspocus server."
+          invalid_scheme: "Must use a WebSocket protocol (ws:// or wss://)."
         hocuspocus_server_secret:
           label: "Client secret"
           caption: "Paste the secret provided by the Hocuspocus server."

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -151,7 +151,7 @@ en:
           some_unwritable: Some values are configured via environment variables and cannot be edited here.
         hocuspocus_server_url:
           label: "Hocuspocus server URL"
-          caption: "The address of a working Hocuspocus server."
+          caption: "The WebSocket address of a working Hocuspocus server."
           invalid_scheme: "Must use a WebSocket protocol (ws:// or wss://)."
         hocuspocus_server_secret:
           label: "Client secret"

--- a/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
+++ b/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
@@ -62,21 +62,21 @@ RSpec.describe Documents::Admin::Settings::CollaborationServerSettingsParamsCont
       let(:url) { "http://hocuspocus.example.com" }
 
       include_examples "contract is invalid",
-                       collaborative_editing_hocuspocus_url: :invalid_url_scheme
+                       collaborative_editing_hocuspocus_url: :invalid
     end
 
     context "with an https:// URL" do
       let(:url) { "https://hocuspocus.example.com" }
 
       include_examples "contract is invalid",
-                       collaborative_editing_hocuspocus_url: :invalid_url_scheme
+                       collaborative_editing_hocuspocus_url: :invalid
     end
 
     context "with a completely invalid URL" do
       let(:url) { "not a url at all %%%" }
 
       include_examples "contract is invalid",
-                       collaborative_editing_hocuspocus_url: :invalid_url
+                       collaborative_editing_hocuspocus_url: :invalid
     end
 
     context "with a blank URL" do

--- a/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
+++ b/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+require "contracts/shared/model_contract_shared_context"
+
+RSpec.describe Documents::Admin::Settings::CollaborationServerSettingsParamsContract do
+  include_context "ModelContract shared context"
+
+  shared_let(:current_user) { create(:admin) }
+  let(:setting) { Setting }
+  let(:params) { { collaborative_editing_hocuspocus_url: url } }
+  let(:url) { "wss://hocuspocus.example.com" }
+  let(:contract) do
+    described_class.new(setting, current_user, params:)
+  end
+
+  it_behaves_like "contract is valid for active admins and invalid for regular users"
+
+  describe "URL scheme validation" do
+    context "with a valid wss:// URL" do
+      let(:url) { "wss://hocuspocus.example.com" }
+
+      include_examples "contract is valid"
+    end
+
+    context "with a valid ws:// URL" do
+      let(:url) { "ws://hocuspocus.example.com" }
+
+      include_examples "contract is valid"
+    end
+
+    context "with an http:// URL" do
+      let(:url) { "http://hocuspocus.example.com" }
+
+      include_examples "contract is invalid",
+                       collaborative_editing_hocuspocus_url: :invalid_url_scheme
+    end
+
+    context "with an https:// URL" do
+      let(:url) { "https://hocuspocus.example.com" }
+
+      include_examples "contract is invalid",
+                       collaborative_editing_hocuspocus_url: :invalid_url_scheme
+    end
+
+    context "with a completely invalid URL" do
+      let(:url) { "not a url at all %%%" }
+
+      include_examples "contract is invalid",
+                       collaborative_editing_hocuspocus_url: :invalid_url
+    end
+
+    context "with a blank URL" do
+      let(:url) { "" }
+
+      include_examples "contract is valid"
+    end
+
+    context "when URL is not provided in params" do
+      let(:params) { {} }
+
+      include_examples "contract is valid"
+    end
+  end
+end

--- a/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
+++ b/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe Documents::Admin::Settings::CollaborationServerSettingsParamsCont
 
   it_behaves_like "contract is valid for active admins and invalid for regular users"
 
+  describe ".valid_hocuspocus_url?" do
+    it { expect(described_class.valid_hocuspocus_url?("wss://example.com")).to be true }
+    it { expect(described_class.valid_hocuspocus_url?("ws://example.com")).to be true }
+    it { expect(described_class.valid_hocuspocus_url?("https://example.com")).to be false }
+    it { expect(described_class.valid_hocuspocus_url?("http://example.com")).to be false }
+    it { expect(described_class.valid_hocuspocus_url?("not a url %%%")).to be false }
+    it { expect(described_class.valid_hocuspocus_url?("")).to be true }
+    it { expect(described_class.valid_hocuspocus_url?(nil)).to be true }
+  end
+
   describe "URL scheme validation" do
     context "with a valid wss:// URL" do
       let(:url) { "wss://hocuspocus.example.com" }

--- a/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
+++ b/modules/documents/spec/contracts/documents/admin/settings/collaboration_server_settings_params_contract_spec.rb
@@ -45,16 +45,6 @@ RSpec.describe Documents::Admin::Settings::CollaborationServerSettingsParamsCont
 
   it_behaves_like "contract is valid for active admins and invalid for regular users"
 
-  describe ".valid_hocuspocus_url?" do
-    it { expect(described_class.valid_hocuspocus_url?("wss://example.com")).to be true }
-    it { expect(described_class.valid_hocuspocus_url?("ws://example.com")).to be true }
-    it { expect(described_class.valid_hocuspocus_url?("https://example.com")).to be false }
-    it { expect(described_class.valid_hocuspocus_url?("http://example.com")).to be false }
-    it { expect(described_class.valid_hocuspocus_url?("not a url %%%")).to be false }
-    it { expect(described_class.valid_hocuspocus_url?("")).to be true }
-    it { expect(described_class.valid_hocuspocus_url?(nil)).to be true }
-  end
-
   describe "URL scheme validation" do
     context "with a valid wss:// URL" do
       let(:url) { "wss://hocuspocus.example.com" }

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -127,6 +127,22 @@ RSpec.describe "Document collaboration settings admin",
     end
   end
 
+  context "with an invalid URL scheme set via environment variable",
+          with_env: { "OPENPROJECT_COLLABORATIVE_EDITING_HOCUSPOCUS_URL" => "https://env-hocuspocus.example.com" },
+          with_settings: { collaborative_editing_hocuspocus_secret: "secret1234" } do
+    before do
+      reset(:collaborative_editing_hocuspocus_url)
+      visit admin_settings_document_collaboration_settings_path
+    end
+
+    it "shows a warning banner about the invalid URL scheme" do
+      expect(page).to have_css(".Banner--warning", text: "unsupported protocol")
+      expect(page).to have_field("Hocuspocus server URL",
+                                 with: "https://env-hocuspocus.example.com",
+                                 disabled: true)
+    end
+  end
+
   context "with secret set via environment variable",
           with_env: { "OPENPROJECT_COLLABORATIVE_EDITING_HOCUSPOCUS_SECRET" => "envsupersecret" },
           with_settings: { collaborative_editing_hocuspocus_url: "wss://env-hocuspocus.example.com" } do

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -93,13 +93,14 @@ RSpec.describe "Document collaboration settings admin",
             collaborative_editing_hocuspocus_url: "wss://hocuspocus.example.com",
             collaborative_editing_hocuspocus_secret: "secret1234"
           } do
-    it "rejects https:// URLs and shows an error" do
+    it "rejects https:// URLs and shows inline validation error" do
       visit admin_settings_document_collaboration_settings_path
 
       fill_in "Hocuspocus server URL", with: "https://hocuspocus.example.com"
       click_on("Save")
 
-      expect_flash(type: :error, message: "Hocuspocus server URL is not a supported protocol (allowed: ws, wss).")
+      # Inline validation shown on the field
+      expect(page).to have_content("is not a supported protocol")
 
       # Setting unchanged
       expect(Setting.collaborative_editing_hocuspocus_url).to eq("wss://hocuspocus.example.com")

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -87,6 +87,25 @@ RSpec.describe "Document collaboration settings admin",
     end
   end
 
+  context "when submitting an invalid URL scheme",
+          with_settings: {
+            real_time_text_collaboration_enabled: true,
+            collaborative_editing_hocuspocus_url: "wss://hocuspocus.example.com",
+            collaborative_editing_hocuspocus_secret: "secret1234"
+          } do
+    it "rejects https:// URLs and shows an error" do
+      visit admin_settings_document_collaboration_settings_path
+
+      fill_in "Hocuspocus server URL", with: "https://hocuspocus.example.com"
+      click_on("Save")
+
+      expect_flash(type: :error, message: "Hocuspocus server URL is not a supported protocol (allowed: ws, wss).")
+
+      # Setting unchanged
+      expect(Setting.collaborative_editing_hocuspocus_url).to eq("wss://hocuspocus.example.com")
+    end
+  end
+
   context "with hocuspocus url set via environment variable",
           with_env: { "OPENPROJECT_COLLABORATIVE_EDITING_HOCUSPOCUS_URL" => "wss://env-hocuspocus.example.com" },
           with_settings: { collaborative_editing_hocuspocus_secret: "secret1234" } do

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -135,11 +135,11 @@ RSpec.describe "Document collaboration settings admin",
       visit admin_settings_document_collaboration_settings_path
     end
 
-    it "shows a warning banner about the invalid URL scheme" do
-      expect(page).to have_css(".Banner--warning", text: "unsupported protocol")
+    it "shows an inline validation error on the URL field" do
       expect(page).to have_field("Hocuspocus server URL",
                                  with: "https://env-hocuspocus.example.com",
                                  disabled: true)
+      expect(page).to have_content("Must use a WebSocket protocol")
     end
   end
 

--- a/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
+++ b/modules/documents/spec/features/documents/admin/settings/document_collaboration_settings_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Document collaboration settings admin",
       click_on("Save")
 
       # Inline validation shown on the field
-      expect(page).to have_content("is not a supported protocol")
+      expect(page).to have_content("Must use a WebSocket protocol (ws:// or wss://).")
 
       # Setting unchanged
       expect(Setting.collaborative_editing_hocuspocus_url).to eq("wss://hocuspocus.example.com")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/71888

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The Hocuspocus server URL setting accepted any scheme (http, https, ftp, etc.) but should only accept WebSocket protocols `(ws://, wss://)`. Misconfiguration with `https://` causes CSP errors at runtime. We need proactive validation in the contract to reject invalid schemes at save time, surfacing errors in the admin UI.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="1444" height="497" alt="Screenshot 2026-02-19 at 8 22 22 PM" src="https://github.com/user-attachments/assets/05cb4240-1026-4274-a705-237bc78bbcef" />
<img width="1416" height="473" alt="Screenshot 2026-02-19 at 7 48 56 PM" src="https://github.com/user-attachments/assets/2ca4ab39-0324-4fc3-b261-96f607fa35b6" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Adds contract-level validation to ensure the collaborative editing hocuspocus URL only accepts WebSocket protocols `(ws://, wss://)`. Previously, misconfiguration with https:// would silently cause Content Security Policy errors at runtime.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
