### PR TITLE
[72373]: Edited offline status banner and add header indicator

### DIFF
--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -136,3 +136,25 @@ $op-enterprise-banner-fixed-height-large: 320px
 
   &--dismiss
     margin-left: var(--controlStack-medium-gap-condensed)
+
+.flash-warn,
+.flash-success
+  position: fixed
+  top: 10%
+  z-index: 999
+  left: 50%
+  transform: translateX(-50%)
+  width: 90%
+  max-width: 934px
+  align-items: center
+  border-radius: 6px
+
+  .Banner-visual
+    align-self: center
+
+  #connection-error-retry-button
+    border-radius: 6px
+    background-color: #F6F8FA
+    border: 1px solid #D0D7DE
+    font-size: 14px
+    font-weight: 600

--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -93,11 +93,15 @@ module OpTurbo
     end
 
     def render_success_flash_message_via_turbo_stream(**)
-      render_flash_message_via_turbo_stream(**, scheme: :success)
+      render_flash_message_via_turbo_stream(**, scheme: :success, icon: :"check")
     end
 
     def render_error_flash_message_via_turbo_stream(**)
       render_flash_message_via_turbo_stream(**, scheme: :danger, icon: :stop)
+    end
+
+    def render_warning_flash_message_via_turbo_stream(**)
+      render_flash_message_via_turbo_stream(**, scheme: :warning, icon: :"cloud-offline")
     end
 
     def render_live_region_update_message(message:, politeness: "polite", delay: nil)
@@ -106,10 +110,15 @@ module OpTurbo
         .render_in(view_context)
     end
 
-    def render_flash_message_via_turbo_stream(message:, component: OpPrimer::FlashComponent, **)
+    def render_flash_message_via_turbo_stream(message:, component: OpPrimer::FlashComponent, action_button_arguments: nil, action_button_content: nil, **)
       return if message.blank?
 
       instance = component.new(**).with_content(message)
+      
+      if action_button_arguments.present?
+        instance.with_action_button(**action_button_arguments) { action_button_content }
+      end
+      
       turbo_streams << instance.render_as_turbo_stream(view_context:, action: :flash)
     end
 

--- a/frontend/src/react/OpBlockNoteContainer.tsx
+++ b/frontend/src/react/OpBlockNoteContainer.tsx
@@ -78,6 +78,14 @@ export default function OpBlockNoteContainer({ inputField,
   const { isLoading, connectionError } = useCollaboration(hocuspocusProvider, doc, inputField);
   const hadErrorRef = useRef(false);
 
+  // Dispatch a custom DOM event to notify the Stimulus connection-status controller
+  // about the current connection state. This bridges React (BlockNote editor) and
+  // Stimulus, allowing the header indicator to show/hide without direct coupling.
+  useEffect(() => {
+    document.dispatchEvent(new CustomEvent('documents:connection-status-changed', {
+      detail:{ offline:connectionError }
+    }));
+  }, [connectionError]);
   // Fetch error/recovery template based on connection state
   useEffect(() => {
     if (!errorContainer) return;

--- a/frontend/src/stimulus/controllers/dynamic/connection-status.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/connection-status.controller.ts
@@ -1,0 +1,53 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ *
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static targets = ['indicator'];
+  declare readonly indicatorTarget: HTMLElement;
+
+  connect() {
+    // Listen for connection state changes dispatched by the BlockNote React editor
+    document.addEventListener('documents:connection-status-changed', this.onStatusChange);
+  }
+
+  disconnect() {
+    document.removeEventListener('documents:connection-status-changed', this.onStatusChange);
+  }
+
+  // Show the offline indicator in the page header when the editor loses connection,
+  // hide it when the connection is restored
+  private onStatusChange = (event: Event) => {
+    const { offline } = (event as CustomEvent<{ offline:boolean }>).detail;
+    this.indicatorTarget.style.display = offline ? '' : 'none';
+  };
+}

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -40,7 +40,7 @@ import OpZenModeController from 'core-stimulus/controllers/zen-mode.controller';
 import CheckAllController from 'core-stimulus/controllers/check-all.controller';
 import CheckableController from 'core-stimulus/controllers/checkable.controller';
 import TruncationController from 'core-stimulus/controllers/truncation.controller';
-
+import ConnectionStatusController from './controllers/dynamic/connection-status.controller'
 declare global {
   interface Window {
     Stimulus:Application;
@@ -85,6 +85,7 @@ OpenProjectStimulusApplication.preregister('editable-page-header-title', Editabl
 OpenProjectStimulusApplication.preregister('check-all', CheckAllController);
 OpenProjectStimulusApplication.preregister('checkable', CheckableController);
 OpenProjectStimulusApplication.preregister('truncation', TruncationController);
+OpenProjectStimulusApplication.preregister('documents--connection-status', ConnectionStatusController);
 
 const instance = OpenProjectStimulusApplication.start();
 window.Stimulus = instance;

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -31,7 +31,7 @@
 
 <%=
   component_wrapper do
-    flex_layout(tag: :div, align_items: :center, test_selector: "document-info-line") do |flex|
+    flex_layout(tag: :div, align_items: :center, data: { controller: "documents--connection-status" }, test_selector: "document-info-line") do |flex|
       flex.with_column(hide: :sm, mr: 3) do
         if allowed_to_manage_documents?
           render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
@@ -61,6 +61,10 @@
 
       flex.with_column(mr: 3) do
         render(Documents::ShowEditView::PageHeader::LiveUsersComponent.new)
+      end
+
+      flex.with_column(mr: 3) do
+        render(Documents::ShowEditView::PageHeader::LiveConnectionStatusComponent.new)
       end
 
       flex.with_column do

--- a/modules/documents/app/components/documents/show_edit_view/page_header/live_connection_status_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/live_connection_status_component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+
+module Documents
+  module ShowEditView
+    module PageHeader
+      # Displays an offline status indicator in the document page header.
+      # Hidden by default and toggled by the documents--connection-status
+      # Stimulus controller, which listens for connection state changes
+      # dispatched by the BlockNote React editor.
+      class LiveConnectionStatusComponent < ApplicationComponent
+        include OpPrimer::ComponentHelpers
+        include OpTurbo::Streamable
+
+        def call
+          # The `indicator` target is referenced by the Stimulus controller
+          # to show/hide this component when the connection state changes
+          component_wrapper(
+            tag: :span,
+            display: :none,
+            data: { "documents--connection-status-target": "indicator" }
+          ) do
+            flex_layout(align_items: :center) do |flex|
+              flex.with_column(mr: 1) do
+                render(Primer::Beta::Octicon.new(icon: :"cloud-offline", color: :subtle))
+              end
+              flex.with_column do
+                render(Primer::Beta::Text.new(color: :subtle)) do
+                  I18n.t("documents.show_edit_view.connection_status.offline")
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -79,7 +79,19 @@ class DocumentsController < ApplicationController
   end
 
   def render_connection_error
-    update_via_turbo_stream(component: Documents::ShowEditView::ConnectionErrorNoticeComponent.new)
+    render_warning_flash_message_via_turbo_stream(
+      message: I18n.t("documents.show_edit_view.connection_error_notice.description"),
+      action_button_content: I18n.t("documents.show_edit_view.connection_error_notice.action"),
+      action_button_arguments: {
+        id: "connection-error-retry-button",
+        tag: :button,
+        data: { 
+          turbo: false,
+          action: "click->flash#reloadPage"
+        },
+        size: :medium
+      }
+    )
 
     respond_with_turbo_streams
   end

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -47,7 +47,6 @@ en:
         content_binary: "Content binary"
         title: "Title"
 
-
   activity:
     filter:
       document: "Documents"
@@ -91,12 +90,13 @@ en:
     show_edit_view:
       connection_error_notice:
         description: |-
-          Unable to open document because the real-time text collaboration server is unreachable.
-          Please contact the administrator if the problem persists.
-        action: Try again
+          You are currently offline. You can continue editing. Your changes will be synced when the connection is restored.
+        action: "Retry"
       connection_recovery_notice:
-        description: "The connection to the real-time text collaboration server has been restored."
+        description: "Your changes have been synced."
       tabs: "Document tabs"
+      connection_status:
+        offline: "Currently offline."
 
     index_page:
       name: "Name"
@@ -166,7 +166,6 @@ en:
           Hocuspocus server.
         primary_action: Enable real-time collaboration
         success: Real-time collaboration has been enabled.
-
 
       disable_text_collaboration_dialog:
         title: Disable real-time collaboration


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/72373/activity

# What are you trying to accomplish?
Add user-facing feedback for connection state in the collaborative document editor.
When the editor loses connection to the Hocuspocus server, users now see:

1. A warning flash banner with a "Retry" button that reloads the page
2. A "Currently offline" indicator with a cloud icon in the document page header

# What approach did you choose and why?
The offline/online state is already tracked in the React `useCollaboration` hook via `connectionError`. To communicate this state to the Stimulus-based page header without tight coupling, a custom DOM event `documents:connection-status-changed` is dispatched from `OpBlockNoteContainer` whenever the connection state changes.

A new Stimulus controller `documents--connection-status` listens for this event and toggles the visibility of the `LiveConnectionStatusComponent` in the header.

The flash banners are rendered server-side via existing turbo stream infrastructure (`render_warning_flash_message_via_turbo_stream` / `render_success_flash_message_via_turbo_stream`), extended to support an optional action button.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
