### PR TITLE
[72771] Chart doesn't expand and Cost list is cut when costs go over budget

### DIFF
--- a/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
@@ -67,7 +67,7 @@ export class ActualCostsComponent {
 
   readonly barChartOptions:Signal<ChartConfiguration<'bar'>['options']> = computed<ChartConfiguration<'bar'>['options']>(() => ({
     font: chartFont,
-    aspectRatio: 1.5,
+    aspectRatio: 1,
     scales: {
       x: {
         stacked: true,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72771

# What are you trying to accomplish?
Change the aspect ratio to 1 to better support small screens. I could not reproduce the original issue but the widget looks better with that on small screens. So I guess it is a worthy change 🤷‍♀️ 

## Screenshots
**Before**
<img width="687" height="621" alt="Bildschirmfoto 2026-03-04 um 11 56 09" src="https://github.com/user-attachments/assets/7044c032-cd84-4d1b-9ca9-73dc337e4558" />


**After**
<img width="687" height="484" alt="Bildschirmfoto 2026-03-04 um 11 54 22" src="https://github.com/user-attachments/assets/b2c37de6-cc3f-49d0-9c29-b1d46c820a94" />
