### PR TITLE
[#72773] Rework Permission Renamer

### DIFF
--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -6,18 +6,11 @@ require Rails.root.join("db/migrate/migration_utils/permission_adder")
 class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
   def up
     ::Migration::MigrationUtils::PermissionRenamer.rename(:view_master_backlog, :view_sprints)
-
-    # TODO: This could also use the PermissionRenamer.rename, but since that method is using an
-    # SQL update query, we can potentially end up having duplicate permissions defined,
-    # if a user has both view_master_backlog and view_taskboards.
-    ::Migration::MigrationUtils::PermissionAdder.add(:view_taskboards, :view_sprints)
-    RolePermission.delete_by(permission: "view_taskboards")
+    ::Migration::MigrationUtils::PermissionRenamer.rename(:view_taskboards, :view_sprints)
 
     ::Migration::MigrationUtils::PermissionAdder.add(:manage_versions, :create_sprints)
-    ::Migration::MigrationUtils::PermissionAdder.add(:select_done_statuses, :create_sprints)
-    ::Migration::MigrationUtils::PermissionAdder.add(:update_sprints, :create_sprints)
-
-    RolePermission.delete_by(permission: %w(update_sprints select_done_statuses))
+    ::Migration::MigrationUtils::PermissionRenamer.rename(:select_done_statuses, :create_sprints)
+    ::Migration::MigrationUtils::PermissionRenamer.rename(:update_sprints, :create_sprints)
 
     ::Migration::MigrationUtils::PermissionAdder.add(:assign_versions, :manage_sprint_items)
     ::Migration::MigrationUtils::PermissionAdder.add(:add_work_packages, :manage_sprint_items)
@@ -26,7 +19,7 @@ class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
 
   def down
     ::Migration::MigrationUtils::PermissionAdder.add(:view_sprints, :view_taskboards, force: true)
-    ::Migration::MigrationUtils::PermissionRenamer.rename("view_sprints", "view_master_backlog")
+    ::Migration::MigrationUtils::PermissionRenamer.rename(:view_sprints, :view_master_backlog, force: true)
 
     # Note: Some roles might receive extra permissions on the way down because,
     # we need to add back all the roles that have been merged on the way up.

--- a/db/migrate/migration_utils/permission_renamer.rb
+++ b/db/migrate/migration_utils/permission_renamer.rb
@@ -28,34 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
+require Rails.root.join("db/migrate/migration_utils/permission_adder")
+
 module Migration
   module MigrationUtils
     class PermissionRenamer
       class << self
-        # TODO: Rewrite this method to consider already existing permissions, in order to avoid
-        # duplicates. It can be rewritten to use the PermissionAdder, which already avoids adding
-        # duplicates:
-        #   def rename(from, to, force: false)
-        #     ::Migration::MigrationUtils::PermissionAdder.add(from, to, force:)
-        #     RolePermission.delete_by(permission: from)
-        #   end
-
-        def rename(from, to)
-          ActiveRecord::Base.connection.execute <<-SQL.squish
-          UPDATE #{role_permissions_table}
-          SET permission = #{quote_value(to)}
-          WHERE permission = #{quote_value(from)}
-          SQL
-        end
-
-        private
-
-        def role_permissions_table
-          @role_permissions_table ||= ActiveRecord::Base.connection.quote_table_name("role_permissions")
-        end
-
-        def quote_value(value)
-          ActiveRecord::Base.connection.quote(value)
+        # The `force: true` argument is the default because usually when a rename
+        # happens, the `from`` permission is no longer defined.
+        def rename(from, to, force: true)
+          ::Migration::MigrationUtils::PermissionAdder.add(from, to, force:)
+          RolePermission.delete_by(permission: from)
         end
       end
     end

--- a/modules/overviews/spec/migrations/rename_manage_overview_to_manage_dashboards_spec.rb
+++ b/modules/overviews/spec/migrations/rename_manage_overview_to_manage_dashboards_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("modules/overviews/db/migrate/20250910085916_rename_manage_overview_to_manage_dashboards")
+
+RSpec.describe RenameManageOverviewToManageDashboards, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  let!(:empty_role) { create(:project_role) }
+  let!(:role_with_permission) do
+    create(:project_role, permissions: %i[manage_overview], add_public_permissions: false)
+  end
+
+  describe "migrating up" do
+    it "does not add permissions to a role without manage_overview" do
+      expect { migrate }.not_to change { empty_role.reload.permissions }
+    end
+
+    it "renames manage_overview to manage_dashboards" do
+      expect { migrate }
+        .to change { role_with_permission.reload.permissions }
+        .from(match_array(%i[manage_overview]))
+        .to(match_array(%i[manage_dashboards]))
+    end
+  end
+
+  describe "migrating down" do
+    subject(:rollback) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) } }
+
+    before { migrate }
+
+    it "reverts manage_dashboards to manage_overview" do
+      expect { rollback }
+        .to change { role_with_permission.reload.permissions }
+        .from(match_array(%i[manage_dashboards]))
+        .to(match_array(%i[manage_overview]))
+    end
+  end
+end

--- a/spec/migrations/rename_comment_permissions_spec.rb
+++ b/spec/migrations/rename_comment_permissions_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/20250422072119_rename_comment_permissions")
+
+RSpec.describe RenameCommentPermissions, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  let(:old_permissions) do
+    %i[add_work_package_notes edit_own_work_package_notes edit_work_package_notes
+       view_comments_with_restricted_visibility add_comments_with_restricted_visibility
+       edit_own_comments_with_restricted_visibility edit_others_comments_with_restricted_visibility]
+  end
+  let(:new_permissions) do
+    %i[add_work_package_comments edit_own_work_package_comments edit_work_package_comments
+       view_internal_comments add_internal_comments
+       edit_own_internal_comments edit_others_internal_comments]
+  end
+
+  let!(:empty_role) { create(:project_role) }
+  let!(:role_with_all) do
+    create(:project_role, permissions: old_permissions, add_public_permissions: false)
+  end
+  let!(:role_with_notes_only) do
+    create(:project_role, permissions: %i[add_work_package_notes edit_own_work_package_notes], add_public_permissions: false)
+  end
+
+  describe "migrating up" do
+    it "does not add permissions to a role without comment permissions" do
+      expect { migrate }.not_to change { empty_role.reload.permissions }
+    end
+
+    it "renames all comment permissions" do
+      expect { migrate }
+        .to change { role_with_all.reload.permissions }
+        .from(match_array(old_permissions))
+        .to(match_array(new_permissions))
+    end
+
+    it "renames only the matching permissions" do
+      expect { migrate }
+        .to change { role_with_notes_only.reload.permissions }
+        .from(match_array(%i[add_work_package_notes edit_own_work_package_notes]))
+        .to(match_array(%i[add_work_package_comments edit_own_work_package_comments]))
+    end
+  end
+
+  describe "migrating down" do
+    subject(:rollback) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:down) } }
+
+    before { migrate }
+
+    it "reverts all comment permissions" do
+      expect { rollback }
+        .to change { role_with_all.reload.permissions }
+        .from(match_array(new_permissions))
+        .to(match_array(old_permissions))
+    end
+
+    it "reverts only the matching permissions" do
+      expect { rollback }
+        .to change { role_with_notes_only.reload.permissions }
+        .from(match_array(%i[add_work_package_comments edit_own_work_package_comments]))
+        .to(match_array(%i[add_work_package_notes edit_own_work_package_notes]))
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/72773

# What are you trying to accomplish?
Follow up on a discussion here https://github.com/opf/openproject/pull/22001#discussion_r2877553419

# What approach did you choose and why?
Use the `Migration::MigrationUtils::PermissionAdder` to implement the `rename` method, this way it will automatically ignore duplicate permissions.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
