### PR TITLE
Allow all projects in a Basic board by default.

### DIFF
--- a/app/models/queries/work_packages/filter/project_filter.rb
+++ b/app/models/queries/work_packages/filter/project_filter.rb
@@ -46,7 +46,7 @@ class Queries::WorkPackages::Filter::ProjectFilter < Queries::WorkPackages::Filt
   end
 
   def type
-    :list
+    :list_optional
   end
 
   def self.key

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -444,6 +444,13 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     const existingFilters = (this.resource.options.filters || []) as ApiV3Filter[];
 
     const newFilters = existingFilters.concat(filters);
+
+    // For Basic boards, ensure work packages from all projects are shown
+    // by adding a project filter with the 'any' operator if not already set.
+    if (this.board.isFree && !newFilters.some((f) => 'project' in f)) {
+      newFilters.push({ project: { operator: '*', values: [] } });
+    }
+
     const newColumnsQueryProps:any = {
       'columns[]': ['id', 'subject'],
       showHierarchies: false,

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -38,7 +38,7 @@ import {
 } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -74,21 +74,31 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
     const filters:ApiV3FilterBuilder = new ApiV3FilterBuilder();
     const results = this.querySpace.results.value;
 
-    filters.add('subjectOrId', '**', [searchString]);
+    filters.add('typeahead', '**', [searchString]);
 
     if (results && results.elements.length > 0) {
       filters.add('id', '!', results.elements.map((wp:WorkPackageResource) => wp.id!));
     }
-    // Add the subproject filter, if any
+    // If the column query has a 'project' filter, use the global endpoint and forward
+    // that filter so the autocomplete respects it. Basic boards always have one (added
+    // by the board to show all projects, or narrowed by the user). Action boards may
+    // also have one if the user added it explicitly.
+    // Otherwise stay scoped to the current project and forward the 'subprojectId' filter.
     const query = this.querySpace.query.value;
+    let projectScopeId:string|null = this.CurrentProject.id;
     if (query?.filters) {
       const currentFilters = this.urlParamsHelper.buildV3GetFilters(query.filters);
-      filters.merge(currentFilters, 'subprojectId');
+      if (currentFilters.some((f) => 'project' in f)) {
+        filters.merge(currentFilters, 'project');
+        projectScopeId = null;
+      } else {
+        filters.merge(currentFilters, 'subprojectId');
+      }
     }
 
     return this
       .apiV3Service
-      .withOptionalProject(this.CurrentProject.id)
+      .withOptionalProject(projectScopeId)
       .work_packages
       .filtered(filters)
       .get()

--- a/frontend/src/app/shared/helpers/api-v3/api-v3-filter-builder.ts
+++ b/frontend/src/app/shared/helpers/api-v3/api-v3-filter-builder.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-export type FilterOperator = '='|'!*'|'!'|'~'|'o'|'>t-'|'<>d'|'**'|'ow';
+export type FilterOperator = '='|'!*'|'*'|'!'|'~'|'o'|'>t-'|'<>d'|'**'|'ow';
 export const FalseValue = ['f'];
 export const TrueValue = ['t'];
 

--- a/spec/models/queries/work_packages/filter/project_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/project_filter_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 
 RSpec.describe Queries::WorkPackages::Filter::ProjectFilter do
   it_behaves_like "basic query filter" do
-    let(:type) { :list }
+    let(:type) { :list_optional }
     let(:class_key) { :project_id }
     let(:visible_projects) { build_stubbed_list(:project, 2) }
 

--- a/spec/models/query/results_project_filter_integration_spec.rb
+++ b/spec/models/query/results_project_filter_integration_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe Query::Results, "Project filter integration" do
     login_as user
   end
 
+  describe "any project (wildcard operator)" do
+    before do
+      query.add_filter "project_id", "*", []
+    end
+
+    it "shows work packages from all visible projects, ignoring the query's project scope" do
+      expect(query_results.work_packages)
+        .to contain_exactly(parent_wp, child_wp, second_parent_wp, second_child_wp)
+    end
+  end
+
   describe "both parent projects selected" do
     before do
       query.add_filter "project_id", "=", [parent_project.id, second_parent_project.id]


### PR DESCRIPTION
## TL;DR

This PR will change how Basic Boards work. By default they will allow to work fully cross project. Any work package of any project can be added to a board if the "Include projects" were extended accordingly.

## Background story and motivation

On community.openproject.org someone had changed the whole project hierarchy. This lead to many basic boards not showing all the work packages anymore that used to be on the board. Basic boards could only show work packages from the project that owned the board or from its sub-projects. So, when the project hierarchy got completely changed, many projects have moved out of the sub-project branch of the project that owned the board. Consequently many work packages from the boards were not visible anymore. Big drama! :smile: 

## Ticket
<!-- Provide the link to respective work package -->
Addresses  work package ["Boards + Team planner: "Add existing" autocompleter should respect the current "Project" filter / "Include projects""](https://community.openproject.org/wp/47864) but in fact, the PR goes beyond it. 

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

## What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- When picking an existing WP for a board, apply the same project filters as the board's project filters. This allows to add WPs outside the current project and its subprojects
- Allow project filter to also have operators for "all" and "none".
- Make Basic boards by default show any work package that it holds in its columns, independent of to which project they belong.
- However, if people set a project filter via "Include projects" they still can narrow down what is shown on the board to only those projects that were explicitly selected.
