### PR TITLE
[#71250] Update existing Backlogs view to use new Sprint model

### DIFF
--- a/app/forms/versions/form.rb
+++ b/app/forms/versions/form.rb
@@ -113,14 +113,44 @@ module Versions
       if backlogs_enabled?
         setting = version_setting_for_project
 
-        f.select_list(
-          name: "version[version_settings_attributes][][display]",
-          scope_name_to_model: false,
-          label: I18n.t(:label_column_in_backlog),
-          input_width: :small
-        ) do |list|
-          position_display_options.each do |label, value|
-            list.option(label:, value:, selected: setting.display == value)
+        if OpenProject::FeatureDecisions.scrum_projects_active?
+          # We originally planned to render a check_box here. But since this changes the way Rails will submit the parameters,
+          # this would require changing the controller or services, too. With a feature flag in place, this adds quite a
+          # lot of complexity.
+          # To circumvent this, we will use a select list with two options for now. This will not require any changes to
+          # controllers or services. We can fix this once the feature flag has been removed.
+          f.select_list(
+            name: "version[version_settings_attributes][][display]",
+            scope_name_to_model: false,
+            label: I18n.t(:label_used_as_backlog),
+            input_width: :small
+          ) do |list|
+            # Maintain the current setting for the sake of migrating sprints to versions later on
+            current_display_setting = setting.display
+            value_for_no = if current_display_setting == VersionSetting::DISPLAY_RIGHT || current_display_setting.nil?
+                             VersionSetting::DISPLAY_NONE
+                           else
+                             current_display_setting
+                           end
+
+            list.option(label: I18n.t(:general_text_no),
+                        value: value_for_no,
+                        selected: setting.display != VersionSetting::DISPLAY_RIGHT)
+
+            list.option(label: I18n.t(:general_text_yes),
+                        value: VersionSetting::DISPLAY_RIGHT,
+                        selected: setting.display == VersionSetting::DISPLAY_RIGHT)
+          end
+        else
+          f.select_list(
+            name: "version[version_settings_attributes][][display]",
+            scope_name_to_model: false,
+            label: I18n.t(:label_column_in_backlog),
+            input_width: :small
+          ) do |list|
+            position_display_options.each do |label, value|
+              list.option(label:, value:, selected: setting.display == value)
+            end
           end
         end
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -557,6 +557,7 @@ class PermittedParams
           :priority_id,
           :remaining_hours,
           :responsible_id,
+          :sprint_id,
           :start_date,
           :status_id,
           :type_id,

--- a/modules/backlogs/app/components/backlogs/new_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/new_sprint_dialog_component.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(
     Primer::Alpha::Dialog.new(
-      title: t(:label_sprint_new),
+      title:,
       size: :large,
       id: DIALOG_ID
     )
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
             type: :submit
           )
         ) do
-          t("button_create")
+          button_caption
         end
       end
     end

--- a/modules/backlogs/app/components/backlogs/new_sprint_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/new_sprint_dialog_component.rb
@@ -32,30 +32,34 @@ module Backlogs
   class NewSprintDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
+    include Primer::FetchOrFallbackHelper
 
     DIALOG_ID = "new-sprint-dialog"
     FORM_ID = "new-sprint-dialog-form"
     FOOTER_ID = "new-sprint-dialog-footer"
 
-    def initialize(sprint:, state: :create)
+    STATE_DEFAULT = :create
+    STATE_OPTIONS = [STATE_DEFAULT, :edit].freeze
+
+    attr_reader :sprint, :state
+
+    delegate :create?, :edit?, to: :state
+
+    def initialize(sprint:, state: STATE_DEFAULT)
       super
 
       @sprint = sprint
-      @state = state
+      @state = ActiveSupport::StringInquirer.new(fetch_or_fallback(STATE_OPTIONS, state, STATE_DEFAULT).to_s)
     end
 
     private
 
-    def state_create? = @state == :create
-
-    def state_edit? = @state == :edit
-
     def title
-      state_create? ? t(:label_sprint_new) : t(:label_sprint_edit)
+      create? ? t(:label_sprint_new) : t(:label_sprint_edit)
     end
 
     def button_caption
-      state_create? ? t(:button_create) : t(:button_save)
+      create? ? t(:button_create) : t(:button_save)
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/new_sprint_form_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/new_sprint_form_component.html.erb
@@ -33,9 +33,9 @@ See COPYRIGHT and LICENSE files for more details.
       id: Backlogs::NewSprintFormComponent::FORM_ID,
       model: @sprint,
       scope: :sprint,
-      method: :post,
+      method: http_verb,
       class: "op-sprints--form",
-      url: project_sprints_path(@sprint.project_id),
+      url: form_url,
       data: data_attributes
     ) do |f|
       flex_layout(mb: 2) do |flex|

--- a/modules/backlogs/app/components/backlogs/new_sprint_form_component.rb
+++ b/modules/backlogs/app/components/backlogs/new_sprint_form_component.rb
@@ -53,8 +53,7 @@ module Backlogs
       if @sprint.new_record?
         project_sprints_path(@sprint.project_id)
       else
-        # TODO: update path
-        ""
+        update_agile_sprint_project_sprint_path(@sprint.project_id, @sprint.id)
       end
     end
 

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -1,0 +1,63 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= component_wrapper(tag: :section) do %>
+  <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
+    <% border_box.with_header do %>
+      <%= render(Backlogs::SprintHeaderComponent.new(sprint:, folded: folded?)) %>
+    <% end %>
+    <% if stories.empty? %>
+      <% border_box.with_row(data: { empty_list_item: true }) do %>
+        <%=
+          render Primer::Beta::Blankslate.new(role: "status", aria: { live: "polite" }) do |blankslate|
+            blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title", name: sprint.name))
+            blankslate.with_description_content(t(".blankslate_description"))
+          end
+        %>
+      <% end %>
+    <% end %>
+    <% stories.each do |story| %>
+      <% border_box.with_row(
+           id: dom_id(story),
+           classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
+           data: draggable_item_config(story).merge(
+             story: true,
+             controller: "backlogs--story",
+             backlogs__story_id_value: story.id,
+             backlogs__story_split_url_value: details_backlogs_project_backlogs_path(project, story),
+             backlogs__story_full_url_value: work_package_path(story),
+             backlogs__story_selected_class: "Box-row--blue"
+           ),
+           tabindex: 0
+         ) do %>
+        <%= render(Backlogs::StoryComponent.new(story:, sprint:, max_position:)) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -55,11 +55,11 @@ module Backlogs
     end
 
     def stories
-      @sprint.work_packages
+      sprint.work_packages
     end
 
     def wrapper_uniq_by
-      @sprint.id
+      sprint.id
     end
 
     private
@@ -76,7 +76,7 @@ module Backlogs
       {
         generic_drag_and_drop_target: "container",
         target_container_accessor: ":scope > ul",
-        target_id: @sprint.id,
+        target_id: sprint.id,
         target_allowed_drag_type: "story"
       }
     end

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -29,40 +29,63 @@
 #++
 
 module Backlogs
-  class NewSprintFormComponent < ApplicationComponent
-    include ApplicationHelper
+  class SprintComponent < ApplicationComponent
+    include Primer::AttributesHelper
     include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
+    include RbCommonHelper
 
-    FORM_ID = NewSprintDialogComponent::FORM_ID
+    attr_reader :sprint, :current_user
 
-    def initialize(sprint:, base_errors: nil)
-      super
+    delegate :project, to: :sprint
+
+    def initialize(sprint:, current_user: User.current, **system_arguments)
+      super()
 
       @sprint = sprint
-      @base_errors = base_errors
+      @current_user = current_user
+
+      @system_arguments = system_arguments
+      @system_arguments[:id] = dom_id(sprint)
+      @system_arguments[:list_id] = "#{@system_arguments[:id]}-list"
+      @system_arguments[:padding] = :condensed
+      @system_arguments[:data] = merge_data(
+        @system_arguments,
+        { data: drop_target_config }
+      )
+    end
+
+    def stories
+      @sprint.work_packages
+    end
+
+    def wrapper_uniq_by
+      @sprint.id
     end
 
     private
 
-    def http_verb
-      @sprint.new_record? ? :post : :put
+    def folded?
+      current_user.backlogs_preference(:versions_default_fold_state) == "closed"
     end
 
-    def form_url
-      if @sprint.new_record?
-        project_sprints_path(@sprint.project_id)
-      else
-        # TODO: update path
-        ""
-      end
+    def max_position
+      stories.filter_map(&:position).max
     end
 
-    def data_attributes
+    def drop_target_config
       {
-        controller: "refresh-on-form-changes",
-        "refresh-on-form-changes-target": "form",
-        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_project_sprints_path(@sprint.project_id)
+        generic_drag_and_drop_target: "container",
+        target_container_accessor: ":scope > ul",
+        target_id: @sprint.id,
+        target_allowed_drag_type: "story"
+      }
+    end
+
+    def draggable_item_config(story)
+      {
+        draggable_id: story.id,
+        draggable_type: "story",
+        drop_url: move_backlogs_project_sprint_story_path(project, sprint, story)
       }
     end
   end

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -28,63 +28,50 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= component_wrapper(tag: :header) do %>
-  <% if show? %>
-    <%= grid_layout("op-backlogs-header", tag: :div) do |grid| %>
-      <% grid.with_area(:collapsible) do %>
-        <%=
-          render(
-            Primer::OpenProject::BorderBox::CollapsibleHeader.new(
-              collapsible_id: "#{dom_id(sprint)}-list",
-              collapsed:,
-              multi_line: false
-            )
-          ) do |collapsible|
-            collapsible.with_title { sprint.name }
-            collapsible.with_count(
-              scheme: :default,
-              count: story_count,
-              round: true,
-              aria: {
-                label: t(".label_story_count", count: story_count),
-                live: "polite"
-              }
-            )
-            collapsible.with_description(role: "group") do
-              format_date_range(date_range)
-            end
+  <%= grid_layout("op-backlogs-header", tag: :div) do |grid| %>
+    <% grid.with_area(:collapsible) do %>
+      <%=
+        render(
+          Primer::OpenProject::BorderBox::CollapsibleHeader.new(
+            collapsible_id: "#{dom_id(sprint)}-list",
+            collapsed:,
+            multi_line: false
+          )
+        ) do |collapsible|
+          collapsible.with_title { sprint.name }
+          collapsible.with_count(
+            scheme: :default,
+            count: story_count,
+            round: true,
+            aria: {
+              label: t(".label_story_count", count: story_count),
+              live: "polite"
+            }
+          )
+          collapsible.with_description(role: "group") do
+            format_date_range(date_range)
           end
-        %>
-      <% end %>
+        end
+      %>
+    <% end %>
 
-      <% grid.with_area(:points) do %>
-        <%=
-          render(
-            Primer::Beta::Text.new(
-              color: :subtle,
-              classes: "velocity",
-              aria: { live: "polite" }
-            )
-          ) do
-        %>
-          <%= story_points %>
-          <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
-        <% end %>
-      <% end %>
-
-      <% grid.with_area(:menu) do %>
-        <%= render(Backlogs::SprintMenuComponent.new(sprint:, project:)) %>
+    <% grid.with_area(:points) do %>
+      <%=
+        render(
+          Primer::Beta::Text.new(
+            color: :subtle,
+            classes: "velocity",
+            aria: { live: "polite" }
+          )
+        ) do
+      %>
+        <%= story_points %>
+        <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
       <% end %>
     <% end %>
-  <% else %>
-    <%=
-      primer_form_with(
-        url: backlogs_project_sprint_path(project, sprint),
-        model: sprint,
-        method: :patch,
-        class: "op-backlogs-header-form"
-      ) do |f|
-        render(Backlogs::BacklogHeaderForm.new(f, cancel_path: show_name_backlogs_project_sprint_path(project, sprint)))
-      end
-    %>
+
+    <% grid.with_area(:menu) do %>
+      <%= render(Backlogs::SprintMenuComponent.new(sprint:, project:)) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -33,10 +33,10 @@ See COPYRIGHT and LICENSE files for more details.
       <% grid.with_area(:collapsible) do %>
         <%=
           render(
-            Backlogs::CollapsibleComponent.new(
+            Primer::OpenProject::BorderBox::CollapsibleHeader.new(
               collapsible_id: "#{dom_id(sprint)}-list",
-              toggle_label: t(".label_toggle_backlog", name: sprint.name),
-              collapsed:
+              collapsed:,
+              multi_line: false
             )
           ) do |collapsible|
             collapsible.with_title { sprint.name }

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -1,0 +1,90 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= component_wrapper(tag: :header) do %>
+  <% if show? %>
+    <%= grid_layout("op-backlogs-header", tag: :div) do |grid| %>
+      <% grid.with_area(:collapsible) do %>
+        <%=
+          render(
+            Backlogs::CollapsibleComponent.new(
+              collapsible_id: "#{dom_id(sprint)}-list",
+              toggle_label: t(".label_toggle_backlog", name: sprint.name),
+              collapsed:
+            )
+          ) do |collapsible|
+            collapsible.with_title { sprint.name }
+            collapsible.with_count(
+              scheme: :default,
+              count: story_count,
+              round: true,
+              aria: {
+                label: t(".label_story_count", count: story_count),
+                live: "polite"
+              }
+            )
+            collapsible.with_description(role: "group") do
+              format_date_range(date_range)
+            end
+          end
+        %>
+      <% end %>
+
+      <% grid.with_area(:points) do %>
+        <%=
+          render(
+            Primer::Beta::Text.new(
+              color: :subtle,
+              classes: "velocity",
+              aria: { live: "polite" }
+            )
+          ) do
+        %>
+          <%= story_points %>
+          <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
+        <% end %>
+      <% end %>
+
+      <% grid.with_area(:menu) do %>
+        <%= render(Backlogs::SprintMenuComponent.new(sprint:, project:)) %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%=
+      primer_form_with(
+        url: backlogs_project_sprint_path(project, sprint),
+        model: sprint,
+        method: :patch,
+        class: "op-backlogs-header-form"
+      ) do |f|
+        render(Backlogs::BacklogHeaderForm.new(f, cancel_path: show_name_backlogs_project_sprint_path(project, sprint)))
+      end
+    %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.rb
@@ -36,25 +36,19 @@ module Backlogs
     include Redmine::I18n
     include RbCommonHelper
 
-    STATE_DEFAULT = :show
-    STATE_OPTIONS = [STATE_DEFAULT, :edit].freeze
-
-    attr_reader :sprint, :state, :collapsed, :current_user
+    attr_reader :sprint, :collapsed, :current_user
 
     delegate :project, to: :sprint
     delegate :name, to: :sprint, prefix: :sprint
-    delegate :edit?, :show?, to: :state
 
     def initialize(
       sprint:,
-      state: STATE_DEFAULT,
       folded: false,
       current_user: User.current
     )
       super()
 
       @sprint = sprint
-      @state = ActiveSupport::StringInquirer.new(fetch_or_fallback(STATE_OPTIONS, state, STATE_DEFAULT).to_s)
       @collapsed = folded
       @current_user = current_user
     end

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.rb
@@ -29,41 +29,56 @@
 #++
 
 module Backlogs
-  class NewSprintFormComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpTurbo::Streamable
+  class SprintHeaderComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+    include Primer::FetchOrFallbackHelper
+    include Redmine::I18n
+    include RbCommonHelper
 
-    FORM_ID = NewSprintDialogComponent::FORM_ID
+    STATE_DEFAULT = :show
+    STATE_OPTIONS = [STATE_DEFAULT, :edit].freeze
 
-    def initialize(sprint:, base_errors: nil)
-      super
+    attr_reader :sprint, :state, :collapsed, :current_user
+
+    delegate :project, to: :sprint
+    delegate :name, to: :sprint, prefix: :sprint
+    delegate :edit?, :show?, to: :state
+
+    def initialize(
+      sprint:,
+      state: STATE_DEFAULT,
+      folded: false,
+      current_user: User.current
+    )
+      super()
 
       @sprint = sprint
-      @base_errors = base_errors
+      @state = ActiveSupport::StringInquirer.new(fetch_or_fallback(STATE_OPTIONS, state, STATE_DEFAULT).to_s)
+      @collapsed = folded
+      @current_user = current_user
+    end
+
+    def wrapper_uniq_by
+      sprint.id
+    end
+
+    def stories
+      @sprint.work_packages
     end
 
     private
 
-    def http_verb
-      @sprint.new_record? ? :post : :put
+    def story_points
+      @story_points ||= stories.sum { |story| story.story_points || 0 }
     end
 
-    def form_url
-      if @sprint.new_record?
-        project_sprints_path(@sprint.project_id)
-      else
-        # TODO: update path
-        ""
-      end
+    def story_count
+      @story_count ||= stories.size
     end
 
-    def data_attributes
-      {
-        controller: "refresh-on-form-changes",
-        "refresh-on-form-changes-target": "form",
-        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_project_sprints_path(@sprint.project_id)
-      }
+    def date_range
+      [sprint.start_date, sprint.finish_date]
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -74,25 +74,23 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :"op-view-list")
     end
 
-    menu.with_item(
-      # TODO: what to do with the task board?
-      scheme: :danger,
-      label: t(".action_menu.task_board"),
-      tag: :a,
-      href: backlogs_project_sprint_taskboard_path(project, sprint)
-    ) do |item|
-      item.with_leading_visual_icon(icon: :"op-view-cards")
-    end
-
-    menu.with_item(
-      # TODO: what to do with the burndown chart?
-      scheme: :danger,
-      label: t(".action_menu.burndown_chart"),
-      tag: :a,
-      href: backlogs_project_sprint_burndown_chart_path(project, sprint),
-      disabled: !sprint.has_burndown?
-    ) do |item|
-      item.with_leading_visual_icon(icon: :graph)
-    end
+    # menu.with_item(
+    #   # TODO: what to do with the task board?
+    #   label: t(".action_menu.task_board"),
+    #   tag: :a,
+    #   href: backlogs_project_sprint_taskboard_path(project, sprint)
+    # ) do |item|
+    #   item.with_leading_visual_icon(icon: :"op-view-cards")
+    # end
+    #
+    # menu.with_item(
+    #   # TODO: what to do with the burndown chart?
+    #   label: t(".action_menu.burndown_chart"),
+    #   tag: :a,
+    #   href: backlogs_project_sprint_burndown_chart_path(project, sprint),
+    #   disabled: !sprint.has_burndown?
+    # ) do |item|
+    #   item.with_leading_visual_icon(icon: :graph)
+    # end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -36,7 +36,6 @@ See COPYRIGHT and LICENSE files for more details.
       tooltip_direction: :se
     )
 
-    # TODO render sprint dialog in edit mode
     if user_allowed?(:update_sprints)
       menu.with_item(
         label: t(".action_menu.edit_sprint"),

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
       tooltip_direction: :se
     )
 
-    if user_allowed?(:update_sprints)
+    if user_allowed?(:create_sprints)
       menu.with_item(
         label: t(".action_menu.edit_sprint"),
         href: edit_dialog_project_sprint_path(project, sprint),
@@ -60,7 +60,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:update_sprints) || user_allowed?(:add_work_packages)
+    if user_allowed?(:create_sprints) || user_allowed?(:add_work_packages)
       menu.with_divider
     end
 
@@ -74,16 +74,14 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :"op-view-list")
     end
 
-    if user_allowed?(:view_taskboards)
-      menu.with_item(
-        # TODO: what to do with the task board?
-        scheme: :danger,
-        label: t(".action_menu.task_board"),
-        tag: :a,
-        href: backlogs_project_sprint_taskboard_path(project, sprint)
-      ) do |item|
-        item.with_leading_visual_icon(icon: :"op-view-cards")
-      end
+    menu.with_item(
+      # TODO: what to do with the task board?
+      scheme: :danger,
+      label: t(".action_menu.task_board"),
+      tag: :a,
+      href: backlogs_project_sprint_taskboard_path(project, sprint)
+    ) do |item|
+      item.with_leading_visual_icon(icon: :"op-view-cards")
     end
 
     menu.with_item(

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:add_work_packages)
+    if user_allowed?(:manage_sprint_items)
       menu.with_item(
         label: t(".action_menu.new_story"),
         href: new_project_work_packages_dialog_path(

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -1,0 +1,113 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%=
+  render(Primer::Alpha::ActionMenu.new(anchor_align: :end, classes: "hide-when-print")) do |menu|
+    menu.with_show_button(
+      scheme: :invisible,
+      icon: :"kebab-horizontal",
+      "aria-label": t(".label_actions"),
+      tooltip_direction: :se
+    )
+
+    # TODO render sprint dialog in edit mode
+    if user_allowed?(:update_sprints)
+      menu.with_item(
+        label: t(".action_menu.edit_sprint"),
+        href: edit_dialog_project_sprint_path(project, sprint),
+        content_arguments: { data: { controller: "async-dialog" } }
+      ) do |item|
+        item.with_leading_visual_icon(icon: :pencil)
+      end
+    end
+
+    if user_allowed?(:add_work_packages)
+      menu.with_item(
+        label: t(".action_menu.new_story"),
+        href: new_project_work_packages_dialog_path(
+          project,
+          sprint_id: sprint.id,
+          type_id: available_story_types.first
+        ),
+        content_arguments: { data: { turbo_stream: true } }
+      ) do |item|
+        item.with_leading_visual_icon(icon: :compose)
+      end
+    end
+
+    if user_allowed?(:update_sprints) || user_allowed?(:add_work_packages)
+      menu.with_divider
+    end
+
+    menu.with_item(
+      # TODO: sprint_id filter does not exist for work packages. Add?
+      scheme: :danger,
+      label: t(".action_menu.stories_tasks"),
+      tag: :a,
+      href: project_work_packages_path(project, sprint_id: sprint.id)
+    ) do |item|
+      item.with_leading_visual_icon(icon: :"op-view-list")
+    end
+
+    if user_allowed?(:view_taskboards)
+      menu.with_item(
+        # TODO: what to do with the task board?
+        scheme: :danger,
+        label: t(".action_menu.task_board"),
+        tag: :a,
+        href: backlogs_project_sprint_taskboard_path(project, sprint)
+      ) do |item|
+        item.with_leading_visual_icon(icon: :"op-view-cards")
+      end
+    end
+
+    menu.with_item(
+      # TODO: what to do with the burndown chart?
+      scheme: :danger,
+      label: t(".action_menu.burndown_chart"),
+      tag: :a,
+      href: backlogs_project_sprint_burndown_chart_path(project, sprint),
+      disabled: !sprint.has_burndown?
+    ) do |item|
+      item.with_leading_visual_icon(icon: :graph)
+    end
+
+    if project.module_enabled? "wiki"
+      menu.with_item(
+        # TODO: will we keep the association between sprints and wiki pages?
+        scheme: :danger,
+        label: t(".action_menu.wiki"),
+        tag: :a,
+        href: edit_backlogs_project_sprint_wiki_path(project, sprint)
+      ) do |item|
+        item.with_leading_visual_icon(icon: :book)
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -94,17 +94,5 @@ See COPYRIGHT and LICENSE files for more details.
     ) do |item|
       item.with_leading_visual_icon(icon: :graph)
     end
-
-    if project.module_enabled? "wiki"
-      menu.with_item(
-        # TODO: will we keep the association between sprints and wiki pages?
-        scheme: :danger,
-        label: t(".action_menu.wiki"),
-        tag: :a,
-        href: edit_backlogs_project_sprint_wiki_path(project, sprint)
-      ) do |item|
-        item.with_leading_visual_icon(icon: :book)
-      end
-    end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -29,41 +29,31 @@
 #++
 
 module Backlogs
-  class NewSprintFormComponent < ApplicationComponent
-    include ApplicationHelper
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
+  class SprintMenuComponent < ApplicationComponent
+    include RbCommonHelper
 
-    FORM_ID = NewSprintDialogComponent::FORM_ID
+    attr_reader :sprint, :project, :current_user
 
-    def initialize(sprint:, base_errors: nil)
-      super
+    def initialize(sprint:, project:, current_user: User.current)
+      super()
 
       @sprint = sprint
-      @base_errors = base_errors
+      @project = project
+      @current_user = current_user
+    end
+
+    def stories
+      @sprint.work_packages
     end
 
     private
 
-    def http_verb
-      @sprint.new_record? ? :post : :put
+    def user_allowed?(permission)
+      current_user.allowed_in_project?(permission, project)
     end
 
-    def form_url
-      if @sprint.new_record?
-        project_sprints_path(@sprint.project_id)
-      else
-        # TODO: update path
-        ""
-      end
-    end
-
-    def data_attributes
-      {
-        controller: "refresh-on-form-changes",
-        "refresh-on-form-changes-target": "form",
-        "refresh-on-form-changes-turbo-stream-url-value": refresh_form_project_sprints_path(@sprint.project_id)
-      }
+    def available_story_types
+      @available_story_types ||= story_types & project.types
     end
   end
 end

--- a/modules/backlogs/app/contracts/sprints/update_contract.rb
+++ b/modules/backlogs/app/contracts/sprints/update_contract.rb
@@ -37,7 +37,7 @@ module Sprints
     def user_allowed_to_update
       return if model.project.nil?
 
-      unless user.allowed_in_project?(:update_sprints, model.project)
+      unless user.allowed_in_project?(:create_sprints, model.project)
         errors.add :base, :error_unauthorized
       end
     end

--- a/modules/backlogs/app/contracts/sprints/update_contract.rb
+++ b/modules/backlogs/app/contracts/sprints/update_contract.rb
@@ -28,34 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Backlogs
-  class NewSprintDialogComponent < ApplicationComponent
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
-
-    DIALOG_ID = "new-sprint-dialog"
-    FORM_ID = "new-sprint-dialog-form"
-    FOOTER_ID = "new-sprint-dialog-footer"
-
-    def initialize(sprint:, state: :create)
-      super
-
-      @sprint = sprint
-      @state = state
-    end
+module Sprints
+  class UpdateContract < BaseContract
+    validate :user_allowed_to_update
 
     private
 
-    def state_create? = @state == :create
+    def user_allowed_to_update
+      return if model.project.nil?
 
-    def state_edit? = @state == :edit
-
-    def title
-      state_create? ? t(:label_sprint_new) : t(:label_sprint_edit)
-    end
-
-    def button_caption
-      state_create? ? t(:button_create) : t(:button_save)
+      unless user.allowed_in_project?(:update_sprints, model.project)
+        errors.add :base, :error_unauthorized
+      end
     end
   end
 end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -36,14 +36,20 @@ class RbMasterBacklogsController < RbApplicationController
   before_action :load_backlogs, only: :index
 
   def index
-    if turbo_frame_request?
-      if scrum_projects_enabled?
+    if OpenProject::FeatureDecisions.scrum_projects_active?
+      # Feature flag is active, render the new views
+      if turbo_frame_request?
         render partial: "agile_list", layout: false
       else
-        render partial: "list", layout: false
+        render :agile_index
       end
     else
-      render :index
+      # Feature flag is not active, render legacy views
+      if turbo_frame_request? # rubocop:disable Style/IfInsideElse
+        render partial: "list", layout: false
+      else
+        render :index
+      end
     end
   end
 
@@ -63,7 +69,7 @@ class RbMasterBacklogsController < RbApplicationController
   def load_backlogs
     @owner_backlogs = Backlog.owner_backlogs(@project)
 
-    if scrum_projects_enabled?
+    if OpenProject::FeatureDecisions.scrum_projects_active?
       @sprints = @project.sprints.open.order_by_date
     else
       @sprint_backlogs = Backlog.sprint_backlogs(@project)

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -70,7 +70,7 @@ class RbMasterBacklogsController < RbApplicationController
     @owner_backlogs = Backlog.owner_backlogs(@project)
 
     if OpenProject::FeatureDecisions.scrum_projects_active?
-      @sprints = @project.sprints.not_completed.order_by_date
+      @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
     else
       @sprint_backlogs = Backlog.sprint_backlogs(@project)
     end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -35,11 +35,13 @@ class RbMasterBacklogsController < RbApplicationController
 
   before_action :load_backlogs, only: :index
 
-  helper_method :scrum_projects_enabled?
-
   def index
     if turbo_frame_request?
-      render partial: "list", layout: false
+      if scrum_projects_enabled?
+        render partial: "agile_list", layout: false
+      else
+        render partial: "list", layout: false
+      end
     else
       render :index
     end
@@ -66,9 +68,5 @@ class RbMasterBacklogsController < RbApplicationController
     else
       @sprint_backlogs = Backlog.sprint_backlogs(@project)
     end
-  end
-
-  def scrum_projects_enabled?
-    OpenProject::FeatureDecisions.scrum_projects_active?
   end
 end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -58,7 +58,12 @@ class RbMasterBacklogsController < RbApplicationController
       render "work_packages/split_view", layout: false
     else
       load_backlogs
-      render :index
+
+      if OpenProject::FeatureDecisions.scrum_projects_active?
+        render :agile_index
+      else
+        render :index
+      end
     end
   end
 

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -35,6 +35,8 @@ class RbMasterBacklogsController < RbApplicationController
 
   before_action :load_backlogs, only: :index
 
+  helper_method :scrum_projects_enabled?
+
   def index
     if turbo_frame_request?
       render partial: "list", layout: false
@@ -58,6 +60,15 @@ class RbMasterBacklogsController < RbApplicationController
 
   def load_backlogs
     @owner_backlogs = Backlog.owner_backlogs(@project)
-    @sprint_backlogs = Backlog.sprint_backlogs(@project)
+
+    if scrum_projects_enabled?
+      @sprints = @project.sprints.open.order_by_date
+    else
+      @sprint_backlogs = Backlog.sprint_backlogs(@project)
+    end
+  end
+
+  def scrum_projects_enabled?
+    OpenProject::FeatureDecisions.scrum_projects_active?
   end
 end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -70,7 +70,7 @@ class RbMasterBacklogsController < RbApplicationController
     @owner_backlogs = Backlog.owner_backlogs(@project)
 
     if OpenProject::FeatureDecisions.scrum_projects_active?
-      @sprints = @project.sprints.open.order_by_date
+      @sprints = @project.sprints.not_completed.order_by_date
     else
       @sprint_backlogs = Backlog.sprint_backlogs(@project)
     end

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -81,13 +81,12 @@ class RbSprintsController < RbApplicationController
              .call(attributes: converted_agile_sprint_params)
 
     if call.success?
-      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_create))
-      replace_backlogs_container_via_turbo_stream
+      flash[:notice] = I18n.t(:notice_successful_create)
+      render turbo_stream: turbo_stream.redirect_to(backlogs_project_backlogs_path(@project))
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
+      respond_with_turbo_streams
     end
-
-    respond_with_turbo_streams
   end
 
   # Called like this due to `update` being taken by legacy sprints.
@@ -172,18 +171,6 @@ class RbSprintsController < RbApplicationController
       ),
       status: :bad_request
     )
-  end
-
-  # This is usually done by the RbMasterBacklogsController, it feels wrong to have this here
-  def replace_backlogs_container_via_turbo_stream
-    @owner_backlogs = Backlog.owner_backlogs(@project)
-    @sprints = @project.sprints.open.order_by_date
-
-    turbo_streams << OpTurbo::StreamComponent.new(
-      action: :replace,
-      target: "backlogs_container",
-      template: render_to_string(partial: "rb_master_backlogs/agile_list", layout: false)
-    ).render_in(view_context)
   end
 
   # Overrides load_sprint_and_project to load the sprint from :id instead of :sprint_id

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -54,14 +54,14 @@ class RbSprintsController < RbApplicationController
   end
 
   def edit_dialog
-    @sprint = Agile::Sprint.visible.find(params[:id])
+    @sprint = Agile::Sprint.for_project(@project).visible.find(params[:id])
 
     respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: @sprint, state: :edit)
   end
 
   def refresh_form
-    id = edit_agile_sprint_params[:sprint][:id]
-    sprint = id.present? ? Agile::Sprint.visible.find(id) : Agile::Sprint.new
+    id = edit_agile_sprint_params.dig(:sprint, :id)
+    sprint = id.present? ? Agile::Sprint.for_project(@project).visible.find(id) : Agile::Sprint.new
 
     call = Sprints::SetAttributesService.new(
       user: current_user,
@@ -90,7 +90,7 @@ class RbSprintsController < RbApplicationController
 
   # Called like this due to `update` being taken by legacy sprints.
   def update_agile_sprint # rubocop:disable Metrics/AbcSize
-    @sprint = Agile::Sprint.visible.find(params[:id])
+    @sprint = Agile::Sprint.for_project(@project).visible.find(params[:id])
 
     call = Sprints::UpdateService
              .new(user: current_user, model: @sprint)

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -54,15 +54,14 @@ class RbSprintsController < RbApplicationController
   end
 
   def edit_dialog
-    # TODO: visible-scope?
-    @sprint = Agile::Sprint.find(params[:id])
+    @sprint = Agile::Sprint.visible.find(params[:id])
 
     respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: @sprint, state: :edit)
   end
 
   def refresh_form
     id = edit_agile_sprint_params[:sprint][:id]
-    sprint = id.present? ? Agile::Sprint.find(id) : Agile::Sprint.new
+    sprint = id.present? ? Agile::Sprint.visible.find(id) : Agile::Sprint.new
 
     call = Sprints::SetAttributesService.new(
       user: current_user,
@@ -91,8 +90,7 @@ class RbSprintsController < RbApplicationController
 
   # Called like this due to `update` being taken by legacy sprints.
   def update_agile_sprint # rubocop:disable Metrics/AbcSize
-    # TODO: visible-scope?
-    @sprint = Agile::Sprint.find(params[:id])
+    @sprint = Agile::Sprint.visible.find(params[:id])
 
     call = Sprints::UpdateService
              .new(user: current_user, model: @sprint)

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -98,7 +98,7 @@ class RbSprintsController < RbApplicationController
 
     if call.success?
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
-      update_sprint_header_component_via_turbo_stream(sprint: call.result, state: :show)
+      update_sprint_header_component_via_turbo_stream(sprint: call.result)
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
     end
@@ -152,13 +152,8 @@ class RbSprintsController < RbApplicationController
     )
   end
 
-  def update_sprint_header_component_via_turbo_stream(sprint:, state: :show)
-    update_via_turbo_stream(
-      component: Backlogs::SprintHeaderComponent.new(
-        sprint:,
-        state:
-      )
-    )
+  def update_sprint_header_component_via_turbo_stream(sprint:)
+    update_via_turbo_stream(component: Backlogs::SprintHeaderComponent.new(sprint:))
   end
 
   def update_new_sprint_form_component_via_turbo_stream(sprint:, base_errors: nil)

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -75,7 +75,7 @@ class RbSprintsController < RbApplicationController
     respond_with_turbo_streams
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     call = Sprints::CreateService
              .new(user: current_user)
              .call(attributes: converted_agile_sprint_params)
@@ -90,7 +90,7 @@ class RbSprintsController < RbApplicationController
   end
 
   # Called like this due to `update` being taken by legacy sprints.
-  def update_agile_sprint
+  def update_agile_sprint # rubocop:disable Metrics/AbcSize
     # TODO: visible-scope?
     @sprint = Agile::Sprint.find(params[:id])
 

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -31,7 +31,11 @@
 class RbSprintsController < RbApplicationController
   include OpTurbo::ComponentStream
 
-  NEW_SPRINT_ACTIONS = %i[new_dialog edit_dialog create refresh_form].freeze
+  NEW_SPRINT_ACTIONS = %i[new_dialog
+                          edit_dialog
+                          create
+                          refresh_form
+                          update_agile_sprint].freeze
 
   skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS
 
@@ -53,13 +57,16 @@ class RbSprintsController < RbApplicationController
     # TODO: visible-scope?
     @sprint = Agile::Sprint.find(params[:id])
 
-    respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: @sprint)
+    respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: @sprint, state: :edit)
   end
 
   def refresh_form
+    id = edit_agile_sprint_params[:sprint][:id]
+    sprint = id.present? ? Agile::Sprint.find(id) : Agile::Sprint.new
+
     call = Sprints::SetAttributesService.new(
       user: current_user,
-      model: Agile::Sprint.new,
+      model: sprint,
       contract_class: EmptyContract
     ).call(attributes: converted_agile_sprint_params)
 
@@ -84,7 +91,21 @@ class RbSprintsController < RbApplicationController
 
   # Called like this due to `update` being taken by legacy sprints.
   def update_agile_sprint
-    # TODO: implement
+    # TODO: visible-scope?
+    @sprint = Agile::Sprint.find(params[:id])
+
+    call = Sprints::UpdateService
+             .new(user: current_user, model: @sprint)
+             .call(attributes: agile_sprint_params[:sprint])
+
+    if call.success?
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+      update_sprint_header_component_via_turbo_stream(sprint: call.result, state: :show)
+    else
+      update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
+    end
+
+    respond_with_turbo_streams
   end
 
   def edit_name
@@ -133,6 +154,15 @@ class RbSprintsController < RbApplicationController
     )
   end
 
+  def update_sprint_header_component_via_turbo_stream(sprint:, state: :show)
+    update_via_turbo_stream(
+      component: Backlogs::SprintHeaderComponent.new(
+        sprint:,
+        state:
+      )
+    )
+  end
+
   def update_new_sprint_form_component_via_turbo_stream(sprint:, base_errors: nil)
     update_via_turbo_stream(
       component: Backlogs::NewSprintFormComponent.new(
@@ -159,6 +189,10 @@ class RbSprintsController < RbApplicationController
 
   def agile_sprint_params
     params.permit(sprint: %i[name start_date finish_date])
+  end
+
+  def edit_agile_sprint_params
+    params.permit(sprint: %i[id name start_date finish_date])
   end
 
   def converted_agile_sprint_params

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -31,7 +31,7 @@
 class RbSprintsController < RbApplicationController
   include OpTurbo::ComponentStream
 
-  NEW_SPRINT_ACTIONS = %i[new_dialog create refresh_form].freeze
+  NEW_SPRINT_ACTIONS = %i[new_dialog edit_dialog create refresh_form].freeze
 
   skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS
 
@@ -47,6 +47,13 @@ class RbSprintsController < RbApplicationController
     ).call(attributes: converted_agile_sprint_params)
 
     respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: call.result)
+  end
+
+  def edit_dialog
+    # TODO: visible-scope?
+    @sprint = Agile::Sprint.find(params[:id])
+
+    respond_with_dialog Backlogs::NewSprintDialogComponent.new(sprint: @sprint)
   end
 
   def refresh_form
@@ -73,6 +80,11 @@ class RbSprintsController < RbApplicationController
     end
 
     respond_with_turbo_streams
+  end
+
+  # Called like this due to `update` being taken by legacy sprints.
+  def update_agile_sprint
+    # TODO: implement
   end
 
   def edit_name

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -82,6 +82,7 @@ class RbSprintsController < RbApplicationController
 
     if call.success?
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_create))
+      replace_backlogs_container_via_turbo_stream
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
     end
@@ -171,6 +172,18 @@ class RbSprintsController < RbApplicationController
       ),
       status: :bad_request
     )
+  end
+
+  # This is usually done by the RbMasterBacklogsController, it feels wrong to have this here
+  def replace_backlogs_container_via_turbo_stream
+    @owner_backlogs = Backlog.owner_backlogs(@project)
+    @sprints = @project.sprints.open.order_by_date
+
+    turbo_streams << OpTurbo::StreamComponent.new(
+      action: :replace,
+      target: "backlogs_container",
+      template: render_to_string(partial: "rb_master_backlogs/agile_list", layout: false)
+    ).render_in(view_context)
   end
 
   # Overrides load_sprint_and_project to load the sprint from :id instead of :sprint_id

--- a/modules/backlogs/app/forms/backlogs/sprints/details_form.rb
+++ b/modules/backlogs/app/forms/backlogs/sprints/details_form.rb
@@ -32,6 +32,8 @@ module Backlogs
   module Sprints
     class DetailsForm < ApplicationForm
       form do |f|
+        f.hidden(name: :id)
+
         f.text_field(
           label: attribute_name(:name),
           name: :name,

--- a/modules/backlogs/app/helpers/rb_common_helper.rb
+++ b/modules/backlogs/app/helpers/rb_common_helper.rb
@@ -132,8 +132,12 @@ module RbCommonHelper
     item.remaining_hours.blank? || item.remaining_hours == 0 ? "" : item.remaining_hours
   end
 
+  def scrum_projects_enabled?
+    OpenProject::FeatureDecisions.scrum_projects_active?
+  end
+
   def allow_sprint_creation?(project)
-    OpenProject::FeatureDecisions.scrum_projects_active? && User.current.allowed_in_project?(:create_sprints, project)
+    scrum_projects_enabled? && User.current.allowed_in_project?(:create_sprints, project)
   end
 
   private

--- a/modules/backlogs/app/helpers/rb_common_helper.rb
+++ b/modules/backlogs/app/helpers/rb_common_helper.rb
@@ -137,7 +137,7 @@ module RbCommonHelper
   end
 
   def allow_sprint_creation?(project)
-    scrum_projects_enabled? && User.current.allowed_in_project?(:create_sprints, project)
+    scrum_projects_enabled? && current_user.allowed_in_project?(:create_sprints, project)
   end
 
   private

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -89,8 +89,6 @@ module Agile
       Day.working.from_range(from: start_date, to: finish_date).count
     end
 
-    def has_burndown? = false
-
     private
 
     # TODO: consider moving this validation to the database level to ensure data integrity.

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -44,6 +44,8 @@ module Agile
       order(arel_table[:start_date].asc.nulls_last,
             arel_table[:finish_date].asc.nulls_last)
     end
+    # FIXME: replace this stub with a meaningful implementation.
+    scope :visible, -> { all }
 
     enum :status,
          {

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -41,7 +41,8 @@ module Agile
     scope :for_project, ->(project) { where(project:) }
     scope :not_completed, -> { !completed }
     scope :order_by_date, -> do
-      reorder(Arel.sql("start_date ASC NULLS LAST, finish_date ASC NULLS LAST"))
+      order(arel_table[:start_date].asc.nulls_last,
+            arel_table[:finish_date].asc.nulls_last)
     end
 
     enum :status,

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -39,6 +39,10 @@ module Agile
     has_many :work_packages, dependent: :nullify
 
     scope :for_project, ->(project) { where(project:) }
+    scope :open, -> { !completed }
+    scope :order_by_date, -> do
+      reorder(Arel.sql("start_date ASC NULLS LAST, finish_date ASC NULLS LAST"))
+    end
 
     enum :status,
          {
@@ -81,6 +85,8 @@ module Agile
 
       Day.working.from_range(from: start_date, to: finish_date).count
     end
+
+    def has_burndown? = false
 
     private
 

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -39,7 +39,7 @@ module Agile
     has_many :work_packages, dependent: :nullify
 
     scope :for_project, ->(project) { where(project:) }
-    scope :open, -> { !completed }
+    scope :not_completed, -> { !completed }
     scope :order_by_date, -> do
       reorder(Arel.sql("start_date ASC NULLS LAST, finish_date ASC NULLS LAST"))
     end

--- a/modules/backlogs/app/services/sprints/update_service.rb
+++ b/modules/backlogs/app/services/sprints/update_service.rb
@@ -28,34 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Backlogs
-  class NewSprintDialogComponent < ApplicationComponent
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
-
-    DIALOG_ID = "new-sprint-dialog"
-    FORM_ID = "new-sprint-dialog-form"
-    FOOTER_ID = "new-sprint-dialog-footer"
-
-    def initialize(sprint:, state: :create)
-      super
-
-      @sprint = sprint
-      @state = state
-    end
-
-    private
-
-    def state_create? = @state == :create
-
-    def state_edit? = @state == :edit
-
-    def title
-      state_create? ? t(:label_sprint_new) : t(:label_sprint_edit)
-    end
-
-    def button_caption
-      state_create? ? t(:button_create) : t(:button_save)
-    end
+class Sprints::UpdateService < BaseServices::Update
+  def instance_class
+    Agile::Sprint
   end
 end

--- a/modules/backlogs/app/views/rb_master_backlogs/_agile_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_agile_list.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% else %>
     <div class="op-backlogs-container" data-controller="generic-drag-and-drop">
       <div id="sprint_backlogs_container" class="op-backlogs-lists">
-        <%= render(Backlogs::SprintComponent.with_collection(@sprints, project: @project)) %>
+        <%= render(Backlogs::SprintComponent.with_collection(@sprints)) %>
       </div>
       <div id="owner_backlogs_container" class="op-backlogs-lists">
         <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>

--- a/modules/backlogs/app/views/rb_master_backlogs/_agile_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_agile_list.html.erb
@@ -28,13 +28,13 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <turbo-frame id="backlogs_container" refresh="morph" class="op-backlogs-page">
-  <% if @owner_backlogs.empty? && @sprint_backlogs.empty? %>
+  <% if @owner_backlogs.empty? && @sprints.empty? %>
     <%=
       render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
         blankslate.with_visual_icon(icon: :versions)
         blankslate.with_heading(tag: :h2).with_content(t(:backlogs_empty_title))
 
-        if current_user.allowed_in_project?(:create_sprints, @project)
+        if current_user.allowed_in_project?(:manage_versions, @project)
           blankslate.with_description_content(t(:backlogs_empty_action_text))
         end
       end
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% else %>
     <div class="op-backlogs-container" data-controller="generic-drag-and-drop">
       <div id="sprint_backlogs_container" class="op-backlogs-lists">
-        <%= render(Backlogs::BacklogComponent.with_collection(@sprint_backlogs, project: @project)) %>
+        <%= render(Backlogs::SprintComponent.with_collection(@sprints, project: @project)) %>
       </div>
       <div id="owner_backlogs_container" class="op-backlogs-lists">
         <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>

--- a/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="backlogs_container" refresh="morph" class="op-backlogs-page">
-  <% if @owner_backlogs.empty? && @sprint_backlogs.empty? %>
+  <% if @owner_backlogs.empty? && @sprint_backlogs.empty? # TODO: add feature flag condition here? %>
     <%=
       render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
         blankslate.with_visual_icon(icon: :versions)
@@ -13,7 +13,11 @@
   <% else %>
     <div class="op-backlogs-container" data-controller="generic-drag-and-drop">
       <div id="sprint_backlogs_container" class="op-backlogs-lists">
-        <%= render(Backlogs::BacklogComponent.with_collection(@sprint_backlogs, project: @project)) %>
+        <% if scrum_projects_enabled? %>
+          <%= render(Backlogs::SprintComponent.with_collection(@sprints, project: @project)) %>
+        <% else %>
+          <%= render(Backlogs::BacklogComponent.with_collection(@sprint_backlogs, project: @project)) %>
+        <% end %>
       </div>
       <div id="owner_backlogs_container" class="op-backlogs-lists">
         <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>

--- a/modules/backlogs/app/views/rb_master_backlogs/agile_index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/agile_index.html.erb
@@ -1,0 +1,95 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<% html_title t(:label_backlogs) %>
+
+<% content_controller "backlogs",
+                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project),
+                      "backlogs-backlogs--story-outlet": "li[data-story]" %>
+
+<% content_for :content_header do %>
+  <%=
+    render Primer::OpenProject::PageHeader.new do |header|
+      header.with_title { t(:label_backlogs) }
+      header.with_breadcrumbs(
+        [{ href: project_overview_path(@project), text: @project.name },
+         t(:label_backlogs)]
+      )
+    end
+  %>
+
+  <%=
+    render(Primer::OpenProject::SubHeader.new) do |subheader|
+      if allow_sprint_creation?(@project)
+        # Scrum sprints are available, show an action menu to create Sprints and Versions
+        subheader.with_action_menu(
+          leading_icon: :plus,
+          trailing_icon: :"triangle-down",
+          label: t(:button_create),
+          button_arguments: { scheme: :primary }
+        ) do |menu|
+          menu.with_item(
+            label: Version.human_model_name,
+            href: new_project_version_path(@project)
+          )
+
+          menu.with_item(
+            label: Agile::Sprint.human_model_name,
+            href: new_dialog_project_sprints_path(@project),
+            content_arguments: {
+              data: {
+                controller: "async-dialog",
+                test_selector: "op-sprints--new-sprint-button"
+              }
+            }
+          )
+        end
+      else
+        # No scrum sprints, we only show a "+ Version" button
+        subheader.with_action_button(
+          scheme: :primary,
+          leading_icon: :plus,
+          label: I18n.t(:label_version_new),
+          tag: :a,
+          href: new_project_version_path(@project)
+        ) do
+          Version.human_model_name
+        end
+      end
+    end
+  %>
+<% end %>
+
+<% content_for :content_body do %>
+  <%= render partial: "agile_list" %>
+<% end %>
+
+<% content_for :content_body_right do %>
+  <%= render(split_view_instance) if render_work_package_split_view? %>
+<% end %>

--- a/modules/backlogs/app/views/rb_master_backlogs/agile_index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/agile_index.html.erb
@@ -30,7 +30,6 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_backlogs) %>
 
 <% content_controller "backlogs",
-                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project),
                       "backlogs-backlogs--story-outlet": "li[data-story]" %>
 
 <% content_for :content_header do %>

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -29,10 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_backlogs) %>
 
-<% content_controller "backlogs",
-                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project),
-                      "backlogs-backlogs--story-outlet": "li[data-story]" %>
-
 <% content_for :content_header do %>
   <%=
     render Primer::OpenProject::PageHeader.new do |header|

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -29,6 +29,10 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_backlogs) %>
 
+<% content_controller "backlogs",
+                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project),
+                      "backlogs-backlogs--story-outlet": "li[data-story]" %>
+
 <% content_for :content_header do %>
   <%=
     render Primer::OpenProject::PageHeader.new do |header|

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
   label_column_in_backlog: "Column in backlog"
   label_points_burn_down: "Down"
   label_points_burn_up: "Up"
+  label_sprint_edit: "Edit sprint"
   label_sprint_impediments: "Sprint Impediments"
   label_sprint_new: "New sprint"
   label_task_board: "Task board"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -169,6 +169,7 @@ en:
   label_backlogs_unconfigured: "You have not configured Backlogs yet. Please go to %{administration} > %{plugins}, then click on the %{configure} link for this plugin. Once you have set the fields, come back to this page to start using the tool."
   label_blocks_ids: "IDs of blocked work packages"
   label_column_in_backlog: "Column in backlog"
+  label_used_as_backlog: "Used as backlog"
   label_points_burn_down: "Down"
   label_points_burn_up: "Up"
   label_sprint_edit: "Edit sprint"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -98,12 +98,23 @@ en:
       blankslate_title: "%{name} is empty"
       blankslate_description: "No items planned yet. Drag items here to add them."
 
+    sprint_component:
+      blankslate_title: "%{name} is empty"
+      blankslate_description: "No items planned yet. Drag items here to add them."
+
     backlog_header_component:
       label_toggle_backlog: "Collapse/Expand %{name}"
       label_story_count:
         zero: "No stories in backlog"
         one: "%{count} story in backlog"
         other: "%{count} stories in backlog"
+
+    sprint_header_component:
+      label_toggle_backlog: "Collapse/Expand %{name}"
+      label_story_count:
+        zero: "No stories in sprint"
+        one: "%{count} story in sprint"
+        other: "%{count} stories in sprint"
 
     backlog_menu_component:
       label_actions: "Backlog actions"
@@ -115,6 +126,15 @@ en:
         burndown_chart: "Burndown chart"
         wiki: "Wiki"
         properties: "Properties"
+
+    sprint_menu_component:
+      label_actions: "Sprint actions"
+      action_menu:
+        edit_sprint: "Edit sprint"
+        new_story: "New story"
+        stories_tasks: "Stories/Tasks"
+        task_board: "Task board"
+        burndown_chart: "Burndown chart"
 
     story_component:
       label_drag_story: "Move %{name}"

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -30,11 +30,15 @@ Rails.application.routes.draw do
   # Routes for the new Agile::Sprint
   # Scoped under projects for permissions:
   resources :projects, only: [] do
-    resources :sprints, controller: :rb_sprints, only: %i[] do
+    resources :sprints, controller: :rb_sprints, only: %i[create] do
       collection do
         get :new_dialog
         get :refresh_form
-        post :create
+      end
+
+      member do
+        get :edit_dialog
+        put :update_agile_sprint
       end
     end
   end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -86,7 +86,7 @@ module OpenProject::Backlogs
                    require: :member
 
         permission :create_sprints,
-                   { rb_sprints: %i[new_dialog refresh_form create edit_name update],
+                   { rb_sprints: %i[new_dialog refresh_form create edit_name update edit_dialog update_agile_sprint],
                      rb_wikis: %i[edit update] },
                    permissible_on: :project,
                    require: :member,

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::SprintComponent, type: :component do
+  shared_let(:type_feature) { create(:type_feature) }
+  shared_let(:type_task) { create(:type_task) }
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  let(:project) { create(:project, types: [type_feature, type_task]) }
+  let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: Date.tomorrow) }
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+      .and_return("story_types" => [type_feature.id.to_s], "task_type" => type_task.id.to_s)
+
+    allow(user).to receive(:backlogs_preference).with(:versions_default_fold_state).and_return("open")
+  end
+
+  def render_component
+    render_inline(described_class.new(sprint:, current_user: user))
+  end
+
+  describe "rendering" do
+    context "with stories" do
+      let!(:story1) do
+        create(:work_package,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: 5,
+               position: 1,
+               sprint: sprint)
+      end
+      let!(:story2) do
+        create(:work_package,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: 3,
+               position: 2,
+               sprint: sprint)
+      end
+
+      it "renders a Primer::Beta::BorderBox" do
+        render_component
+
+        expect(page).to have_css(".Box")
+      end
+
+      it "has the sprint ID in the DOM id" do
+        render_component
+
+        expect(page).to have_css(".Box#agile_sprint_#{sprint.id}")
+      end
+
+      it "renders BacklogHeaderComponent in header" do
+        render_component
+
+        expect(page).to have_css(".Box-header h3", text: "Sprint 1")
+      end
+
+      it "renders StoryComponent for each story" do
+        render_component
+
+        expect(page).to have_css(".Box-row", count: 2) # 2 stories
+        expect(page).to have_text(story1.subject)
+        expect(page).to have_text(story2.subject)
+      end
+
+      it "has drop target data attributes" do
+        render_component
+
+        box = page.find(".Box")
+        expect(box["data-target-id"]).to eq(sprint.id.to_s)
+        expect(box["data-target-allowed-drag-type"]).to eq("story")
+      end
+
+      it "has draggable data attributes on story rows" do
+        render_component
+
+        story_row = page.find(".Box-row[id='work_package_#{story1.id}']")
+        expect(story_row["data-draggable-id"]).to eq(story1.id.to_s)
+        expect(story_row["data-draggable-type"]).to eq("story")
+        expect(story_row["data-drop-url"]).to include("move")
+      end
+
+      it "renders story rows with proper classes" do
+        render_component
+
+        story_row = page.find(".Box-row[id='work_package_#{story1.id}']")
+        expect(story_row[:class]).to include("Box-row--hover-blue")
+        expect(story_row[:class]).to include("Box-row--focus-gray")
+        expect(story_row[:class]).to include("Box-row--clickable")
+      end
+    end
+
+    context "without stories" do
+      let(:rendered_component) { render_component }
+
+      it_behaves_like "rendering Blank Slate", heading: "Sprint 1 is empty"
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
+  shared_let(:type_feature) { create(:type_feature) }
+  shared_let(:type_task) { create(:type_task) }
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  let(:project) { create(:project, types: [type_feature, type_task]) }
+  let(:start_date) { Date.new(2024, 1, 15) }
+  let(:finish_date) { Date.new(2024, 1, 29) }
+  let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date:, finish_date:) }
+  let(:state) { :show }
+  let(:folded) { false }
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+      .and_return("story_types" => [type_feature.id.to_s], "task_type" => type_task.id.to_s)
+  end
+
+  def render_component(folded: false)
+    render_inline(described_class.new(sprint:, folded:, current_user: user))
+  end
+
+  describe "show state (default)" do
+    context "with stories" do
+      let!(:story1) do
+        create(:story,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: 5,
+               sprint:)
+      end
+      let!(:story2) do
+        create(:story,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: 3,
+               sprint:)
+      end
+      let!(:story_with_nil_points) do
+        create(:story,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: nil,
+               sprint:)
+      end
+
+      it "displays sprint name in h4" do
+        render_component
+
+        expect(page).to have_css("h3", text: "Sprint 1")
+      end
+
+      it "shows story count via Primer::Beta::Counter" do
+        render_component
+
+        expect(page).to have_css(".Counter", text: "3")
+      end
+
+      it "shows formatted date range with time tags" do
+        render_component
+
+        expect(page).to have_css("time[datetime='2024-01-15']")
+        expect(page).to have_css("time[datetime='2024-01-29']")
+      end
+
+      it "shows story points total (nil treated as 0)" do
+        render_component
+
+        # 5 + 3 + 0 = 8 points
+        expect(page).to have_text("8 points", normalize_ws: true)
+      end
+
+      it "renders collapse/expand chevrons" do
+        render_component
+
+        expect(page).to have_octicon(:"chevron-up", visible: :all)
+        expect(page).to have_octicon(:"chevron-down", visible: :all)
+      end
+
+      it "renders BacklogMenuComponent" do
+        render_component
+
+        expect(page).to have_css("action-menu")
+      end
+    end
+
+    context "with no stories" do
+      let(:stories) { [] }
+
+      it "shows 0 story count" do
+        render_component
+
+        expect(page).to have_css(".Counter", text: "0")
+      end
+
+      it "shows 0 points" do
+        render_component
+
+        expect(page).to have_text("0 points", normalize_ws: true)
+      end
+    end
+
+    context "when sprint has no dates" do
+      let(:sprint) { build_stubbed(:agile_sprint, project:, name: "Sprint 1", start_date: nil, finish_date: nil) }
+
+      it "renders without date range" do
+        render_component
+
+        expect(page).to have_no_css("time")
+      end
+    end
+  end
+
+  describe "folded state" do
+    context "when folded is true" do
+      it "renders chevron-up hidden and chevron-down visible" do
+        render_component(folded: true)
+
+        # When folded, chevron-up is hidden (has hidden attribute on svg)
+        # and chevron-down is visible (for expanding)
+        expect(page).to have_css("svg[hidden][data-target='collapsible-header.arrowUp']", visible: :hidden)
+        expect(page).to have_css("svg[data-target='collapsible-header.arrowDown']:not([hidden])", visible: :all)
+      end
+    end
+
+    context "when folded is false" do
+      it "renders chevron-down hidden and chevron-up visible" do
+        render_component(folded: false)
+
+        # When expanded, chevron-down is hidden (has hidden attribute)
+        # and chevron-up is visible (for collapsing)
+        expect(page).to have_css("svg[hidden][data-target='collapsible-header.arrowDown']", visible: :hidden)
+        expect(page).to have_css("svg[data-target='collapsible-header.arrowUp']:not([hidden])", visible: :all)
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::SprintMenuComponent, type: :component do
+  shared_let(:type_feature) { create(:type_feature) }
+  shared_let(:type_task) { create(:type_task) }
+
+  let(:project) { create(:project, types: [type_feature, type_task]) }
+  let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: Date.tomorrow) }
+  let(:stories) { [] }
+  let(:user) { create(:user) }
+  let(:permissions) { [] }
+
+  before do
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+      .and_return("story_types" => [type_feature.id.to_s], "task_type" => type_task.id.to_s)
+
+    # Set up user with specific permissions
+    create(:member,
+           project:,
+           principal: user,
+           roles: [create(:project_role, permissions:)])
+    login_as(user)
+  end
+
+  def render_component
+    render_inline(described_class.new(sprint:, project:, current_user: user))
+  end
+
+  describe "permission-based items" do
+    context "with :manage_sprint_items permission" do
+      let(:permissions) { %i[view_sprints manage_sprint_items] }
+
+      it "shows Add new story item with compose icon" do
+        render_component
+
+        expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.new_story"))
+        expect(page).to have_octicon(:compose)
+      end
+    end
+
+    context "without :manage_sprint_items permission" do
+      let(:permissions) { [:view_sprints] }
+
+      it "does not show Add new story item" do
+        render_component
+
+        expect(page).to have_no_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.new_story"))
+      end
+    end
+
+    context "with :create_sprints permission" do
+      let(:permissions) { %i[view_sprints create_sprints] }
+
+      it "shows Edit item with pencil icon" do
+        render_component
+
+        expect(page).to have_css("action-menu")
+        expect(page).to have_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
+        expect(page).to have_octicon(:pencil)
+      end
+    end
+
+    context "without :create_sprints permission" do
+      let(:permissions) { [:view_sprints] }
+
+      it "does not show Edit item" do
+        render_component
+
+        expect(page).to have_no_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
+      end
+    end
+  end
+
+  describe "always-visible items" do
+    let(:permissions) { [:view_sprints] }
+
+    it "shows Stories/Tasks link" do
+      render_component
+
+      expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.stories_tasks"))
+    end
+  end
+end

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_permissions_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_permissions_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RbSprintsController, "permissions" do
     create(:project, enabled_module_names: %w[work_package_tracking backlogs]).tap do |p|
       create(:member,
              user: current_user,
-             roles: [create(:project_role, permissions: [:update_sprints])],
+             roles: [create(:project_role, permissions: [:create_sprints])],
              project: p)
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe RbSprintsController, "permissions" do
       before do
         create(:member,
                user: current_user,
-               roles: [create(:project_role, permissions: %i[view_work_packages view_versions update_sprints])],
+               roles: [create(:project_role, permissions: %i[view_work_packages view_versions create_sprints])],
                project: sprint_project)
       end
 

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -102,14 +102,16 @@ RSpec.describe RbSprintsController do
           }
         end
 
-        it "responds with success and creates a sprint", :aggregate_failures do
+        it "responds with success, creates a sprint, and redirects to backlogs", :aggregate_failures do
           post :create, format: :turbo_stream, params: params
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
-          expect(response).to have_turbo_stream action: "flash"
-          # See feature spec for detailed expectations on the created sprint and rendered components
+          expect(response.body).to include("turbo-stream")
+          expect(response.body).to include("action=\"redirect_to\"")
+          expect(response.body).to include(backlogs_project_backlogs_path(project))
           expect(project.reload.sprints.last.name).to eq("My Sprint")
+          expect(flash[:notice]).to eq(I18n.t(:notice_successful_create))
         end
 
         context "without the 'create_sprints' permission" do

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -84,6 +84,42 @@ RSpec.describe RbSprintsController do
       end
     end
 
+    describe "GET #edit_dialog" do
+      let!(:sprint) { create(:agile_sprint, project:) }
+
+      context "with the feature flag inactive" do
+        it "responds with forbidden" do
+          get :edit_dialog, params: { project_id: project.id, id: sprint.id }, format: :turbo_stream
+
+          expect(response).not_to be_successful
+          expect(response).to have_http_status :forbidden
+        end
+      end
+
+      context "with the feature flag active", with_flag: { scrum_projects: true } do
+        it "responds with success", :aggregate_failures do
+          get :edit_dialog, params: { project_id: project.id, id: sprint.id }, format: :turbo_stream
+
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "dialog", target: "backlogs-new-sprint-dialog-component"
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:sprint)).to eq(sprint)
+        end
+
+        context "without the 'create_sprints' permission" do
+          let(:permissions) { all_permissions - [:create_sprints] }
+
+          it "responds with forbidden", :aggregate_failures do
+            get :edit_dialog, params: { project_id: project.id, id: sprint.id }, format: :turbo_stream
+
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+    end
+
     describe "POST #create" do
       context "with the feature flag inactive" do
         it "responds with forbidden" do
@@ -127,6 +163,49 @@ RSpec.describe RbSprintsController do
       end
     end
 
+    describe "PUT #update_agile_sprint" do
+      let!(:sprint) { create(:agile_sprint, name: "Original sprint name", project:) }
+
+      context "with the feature flag inactive" do
+        it "responds with forbidden" do
+          put :update_agile_sprint, params: { id: sprint.id, project_id: project.id }, format: :turbo_stream
+
+          expect(response).not_to be_successful
+          expect(response).to have_http_status :forbidden
+        end
+      end
+
+      context "with the feature flag active", with_flag: { scrum_projects: true } do
+        let(:params) do
+          {
+            id: sprint.id,
+            project_id: project.id,
+            sprint: { name: "Changed sprint name" }
+          }
+        end
+
+        it "responds with success", :aggregate_failures do
+          put :update_agile_sprint, format: :turbo_stream, params: params
+
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response.body).to have_turbo_stream action: "flash"
+          expect(sprint.reload.name).to eq("Changed sprint name")
+        end
+
+        context "without the 'create_sprints' permission" do
+          let(:permissions) { all_permissions - [:create_sprints] }
+
+          it "responds with forbidden", :aggregate_failures do
+            put :update_agile_sprint, format: :turbo_stream, params: params
+
+            expect(response).not_to be_successful
+            expect(response).to have_http_status :forbidden
+          end
+        end
+      end
+    end
+
     describe "GET #refresh_form" do
       context "with the feature flag inactive" do
         it "responds with forbidden" do
@@ -151,6 +230,7 @@ RSpec.describe RbSprintsController do
           expect(response).to be_successful
           expect(response).to have_http_status :ok
           expect(response).to have_turbo_stream action: "update", target: "backlogs-new-sprint-form-component"
+          expect(assigns(:sprint)).to be_nil
         end
 
         context "without the 'create_sprints' permission" do
@@ -161,6 +241,24 @@ RSpec.describe RbSprintsController do
 
             expect(response).not_to be_successful
             expect(response).to have_http_status :forbidden
+          end
+        end
+
+        context "when refreshing the form in edit mode by passing a sprint id" do
+          let!(:sprint) { create(:agile_sprint, project:) }
+          let(:params) do
+            {
+              project_id: project.id,
+              sprint: { id: sprint.id, name: "My Sprint", start_date: "2025-10-05", finish_date: "2025-10-15" }
+            }
+          end
+
+          it "responds with success", :aggregate_failures do
+            get :refresh_form, format: :turbo_stream, params: params
+
+            expect(response).to be_successful
+            expect(response).to have_http_status :ok
+            expect(response).to have_turbo_stream action: "update", target: "backlogs-new-sprint-form-component"
           end
         end
       end

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe RbSprintsController do
           expect(response).to be_successful
           expect(response).to have_http_status :ok
           expect(response.body).to have_turbo_stream action: "flash"
+          expect(response.body).to include("Successful update.")
           expect(sprint.reload.name).to eq("Changed sprint name")
         end
 

--- a/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
+++ b/modules/backlogs/spec/features/backlogs_in_backlog_view_spec.rb
@@ -123,13 +123,13 @@ RSpec.describe "Backlogs in backlog view", :js do
 
     # Versions can be folded
     backlogs_page
-      .expect_story_in_sprint(sprint_story1, sprint)
+      .expect_story_in_backlog(sprint_story1, sprint)
 
     backlogs_page
       .fold_backlog(sprint)
 
     backlogs_page
-      .expect_story_not_in_sprint(sprint_story1, sprint)
+      .expect_story_not_in_backlog(sprint_story1, sprint)
 
     # The backlogs can be folded by default
     visit my_interface_path
@@ -142,13 +142,13 @@ RSpec.describe "Backlogs in backlog view", :js do
     backlogs_page.visit!
 
     backlogs_page
-      .expect_story_not_in_sprint(sprint_story1, sprint)
+      .expect_story_not_in_backlog(sprint_story1, sprint)
 
     backlogs_page
       .fold_backlog(sprint)
 
     backlogs_page
-      .expect_story_in_sprint(sprint_story1, sprint)
+      .expect_story_in_backlog(sprint_story1, sprint)
 
     # Alter the attributes of the sprint
     sleep(0.5)

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Create", :js do
           click_on "Create"
         end
 
-        wait_for_reload
+        expect_and_dismiss_flash(message: "Successful creation.")
         backlogs_page.expect_sprint_names_in_order(initial_sprint.name, "Created sprint")
 
         sprint = project.reload.sprints.last

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe "Create", :js do
   end
   let(:backlogs_page) { Pages::Backlogs.new(project) }
 
+  let!(:initial_sprint) do
+    create(:agile_sprint,
+           project:,
+           name: "Initial sprint",
+           start_date: Date.new(2025, 9, 5),
+           finish_date: Date.new(2025, 9, 15))
+  end
+
   let(:story_type) do
     create(:type_feature)
   end
@@ -77,34 +85,37 @@ RSpec.describe "Create", :js do
 
   context "with the feature flag active", with_flag: { scrum_projects: true } do
     context "with the 'create_sprints' permissions" do
-      before do
-        click_on "Create"
-        new_sprint_button = page.find_test_selector("op-sprints--new-sprint-button")
-        new_sprint_button&.click
-      end
-
       let(:start_date) { Date.new(2025, 10, 5) }
       let(:start_date_fmt) { start_date.strftime("%Y-%m-%d") }
       let(:finish_date) { Date.new(2025, 10, 20) }
       let(:finish_date_fmt) { finish_date.strftime("%Y-%m-%d") }
 
       it "allows creating a new sprint" do
+        backlogs_page.expect_sprint_names_in_order(initial_sprint.name)
+
+        backlogs_page.open_create_sprint_dialog
+
         within_dialog "New sprint" do
-          page.fill_in "Sprint name", with: "My first sprint"
+          page.fill_in "Sprint name", with: "Created sprint"
           page.fill_in "Start date", with: start_date_fmt
           page.fill_in "Finish date", with: finish_date_fmt
 
           click_on "Create"
         end
 
+        wait_for_reload
+        backlogs_page.expect_sprint_names_in_order(initial_sprint.name, "Created sprint")
+
         sprint = project.reload.sprints.last
         expect(sprint).to be_present
-        expect(sprint.name).to eq "My first sprint"
+        expect(sprint.name).to eq "Created sprint"
         expect(sprint.start_date).to eq start_date
         expect(sprint.finish_date).to eq finish_date
       end
 
       it "previews the sprint duration when changing the dates" do
+        backlogs_page.open_create_sprint_dialog
+
         within_dialog "New sprint" do
           expect(page).to have_field "Duration", with: "", readonly: true
 
@@ -119,6 +130,8 @@ RSpec.describe "Create", :js do
         let(:too_early_finish_date) { start_date - 1.day }
 
         it "validates required fields are present" do
+          backlogs_page.open_create_sprint_dialog
+
           within_dialog "New sprint" do
             page.fill_in "Sprint name", with: ""
 
@@ -131,6 +144,8 @@ RSpec.describe "Create", :js do
         end
 
         it "validates finish date is not before start date" do
+          backlogs_page.open_create_sprint_dialog
+
           within_dialog "New sprint" do
             page.fill_in "Start date", with: start_date_fmt
             page.fill_in "Finish date", with: too_early_finish_date.strftime("%Y-%m-%d")
@@ -147,7 +162,11 @@ RSpec.describe "Create", :js do
       end
 
       describe "proposed sprint names" do
+        let!(:initial_sprint) { nil } # override so that initial sprint is not present
+
         it "prefilled with 'Sprint 1' if there are no previous sprints" do
+          backlogs_page.open_create_sprint_dialog
+
           within_dialog "New sprint" do
             expect(page).to have_field "Sprint name *", with: "Sprint 1", required: true, focused: true
           end
@@ -158,9 +177,7 @@ RSpec.describe "Create", :js do
             create(:agile_sprint, name: "Be ambitious 42", project:)
 
             backlogs_page.visit!
-            click_on "Create"
-            new_sprint_button = page.find_test_selector("op-sprints--new-sprint-button")
-            new_sprint_button.click
+            backlogs_page.open_create_sprint_dialog
           end
 
           it "offers the next sprint name with a number increment" do

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlogs"
+
+RSpec.describe "Edit", :js do
+  let(:project) { create(:project) }
+  let(:all_permissions) { %i[view_sprints add_work_packages view_work_packages create_sprints] }
+  let(:permissions) { all_permissions }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:backlogs_page) { Pages::Backlogs.new(project) }
+
+  let(:story_type) do
+    create(:type_feature)
+  end
+  let(:story_type2) do
+    type = create(:type)
+
+    project.types << type
+
+    type
+  end
+  let(:inactive_story_type) do
+    create(:type)
+  end
+
+  let(:task_type) do
+    type = create(:type_task)
+    project.types << type
+
+    type
+  end
+
+  let!(:closed_sprint) do
+    create(:agile_sprint,
+           project:,
+           status: "completed",
+           start_date: Date.new(2025, 8, 25),
+           finish_date: Date.new(2025, 9, 4))
+  end
+
+  let!(:first_sprint) do
+    create(:agile_sprint,
+           project:,
+           start_date: Date.new(2025, 9, 5),
+           finish_date: Date.new(2025, 9, 15))
+  end
+
+  let!(:second_sprint) do
+    create(:agile_sprint,
+           project:,
+           start_date: Date.new(2025, 9, 16),
+           finish_date: Date.new(2025, 9, 26))
+  end
+
+  let!(:work_package) do
+    create(:work_package, subject: "First work package", project:, sprint: first_sprint, type: story_type)
+  end
+
+  # Necessary so that work packages can be created via dialog
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+
+  before do
+    login_as(user)
+
+    # Legacy backlogs module requires type configuration
+    allow(Setting)
+      .to receive(:plugin_openproject_backlogs)
+            .and_return("story_types" => [story_type.id.to_s,
+                                          story_type2.id.to_s,
+                                          inactive_story_type.id.to_s],
+                        "task_type" => task_type.id.to_s)
+
+    backlogs_page.visit!
+  end
+
+  context "with the feature flag active", with_flag: { scrum_projects: true } do
+    it "lists all open sprints" do
+      backlogs_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
+
+      backlogs_page.expect_story_in_sprint(work_package, first_sprint)
+      backlogs_page.expect_story_not_in_sprint(work_package, second_sprint)
+    end
+
+    it "adds a work package to a sprint" do
+      backlogs_page.click_in_sprint_menu(first_sprint, "New story")
+      backlogs_page.expect_create_work_package_dialog
+
+      page.within("#create-work-package-dialog") do
+        page.fill_in "Subject", with: "Story created in sprint"
+
+        click_on "Create"
+      end
+
+      wait_for_reload
+
+      expect_and_dismiss_flash type: :success, message: "New work package created and added as a child"
+      created_wp = first_sprint.reload.work_packages.last
+      expect(created_wp.subject).to eq("Story created in sprint")
+      backlogs_page.expect_story_in_sprint(created_wp, first_sprint)
+    end
+
+    context "with the 'create_sprints' permissions" do
+      context "when editing a sprint" do
+        it "displays all menu entries" do
+          backlogs_page.within_sprint_menu(first_sprint) do |menu|
+            expect(menu).to have_selector :menuitem, count: 4
+            expect(menu).to have_selector :menuitem, "Edit sprint"
+            expect(menu).to have_selector :menuitem, "New story"
+            expect(menu).to have_selector :menuitem, "Stories/Tasks"
+            expect(menu).to have_selector :menuitem, "Task board"
+            expect(menu).to have_selector :menuitem, "Burndown chart", disabled: true # disabled item does not count
+          end
+        end
+
+        it "edits the sprint name" do
+          backlogs_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
+
+          backlogs_page.click_in_sprint_menu(first_sprint, "Edit sprint")
+          backlogs_page.expect_sprint_dialog
+
+          within_dialog "Edit sprint" do
+            page.fill_in "Sprint name", with: "Changed name"
+            page.click_button "Save"
+          end
+
+          wait_for_reload
+          backlogs_page.expect_sprint_names_in_order("Changed name", second_sprint.name)
+        end
+
+        context "when lacking the 'add_work_packages' permission" do
+          let(:permissions) { all_permissions - %i[add_work_packages] }
+
+          it "has no menu entry for creating a new story" do
+            backlogs_page.within_sprint_menu(first_sprint) do |menu|
+              expect(menu).to have_selector :menuitem, count: 3
+              expect(menu).to have_selector :menuitem, "Edit sprint"
+              expect(menu).to have_selector :menuitem, "Stories/Tasks"
+              expect(menu).to have_selector :menuitem, "Task board"
+              expect(menu).to have_selector :menuitem, "Burndown chart", disabled: true
+
+              expect(menu).to have_no_selector :menuitem, "New story"
+            end
+          end
+        end
+      end
+    end
+
+    context "without the necessary permissions" do
+      let(:permissions) { all_permissions - [:create_sprints] }
+
+      it "is missing the 'new sprint' button" do
+        expect(page).to have_no_button "Create"
+        expect(page).not_to have_test_selector("op-sprints--new-sprint-button")
+      end
+
+      it "has no menu entry for editing a sprint" do
+        backlogs_page.within_sprint_menu(first_sprint) do |menu|
+          expect(menu).to have_selector :menuitem, "Stories/Tasks"
+          expect(menu).to have_no_selector :menuitem, "Edit sprint"
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -33,7 +33,7 @@ require_relative "../../support/pages/backlogs"
 
 RSpec.describe "Edit", :js do
   let(:project) { create(:project) }
-  let(:all_permissions) { %i[view_sprints add_work_packages view_work_packages create_sprints] }
+  let(:all_permissions) { %i[view_sprints add_work_packages view_work_packages create_sprints manage_sprint_items] }
   let(:permissions) { all_permissions }
   let(:user) do
     create(:user, member_with_permissions: { project => permissions })
@@ -135,12 +135,10 @@ RSpec.describe "Edit", :js do
       context "when editing a sprint" do
         it "displays all menu entries" do
           backlogs_page.within_sprint_menu(first_sprint) do |menu|
-            expect(menu).to have_selector :menuitem, count: 4
+            expect(menu).to have_selector :menuitem, count: 3
             expect(menu).to have_selector :menuitem, "Edit sprint"
             expect(menu).to have_selector :menuitem, "New story"
             expect(menu).to have_selector :menuitem, "Stories/Tasks"
-            expect(menu).to have_selector :menuitem, "Task board"
-            expect(menu).to have_selector :menuitem, "Burndown chart", disabled: true # disabled item does not count
           end
         end
 
@@ -159,16 +157,14 @@ RSpec.describe "Edit", :js do
           backlogs_page.expect_sprint_names_in_order("Changed name", second_sprint.name)
         end
 
-        context "when lacking the 'add_work_packages' permission" do
-          let(:permissions) { all_permissions - %i[add_work_packages] }
+        context "when lacking the 'manage_sprint_items' permission" do
+          let(:permissions) { all_permissions - %i[manage_sprint_items] }
 
           it "has no menu entry for creating a new story" do
             backlogs_page.within_sprint_menu(first_sprint) do |menu|
-              expect(menu).to have_selector :menuitem, count: 3
+              expect(menu).to have_selector :menuitem, count: 2
               expect(menu).to have_selector :menuitem, "Edit sprint"
               expect(menu).to have_selector :menuitem, "Stories/Tasks"
-              expect(menu).to have_selector :menuitem, "Task board"
-              expect(menu).to have_selector :menuitem, "Burndown chart", disabled: true
 
               expect(menu).to have_no_selector :menuitem, "New story"
             end

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -144,22 +144,22 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
 
   it "displays stories in correct order, calculates velocity, and allows editing story points" do
     backlogs_page
-      .expect_story_in_sprint(sprint_story1, sprint)
+      .expect_story_in_backlog(sprint_story1, sprint)
 
     backlogs_page
-      .expect_story_in_sprint(sprint_story2, sprint)
+      .expect_story_in_backlog(sprint_story2, sprint)
 
     backlogs_page
-      .expect_story_in_sprint(backlog_story1, backlog)
+      .expect_story_in_backlog(backlog_story1, backlog)
 
     backlogs_page
-      .expect_story_not_in_sprint(sprint_story2_parent, sprint)
+      .expect_story_not_in_backlog(sprint_story2_parent, sprint)
 
     backlogs_page
-      .expect_story_not_in_sprint(sprint_story1_task, sprint)
+      .expect_story_not_in_backlog(sprint_story1_task, sprint)
 
     backlogs_page
-      .expect_story_not_in_sprint(sprint_story_in_other_project, sprint)
+      .expect_story_not_in_backlog(sprint_story_in_other_project, sprint)
 
     backlogs_page
       .expect_stories_in_order(sprint, sprint_story1, sprint_story2)
@@ -182,14 +182,14 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
     backlogs_page
       .edit_story_in_details_view(sprint_story1, version: backlog)
 
-    backlogs_page.expect_story_not_in_sprint(sprint_story1, sprint)
-    backlogs_page.expect_story_in_sprint(sprint_story1, backlog)
+    backlogs_page.expect_story_not_in_backlog(sprint_story1, sprint)
+    backlogs_page.expect_story_in_backlog(sprint_story1, backlog)
   end
 
   it "removes story from sprint when type is changed to non-story type via details view" do
     backlogs_page
       .edit_story_in_details_view(sprint_story2, type: task.name)
 
-    backlogs_page.expect_story_not_in_sprint(sprint_story2, sprint)
+    backlogs_page.expect_story_not_in_backlog(sprint_story2, sprint)
   end
 end

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -119,6 +119,14 @@ module Pages
       end
     end
 
+    def sprint_names_in_order
+      page.find_all("#sprint_backlogs_container > section .op-backlogs-collapsible--title").map(&:text)
+    end
+
+    def expect_sprint_names_in_order(*sprint_names)
+      expect(sprint_names_in_order).to match_array(sprint_names)
+    end
+
     def expect_sprint(sprint)
       expect(page)
         .to have_css("#sprint_backlogs_container #{backlog_selector(sprint)}")
@@ -194,6 +202,12 @@ module Pages
       expect(page).to have_current_path details_backlogs_project_backlogs_path(story.project, story)
 
       yield details_view
+    end
+
+    def open_create_sprint_dialog
+      click_on "Create"
+      new_sprint_button = page.find_test_selector("op-sprints--new-sprint-button")
+      new_sprint_button&.click
     end
 
     private

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -126,7 +126,7 @@ module Pages
     end
 
     def sprint_names_in_order
-      page.find_all("#sprint_backlogs_container > section .op-backlogs-collapsible--title").map(&:text)
+      page.find_all("#sprint_backlogs_container > section .CollapsibleHeader-title").map(&:text)
     end
 
     def expect_sprint_names_in_order(*sprint_names)

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -225,9 +225,11 @@ module Pages
     end
 
     def open_create_sprint_dialog
-      click_on "Create"
-      new_sprint_button = page.find_test_selector("op-sprints--new-sprint-button")
-      new_sprint_button&.click
+      find(:button, accessible_name: "Create").click
+
+      within(:menu) do |menu|
+        menu.find(:menuitem, "Sprint").click
+      end
     end
 
     def expect_sprint_dialog

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -144,30 +144,30 @@ module Pages
     end
 
     def expect_story_in_sprint(story, sprint)
-      if sprint.is_a?(Agile::Sprint)
-        within_sprint(sprint) do
-          expect(page)
-            .to have_selector(work_package_selector(story).to_s)
-        end
-      else
-        within_backlog(sprint) do
-          expect(page)
-            .to have_selector(story_selector(story).to_s)
-        end
+      within_sprint(sprint) do
+        expect(page)
+          .to have_selector(work_package_selector(story).to_s)
+      end
+    end
+
+    def expect_story_in_backlog(story, backlog)
+      within_backlog(backlog) do
+        expect(page)
+          .to have_selector(story_selector(story).to_s)
       end
     end
 
     def expect_story_not_in_sprint(story, sprint)
-      if sprint.is_a?(Agile::Sprint)
-        within_sprint(sprint) do
-          expect(page)
-            .to have_no_selector(work_package_selector(story).to_s)
-        end
-      else
-        within_backlog(sprint) do
-          expect(page)
-            .to have_no_selector(story_selector(story).to_s)
-        end
+      within_sprint(sprint) do
+        expect(page)
+          .to have_no_selector(work_package_selector(story).to_s)
+      end
+    end
+
+    def expect_story_not_in_backlog(story, backlog)
+      within_backlog(backlog) do
+        expect(page)
+          .to have_no_selector(story_selector(story).to_s)
       end
     end
 

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -130,7 +130,7 @@ module Pages
     end
 
     def expect_sprint_names_in_order(*sprint_names)
-      expect(sprint_names_in_order).to match_array(sprint_names)
+      expect(sprint_names_in_order).to eq(sprint_names)
     end
 
     def expect_sprint(sprint)

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -100,6 +100,12 @@ module Pages
       end
     end
 
+    def click_in_sprint_menu(sprint, item_name)
+      within_sprint_menu(sprint) do |menu|
+        menu.find(:menuitem, text: item_name).click
+      end
+    end
+
     def click_in_story_menu(story, item_name)
       within_story_menu(story) do |menu|
         menu.find(:menuitem, text: item_name).click
@@ -138,16 +144,30 @@ module Pages
     end
 
     def expect_story_in_sprint(story, sprint)
-      within_backlog(sprint) do
-        expect(page)
-          .to have_selector(story_selector(story).to_s)
+      if sprint.is_a?(Agile::Sprint)
+        within_sprint(sprint) do
+          expect(page)
+            .to have_selector(work_package_selector(story).to_s)
+        end
+      else
+        within_backlog(sprint) do
+          expect(page)
+            .to have_selector(story_selector(story).to_s)
+        end
       end
     end
 
     def expect_story_not_in_sprint(story, sprint)
-      within_backlog(sprint) do
-        expect(page)
-          .to have_no_selector(story_selector(story).to_s)
+      if sprint.is_a?(Agile::Sprint)
+        within_sprint(sprint) do
+          expect(page)
+            .to have_no_selector(work_package_selector(story).to_s)
+        end
+      else
+        within_backlog(sprint) do
+          expect(page)
+            .to have_no_selector(story_selector(story).to_s)
+        end
       end
     end
 
@@ -210,6 +230,22 @@ module Pages
       new_sprint_button&.click
     end
 
+    def expect_sprint_dialog
+      expect(page).to have_css("#new-sprint-dialog")
+    end
+
+    def expect_create_work_package_dialog
+      expect(page).to have_css("#create-work-package-dialog")
+    end
+
+    def within_sprint_menu(backlog, &)
+      within_sprint(backlog) do
+        find(:button, accessible_name: "Sprint actions").click
+
+        within(:menu, &)
+      end
+    end
+
     private
 
     def within_story(story, &)
@@ -220,12 +256,24 @@ module Pages
       within(backlog_selector(backlog), &)
     end
 
+    def within_sprint(sprint, &)
+      within(sprint_selector(sprint), &)
+    end
+
+    def sprint_selector(sprint)
+      "#agile_sprint_#{sprint.id}"
+    end
+
     def backlog_selector(backlog)
       "#backlog_#{backlog.id}"
     end
 
     def story_selector(story)
       "#story_#{story.id}"
+    end
+
+    def work_package_selector(story)
+      "#work_package_#{story.id}"
     end
   end
 end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -549,6 +549,12 @@ RSpec.describe PermittedParams do
       it_behaves_like "allows params"
     end
 
+    describe "sprint_id" do
+      let(:hash) { { "sprint_id" => "1" } }
+
+      it_behaves_like "allows params"
+    end
+
     describe "notes" do
       let(:hash) { { "journal_notes" => "blubs" } }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71250

* Copied `views/rb_master_backlogs/_list.html.erb` to `views/rb_master_backlogs/_agile_list.html.erb`
  * Renders the `SprintComponent` instead of the `BacklogComponent` on the left hand side. The right side of the view remains unchanged and will still show versions.
* Copied and renamed `BacklogComponent` to `SprintComponent`
  * It uses the `SprintHeaderComponent` instead of the `BacklogHeaderComponent`
  * It uses the `SprintMenuComponent` instead of the `BacklogMenuComponent`
* Consequently, `BacklogHeaderComponent` has been copied to `SprintHeaderComponent`
* `BacklogMenuComponent` has been copied to `SprintMenuComponent`
  * The menu for sprints has the following modifications:
    * Editing a Sprint will open the Sprint dialog in edit mode.
    * Adding a story will add a work package to the Sprint (same as before, but with the `Agile::Sprint` instance as a target instead of a Version)
    * The other menu points (taskboard, burndown chart, etc.) have been colored red. They do not work at the moment due to missing routes and dependency on other tickets. Ignore these menu points. It's fine if they have a broken link. This entire view is hidden behind a feature flag.
    * The "wiki" and "properties" menu action has been removed.

The above changes come with some complimentary updates to the dialog, form and controller. I tried to keep the changes to the copied views to a minimum.

## With this PR, you can

* View and edit `Agile::Sprint` instances on the left side of the view.
* Add work packages to these sprints (via the sprint action menu -> new story)
* Designate a Version to be used as backlog. It will show up on the right side.

Additionally, the version settings page gets a small modification. Instead of having the option to choose the backlogs column left, right or none, you can now only select whether or not this version will be "used as backlog". We planned to implement this via checkbox. But doing so causes the params to be structured differently. So I went for a select with two options (yes and no) instead. Bad UX, but maybe good enough for now.

## With this PR, you can NOT

Note that drag and drop for work packages/stories does not work. There is a [separate implementation chunk](https://community.openproject.org/wp/72849) to tackle this.

## To do:

- [ ] ~Ensure drag and drop between sprints is working~ will be handled in [72849](https://community.openproject.org/wp/72849)
- [ ] ~Ensure drag and drop between versions and sprints is working~ will be handled in [72849](https://community.openproject.org/wp/72849)
- [ ] ~Implement backlog switch select input~ Will be handled in [72876](https://community.openproject.org/wp/72876)
- [x] Version settings: replace column select with checkbox ("used as backlog")
- [x] Ensure the improvements from #22166 are applied to the copied components
- [x] Fix specs
- [x] Write new controller specs for the edit/update action
- [x] Write a feature spec for displaying and editing sprints on the left hand side of the view


## Screenshots
Sprints to the left, versions to the right:
<img width="1456" height="823" alt="image" src="https://github.com/user-attachments/assets/55126b82-6f94-4e26-9fce-16a6afa237af" />

Editing a sprint using the sprint dialog:
<img width="1160" height="823" alt="image" src="https://github.com/user-attachments/assets/4cc6613f-f0a1-4949-9e96-a88daf8ed38e" />

Version settings updated to show a yes/no selection for "used as backlog":
<img width="1160" height="823" alt="image" src="https://github.com/user-attachments/assets/d8620ea1-84fe-4ca8-9d6d-e8f163dadb77" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
