### PR TITLE
Validate schemes for CopyToClipboardComponent

### DIFF
--- a/app/components/op_primer/copy_to_clipboard_component.rb
+++ b/app/components/op_primer/copy_to_clipboard_component.rb
@@ -32,14 +32,25 @@ module OpPrimer
   class CopyToClipboardComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
+    SCHEME_OPTIONS = %i[value link].freeze
+
     alias_method :value, :model
 
     def initialize(value = nil, scheme: :value, **system_arguments)
       super(value)
 
-      @scheme = scheme
+      @scheme = validate_scheme!(scheme)
       @system_arguments = system_arguments
       @id = SecureRandom.hex(8)
+    end
+
+    private
+
+    def validate_scheme!(scheme)
+      scheme = scheme.to_sym
+      raise ArgumentError, "scheme must be one of #{SCHEME_OPTIONS}" unless SCHEME_OPTIONS.include?(scheme)
+
+      scheme
     end
   end
 end

--- a/lookbook/previews/op_primer/copy_to_clipboard_component_preview.rb
+++ b/lookbook/previews/op_primer/copy_to_clipboard_component_preview.rb
@@ -37,6 +37,12 @@ module OpPrimer
     end
 
     # @param url text
+    # @param scheme [Symbol] select [value, link]
+    def playground(url: "https://example.org", scheme: :value)
+      render(OpPrimer::CopyToClipboardComponent.new(url, scheme:))
+    end
+
+    # @param url text
     def as_link(url: "http://example.org")
       render(OpPrimer::CopyToClipboardComponent.new(url, scheme: :link))
     end

--- a/modules/auth_saml/app/components/saml/providers/side_panel/information_component.html.erb
+++ b/modules/auth_saml/app/components/saml/providers/side_panel/information_component.html.erb
@@ -9,7 +9,7 @@
       end
 
       collection.with_component(
-        OpPrimer::CopyToClipboardComponent.new(provider.sp_entity_id, scheme: :input)
+        OpPrimer::CopyToClipboardComponent.new(provider.sp_entity_id, scheme: :value)
       )
 
       collection.with_component(Primer::Beta::Heading.new(tag: :h5, mt: 4, mb: 1)) do

--- a/modules/openid_connect/app/components/openid_connect/providers/side_panel/information_component.html.erb
+++ b/modules/openid_connect/app/components/openid_connect/providers/side_panel/information_component.html.erb
@@ -9,7 +9,7 @@
       end
 
       collection.with_component(
-        OpPrimer::CopyToClipboardComponent.new(provider.slug, scheme: :input)
+        OpPrimer::CopyToClipboardComponent.new(provider.slug, scheme: :value)
       )
 
       collection.with_component(Primer::Beta::Heading.new(tag: :h5, mt: 4, mb: 1)) do
@@ -17,7 +17,7 @@
       end
 
       collection.with_component(
-        OpPrimer::CopyToClipboardComponent.new(provider.callback_url, scheme: :input)
+        OpPrimer::CopyToClipboardComponent.new(provider.callback_url, scheme: :value)
       )
 
       collection.with_component(Primer::Beta::Heading.new(tag: :h5, mt: 4, mb: 1)) do
@@ -25,7 +25,7 @@
       end
 
       collection.with_component(
-        OpPrimer::CopyToClipboardComponent.new(provider.backchannel_logout_url, scheme: :input)
+        OpPrimer::CopyToClipboardComponent.new(provider.backchannel_logout_url, scheme: :value)
       )
     end
   end


### PR DESCRIPTION
When trying to use this component, I wanted to use the input scheme that I copied from elsewhere in the code. At first I was surprised that the lookbook didn't yet contain a playground, where I could try this style out.

After adding it, I was surprised that it didn't look like an input at all and learned that this scheme does not even exist... But it was already used multiple times :O

# Ticket

none