### PR TITLE
[#72801] Sharing permission dependencies are not migrated

### DIFF
--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -13,25 +13,25 @@ class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
     ::Migration::MigrationUtils::PermissionRenamer.rename(:update_sprints, :create_sprints)
 
     ::Migration::MigrationUtils::PermissionAdder.add(:assign_versions, :manage_sprint_items)
-    ::Migration::MigrationUtils::PermissionAdder.add(:add_work_packages, :manage_sprint_items)
-    ::Migration::MigrationUtils::PermissionAdder.add(:edit_work_packages, :manage_sprint_items)
   end
 
   def down
-    ::Migration::MigrationUtils::PermissionAdder.add(:view_sprints, :view_taskboards, force: true)
-    ::Migration::MigrationUtils::PermissionRenamer.rename(:view_sprints, :view_master_backlog, force: true)
+    # Note: Ideally the `:view_taskboards`, `:view_master_backlog`, `:manage_versions`,
+    # `:select_done_statuses`, `:update_sprints` permissions should be restored too,
+    # but unfortunately we cannot know which one lead to the user gaining `:view_sprints`
+    # or `:create_sprints` permissions.
+    # There are 2 possible solutions for this issue:
+    #   1. Grant both the `:view_taskboards`, `:view_master_backlog` where `:view_sprints` was granted.
+    #      Respectively, grant `:manage_versions`, `:select_done_statuses`, `:update_sprints` permissions
+    #      where `:create_sprints` was granted. Unfortunately this leads to users gaining permissions
+    #      they didn't possibly had before the migration.
+    #   2. Grant none of the undecisible permissions, which leads to users losing permissions they had
+    #      before the migration.
+    #
+    # The conservative approach here is to pick #2, because it avoids accidentally leaking permissions
+    # to users.
 
-    # Note: Some roles might receive extra permissions on the way down because,
-    # we need to add back all the roles that have been merged on the way up.
-    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :manage_versions)
-    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :select_done_statuses, force: true)
-    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :update_sprints, force: true)
-
-    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :assign_versions)
-    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :add_work_packages)
-    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :edit_work_packages)
-
-    # Remove new permissions that were added during up
-    RolePermission.delete_by(permission: %w(create_sprints manage_sprint_items))
+    # Remove new permissions that were added during the up migration
+    RolePermission.delete_by(permission: %w(view_sprints create_sprints manage_sprint_items))
   end
 end

--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -9,7 +9,6 @@ class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
     ::Migration::MigrationUtils::PermissionRenamer.rename(:view_taskboards, :view_sprints)
 
     ::Migration::MigrationUtils::PermissionAdder.add(:manage_versions, :create_sprints)
-    ::Migration::MigrationUtils::PermissionRenamer.rename(:select_done_statuses, :create_sprints)
     ::Migration::MigrationUtils::PermissionRenamer.rename(:update_sprints, :create_sprints)
 
     ::Migration::MigrationUtils::PermissionAdder.add(:assign_versions, :manage_sprint_items)
@@ -17,14 +16,13 @@ class MigrateBacklogsPermissions < ActiveRecord::Migration[8.1]
 
   def down
     # Note: Ideally the `:view_taskboards`, `:view_master_backlog`, `:manage_versions`,
-    # `:select_done_statuses`, `:update_sprints` permissions should be restored too,
-    # but unfortunately we cannot know which one lead to the user gaining `:view_sprints`
-    # or `:create_sprints` permissions.
+    # `:update_sprints` permissions should be restored too, but unfortunately we cannot know
+    #  which one lead to the user gaining `:view_sprints` or `:create_sprints` permissions.
     # There are 2 possible solutions for this issue:
     #   1. Grant both the `:view_taskboards`, `:view_master_backlog` where `:view_sprints` was granted.
-    #      Respectively, grant `:manage_versions`, `:select_done_statuses`, `:update_sprints` permissions
-    #      where `:create_sprints` was granted. Unfortunately this leads to users gaining permissions
-    #      they didn't possibly had before the migration.
+    #      Respectively, grant `:manage_versions`, `:update_sprints` permissions where `:create_sprints`
+    #      was granted. Unfortunately this leads to users gaining permissions they didn't possibly had
+    #      before the migration.
     #   2. Grant none of the undecisible permissions, which leads to users losing permissions they had
     #      before the migration.
     #

--- a/db/migrate/20260304160505_fix_sprint_role_dependencies.rb
+++ b/db/migrate/20260304160505_fix_sprint_role_dependencies.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require Rails.root.join("db/migrate/migration_utils/permission_adder")
+
+class FixSprintRoleDependencies < ActiveRecord::Migration[8.1]
+  def change
+    ::Migration::MigrationUtils::PermissionAdder.add(:manage_sprint_items, :view_sprints)
+    ::Migration::MigrationUtils::PermissionAdder.add(:create_sprints, :view_sprints)
+    ::Migration::MigrationUtils::PermissionAdder.add(:view_sprints, :view_work_packages)
+  end
+end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -155,11 +155,12 @@ en:
   label_sprint_new: "New sprint"
   label_task_board: "Task board"
 
-  permission_view_sprints: "View sprints"
   permission_create_sprints: "Create sprints"
-  permission_start_complete_sprint: "Start/complete sprint"
   permission_manage_sprint_items: "Manage sprint items"
+  permission_select_done_statuses: "Select done statuses"
   permission_share_sprint: "Share sprint"
+  permission_start_complete_sprint: "Start/complete sprint"
+  permission_view_sprints: "View sprints"
 
   project_module_backlogs: "Backlogs"
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -78,10 +78,16 @@ module OpenProject::Backlogs
                    permissible_on: :project,
                    dependencies: :view_work_packages
 
+        permission :select_done_statuses,
+                   {
+                     "projects/settings/backlogs": %i[show update rebuild_positions]
+                   },
+                   permissible_on: :project,
+                   require: :member
+
         permission :create_sprints,
                    { rb_sprints: %i[new_dialog refresh_form create edit_name update],
-                     rb_wikis: %i[edit update],
-                     "projects/settings/backlogs": %i[show update rebuild_positions] },
+                     rb_wikis: %i[edit update] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -97,7 +97,7 @@ module OpenProject::Backlogs
                    { rb_stories: %i[move reorder] },
                    permissible_on: :project,
                    require: :member,
-                   dependencies: %i[view_sprints add_work_packages edit_work_packages]
+                   dependencies: :view_sprints
 
         permission :share_sprint,
                    {},

--- a/modules/backlogs/spec/features/resolved_status_spec.rb
+++ b/modules/backlogs/spec/features/resolved_status_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Resolved status" do
   let!(:status) { create(:status, is_default: true) }
   let(:role) do
     create(:project_role,
-           permissions: %i[create_sprints view_sprints])
+           permissions: %i[select_done_statuses view_sprints])
   end
   let!(:current_user) do
     create(:user,

--- a/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe OpenProject::AccessControl, "Backlogs module permissions" do # ru
     subject { described_class.permission(:manage_sprint_items) }
 
     it "depends on view_sprints, add_work_packages, and edit_work_packages" do
-      expect(subject.dependencies).to contain_exactly(:view_sprints, :add_work_packages, :edit_work_packages)
+      expect(subject.dependencies).to contain_exactly(:view_sprints)
     end
   end
 

--- a/spec/migrations/fix_sprint_role_dependencies_spec.rb
+++ b/spec/migrations/fix_sprint_role_dependencies_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+require Rails.root.join("db/migrate/20260304160505_fix_sprint_role_dependencies")
+
+RSpec.describe FixSprintRoleDependencies, type: :model do
+  let!(:role) { create(:project_role, permissions:, add_public_permissions: false) }
+
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  describe "completing depencencies for view_sprints permission" do
+    context "when view_work_packages is missing" do
+      let(:permissions) { [:view_sprints] }
+
+      it "adds view_work_packages" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .from(match_array(%i[view_sprints]))
+          .to(match_array(%i[view_sprints view_work_packages]))
+      end
+    end
+
+    context "when view_work_packages is present" do
+      let(:permissions) { %i[view_sprints view_work_packages] }
+
+      it "does not duplicate view_work_packages" do
+        expect { migrate }.not_to change { role.reload.permissions }
+      end
+    end
+  end
+
+  describe "completing dependencies for create_sprints permission" do
+    context "when view_sprints and view_work_packages are missing" do
+      let(:permissions) { [:create_sprints] }
+
+      it "adds view_sprints and view_work_packages" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .from(match_array(%i[create_sprints]))
+          .to(match_array(%i[create_sprints view_sprints view_work_packages]))
+      end
+    end
+
+    context "when view_work_packages is present" do
+      let(:permissions) { %i[create_sprints view_work_packages] }
+
+      it "adds view_sprints" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .from(match_array(%i[create_sprints view_work_packages]))
+          .to(match_array(%i[create_sprints view_sprints view_work_packages]))
+      end
+    end
+
+    context "when view_sprints and view_work_packages are present" do
+      let(:permissions) { %i[create_sprints view_sprints view_work_packages] }
+
+      it "does not change the permissions" do
+        expect { migrate }.not_to change { role.reload.permissions }
+      end
+    end
+  end
+
+  describe "completing dependencies for manage_sprint_items permission" do
+    context "when view_sprints and view_work_packages are missing" do
+      let(:permissions) { [:manage_sprint_items] }
+
+      it "adds view_sprints and view_work_packages" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .from(match_array(%i[manage_sprint_items]))
+          .to(match_array(%i[manage_sprint_items view_sprints view_work_packages]))
+      end
+    end
+
+    context "when view_work_packages is present" do
+      let(:permissions) { %i[manage_sprint_items view_work_packages] }
+
+      it "adds view_sprints" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .from(match_array(%i[manage_sprint_items view_work_packages]))
+          .to(match_array(%i[manage_sprint_items view_sprints view_work_packages]))
+      end
+    end
+
+    context "when view_sprints and view_work_packages are present" do
+      let(:permissions) { %i[manage_sprint_items view_sprints view_work_packages] }
+
+      it "does not change the permissions" do
+        expect { migrate }.not_to change { role.reload.permissions }
+      end
+    end
+  end
+
+  describe "completing combined dependencies with view_work_packages missing" do
+    let(:permissions) { %i[view_sprints create_sprints manage_sprint_items] }
+
+    it "adds view_work_packages without duplicating view_sprints" do
+      expect { migrate }
+        .to change { role.reload.permissions }
+        .from(match_array(%i[view_sprints create_sprints manage_sprint_items]))
+        .to(match_array(%i[view_sprints create_sprints manage_sprint_items view_work_packages]))
+    end
+  end
+
+  describe "not copmpleting dependencies for other roles" do
+    let(:permissions) { [:edit_work_packages] }
+
+    it "does not change the permissions" do
+      expect { migrate }.not_to change { role.reload.permissions }
+    end
+  end
+end

--- a/spec/migrations/migrate_backlogs_permissions_spec.rb
+++ b/spec/migrations/migrate_backlogs_permissions_spec.rb
@@ -34,82 +34,69 @@ require Rails.root.join("db/migrate/20260212145213_migrate_backlogs_permissions"
 RSpec.describe MigrateBacklogsPermissions, type: :model do
   subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
 
-  let!(:empty_role) { create(:project_role) }
-  # Using add_public_permissions: false to keep permission sets minimal.
-  let!(:backlog_viewer_role) do
-    create(:project_role, permissions: %i[view_master_backlog], add_public_permissions: false)
+  # source permission => expected permissions after up migration.
+  up_mapping = {
+    view_master_backlog: %i[view_sprints],
+    view_taskboards: %i[view_sprints],
+    select_done_statuses: %i[create_sprints],
+    update_sprints: %i[create_sprints],
+    manage_versions: %i[manage_versions create_sprints],
+    assign_versions: %i[assign_versions manage_sprint_items]
+  }
+
+  # source permission => expected permissions after rollback.
+  # Backlogs-specific permissions (view_master_backlog, view_taskboards, select_done_statuses,
+  # update_sprints) are lost because the down migration cannot determine the original source.
+  down_mapping = {
+    view_master_backlog: [],
+    view_taskboards: [],
+    select_done_statuses: [],
+    update_sprints: [],
+    manage_versions: %i[manage_versions],
+    assign_versions: %i[assign_versions]
+  }
+
+  let(:all_source_permissions) do
+    %i(view_master_backlog
+       view_taskboards
+       select_done_statuses
+       update_sprints
+       manage_versions
+       assign_versions)
   end
-  let!(:taskboard_viewer_role) do
-    create(:project_role, permissions: %i[view_taskboards], add_public_permissions: false)
-  end
-  let(:member_role_permissions) do
-    %i[view_master_backlog view_taskboards add_work_packages
-       edit_work_packages assign_versions]
-  end
-  let(:migrated_member_role_permissions) do
-    %i[add_work_packages edit_work_packages assign_versions view_sprints manage_sprint_items]
-  end
-  let!(:member_role) do
-    create(:project_role, permissions: member_role_permissions, add_public_permissions: false)
-  end
-  let(:manager_role_permissions) do
-    %i[view_master_backlog view_taskboards manage_versions select_done_statuses
-       update_sprints assign_versions add_work_packages edit_work_packages]
-  end
-  let(:migrated_manager_role_permissions) do
-    %i[manage_versions add_work_packages edit_work_packages assign_versions
-       view_sprints create_sprints manage_sprint_items]
-  end
-  let!(:manager_role) do
-    create(:project_role, permissions: manager_role_permissions, add_public_permissions: false)
-  end
+
+  let!(:role) { create(:project_role, permissions:, add_public_permissions: false) }
 
   describe "migrating up" do
-    it "does not add any permissions to a role without backlogs permissions" do
-      expect { migrate }.not_to change { empty_role.reload.permissions }
+    context "with a role having no backlogs permissions" do
+      let(:permissions) { [] }
+
+      it "does not change permissions" do
+        expect { migrate }.not_to change { role.reload.permissions }
+      end
     end
 
-    it "migrates manager_role permissions correctly" do
-      expect { migrate }
-        .to change { manager_role.reload.permissions }
-        .from(match_array(manager_role_permissions))
-        .to(match_array(migrated_manager_role_permissions))
+    up_mapping.each do |source_permission, expected_permissions|
+      context "with a role having only :#{source_permission} permission" do
+        let(:permissions) { [source_permission] }
+
+        it "results in #{expected_permissions}" do
+          expect { migrate }
+            .to change { role.reload.permissions }
+            .from(contain_exactly(source_permission))
+            .to(match_array(expected_permissions))
+        end
+      end
     end
 
-    it "migrates backlog_viewer_role permissions correctly" do
-      expect { migrate }
-        .to change { backlog_viewer_role.reload.permissions }
-        .from(match_array(%i[view_master_backlog]))
-        .to(match_array(%i[view_sprints]))
-    end
+    context "with a role combining all source permissions" do
+      let(:permissions) { all_source_permissions }
 
-    it "migrates taskboard_viewer_role permissions correctly" do
-      expect { migrate }
-        .to change { taskboard_viewer_role.reload.permissions }
-        .from(match_array(%i[view_taskboards]))
-        .to(match_array(%i[view_sprints]))
-    end
-
-    it "migrates member_role permissions correctly" do
-      expect { migrate }
-        .to change { member_role.reload.permissions }
-        .from(match_array(member_role_permissions))
-        .to(match_array(migrated_member_role_permissions))
-    end
-
-    it "does not duplicate view_sprints when role had both view_master_backlog and view_taskboards" do
-      migrate
-      expect(manager_role.reload.role_permissions.where(permission: "view_sprints").count).to eq(1)
-    end
-
-    it "does not duplicate create_sprints when role has multiple source permissions" do
-      migrate
-      expect(manager_role.reload.role_permissions.where(permission: "create_sprints").count).to eq(1)
-    end
-
-    it "does not duplicate manage_sprint_items when role has multiple source permissions" do
-      migrate
-      expect(manager_role.reload.role_permissions.where(permission: "manage_sprint_items").count).to eq(1)
+      it "migrates to all new permissions plus retained core permissions" do
+        expect { migrate }
+          .to change { role.reload.permissions }
+          .to(match_array(%i[view_sprints create_sprints manage_sprint_items manage_versions assign_versions]))
+      end
     end
   end
 
@@ -118,25 +105,26 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
 
     before { migrate }
 
-    it "reverts backlog_viewer_role permissions" do
-      expect { rollback }
-        .to change { backlog_viewer_role.reload.permissions }
-        .from(match_array(%i[view_sprints]))
-        .to(match_array(%i[view_taskboards view_master_backlog]))
+    down_mapping.each do |source_permission, expected_permissions|
+      context "with a role originally having only :#{source_permission} permission" do
+        let(:permissions) { [source_permission] }
+
+        it "retains #{expected_permissions.empty? ? 'no' : expected_permissions} permissions" do
+          expect { rollback }
+            .to change { role.reload.permissions }
+            .to(match_array(expected_permissions))
+        end
+      end
     end
 
-    it "reverts manager_role permissions" do
-      expect { rollback }
-        .to change { manager_role.reload.permissions }
-        .from(match_array(migrated_manager_role_permissions))
-        .to(match_array(manager_role_permissions))
-    end
+    context "with a role combining all source permissions" do
+      let(:permissions) { all_source_permissions }
 
-    it "reverts member_role permissions" do
-      expect { rollback }
-        .to change { member_role.reload.permissions }
-        .from(match_array(migrated_member_role_permissions))
-        .to(match_array(member_role_permissions))
+      it "retains only core permissions that were not deleted during up" do
+        expect { rollback }
+          .to change { role.reload.permissions }
+          .to(match_array(%i[manage_versions assign_versions]))
+      end
     end
   end
 end

--- a/spec/migrations/migrate_backlogs_permissions_spec.rb
+++ b/spec/migrations/migrate_backlogs_permissions_spec.rb
@@ -38,19 +38,17 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
   up_mapping = {
     view_master_backlog: %i[view_sprints],
     view_taskboards: %i[view_sprints],
-    select_done_statuses: %i[create_sprints],
     update_sprints: %i[create_sprints],
     manage_versions: %i[manage_versions create_sprints],
     assign_versions: %i[assign_versions manage_sprint_items]
   }
 
   # source permission => expected permissions after rollback.
-  # Backlogs-specific permissions (view_master_backlog, view_taskboards, select_done_statuses,
-  # update_sprints) are lost because the down migration cannot determine the original source.
+  # Backlogs-specific permissions (view_master_backlog, view_taskboards, update_sprints)
+  # are lost because the down migration cannot determine the original source.
   down_mapping = {
     view_master_backlog: [],
     view_taskboards: [],
-    select_done_statuses: [],
     update_sprints: [],
     manage_versions: %i[manage_versions],
     assign_versions: %i[assign_versions]
@@ -59,7 +57,6 @@ RSpec.describe MigrateBacklogsPermissions, type: :model do
   let(:all_source_permissions) do
     %i(view_master_backlog
        view_taskboards
-       select_done_statuses
        update_sprints
        manage_versions
        assign_versions)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/72801

# What are you trying to accomplish?
- Complete missing dependencies for view_sprints, create_sprints,
manage_sprint_items permissions
- When migrating backlog permissions down, do not restore permissions
where the source permission cannot be determined.
- When migrating up, do not add manage_sprint_items to roles with add or
edit work package permission
- Remove unnecessary dependencies of the manage_sprint_items

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
