### PR TITLE
[#72872] Items are not staying assigned to a meeting section on meeting template  

### DIFF
--- a/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/drop_service.rb
@@ -85,7 +85,7 @@ module MeetingAgendaItems
         service_call.result = { section_changed:, current_section:, old_section: }
       rescue StandardError => e
         service_call.success = false
-        service_call.errors = e.message
+        service_call.errors.add(:base, e.message)
       end
 
       service_call
@@ -127,7 +127,7 @@ module MeetingAgendaItems
                        end
 
       # allows from current meeting to backlog
-      if @meeting.backlog.id == new_section_id.to_i
+      if @meeting.backlog&.id == new_section_id.to_i
         target_section ||= @meeting.backlog
       end
 

--- a/modules/meeting/spec/services/meeting_agenda_items/drop_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_agenda_items/drop_service_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe MeetingAgendaItems::DropService do
           end.not_to change { meeting_agenda_item }
 
           expect(service_call).to be_failure
-          expect(service_call.errors).to match(/Couldn't find MeetingSection/)
+          expect(service_call.errors[:base].join).to match(/Couldn't find MeetingSection/)
         end
       end
 
@@ -161,7 +161,7 @@ RSpec.describe MeetingAgendaItems::DropService do
           expect { service_call }.not_to change { meeting_agenda_item.reload.meeting_section_id }
 
           expect(service_call).to be_failure
-          expect(service_call.errors).to match(/Couldn't find MeetingSection/)
+          expect(service_call.errors[:base].join).to match(/Couldn't find MeetingSection/)
         end
       end
 
@@ -172,7 +172,7 @@ RSpec.describe MeetingAgendaItems::DropService do
           expect { service_call }.not_to change { meeting_agenda_item.reload.meeting_section_id }
 
           expect(service_call).to be_failure
-          expect(service_call.errors).to match(/Couldn't find MeetingSection/)
+          expect(service_call.errors[:base].join).to match(/Couldn't find MeetingSection/)
         end
       end
     end
@@ -216,7 +216,7 @@ RSpec.describe MeetingAgendaItems::DropService do
             .not_to change { meeting_agenda_item.reload.meeting_section_id }
 
           expect(result).to be_failure
-          expect(result.errors).to match(/Couldn't find MeetingSection/)
+          expect(result.errors[:base].join).to match(/Couldn't find MeetingSection/)
         end
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72872

I also changed the errors assignment since it wasn't being handled correctly before and the actual error was swallowed up.
