### PR TITLE
[71106] Activity tab overflows with long names

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component/details.sass
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.sass
@@ -51,3 +51,4 @@
         color: var(--bgColor-accent-emphasis)
     &--journal-detail-description-container
         max-width: 95% // otherwise the stem branch might get too short for long descriptions
+        @include text-shortener(false)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71106

# What are you trying to accomplish?
Truncate long texts in activity description

## Screenshots
**After**
<img width="562" height="161" alt="Bildschirmfoto 2026-02-23 um 09 23 25" src="https://github.com/user-attachments/assets/e9a04562-c731-4528-8b9e-ee0fce99d222" />

**Before**
<img width="565" height="158" alt="Bildschirmfoto 2026-02-23 um 09 24 17" src="https://github.com/user-attachments/assets/77f03dc9-bc8d-44ef-8724-2366d513fb82" />
