### PR TITLE
[72248] Titles and totals are cut off 

### DIFF
--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -44,6 +44,10 @@ $widget-box--enumeration-width: 20px
 
       &_half-width
         flex-basis: calc(25% - var(--stack-gap-normal))
+        min-width: 200px
+
+        @media screen and (max-width: $breakpoint-lg)
+          flex-basis: calc(50% - var(--stack-gap-normal))
 
       &_full-width
         flex-basis: 100%
@@ -188,6 +192,7 @@ $widget-box--enumeration-width: 20px
     font-weight: var(--base-text-weight-bold)
     color: var(--fgColor-default) !important
     padding: 0 !important
+    @include text-shortener
 
   .toolbar--editable-toolbar
     height: 20px


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72248

# What are you trying to accomplish?
Avoid too heavy shrinking of small budget widgets by:

* Providing a minimal width
* Truncating the header if necessary
* Increasing the width of the widgets on smaller screens

There is one edge case where the widgets wrap not evenly but the last one moves to the next row already. 

## Screenshots


<img width="656" height="292" alt="Bildschirmfoto 2026-02-27 um 11 52 04" src="https://github.com/user-attachments/assets/3e9d5b8d-cd29-4f6d-90a9-cf4ac059c8ab" />
