### PR TITLE
Rename column in OAuth application tokens table

### DIFF
--- a/app/components/my/access_token/oauth_application/row_component.rb
+++ b/app/components/my/access_token/oauth_application/row_component.rb
@@ -52,7 +52,7 @@ module My
           end
         end
 
-        def last_used_at
+        def last_refreshed_at
           return "—" if oauth_application_tokens.empty?
 
           helpers.format_time(oauth_application_tokens.max_by(&:created_at).created_at)

--- a/app/components/my/access_token/oauth_application/table_component.rb
+++ b/app/components/my/access_token/oauth_application/table_component.rb
@@ -32,15 +32,15 @@ module My
   module AccessToken
     module OAuthApplication
       class TableComponent < OpPrimer::BorderBoxTableComponent
-        columns :name, :active_tokens, :last_used_at
+        columns :name, :active_tokens, :last_refreshed_at
         main_column :name
-        mobile_labels :active_tokens, :last_used_at
+        mobile_labels :active_tokens, :last_refreshed_at
 
         def headers
           [
             [:name, { caption: I18n.t("attributes.name") }],
             [:active_tokens, { caption: I18n.t("my_account.access_tokens.oauth_application.active_tokens") }],
-            [:last_used_at, { caption: I18n.t("my_account.access_tokens.oauth_application.last_used_at") }]
+            [:last_refreshed_at, { caption: I18n.t("my_account.access_tokens.oauth_application.last_refreshed_at") }]
           ]
         end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3156,7 +3156,7 @@ en:
         active_tokens: "Active tokens"
         blank_description: "There is no third-party application access configured and active for you."
         blank_title: "No OAuth application token"
-        last_used_at: "Last used at"
+        last_refreshed_at: "Last refreshed at"
         title: "OAuth"
         table_title: "OAuth application tokens"
         text_hint: "OAuth application tokens allow third-party applications to connect with this OpenProject instance."


### PR DESCRIPTION
The column doesn't quite show when a token was last used, but rather when the corresponding client last refreshed a token for this app.

The new column title is hopefully a bit more clear on what's being indicated.