### PR TITLE
[72676] 'Actual costs per months' widget does not show previous 11 months

### DIFF
--- a/modules/costs/app/components/costs/widgets/actual_costs.rb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.rb
@@ -40,7 +40,9 @@ module Costs
       def initialize(...)
         super
 
-        @aggregated_costs = Costs::AggregatedCosts.new(project:, current_user:, date_range: 11.months.ago.to_date..Date.current)
+        start_date = Date.current.beginning_of_month - 11.months
+        end_date   = Date.current.end_of_month
+        @aggregated_costs = Costs::AggregatedCosts.new(project:, current_user:, date_range: start_date..end_date)
       end
 
       def render?

--- a/modules/costs/app/components/costs/widgets/actual_costs.rb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.rb
@@ -40,7 +40,7 @@ module Costs
       def initialize(...)
         super
 
-        @aggregated_costs = Costs::AggregatedCosts.new(project:, current_user:, date_range: Date.current.all_year)
+        @aggregated_costs = Costs::AggregatedCosts.new(project:, current_user:, date_range: 11.months.ago.to_date..Date.current)
       end
 
       def render?


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72676

# What are you trying to accomplish?
Show last 11month and current month instead of the current year
