### PR TITLE
bump version of op-blocknote-extensions to 0.0.23

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -108,7 +108,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.1.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.22/op-blocknote-extensions-0.0.22.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
         "openapi-explorer": "^2.4.788",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -19984,9 +19984,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.22",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.22/op-blocknote-extensions-0.0.22.tgz",
-      "integrity": "sha512-EL8/u9ZvRjWjsbOu0ot/+VNKYXnr8bkEHmUiUpyK4FUYfumwc6w7Se0Ob78BSitQgRiP3eEfg0E8pp1kS0eOQQ==",
+      "version": "0.0.23",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
+      "integrity": "sha512-QMGmGYt4KXooWRuYN8bVV+6oJVoeMmXBrQ8qlPaVeIzqS4fx7aWHQ6WU2vLuQAXVOF7SQweRTPnRKfpLG6O4eg==",
       "dependencies": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",
@@ -38653,8 +38653,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.22/op-blocknote-extensions-0.0.22.tgz",
-      "integrity": "sha512-EL8/u9ZvRjWjsbOu0ot/+VNKYXnr8bkEHmUiUpyK4FUYfumwc6w7Se0Ob78BSitQgRiP3eEfg0E8pp1kS0eOQQ==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
+      "integrity": "sha512-QMGmGYt4KXooWRuYN8bVV+6oJVoeMmXBrQ8qlPaVeIzqS4fx7aWHQ6WU2vLuQAXVOF7SQweRTPnRKfpLG6O4eg==",
       "requires": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.1.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.22/op-blocknote-extensions-0.0.22.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
     "openapi-explorer": "^2.4.788",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION
https://community.openproject.org/wp/71898