### PR TITLE
Pass enabled value to external links controller so it can be properly disabled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -305,6 +305,7 @@ module ApplicationHelper
       controller: "application auto-theme-switcher hover-card-trigger beforeunload external-links highlight-target-element",
       relative_url_root: root_path,
       overflowing_identifier: ".__overflowing_body",
+      external_links_enabled_value: Setting.capture_external_links?,
       rendered_at: Time.zone.now.iso8601,
       turbo: local_assigns[:turbo_opt_out] ? "false" : nil
     }.merge(user_theme_data_attributes)

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -70,6 +70,12 @@ const shouldProcessLink = (link:HTMLAnchorElement) => {
  * dynamically loaded content.
  */
 export default class ExternalLinksController extends ApplicationController {
+  static values = {
+    enabled: Boolean
+  };
+
+  declare readonly enabledValue:boolean;
+
   connect() {
     useMutation(this, { attributes: true, childList: true, subtree: true, attributeFilter: ['target', 'href'] });
 
@@ -77,9 +83,9 @@ export default class ExternalLinksController extends ApplicationController {
     document.querySelectorAll<HTMLAnchorElement>(LINK_QUERY).forEach((link)=>{
       if (!shouldProcessLink(link)) return;
 
-      if (isLinkBlank(link)) updateBlankLink(link);
+      if (isLinkBlank(link)) this.updateBlankLink(link);
 
-      if (isLinkExternal(link)) updateExternalLink(link);
+      if (isLinkExternal(link)) this.updateExternalLink(link);
     });
   }
 
@@ -89,16 +95,16 @@ export default class ExternalLinksController extends ApplicationController {
         if (isElement(node)) {
           // Added element itself is an external link
           if (isLink(node) && shouldProcessLink(node)) {
-            if (isLinkBlank(node)) updateBlankLink(node);
-            if (isLinkExternal(node)) updateExternalLink(node);
+            if (isLinkBlank(node)) this.updateBlankLink(node);
+            if (isLinkExternal(node)) this.updateExternalLink(node);
           }
 
           node.querySelectorAll<HTMLAnchorElement>(LINK_QUERY).forEach((link)=>{
             if (!shouldProcessLink(link)) return;
 
-            if (isLinkBlank(link)) updateBlankLink(link);
+            if (isLinkBlank(link)) this.updateBlankLink(link);
 
-            if (isLinkExternal(link)) updateExternalLink(link);
+            if (isLinkExternal(link)) this.updateExternalLink(link);
           });
         }
       });
@@ -110,28 +116,29 @@ export default class ExternalLinksController extends ApplicationController {
         isLink(mutation.target) &&
         shouldProcessLink(mutation.target)
       ) {
-        if (mutation.attributeName === 'target' && isLinkBlank(mutation.target)) updateBlankLink(mutation.target);
-        if (mutation.attributeName === 'href' && isLinkExternal(mutation.target)) updateExternalLink(mutation.target);
+        if (mutation.attributeName === 'target' && isLinkBlank(mutation.target)) this.updateBlankLink(mutation.target);
+        if (mutation.attributeName === 'href' && isLinkExternal(mutation.target)) this.updateExternalLink(mutation.target);
       }
     });
   }
-}
 
-function updateBlankLink(link:HTMLAnchorElement) {
-  // Ensure accessibility description
-  attributeTokenList(link, 'aria-describedby').add(BLANK_LINK_DESCRIPTION_ID);
-}
-
-function updateExternalLink(link:HTMLAnchorElement) {
-  // Ensure external link behavior
-  link.target = '_blank';
-  attributeTokenList(link, 'rel').add('noopener', 'noreferrer');
-
-  // Capture external links through redirect page
-  // The backend controller will redirect directly if the feature is disabled
-  if (!link.dataset.allowExternalLink) {
-    const originalHref = link.href;
-    const basePath = window.appBasePath ?? '';
-    link.href = `${basePath}/external_redirect?url=${encodeURIComponent(originalHref)}`;
+  private updateBlankLink(link:HTMLAnchorElement) {
+    // Ensure accessibility description
+    attributeTokenList(link, 'aria-describedby').add(BLANK_LINK_DESCRIPTION_ID);
   }
+
+  private updateExternalLink(link:HTMLAnchorElement) {
+    // Ensure external link behavior
+    link.target = '_blank';
+    attributeTokenList(link, 'rel').add('noopener', 'noreferrer');
+
+    // Capture external links through redirect page
+    // The backend controller will redirect directly if the feature is disabled
+    if (this.enabledValue && !link.dataset.allowExternalLink) {
+      const originalHref = link.href;
+      const basePath = window.appBasePath ?? '';
+      link.href = `${basePath}/external_redirect?url=${encodeURIComponent(originalHref)}`;
+    }
+  }
+
 }

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -78,11 +78,10 @@ en:
         participation_status: "Participation status"
     errors:
       models:
-        meeting_agenda_item:
-          section_not_belong_to_meeting: "Section does not belong to the same meeting."
         meeting_participant:
           user_invalid: "is not a valid participant."
         meeting_agenda_item:
+          section_not_belong_to_meeting: "Section does not belong to the same meeting."
           user_invalid: "is not a valid participant."
         recurring_meeting_interim_response:
           not_an_occurrence: "is not a valid occurrence time for this recurring meeting"

--- a/spec/features/a11y/external_links_spec.rb
+++ b/spec/features/a11y/external_links_spec.rb
@@ -54,8 +54,7 @@ RSpec.describe "External links", :js do
       document.body.appendChild(link);
     JS
 
-    href = external_redirect_path(url: "https://example.com/")
-    link = page.find_link("External Example", href:, match: :first)
+    link = page.find_link("External Example", href: "https://example.com", match: :first)
 
     # Verify accessibility and security attributes
     expect(link[:target]).to eq("_blank")

--- a/spec/features/external_link_capture_spec.rb
+++ b/spec/features/external_link_capture_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe "External link capture", :js, :selenium do
     it "keeps the default external link behaviour" do
       visit project_wiki_path(project, wiki_page)
 
-      href = external_redirect_path(url: external_url)
-      link = page.find_link("OpenProject", href:)
+      link = page.find_link("OpenProject", href: external_url)
       new_window = window_opened_by { link.click }
 
       within_window new_window do

--- a/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
+++ b/spec/features/projects/project_custom_fields/overview_page/dialog/inputs_spec.rb
@@ -203,8 +203,7 @@ RSpec.describe "Edit project custom fields on project overview page", :js do
 
         it "renders the custom field as a link" do
           page.within_test_selector "project-custom-field-#{link_project_custom_field.id}" do
-            href = external_redirect_path(url: "https://www.openproject.org/")
-            expect(page).to have_link("https://www.openproject.org", href:)
+            expect(page).to have_link("https://www.openproject.org", href: "https://www.openproject.org")
           end
         end
       end

--- a/spec/features/wiki/wiki_page_external_link_spec.rb
+++ b/spec/features/wiki/wiki_page_external_link_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe "Wiki page external link", :js, :selenium do
   it "opens that link in a new window or tab" do
     visit project_wiki_path(project, wiki_page)
 
-    href = external_redirect_path(url: external_url)
-    link = page.find_link("OpenProject", href:)
+    link = page.find_link("OpenProject", href: external_url)
     new_window = window_opened_by { link.click }
     within_window new_window do
       expect(page.current_url).to start_with external_url

--- a/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
+++ b/spec/features/work_packages/details/custom_fields/custom_field_spec.rb
@@ -251,8 +251,7 @@ RSpec.describe "custom field inplace editor", :js do
       field.update "http://example.com"
 
       field.expect_state_text "http://example.com"
-      href = external_redirect_path(url: "http://example.com/")
-      expect(field.display_element).to have_link("http://example.com", href:)
+      expect(field.display_element).to have_link("http://example.com", href: "http://example.com")
 
       field.update "bogus", expect_failure: true
 
@@ -262,8 +261,8 @@ RSpec.describe "custom field inplace editor", :js do
       field.save!
 
       field.expect_state_text "http://community.openproject.org"
-      href = external_redirect_path(url: "http://community.openproject.org/")
-      expect(field.display_element).to have_link("http://community.openproject.org", href:)
+      expect(field.display_element).to have_link("http://community.openproject.org",
+                                                 href: "http://community.openproject.org")
     end
   end
 end

--- a/spec/features/work_packages/details/markdown/todolist_spec.rb
+++ b/spec/features/work_packages/details/markdown/todolist_spec.rb
@@ -186,11 +186,9 @@ RSpec.describe "Todolists in CKEditor", :js, :selenium do
       expect(page).to have_css(".op-uc-list--task-checkbox", count: 3)
       expect(page).to have_css(".op-uc-list--task-checkbox[checked]", count: 1)
 
-      link = external_redirect_path(url: "https://community.openproject.com/")
-      expect(page).to have_css(".op-uc-list--item a[href='#{link}']")
+      expect(page).to have_css(".op-uc-list--item a[href='https://community.openproject.com/']")
 
-      link = external_redirect_path(url: "https://community.openproject.com/nested")
-      nested_link = page.find(".op-uc-list--item .op-uc-list--item a[href='#{link}']")
+      nested_link = page.find(".op-uc-list--item .op-uc-list--item a[href='https://community.openproject.com/nested']")
       expect(nested_link.text).to eq "This is a link"
 
       description = WorkPackage.last.description

--- a/spec/features/wysiwyg/linking_spec.rb
+++ b/spec/features/wysiwyg/linking_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Wysiwyg linking", :js do
         "[http://example.org/link with spaces](http://example.org/link%20with%20spaces)"
       )
 
-      expect(page).to have_link(href: external_redirect_path(url: "http://example.org/link%20with%20spaces"))
+      expect(page).to have_link(href: "http://example.org/link%20with%20spaces")
     end
   end
 
@@ -76,7 +76,7 @@ RSpec.describe "Wysiwyg linking", :js do
       editor.insert_link "https://example.org/path"
       click_on "Save"
       expect_flash(message: "Successful update.")
-      expect(page).to have_link(href: external_redirect_path(url: "https://example.org/path"))
+      expect(page).to have_link(href: "https://example.org/path")
     end
 
     it "allows linking the custom protocol" do

--- a/spec/views/layouts/base.html.erb_spec.rb
+++ b/spec/views/layouts/base.html.erb_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "layouts/base" do
   include Capybara::RSpecMatchers
 
   include Redmine::MenuManager::MenuHelper
+
   helper Redmine::MenuManager::MenuHelper
   let(:user) { build_stubbed(:user) }
   let(:anonymous) { build_stubbed(:anonymous) }
@@ -104,7 +105,7 @@ RSpec.describe "layouts/base" do
   describe "icons" do
     let(:current_user) { anonymous }
 
-    context "not in development environment" do
+    context "when not in development environment" do
       before do
         render
       end
@@ -189,12 +190,11 @@ RSpec.describe "layouts/base" do
     let(:a_token) { EnterpriseToken.new }
     let(:current_user) { anonymous }
 
-    context "EE is active and styles are present" do
+    context "when EE is active and styles are present", with_ee: %i[define_custom_style capture_external_links] do
       let(:custom_style) { create(:custom_style) }
       let(:primary_color) { create(:"design_color_primary-button-color") }
 
       before do
-        allow(EnterpriseToken).to receive(:allows_to?).with(:define_custom_style).and_return(true)
         allow(CustomStyle).to receive(:current).and_return(custom_style)
       end
 


### PR DESCRIPTION
https://community.openproject.org/projects/openproject/work_packages/71946/activity

Without this setting passed to the frontend, all links will always be rewritten in the frontend, even if the feature is disabled. This has the side-effect of not being able to easily copy/paste links.