### PR TITLE
[#72797, #72795] Budget widgets: always aggregate budgets from subprojects, adjust BudgetByCostType caption

### DIFF
--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
@@ -33,16 +33,10 @@ See COPYRIGHT and LICENSE files for more details.
       flex_layout do |flex|
         flex.with_row do
           render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
-            if project.portfolio?
-              t(
-                ".caption",
-                count: budget_count,
-                portfolios: t(".portfolio", count: workspace_counts[:portfolio] || 0),
-                subprograms: t(".subprogram", count: workspace_counts[:program] || 0),
-                subprojects: t(".subproject", count: workspace_counts[:project] || 0)
-              )
+            if project.children.any?
+              t(".caption_with_subitems", count: budget_count, workspace: project.workspace_label)
             else
-              t(".caption_simple", count: budget_count)
+              t(".caption", count: budget_count, workspace: project.workspace_label)
             end
           end
         end

--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.rb
@@ -34,7 +34,6 @@ module Budgets
       REQUIRED_PERMISSIONS = %i[view_budgets view_cost_rates].freeze
 
       delegate :budget_count, :has_budgets?, :budgeted_labor, :budgeted_material_by_type,
-               :workspace_counts,
                to: :@aggregated_budgets
 
       def initialize(...)

--- a/modules/budgets/app/models/budgets/project_aggregation.rb
+++ b/modules/budgets/app/models/budgets/project_aggregation.rb
@@ -45,8 +45,6 @@ module Budgets::ProjectAggregation
   private
 
   def applicable_projects
-    return Project.where(id: project.id) unless project.portfolio?
-
     project.self_and_descendants.reorder(nil)
   end
 end

--- a/modules/budgets/app/models/budgets/project_aggregation.rb
+++ b/modules/budgets/app/models/budgets/project_aggregation.rb
@@ -35,13 +35,6 @@ module Budgets::ProjectAggregation
     attr_reader :project, :current_user
   end
 
-  def workspace_counts
-    project.descendants.reorder(nil)
-      .group(:workspace_type)
-      .count
-      .with_indifferent_access
-  end
-
   private
 
   def applicable_projects

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -91,23 +91,12 @@ en:
           description: "Get an overview of your budgets and costs to efficiently track the health status of your project"
         caption:
           zero: "No budget data."
-          one: "Data aggregated from %{count} budget included in %{portfolios}, %{subprograms} and %{subprojects}."
-          other: "Data aggregated from %{count} budgets included in %{portfolios}, %{subprograms} and %{subprojects}."
-        caption_simple:
-          one: "Data aggregated from %{count} budget."
-          other: "Data aggregated from %{count} budgets."
-        portfolio:
-          zero: "no portfolios"
-          one: "1 portfolio"
-          other: "%{count} portfolios"
-        subprogram:
-          zero: "no subprograms"
-          one: "1 subprogram"
-          other: "%{count} subprograms"
-        subproject:
-          zero: "no subprojects"
-          one: "1 subproject"
-          other: "%{count} subprojects"
+          one: "Data aggregated from %{count} budget included in this %{workspace}."
+          other: "Data aggregated from %{count} budgets included in this %{workspace}."
+        caption_with_subitems:
+          zero: "No budget data."
+          one: "Data aggregated from %{count} budget included in this %{workspace} and its subitems."
+          other: "Data aggregated from %{count} budgets included in this %{workspace} and its subitems."
         view_details: "View budget details"
 
   events:

--- a/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
+++ b/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
       expect(rendered_component).to have_css("opce-budget-by-cost-type")
     end
 
-    it "displays simple caption for non-portfolio project" do
-      expect(rendered_component).to have_text(/Data aggregated from 1 budget\./)
-      expect(rendered_component).to have_no_text(/portfolios/)
+    it "displays caption with workspace type (no subitems for leaf project)" do
+      expect(rendered_component).to have_text(/Data aggregated from 1 budget included in this Project\./)
+      expect(rendered_component).to have_no_text(/subitems/)
     end
 
     it "passes currency attribute" do
@@ -112,15 +112,15 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
     end
   end
 
-  context "with a portfolio project" do
-    let(:project) { create(:portfolio) }
+  context "with a project that has children" do
+    let(:project) { create(:project_with_types) }
+    let!(:child) { create(:project_with_types, parent: project) }
     let!(:budget) { create(:budget, project:) }
 
-    it "displays full caption with portfolio detail" do
-      expect(rendered_component).to have_text(/Data aggregated from 1 budget included in/)
-      expect(rendered_component).to have_text(/portfolios/)
-      expect(rendered_component).to have_text(/subprograms/)
-      expect(rendered_component).to have_text(/subprojects/)
+    it "displays caption with workspace type and subitems" do
+      expect(rendered_component).to have_text(
+        /Data aggregated from 1 budget included in this Project and its subitems\./
+      )
     end
   end
 

--- a/modules/budgets/spec/models/budgets/aggregated_budgets_spec.rb
+++ b/modules/budgets/spec/models/budgets/aggregated_budgets_spec.rb
@@ -119,6 +119,47 @@ RSpec.describe Budgets::AggregatedBudgets do
     end
   end
 
+  describe "subproject aggregation for regular projects" do
+    let(:child_project) do
+      create(:project_with_types, parent: project).tap do |p|
+        p.enabled_module_names += %w[budgets]
+        p.save!
+      end
+    end
+
+    before do
+      child_project
+      project.reload
+      create(:member, project: child_project, user:,
+                      roles: [create(:project_role, permissions: %i[view_budgets])])
+    end
+
+    context "with a budget in the child project" do
+      let!(:budget) { create(:budget, project: child_project, base_amount: BigDecimal("4000")) }
+
+      it "includes child project budgets in budget_count" do
+        expect(aggregated.budget_count).to eq(1)
+      end
+
+      it "includes child project base amounts in budgeted_base" do
+        expect(aggregated.budgeted_base).to eq(BigDecimal("4000"))
+      end
+    end
+
+    context "with budgets in both parent and child project" do
+      let!(:parent_budget) { create(:budget, project:, base_amount: BigDecimal("2000")) }
+      let!(:child_budget) { create(:budget, project: child_project, base_amount: BigDecimal("4000")) }
+
+      it "aggregates budget counts from parent and child" do
+        expect(aggregated.budget_count).to eq(2)
+      end
+
+      it "aggregates base amounts from parent and child" do
+        expect(aggregated.budgeted_base).to eq(BigDecimal("6000"))
+      end
+    end
+  end
+
   describe "portfolio project support" do
     let(:portfolio) do
       create(:portfolio).tap do |p|


### PR DESCRIPTION


# Ticket

https://community.openproject.org/wp/72797
https://community.openproject.org/wp/72795

# What are you trying to accomplish?

Two fixes for budget widgets:

1. Fixes data from subitems not being aggregated for non Portfolio workspaces.
2. Rephrases Budget by Cost Type caption, removing the (hard to translate) workspace tallies.

## Screenshots

| Before | After |
|--------|--------|
| <img width="797" height="663" alt="Screenshot 2026-03-05 at 00 31 09" src="https://github.com/user-attachments/assets/2434d7ee-e402-4c71-b1d9-866dbbd2a98f" /> | <img width="799" height="666" alt="Screenshot 2026-03-05 at 00 23 48" src="https://github.com/user-attachments/assets/2eef7434-aa62-48ab-988f-c8e62f23b089" />|

# What approach did you choose and why?

1. Removes the `project.portfolio?` guard from `applicable_projects` in `Budgets::ProjectAggregation`, so budgets and costs are aggregated from subprojects regardless of workspace type.
2. Removes `workspace_counts` from `Budgets::ProjectAggregation` and the portfolio-specific caption branch from the widget. Caption now reads "Data aggregated from X budgets included in %{workspace}." for leaf projects, or "…and its subitems." when the workspace has children, regardless of workspace type.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
