### PR TITLE
[#72520] Custom Logo not displayed in PDF export

### DIFF
--- a/lib/open_project/file_command_content_type_detector.rb
+++ b/lib/open_project/file_command_content_type_detector.rb
@@ -77,7 +77,7 @@ module OpenProject
 
     def type_from_file_command
       # On BSDs, `file` doesn't give a result code of 1 if the file doesn't exist.
-      type, status = Open3.capture2("file", "-b", "--mime", "--", Shellwords.escape(@filename))
+      type, status = Open3.capture2("file", "-b", "--mime", "--", @filename)
 
       if type.nil? || status.to_i > 0 || type.match(/\(.*?\)/)
         type = SENSIBLE_DEFAULT

--- a/spec/lib/open_project/file_command_content_type_detector_spec.rb
+++ b/spec/lib/open_project/file_command_content_type_detector_spec.rb
@@ -97,12 +97,4 @@ RSpec.describe OpenProject::FileCommandContentTypeDetector do
 
     expect(Open3).to have_received(:capture2).with("file", "-b", "--mime", "--", "--help")
   end
-
-  it "sanitizes the filename to prevent command injection" do
-    allow(Open3).to receive(:capture2)
-
-    described_class.new("'; rm -rf /\"").detect
-
-    expect(Open3).to have_received(:capture2).with("file", "-b", "--mime", "--", "\\'\\;\\ rm\\ -rf\\ /\\\"")
-  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/72520

# What are you trying to achieve?

Customer has uploaded a file with an umlaut "Logo grün 2022 ohne Text und Hintergrund.png"
MIME detection reported the wrong type "application/binary", so it was not included in the PDF
- caused by a shell escaped, so the tool "file" could not find the file with the escaped name.

`Open3.capture2("file", "-b", "--mime", "--", Shellwords.escape(@filename))`

This shell escaping seems only to be necessary if the command is one large string:
`Open3.capture2("file -b --mime -- #{Shellwords.escape(@filename)}")`
for which it would work and the escaped file would be found.

But the array parameter does work differently and is not vulnerable in the same way a concat string is.

=> `Open3.capture2("file", "-b", "--mime", "--", @filename)`

# Merge checklist

- [x] Updated tests (removed the test about escaping)
