### PR TITLE
[#72795] Rephrase Budget by Cost Type caption

### DIFF
--- a/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
+++ b/modules/budgets/app/components/budgets/widgets/budget_by_cost_type.html.erb
@@ -34,9 +34,10 @@ See COPYRIGHT and LICENSE files for more details.
         flex.with_row do
           render(Primer::Beta::Text.new(color: :subtle, font_size: :small)) do
             if project.children.any?
-              t(".caption_with_subitems", count: budget_count, workspace: project.workspace_label)
+              t(".count_caption_with_subitems.#{project.workspace_type.presence_in(%w[project program portfolio]) || 'project'}",
+                count: budget_count)
             else
-              t(".caption", count: budget_count, workspace: project.workspace_label)
+              t(".count_caption", count: budget_count)
             end
           end
         end

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -92,14 +92,23 @@ en:
         blankslate_zero:
           heading: "Budget details missing"
           description: "Add details about your planned budget to see data here"
-        caption:
+        count_caption:
           zero: "No budget data."
-          one: "Data aggregated from %{count} budget included in this %{workspace}."
-          other: "Data aggregated from %{count} budgets included in this %{workspace}."
-        caption_with_subitems:
-          zero: "No budget data."
-          one: "Data aggregated from %{count} budget included in this %{workspace} and its subitems."
-          other: "Data aggregated from %{count} budgets included in this %{workspace} and its subitems."
+          one: "Data aggregated from %{count} budget"
+          other: "Data aggregated from %{count} budgets"
+        count_caption_with_subitems:
+          project:
+            zero: "No budget data."
+            one: "Data aggregated from %{count} budget included in this project and its subitems."
+            other: "Data aggregated from %{count} budgets included in this project and its subitems."
+          program:
+            zero: "No budget data."
+            one: "Data aggregated from %{count} budget included in this program and its subitems."
+            other: "Data aggregated from %{count} budgets included in this program and its subitems."
+          portfolio:
+            zero: "No budget data."
+            one: "Data aggregated from %{count} budget included in this portfolio and its subitems."
+            other: "Data aggregated from %{count} budgets included in this portfolio and its subitems."
         view_details: "View budget details"
 
   events:

--- a/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
+++ b/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
@@ -65,8 +65,19 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
     end
 
     it "displays caption with workspace type (no subitems for leaf project)" do
-      expect(rendered_component).to have_text(/Data aggregated from 1 budget included in this Project\./)
+      expect(rendered_component).to have_text("Data aggregated from 1 budget")
+      expect(rendered_component).to have_no_text(/Project/)
       expect(rendered_component).to have_no_text(/subitems/)
+    end
+
+    it "interpolates count in the one branch" do
+      expect(I18n.t("budgets.widgets.budget_by_cost_type.count_caption", count: 1)).to eq("Data aggregated from 1 budget")
+    end
+
+    it "pluralizes the caption without subitems" do
+      create(:budget, project: project)
+
+      expect(rendered_component).to have_text("Data aggregated from 2 budgets")
     end
 
     it "passes currency attribute" do
@@ -125,9 +136,47 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
     end
 
     it "displays caption with workspace type and subitems" do
-      expect(rendered_component).to have_text(
-        /Data aggregated from 1 budget included in this Project and its subitems\./
-      )
+      expect(rendered_component).to have_text("Data aggregated from 1 budget included in this project and its subitems.")
+    end
+
+    it "pluralizes the project caption with subitems" do
+      create(:budget, project:)
+
+      expect(rendered_component).to have_text("Data aggregated from 2 budgets included in this project and its subitems.")
+    end
+  end
+
+  context "with a program that has children" do
+    let(:project) { create(:program) }
+    let!(:child) { create(:project_with_types, parent: project) }
+    let!(:budget) { create(:budget, project:) }
+    let!(:labor_item) do
+      create(:labor_budget_item,
+             budget: budget,
+             user: current_user,
+             hours: 100,
+             amount: BigDecimal("5000"))
+    end
+
+    it "displays the program-specific caption with subitems" do
+      expect(rendered_component).to have_text("Data aggregated from 1 budget included in this program and its subitems.")
+    end
+  end
+
+  context "with a portfolio that has children" do
+    let(:project) { create(:portfolio) }
+    let!(:child) { create(:project_with_types, parent: project) }
+    let!(:budget) { create(:budget, project:) }
+    let!(:labor_item) do
+      create(:labor_budget_item,
+             budget: budget,
+             user: current_user,
+             hours: 100,
+             amount: BigDecimal("5000"))
+    end
+
+    it "displays the portfolio-specific caption with subitems" do
+      expect(rendered_component).to have_text("Data aggregated from 1 budget included in this portfolio and its subitems.")
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/72795

# What are you trying to accomplish?

Updates the Budget by Cost Type widget caption to use shorter copy for leaf workspaces and workspace-specific translations for project, program, and portfolio subitem variants.

## Screenshots

<img width="608" height="616" alt="image" src="https://github.com/user-attachments/assets/a35e9475-ea91-42c6-a090-986586d6adbd" />


# What approach did you choose and why?

This removes the generic %{workspace} interpolation so translators can adapt grammar for languages with cases and genders, and adds component coverage for the new caption variants.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
