### PR TITLE
turn sharing into an enum

### DIFF
--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -38,17 +38,27 @@ module Agile
     belongs_to :project
     has_many :work_packages, dependent: :nullify
 
-    enum :status, {
-      in_planning: "in_planning",
-      active: "active",
-      completed: "completed"
-    }, default: "in_planning", validate: true
+    enum :status,
+         {
+           in_planning: "in_planning",
+           active: "active",
+           completed: "completed"
+         },
+         default: "in_planning",
+         validate: true
 
-    SPRINT_SHARINGS = %w(none descendants system).freeze
+    enum :sharing,
+         {
+           none: "none",
+           descendants: "descendants",
+           system: "system"
+         },
+         default: "none",
+         prefix: :sharing_with,
+         validate: true
 
     validates :name, presence: true
     validates :project, presence: true
-    validates :sharing, presence: true, inclusion: { in: SPRINT_SHARINGS }
     validates :start_date, presence: true
     validates :finish_date,
               presence: true,

--- a/modules/backlogs/spec/models/agile/sprint_spec.rb
+++ b/modules/backlogs/spec/models/agile/sprint_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Agile::Sprint do
     it { is_expected.to validate_presence_of(:finish_date) }
     it { is_expected.to validate_presence_of(:project) }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class.statuses.keys) }
-    it { is_expected.to validate_inclusion_of(:sharing).in_array(described_class::SPRINT_SHARINGS) }
+    it { is_expected.to validate_inclusion_of(:sharing).in_array(described_class.sharings.keys) }
 
     it "validates finish_date is after or equal to start_date" do
       sprint.finish_date = sprint.start_date - 1.day
@@ -96,16 +96,15 @@ RSpec.describe Agile::Sprint do
     end
 
     it "status defaults to in_planning" do
-      expect(sprint.status).to eq("in_planning")
+      expect(sprint).to be_in_planning
     end
 
-    it "allows sharing settings" do
-      expect(sprint).to allow_values(*%w[none descendants system]).for(:sharing)
-      expect(sprint).not_to allow_value(*%w[invalid_value hierarchy tree]).for(:sharing)
+    it "has sharing enum with correct values" do
+      expect(described_class.sharings.keys).to contain_exactly("none", "descendants", "system")
     end
 
     it "sharing defaults to none" do
-      expect(sprint.sharing).to eq("none")
+      expect(sprint).to be_sharing_with_none
     end
   end
 


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Sharing should be an enum just as status. With the prefix of `sharing_with_XYZ` it reads nicely. 

# Merge checklist

- [x] Added/updated tests