### PR TITLE
[fix] check for sane file references when importing bcf

### DIFF
--- a/modules/bim/app/controllers/bim/bcf/issues_controller.rb
+++ b/modules/bim/app/controllers/bim/bcf/issues_controller.rb
@@ -76,7 +76,7 @@ module Bim
       private
 
       def upload_error_redirect
-        redirect_to action: :upload, status: :unprocessable_entity
+        redirect_to action: :upload
       end
 
       def import_file

--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
@@ -182,16 +182,17 @@ module OpenProject::Bim::BcfXml
 
     ##
     # Extract viewpoints from XML
+    # rubocop:disable Metrics/AbcSize
     def build_viewpoints
       extractor.viewpoints.each do |vp|
         next if issue.viewpoints.has_uuid?(vp[:uuid])
 
         if vp[:viewpoint] != File.basename(vp[:viewpoint])
-          raise StandardError.new "Viewpoint file reference is not a file basename."
+          raise "Viewpoint file reference is not a file basename."
         end
 
         if vp[:snapshot] != File.basename(vp[:snapshot])
-          raise StandardError.new "Snapshot file reference is not a file basename."
+          raise "Snapshot file reference is not a file basename."
         end
 
         viewpoint = issue.viewpoints.build(
@@ -209,6 +210,7 @@ module OpenProject::Bim::BcfXml
         viewpoint.build_snapshot(file, user:)
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     ##
     # Find existing issue or create new

--- a/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/issue_reader.rb
@@ -186,6 +186,14 @@ module OpenProject::Bim::BcfXml
       extractor.viewpoints.each do |vp|
         next if issue.viewpoints.has_uuid?(vp[:uuid])
 
+        if vp[:viewpoint] != File.basename(vp[:viewpoint])
+          raise StandardError.new "Viewpoint file reference is not a file basename."
+        end
+
+        if vp[:snapshot] != File.basename(vp[:snapshot])
+          raise StandardError.new "Snapshot file reference is not a file basename."
+        end
+
         viewpoint = issue.viewpoints.build(
           issue:,
           uuid: vp[:uuid],

--- a/modules/bim/spec/controllers/issues_controller_spec.rb
+++ b/modules/bim/spec/controllers/issues_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Bim::Bcf::IssuesController do
 
       it "redirects back to where we started from" do
         expect { action }.not_to change { Attachment.count }
-        expect(response).to have_http_status 422
+        expect(response).to have_http_status 302
         expect(response.headers["Location"]).to end_with "/projects/bim_project/issues/upload"
       end
     end


### PR DESCRIPTION
# What are you trying to accomplish?
- check for viewpoint and snapshot references when importing bcf files

### Ticket
[#72516](https://community.openproject.org/wp/72516)