### PR TITLE
[OP-19002] Handle generated Crowdin conflicts in release-to-dev merges

### DIFF
--- a/.github/workflows/create-merge-release-into-dev-pr.yml
+++ b/.github/workflows/create-merge-release-into-dev-pr.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           ref: ${{ env.BASE_BRANCH }}
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+
       - name: Fetch dev branch upto release branch
         run: git fetch --shallow-exclude "$RELEASE_BRANCH" origin "$BASE_BRANCH" || git fetch --depth 1 origin "$BASE_BRANCH"
 
@@ -100,7 +103,31 @@ jobs:
 
               TEMP_BRANCH="merge-$RELEASE_BRANCH-$(date "+%Y%m%d%H%M%S")"
 
-              git branch "$TEMP_BRANCH" "$RELEASE_BRANCH"
+              git switch -c "$TEMP_BRANCH" "$RELEASE_BRANCH"
+
+              if ! git merge --no-edit --no-ff "$BASE_BRANCH"; then
+                if script/i18n/merge_generated_locale_conflicts; then
+                  if git diff --quiet --diff-filter=U; then
+                    git commit --no-edit
+                    merge_note=$'> [!NOTE]\n> Generated locale conflicts under Crowdin paths were automatically resolved. The helper prefers the dev side for conflicting leaf values and only auto-writes files whose merged YAML matches an existing merge stage.'
+                  else
+                    git merge --abort
+                    merge_note=$'> [!WARNING]\n> Generated locale conflicts were auto-resolved, but non-generated conflicts remain.\n> Please rerun `script/i18n/merge_generated_locale_conflicts` after resolving the remaining conflicts manually.'
+                  fi
+                else
+                  merge_status=$?
+                  if [ "$merge_status" -eq 2 ]; then
+                    git merge --abort
+                    merge_note=$'> [!WARNING]\n> Some generated locale conflicts could not be auto-resolved.\n> Please rerun `script/i18n/merge_generated_locale_conflicts` while manually resolving this branch.'
+                  else
+                    exit "$merge_status"
+                  fi
+                fi
+              fi
+
+              if [ -n "${merge_note:-}" ]; then
+                pr_body="$merge_note"$'\n\n'"$pr_body"
+              fi
 
               git push origin "$TEMP_BRANCH"
 

--- a/docs/development/git-workflow/README.md
+++ b/docs/development/git-workflow/README.md
@@ -95,6 +95,18 @@ Bugfixes for one of the actively supported versions of OpenProject should be iss
 
  A fix for the current version (called "Hotfix" and the branch ideally being named `fix/XYZ`) should target `release/*` and a fix for the former version (called "Backport" and the branch ideally being named `backport/XYZ`) should target `backport/*`. We will try to merge hotfixes into dev branch but if that is no trivial task, we might ask you to create another PR for that.
 
+#### Merging the latest release into `dev`
+
+We use the `create-merge-release-into-dev-pr` workflow to keep `dev` up to date with the latest release branch. If the workflow cannot merge automatically, it creates a `merge-release/X.Y-<timestamp>` branch and opens a pull request for manual conflict resolution.
+
+Generated Crowdin locale files under `config/locales/crowdin/*.yml` and `modules/*/config/locales/crowdin/*.yml` are a special case. The workflow already tries to resolve those conflicts automatically when it creates the `merge-release/...` branch. Auto-resolved changes are only committed when all remaining conflicts can be resolved; otherwise the merge is aborted and no partial resolutions are kept. If you are resolving one of these branches locally, you can rerun the same helper after merging `dev` into the temporary branch:
+
+```shell
+script/i18n/merge_generated_locale_conflicts
+```
+
+The helper uses three-way YAML merge logic for generated locale conflicts, permits the locale files' symbol values, and prefers the `dev` side when both branches changed the same leaf differently. To avoid reserializing generated locale files, it only auto-writes a file when the merged parsed YAML matches one of the existing merge stages. This means that even non-overlapping changes can still be left unresolved if the combined result would differ from all stages. Any files still reported afterwards require manual review and resolution before pushing the branch.
+
 #### Tagging
 
 The stable/X branch with the highest number is the currently supported stable release. Its commits are tagged (e.g. v12.5.8) to pinpoint individual releases.

--- a/lib/open_project/generated_locale_conflict_merger.rb
+++ b/lib/open_project/generated_locale_conflict_merger.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "open3"
+require "yaml"
+
+module OpenProject
+  class GeneratedLocaleConflictMerger
+    class MergeError < StandardError; end
+    StageContent = Data.define(:raw, :parsed)
+    Result = Data.define(:resolved_files, :unresolved_files, :non_generated_files) do
+      def all_generated_resolved? = unresolved_files.empty?
+    end
+
+    GENERATED_LOCALE_PATTERN = "**/config/locales/crowdin/*.yml"
+    MISSING = Object.new
+
+    def initialize(git: Git.new, file_writer: File, out: $stdout, err: $stderr)
+      @git = git
+      @file_writer = file_writer
+      @out = out
+      @err = err
+    end
+
+    def call
+      generated_files, non_generated_files = partition_conflicted_files
+      unresolved_files = []
+      resolved_files = resolve_generated_files(generated_files, unresolved_files)
+      log_remaining_unresolved_files(unresolved_files, non_generated_files)
+
+      Result.new(resolved_files:, unresolved_files:, non_generated_files:)
+    end
+
+    private
+
+    attr_reader :err, :file_writer, :git, :out
+
+    def partition_conflicted_files
+      git.conflicted_files.partition { |path| generated_locale?(path) }
+    end
+
+    def resolve_generated_files(generated_files, unresolved_files)
+      generated_files.each_with_object([]) do |path, resolved|
+        resolved << merge_file(path)
+      rescue MergeError => e
+        err.puts "Leaving #{path} unresolved: #{e.message}"
+        unresolved_files << path
+      end
+    end
+
+    def log_remaining_unresolved_files(unresolved_files, non_generated_files)
+      files = unresolved_files + non_generated_files
+      return if files.empty?
+
+      err.puts "Files still requiring manual resolution:"
+      files.each { |path| err.puts "  #{path}" }
+    end
+
+    def generated_locale?(path)
+      File.fnmatch?(GENERATED_LOCALE_PATTERN, path, File::FNM_PATHNAME)
+    end
+
+    def merge_file(path)
+      base, ours, theirs = load_stages(path)
+
+      merged = merge_value(base.parsed, ours.parsed, theirs.parsed)
+
+      if missing?(merged)
+        git.rm(path)
+        out.puts "Auto-removed #{path}"
+        return path
+      end
+
+      write_merged_file(path, merged, base:, ours:, theirs:)
+    end
+
+    def load_stage(stage, path)
+      contents = git.cat_file(stage, path)
+      parsed = YAML.safe_load(contents, permitted_classes: [Symbol])
+      raise MergeError, "expected top-level YAML mapping in stage #{stage}" unless parsed.is_a?(Hash)
+
+      StageContent.new(raw: contents, parsed:)
+    rescue Psych::SyntaxError => e
+      raise MergeError, "invalid YAML in stage #{stage}: #{e.message}"
+    rescue Git::MissingStageEntry
+      StageContent.new(raw: nil, parsed: MISSING)
+    end
+
+    def load_stages(path)
+      (1..3).map { |stage| load_stage(stage, path) }
+    end
+
+    def write_merged_file(path, merged, base:, ours:, theirs:)
+      raw_yaml = raw_yaml_for(merged, base:, ours:, theirs:)
+      raise MergeError, "merged YAML differs from all merge stages" if raw_yaml.nil?
+
+      file_writer.write(path, raw_yaml)
+      git.add(path)
+      out.puts "Auto-resolved #{path}"
+      path
+    end
+
+    def raw_yaml_for(merged, base:, ours:, theirs:)
+      [theirs, ours, base]
+        .find { |stage| merged == stage.parsed }
+        &.raw
+    end
+
+    # rubocop:disable Style/EmptyCaseCondition, Lint/DuplicateBranch
+    def merge_value(base, ours, theirs)
+      case
+      when missing?(ours) && missing?(theirs)
+        MISSING
+      when ours == base
+        theirs
+      when theirs == base || ours == theirs
+        ours
+      when recursive_hash_merge?(base, ours, theirs)
+        merge_hash(base, ours, theirs)
+      else
+        theirs # conflict: prefer dev (theirs) side
+      end
+    end
+    # rubocop:enable Style/EmptyCaseCondition, Lint/DuplicateBranch
+
+    def merge_hash(base, ours, theirs)
+      base, ours, theirs = [base, ours, theirs].map { |value| missing?(value) ? {} : value }
+
+      (base.keys | ours.keys | theirs.keys).each_with_object({}) do |key, merged|
+        merged_value = merge_value(
+          base.fetch(key, MISSING),
+          ours.fetch(key, MISSING),
+          theirs.fetch(key, MISSING)
+        )
+
+        merged[key] = merged_value unless missing?(merged_value)
+      end
+    end
+
+    def recursive_hash_merge?(base, ours, theirs)
+      [base, ours, theirs].all? { |value| missing?(value) || value.is_a?(Hash) }
+    end
+
+    def missing?(value)
+      value.equal?(MISSING)
+    end
+
+    class Git
+      class MissingStageEntry < StandardError; end
+
+      def conflicted_files
+        capture!("git", "diff", "--name-only", "--diff-filter=U").split("\n")
+      end
+
+      def cat_file(stage, path)
+        object_id = stage_object_ids(path)[stage]
+        raise MissingStageEntry, "missing stage #{stage}" if object_id.nil?
+
+        capture!("git", "cat-file", "blob", object_id)
+      end
+
+      def add(path)
+        system("git", "add", "--", path, exception: true)
+      end
+
+      def rm(path)
+        system("git", "rm", "--", path, exception: true)
+      end
+
+      private
+
+      def capture!(*command)
+        stdout, stderr, status = Open3.capture3(*command)
+        $stderr.print(stderr) unless stderr.empty?
+        raise "command failed: #{command.join(' ')}\n#{stderr}" unless status.success?
+
+        stdout
+      end
+
+      def stage_object_ids(path)
+        @stage_object_ids ||= {}
+        @stage_object_ids[path] ||= load_stage_object_ids(path)
+      end
+
+      def load_stage_object_ids(path)
+        output = capture!("git", "ls-files", "--stage", "--", path)
+        output.lines.each_with_object({}) do |line, ids|
+          _mode, sha, line_stage, _path = line.split(/\s+/, 4)
+          ids[line_stage.to_i] = sha
+        end
+      end
+    end
+  end
+end

--- a/script/i18n/merge_generated_locale_conflicts
+++ b/script/i18n/merge_generated_locale_conflicts
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require_relative "../../lib/open_project/generated_locale_conflict_merger"
+
+result = OpenProject::GeneratedLocaleConflictMerger.new.call
+exit 2 unless result.all_generated_resolved?

--- a/spec/lib/open_project/generated_locale_conflict_merger_spec.rb
+++ b/spec/lib/open_project/generated_locale_conflict_merger_spec.rb
@@ -1,0 +1,650 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::GeneratedLocaleConflictMerger do
+  let(:git) { instance_double(described_class::Git) }
+  let(:file_writer) { class_double(File) }
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  subject(:merger) do
+    described_class.new(
+      git:,
+      file_writer:,
+      out: stdout,
+      err: stderr
+    )
+  end
+
+  describe "#call" do
+    let(:generated_path) { "config/locales/crowdin/es.yml" }
+    let(:other_path) { "docs/api/apiv3/openapi-spec.yml" }
+
+    before do
+      allow(git).to receive(:conflicted_files).and_return(conflicted_files)
+    end
+
+    context "when there are no conflicted files" do
+      let(:conflicted_files) { [] }
+
+      it "returns an empty result" do
+        result = merger.call
+
+        expect(result).to have_attributes(resolved_files: [], unresolved_files: [], non_generated_files: [])
+      end
+    end
+
+    context "when only non-generated files are conflicted" do
+      let(:conflicted_files) { [other_path] }
+
+      it "reports them as non-generated" do
+        result = merger.call
+
+        expect(result.resolved_files).to eq([])
+        expect(result.unresolved_files).to eq([])
+        expect(result.non_generated_files).to eq([other_path])
+        expect(stderr.string).to include(other_path)
+      end
+    end
+
+    context "when only one side changed a generated locale file" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: New
+        YAML
+      end
+
+      it "writes the changed side and stages the file" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            title: New
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when both sides changed different nested keys" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: Old first
+            second: Old second
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: New first
+            second: Old second
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: Old first
+            second: New second
+        YAML
+      end
+
+      it "leaves the file unresolved instead of reserializing it" do
+        result = merger.call
+
+        expect(file_writer).not_to have_received(:write)
+        expect(git).not_to have_received(:add)
+        expect(result.resolved_files).to eq([])
+        expect(result.unresolved_files).to eq([generated_path])
+        expect(stderr.string).to include("merged YAML differs from all merge stages")
+      end
+    end
+
+    context "when both sides changed the same leaf differently" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Release value
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Dev value
+        YAML
+      end
+
+      it "prefers the dev side and stages the file" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            title: Dev value
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when a generated locale file contains invalid yaml" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: [broken
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: New
+        YAML
+      end
+
+      it "leaves the file unresolved" do
+        result = merger.call
+
+        expect(result.unresolved_files).to eq([generated_path])
+        expect(stderr.string).to include("invalid YAML")
+      end
+    end
+
+    context "when a generated locale file has a non-hash top level value" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          - item
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: New
+        YAML
+      end
+
+      it "leaves the file unresolved" do
+        result = merger.call
+
+        expect(result.unresolved_files).to eq([generated_path])
+        expect(stderr.string).to include("expected top-level YAML mapping")
+      end
+    end
+
+    context "when a key was removed on one side only" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+            remove_me: Remove me
+        YAML
+      end
+
+      it "keeps the deletion" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            keep: Keep
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when a key was removed on the dev side only" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            keep: Keep
+        YAML
+      end
+
+      it "keeps the deletion from dev side" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            keep: Keep
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+      end
+    end
+
+    context "when the release side deleted the file" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:rm)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path)
+                                  .and_raise(described_class::Git::MissingStageEntry, "missing stage 2")
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            remove_me: Remove me
+        YAML
+      end
+
+      it "removes the file and stages the deletion" do
+        result = merger.call
+
+        expect(file_writer).not_to have_received(:write)
+        expect(git).not_to have_received(:add)
+        expect(git).to have_received(:rm).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when the dev side deleted the file" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:rm)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            remove_me: Remove me
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path)
+                                  .and_raise(described_class::Git::MissingStageEntry, "missing stage 3")
+      end
+
+      it "removes the file and stages the deletion" do
+        result = merger.call
+
+        expect(file_writer).not_to have_received(:write)
+        expect(git).not_to have_received(:add)
+        expect(git).to have_received(:rm).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when both sides added the same key with different values (no base)" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path)
+                                  .and_raise(described_class::Git::MissingStageEntry, "missing stage 1")
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Release value
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Dev value
+        YAML
+      end
+
+      it "prefers the dev side" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            title: Dev value
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+      end
+    end
+
+    context "when a generated locale file contains symbol values" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            date:
+              order:
+                - ':año'
+                - :mes
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            date:
+              order:
+                - ':año'
+                - :mes
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            date:
+              order:
+                - ':año'
+                - :mes
+                - ':día'
+        YAML
+      end
+
+      it "permits Symbol and writes the merged content" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            date:
+              order:
+                - ':año'
+                - :mes
+                - ':día'
+        YAML
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when the merged content matches dev exactly" do
+      let(:conflicted_files) { [generated_path] }
+      let(:theirs_yaml) do
+        <<~YAML
+          # a preserved comment
+          ---
+          es:
+            title: "Dev value"
+            description: >
+              Wrapped text
+        YAML
+      end
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old value
+            description: Wrapped text
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Release value
+            description: Wrapped text
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(theirs_yaml)
+      end
+
+      it "writes the raw dev YAML instead of reserializing" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, theirs_yaml)
+        expect(git).to have_received(:add).with(generated_path)
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+      end
+    end
+
+    context "when a merged file differs from every raw stage" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: Old first
+            second: Old second
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: Release first
+            second: Old second
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            first: Old first
+            second: Dev second
+        YAML
+      end
+
+      it "leaves the file unresolved instead of reserializing it" do
+        result = merger.call
+
+        expect(file_writer).not_to have_received(:write)
+        expect(git).not_to have_received(:add)
+        expect(result.resolved_files).to eq([])
+        expect(result.unresolved_files).to eq([generated_path])
+        expect(stderr.string).to include("merged YAML differs from all merge stages")
+      end
+    end
+
+    context "when a stage entry is missing for an added file" do
+      let(:conflicted_files) { [generated_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path)
+                                  .and_raise(described_class::Git::MissingStageEntry, "missing stage 1")
+        allow(git).to receive(:cat_file).with(2, generated_path)
+                                  .and_raise(described_class::Git::MissingStageEntry, "missing stage 2")
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            added: true
+        YAML
+      end
+
+      it "accepts the added file contents" do
+        result = merger.call
+
+        expect(file_writer).to have_received(:write).with(generated_path, <<~YAML)
+          ---
+          es:
+            added: true
+        YAML
+        expect(result.resolved_files).to eq([generated_path])
+      end
+    end
+
+    context "when generated and non-generated conflicts are mixed" do
+      let(:conflicted_files) { [generated_path, other_path] }
+
+      before do
+        allow(file_writer).to receive(:write)
+        allow(git).to receive(:add)
+        allow(git).to receive(:cat_file).with(1, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(2, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: Old
+        YAML
+        allow(git).to receive(:cat_file).with(3, generated_path).and_return(<<~YAML)
+          ---
+          es:
+            title: New
+        YAML
+      end
+
+      it "resolves only the generated file" do
+        result = merger.call
+
+        expect(result.resolved_files).to eq([generated_path])
+        expect(result.unresolved_files).to eq([])
+        expect(result.non_generated_files).to eq([other_path])
+      end
+    end
+  end
+
+  describe described_class::Git do
+    subject(:git) { described_class.new }
+
+    let(:path) { "config/locales/crowdin/es.yml" }
+    let(:success) { instance_double(Process::Status, success?: true) }
+
+    it "loads stage object ids once per path" do
+      allow(Open3).to receive(:capture3)
+                        .with("git", "ls-files", "--stage", "--", path)
+                        .once
+                        .and_return([
+                                      <<~OUT,
+                                        100644 sha-base 1\t#{path}
+                                        100644 sha-ours 2\t#{path}
+                                      OUT
+                                      "",
+                                      success
+                                    ])
+      allow(Open3).to receive(:capture3)
+                        .with("git", "cat-file", "blob", "sha-base")
+                        .and_return(["base", "", success])
+      allow(Open3).to receive(:capture3)
+                        .with("git", "cat-file", "blob", "sha-ours")
+                        .and_return(["ours", "", success])
+
+      expect(git.cat_file(1, path)).to eq("base")
+      expect(git.cat_file(2, path)).to eq("ours")
+    end
+
+    it "raises when a requested stage is missing" do
+      allow(Open3).to receive(:capture3)
+                        .with("git", "ls-files", "--stage", "--", path)
+                        .and_return(["100644 sha-base 1\t#{path}\n", "", success])
+
+      expect { git.cat_file(3, path) }
+        .to raise_error(described_class::MissingStageEntry, "missing stage 3")
+    end
+  end
+end

--- a/spec/scripts/merge_generated_locale_conflicts_spec.rb
+++ b/spec/scripts/merge_generated_locale_conflicts_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "script/i18n/merge_generated_locale_conflicts" do # rubocop:disable RSpec/DescribeClass
+  let(:script_path) { Rails.root.join("script/i18n/merge_generated_locale_conflicts") }
+  let(:merger) { instance_double(OpenProject::GeneratedLocaleConflictMerger, call: result) }
+
+  before do
+    allow(OpenProject::GeneratedLocaleConflictMerger).to receive(:new).and_return(merger)
+  end
+
+  context "when all generated conflicts were resolved" do
+    let(:result) do
+      OpenProject::GeneratedLocaleConflictMerger::Result.new(
+        resolved_files: ["config/locales/crowdin/es.yml"],
+        unresolved_files: [],
+        non_generated_files: []
+      )
+    end
+
+    it "exits successfully" do
+      expect { load script_path }.not_to raise_error
+    end
+  end
+
+  context "when non-generated conflicts remain but all generated are resolved" do
+    let(:result) do
+      OpenProject::GeneratedLocaleConflictMerger::Result.new(
+        resolved_files: ["config/locales/crowdin/es.yml"],
+        unresolved_files: [],
+        non_generated_files: ["docs/api/apiv3/openapi-spec.yml"]
+      )
+    end
+
+    it "exits successfully" do
+      expect { load script_path }.not_to raise_error
+    end
+  end
+
+  context "when generated conflicts remain unresolved" do
+    let(:result) do
+      OpenProject::GeneratedLocaleConflictMerger::Result.new(
+        resolved_files: [],
+        unresolved_files: ["config/locales/crowdin/es.yml"],
+        non_generated_files: []
+      )
+    end
+
+    it "exits with status 2" do
+      expect { load script_path }
+        .to raise_error(SystemExit) { |error| expect(error.status).to eq(2) }
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/OP-19002

# Summary

**Goal: Reduce manual conflict resolution work when `create-merge-release-into-dev-pr` opens a PR for merging the latest `release/*` branch into `dev`.**

This adds a helper that handles generated Crowdin locale conflicts on the temporary `merge-release/...` branch and wires it into the workflow. It also documents the same helper for developers resolving those branches locally.

# Why this approach

Although Crowdin locale files are generated artifacts, they are generated independently on `dev` and release branches. A three-way merge preserves non-overlapping generated changes without blindly taking one side when both branches changed the same translation entry differently. **Later Crowdin runs can still normalize the files, but this reduces manual conflict work without discarding valid branch-specific generated output.**

`.gitattributes` would apply globally, but this behavior is specific to the release-to-dev maintenance workflow. Keeping it in the workflow/helper makes the automation targeted and easier to reason about.

# What changed

- added `OpenProject::GeneratedLocaleConflictMerger`
- added `script/i18n/merge_generated_locale_conflicts`
- updated `create-merge-release-into-dev-pr` to run the helper on the PR branch path
- documented the local conflict-resolution workflow
- added focused specs for merge behavior, symbol-valued YAML, formatting preservation, and safe deletions

# Merge behavior

The helper only touches unresolved files matching `**/config/locales/crowdin/*.yml` (i.e. `config/locales/crowdin/*.yml` and `modules/*/config/locales/crowdin/*.yml`).

It:
- parses merge stages as YAML
- recursively merges hash-shaped locale data
- permits symbol-valued YAML entries used by locale files
- prefers the `dev` side when both branches changed the same leaf differently
- preserves the raw YAML from a merge stage when the resolved content already matches that stage — to avoid reserialization churn, files whose merged YAML differs from all raw stages are left unresolved
- stages `git rm` when deletion is the correct safe result

Only expected merge failures (invalid YAML, non-hash top-level, no matching raw stage) are caught via `MergeError`. Git plumbing errors and other unexpected failures propagate as real errors rather than being silently treated as unresolved files.

Files outside the generated Crowdin locale paths are left alone. If conflicts remain after running the helper, they still require manual resolution.

# Workflow integration

After `git merge` fails, the workflow follows one of four paths:

1. **Script exits 0, no remaining conflicts** — all conflicts (generated and otherwise) are resolved; the merge is committed with a NOTE explaining the auto-resolution
2. **Script exits 0, non-generated conflicts remain** — generated locale conflicts were resolved but other files still conflict; the merge is aborted and the PR is opened with a WARNING directing the developer to resolve the remaining conflicts and rerun the helper
3. **Script exits 2** — some generated locale conflicts could not be auto-resolved; the merge is aborted and the PR is opened with a WARNING
4. **Script exits with any other code** — unexpected error (e.g. git plumbing failure); the workflow fails immediately

# Merge checklist
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Helper tested resolving conflicts on actual branch
  - [X] #22250
  - [x] #22274
  - [x] #22299 (at 113038)
  - [x] #22299 (at b36c094 - merge redone and force pushed)
  - [x] merge-release/17.3-20260403042014 (commit dd70eceac9a; resolved `config/locales/crowdin/ru.yml` and `modules/backlogs/config/locales/crowdin/ru.yml`)
  - [x] #22723
  - [x] #22724
  - [x] #22725

