### PR TITLE
[72762] CF is in focus even if user does not click on it

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/multi-select-edit-field.component.ts
@@ -212,9 +212,11 @@ export class MultiSelectEditFieldComponent extends EditFieldComponent implements
           this.setValues(values.elements);
         }
 
-        // Focus and open the field once the values are loaded
-        this.ngSelectComponent.focus();
-        this.openAutocompleteSelectField();
+        if (this.requestFocus) {
+          // Focus and open the field once the values are loaded
+          this.ngSelectComponent.focus();
+          this.openAutocompleteSelectField();
+        }
       });
     } else {
       this.setValues([]);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72762

# What are you trying to accomplish?
Do not focus the fields when focus is not requested (basically when the user did not explicitly click it)


