### PR TITLE
[#72834] Migrate frontend specs to Zoneless, removing zone.js

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25956,12 +25956,6 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
-    "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "dev": true
-    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -42843,12 +42837,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
       "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-      "dev": true
-    },
-    "zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
       "dev": true
     },
     "zwitch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,6 @@
     "globals": "^17.3.0",
     "jasmine-core": "~6.0.1",
     "jasmine-spec-reporter": "~7.0.0",
-    "zone.js": "~0.15.1",
     "karma": "~6.4.4",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.1",

--- a/frontend/src/app/core/apiv3/api-v3.service.spec.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.spec.ts
@@ -28,7 +28,6 @@
 
 import {
   TestBed,
-  waitForAsync,
 } from '@angular/core/testing';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -37,19 +36,16 @@ import { States } from 'core-app/core/states/states.service';
 describe('APIv3Service', () => {
   let service:ApiV3Service;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       providers: [
         States,
         PathHelperService,
         ApiV3Service,
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(ApiV3Service);
-      });
-  }));
+    }).compileComponents();
+    service = TestBed.inject(ApiV3Service);
+  });
 
   function encodeParams(object:any) {
     return new URLSearchParams(object).toString();

--- a/frontend/src/app/features/bim/bcf/api/bcf-api.service.spec.ts
+++ b/frontend/src/app/features/bim/bcf/api/bcf-api.service.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { BcfApiService } from 'core-app/features/bim/bcf/api/bcf-api.service';
 import { BcfResourceCollectionPath, BcfResourcePath } from 'core-app/features/bim/bcf/api/bcf-path-resources';
 import { BcfTopicPaths } from 'core-app/features/bim/bcf/api/topics/bcf-topic.paths';
@@ -34,18 +34,14 @@ import { BcfTopicPaths } from 'core-app/features/bim/bcf/api/topics/bcf-topic.pa
 describe('BcfApiService', () => {
   let service:BcfApiService;
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       providers: [
         BcfApiService,
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(BcfApiService);
-      });
-  }));
+    }).compileComponents();
+    service = TestBed.inject(BcfApiService);
+  });
 
   describe('building the path', () => {
     it('can build projects', () => {

--- a/frontend/src/app/features/calendar/op-calendar.service.spec.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.spec.ts
@@ -26,18 +26,17 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { waitForAsync } from '@angular/core/testing';
 import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
 
 describe('OP calendar service', () => {
   let service:OpCalendarService;
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(() => {
     // This is not a valid constructor call, but since we only want to test a helper method that does not
     // depend on injected services, we can pass null values here.
     // @ts-expect-error ignore invalid constructor call since we don't need a completely valid instance
     service = new OpCalendarService(null, null, null);
-  }));
+  });
 
   describe('stripYearFromDateFormat', () => {
     it('from dotted syntax', () => {

--- a/frontend/src/app/features/hal/resources/hal-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/hal-resource.spec.ts
@@ -27,7 +27,7 @@
 //++
 
 import { Injector } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { States } from 'core-app/core/states/states.service';
@@ -49,9 +49,8 @@ describe('HalResource', () => {
   class OtherResource extends HalResource {
   }
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
     imports: [OpenprojectHalModule],
     providers: [
         HalResourceService,
@@ -60,13 +59,10 @@ describe('HalResource', () => {
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
     ]
-})
-      .compileComponents()
-      .then(() => {
-        halResourceService = TestBed.inject(HalResourceService);
-        injector = TestBed.inject(Injector);
-      });
-  }));
+}).compileComponents();
+    halResourceService = TestBed.inject(HalResourceService);
+    injector = TestBed.inject(Injector);
+  });
 
   it('should be instantiable using a default object', () => {
     const resource = halResourceService.createHalResource({}, true);

--- a/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { Injector } from '@angular/core';
 import { States } from 'core-app/core/states/states.service';
@@ -68,9 +68,8 @@ describe('WorkPackage', () => {
     loadWeekdays: () => of(true),
   };
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
     imports: [OpenprojectHalModule],
     providers: [
         HalResourceService,
@@ -91,16 +90,13 @@ describe('WorkPackage', () => {
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
     ]
-})
-      .compileComponents()
-      .then(() => {
-        halResourceService = TestBed.inject(HalResourceService);
-        injector = TestBed.inject(Injector);
-        halResourceNotification = injector.get(HalResourceNotificationService);
+}).compileComponents();
+    halResourceService = TestBed.inject(HalResourceService);
+    injector = TestBed.inject(Injector);
+    halResourceNotification = injector.get(HalResourceNotificationService);
 
-        halResourceService.registerResource('WorkPackage', { cls: WorkPackageResource });
-      });
-  }));
+    halResourceService.registerResource('WorkPackage', { cls: WorkPackageResource });
+  });
 
   describe('when creating an empty work package', () => {
     beforeEach(createWorkPackage);

--- a/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.spec.ts
@@ -28,7 +28,7 @@
 
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { States } from 'core-app/core/states/states.service';
 import { WorkPackageViewPaginationService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service';
 import { WorkPackageTablePaginationComponent } from 'core-app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component';
@@ -67,15 +67,14 @@ function pageString(element:HTMLElement) {
 }
 
 describe('wpTablePagination Directive', () => {
-  beforeEach(waitForAsync(() => {
+  beforeEach(async () => {
     window.OpenProject = new OpenProject();
 
     const WeekdayServiceStub = {
       loadWeekdays: () => of(true),
     };
 
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
     declarations: [
         WorkPackageTablePaginationComponent,
         OpIconComponent,
@@ -95,7 +94,7 @@ describe('wpTablePagination Directive', () => {
         provideHttpClient(withInterceptorsFromDi()),
     ]
 }).compileComponents();
-  }));
+  });
 
   describe('page ranges and links', () => {
     it('should display the correct page range',

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.spec.ts
@@ -1,5 +1,5 @@
 import { Input, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
@@ -61,9 +61,9 @@ describe('WpTabsComponent', () => {
     fixture.detectChanges();
   });
 
-  it('displays the visible tab', fakeAsync(() => {
+  it('displays the visible tab', () => {
     const tabLink:HTMLElement = fixture.debugElement.query(By.css('[data-qa-tab-id="displayable-test-tab"]')).nativeElement;
 
     expect(tabLink.innerText).toContain('Displayable TestTab');
-  }));
+  });
 });

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.spec.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { States } from 'core-app/core/states/states.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { WorkPackageViewHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
@@ -58,7 +58,7 @@ describe('WorkPackageViewIndentation service', () => {
     };
   }
 
-  beforeEach(waitForAsync(() => {
+  beforeEach(async () => {
     parentServiceSpy = jasmine.createSpyObj(
       'WorkPackageRelationHierarchyService',
       ['changeParent'],
@@ -66,8 +66,7 @@ describe('WorkPackageViewIndentation service', () => {
 
     parentServiceSpy.changeParent.and.resolveTo();
 
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       providers: [
         States,
         IsolatedQuerySpace,
@@ -77,15 +76,12 @@ describe('WorkPackageViewIndentation service', () => {
         { provide: WorkPackageRelationsHierarchyService, useValue: parentServiceSpy },
         WorkPackageViewHierarchyIdentationService,
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(WorkPackageViewHierarchyIdentationService);
-        querySpace = TestBed.inject(IsolatedQuerySpace);
-        hierarchyServiceStub = TestBed.inject(WorkPackageViewHierarchiesService);
-        states = TestBed.inject(States);
-      });
-  }));
+    }).compileComponents();
+    service = TestBed.inject(WorkPackageViewHierarchyIdentationService);
+    querySpace = TestBed.inject(IsolatedQuerySpace);
+    hierarchyServiceStub = TestBed.inject(WorkPackageViewHierarchiesService);
+    states = TestBed.inject(States);
+  });
 
   describe('canIndent', () => {
     it('Cannot indent without changeParent link', () => {

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.spec.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA, DebugElement } from '@angular/core';
 import { AttributeHelpTextComponent } from 'core-app/shared/components/attribute-help-texts/attribute-help-text.component';
 import { By } from '@angular/platform-browser';
@@ -97,7 +97,7 @@ describe('AttributeHelpTextComponent', () => {
     expect(button.nativeElement.dataset.qaHelpTextFor).toEqual('subject');
   });
 
-  it('should call modalService on click', fakeAsync(() => {
+  it('should call modalService on click', async () => {
     const button = element.query(By.css("[role='button']"));
     button.nativeElement.click();
 
@@ -105,14 +105,14 @@ describe('AttributeHelpTextComponent', () => {
 
     expect(button.nativeElement.ariaDisabled).toEqual('true');
 
-    flush();
+    await Promise.resolve(); // flush Promise microtask queue
     fixture.detectChanges();
 
     expect(modalServiceStub.show).toHaveBeenCalledOnceWith('1');
     expect(button.nativeElement.ariaDisabled).toEqual('false');
-  }));
+  });
 
-  it('should call modalService only once', fakeAsync(() => {
+  it('should call modalService only once', async () => {
     const button = element.query(By.css("[role='button']"));
     button.nativeElement.click();
 
@@ -125,10 +125,10 @@ describe('AttributeHelpTextComponent', () => {
     button.triggerEventHandler('keydown.space');
 
     fixture.detectChanges();
-    flush();
+    await Promise.resolve(); // flush Promise microtask queue
     fixture.detectChanges();
 
     expect(modalServiceStub.show).toHaveBeenCalledOnceWith('1');
     expect(button.nativeElement.ariaDisabled).toEqual('false');
-  }));
+  });
 });

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.spec.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.spec.ts
@@ -17,11 +17,11 @@ describe('AttributeHelpTextComponent', () => {
   let modalServiceStub:jasmine.SpyObj<AttributeHelpTextModalService>;
   const i18nStub = { t: (_scope:string|string[], _options?:Record<string, any>) => 'Show help text' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     modalServiceStub = jasmine.createSpyObj('AttributeHelpTextModalService', ['show']);
     modalServiceStub.show.and.resolveTo();
 
-    void TestBed
+    await TestBed
       .configureTestingModule({
         declarations: [
           AttributeHelpTextComponent,
@@ -105,7 +105,9 @@ describe('AttributeHelpTextComponent', () => {
 
     expect(button.nativeElement.ariaDisabled).toEqual('true');
 
-    await Promise.resolve(); // flush Promise microtask queue
+    await Promise.resolve();
+    await modalServiceStub.show.calls.mostRecent().returnValue;
+    await new Promise(resolve => setTimeout(resolve, 0));
     fixture.detectChanges();
 
     expect(modalServiceStub.show).toHaveBeenCalledOnceWith('1');
@@ -125,7 +127,9 @@ describe('AttributeHelpTextComponent', () => {
     button.triggerEventHandler('keydown.space');
 
     fixture.detectChanges();
-    await Promise.resolve(); // flush Promise microtask queue
+    await Promise.resolve();
+    await modalServiceStub.show.calls.mostRecent().returnValue;
+    await new Promise(resolve => setTimeout(resolve, 0));
     fixture.detectChanges();
 
     expect(modalServiceStub.show).toHaveBeenCalledOnceWith('1');

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { States } from 'core-app/core/states/states.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -79,62 +79,72 @@ describe('autocompleter', () => {
     fixture.componentInstance.debounceTimeMs = 0;
   });
 
-  it('should load the ng-select correctly', fakeAsync(() => {
-    fixture.detectChanges();
-    tick();
+  it('should load the ng-select correctly', () => {
+    jasmine.clock().install();
+    try {
+      fixture.detectChanges();
+      jasmine.clock().tick(0);
 
-    const autocompleter = document.querySelector('.ng-select-container');
+      const autocompleter = document.querySelector('.ng-select-container');
 
-    expect(document.contains(autocompleter)).toBeTruthy();
-  }));
+      expect(document.contains(autocompleter)).toBeTruthy();
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
 
   describe('without debounce', () => {
-    it('should load items', fakeAsync(() => {
-      tick();
-      fixture.detectChanges();
-      fixture.componentInstance.ngAfterViewInit();
-      tick(1000);
-      fixture.detectChanges();
-      const select = fixture.componentInstance.ngSelectInstance;
+    it('should load items', () => {
+      jasmine.clock().install();
+      try {
+        jasmine.clock().tick(0);
+        fixture.detectChanges();
+        fixture.componentInstance.ngAfterViewInit();
+        jasmine.clock().tick(1000);
+        fixture.detectChanges();
+        const select = fixture.componentInstance.ngSelectInstance;
 
-      expect(select.isOpen).toBeFalse();
-      select.open();
-      select.focus();
+        expect(select.isOpen).toBeFalse();
+        select.open();
+        select.focus();
 
-      expect(select.isOpen).toBeTrue();
+        expect(select.isOpen).toBeTrue();
 
-      expect(select.itemsList.items.length).toEqual(0);
+        expect(select.itemsList.items.length).toEqual(0);
 
-      const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
-      const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+        const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+        const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
-      fixture.detectChanges();
-      tick();
+        fixture.detectChanges();
+        jasmine.clock().tick(0);
 
-      expect(getOptionsFnSpy).toHaveBeenCalledWith('');
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('');
 
-      inputElement.value = 'Wor';
-      inputElement.dispatchEvent(new Event('input'));
-      fixture.detectChanges();
-      tick();
+        inputElement.value = 'Wor';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        jasmine.clock().tick(0);
 
-      expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
 
-      fixture.detectChanges();
+        fixture.detectChanges();
 
-      expect(select.itemsList.items.length).toEqual(2);
+        expect(select.itemsList.items.length).toEqual(2);
 
-      inputElement.value = 'package 2';
-      inputElement.dispatchEvent(new Event('input'));
-      fixture.detectChanges();
-      tick();
+        inputElement.value = 'package 2';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        jasmine.clock().tick(0);
 
-      expect(getOptionsFnSpy).toHaveBeenCalledWith('package 2');
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('package 2');
 
-      fixture.detectChanges();
+        fixture.detectChanges();
 
-      expect(select.itemsList.items.length).toEqual(1);
-    }));
+        expect(select.itemsList.items.length).toEqual(1);
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
   });
 
   describe('with debounce', () => {
@@ -142,39 +152,44 @@ describe('autocompleter', () => {
       fixture.componentInstance.debounceTimeMs = 50;
     });
 
-    it('should load items with debounce', fakeAsync(() => {
-      tick();
-      fixture.detectChanges();
-      fixture.componentInstance.ngAfterViewInit();
-      tick(1000);
-      fixture.detectChanges();
-      const select = fixture.componentInstance.ngSelectInstance;
+    it('should load items with debounce', () => {
+      jasmine.clock().install();
+      try {
+        jasmine.clock().tick(0);
+        fixture.detectChanges();
+        fixture.componentInstance.ngAfterViewInit();
+        jasmine.clock().tick(1000);
+        fixture.detectChanges();
+        const select = fixture.componentInstance.ngSelectInstance;
 
-      expect(select.isOpen).toBeFalse();
-      select.open();
-      select.focus();
+        expect(select.isOpen).toBeFalse();
+        select.open();
+        select.focus();
 
-      expect(select.isOpen).toBeTrue();
+        expect(select.isOpen).toBeTrue();
 
-      expect(select.itemsList.items.length).toEqual(0);
+        expect(select.itemsList.items.length).toEqual(0);
 
-      const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
-      const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+        const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+        const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
-      fixture.detectChanges();
+        fixture.detectChanges();
 
-      expect(getOptionsFnSpy).toHaveBeenCalledWith('');
-      getOptionsFnSpy.calls.reset();
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('');
+        getOptionsFnSpy.calls.reset();
 
-      inputElement.value = 'Wor';
-      inputElement.dispatchEvent(new Event('input'));
-      fixture.detectChanges();
-      tick();
+        inputElement.value = 'Wor';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        jasmine.clock().tick(0);
 
-      expect(getOptionsFnSpy).not.toHaveBeenCalled();
-      tick(50);
+        expect(getOptionsFnSpy).not.toHaveBeenCalled();
+        jasmine.clock().tick(50);
 
-      expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
-    }));
+        expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
   });
 });

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -52,13 +52,13 @@ describe('autocompleter', () => {
     },
   ];
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-    declarations: [OpAutocompleterComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [NgSelectModule],
-    providers: [States, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OpAutocompleterComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [NgSelectModule],
+      providers: [States, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OpAutocompleterComponent);
     getOptionsFnSpy = jasmine.createSpy('getOptionsFn').and.callFake((searchTerm:string) => {
@@ -152,44 +152,44 @@ describe('autocompleter', () => {
       fixture.componentInstance.debounceTimeMs = 50;
     });
 
-    it('should load items with debounce', () => {
-      jasmine.clock().install();
-      try {
-        jasmine.clock().tick(0);
-        fixture.detectChanges();
-        fixture.componentInstance.ngAfterViewInit();
-        jasmine.clock().tick(1000);
-        fixture.detectChanges();
-        const select = fixture.componentInstance.ngSelectInstance;
+    it('should load items with debounce', async () => {
+      fixture.detectChanges();
+      fixture.componentInstance.ngAfterViewInit();
 
-        expect(select.isOpen).toBeFalse();
-        select.open();
-        select.focus();
+      // Wait for ngAfterViewInit's internal setTimeout(25ms) and debounce to fire.
+      await new Promise(resolve => setTimeout(resolve, 100));
+      fixture.detectChanges();
+      const select = fixture.componentInstance.ngSelectInstance;
 
-        expect(select.isOpen).toBeTrue();
+      expect(select.isOpen).toBeFalse();
+      select.open();
+      select.focus();
 
-        expect(select.itemsList.items.length).toEqual(0);
+      expect(select.isOpen).toBeTrue();
 
-        const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
-        const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
+      expect(select.itemsList.items.length).toEqual(0);
 
-        fixture.detectChanges();
+      const inputDebugElement = fixture.debugElement.query(By.css('input[role=combobox]'));
+      const inputElement = inputDebugElement.nativeElement as HTMLInputElement;
 
-        expect(getOptionsFnSpy).toHaveBeenCalledWith('');
-        getOptionsFnSpy.calls.reset();
+      fixture.detectChanges();
 
-        inputElement.value = 'Wor';
-        inputElement.dispatchEvent(new Event('input'));
-        fixture.detectChanges();
-        jasmine.clock().tick(0);
+      // Wait for the initial '' search to fire via debounce.
+      await new Promise(resolve => setTimeout(resolve, 100));
 
-        expect(getOptionsFnSpy).not.toHaveBeenCalled();
-        jasmine.clock().tick(50);
+      expect(getOptionsFnSpy).toHaveBeenCalledWith('');
+      getOptionsFnSpy.calls.reset();
 
-        expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
-      } finally {
-        jasmine.clock().uninstall();
-      }
+      inputElement.value = 'Wor';
+      inputElement.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+
+      expect(getOptionsFnSpy).not.toHaveBeenCalled();
+
+      // Wait for debounce (debounceTimeMs=50, but 0 in test env).
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
     });
   });
 });

--- a/frontend/src/app/shared/components/icon/op-icon.spec.ts
+++ b/frontend/src/app/shared/components/icon/op-icon.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
 import { OpIconComponent } from './icon.component';
@@ -36,14 +36,13 @@ describe('opIcon Directive', () => {
   let fixture:ComponentFixture<OpIconComponent>;
   let element:DebugElement;
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [
         OpIconComponent,
       ],
     }).compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OpIconComponent);

--- a/frontend/src/app/shared/components/primer/icon-button.component.spec.ts
+++ b/frontend/src/app/shared/components/primer/icon-button.component.spec.ts
@@ -28,16 +28,16 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PrimerIconButtonComponent } from './icon-button.component';
 
 describe('PrimerIconButtonComponent', () => {
   let component:PrimerIconButtonComponent;
   let fixture:ComponentFixture<PrimerIconButtonComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({imports: [PrimerIconButtonComponent]});
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [PrimerIconButtonComponent]}).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PrimerIconButtonComponent);

--- a/frontend/src/app/shared/components/toaster/toast.service.spec.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
@@ -38,9 +38,8 @@ import { HttpEvent, provideHttpClient, withInterceptorsFromDi } from '@angular/c
 describe('ToastService', () => {
   let toastService:ToastService;
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
     imports: [OpenprojectHalModule],
     providers: [
         { provide: ConfigurationService, useValue: { autoHidePopups: () => true } },
@@ -49,12 +48,9 @@ describe('ToastService', () => {
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
     ]
-})
-      .compileComponents()
-      .then(() => {
-        toastService = TestBed.inject(ToastService);
-      });
-  }));
+}).compileComponents();
+    toastService = TestBed.inject(ToastService);
+  });
 
   it('should be able to create warnings', () => {
     const toaster = toastService.addWarning('warning!');

--- a/frontend/src/app/shared/components/user-link/user-link.component.spec.ts
+++ b/frontend/src/app/shared/components/user-link/user-link.component.spec.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { UserResource } from 'core-app/features/hal/resources/user-resource';
@@ -46,9 +46,8 @@ describe('UserLinkComponent component test', () => {
   let element:HTMLElement;
   let user:UserResource;
 
-  beforeEach(waitForAsync(() => {
-    // noinspection JSIgnoredPromiseFromCall
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [
         UserLinkComponent,
       ],
@@ -61,11 +60,11 @@ describe('UserLinkComponent component test', () => {
     fixture = TestBed.createComponent(UserLinkComponent);
     app = fixture.debugElement.componentInstance;
     element = fixture.elementRef.nativeElement;
-  }));
+  });
 
   describe('inner element', () => {
-    describe('with the uer having the showUserPath attribute', () => {
-      beforeEach(waitForAsync(() => {
+    describe('with the user having the showUserPath attribute', () => {
+      beforeEach(() => {
         user = {
           name: 'First Last',
           showUserPath: '/users/1',
@@ -73,7 +72,7 @@ describe('UserLinkComponent component test', () => {
 
         fixture.componentRef.setInput('user', user);
         fixture.detectChanges();
-      }));
+      });
 
       it('should render an inner link with specified classes', () => {
         const link = element.querySelector('a')!;
@@ -85,7 +84,7 @@ describe('UserLinkComponent component test', () => {
     });
 
     describe('with the user not having the showUserPath attribute', () => {
-      beforeEach(waitForAsync(() => {
+      beforeEach(() => {
         user = {
           name: 'First Last',
           showUserPath: null,
@@ -93,7 +92,7 @@ describe('UserLinkComponent component test', () => {
 
         fixture.componentRef.setInput('user', user);
         fixture.detectChanges();
-      }));
+      });
 
       it('renders only the name', () => {
         const link = element.querySelector('a');

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,10 +1,5 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-// Require the reflect ES7 polyfill for JIT
-import 'zone.js'; // Included with Angular CLI.
-import 'core-js/es/reflect';
-
-import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import {

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -28,7 +28,6 @@
 
 import { GitActionsService } from './git-actions.service';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
-import { TestBed, waitForAsync } from '@angular/core/testing';
 import { PathHelperService } from "core-app/core/path-helper/path-helper.service";
 
 describe('GitActionsService', function() {
@@ -47,17 +46,6 @@ describe('GitActionsService', function() {
     const workPackage = { ...defaults, ...overrides };
     return(workPackage as WorkPackageResource);
   };
-
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        GitActionsService
-      ]
-    }).compileComponents()
-      .then(() => {
-        service = TestBed.inject(GitActionsService);
-      });
-  }));
 
   beforeEach(() => {
     service = new GitActionsService();


### PR DESCRIPTION
> [!IMPORTANT]
> This Pull Request is based off #22219. Please review/merge that PR first.

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
This PR keeps the Angular spec suite working after the zoneless migration in #22219.

It removes the remaining `zone.js` test-environment dependency and updates the affected specs so they run deterministically without Zone.

# What approach did you choose and why?
I rebased this branch onto the current `code-maintenance/remove-zone.js` branch and kept the changes limited to test setup and migrated specs.

The specs were updated to use zoneless-safe patterns instead of relying on Zone behavior, including:
- awaiting `compileComponents()` where setup is asynchronous
- using `setInput()` and explicit change detection where needed
- replacing real timer sleeps with Jasmine fake timers

This keeps the follow-up focused on test migration only and avoids mixing in unrelated production changes.

# Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
