### PR TITLE
[fix] make project visible for representer test

### DIFF
--- a/docs/api/apiv3/components/schemas/meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_model.yml
@@ -53,7 +53,6 @@ properties:
     required:
       - attachments
       - author
-      - project
     properties:
       attachments:
         $ref: './attachments_model.yml'

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe API::V3::Meetings::MeetingRepresenter do
   include API::V3::Utilities::PathHelper
 
-  let(:workspace) { build_stubbed(:project, public: true) }
+  let(:workspace) { build_stubbed(:project) }
   let(:current_user) do
     build_stubbed(:user)
   end

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -33,7 +33,7 @@ require "spec_helper"
 RSpec.describe API::V3::Meetings::MeetingRepresenter do
   include API::V3::Utilities::PathHelper
 
-  let(:workspace) { build_stubbed(:project) }
+  let(:workspace) { build_stubbed(:project, public: true) }
   let(:current_user) do
     build_stubbed(:user)
   end


### PR DESCRIPTION
# What are you trying to accomplish?
- when rendering a meeting with any user, the project must be visible, the representer test now reflects that

