### PR TITLE
Add IndexedDB offline persistence for document editing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -127,6 +127,7 @@
         "typedjson": "^1.5.1",
         "urijs": "^1.19.11",
         "uuid": "^13.0.0",
+        "y-indexeddb": "^9.0.12",
         "zone.js": "~0.15.1"
       },
       "devDependencies": {
@@ -25809,6 +25810,26 @@
         "repeat-string": "^1.5.2"
       }
     },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/y-prosemirror": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
@@ -42770,6 +42791,14 @@
       "integrity": "sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==",
       "requires": {
         "repeat-string": "^1.5.2"
+      }
+    },
+    "y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "requires": {
+        "lib0": "^0.2.74"
       }
     },
     "y-prosemirror": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -182,6 +182,7 @@
     "typedjson": "^1.5.1",
     "urijs": "^1.19.11",
     "uuid": "^13.0.0",
+    "y-indexeddb": "^9.0.12",
     "zone.js": "~0.15.1"
   },
   "optionalDependencies": {

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -107,7 +107,7 @@ class BlockNoteElement extends HTMLElement {
 
     this.renderCallback = (provider:HocuspocusProvider) => {
       this.reactRoot?.render(
-        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
+        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider, LiveCollaborationManager.hasCachedDocument))
       );
     };
 
@@ -132,7 +132,7 @@ class BlockNoteElement extends HTMLElement {
     }
   }
 
-  private BlockNoteReactContainer = (hocuspocusProvider:HocuspocusProvider) => {
+  private BlockNoteReactContainer = (hocuspocusProvider:HocuspocusProvider, hasCachedDocument:boolean) => {
     return React.createElement(
       ShadowDomWrapper,
       { target: this.editorMount },
@@ -144,7 +144,8 @@ class BlockNoteElement extends HTMLElement {
           openProjectUrl: this.getAttribute('open-project-url') ?? '',
           attachmentsUploadUrl: this.getAttribute('attachments-upload-url') ?? '',
           attachmentsCollectionKey: this.getAttribute('attachments-collection-key') ?? '',
-          hocuspocusProvider,
+          hocuspocusProvider: hocuspocusProvider,
+          hasCachedDocument: hasCachedDocument,
           errorContainer: this.errorContainer,
         }
       )

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -44,6 +44,7 @@ export interface OpBlockNoteContainerProps {
   attachmentsUploadUrl:string;
   attachmentsCollectionKey:string;
   hocuspocusProvider:HocuspocusProvider;
+  hasCachedDocument?:boolean;
   errorContainer?:HTMLElement;
 }
 
@@ -54,10 +55,11 @@ export default function OpBlockNoteContainer({
   attachmentsUploadUrl,
   attachmentsCollectionKey,
   hocuspocusProvider,
+  hasCachedDocument = false,
   errorContainer,
 }:OpBlockNoteContainerProps) {
   const doc:Y.Doc = hocuspocusProvider.document;
-  const { isLoading, offlineMode } = useCollaboration(hocuspocusProvider);
+  const { isLoading, offlineMode, blockingOffline } = useCollaboration(hocuspocusProvider, hasCachedDocument);
   const hadErrorRef = useRef(false);
 
   // Fetch error/recovery template based on connection state
@@ -66,7 +68,7 @@ export default function OpBlockNoteContainer({
 
     if (offlineMode) {
       hadErrorRef.current = true;
-      void fetchConnectionTemplate('error', errorContainer, { blocking: true });
+      void fetchConnectionTemplate('error', errorContainer, { blocking: blockingOffline });
     } else if (hadErrorRef.current) {
       // Only fetch recovery if we previously had an error (avoid fetching on initial render)
       void fetchConnectionTemplate('recovery', errorContainer);
@@ -77,10 +79,11 @@ export default function OpBlockNoteContainer({
     return <DocumentLoadingSkeleton />;
   }
 
-  // Without IndexedDB offline persistence, all offline is blocking — hide the
-  // editor entirely to prevent a fresh empty Y.Doc from being synced as
-  // authoritative server state on reconnect.
-  if (offlineMode) {
+  // When offline with no local cache, show only the error banner (rendered via
+  // errorContainer) and hide the editor entirely. A fresh empty Y.Doc must not be
+  // editable — it would be synced as authoritative server state on reconnect,
+  // overwriting real document content.
+  if (blockingOffline) {
     return null;
   }
 

--- a/frontend/src/react/hooks/useCollaboration.ts
+++ b/frontend/src/react/hooks/useCollaboration.ts
@@ -123,32 +123,39 @@ function useProviderAuthError(onAuthError:() => void) {
  * exposes it as React state for the BlockNote editor.
  *
  * Returns:
- * - `isLoading`   — true while waiting for the first sync after mount.
- * - `offlineMode` — true when the connection is lost or timed out; the editor
- *                   is hidden entirely (blocking) because there is no local
- *                   cache to edit from.
+ * - `isLoading`       — true while waiting for the first sync after mount.
+ * - `offlineMode`     — true when the connection is lost or timed out; the editor
+ *                       remains editable and changes are queued locally (IndexedDB)
+ *                       until the server is reachable again (only when hasCachedDocument).
+ * - `blockingOffline` — true when offline AND IndexedDB had no cached content at
+ *                       provider initialisation; the caller should hide the editor
+ *                       entirely to prevent a fresh empty Y.Doc from being synced as
+ *                       authoritative server state on reconnect.
  *
  * Transitions:
- *   mount → synced              : isLoading false, offlineMode false
- *   mount → timeout (5s)        : isLoading false, offlineMode true
- *   connected → disconnect      : offlineMode true
- *   offline → re-synced         : offlineMode false
- *   any → auth error            : isLoading false, offlineMode true
+ *   mount → synced                              : isLoading false, offlineMode false
+ *   mount → timeout (5s), hasCachedDocument     : isLoading false, offlineMode true
+ *   mount → timeout (5s), !hasCachedDocument    : isLoading false, blockingOffline true
+ *   connected → disconnect                      : offlineMode true
+ *   offline → re-synced                         : offlineMode false
+ *   any → auth error                            : isLoading false, blockingOffline true (cache cleared)
  */
-function useCollaboration(provider:HocuspocusProvider) {
+function useCollaboration(provider:HocuspocusProvider, hasCachedDocument = false) {
   const [isLoading, setIsLoading] = useState(true);
   const [offlineMode, setOfflineMode] = useState(false);
+  // Initialized from prop; set to false on auth error to reflect that the cache was cleared.
+  const [hasCachedDocumentState, setHasCachedDocumentState] = useState(hasCachedDocument);
 
   const handleSynced = useCallback(() => {
     debugLog('(BlockNote Editor) synced with collaboration server');
     setIsLoading(false);
-    setOfflineMode(false);
+    setOfflineMode(false); // banner disappears
   }, []);
 
   const handleDisconnect = useCallback(() => {
     debugLog('(BlockNote Editor) Disconnected - offline mode');
     setIsLoading(false);
-    setOfflineMode(true);
+    setOfflineMode(true); // show the banner, editing is available
   }, []);
 
   const handleTimeout = useCallback(() => {
@@ -158,6 +165,9 @@ function useCollaboration(provider:HocuspocusProvider) {
   }, []);
 
   const handleAuthError = useCallback(() => {
+    // Treat as no local cache: the IDB was cleared by the controller on auth error.
+    // This ensures blockingOffline=true regardless of the initial hasCachedDocument value.
+    setHasCachedDocumentState(false);
     setOfflineMode(true);
     setIsLoading(false);
   }, []);
@@ -166,7 +176,11 @@ function useCollaboration(provider:HocuspocusProvider) {
   useCollaborationProvider(provider, handleSynced, handleDisconnect);
   useProviderAuthError(handleAuthError);
 
-  return { isLoading, offlineMode } as const;
+  // When offline with no local cache, block the editor entirely to prevent an
+  // empty Y.Doc from being synced as the authoritative document on reconnect.
+  const blockingOffline = offlineMode && !hasCachedDocumentState;
+
+  return { isLoading, offlineMode, blockingOffline } as const;
 }
 
 export { useCollaboration };

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -38,6 +38,10 @@ import {
 } from 'core-stimulus/services/documents/token-refresh.service';
 import type { Doc } from 'yjs';
 import * as Y from 'yjs';
+import { clearDocument, IndexeddbPersistence } from 'y-indexeddb';
+import { debugLog } from 'core-app/shared/helpers/debug_output';
+
+const INDEXEDDB_SYNC_TIMEOUT_MS = 10_000;
 
 export default class extends Controller {
   static values = {
@@ -55,7 +59,9 @@ export default class extends Controller {
   declare readonly refreshUrlValue:string;
 
   private tokenRefreshService:TokenRefreshService | null = null;
+  private indexeddbPersistence:IndexeddbPersistence | null = null;
   private ownedProvider:HocuspocusProvider | null = null;
+  private authErrorAbortController:AbortController | null = null;
   private currentToken = '';
   private canUseCachedToken = true;
 
@@ -71,20 +77,101 @@ export default class extends Controller {
     return this.currentToken;
   };
 
-  connect():void {
+  private waitForIndexedDBSync = (ydoc:Doc):Promise<void> => {
+    const persistence = new IndexeddbPersistence(this.documentNameValue, ydoc);
+    this.indexeddbPersistence = persistence;
+
+    // y-indexeddb does not emit an 'error' event, so a timeout is the only
+    // protection against hanging indefinitely (e.g. private browsing, quota exceeded)
+    let timeoutId:ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new Error('IndexedDB sync timed out')),
+        INDEXEDDB_SYNC_TIMEOUT_MS,
+      );
+    });
+
+    return Promise.race([
+      persistence.whenSynced.then(() => {
+        clearTimeout(timeoutId);
+        debugLog('(BlockNote Editor) Local document synced via IndexedDB');
+      }),
+      timeout,
+    ]);
+  };
+
+  private destroyIndexedDBPersistence():void {
+    void this.indexeddbPersistence?.destroy();
+    this.indexeddbPersistence = null;
+  }
+
+  // Purges the locally-cached document content when an auth error occurs.
+  // Covers both auth error sources: HP WebSocket onAuthenticationFailed and
+  // TokenRefreshService session expiry — both dispatch PROVIDER_AUTH_ERROR_EVENT.
+  private clearIndexedDBCache = ():void => {
+    if (this.indexeddbPersistence) {
+      void this.indexeddbPersistence.clearData();
+      this.indexeddbPersistence = null;
+    } else {
+      // Persistence may have been destroyed already; clear the database by name
+      void clearDocument(this.documentNameValue);
+    }
+  };
+
+  private async setupProvider():Promise<void> {
+    // Clean up any prior incomplete setup to prevent leaking persistence
+    // instances on concurrent connect() invocations (e.g., rapid Turbo navigation)
+    this.destroyIndexedDBPersistence();
+    this.authErrorAbortController?.abort();
+    this.authErrorAbortController = new AbortController();
+
     this.currentToken = this.tokenPayloadValue;
 
     const ydoc:Doc = new Y.Doc();
+
+    // Waiting for the synchronization of the local copy of IndexedDB
+    try {
+      await this.waitForIndexedDBSync(ydoc);
+    } catch (error) {
+      // IndexedDB unavailable or timed out — destroy the partial instance and
+      // continue without offline persistence so the editor still renders.
+      debugLog(
+        '(BlockNote Editor) Failed to sync IndexedDB persistence, continuing without offline persistence',
+        error,
+      );
+      this.destroyIndexedDBPersistence();
+    }
+
+    // Detect whether IndexedDB contained cached content for this document.
+    // A non-trivial state vector (> 1 byte) means the Y.Doc has real operations from a previous session.
+    const hasCachedDocument = Y.encodeStateVector(ydoc).byteLength > 1;
+    LiveCollaborationManager.setHasCachedDocument(hasCachedDocument);
+
+    // If disconnect() was called during the IndexedDB await (e.g., Turbo navigation),
+    // abort to avoid overwriting the active provider on the new page.
+    if (!this.element.isConnected) {
+      this.destroyIndexedDBPersistence();
+      ydoc.destroy();
+      return;
+    }
+
+    // Connecting the Hocuspocus Provider after the local data has been loaded
     const provider = new HocuspocusProvider({
       url: this.hocuspocusUrlValue,
       name: this.documentNameValue,
       token: this.getToken,
       document: ydoc,
-      onAuthenticationFailed: () => {
-        document.dispatchEvent(new CustomEvent(PROVIDER_AUTH_ERROR_EVENT, {
-          detail: { kind: 'authentication' as ProviderAuthErrorKind, message: 'Authentication failed' },
-        }));
+      onAuthenticationFailed:() => {
+        document.dispatchEvent(
+          new CustomEvent(PROVIDER_AUTH_ERROR_EVENT, {
+            detail: { kind:'authentication' as ProviderAuthErrorKind, message:'Authentication failed' },
+          }),
+        );
       },
+    });
+
+    document.addEventListener(PROVIDER_AUTH_ERROR_EVENT, this.clearIndexedDBCache, {
+      signal: this.authErrorAbortController.signal,
     });
 
     LiveCollaborationManager.initializeYjsProvider(provider, ydoc);
@@ -93,21 +180,28 @@ export default class extends Controller {
     if (this.refreshUrlValue && this.tokenExpiresInSecondsValue) {
       // Destroy any existing service to prevent duplicate timers if connect() is called multiple times
       this.tokenRefreshService?.destroy();
-      this.tokenRefreshService = new TokenRefreshService(
-        provider,
-        this.refreshUrlValue,
-        (newToken) => {
-          this.currentToken = newToken;
-          this.canUseCachedToken = true;
-        },
-      );
+      this.tokenRefreshService = new TokenRefreshService(provider, this.refreshUrlValue, (newToken) => {
+        this.currentToken = newToken;
+        this.canUseCachedToken = true;
+      });
       this.tokenRefreshService.scheduleRefresh(this.tokenExpiresInSecondsValue);
     }
+  }
+
+  connect():void {
+    this.setupProvider().catch((error) => {
+      debugLog('(BlockNote Editor) Failed to initialize Yjs provider', error);
+    });
   }
 
   disconnect():void {
     this.tokenRefreshService?.destroy();
     this.tokenRefreshService = null;
+
+    this.authErrorAbortController?.abort();
+    this.authErrorAbortController = null;
+
+    this.destroyIndexedDBPersistence();
 
     // Only destroy if we still own the active provider. During Turbo navigation,
     // a new controller may have already replaced it — see destroyIfOwner().

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -38,6 +38,20 @@ class LiveCollaborationManagerClass {
   yjsDocInstance:Doc|null = null;
 
   private listeners:Listener[] = [];
+  private hasCachedDocumentValue = false;
+
+  /**
+   * Records whether IndexedDB had locally-cached document content at the time the
+   * provider was set up. Used by the editor to decide between soft offline mode
+   * (has cache → editing allowed) and hard blocking mode (no cache → editor hidden).
+   */
+  setHasCachedDocument(value:boolean):void {
+    this.hasCachedDocumentValue = value;
+  }
+
+  get hasCachedDocument():boolean {
+    return this.hasCachedDocumentValue;
+  }
 
   /**
    * Initializes the YJS Provider
@@ -84,6 +98,7 @@ class LiveCollaborationManagerClass {
     this.destroyYjsDoc();
 
     this.listeners = [];
+    this.hasCachedDocumentValue = false;
   }
 
   private destroyYjsProvider():void {

--- a/modules/documents/spec/features/real_time_collaboration_spec.rb
+++ b/modules/documents/spec/features/real_time_collaboration_spec.rb
@@ -67,6 +67,28 @@ RSpec.describe "Real-time collaboration with Hocuspocus for documents",
         wait_for { document.reload.content_binary }.to be_present
         expect(document.description).to eq("Hello Hocuspocus\n")
       end
+
+      it "saves offline edits to the server when reconnected" do
+        # Phase 1: type to populate IndexedDB; confirmed once Hocuspocus has saved it
+        visit document_path(document)
+        editor.fill_in("Initial content")
+        wait_for { document.reload.content_binary }.to be_present
+
+        # Phase 2: offline → soft offline (has cache) → replace content
+        Setting.collaborative_editing_hocuspocus_url = "ws://127.0.0.1:9999"
+        visit document_path(document)
+
+        expect(editor.shadow_root).to have_css(
+          "[data-test-selector='connection-error-notice']", wait: 10
+        )
+        editor.fill_in("Offline edit")
+
+        # Phase 3: reconnect → IndexedDB edits forwarded to server
+        Setting.collaborative_editing_hocuspocus_url = "ws://127.0.0.1:1234"
+        visit document_path(document)
+
+        wait_for { document.reload.description }.to eq("Initial content\n\nOffline edit\n")
+      end
     end
 
     context "with readonly permission" do
@@ -90,12 +112,63 @@ RSpec.describe "Real-time collaboration with Hocuspocus for documents",
         expect(document.description).to eq("Hello Hocuspocus\n")
       end
     end
+
+    context "in soft offline mode (after a prior connection)" do
+      # IndexedDB is populated on the first visit (Hocuspocus online), so the
+      # second visit with an unreachable server enters soft offline mode:
+      # the editor stays editable and changes are queued locally.
+
+      context "with write permission" do
+        before { login_as(admin) }
+
+        it "allows editing and shows offline warning" do
+          # Phase 1: populate IndexedDB with confirmed content
+          visit document_path(document)
+          editor.fill_in("Initial content")
+          wait_for { document.reload.content_binary }.to be_present
+
+          Setting.collaborative_editing_hocuspocus_url = "ws://127.0.0.1:9999"
+          visit document_path(document)
+
+          expect(editor.shadow_root).to have_css(
+            "[data-test-selector='connection-error-notice']",
+            text: "You are currently offline. You can continue editing. " \
+                  "Your changes will be synced when the connection is restored.",
+            wait: 10
+          )
+          expect(editor.shadow_root).to have_css("div[role='textbox']")
+        end
+      end
+
+      context "with readonly permission" do
+        it "shows readonly offline warning" do
+          # Phase 1: admin populates IndexedDB (readonly user cannot type)
+          login_as(admin)
+          visit document_path(document)
+          editor.fill_in("Initial content")
+          wait_for { document.reload.content_binary }.to be_present
+
+          # Phase 2: offline visit as readonly user → soft offline
+          login_as(readonly_user)
+          Setting.collaborative_editing_hocuspocus_url = "ws://127.0.0.1:9999"
+          visit document_path(document)
+
+          expect(editor.shadow_root).to have_css(
+            "[data-test-selector='connection-error-notice']",
+            text: "You are currently offline. " \
+                  "Real-time updates will resume once the connection is restored.",
+            wait: 10
+          )
+        end
+      end
+    end
   end
 
   context "when in offline mode (without a connection to the hocuspocus server)" do
     # No Hocuspocus server is started here. On the first visit there is no
-    # local cache, so the editor is blocked entirely to prevent an empty
-    # Y.Doc from being synced as authoritative state on reconnect.
+    # IndexedDB cache, so hasLocalCache is false and the editor is blocked
+    # entirely (blockingOffline = true) to prevent an empty Y.Doc from being
+    # synced as authoritative state on reconnect.
     shared_examples "a blocked offline editor" do
       it "blocks the editor and shows a server-unavailable message" do
         visit document_path(document)


### PR DESCRIPTION
# Ticket

* https://community.openproject.org/wp/72373

# What are you trying to accomplish?

Add offline editing support for collaborative documents using IndexedDB as a local persistence layer. When a user loses connection to the Hocuspocus server, their edits are stored locally in IndexedDB and automatically synced when the connection is restored.

This PR builds on top of #22564 (collaboration refinements) and adds only the IndexedDB-specific functionality:

- y-indexeddb dependency for Y.Doc persistence in the browser
- IndexeddbPersistence setup in the Stimulus controller with timeout and graceful fallback
- Cached document detection via Y.js state vector to distinguish soft offline (editable with cache) from blocking offline (no cache, editor hidden)
- IndexedDB cache clearing on authentication errors
- `hasCachedDocument` prop chain through LiveCollaborationManager, block-note-element, OpBlockNoteContainer, and useCollaboration hook
- `blockingOffline` return value from useCollaboration for conditional editor visibility
- Feature specs for soft offline mode and offline-edit-then-reconnect sync

## Screenshots

https://github.com/user-attachments/assets/409fdfd8-682b-4c38-afad-ab16d6680841

> [!NOTE]
> This is not the final design — updates will be done separately

# What approach did you choose and why?

Uses y-indexeddb to persist the Y.Doc state in the browser's IndexedDB. On page load, the controller waits for IndexedDB sync (with a 10s timeout via Promise.race) before initializing the HocuspocusProvider, so the local state is merged with the server via Y.js CRDTs.

The soft vs blocking offline distinction prevents a fresh empty Y.Doc (no prior cache) from being synced as authoritative content on reconnect — which would overwrite real document content on the server.

**Known limitation:** IndexedDB data is not encrypted at rest. This is a security concern being evaluated separately and may require a composition wrapper with AES-256-GCM encryption before shipping to production.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)