### PR TITLE
[#72674] Can not rename a meeting which was created as part of a series  

### DIFF
--- a/modules/meeting/app/services/recurring_meetings/update_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/update_service.rb
@@ -37,6 +37,7 @@ module RecurringMeetings
     def validate_params
       @old_schedule_model = model.dup
       @old_location = model.template.location
+      @old_title = model.title
       super
     end
 
@@ -52,6 +53,8 @@ module RecurringMeetings
       end
 
       cleanup_cancelled_schedules(recurring_meeting)
+      update_future_occurrence_titles(recurring_meeting)
+
       update_template(call)
     end
 
@@ -151,6 +154,18 @@ module RecurringMeetings
         .find_each do |scheduled|
           occurring = recurring_meeting.schedule.occurs_at?(scheduled.start_time)
           scheduled.delete unless occurring
+      end
+    end
+
+    def update_future_occurrence_titles(recurring_meeting)
+      new_title = @template_params[:title]
+      return if new_title == @old_title
+
+      recurring_meeting
+        .scheduled_instances(upcoming: true)
+        .instantiated
+        .each do |scheduled|
+          scheduled.meeting.update_column(:title, new_title)
       end
     end
 

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -373,4 +373,24 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
       end
     end
   end
+
+  describe "updating series title" do
+    let!(:scheduled_meetings) do
+      Array.new(3) do |i|
+        create(:scheduled_meeting,
+               :persisted,
+               recurring_meeting: series,
+               start_time: Time.zone.today + (i + 1).days + 10.hours)
+      end
+    end
+    let(:params) { { title: "Updated series title" } }
+
+    it "updates open future meeting occurrence titles" do
+      expect(service_result).to be_success
+
+      scheduled_meetings.each do |scheduled|
+        expect(scheduled.meeting.reload.title).to eq("Updated series title")
+      end
+    end
+  end
 end

--- a/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/update_service_integration_spec.rb
@@ -375,7 +375,13 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
   end
 
   describe "updating series title" do
-    let!(:scheduled_meetings) do
+    shared_let(:past_scheduled_meeting) do
+      create(:scheduled_meeting,
+             :persisted,
+             recurring_meeting: series,
+             start_time: Time.zone.yesterday + 10.hours)
+    end
+    shared_let(:scheduled_meetings) do
       Array.new(3) do |i|
         create(:scheduled_meeting,
                :persisted,
@@ -383,6 +389,7 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
                start_time: Time.zone.today + (i + 1).days + 10.hours)
       end
     end
+
     let(:params) { { title: "Updated series title" } }
 
     it "updates open future meeting occurrence titles" do
@@ -391,6 +398,12 @@ RSpec.describe RecurringMeetings::UpdateService, "integration", type: :model do
       scheduled_meetings.each do |scheduled|
         expect(scheduled.meeting.reload.title).to eq("Updated series title")
       end
+    end
+
+    it "does not update past meeting occurrence titles" do
+      expect(service_result).to be_success
+
+      expect(past_scheduled_meeting.meeting.reload.title).not_to eq("Updated series title")
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72674

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
