### PR TITLE
[#72541] Comment field not included in PDF export of PIR

### DIFF
--- a/app/models/project/pdf_export/common/project_attributes.rb
+++ b/app/models/project/pdf_export/common/project_attributes.rb
@@ -80,8 +80,10 @@ module Project::PDFExport::Common::ProjectAttributes
   end
 
   def process_field(project, field)
-    if field[:custom_field]
+    if custom_field?(field)
       process_custom_attribute_field(project, field)
+    elsif custom_comment?(field)
+      process_custom_comment_field(project, field)
     elsif project_phase?(field)
       process_project_phase_field(project, field)
     elsif can_view_attribute?(project, field[:key])
@@ -164,6 +166,10 @@ module Project::PDFExport::Common::ProjectAttributes
     end
   end
 
+  def process_custom_comment_field(project, field)
+    field.merge(value: format_attribute(project, field[:key], :pdf))
+  end
+
   def process_attribute_field(project, field)
     field.merge(value: format_attribute(project, field[:key], :pdf), formattable: attribute_formattable?(field[:key]))
   end
@@ -173,11 +179,15 @@ module Project::PDFExport::Common::ProjectAttributes
   end
 
   def custom_field?(field)
-    field[:key].to_s.start_with?("cf_")
+    field[:key]&.start_with?("cf_")
+  end
+
+  def custom_comment?(field)
+    field[:key]&.start_with?("cfc_")
   end
 
   def project_phase?(field)
-    field[:key].to_s.start_with?("project_phase_")
+    field[:key]&.start_with?("project_phase_")
   end
 
   def custom_field_active_in_project?(project, custom_field)

--- a/app/models/project/pdf_export/project_initiation.rb
+++ b/app/models/project/pdf_export/project_initiation.rb
@@ -190,8 +190,19 @@ class Project::PDFExport::ProjectInitiation < Exports::Exporter
            .map do |section, custom_fields|
              {
                caption: section.name,
-               fields: custom_fields.map do |custom_field|
-                 { key: "cf_#{custom_field.id}", caption: custom_field.name, custom_field: }
+               fields: custom_fields.each_with_object([]) do |custom_field, fields|
+                 fields << {
+                   key: "cf_#{custom_field.id}",
+                   caption: custom_field.name,
+                   custom_field:
+                 }
+                 if custom_field.has_comment?
+                   fields << {
+                     key: "cfc_#{custom_field.id}",
+                     caption: I18n.t(:label_custom_comment, name: custom_field.name),
+                     custom_field:
+                   }
+                 end
                end
              }
     end

--- a/spec/models/project/pdf_export/project_initiation_spec.rb
+++ b/spec/models/project/pdf_export/project_initiation_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Project::PDFExport::ProjectInitiation do
       string_cf.update!(project_custom_field_section: section_a)
       text_cf.update!(project_custom_field_section: section_a)
       link_cf.update!(project_custom_field_section: section_a)
+      hidden_cf.update!(project_custom_field_section: section_a)
       unset_string_cf.update!(project_custom_field_section: section_a)
       disabled_custom_field.update!(project_custom_field_section: section_a)
 
@@ -118,8 +119,8 @@ RSpec.describe Project::PDFExport::ProjectInitiation do
       disabled_mapping
     end
 
-    it "exports a PDF containing project initiation with custom attributes grouped by sections" do
-      expected_document = [
+    let(:expected_document) do
+      [
         heading, project.name, Setting.app_title, export_time_formatted, # cover page
         heading,
         project.name,
@@ -134,6 +135,7 @@ RSpec.describe Project::PDFExport::ProjectInitiation do
 
         "Section B",
         version_cf.name, system_version,
+        "#{version_cf.name} comment", "Comment visible to members",
         user_cf.name, "Other User",
         date_cf.name, format_date(Time.zone.today),
         float_cf.name, "4.5",
@@ -141,8 +143,46 @@ RSpec.describe Project::PDFExport::ProjectInitiation do
 
         "1/1", heading, project.name
       ].join(" ")
+    end
 
+    it "exports a PDF containing project initiation with custom attributes grouped by sections" do
       expect(subject).to eq expected_document
+    end
+
+    context "as admin" do
+      let(:current_user) { build(:admin) }
+
+      let(:expected_document) do
+        [
+          heading, project.name, Setting.app_title, export_time_formatted, # cover page
+          heading,
+          project.name,
+          "The description of the project",
+
+          "Section A",
+          hidden_cf.name, "hidden",
+          "#{hidden_cf.name} comment", "Comment visible to admins",
+          link_cf.name, "https://www.example.com",
+          text_cf.name, "Some ", "long", " text",
+          string_cf.name, "Some small text",
+          bool_cf.name, "Yes",
+          unset_string_cf.name, "–",
+
+          "Section B",
+          version_cf.name, system_version,
+          "#{version_cf.name} comment", "Comment visible to members",
+          user_cf.name, "Other User",
+          date_cf.name, format_date(Time.zone.today),
+          float_cf.name, "4.5",
+          int_cf.name, "5",
+
+          "1/1", heading, project.name
+        ].join(" ")
+      end
+
+      it "exports a PDF containing project initiation with custom attributes grouped by sections" do
+        expect(subject).to eq expected_document
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/72541

# What are you trying to accomplish?
Export custom comments as part of PDF export of PIR

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
