### PR TITLE
Revert external links capture within blocknote shadow dom

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -31,7 +31,6 @@
 import { User } from '@blocknote/core/comments';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Application } from '@hotwired/stimulus';
-import ExternalLinksController from 'core-stimulus/controllers/external-links.controller';
 import FlashController from 'core-stimulus/controllers/flash.controller';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { ShadowDomWrapper } from 'op-blocknote-extensions';
@@ -74,10 +73,6 @@ class BlockNoteElement extends HTMLElement {
 
     this.editorMount = document.createElement('div');
 
-    // Copy over definition for external-links handling
-    this.editorMount.dataset.controller = 'external-links';
-    this.editorMount.dataset.externalLinksEnabledValue = document.body.dataset.externalLinksEnabledValue;
-
     this.stimulusRoot.appendChild(this.errorContainer);
     this.stimulusRoot.appendChild(this.editorMount);
     shadowRoot.appendChild(this.stimulusRoot);
@@ -103,7 +98,6 @@ class BlockNoteElement extends HTMLElement {
     // Initialize Stimulus application within shadow DOM
     this.stimulusApp = Application.start(this.stimulusRoot);
     this.stimulusApp.register('flash', FlashController);
-    this.stimulusApp.register('external-links', ExternalLinksController);
 
     // Initialize React application within shadow DOM
     this.reactRoot = createRoot(this.editorMount);


### PR DESCRIPTION
https://community.openproject.org/wp/71111

Mutation observers in external-links controller seemingly clash with blocknote. Similar issue with Angular Zone.js- which is why blocknote exists in a shadow dom in the first place.

This is a temporarily revert while we come up with a fix

Reverts #[22006](https://github.com/opf/openproject/pull/22006)

<img width="2330" height="1399" alt="Screenshot 2026-03-03 at 5 55 58 PM" src="https://github.com/user-attachments/assets/9c44084a-9d49-4810-a616-1cbe0a64f08e" />
