### PR TITLE
[71135] Multi-user custom field requires clicking twice in order to be in focus

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -211,6 +211,10 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
         } else {
           this.setValues(values.elements);
         }
+
+        // Focus and open the field once the values are loaded
+        this.ngSelectComponent.focus();
+        this.openAutocompleteSelectField();
       });
     } else {
       this.setValues([]);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71135

# What are you trying to accomplish?
Focus the field after loading the values

