### PR TITLE
[72677] Codeblock editor appears behind new WP dialog

### DIFF
--- a/app/components/work_packages/dialogs/create_form_component.html.erb
+++ b/app/components/work_packages/dialogs/create_form_component.html.erb
@@ -6,7 +6,7 @@
       url: project_work_packages_dialog_path(project),
       method: :post,
       html: {
-        id: 'create-work-package-form',
+        id: "create-work-package-form",
         data: {
           controller: "work-packages--create-dialog",
           "work-packages--create-dialog-refresh-url-value": refresh_form_project_work_packages_dialog_path(project)
@@ -22,6 +22,10 @@
 
         modal_body.with_row do
           render(WorkPackages::Dialogs::CreateForm.new(f, work_package:, wrapper_id: "#create-work-package-dialog"))
+        end
+
+        modal_body.with_row do
+          helpers.angular_component_tag "opce-custom-modal-overlay"
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72677

# What are you trying to accomplish?
Show code dialog in front of the creation dialog by making use of the custom Target machnism we already have in place. We just have to add the div which maps the custom target
