### PR TITLE
[71863] Editor is not focused when activating edit field

### DIFF
--- a/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/rich_text_area_component.rb
@@ -55,7 +55,13 @@ module OpenProject
         end
 
         def call
-          form.rich_text_area(name: attribute, **@system_arguments)
+          form.rich_text_area(name: attribute,
+                              wrapper_data_attributes: {
+                                controller: "ckeditor-focus",
+                                ckeditor_focus_target: "editor",
+                                ckeditor_focus_autofocus_value: true
+                              },
+                              **@system_arguments)
 
           form.group(layout: :horizontal, justify_content: :flex_end) do |button_group|
             button_group.submit(name: :reset,

--- a/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/text_input_component.rb
@@ -49,6 +49,7 @@ module OpenProject
 
         def call
           form.text_field name: attribute,
+                          autofocus: true,
                           data: { controller: "inplace-edit",
                                   inplace_edit_url_value: reset_url,
                                   action: "keydown.esc->inplace-edit#request" },


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/71863

# What are you trying to accomplish?
Automatically focus the ckEditor when clicking into it. Thereby we try to remember the click position to set the cursor to the correct place. This works in most of cases, however due to the offset there are some edge cases where the cursor is one letter next to actual click position.
