### PR TITLE
[#72222] Remove presenter field/participants references in onetime templates  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.html.erb
@@ -6,7 +6,7 @@
       url: @submit_path,
       namespace: "form_#{wrapper_uniq_by}"
     ) do |f|
-      grid_layout("op-meeting-agenda-item-form", tag: :div) do |grid|
+      grid_layout("op-meeting-agenda-item-form", classes: conditional_layout_classes, tag: :div) do |grid|
         grid.with_area(:title) do
           case @type
           when :simple
@@ -20,8 +20,10 @@
           render(MeetingAgendaItem::Duration.new(f))
         end
 
-        grid.with_area(:presenter) do
-          render(MeetingAgendaItem::Presenter.new(f))
+        unless @meeting.onetime_template?
+          grid.with_area(:presenter) do
+            render(MeetingAgendaItem::Presenter.new(f))
+          end
         end
 
         grid.with_area(

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.rb
@@ -87,5 +87,11 @@ module MeetingAgendaItems
         :none
       end
     end
+
+    def conditional_layout_classes
+      classes = []
+      classes << "op-meeting-agenda-item-form_hidden-presenter" if @meeting.onetime_template?
+      classes.join(" ")
+    end
   end
 end

--- a/modules/meeting/app/components/meeting_agenda_items/form_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/form_component.sass
@@ -10,6 +10,9 @@
   // and thus break the whole layout if there is no container around them
   position: relative
 
+  &_hidden-presenter
+    grid-template-areas: "title title duration" "notes notes notes" "add_note actions actions"
+
   &--actions
     justify-self: end
 
@@ -24,3 +27,6 @@
   @media screen and (max-width: $breakpoint-md)
     grid-template-columns: 100px minmax(0, 100%)
     grid-template-areas: "title title" "duration presenter" "notes notes" "add_note actions"
+
+    &_hidden-presenter
+      grid-template-areas: "title title" "duration duration" "notes notes" "add_note actions"

--- a/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/form_component_spec.rb
@@ -99,4 +99,12 @@ RSpec.describe MeetingAgendaItems::FormComponent, type: :component do
   it "renders Cancel button" do
     expect(rendered_component).to have_link "Cancel", href: cancel_path
   end
+
+  context "when meeting is a onetime template" do
+    let(:meeting) { build_stubbed(:onetime_template) }
+
+    it "does not render the presenter field" do
+      expect(rendered_component).to have_no_element :label, text: "Presenter"
+    end
+  end
 end

--- a/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
@@ -30,6 +30,8 @@
 
 require "spec_helper"
 
+require_relative "../../support/pages/meetings/show"
+
 RSpec.describe "Onetime templates CRUD", :js do
   shared_let(:admin) { create(:admin) }
   shared_let(:project) { create(:project, enabled_module_names: %i[meetings]) }
@@ -294,6 +296,26 @@ RSpec.describe "Onetime templates CRUD", :js do
         expect(page).to have_link("Edit template")
         expect(page).to have_link("Delete template")
       end
+    end
+  end
+
+  describe "adding agenda items to a template" do
+    let(:template) { create(:onetime_template, project:, title: "My template") }
+    let(:show_page) { Pages::Meetings::Show.new(template) }
+
+    before { show_page.visit! }
+
+    it "does not show or save a presenter" do
+      show_page.add_agenda_item do
+        expect(page).to have_no_css("label", text: "Presenter")
+
+        fill_in "Title", with: "Introduction"
+      end
+
+      wait_for_network_idle
+
+      show_page.expect_agenda_item title: "Introduction"
+      expect(MeetingAgendaItem.last.presenter).to be_nil
     end
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72222

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
