### PR TITLE
Indicate MCP server url in config UI

### DIFF
--- a/app/components/mcp_configurations/server_url_component.html.erb
+++ b/app/components/mcp_configurations/server_url_component.html.erb
@@ -1,0 +1,50 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+render(Primer::OpenProject::InputGroup.new(input_width: :large)) do |input_group|
+  input_group.with_text_input(
+    name: :server_url,
+    label: t(".label"),
+    visually_hide_label: false,
+    value: server_url
+  )
+
+  input_group.with_trailing_action_clipboard_copy_button(
+    value: server_url,
+    aria: {
+      label: I18n.t("button_copy_to_clipboard")
+    }
+  )
+
+  input_group.with_caption do
+    t(".caption")
+  end
+end
+%>

--- a/app/components/mcp_configurations/server_url_component.rb
+++ b/app/components/mcp_configurations/server_url_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module McpConfigurations
+  class ServerUrlComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    def server_url
+      url_helpers.api_mcp_url
+    end
+  end
+end

--- a/app/forms/mcp_configurations/server_form.rb
+++ b/app/forms/mcp_configurations/server_form.rb
@@ -39,6 +39,10 @@ module McpConfigurations
       )
 
       if server_enabled?
+        f.html_content do
+          render(McpConfigurations::ServerUrlComponent.new)
+        end
+
         f.text_field(
           name: :title,
           label: McpConfiguration.human_attribute_name(:title),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -635,6 +635,11 @@ en:
     confirmation_live_message_checked: "The button to proceed is now active."
     confirmation_live_message_unchecked: "The button to proceed is now inactive. You need to tick the checkbox to continue."
 
+  mcp_configurations:
+    server_url_component:
+      caption: "The URL at which the OpenProject MCP server will be reachable. Required for setting up MCP clients."
+      label: "Server URL"
+
   op_dry_validation:
     or: "or"
     errors:


### PR DESCRIPTION
Giving admins quick access to this URL, because it will be required during setup of a client.

Visual appearance was clarified with UX already.