### PR TITLE
Clarify cost admin settings form

### DIFF
--- a/modules/costs/app/views/admin/costs_settings/show.html.erb
+++ b/modules/costs/app/views/admin/costs_settings/show.html.erb
@@ -42,8 +42,19 @@ See COPYRIGHT and LICENSE files for more details.
           subhead.with_description { I18n.t(:description_costs_settings) }
         end
       end
-      form.text_field(name: :costs_currency, input_width: :small)
-      form.text_field(name: :costs_currency_format, input_width: :small)
+      form.text_field(
+        name: :costs_currency,
+        input_width: :xsmall,
+        caption: I18n.t(:setting_costs_currency_caption)
+      )
+      form.select_list(
+        name: :costs_currency_format,
+        values: [
+          [I18n.t(:setting_costs_currency_format_prefix), "%u %n"],
+          [I18n.t(:setting_costs_currency_format_suffix), "%n %u"]
+        ],
+        input_width: :small
+      )
 
       form.submit
     end

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -224,7 +224,10 @@ en:
 
   setting_allow_tracking_start_and_end_times: "Allow start and finish times"
   setting_costs_currency: "Currency"
-  setting_costs_currency_format: "Format of currency"
+  setting_costs_currency_caption: "This is the unit of currency. It can be a three-letter ISO code like EUR, USD or JPY or a symbol like €, $ or ¥."
+  setting_costs_currency_format: "Currency format"
+  setting_costs_currency_format_prefix: "Before the number (e.g. EUR 100)"
+  setting_costs_currency_format_suffix: "After the number (e.g. 100 EUR)"
   setting_enforce_tracking_start_and_end_times: "Require start and finish times"
   setting_enforce_without_allow: "Requiring start and finish times is not possible without allowing them"
   setting_allow_tracking_start_and_end_times_caption: "Enables entering start and finish times when logging time."

--- a/modules/costs/db/migrate/20260303172517_suffix_or_prefix_currency_format.rb
+++ b/modules/costs/db/migrate/20260303172517_suffix_or_prefix_currency_format.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SuffixOrPrefixCurrencyFormat < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE settings
+      SET value = '%n %u'
+      WHERE name = 'costs_currency_format'
+      AND value NOT IN ('%u %n', '%n %u');
+    SQL
+  end
+end

--- a/modules/costs/lib/costs/engine.rb
+++ b/modules/costs/lib/costs/engine.rb
@@ -167,7 +167,7 @@ module Costs
 
     initializer "costs.settings" do
       ::Settings::Definition.add "costs_currency", default: "€", format: :string
-      ::Settings::Definition.add "costs_currency_format", default: "%n %u", format: :string
+      ::Settings::Definition.add "costs_currency_format", default: "%n %u", format: :string, allowed: ["%u %n", "%n %u"]
       ::Settings::Definition.add "allow_tracking_start_and_end_times", default: false, format: :boolean
       ::Settings::Definition.add "enforce_tracking_start_and_end_times", default: false, format: :boolean
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72684

# What are you trying to accomplish?

Clarify the costs admin settings form:
* Caption added to the currency field
* Format turned into a select with two options. That way, users can no longer add values that break the system.

<img width="666" height="297" alt="image" src="https://github.com/user-attachments/assets/62158284-100f-4681-ad54-8cf628300de7" />

The two valid formats are now enforced by the settings definition as well. A migration will force existing values to one of the valid ones.