### PR TITLE
[72766] Colors in the 'Actual cost per month' graph legend and on the chart do not match if users do not have a set rate

### DIFF
--- a/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
+++ b/frontend/src/app/shared/components/budget-graphs/overview/actual-costs.component.ts
@@ -77,7 +77,7 @@ export class ActualCostsComponent {
     },
     plugins: {
       ...chartLegend,
-      'primer-colors': { labelBased: true },
+      'primer-colors': { datasetLabelBased: true },
       tooltip: {
         enabled: false,
         external: createBarTooltipRenderer(this.formatCurrency.bind(this)),

--- a/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/plugin.primer-colors.ts
@@ -36,7 +36,10 @@ import {
 
 export interface PrimerColorsPluginOptions {
   enabled?:boolean;
+  // Color each data point by its axis label (chart.data.labels) — intended for pie/donut charts
   labelBased?:boolean;
+  // Color each dataset uniformly by its dataset.label — intended for bar charts
+  datasetLabelBased?:boolean;
 }
 
 declare module 'chart.js' {
@@ -187,16 +190,14 @@ const plugin:Plugin<ChartType, PrimerColorsPluginOptions> = {
     }
 
     const { data: { datasets } } = chart.config;
-    if (options.labelBased) {
-      if (datasets.length === 1) {
-        assignColorsByLabel(datasets[0], (chart.data.labels ?? []) as string[]);
-      } else {
-        const labels = datasets.map((d) => d.label ?? '');
-        const colorMap = buildLabelColorMap(labels);
-        datasets.forEach((dataset:ChartDataset) => {
-          colorizeMultiDataset(dataset, colorMap.get(dataset.label ?? '') ?? 0);
-        });
-      }
+    if (options.datasetLabelBased || (options.labelBased && datasets.length !== 1)) {
+      const labels = datasets.map((d) => d.label ?? '');
+      const colorMap = buildLabelColorMap(labels);
+      datasets.forEach((dataset:ChartDataset) => {
+        colorizeMultiDataset(dataset, colorMap.get(dataset.label ?? '') ?? 0);
+      });
+    } else if (options.labelBased && datasets.length === 1) {
+      assignColorsByLabel(datasets[0], (chart.data.labels ?? []) as string[]);
     } else if (datasets.length === 1) {
       const colorizer = getColorizer();
       datasets.forEach(colorizer);


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/72766

# What are you trying to accomplish?
Fix color inconsistency in ActualCosts chart with a single dataset

When only one dataset was present, the primer-colors plugin used x-axis date labels for color assignment, causing each bar to get a different color and making the legend and chart inconsistent with the BudgetByCostType chart.

