### PR TITLE
[72361][72365] Handle empty descriptions in project overview widgets

### DIFF
--- a/modules/grids/app/components/grids/widgets/description.html.erb
+++ b/modules/grids/app/components/grids/widgets/description.html.erb
@@ -30,19 +30,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper(test_selector: "op-overview-widget--project-description") do
-    if project.description.present?
-      render OpenProject::Common::InplaceEditFieldComponent.new(
-        model: @project,
-        attribute: :description,
-        visually_hide_label: true,
-        rich_text_options: {
-          showAttachments: false,
-          editorType: "constrained",
-          macros: false
-        }
-      )
-    else
-      render(Primer::Beta::Text.new(color: :subtle)) { t(:"js.grid.widgets.project_description.no_results") }
-    end
+    render OpenProject::Common::InplaceEditFieldComponent.new(
+      model: @project,
+      attribute: :description,
+      visually_hide_label: true,
+      rich_text_options: {
+        showAttachments: false,
+        editorType: "constrained",
+        macros: false
+      }
+    )
   end
 %>

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -17,7 +17,6 @@ en:
           title: 'News'
         project_description:
           title: 'Description'
-          no_results: "No description has been written yet. One can be provided in the 'Project settings'."
         project_status:
           title: 'Status'
           not_started: 'Not started'


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72361
https://community.openproject.org/wp/72365

# What are you trying to accomplish?
Remove outdated placeholder when no description is present. The permission handling and placeholder handling is done within the `InplaceEditFieldComponent`

