### PR TITLE
[68533] Documents index page: pagination per page options overflow on mobile

### DIFF
--- a/frontend/src/global_styles/content/_pagination.sass
+++ b/frontend/src/global_styles/content/_pagination.sass
@@ -44,6 +44,9 @@ $pagination--font-size: 0.8125rem
     flex-shrink: 1
     margin: 10px 0 0 5px
 
+    @media screen and (max-width: $breakpoint-sm)
+      display: none    
+
   &--items
     list-style-type: none
     display: flex


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68533

# What are you trying to accomplish?
This is only a quick fix to improve the mobile behaviour of paginations. To gain space, we hide the "per Page" options on mobile. We are currently working on a standardized Primer pagination component which will solve that problem better.
