### PR TITLE
Indicate session cookies as SameSite=lax

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -36,6 +36,7 @@ relative_url_root = config["rails_relative_url_root"].presence
 session_options = {
   key: config["session_cookie_name"],
   httponly: true,
+  same_site: :lax,
   secure: config.https?,
   path: relative_url_root
 }


### PR DESCRIPTION
This is an additional measure ensuring that cross-site requests can't be performed in the scope of the user's session.

Some browsers might already expose this as the default behaviour, but it's generally recommended to set this explicitly whenever a cookie is not needed in a cross-site context.

# Ticket & References

Noticed in the context of https://community.openproject.org/wp/72745

Also see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value