### PR TITLE
Feature/72354 enable column sorting on versions overview

### DIFF
--- a/app/components/versions/table_component.rb
+++ b/app/components/versions/table_component.rb
@@ -39,7 +39,7 @@ module Versions
     end
 
     def sortable_column?(name)
-      %w[name start_date effective_date status].include?(name.to_s)
+      sortable_columns_correlation.key? name.to_s
     end
 
     def initial_sort
@@ -48,15 +48,15 @@ module Versions
 
     def sortable_columns_correlation
       {
-        'name' => 'versions.name',
-        'start_date' => 'versions.start_date',
-        'effective_date' => 'versions.effective_date',
-        'status' => 'versions.status'
+        "name" => "versions.name",
+        "start_date" => "versions.start_date",
+        "effective_date" => "versions.effective_date",
+        "status" => "versions.status"
       }.with_indifferent_access
     end
 
     def initial_sort_correlation
-      ['versions.name', 'asc']
+      ["versions.name", "asc"]
     end
 
     def headers

--- a/app/components/versions/table_component.rb
+++ b/app/components/versions/table_component.rb
@@ -35,7 +35,28 @@ module Versions
     columns :name, :project, :start_date, :effective_date, :description, :status, :sharing, :wiki_page_title
 
     def sortable?
-      false
+      true
+    end
+
+    def sortable_column?(name)
+      %w[name start_date effective_date status].include?(name.to_s)
+    end
+
+    def initial_sort
+      %i[name asc]
+    end
+
+    def sortable_columns_correlation
+      {
+        'name' => 'versions.name',
+        'start_date' => 'versions.start_date',
+        'effective_date' => 'versions.effective_date',
+        'status' => 'versions.status'
+      }.with_indifferent_access
+    end
+
+    def initial_sort_correlation
+      ['versions.name', 'asc']
     end
 
     def headers

--- a/app/controllers/projects/settings/versions_controller.rb
+++ b/app/controllers/projects/settings/versions_controller.rb
@@ -32,6 +32,6 @@ class Projects::Settings::VersionsController < Projects::SettingsController
   menu_item :settings_versions
 
   def show
-    @versions = @project.shared_versions.order(:name)
+    @versions = @project.shared_versions
   end
 end


### PR DESCRIPTION
# Ticket
(https://community.openproject.org/projects/openproject/work_packages/72354/activity)

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Enable column sorting on the Versions overview table in Project Settings 
(OpenProject / Project Settings / Versions).

Currently the Versions table has no sorting capability. This PR adds the 
ability to sort by any column: Name, Start Date, Finish Date, and Status.

## Screenshots
Before:
<img width="2279" height="481" alt="image" src="https://github.com/user-attachments/assets/9f57b731-9ac8-4150-83f6-a2681a15564c" />

After:
<img width="2265" height="442" alt="image" src="https://github.com/user-attachments/assets/63ee1bc4-104a-4a7a-a932-c23afd7fd2ec" />

# What approach did you choose and why?
Added sorting support by overriding the following methods in the Versions 
query component:

- `sortable?` — enables sorting on the table
- `sortable_column?(name)` — whitelists sortable columns: name, start_date, 
  effective_date, status
- `sortable_columns_correlation` — maps column names to fully table-qualified 
  SQL names (e.g. `versions.effective_date`) to prevent ambiguous column errors 
  when JOIN queries are present
- `initial_sort` / `initial_sort_correlation` — keeps default sort as Name ASC 
  for backwards compatibility

The table-qualification approach was chosen specifically to handle the case 
where shared versions across multiple projects trigger JOIN queries, which 
would otherwise cause ambiguous column name errors in PostgreSQL.

# Merge checklist

- [ ] Added/updated tests - Note: Tests are not included in this PR.
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
