### PR TITLE
[72459] Wrong wording in Enterprise on-prem support token input field

### DIFF
--- a/app/forms/enterprise_tokens/token_form.rb
+++ b/app/forms/enterprise_tokens/token_form.rb
@@ -29,14 +29,23 @@
 #++
 module EnterpriseTokens
   class TokenForm < ApplicationForm
+    include Redmine::I18n
+
     form do |f|
       f.text_area(
         name: :encoded_token,
         label: I18n.t("admin.enterprise.create_dialog.type_token_text"),
         placeholder: I18n.t("admin.enterprise.create_dialog.token_placeholder"),
+        caption:,
         rows: 10,
         style: "resize: none"
       )
+    end
+
+    def caption
+      link_translate("admin.enterprise.create_dialog.token_caption",
+                     links: { docs_url: %i[enterprise_guide on_premises activate] },
+                     external: true)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,8 +92,9 @@ en:
         confirmation: "Are you sure you want to delete this Enterprise edition support token?"
       create_dialog:
         title: "Add Enterprise token"
-        type_token_text: "Type support token text"
+        type_token_text: "Your Enterprise token text"
         token_placeholder: "Paste your Enterprise edition support token here"
+        token_caption: "To learn more about how to activate Enterprise edition check our [documentation](docs_url)."
       add_token: "Upload an Enterprise edition support token"
       replace_token: "Replace your current support token"
       order: "Order Enterprise on-premises edition"

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -68,6 +68,10 @@ enterprise_features:
     href: https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-status/#create-a-new-work-package-status
   work_package_subject_generation:
     href: https://www.openproject.org/docs/system-admin-guide/manage-work-packages/work-package-types/automatic-subjects/
+enterprise_guide:
+  on_premises:
+    activate:
+      href: https://www.openproject.org/docs/enterprise-guide/enterprise-on-premises-guide/activate-enterprise-on-premises/
 enterprise_support:
   href: https://www.openproject.org/docs/enterprise-guide/support/
   label: :label_enterprise_support

--- a/spec/features/admin/enterprise/enterprise_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Enterprise token", :js do
       click_button "Add Enterprise token"
 
       expect(page).to have_dialog("Add Enterprise token")
-      expect(page).to have_field("Type support token text", type: "textarea")
+      expect(page).to have_field("Your Enterprise token text", type: "textarea")
     end
 
     context "with invalid input" do
@@ -135,7 +135,7 @@ RSpec.describe "Enterprise token", :js do
         enterprise_tokens_page.expect_add_token_validation_error("This token has already been added.")
 
         # Try importing with blank spaces and newlines before and after
-        fill_in "Type support token text", with: " \nfoobar \n"
+        fill_in "Your Enterprise token text", with: " \nfoobar \n"
         click_button "Add"
 
         # The dialog is still open with an error message on token field

--- a/spec/support/pages/admin/enterprise_tokens/index.rb
+++ b/spec/support/pages/admin/enterprise_tokens/index.rb
@@ -41,7 +41,7 @@ module Pages
         def add_enterprise_token(token_text)
           click_button "Add Enterprise token"
           modals.expect_modal("Add Enterprise token")
-          fill_in "Type support token text", with: token_text
+          fill_in "Your Enterprise token text", with: token_text
           click_button "Add"
         end
 
@@ -53,7 +53,7 @@ module Pages
 
         def expect_add_token_validation_error(message)
           expect(page).to have_dialog("Add Enterprise token")
-          expect(page).to have_field("Type support token text", validation_error: message)
+          expect(page).to have_field("Your Enterprise token text", validation_error: message)
         end
 
         private


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72459

# What are you trying to accomplish?
Update texts and caption in EE token dialog

## Screenshots

<img width="515" height="467" alt="Bildschirmfoto 2026-02-25 um 10 09 28" src="https://github.com/user-attachments/assets/888d954b-4e33-4b42-a583-033844ff7c50" />

