### PR TITLE
[72262] Replace EUR with € in cost currency setting default and harmonize widgets

### DIFF
--- a/modules/budgets/spec/components/budgets/widgets/budget_totals_spec.rb
+++ b/modules/budgets/spec/components/budgets/widgets/budget_totals_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Budgets::Widgets::BudgetTotals, type: :component do
 
     it "displays budget total" do
       expect(rendered_component).to have_heading("Total planned budget")
-      expect(rendered_component).to have_primer_text("10,000 EUR")
+      expect(rendered_component).to have_primer_text("10,000 €")
     end
 
     it "displays spent ratio as percentage" do
@@ -64,12 +64,12 @@ RSpec.describe Budgets::Widgets::BudgetTotals, type: :component do
 
     it "displays remaining budget equal to planned budget" do
       expect(rendered_component).to have_heading("Remaining budget")
-      expect(rendered_component).to have_primer_text("10,000 EUR", color: "default")
+      expect(rendered_component).to have_primer_text("10,000 €", color: "default")
     end
 
     it "displays zero actual costs" do
       expect(rendered_component).to have_heading("Total actual costs")
-      expect(rendered_component).to have_primer_text("0 EUR")
+      expect(rendered_component).to have_primer_text("0 €")
     end
   end
 
@@ -85,12 +85,12 @@ RSpec.describe Budgets::Widgets::BudgetTotals, type: :component do
 
     it "displays actual costs based on time entries" do
       expect(rendered_component).to have_heading("Total actual costs")
-      expect(rendered_component).to have_primer_text("2,000 EUR")
+      expect(rendered_component).to have_primer_text("2,000 €")
     end
 
     it "displays remaining budget reduced by spending" do
       expect(rendered_component).to have_heading("Remaining budget")
-      expect(rendered_component).to have_primer_text("8,000 EUR", color: "default")
+      expect(rendered_component).to have_primer_text("8,000 €", color: "default")
     end
 
     it "displays spent ratio as percentage" do
@@ -111,7 +111,7 @@ RSpec.describe Budgets::Widgets::BudgetTotals, type: :component do
 
     it "displays negative remaining budget in red" do
       expect(rendered_component).to have_heading("Remaining budget")
-      expect(rendered_component).to have_primer_text("-EUR5,000", color: "danger")
+      expect(rendered_component).to have_primer_text("-5,000 €", color: "danger")
     end
 
     it "displays over-100% spent ratio in red" do
@@ -121,7 +121,7 @@ RSpec.describe Budgets::Widgets::BudgetTotals, type: :component do
 
     it "displays actual costs exceeding budget" do
       expect(rendered_component).to have_heading("Total actual costs")
-      expect(rendered_component).to have_primer_text("10,000 EUR")
+      expect(rendered_component).to have_primer_text("10,000 €")
     end
   end
 

--- a/modules/budgets/spec/features/budgets/add_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/add_budget_spec.rb
@@ -118,29 +118,29 @@ RSpec.describe "adding a new budget", :js do
 
         fill_in Budget.human_attribute_name(:subject), with: "First Aid"
 
-        new_budget_page.add_unit_costs! "3,50", comment: "RadAway", expected_costs: "175,00 EUR"
-        new_budget_page.add_unit_costs! "1.000,50", comment: "Rad-X", expected_costs: "50.025,00 EUR"
+        new_budget_page.add_unit_costs! "3,50", comment: "RadAway", expected_costs: "175,00 €"
+        new_budget_page.add_unit_costs! "1.000,50", comment: "Rad-X", expected_costs: "50.025,00 €"
 
-        new_budget_page.add_labor_costs! "5000,10", user_name: user.name, comment: "treatment", expected_costs: "125.002,50 EUR"
-        new_budget_page.add_labor_costs! "0,5", user_name: user.name, comment: "attendance", expected_costs: "12,50 EUR"
+        new_budget_page.add_labor_costs! "5000,10", user_name: user.name, comment: "treatment", expected_costs: "125.002,50 €"
+        new_budget_page.add_labor_costs! "0,5", user_name: user.name, comment: "attendance", expected_costs: "12,50 €"
 
         page.find('[data-test-selector="budgets-create-button"]').click
         expect_and_dismiss_flash(message: I18n.t(:notice_successful_create))
 
-        expect(new_budget_page.unit_costs_at(1)).to have_content "175,00 EUR"
-        expect(new_budget_page.unit_costs_at(2)).to have_content "50.025,00 EUR"
-        expect(new_budget_page.overall_unit_costs).to have_content "50.200,00 EUR"
+        expect(new_budget_page.unit_costs_at(1)).to have_content "175,00 €"
+        expect(new_budget_page.unit_costs_at(2)).to have_content "50.025,00 €"
+        expect(new_budget_page.overall_unit_costs).to have_content "50.200,00 €"
 
-        expect(new_budget_page.labor_costs_at(1)).to have_content "125.002,50 EUR"
-        expect(new_budget_page.labor_costs_at(2)).to have_content "12,50 EUR"
-        expect(new_budget_page.overall_labor_costs).to have_content "125.015,00 EUR"
+        expect(new_budget_page.labor_costs_at(1)).to have_content "125.002,50 €"
+        expect(new_budget_page.labor_costs_at(2)).to have_content "12,50 €"
+        expect(new_budget_page.overall_labor_costs).to have_content "125.015,00 €"
 
         click_on I18n.t(:button_update)
 
-        budget_page.expect_planned_costs! type: :material, row: 1, expected: "175,00 EUR"
-        budget_page.expect_planned_costs! type: :material, row: 2, expected: "50.025,00 EUR"
-        budget_page.expect_planned_costs! type: :labor, row: 1, expected: "125.002,50 EUR"
-        budget_page.expect_planned_costs! type: :labor, row: 2, expected: "12,50 EUR"
+        budget_page.expect_planned_costs! type: :material, row: 1, expected: "175,00 €"
+        budget_page.expect_planned_costs! type: :material, row: 2, expected: "50.025,00 €"
+        budget_page.expect_planned_costs! type: :labor, row: 1, expected: "125.002,50 €"
+        budget_page.expect_planned_costs! type: :labor, row: 2, expected: "12,50 €"
 
         fields = page
           .all("input.budget-item-value")
@@ -165,15 +165,15 @@ RSpec.describe "adding a new budget", :js do
       click_on "Create"
       expect(page).to have_content("Successful creation")
 
-      expect(page).to have_css("td.currency", text: "150.00 EUR")
-      expect(new_budget_page.unit_costs_at(1)).to have_content "150.00 EUR"
-      expect(new_budget_page.unit_costs_at(2)).to have_content "100.00 EUR"
-      expect(new_budget_page.overall_unit_costs).to have_content "250.00 EUR"
+      expect(page).to have_css("td.currency", text: "150.00 €")
+      expect(new_budget_page.unit_costs_at(1)).to have_content "150.00 €"
+      expect(new_budget_page.unit_costs_at(2)).to have_content "100.00 €"
+      expect(new_budget_page.overall_unit_costs).to have_content "250.00 €"
 
-      expect(page).to have_css("td.currency", text: "125.00 EUR")
-      expect(new_budget_page.labor_costs_at(1)).to have_content "125.00 EUR"
-      expect(new_budget_page.labor_costs_at(2)).to have_content "50.00 EUR"
-      expect(new_budget_page.overall_labor_costs).to have_content "175.00 EUR"
+      expect(page).to have_css("td.currency", text: "125.00 €")
+      expect(new_budget_page.labor_costs_at(1)).to have_content "125.00 €"
+      expect(new_budget_page.labor_costs_at(2)).to have_content "50.00 €"
+      expect(new_budget_page.overall_labor_costs).to have_content "175.00 €"
     end
   end
 end

--- a/modules/budgets/spec/features/budgets/copy_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/copy_budget_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe "Copying a budget", :js do
 
     budget_page.expect_subject(budget_subject)
 
-    budget_page.expect_planned_costs!(type: :labor, row: 1, expected: "125.00 EUR")
-    budget_page.expect_planned_costs!(type: :material, row: 1, expected: "150.00 EUR")
-    budget_page.expect_planned_costs!(type: :material, row: 2, expected: "600,000.00 EUR")
+    budget_page.expect_planned_costs!(type: :labor, row: 1, expected: "125.00 €")
+    budget_page.expect_planned_costs!(type: :material, row: 1, expected: "150.00 €")
+    budget_page.expect_planned_costs!(type: :material, row: 2, expected: "600,000.00 €")
 
     click_button "Create"
 

--- a/modules/budgets/spec/features/budgets/update_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/update_budget_spec.rb
@@ -28,7 +28,7 @@
 
 require_relative "../../spec_helper"
 
-RSpec.describe "updating a budget", :js do
+RSpec.describe "updating a budget", :js, with_settings: { costs_currency: "EUR" } do
   let(:project) do
     create(:project_with_types,
            enabled_module_names: %i[budgets costs work_package_tracking],

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -166,7 +166,7 @@ module Costs
     end
 
     initializer "costs.settings" do
-      ::Settings::Definition.add "costs_currency", default: "EUR", format: :string
+      ::Settings::Definition.add "costs_currency", default: "€", format: :string
       ::Settings::Definition.add "costs_currency_format", default: "%n %u", format: :string
       ::Settings::Definition.add "allow_tracking_start_and_end_times", default: false, format: :boolean
       ::Settings::Definition.add "enforce_tracking_start_and_end_times", default: false, format: :boolean

--- a/modules/costs/lib/costs/patches/number_to_currency_converter_patch.rb
+++ b/modules/costs/lib/costs/patches/number_to_currency_converter_patch.rb
@@ -34,7 +34,8 @@ module Costs::Patches::NumberToCurrencyConverterPatch
   module InstanceMethods
     def i18n_opts
       super.merge(unit: ERB::Util.h(Setting.costs_currency),
-                  format: ERB::Util.h(Setting.costs_currency_format))
+                  format: ERB::Util.h(Setting.costs_currency_format),
+                  negative_format: "-#{ERB::Util.h(Setting.costs_currency_format)}")
     end
   end
 end

--- a/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
+++ b/modules/costs/spec/features/cost_entries/add_cost_entry_spec.rb
@@ -77,16 +77,16 @@ RSpec.describe "Work Package cost fields", :js do
     fill_in "cost_entry_units", with: "1"
 
     expect(page).to have_css("#cost_entry_unit_name", text: "A single")
-    expect(page).to have_css("#cost_entry_costs", text: "1.00 EUR")
+    expect(page).to have_css("#cost_entry_costs", text: "1.00 €")
 
     fill_in "cost_entry_units", with: "2"
     expect(page).to have_css("#cost_entry_unit_name", text: "A plural")
-    expect(page).to have_css("#cost_entry_costs", text: "2.00 EUR")
+    expect(page).to have_css("#cost_entry_costs", text: "2.00 €")
 
     # Switch cost type
     select "B", from: "cost_entry_cost_type_id"
     expect(page).to have_css("#cost_entry_unit_name", text: "B plural")
-    expect(page).to have_css("#cost_entry_costs", text: "4.00 EUR")
+    expect(page).to have_css("#cost_entry_costs", text: "4.00 €")
 
     # Override costs
     find_by_id("cost_entry_costs").click
@@ -104,7 +104,7 @@ RSpec.describe "Work Package cost fields", :js do
     expect(entry.real_costs).to eq(15.52)
 
     visit edit_cost_entry_path(entry)
-    expect(page).to have_css("#cost_entry_costs", text: "15.52 EUR")
+    expect(page).to have_css("#cost_entry_costs", text: "15.52 €")
   end
 
   context "with german locale" do
@@ -116,11 +116,11 @@ RSpec.describe "Work Package cost fields", :js do
       full_view.select_log_unit_costs_action
 
       fill_in CostEntry.human_attribute_name(:units), with: "1,42"
-      expect(page).to have_css("#cost_entry_costs", text: "1,42 EUR")
+      expect(page).to have_css("#cost_entry_costs", text: "1,42 €")
 
       select "B", from: CostEntry.human_attribute_name(:cost_type)
       expect(page).to have_css("#cost_entry_unit_name", text: "B plural")
-      expect(page).to have_css("#cost_entry_costs", text: "2,84 EUR")
+      expect(page).to have_css("#cost_entry_costs", text: "2,84 €")
 
       # Override costs
       find_by_id("cost_entry_costs").click
@@ -139,7 +139,7 @@ RSpec.describe "Work Package cost fields", :js do
 
       # Can edit the costs again
       visit edit_cost_entry_path(entry)
-      expect(page).to have_css("#cost_entry_costs", text: "1.350,25 EUR")
+      expect(page).to have_css("#cost_entry_costs", text: "1.350,25 €")
 
       # Toggle the cost button
       SeleniumHubWaiter.wait
@@ -151,7 +151,7 @@ RSpec.describe "Work Package cost fields", :js do
       click_on I18n.t(:button_save)
 
       # Add explicit wait for the updated cost value
-      wait_for { page }.to have_css("#cost_entry_costs", text: "55.000,55 EUR")
+      wait_for { page }.to have_css("#cost_entry_costs", text: "55.000,55 €")
 
       entry.reload
       expect(entry.units).to eq(1.42)

--- a/modules/costs/spec/features/members_hourly_rates_spec.rb
+++ b/modules/costs/spec/features/members_hourly_rates_spec.rb
@@ -80,33 +80,33 @@ RSpec.describe "hourly rates on a member", :js do
   end
 
   it "displays always the currently active rate" do
-    expect_current_rate_in_members_table("0.00 EUR")
+    expect_current_rate_in_members_table("0.00 €")
 
-    click_link("0.00 EUR")
+    click_link("0.00 €")
     SeleniumHubWaiter.wait
 
     add_rate(date: Date.current, rate: 10)
 
     click_button "Save"
 
-    expect_current_rate_in_members_table("10.00 EUR")
+    expect_current_rate_in_members_table("10.00 €")
 
     SeleniumHubWaiter.wait
-    click_link("10.00 EUR")
+    click_link("10.00 €")
 
     add_rate(date: 3.days.ago, rate: 20)
 
     click_button "Save"
 
-    expect_current_rate_in_members_table("10.00 EUR")
+    expect_current_rate_in_members_table("10.00 €")
 
     SeleniumHubWaiter.wait
-    click_link("10.00 EUR")
+    click_link("10.00 €")
 
     change_rate_date(from: Date.current, to: 5.days.ago)
 
     click_button "Save"
 
-    expect_current_rate_in_members_table("20.00 EUR")
+    expect_current_rate_in_members_table("20.00 €")
   end
 end

--- a/modules/costs/spec/features/view_own_rates_spec.rb
+++ b/modules/costs/spec/features/view_own_rates_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe "Only see your own rates", :js do
     # All the values do not include the entries made by the other user
     wp_page.expect_attributes spent_time: "1h",
                               costs_by_type: "2 Translations",
-                              overall_costs: "24.00 EUR",
-                              labor_costs: "10.00 EUR",
-                              material_costs: "14.00 EUR"
+                              overall_costs: "24.00 €",
+                              labor_costs: "10.00 €",
+                              material_costs: "14.00 €"
   end
 end

--- a/modules/costs/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/modules/costs/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_hourly_rates view_time_entries] }
 
           it "is expected to have a laborCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("laborCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("laborCosts")
           end
         end
 
@@ -185,7 +185,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_own_hourly_rate view_own_time_entries] }
 
           it "is expected to have a laborCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("laborCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("laborCosts")
           end
         end
 
@@ -205,7 +205,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_own_cost_entries view_cost_rates] }
 
           it "is expected to have a materialCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("materialCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("materialCosts")
           end
         end
 
@@ -213,7 +213,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_cost_entries view_cost_rates] }
 
           it "is expected to have a materialCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("materialCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("materialCosts")
           end
         end
 
@@ -235,7 +235,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_hourly_rates view_time_entries] }
 
           it "is expected to have a overallCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("overallCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("overallCosts")
           end
         end
 
@@ -243,7 +243,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_own_time_entries view_own_hourly_rate] }
 
           it "is expected to have a overallCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("overallCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("overallCosts")
           end
         end
 
@@ -251,7 +251,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_own_cost_entries view_cost_rates] }
 
           it "is expected to have a overallCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("overallCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("overallCosts")
           end
         end
 
@@ -259,7 +259,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
           let(:additional_permissions) { %i[view_cost_entries view_cost_rates] }
 
           it "is expected to have a overallCosts attribute" do
-            expect(subject).to be_json_eql("6,000.00 EUR".to_json).at_path("overallCosts")
+            expect(subject).to be_json_eql("6,000.00 €".to_json).at_path("overallCosts")
           end
         end
 

--- a/modules/reporting/spec/features/permissions_spec.rb
+++ b/modules/reporting/spec/features/permissions_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Cost report calculations", :js do
       report_page.switch_to_type "Translations"
 
       expect(page).to have_content "3.0 plural_unit"
-      expect(page).to have_content "21.00 EUR"
+      expect(page).to have_content "21.00 €"
     end
   end
 

--- a/spec/features/work_packages/index_sums_spec.rb
+++ b/spec/features/work_packages/index_sums_spec.rb
@@ -148,9 +148,9 @@ RSpec.describe "Work package index sums", :js do
         expect(row).to have_css(".percentageDone", text: "50%")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
-        expect(row).to have_css(".laborCosts", text: "15.00 EUR")
-        expect(row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-        expect(row).to have_css(".overallCosts", text: "22.50 EUR")
+        expect(row).to have_css(".laborCosts", text: "15.00 €")
+        expect(row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+        expect(row).to have_css(".overallCosts", text: "22.50 €")
       end
     end
 
@@ -167,9 +167,9 @@ RSpec.describe "Work package index sums", :js do
         expect(row).to have_css(".percentageDone", text: "44%")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
-        expect(row).to have_css(".laborCosts", text: "15.00 EUR")
-        expect(row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-        expect(row).to have_css(".overallCosts", text: "22.50 EUR")
+        expect(row).to have_css(".laborCosts", text: "15.00 €")
+        expect(row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+        expect(row).to have_css(".overallCosts", text: "22.50 €")
       end
     end
 
@@ -188,9 +188,9 @@ RSpec.describe "Work package index sums", :js do
       expect(first_sum_row).to have_css(".percentageDone", text: "40%")
       expect(first_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "5")
       expect(first_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "5.5")
-      expect(first_sum_row).to have_css(".laborCosts", text: "15.00 EUR")
-      expect(first_sum_row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-      expect(first_sum_row).to have_css(".overallCosts", text: "22.50 EUR")
+      expect(first_sum_row).to have_css(".laborCosts", text: "15.00 €")
+      expect(first_sum_row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+      expect(first_sum_row).to have_css(".overallCosts", text: "22.50 €")
     end
 
     # Second status row
@@ -213,9 +213,9 @@ RSpec.describe "Work package index sums", :js do
         expect(row).to have_css(".percentageDone", text: "44%")
         expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
         expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
-        expect(row).to have_css(".laborCosts", text: "15.00 EUR")
-        expect(row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-        expect(row).to have_css(".overallCosts", text: "22.50 EUR")
+        expect(row).to have_css(".laborCosts", text: "15.00 €")
+        expect(row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+        expect(row).to have_css(".overallCosts", text: "22.50 €")
       end
     end
 
@@ -289,9 +289,9 @@ RSpec.describe "Work package index sums", :js do
           expect(row).to have_css(".percentageDone", text: "50%")
           expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "24")
           expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "26.4")
-          expect(row).to have_css(".laborCosts", text: "40.00 EUR")
-          expect(row).to have_css(".materialCosts", text: "18.00 EUR") # Unit costs
-          expect(row).to have_css(".overallCosts", text: "58.00 EUR")
+          expect(row).to have_css(".laborCosts", text: "40.00 €")
+          expect(row).to have_css(".materialCosts", text: "18.00 €") # Unit costs
+          expect(row).to have_css(".overallCosts", text: "58.00 €")
         end
       end
 
@@ -336,9 +336,9 @@ RSpec.describe "Work package index sums", :js do
         expect(first_sum_row).to have_css(".percentageDone", text: "50%")
         expect(first_sum_row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "5")
         expect(first_sum_row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "5.5")
-        expect(first_sum_row).to have_css(".laborCosts", text: "15.00 EUR")
-        expect(first_sum_row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-        expect(first_sum_row).to have_css(".overallCosts", text: "22.50 EUR")
+        expect(first_sum_row).to have_css(".laborCosts", text: "15.00 €")
+        expect(first_sum_row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+        expect(first_sum_row).to have_css(".overallCosts", text: "22.50 €")
       end
 
       # Second status row
@@ -361,9 +361,9 @@ RSpec.describe "Work package index sums", :js do
           expect(row).to have_css(".percentageDone", text: "50%")
           expect(row).to have_css(".#{int_cf.attribute_name(:camel_case)}", text: "12")
           expect(row).to have_css(".#{float_cf.attribute_name(:camel_case)}", text: "13.2")
-          expect(row).to have_css(".laborCosts", text: "15.00 EUR")
-          expect(row).to have_css(".materialCosts", text: "7.50 EUR") # Unit costs
-          expect(row).to have_css(".overallCosts", text: "22.50 EUR")
+          expect(row).to have_css(".laborCosts", text: "15.00 €")
+          expect(row).to have_css(".materialCosts", text: "7.50 €") # Unit costs
+          expect(row).to have_css(".overallCosts", text: "22.50 €")
         end
       end
     end

--- a/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_sums_representer_spec.rb
@@ -87,21 +87,21 @@ RSpec.describe API::V3::WorkPackages::WorkPackageSumsRepresenter do
 
   describe "materialCosts" do
     it "is represented" do
-      expected = "5.00 EUR"
+      expected = "5.00 €"
       expect(subject).to be_json_eql(expected.to_json).at_path("materialCosts")
     end
   end
 
   describe "laborCosts" do
     it "is represented" do
-      expected = "10.00 EUR"
+      expected = "10.00 €"
       expect(subject).to be_json_eql(expected.to_json).at_path("laborCosts")
     end
   end
 
   describe "overallCosts" do
     it "is represented" do
-      expected = "15.00 EUR"
+      expected = "15.00 €"
       expect(subject).to be_json_eql(expected.to_json).at_path("overallCosts")
     end
   end

--- a/spec/requests/api/v3/work_packages/by_workspace_index_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/by_workspace_index_resource_spec.rb
@@ -214,9 +214,9 @@ RSpec.describe "GET api/v3/workspace/:id/work_packages", content_type: :json do
       it "contains the sum element" do
         expected = {
           estimatedTime: "PT3H",
-          laborCosts: "0.00 EUR",
-          materialCosts: "0.00 EUR",
-          overallCosts: "0.00 EUR",
+          laborCosts: "0.00 €",
+          materialCosts: "0.00 €",
+          overallCosts: "0.00 €",
           percentageDone: nil,
           remainingTime: nil,
           storyPoints: nil


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72262

# What are you trying to accomplish?
Apply negative currency format and change default from "EUR" to "€"

## Screenshots

<img width="1455" height="156" alt="Bildschirmfoto 2026-02-23 um 16 11 43" src="https://github.com/user-attachments/assets/af43aeff-76c8-4d47-9d1b-324ce29bc154" />
