### PR TITLE
Allow session auth for MCP

### DIFF
--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -55,7 +55,7 @@ OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope
 end
 
 OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope::MCP_SCOPE, { store: false }) do |_|
-  %i[user_api_token oauth jwt_oidc user_basic_auth basic_auth_failure]
+  %i[user_api_token oauth jwt_oidc user_basic_auth basic_auth_failure session]
 end
 
 Rails.application.configure do |app|


### PR DESCRIPTION
It's probably only borderline useful for now, but it also doesn't hurt too much to support it.

We don't grant any additional privileges compared to APIv3, which also supports session authentication.

# Ticket
https://community.openproject.org/wp/72253