### PR TITLE
Remove deprecated `on_booted` and use `after_booted`

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -129,8 +129,7 @@ if Rails.env.development?
   end
 
   if siginfo_supported
-    # Using on_booted is needed to override puma adding handler to show thread statuses
-    on_booted do
+    after_booted do
       Signal.trap("INFO") do
         system "open", Rails.application.root_url
       end


### PR DESCRIPTION
Fixes deprecation warning when booting the application:

```
... gems/3.4.0/gems/puma-7.2.0/lib/puma.rb:85:in 'Puma.deprecate_method_change': Use 'after_booted', 'on_booted' is deprecated and will be removed in v8
```