### PR TITLE
Allow to filter special characters from folder names created in Nextcloud

### DIFF
--- a/docs/api/apiv3/components/schemas/storage_read_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_read_model.yml
@@ -54,6 +54,13 @@ properties:
       Whether the storage has the application password to use for the Nextcloud storage.
 
       Ignored if the provider type is not Nextcloud.
+  forbiddenFileNameCharacters:
+    type: string
+    description: |-
+      A string with all the characters forbidden to be used for file and folder names in the storage. Used by OpenProject to avoid
+      creating files with unsupported names (e.g. when creating project folders).
+
+      Only supported for provider type Nextcloud so far.
   createdAt:
     type: string
     format: date-time

--- a/docs/api/apiv3/components/schemas/storage_write_model.yml
+++ b/docs/api/apiv3/components/schemas/storage_write_model.yml
@@ -29,6 +29,13 @@ properties:
 
       If a string is provided, the password is set and automatic management is enabled for the storage.
       If null is provided, the password is unset and automatic management is disabled for the storage.
+  forbiddenFileNameCharacters:
+    type: string
+    description: |-
+      A string with all the characters forbidden to be used for file and folder names in the storage. Used by OpenProject to avoid
+      creating files with unsupported names (e.g. when creating project folders).
+
+      Only supported for provider type Nextcloud so far.
   _links:
     type: object
     required:

--- a/modules/storages/app/models/storages/nextcloud_storage.rb
+++ b/modules/storages/app/models/storages/nextcloud_storage.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
@@ -49,6 +49,10 @@ module Storages
     store_attribute :provider_fields, :authentication_method, :string, default: "two_way_oauth2"
     store_attribute :provider_fields, :storage_audience, :string
     store_attribute :provider_fields, :token_exchange_scope, :string
+
+    # Default has been chosen to maximize compatibility with Windows-based Nextcloud clients
+    # also see https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+    store_attribute :provider_fields, :forbidden_file_name_characters, :string, default: "<>:\"\\/|?*"
 
     def self.short_provider_name = :nextcloud
 

--- a/modules/storages/db/migrate/20260226133700_set_nextcloud_default_prohibited_characters.rb
+++ b/modules/storages/db/migrate/20260226133700_set_nextcloud_default_prohibited_characters.rb
@@ -28,41 +28,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Storages
-  module Adapters
-    module Providers
-      module Nextcloud
-        class ManagedFolderIdentifier
-          def initialize(project_storage)
-            @storage = project_storage.storage
-            @project = project_storage.project
-          end
+class SetNextcloudDefaultProhibitedCharacters < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
 
-          def name
-            "#{filter_restricted_characters(@project.name)} (#{@project.id})"
-          end
+  def up
+    execute <<~SQL.squish
+      UPDATE storages
+      SET provider_fields = provider_fields || '{ "forbidden_file_name_characters": "<>:\\"\\\\/|?*" }'::jsonb
+      WHERE provider_type = 'Storages::NextcloudStorage' AND NOT provider_fields ? 'forbidden_file_name_characters'
+    SQL
+  end
 
-          def path
-            "/#{@storage.group_folder}/#{name}/"
-          end
-
-          def location
-            path
-          end
-
-          private
-
-          def filter_restricted_characters(name)
-            # slashes have historically always been replaced with |
-            # hardcoding slash and backslash instead of making them configurable also prevents project names to be usable
-            # for directory-escape attempts (e.g. "../project name")
-            name = name.tr("/\\", "|")
-
-            # other forbidden characters are replaced with _, consistent with other storages
-            name.tr(@storage.forbidden_file_name_characters, "_")
-          end
-        end
-      end
-    end
+  def down
+    # we'll not delete any JSONB data on rollback
+    # though there's also no need to artificially block rollbacks past this version
   end
 end

--- a/modules/storages/lib/api/v3/storages/storage_representer.rb
+++ b/modules/storages/lib/api/v3/storages/storage_representer.rb
@@ -140,6 +140,13 @@ module API::V3::Storages
              end,
              setter: ->(*) {}
 
+    property :forbiddenFileNameCharacters,
+             skip_render: ->(represented:, **) { !represented.provider_type_nextcloud? },
+             getter: ->(represented:, **) do
+               represented.forbidden_file_name_characters if represented.provider_type_nextcloud?
+             end,
+             setter: ->(fragment:, represented:, **) { represented.forbidden_file_name_characters = fragment }
+
     date_time_property :created_at
 
     date_time_property :updated_at

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/managed_folder_identifier_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/managed_folder_identifier_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Storages::Adapters::Providers::Nextcloud::ManagedFolderIdentifier do
+  let(:managed_folder_identifier) { described_class.new(project_storage) }
+
+  let(:project_storage) { create(:project_storage, project:, storage:) }
+  let(:project) { create(:project, name: project_name) }
+  let(:project_name) { "My great Demo project" }
+  let(:storage) { create(:nextcloud_storage) }
+
+  describe "#path" do
+    subject { managed_folder_identifier.path }
+
+    it { is_expected.to eq("/OpenProject/My great Demo project (#{project.id})/") }
+
+    context "when the project name contains a slash" do
+      let(:project_name) { "My great/awesome project" }
+
+      it { is_expected.to eq("/OpenProject/My great|awesome project (#{project.id})/") }
+
+      context "when the pipe character is prohibited by the storage" do
+        let(:storage) { create(:nextcloud_storage, forbidden_file_name_characters: "|") }
+
+        it { is_expected.to eq("/OpenProject/My great_awesome project (#{project.id})/") }
+      end
+    end
+
+    context "when the project name contains a backslash" do
+      let(:project_name) { "My great\\awesome project" }
+
+      it { is_expected.to eq("/OpenProject/My great|awesome project (#{project.id})/") }
+
+      context "when the pipe character is prohibited by the storage" do
+        let(:storage) { create(:nextcloud_storage, forbidden_file_name_characters: "|") }
+
+        it { is_expected.to eq("/OpenProject/My great_awesome project (#{project.id})/") }
+      end
+    end
+
+    context "when the project name contains special characters" do
+      let(:project_name) { "My $pecia| project: The ☃" }
+
+      it { is_expected.to eq("/OpenProject/My $pecia| project: The ☃ (#{project.id})/") }
+
+      context "and when certain characters are prohibited by the storage" do
+        let(:storage) { create(:nextcloud_storage, forbidden_file_name_characters: "$:") }
+
+        it { is_expected.to eq("/OpenProject/My _pecia| project_ The ☃ (#{project.id})/") }
+      end
+    end
+  end
+end

--- a/modules/storages/spec/factories/storage_factory.rb
+++ b/modules/storages/spec/factories/storage_factory.rb
@@ -93,6 +93,7 @@ FactoryBot.define do
     sequence(:host) { |n| "https://host#{n}.example.com/" }
     authentication_method { "two_way_oauth2" }
     storage_audience { nil }
+    forbidden_file_name_characters { "" }
 
     trait :with_oauth_configured do
       after(:create) do |storage, _evaluator|

--- a/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
+++ b/modules/storages/spec/lib/api/v3/storages/storages_representer_rendering_spec.rb
@@ -227,10 +227,18 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
     let(:oauth_application) { build_stubbed(:oauth_application) }
     let(:storage) { build_stubbed(:nextcloud_storage, oauth_application:, oauth_client: oauth_client_credentials) }
 
+    it "fulfills the documented schema" do
+      expect(generated).to match_json_schema.from_docs("storage_read_model")
+    end
+
     it_behaves_like "common file storage properties"
 
     context "if file storage is not completely configured" do
       let(:storage) { build_stubbed(:nextcloud_storage, oauth_client: nil) }
+
+      it "fulfills the documented schema" do
+        expect(generated).to match_json_schema.from_docs("storage_read_model")
+      end
 
       it_behaves_like "property", :configured do
         let(:value) { false }
@@ -357,10 +365,18 @@ RSpec.describe API::V3::Storages::StorageRepresenter, "rendering" do
   context "if file storage has provider type OneDrive" do
     let(:storage) { build_stubbed(:one_drive_storage, oauth_client: oauth_client_credentials) }
 
+    it "fulfills the documented schema" do
+      expect(generated).to match_json_schema.from_docs("storage_read_model")
+    end
+
     it_behaves_like "common file storage properties"
 
     context "if file storage is not completely configured" do
       let(:storage) { build_stubbed(:one_drive_storage, drive_id: nil, oauth_client: oauth_client_credentials) }
+
+      it "fulfills the documented schema" do
+        expect(generated).to match_json_schema.from_docs("storage_read_model")
+      end
 
       it_behaves_like "property", :configured do
         let(:value) { false }


### PR DESCRIPTION
This is the foundation to properly support the "windows compatibility"
mode of Nextcloud. Nextcloud also supports setting up custom character
block lists, that's why we can't work with a hardcoded list of forbidden
characters, but need to allow defining it per storage.

This PR introduces these forbidden characters as a hidden setting (not available via UI), but makes it also available via API already.

# Ticket
https://community.openproject.org/wp/72525

# Screenshots

I just confirmed locally that the fix is fixing:

<img width="289" height="117" alt="image" src="https://github.com/user-attachments/assets/bb91a10f-1c87-4dcb-9482-3534c131ac2c" />

<img width="289" height="117" alt="image" src="https://github.com/user-attachments/assets/08223b3f-8b85-4c92-8d2c-7b65b4c601f6" />
