### PR TITLE
Fix/failing portfolio details component spec

### DIFF
--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
 
     describe "#updated_at" do
       before do
-        allow(portfolio).to receive(:updated_at).and_return(1.month.ago)
+        allow(portfolio).to receive(:updated_at).and_return(31.days.ago)
       end
 
       it "shows when the portfolio was last updated" do


### PR DESCRIPTION
# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- The ~component that returns relative time~ [distance_of_time_in_words](https://apidock.com/rails/ActionView/Helpers/DateHelper/distance_of_time_in_words) method returns number of days if the date is < 30 days ago apparently
- This causes problems when `1.month.ago` is the 2nd of Feb and Feb only has 28 days
- Setting the test data to be 31 days explicitly instead of 1 month fixes this

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
