### PR TITLE
[72761] WP CF of type List does not display info banner upon creation

### DIFF
--- a/app/components/custom_fields/details_component.rb
+++ b/app/components/custom_fields/details_component.rb
@@ -84,18 +84,26 @@ module CustomFields
     end
 
     def persisted_cf_has_no_items_or_projects?
-      if custom_field.list? && custom_field.custom_options.empty?
-        if custom_field.respond_to?(:projects)
-          custom_field.projects.empty?
-        end
+      return false unless custom_field.persisted?
+      return false unless custom_field_has_no_projects?
 
-        true
+      custom_field_has_no_items?
+    end
+
+    private
+
+    def custom_field_has_no_projects?
+      !custom_field.respond_to?(:projects) || custom_field.projects.empty?
+    end
+
+    def custom_field_has_no_items?
+      if custom_field.list?
+        custom_field.custom_options.empty?
+      elsif custom_field.hierarchical_list?
+        custom_field.hierarchy_root.children.empty?
+      else
+        false
       end
-
-      custom_field.persisted? &&
-        custom_field.hierarchical_list? &&
-        custom_field.hierarchy_root.children.empty? &&
-        custom_field.projects.empty?
     end
   end
 end

--- a/app/controllers/concerns/custom_fields/shared_actions.rb
+++ b/app/controllers/concerns/custom_fields/shared_actions.rb
@@ -89,15 +89,11 @@ module CustomFields
         if call.success?
           flash[:notice] = t(:notice_successful_update)
           call_hook(:controller_custom_fields_edit_after_save, custom_field: @custom_field)
-          path = if tab == :list_items
-                   list_item_path(@custom_field,
-                                  id: @custom_field.id)
-                 else
-                   edit_path(@custom_field, id: @custom_field.id)
-                 end
-          redirect_to(path)
+
+          redirect_to(update_path(tab))
         else
-          render action: :edit, status: :unprocessable_entity
+          flash.now[:error] = I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
+          render tab == :list_items ? :list_items : :edit, status: :unprocessable_entity
         end
       end
 
@@ -108,7 +104,7 @@ module CustomFields
           .each_with_index
           .map do |custom_option, index|
             { id: custom_option.id, position: index + 1 }
-        end
+          end
 
         perform_update({ custom_options_attributes: reordered_options }, tab: :list_items)
       end
@@ -170,6 +166,16 @@ module CustomFields
         return unless params[:custom_field]
 
         params[:custom_field][:custom_options_attributes]
+      end
+
+      private
+
+      def update_path(tab)
+        if tab == :list_items
+          list_item_path(@custom_field, id: @custom_field.id)
+        else
+          edit_path(@custom_field, id: @custom_field.id)
+        end
       end
     end
   end

--- a/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
+++ b/spec/features/admin/custom_fields/shared_custom_field_expectations.rb
@@ -49,7 +49,7 @@ RSpec.shared_examples_for "list custom fields" do |type|
     check("multi_value")
 
     click_on "Save"
-    cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+    cf_page.expect_flash(message: "Successful creation.")
     expect(page).to have_field("multi_value", checked: true)
 
     click_link "Items"

--- a/spec/features/admin/custom_fields/time_entries/list_spec.rb
+++ b/spec/features/admin/custom_fields/time_entries/list_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "List custom fields edit", :js do
 
     click_on "Save"
 
-    index_cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+    index_cf_page.expect_flash(message: "Successful creation.")
 
     click_link "Items"
 

--- a/spec/features/admin/custom_fields/work_packages/multi_value_list_spec.rb
+++ b/spec/features/admin/custom_fields/work_packages/multi_value_list_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Multi-value custom fields creation", :js, :selenium do
     fill_in "custom_field_name", with: "My List CF"
 
     click_on "Save"
-    index_cf_page.expect_and_dismiss_flash(message: "Successful creation.")
+    index_cf_page.expect_flash(message: "Successful creation.")
 
     click_link "Items"
     wait_for_network_idle


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72761

# What are you trying to accomplish?
Correctly show the blue info banner when no items are present. Further, show an error message when trying to delete the last custom option

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
