### PR TITLE
[72681] Refine widget blankslate text and position

### DIFF
--- a/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.html
+++ b/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.html
@@ -2,6 +2,4 @@
   <div class="position-relative mx-auto" style="height:60vh;max-height:500px;">
     <canvas baseChart [data]="barChartData()" [options]="barChartOptions()" type="bar"></canvas>
   </div>
-} @else {
-  <op-no-results [title]="text.noResults.title" [message]="text.noResults.description" />
 }

--- a/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
@@ -55,13 +55,6 @@ export class ActualCostsComponent {
   readonly chartData = input.required<string>();
   readonly currency = input<string>('€');
 
-  readonly text = {
-    noResults: {
-      title: this.i18n.t('js.costs.widgets.actual_costs.blankslate.title'),
-      description: this.i18n.t('js.costs.widgets.actual_costs.blankslate.description'),
-    },
-  };
-
   readonly barChartData = computed<ChartData<'bar'>>(() => JSON.parse(this.chartData()) as ChartData<'bar'>);
   readonly hasChartData = computed(() => this.barChartData().datasets.length > 0);
 

--- a/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
@@ -37,7 +37,6 @@ import {
 import { ChartConfiguration, ChartData } from 'chart.js';
 import 'chartjs-adapter-luxon';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { NoResultsComponent } from 'core-app/shared/components/blankslate/no-results.component';
 import { chartFont, chartLegend, createBarTooltipRenderer } from 'core-app/shared/components/budget-graphs/chart.config';
 import PrimerColorsPlugin from 'core-app/shared/components/work-package-graphs/plugin.primer-colors';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
@@ -45,7 +44,7 @@ import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2
 @Component({
   selector: 'opce-actual-costs',
   templateUrl: './actual-costs.component.html',
-  imports: [BaseChartDirective, NoResultsComponent],
+  imports: [BaseChartDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [provideCharts(withDefaultRegisterables(PrimerColorsPlugin))],
 })

--- a/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.html
+++ b/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.html
@@ -2,6 +2,4 @@
   <div class="position-relative mx-auto" style="height:60vh;max-height:500px">
     <canvas baseChart [data]="pieChartData()" [options]="pieChartOptions()" type="pie"></canvas>
   </div>
-} @else {
-  <op-no-results [title]="text.noResults.title" [message]="text.noResults.description" />
 }

--- a/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.ts
@@ -38,13 +38,12 @@ import { ChartConfiguration, ChartData } from 'chart.js';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { chartFont, chartLegend, createPieTooltipRenderer } from 'core-app/shared/components/budget-graphs/chart.config';
 import PrimerColorsPlugin from 'core-app/shared/components/work-package-graphs/plugin.primer-colors';
-import { NoResultsComponent } from 'core-app/shared/components/blankslate/no-results.component';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
 @Component({
   selector: 'opce-budget-by-cost-type',
   templateUrl: './budget-by-cost-type.component.html',
-  imports: [BaseChartDirective, NoResultsComponent],
+  imports: [BaseChartDirective],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [provideCharts(withDefaultRegisterables(PrimerColorsPlugin))],
 })

--- a/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/budget-by-cost-type.component.ts
@@ -54,13 +54,6 @@ export class BudgetByCostTypeComponent {
   readonly chartData = input.required<string>();
   readonly currency = input<string>('€');
 
-  readonly text = {
-    noResults: {
-      title: this.i18n.t('js.budgets.widgets.budget_by_cost_type.blankslate.title'),
-      description: this.i18n.t('js.budgets.widgets.budget_by_cost_type.blankslate.description'),
-    },
-  };
-
   readonly pieChartData = computed<ChartData<'pie'>>(() => JSON.parse(this.chartData()) as ChartData<'pie'>);
   readonly hasChartData = computed(() => this.pieChartData().datasets[0].data.length > 0);
 

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -84,6 +84,10 @@ $widget-box--enumeration-width: 20px
     &--teaser-image
       width: 200px
 
+    // Unfortunately, we cannot add a class to that container, so we have to use the Primer class
+    .blankslate-container
+      margin: auto
+
     .widget-box--enumeration
       margin-left: 1.5rem
       margin-top: 0.5rem

--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper do
-    if has_budgets?
+    if has_budgets? && has_data?
       flex_layout do |flex|
         flex.with_row do
           render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
@@ -66,14 +66,14 @@ See COPYRIGHT and LICENSE files for more details.
     else
       render(Primer::Beta::Blankslate.new) do |blankslate|
         blankslate.with_visual_icon(icon: :"op-budget")
-        blankslate.with_heading(tag: :h3).with_content(t(".blankslate.heading"))
-        blankslate.with_description_content(t(".blankslate.description"))
+        blankslate.with_heading(tag: :h3).with_content(has_budgets? ? t(".blankslate_zero.heading") : t(".blankslate.heading"))
+        blankslate.with_description_content(has_budgets? ? t(".blankslate_zero.description") : t(".blankslate.description"))
         blankslate.with_primary_action(
-          href: helpers.new_projects_budget_path(project),
+          href: has_budgets? ? helpers.projects_budgets_path(project) : helpers.new_projects_budget_path(project),
           scheme: :secondary
         ) do |button|
-          button.with_leading_visual_icon(icon: :plus)
-          Budget.human_model_name
+          button.with_leading_visual_icon(icon: has_budgets? ? :pencil : :plus)
+          has_budgets? ? Budget.human_model_name.pluralize : Budget.human_model_name
         end
       end
     end

--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper do
-    if has_budgets? && has_data?
+    if has_budgets_data?
       flex_layout do |flex|
         flex.with_row do
           render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
@@ -63,17 +63,30 @@ See COPYRIGHT and LICENSE files for more details.
           render(Primer::Beta::Link.new(href: projects_budgets_path(project))) { t(".view_details") }
         end
       end
+    elsif has_budgets?
+      render(Primer::Beta::Blankslate.new) do |blankslate|
+        blankslate.with_visual_icon(icon: :"op-budget")
+        blankslate.with_heading(tag: :h3).with_content(t(".blankslate_zero.heading"))
+        blankslate.with_description_content(t(".blankslate_zero.description"))
+        blankslate.with_primary_action(
+          href: helpers.projects_budgets_path(project),
+          scheme: :secondary
+        ) do |button|
+          button.with_leading_visual_icon(icon: :pencil)
+          Budget.human_model_name.pluralize
+        end
+      end
     else
       render(Primer::Beta::Blankslate.new) do |blankslate|
         blankslate.with_visual_icon(icon: :"op-budget")
-        blankslate.with_heading(tag: :h3).with_content(has_budgets? ? t(".blankslate_zero.heading") : t(".blankslate.heading"))
-        blankslate.with_description_content(has_budgets? ? t(".blankslate_zero.description") : t(".blankslate.description"))
+        blankslate.with_heading(tag: :h3).with_content(t(".blankslate.heading"))
+        blankslate.with_description_content(t(".blankslate.description"))
         blankslate.with_primary_action(
-          href: has_budgets? ? helpers.projects_budgets_path(project) : helpers.new_projects_budget_path(project),
+          href: helpers.new_projects_budget_path(project),
           scheme: :secondary
         ) do |button|
-          button.with_leading_visual_icon(icon: has_budgets? ? :pencil : :plus)
-          has_budgets? ? Budget.human_model_name.pluralize : Budget.human_model_name
+          button.with_leading_visual_icon(icon: :plus)
+          Budget.human_model_name
         end
       end
     end

--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
@@ -55,8 +55,8 @@ module Budgets
         chart_entries.values
       end
 
-      def has_data?
-        chart_data.any?
+      def has_budgets_data?
+        has_budgets? && chart_data.any?
       end
 
       private

--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
@@ -55,6 +55,10 @@ module Budgets
         chart_entries.values
       end
 
+      def has_data?
+        chart_data.any?
+      end
+
       private
 
       def has_required_permissions?

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -83,6 +83,9 @@ en:
         blankslate:
           heading: "Start project controlling"
           description: "Get an overview of your budgets and costs to efficiently track the health status of your project"
+        blankslate_zero:
+          heading: "Budget details missing"
+          description: "Add details about your planned budget to see data here"
         caption:
           zero: "No budget data."
           one: "Data aggregated from %{count} budget included in %{portfolios}, %{subprograms} and %{subprojects}."

--- a/modules/budgets/config/locales/js-en.yml
+++ b/modules/budgets/config/locales/js-en.yml
@@ -28,12 +28,6 @@
 
 en:
   js:
-    budgets:
-      widgets:
-        budget_by_cost_type:
-          blankslate:
-            title: "No budget data"
-            description: "Add planned unit and labor costs to this project to start tracking the budget"
     work_packages:
       properties:
         costObject: "Budget"

--- a/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
+++ b/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
   context "with a portfolio project" do
     let(:project) { create(:portfolio) }
     let!(:budget) { create(:budget, project:) }
+    let!(:labor_item) do
+      create(:labor_budget_item,
+             budget: budget,
+             user: current_user,
+             hours: 100,
+             amount: BigDecimal("5000"))
+    end
 
     it "displays full caption with portfolio detail" do
       expect(rendered_component).to have_text(/Data aggregated from 1 budget included in/)

--- a/modules/costs/app/components/costs/widgets/actual_costs.html.erb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper do
-    if has_spending? && has_data?
+    if has_spending_data?
       flex_layout do |flex|
         flex.with_row(mt: 3, align: :center) do
           helpers.angular_component_tag(

--- a/modules/costs/app/components/costs/widgets/actual_costs.html.erb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%=
   widget_wrapper do
-    if has_spending?
+    if has_spending? && has_data?
       flex_layout do |flex|
         flex.with_row(mt: 3, align: :center) do
           helpers.angular_component_tag(

--- a/modules/costs/app/components/costs/widgets/actual_costs.rb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.rb
@@ -61,6 +61,10 @@ module Costs
         [labor_dataset, *material_datasets].compact
       end
 
+      def has_data?
+        chart_datasets.any?
+      end
+
       private
 
       def has_required_permissions?

--- a/modules/costs/app/components/costs/widgets/actual_costs.rb
+++ b/modules/costs/app/components/costs/widgets/actual_costs.rb
@@ -61,8 +61,8 @@ module Costs
         [labor_dataset, *material_datasets].compact
       end
 
-      def has_data?
-        chart_datasets.any?
+      def has_spending_data?
+        has_spending? && chart_datasets.any?
       end
 
       private

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -256,7 +256,7 @@ en:
         title: "Actual costs by month"
         blankslate:
           heading: "Start tracking your time and costs"
-          description: "Get an overview of your costs and logged time to monitor progress of your project"
+          description: "Get an overview of your costs and logged time to monitor progress of your project. Make sure that work packages are associated with the correct budget."
           action: "Log time"
         view_details: "View actual costs details"
 

--- a/modules/costs/config/locales/js-en.yml
+++ b/modules/costs/config/locales/js-en.yml
@@ -28,12 +28,6 @@
 
 en:
   js:
-    costs:
-      widgets:
-        actual_costs:
-          blankslate:
-            title: "No data for current year"
-            description: "Log spent time and costs for work packages to start tracking actual costs"
     text_are_you_sure: "Are you sure?"
     myTimeTracking:
       noSpecificTime: "No specific time"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72681

# What are you trying to accomplish?
* Vertically center blankslates within widgets
* Render blanksaltes within budget widgets from rails (instead of Angular)
  * Adapt the texts in agreement with @psatyal 
  * The special blankslates for the "actual costs" widget was removed and replaced by the one we already had 
