### PR TITLE
[chore] pass down routed for angular flag

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-new-full-view.html
@@ -27,6 +27,7 @@
         </ul>
       </div>
       <wp-single-view [workPackage]="newWorkPackage"
+                      [routedFromAngular]="routedFromAngular"
                       [showProject]="copying" />
       <wp-edit-actions-bar (onCancel)="cancelAndBack()" />
     </edit-form>

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
@@ -107,6 +107,7 @@
             <ndc-dynamic [ndcDynamicComponent]="attributeGroupComponent(group)"
                    [ndcDynamicInputs]="{ workPackage: workPackage,
                                          group: group,
+                                         routedFromAngular: routedFromAngular,
                                          query: group.query }" />
           </ng-container>
         }

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -104,6 +104,8 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
   /** Should we show the project field */
   @Input() public showProject = false;
 
+  @Input() public routedFromAngular = true;
+
   // Grouped fields returned from API
   public groupedFields:GroupDescriptor[] = [];
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -60,7 +60,8 @@
     <div class="work-packages-full-view--split-container">
       <div class="work-packages-full-view--split-left">
         <div class="work-packages--panel-inner">
-          <wp-single-view [workPackage]="workPackage" />
+          <wp-single-view [workPackage]="workPackage"
+                          [routedFromAngular]="routedFromAngular"/>
         </div>
       </div>
       <div class="work-packages-full-view--split-right work-packages-tab-view--overflow">


### PR DESCRIPTION
# What are you trying to accomplish?
- have the routed for angular flag available in the bahn plugin custom wp query components

# What approach did you choose and why?
- enable that input flag on dynamically loaded embedded query components
