### PR TITLE
Fix default section missing overview visibility area

### DIFF
--- a/db/migrate/20260304164536_fix_empty_display_representation_on_cf_sections.rb
+++ b/db/migrate/20260304164536_fix_empty_display_representation_on_cf_sections.rb
@@ -28,24 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class CustomFieldSection < ApplicationRecord
-  OVERVIEW__SIDEBAR_KEY = "sidebar"
-  OVERVIEW__MAIN_AREA_KEY = "main_area"
-  DEFAULT_OVERVIEW_KEY = OVERVIEW__SIDEBAR_KEY
-
-  acts_as_list scope: [:type]
-
-  validates :name, presence: true
-
-  default_scope { order(:position) }
-
-  store_attribute :display_representation, :overview, :string, default: DEFAULT_OVERVIEW_KEY
-
-  def shown_in_overview_sidebar?
-    overview == OVERVIEW__SIDEBAR_KEY
+class FixEmptyDisplayRepresentationOnCfSections < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE custom_field_sections
+      SET display_representation = '{"overview": "#{CustomFieldSection::DEFAULT_OVERVIEW_KEY}"}'
+      WHERE display_representation = '{}'
+    SQL
   end
 
-  def shown_in_overview_main_area?
-    overview == OVERVIEW__MAIN_AREA_KEY
+  def down
+    # No rollback: we cannot distinguish sections that originally had {}
+    # from ones that legitimately had the default value set.
   end
 end

--- a/spec/models/custom_field_section_spec.rb
+++ b/spec/models/custom_field_section_spec.rb
@@ -28,24 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class CustomFieldSection < ApplicationRecord
-  OVERVIEW__SIDEBAR_KEY = "sidebar"
-  OVERVIEW__MAIN_AREA_KEY = "main_area"
-  DEFAULT_OVERVIEW_KEY = OVERVIEW__SIDEBAR_KEY
+require "spec_helper"
 
-  acts_as_list scope: [:type]
-
-  validates :name, presence: true
-
-  default_scope { order(:position) }
-
-  store_attribute :display_representation, :overview, :string, default: DEFAULT_OVERVIEW_KEY
-
-  def shown_in_overview_sidebar?
-    overview == OVERVIEW__SIDEBAR_KEY
-  end
-
-  def shown_in_overview_main_area?
-    overview == OVERVIEW__MAIN_AREA_KEY
+RSpec.describe CustomFieldSection do
+  it "uses the sidebar as default overview" do
+    expect(described_class.new).to be_shown_in_overview_sidebar
   end
 end

--- a/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
+++ b/spec/seeders/basic_data/project_custom_field_section_seeder_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe BasicData::ProjectCustomFieldSectionSeeder do
     it "creates the corresponding sections with the given attributes", :aggregate_failures do
       expect(ProjectCustomFieldSection.count).to eq(2)
       expect(ProjectCustomFieldSection.find_by(name: "Project Attributes"))
-        .to have_attributes(position: 1)
+        .to have_attributes(position: 1, overview: CustomFieldSection::OVERVIEW__SIDEBAR_KEY)
       expect(ProjectCustomFieldSection.find_by(name: "Project Attributes Two"))
-        .to have_attributes(position: 2)
+        .to have_attributes(position: 2, overview: CustomFieldSection::OVERVIEW__SIDEBAR_KEY)
 
       # references the section in the seed data
       created_status = ProjectCustomFieldSection.last


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72671

# What are you trying to accomplish?

Make sure project attributes added to the default section are visible.

The default custom field section was created with an empty `display_representation` (`{}`), causing project attributes to not appear on the project overview page even when enabled by users.

New sections correctly receive the default overview visibility area (`"sidebar"`), but the default section was not initialized with it.

This is confusing.

## Screenshots

Here is how it looks in the admin: nothing selected

<img width="431" height="294" alt="image" src="https://github.com/user-attachments/assets/197eb09d-c4e6-4226-abc1-2d5aa62a6607" />


# What approach did you choose and why?

The default value set in the database is shadowed by the `store_attribute` config, so the default value has to be set there as well. (actually the one in the db is not really used)

Add a migration to backfill existing default sections that have an empty `display_representation` with the default value `{ overview: "sidebar" }`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
