### PR TITLE
Fix duplicate meetings in ical subscriptions when interim response has time zone != UTC

### DIFF
--- a/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
+++ b/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
@@ -62,10 +62,10 @@ module AllMeetings
 
     def handle_ical_event(event) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
       uid = event.uid&.value_ical
-      recurrence_id = event.recurrence_id&.value_ical
+      recurrence_id = event.recurrence_id&.to_time
 
       # First check if the UID belongs to a single meeeting
-      meeting = Meeting.visible(user).find_by(uid: uid)
+      meeting = Meeting.visible(user).find_by(uid:)
 
       if meeting
         update_participation_status(meeting, event)
@@ -73,7 +73,7 @@ module AllMeetings
       end
 
       # No single meeting found, check for a recurring meeting
-      recurring_meeting = RecurringMeeting.visible(user).find_by(uid: uid)
+      recurring_meeting = RecurringMeeting.visible(user).find_by(uid:)
 
       if recurring_meeting.blank?
         # No recurring meeting, we can leave

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -306,6 +306,12 @@ module Meetings
 
     def add_virtual_occurences_for_interim_responses(recurring_meeting:) # rubocop:disable Metrics/AbcSize
       interim_responses_for(recurring_meeting).each do |start_time, responses|
+        # Ensure interim responses still match the meeting
+        unless recurring_meeting.schedule.occurs_at?(start_time)
+          warn "Interim response has start time that does not match #{recurring_meeting.id}, skipping."
+          next
+        end
+
         calendar.event do |e|
           e.uid = recurring_meeting.uid
           e.summary = recurring_meeting.title

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -70,6 +70,8 @@ en:
         end_after: "Meeting series ends"
         end_date: "End date"
         iterations: "Occurrences"
+      recurring_meeting_interim_response:
+        start_time: "Start time"
       meeting_participant:
         invited: "Invited"
         attended: "Attended"
@@ -80,6 +82,8 @@ en:
           user_invalid: "is not a valid participant."
         meeting_agenda_item:
           user_invalid: "is not a valid participant."
+        recurring_meeting_interim_response:
+          not_an_occurrence: "is not a valid occurrence time for this recurring meeting"
         recurring_meeting:
           must_cover_existing_meetings:
             one: "There is one open meeting in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."

--- a/modules/meeting/spec/models/recurring_meeting_interim_response_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_interim_response_spec.rb
@@ -28,24 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class RecurringMeetingInterimResponse < ApplicationRecord
-  belongs_to :recurring_meeting
-  belongs_to :user
+require "spec_helper"
 
-  enum :participation_status, {
-    needs_action: "needs-action",
-    accepted: "accepted",
-    declined: "declined",
-    tentative: "tentative",
-    # delegated: "delegated", # We currently do not support delegation
-    unknown: "unknown" # this status is used for existing participants when introducing the field
-  }, prefix: :participation
+RSpec.describe RecurringMeetingInterimResponse do
+  let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  let(:recurring_meeting) { create(:recurring_meeting, project:) }
+  let(:user) { create(:user) }
 
-  validate :start_time_must_be_valid_occurrence, if: -> { start_time.present? && recurring_meeting.present? }
+  describe "validations" do
+    describe "#start_time_must_be_valid_occurrence" do
+      context "when start_time matches an occurrence of the recurring meeting" do
+        let(:start_time) { recurring_meeting.start_time + 7.days }
 
-  private
+        it "is valid" do
+          response = described_class.new(recurring_meeting:, user:, start_time:,
+                                         participation_status: :accepted)
+          expect(response).to be_valid
+        end
+      end
 
-  def start_time_must_be_valid_occurrence
-    errors.add(:start_time, :not_an_occurrence) unless recurring_meeting.occurs_at?(start_time)
+      context "when start_time does not match any occurrence" do
+        let(:start_time) { recurring_meeting.start_time + 1.hour }
+
+        it "is invalid" do
+          response = described_class.new(recurring_meeting:, user:, start_time:,
+                                         participation_status: :accepted)
+          expect(response).not_to be_valid
+          expect(response.errors[:start_time])
+            .to include("is not a valid occurrence time for this recurring meeting")
+        end
+      end
+    end
   end
 end

--- a/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe AllMeetings::HandleICalResponseService, type: :model do
 
       context "when no meeting occurrence is found for the recurrence ID" do
         let(:partstat) { "ACCEPTED" }
-        let(:recurrence_date) { 2.years.from_now.change(usec: 0) }
+        let(:recurrence_date) { (recurring_meeting.start_time + 14.days).change(usec: 0) }
 
         let(:additional_ical_properties) do
           "RECURRENCE-ID:#{recurrence_date.utc.strftime('%Y%m%dT%H%M%SZ')}"
@@ -402,7 +402,7 @@ RSpec.describe AllMeetings::HandleICalResponseService, type: :model do
 
       context "when an interim response already for this recurrence (the user has already responded and changes)" do
         let(:partstat) { "DECLINED" }
-        let(:recurrence_date) { recurring_meeting.start_time + 1.month }
+        let(:recurrence_date) { recurring_meeting.start_time + 21.days }
         let!(:existing_response) do
           RecurringMeetingInterimResponse.create!(
             user: user,

--- a/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
@@ -307,6 +307,78 @@ RSpec.describe AllMeetings::HandleICalResponseService, type: :model do
         end
       end
 
+      context "when the RECURRENCE-ID uses a TZID-qualified local time (e.g., from Open-Xchange)" do
+        let(:partstat) { "ACCEPTED" }
+        let(:recurrence_id_in_berlin) { recurrence_id.in_time_zone("Europe/Berlin") }
+
+        let(:ical_string) do
+          <<~ICAL
+            BEGIN:VCALENDAR
+            PRODID:-//Open-Xchange//8.45.77//EN
+            VERSION:2.0
+            CALSCALE:GREGORIAN
+            METHOD:REPLY
+            BEGIN:VTIMEZONE
+            TZID:Europe/Berlin
+            BEGIN:DAYLIGHT
+            TZNAME:CEST
+            TZOFFSETFROM:+0100
+            TZOFFSETTO:+0200
+            DTSTART:19700329T020000
+            RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+            END:DAYLIGHT
+            BEGIN:STANDARD
+            TZNAME:CET
+            TZOFFSETFROM:+0200
+            TZOFFSETTO:+0100
+            DTSTART:19701025T030000
+            RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+            END:STANDARD
+            END:VTIMEZONE
+            BEGIN:VEVENT
+            DTSTART;TZID=Europe/Berlin:#{recurrence_id_in_berlin.strftime('%Y%m%dT%H%M%S')}
+            DTEND;TZID=Europe/Berlin:#{(recurrence_id_in_berlin + 1.hour).strftime('%Y%m%dT%H%M%S')}
+            DTSTAMP:#{Time.current.utc.strftime('%Y%m%dT%H%M%SZ')}
+            ORGANIZER;CN=OpenProject:mailto:meetingresponse@example.com
+            UID:#{recurring_meeting.uid}
+            RECURRENCE-ID;TZID=Europe/Berlin:#{recurrence_id_in_berlin.strftime('%Y%m%dT%H%M%S')}
+            #{attendee_string}
+            CREATED:#{meeting.created_at.utc.strftime('%Y%m%dT%H%M%SZ')}
+            LAST-MODIFIED:#{Time.current.utc.strftime('%Y%m%dT%H%M%SZ')}
+            SEQUENCE:0
+            STATUS:CONFIRMED
+            SUMMARY:#{meeting.title}
+            TRANSP:OPAQUE
+            END:VEVENT
+            END:VCALENDAR
+          ICAL
+        end
+
+        it "finds the meeting occurrence and updates the participant's status" do
+          expect { subject }.to change {
+            meeting.participants.find_by(user: user).participation_status
+          }.from("needs_action").to("accepted")
+          expect(RecurringMeetingInterimResponse.count).to eq(0)
+          expect(subject).to be_success
+        end
+
+        context "when the recurring meeting occurrence is not yet instantiated" do
+          let(:recurrence_id_in_berlin) { (recurring_meeting.start_time + 14.days).in_time_zone("Europe/Berlin") }
+
+          it "creates an interim response with the correct start time" do
+            expect { subject }.to change(RecurringMeetingInterimResponse, :count).by(1)
+
+            expect(subject).to be_success
+
+            interim_response = RecurringMeetingInterimResponse.last
+            expect(interim_response.user).to eq(user)
+            expect(interim_response.recurring_meeting).to eq(recurring_meeting)
+            expect(interim_response.start_time).to eq(recurrence_id_in_berlin.utc)
+            expect(interim_response.participation_status).to eq("accepted")
+          end
+        end
+      end
+
       context "when no meeting occurrence is found for the recurrence ID" do
         let(:partstat) { "ACCEPTED" }
         let(:recurrence_date) { 2.years.from_now.change(usec: 0) }


### PR DESCRIPTION
`event.recurrence_id&.value_ical` returns the raw ICS string e.g.,"20260217T140300" with no timezone information. This resulted in shifting the meeting +1 in case of CET meeting as is the dev weekly


https://community.openproject.org/work_packages/72259