### PR TITLE
Fix flaky `inplace_edit_field_component_spec`

### DIFF
--- a/app/components/open_project/common/inplace_edit_field_component.rb
+++ b/app/components/open_project/common/inplace_edit_field_component.rb
@@ -35,11 +35,13 @@ module OpenProject
 
       attr_reader :model, :attribute, :enforce_edit_mode
 
-      def initialize(model:, attribute:, enforce_edit_mode: false, **system_arguments)
+      def initialize(model:, attribute:, enforce_edit_mode: false,
+                     update_registry: OpenProject::InplaceEdit::UpdateRegistry, **system_arguments)
         super()
         @model = model
         @attribute = attribute
         @enforce_edit_mode = enforce_edit_mode
+        @update_registry = update_registry
         @system_arguments = system_arguments
         @system_arguments[:id] = system_arguments[:id] || SecureRandom.uuid
       end
@@ -85,7 +87,7 @@ module OpenProject
       def writable?
         return @writable if defined?(@writable)
 
-        contract_class = OpenProject::InplaceEdit::UpdateRegistry.fetch_contract(model)
+        contract_class = @update_registry.fetch_contract(model)
         @writable =
           if contract_class.present?
             contract_class.new(model, User.current).writable?(attribute)

--- a/app/components/open_project/common/inplace_edit_field_component.rb
+++ b/app/components/open_project/common/inplace_edit_field_component.rb
@@ -36,7 +36,7 @@ module OpenProject
       attr_reader :model, :attribute, :enforce_edit_mode
 
       def initialize(model:, attribute:, enforce_edit_mode: false,
-                     update_registry: OpenProject::InplaceEdit::UpdateRegistry, **system_arguments)
+                     update_registry: OpenProject::InplaceEdit::UpdateRegistry.default, **system_arguments)
         super()
         @model = model
         @attribute = attribute

--- a/app/controllers/inplace_edit_fields_controller.rb
+++ b/app/controllers/inplace_edit_fields_controller.rb
@@ -45,7 +45,7 @@ class InplaceEditFieldsController < ApplicationController
   end
 
   def update
-    handler = OpenProject::InplaceEdit::UpdateRegistry.fetch_handler(@model)
+    handler = update_registry.fetch_handler(@model)
 
     if handler.present?
       success = handler.call(
@@ -91,7 +91,7 @@ class InplaceEditFieldsController < ApplicationController
     return nil if model_param.blank?
 
     model_class =
-      OpenProject::InplaceEdit::UpdateRegistry.resolve_model_class(model_param)
+      update_registry.resolve_model_class(model_param)
 
     unless model_class &&
            model_class < ApplicationRecord &&
@@ -116,8 +116,13 @@ class InplaceEditFieldsController < ApplicationController
       model: @model,
       attribute: @attribute,
       enforce_edit_mode:,
+      update_registry:,
       **system_arguments.to_h.symbolize_keys
     )
+  end
+
+  def update_registry
+    @update_registry ||= OpenProject::InplaceEdit::UpdateRegistry
   end
 
   def system_arguments

--- a/app/controllers/inplace_edit_fields_controller.rb
+++ b/app/controllers/inplace_edit_fields_controller.rb
@@ -122,7 +122,7 @@ class InplaceEditFieldsController < ApplicationController
   end
 
   def update_registry
-    @update_registry ||= OpenProject::InplaceEdit::UpdateRegistry
+    @update_registry ||= OpenProject::InplaceEdit::UpdateRegistry.default
   end
 
   def system_arguments

--- a/lib/open_project/inplace_edit/field_registry.rb
+++ b/lib/open_project/inplace_edit/field_registry.rb
@@ -46,6 +46,8 @@ module OpenProject
       @default = new
 
       class << self
+        attr_reader :default
+
         delegate :register, :fetch, to: :@default
       end
     end

--- a/lib/open_project/inplace_edit/field_registry.rb
+++ b/lib/open_project/inplace_edit/field_registry.rb
@@ -31,16 +31,22 @@
 module OpenProject
   module InplaceEdit
     class FieldRegistry
-      @registry = {}
+      def initialize
+        @registry = {}
+      end
+
+      def register(attribute_name, field_component)
+        @registry[attribute_name.to_s] = field_component
+      end
+
+      def fetch(attribute_name)
+        @registry.fetch(attribute_name.to_s) { Common::InplaceEditFields::TextInputComponent }
+      end
+
+      @default = new
 
       class << self
-        def register(attribute_name, field_component)
-          @registry[attribute_name.to_s] = field_component
-        end
-
-        def fetch(attribute_name)
-          @registry.fetch(attribute_name.to_s) { Common::InplaceEditFields::TextInputComponent }
-        end
+        delegate :register, :fetch, to: :@default
       end
     end
   end

--- a/lib/open_project/inplace_edit/update_registry.rb
+++ b/lib/open_project/inplace_edit/update_registry.rb
@@ -31,35 +31,41 @@
 module OpenProject
   module InplaceEdit
     class UpdateRegistry
-      @registry = {}
+      def initialize
+        @registry = {}
+      end
+
+      def register(model_class, handler:, contract:)
+        @registry[model_class] = {
+          handler: handler,
+          contract: contract
+        }
+      end
+
+      def registered?(model_class)
+        @registry.key?(model_class)
+      end
+
+      def fetch_handler(model)
+        entry = @registry[model.class]
+        entry && entry[:handler]
+      end
+
+      def fetch_contract(model)
+        entry = @registry[model.class]
+        entry && entry[:contract]
+      end
+
+      def resolve_model_class(param)
+        class_name = param.to_s.camelize
+
+        @registry.keys.find { |klass| klass.name == class_name }
+      end
+
+      @default = new
 
       class << self
-        def register(model_class, handler:, contract:)
-          @registry[model_class] = {
-            handler: handler,
-            contract: contract
-          }
-        end
-
-        def registered?(model_class)
-          @registry.key?(model_class)
-        end
-
-        def fetch_handler(model)
-          entry = @registry[model.class]
-          entry && entry[:handler]
-        end
-
-        def fetch_contract(model)
-          entry = @registry[model.class]
-          entry && entry[:contract]
-        end
-
-        def resolve_model_class(param)
-          class_name = param.to_s.camelize
-
-          @registry.keys.find { |klass| klass.name == class_name }
-        end
+        delegate :register, :registered?, :fetch_handler, :fetch_contract, :resolve_model_class, to: :@default
       end
     end
   end

--- a/lib/open_project/inplace_edit/update_registry.rb
+++ b/lib/open_project/inplace_edit/update_registry.rb
@@ -65,6 +65,8 @@ module OpenProject
       @default = new
 
       class << self
+        attr_reader :default
+
         delegate :register, :registered?, :fetch_handler, :fetch_contract, :resolve_model_class, to: :@default
       end
     end

--- a/spec/components/open_project/common/inplace_edit_field_component_spec.rb
+++ b/spec/components/open_project/common/inplace_edit_field_component_spec.rb
@@ -56,18 +56,21 @@ RSpec.describe OpenProject::Common::InplaceEditFieldComponent, type: :component 
     end
   end
 
+  let(:update_registry) do
+    registry = OpenProject::InplaceEdit::UpdateRegistry.new
+    registry.register(Project, handler: double, contract: contract_class)
+    registry
+  end
+
   before do
     allow(User).to receive(:current).and_return(user)
-    allow(OpenProject::InplaceEdit::UpdateRegistry)
-      .to receive(:fetch_contract)
-            .and_return(contract_class)
   end
 
   context "when attribute is writable" do
     let(:allowed_attributes) { %w(description) }
 
     it "renders display field by default" do
-      render_inline(described_class.new(model: project, attribute: :description))
+      render_inline(described_class.new(model: project, attribute: :description, update_registry:))
 
       expect(rendered_content)
         .to have_css(".op-inplace-edit--display-field.op-inplace-edit--display-field_editable")
@@ -78,7 +81,8 @@ RSpec.describe OpenProject::Common::InplaceEditFieldComponent, type: :component 
         described_class.new(
           model: project,
           attribute: :description,
-          enforce_edit_mode: true
+          enforce_edit_mode: true,
+          update_registry:
         )
       )
 
@@ -91,7 +95,7 @@ RSpec.describe OpenProject::Common::InplaceEditFieldComponent, type: :component 
     let(:allowed_attributes) { %w() }
 
     it "does not mark display field as editable" do
-      render_inline(described_class.new(model: project, attribute: :description))
+      render_inline(described_class.new(model: project, attribute: :description, update_registry:))
 
       expect(rendered_content)
         .not_to include("click->inplace-edit#request")

--- a/spec/controllers/inplace_edit_fields_controller_spec.rb
+++ b/spec/controllers/inplace_edit_fields_controller_spec.rb
@@ -36,11 +36,16 @@ RSpec.describe InplaceEditFieldsController do
   let(:attribute) { :name }
   let(:model_param) { "project" }
 
-  before do
-    allow(controller).to receive(:current_user).and_return(user)
+  let(:update_registry) do
+    contract = double
+    allow(contract).to receive(:new).and_return(double(writable?: true))
+    registry = OpenProject::InplaceEdit::UpdateRegistry.new
+    registry.register(Project, handler:, contract:)
+    registry
+  end
 
-    allow(OpenProject::InplaceEdit::UpdateRegistry)
-      .to receive_messages(registered?: true, fetch_handler: handler)
+  before do
+    allow(controller).to receive_messages(current_user: user, update_registry:)
 
     allow(Project)
       .to receive(:visible)
@@ -136,10 +141,6 @@ RSpec.describe InplaceEditFieldsController do
     let(:handler) { double }
 
     it "returns 404 for unsupported model" do
-      allow(OpenProject::InplaceEdit::UpdateRegistry)
-        .to receive(:registered?)
-              .and_return(false)
-
       get :edit, params: {
         model: "invalid_model",
         id: 123,

--- a/spec/lib/open_project/inplace_edit/field_registry_spec.rb
+++ b/spec/lib/open_project/inplace_edit/field_registry_spec.rb
@@ -33,19 +33,21 @@ require "rails_helper"
 RSpec.describe OpenProject::InplaceEdit::FieldRegistry do
   subject(:registry) { described_class.new }
 
+  let(:rich_text_component) { Class.new }
+
   describe "#register" do
     it "registers a field component for an attribute" do
-      registry.register(:description, :rich_text_component)
+      registry.register(:description, rich_text_component)
 
-      expect(registry.fetch(:description)).to eq(:rich_text_component)
+      expect(registry.fetch(:description)).to eq(rich_text_component)
     end
   end
 
   describe "#fetch" do
     it "returns the registered component for the attribute" do
-      registry.register(:description, :rich_text_component)
+      registry.register(:description, rich_text_component)
 
-      expect(registry.fetch(:description)).to eq(:rich_text_component)
+      expect(registry.fetch(:description)).to eq(rich_text_component)
     end
 
     it "falls back to TextInputComponent if attribute is not registered" do
@@ -54,9 +56,9 @@ RSpec.describe OpenProject::InplaceEdit::FieldRegistry do
     end
 
     it "normalizes attribute names to strings" do
-      registry.register("description", :rich_text_component)
+      registry.register("description", rich_text_component)
 
-      expect(registry.fetch(:description)).to eq(:rich_text_component)
+      expect(registry.fetch(:description)).to eq(rich_text_component)
     end
   end
 end

--- a/spec/lib/open_project/inplace_edit/field_registry_spec.rb
+++ b/spec/lib/open_project/inplace_edit/field_registry_spec.rb
@@ -31,13 +31,9 @@
 require "rails_helper"
 
 RSpec.describe OpenProject::InplaceEdit::FieldRegistry do
-  subject(:registry) { described_class }
+  subject(:registry) { described_class.new }
 
-  before do
-    registry.instance_variable_set(:@registry, {})
-  end
-
-  describe ".register" do
+  describe "#register" do
     it "registers a field component for an attribute" do
       registry.register(:description, :rich_text_component)
 
@@ -45,7 +41,7 @@ RSpec.describe OpenProject::InplaceEdit::FieldRegistry do
     end
   end
 
-  describe ".fetch" do
+  describe "#fetch" do
     it "returns the registered component for the attribute" do
       registry.register(:description, :rich_text_component)
 

--- a/spec/lib/open_project/inplace_edit/update_registry_spec.rb
+++ b/spec/lib/open_project/inplace_edit/update_registry_spec.rb
@@ -30,35 +30,29 @@
 require "rails_helper"
 
 RSpec.describe OpenProject::InplaceEdit::UpdateRegistry do
+  subject(:registry) { described_class.new }
+
   let(:handler) { instance_double(OpenProject::InplaceEdit::Handlers::ProjectUpdate) }
   let(:contract) { instance_double(Projects::UpdateContract) }
 
-  before do
-    described_class.instance_variable_set(:@registry, {})
-  end
-
-  after do
-    described_class.instance_variable_set(:@registry, {})
-  end
-
-  describe ".register" do
+  describe "#register" do
     it "registers handler and contract for a model" do
-      described_class.register(Project, handler:, contract:)
+      registry.register(Project, handler:, contract:)
 
-      expect(described_class.fetch_handler(Project.new)).to eq(handler)
-      expect(described_class.fetch_contract(Project.new)).to eq(contract)
+      expect(registry.fetch_handler(Project.new)).to eq(handler)
+      expect(registry.fetch_contract(Project.new)).to eq(contract)
     end
   end
 
-  describe ".registered?" do
+  describe "#registered?" do
     it "returns true for registered model" do
-      described_class.register(Project, handler:, contract:)
+      registry.register(Project, handler:, contract:)
 
-      expect(described_class.registered?(Project)).to be(true)
+      expect(registry.registered?(Project)).to be(true)
     end
 
     it "returns false for unregistered model" do
-      expect(described_class.registered?(Project)).to be(false)
+      expect(registry.registered?(Project)).to be(false)
     end
   end
 end

--- a/spec/lib/open_project/inplace_edit/update_registry_spec.rb
+++ b/spec/lib/open_project/inplace_edit/update_registry_spec.rb
@@ -32,8 +32,8 @@ require "rails_helper"
 RSpec.describe OpenProject::InplaceEdit::UpdateRegistry do
   subject(:registry) { described_class.new }
 
-  let(:handler) { instance_double(OpenProject::InplaceEdit::Handlers::ProjectUpdate) }
-  let(:contract) { instance_double(Projects::UpdateContract) }
+  let(:handler) { class_double(OpenProject::InplaceEdit::Handlers::ProjectUpdate) }
+  let(:contract) { class_double(Projects::UpdateContract) }
 
   describe "#register" do
     it "registers handler and contract for a model" do


### PR DESCRIPTION
# Ticket

N/A 

# What are you trying to accomplish?

`FieldRegistry` and `UpdateRegistry` stored state in a class-level instance variable, making it shared global state across the test suite. This caused `inplace_edit_field_component_spec` to fail intermittently depending on test run order.

This was reproducible via:

```
bundle exec rspec './spec/components/open_project/common/inplace_edit_field_component_spec.rb[1:1:2]' './spec/lib/open_project/inplace_edit/field_registry_spec.rb[1:2:1]' --seed 50000
```

Example CI run failure:

https://github.com/opf/openproject/actions/runs/22623904699/job/65555464579?pr=21816

Fails with
```
     NoMethodError:
       undefined method 'new' for an instance of Symbol
```

## Screenshots

No visual changes

# What approach did you choose and why?

Both registries were refactored to be instance-based, with a `@default` class-level instance backing the existing class-method API via `delegate` — so all production code (initializer, controller, component) is unchanged. Tests now instantiate a fresh registry per example, eliminating shared state without any before/after cleanup hooks.

As a follow-on, `InplaceEditFieldsController` and `InplaceEditFieldComponent` were updated to accept an injected registry instance (`update_registry=` writer and `update_registry:` keyword arg respectively), removing the remaining `allow(...).to receive` stubs on registry class methods in their specs.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)