### PR TITLE
[chore] add wiki alias to traefik defaults

### DIFF
--- a/docker/dev/tls/docker-compose.yml
+++ b/docker/dev/tls/docker-compose.yml
@@ -17,6 +17,7 @@ services:
           - openproject.${OPENPROJECT_DOCKER_DEV_TLD:-local}
           - openproject-assets.${OPENPROJECT_DOCKER_DEV_TLD:-local}
           - nextcloud.${OPENPROJECT_DOCKER_DEV_TLD:-local}
+          - xwiki.${OPENPROJECT_DOCKER_DEV_TLD:-local}
           - gitlab.${OPENPROJECT_DOCKER_DEV_TLD:-local}
           - keycloak.${OPENPROJECT_DOCKER_DEV_TLD:-local}
           - hocuspocus.${OPENPROJECT_DOCKER_DEV_TLD:-local}


### PR DESCRIPTION
# What are you trying to accomplish?
- starting with xwiki development, this alias belongs to the defaults we are defining here