### PR TITLE
[#72882] Keep out-of-hours reporting and specs stable

### DIFF
--- a/docs/development/testing/handling-flaky-tests/README.md
+++ b/docs/development/testing/handling-flaky-tests/README.md
@@ -37,7 +37,6 @@ To aggregate recent `Test suite` failures and highlight specs that skew outside 
 use:
 
 ```bash
-export GITHUB_USERNAME=...
 export GITHUB_TOKEN=...
 script/report_out_of_hours_ci_failures --days 30
 ```

--- a/docs/development/testing/handling-flaky-tests/README.md
+++ b/docs/development/testing/handling-flaky-tests/README.md
@@ -21,6 +21,10 @@ Developers notice a failing spec in CI runs related to the PR they are working o
 
 The failing spec is suspicious as it seems unrelated to the changes introduced by the commits.
 
+Out-of-hours correlation is a lead, not proof of a datetime bug. Evening or weekend failures can still be caused by
+ordinary flakiness, branch-specific regressions, or infrastructure issues. Start by separating build/setup failures from
+actual `Unit tests` or `Feature tests`, then look for recurring spec names before concluding that time-sensitive logic is involved.
+
 To get the failing spec names, use `script/github_pr_errors` and give it the URL of the failing run as argument, for example:
 
 ```bash
@@ -28,6 +32,17 @@ script/github_pr_errors https://github.com/opf/openproject/actions/runs/18215876
 ```
 
 There are options to display images or display advice to reproduce the failures. Use `--help` to know more.
+
+To aggregate recent `Test suite` failures and highlight specs that skew outside 09:00-18:00 Europe/Berlin Monday to Friday,
+use:
+
+```bash
+export GITHUB_USERNAME=...
+export GITHUB_TOKEN=...
+script/report_out_of_hours_ci_failures --days 30
+```
+
+The report focuses on `dev` and `release/*` runs by default and excludes failures that never reached the unit or feature test steps.
 
 ## Confirming the spec is flaky
 

--- a/modules/meeting/spec/features/meeting_backlogs_spec.rb
+++ b/modules/meeting/spec/features/meeting_backlogs_spec.rb
@@ -247,14 +247,6 @@ RSpec.describe "Meeting Backlogs", :js do
   end
 
   describe "for meeting series" do
-    before_all do
-      travel_to(Date.new(2024, 12, 1))
-    end
-
-    after(:all) do # rubocop:disable RSpec/BeforeAfterAll
-      travel_back
-    end
-
     shared_let(:recurring_meeting) do
       create :recurring_meeting,
              project:,
@@ -274,6 +266,10 @@ RSpec.describe "Meeting Backlogs", :js do
       next_occurrence_time = recurring_meeting.next_occurrence(from_time: recurring_meeting.first_occurrence.to_time + 2.hours)
       RecurringMeetings::InitNextOccurrenceJob.perform_now(recurring_meeting, first_occurrence_time)
       RecurringMeetings::InitNextOccurrenceJob.perform_now(recurring_meeting, next_occurrence_time)
+    end
+
+    after do
+      travel_back
     end
 
     describe "backlog visibility" do

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -32,6 +32,12 @@ require "spec_helper"
 require_relative "../support/pages/meetings/index"
 
 RSpec.describe "Meetings", "Index", :js do
+  shared_let(:business_day_at_noon) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
+
+  after do
+    travel_back
+  end
+
   # The order the Projects are created in is important. By naming `project` alphanumerically
   # after `other_project`, we can ensure that subsequent specs that assert sorting is
   # correct for the right reasons (sorting by Project name and not id)
@@ -55,14 +61,14 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project:,
            title: "Awesome meeting today!",
-           start_time: Time.current)
+           start_time: business_day_at_noon - 5.minutes)
   end
   shared_let(:tomorrows_meeting) do
     create(:meeting,
            :author_participates,
            project:,
            title: "Awesome meeting tomorrow!",
-           start_time: 1.day.from_now,
+           start_time: business_day_at_noon + 1.day,
            duration: 2.0,
            location: "no-protocol.com")
   end
@@ -71,7 +77,7 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project:,
            title: "Boring meeting without a location!",
-           start_time: 1.day.from_now,
+           start_time: business_day_at_noon + 1.day + 5.minutes,
            location: "")
   end
   shared_let(:meeting_with_malicious_location) do
@@ -79,7 +85,7 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project:,
            title: "Sneaky meeting!",
-           start_time: 1.day.from_now,
+           start_time: business_day_at_noon + 1.day + 10.minutes,
            location: "<script>alert('Description');</script>")
   end
   shared_let(:yesterdays_meeting) do
@@ -87,7 +93,7 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project:,
            title: "Awesome meeting yesterday!",
-           start_time: 1.day.ago)
+           start_time: business_day_at_noon - 1.day)
   end
 
   shared_let(:other_project_meeting) do
@@ -95,7 +101,7 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project: other_project,
            title: "Awesome other project meeting!",
-           start_time: 2.days.from_now,
+           start_time: business_day_at_noon + 2.days,
            duration: 2.0,
            location: "not-a-url")
   end
@@ -104,7 +110,7 @@ RSpec.describe "Meetings", "Index", :js do
            :author_participates,
            project:,
            title: "Awesome ongoing meeting!",
-           start_time: 30.minutes.ago)
+           start_time: business_day_at_noon - 30.minutes)
   end
 
   def setup_meeting_involvement
@@ -120,6 +126,7 @@ RSpec.describe "Meetings", "Index", :js do
   end
 
   before do
+    travel_to(business_day_at_noon)
     login_as user
   end
 

--- a/modules/meeting/spec/features/move_to_section_spec.rb
+++ b/modules/meeting/spec/features/move_to_section_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe "Move agenda items to section", :js do
     login_as current_user
   end
 
+  after do
+    travel_back
+  end
+
   describe "for one-time meetings" do
     shared_let(:meeting) do
       create :meeting,

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe "Recurring meetings creation",
     travel_to(Date.new(2024, 12, 1))
   end
 
+  after do
+    travel_back
+  end
+
   context "with a user with permissions" do
     it "can create a recurring meeting" do
       login_as current_user

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_crud_spec.rb
@@ -38,14 +38,6 @@ RSpec.describe "Recurring meetings CRUD",
                :js do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
-  before_all do
-    travel_to(Date.new(2024, 12, 1))
-  end
-
-  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    travel_back
-  end
-
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   shared_let(:user) do
     create :user,
@@ -83,6 +75,10 @@ RSpec.describe "Recurring meetings CRUD",
 
     # Assuming the first init job has run
     RecurringMeetings::InitNextOccurrenceJob.perform_now(meeting, meeting.first_occurrence.to_time)
+  end
+
+  after do
+    travel_back
   end
 
   it "can delete a recurring meeting from the show page and return to the index page" do

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_global_crud_spec.rb
@@ -37,14 +37,6 @@ require_relative "../../support/pages/meetings/index"
 RSpec.describe "Recurring meetings global CRUD", :js do
   include Components::Autocompleter::NgSelectAutocompleteHelpers
 
-  before_all do
-    travel_to(Date.new(2024, 12, 1))
-  end
-
-  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    travel_back
-  end
-
   shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
   shared_let(:user) do
     create :user,
@@ -82,6 +74,10 @@ RSpec.describe "Recurring meetings global CRUD", :js do
 
     # Assuming the first init job has run
     RecurringMeetings::InitNextOccurrenceJob.perform_now(meeting, meeting.first_occurrence.to_time)
+  end
+
+  after do
+    travel_back
   end
 
   it "can delete a recurring meeting from the show page and return to the index page" do

--- a/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/structured_meeting_update_flash_spec.rb
@@ -193,14 +193,6 @@ RSpec.describe "Meetings CRUD",
       end
 
       context "for meeting series, across the same occurrence" do
-        before_all do
-          travel_to(Date.new(2024, 12, 1))
-        end
-
-        after(:all) do # rubocop:disable RSpec/BeforeAfterAll
-          travel_back
-        end
-
         let(:recurring_meeting) do
           create :recurring_meeting,
                  project:,
@@ -220,6 +212,10 @@ RSpec.describe "Meetings CRUD",
           # Assuming the first occurrence is open
           first_occurrence_time = recurring_meeting.first_occurrence.to_time
           RecurringMeetings::InitNextOccurrenceJob.perform_now(recurring_meeting, first_occurrence_time)
+        end
+
+        after do
+          travel_back
         end
 
         it_behaves_like "no flash appears when interacting with backlog in multiple windows"

--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -24,9 +24,7 @@ GITHUB_HTML_OPENPROJECT_PREFIX = "https://github.com/opf/openproject"
 RAILS_ROOT = Pathname.new(__dir__).dirname
 EXCLUDED_JOB_NAMES = %w[eslint rubocop].freeze
 
-if !ENV["GITHUB_USERNAME"]
-  raise "Missing GITHUB_USERNAME env"
-elsif !ENV["GITHUB_TOKEN"]
+if !ENV["GITHUB_TOKEN"]
   raise "Missing GITHUB_TOKEN env, go to https://github.com/settings/tokens and create one with 'repo' access"
 end
 
@@ -181,8 +179,9 @@ end
 def http
   HTTPX
     .plugin(:follow_redirects)
-    .plugin(:basic_auth)
-    .basic_auth(ENV.fetch("GITHUB_USERNAME"), ENV.fetch("GITHUB_TOKEN"))
+    .with_headers(
+      "Authorization" => "Bearer #{ENV.fetch('GITHUB_TOKEN')}"
+    )
 end
 
 def get_http(path)

--- a/script/github_pr_errors
+++ b/script/github_pr_errors
@@ -17,6 +17,8 @@ require "yaml"
 require "httpx"
 require "cgi"
 
+require_relative "support/github_actions_failures"
+
 GITHUB_API_OPENPROJECT_PREFIX = "https://api.github.com/repos/opf/openproject"
 GITHUB_HTML_OPENPROJECT_PREFIX = "https://github.com/opf/openproject"
 RAILS_ROOT = Pathname.new(__dir__).dirname
@@ -337,170 +339,6 @@ Report = Data.define(
   end
 end
 
-class Error
-  attr_accessor :location, :page_html, :page_screenshot, :tests_group, :loading_error
-end
-
-# rubocop:disable Layout/LineLength
-# Looks like this in the job log:
-# Process 28: TEST_ENV_NUMBER=28 RUBYOPT=-I/usr/local/bundle/bundler/gems/turbo_tests-3148ae6c3482/lib -r/usr/local/bundle/gems/bundler-2.5.23/lib/bundler/setup -W0 RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1 /usr/local/bundle/gems/bundler-2.5.23/exe/bundle exec rspec --seed 52674 --format TurboTests::JsonRowsFormatter --out tmp/test-pipes/subprocess-28 --format ParallelTests::RSpec::RuntimeLogger --out spec/support/turbo_runtime_features.log spec/features/api_docs/index_spec.rb spec/features/custom_fields/reorder_options_spec.rb spec/features/projects/projects_portfolio_spec.rb spec/features/projects/template_spec.rb spec/features/versions/edit_spec.rb spec/features/work_packages/details/markdown/description_editor_spec.rb spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb spec/features/work_packages/table/inline_create/inline_create_refresh_spec.rb spec/features/work_packages/table/invalid_query_spec.rb spec/features/work_packages/tabs/activity_revisions_spec.rb
-# rubocop:enable Layout/LineLength
-class TestsGroup
-  attr_accessor :test_env_number, :seed, :files
-
-  def initialize
-    @files = []
-  end
-
-  def include_error?(error)
-    return false if error.location.nil?
-
-    files.any? { |file| error.location.include?(file) }
-  end
-
-  def inspect
-    "#<#{self.class} @test_env_number=#{test_env_number} @seed=#{seed} (#{files.count} files)>"
-  end
-end
-
-class JobErrorsFinder
-  SPEC_FAILURES_PATTERN = %r{^\S+ rspec (\S+) #.+$}
-  SPEC_LOADING_ERRORS_PATTERN = %r{^\S+ An error occurred while loading (\S+)\.\r?$}
-  SCREENSHOT_PATTERN = /\{"message":"Screenshot captured for failed feature test"[^\n]+$/
-  TESTS_GROUP_PATTERN = /Process \d+: TEST_ENV_NUMBER=\d+ [^\n]+$/
-  BRANCH_MERGE_PATTERN = /Merge \w{40} into (\w{40})$/
-
-  attr_reader :failures_explanation, :merge_branch_sha
-
-  def self.scan_logs(report, logs)
-    finder = new
-    logs.each do |log|
-      finder.scan_log(log)
-    end
-    report.with(
-      errors: finder.errors,
-      failures_explanation: finder.failures_explanation,
-      merge_branch_sha: finder.merge_branch_sha
-    )
-  end
-
-  def scan_log(log)
-    find_failures(log)
-    find_failures_explanation(log)
-    find_loading_errors(log)
-    find_screenshots(log)
-    find_tests_groups(log)
-    find_merge_branch_info(log)
-  end
-
-  def errors
-    @errors.values
-  end
-
-  protected
-
-  def initialize
-    @errors = {}
-  end
-
-  def create_error(location)
-    return if location.nil?
-
-    error = Error.new
-    error.location = location
-    @errors[location] ||= error
-  end
-
-  def with_matching_error(location: nil, id: nil)
-    error = @errors[id] || @errors[location]
-    yield error if error && block_given?
-    error
-  end
-
-  def find_failures(log)
-    log.scan(SPEC_FAILURES_PATTERN)
-      .flatten
-      .uniq
-      .sort
-      .each do |rerun_location|
-        create_error(rerun_location)
-      end
-  end
-
-  def find_failures_explanation(log)
-    explanations = []
-    log.split("\n").each do |line|
-      if line.end_with?("Failures:") .. line.end_with?("Failed examples:")
-        explanations << line
-      end
-    end
-    explanations.map! { it[29..] } # Remove leading timestamp (like "2024-02-05T08:37:54.5175930Z")
-    explanations.reject! do |line|
-      line == "Failures:" ||
-        line == "Failed examples:" ||
-        line.include?("gems/rspec-retry-") ||
-        line.include?("gems/webmock-")
-    end
-    @failures_explanation = explanations.join("\n")
-  end
-
-  def find_loading_errors(log)
-    log.scan(SPEC_LOADING_ERRORS_PATTERN)
-      .flatten
-      .uniq
-      .sort
-      .each do |location|
-        error = create_error(location)
-        error.loading_error = true
-      end
-  end
-
-  def find_screenshots(log)
-    log.scan(SCREENSHOT_PATTERN)
-      .map { JSON.parse it }
-      .each do |screenshot_info|
-        id = screenshot_info["test_id"]
-        location = screenshot_info["test_location"]
-        with_matching_error(location:, id:) do |error|
-          error.page_html = screenshot_info["html"]
-          error.page_screenshot = screenshot_info["image"]
-        end
-      end
-  end
-
-  def find_tests_groups(log)
-    tests_groups = log
-      .scan(TESTS_GROUP_PATTERN)
-      .flatten
-      .map { build_tests_group_from_command(it) }
-
-    errors.each do |error|
-      error.tests_group = tests_groups.find { it.include_error?(error) }
-    end
-  end
-
-  def find_merge_branch_info(log)
-    merge_branch_sha = log.scan(BRANCH_MERGE_PATTERN).flatten.first
-    @merge_branch_sha = merge_branch_sha if merge_branch_sha
-  end
-
-  def build_tests_group_from_command(line)
-    tests_group = TestsGroup.new
-    parts = line.split
-    while parts.any?
-      case part = parts.shift
-      when /^TEST_ENV_NUMBER=/
-        tests_group.test_env_number = part.delete_prefix("TEST_ENV_NUMBER=")
-      when "--seed"
-        tests_group.seed = parts.shift
-      when /_spec.rb$/
-        tests_group.files << part
-      end
-    end
-    tests_group
-  end
-end
-
 class Formatter
   def initialize(compact: false)
     @compact = compact
@@ -798,7 +636,12 @@ formatter = Formatter.new(compact: Options.compact)
 
 report = get_failed_jobs_logs(report, formatter)
 
-report = JobErrorsFinder.scan_logs(report, report.failed_job_logs)
+scan_result = GithubActionsFailures::JobErrorsFinder.scan_logs(report.failed_job_logs)
+report = report.with(
+  errors: scan_result.errors,
+  failures_explanation: scan_result.failures_explanation,
+  merge_branch_sha: scan_result.merge_branch_sha
+)
 
 case report.run_status
 when "completed"

--- a/script/report_out_of_hours_ci_failures
+++ b/script/report_out_of_hours_ci_failures
@@ -114,8 +114,9 @@ module OutOfHoursCiFailures
     def http
       @http ||= HTTPX
         .plugin(:follow_redirects)
-        .plugin(:basic_auth)
-        .basic_auth(ENV.fetch("GITHUB_USERNAME"), ENV.fetch("GITHUB_TOKEN"))
+        .with_headers(
+          "Authorization" => "Bearer #{ENV.fetch('GITHUB_TOKEN')}"
+        )
     end
 
     def github_url(path)
@@ -351,9 +352,7 @@ module OutOfHoursCiFailures
 end
 
 if $PROGRAM_NAME == __FILE__
-  if !ENV["GITHUB_USERNAME"]
-    raise "Missing GITHUB_USERNAME env"
-  elsif !ENV["GITHUB_TOKEN"]
+  if !ENV["GITHUB_TOKEN"]
     raise "Missing GITHUB_TOKEN env, go to https://github.com/settings/tokens and create one with 'repo' access"
   end
 

--- a/script/report_out_of_hours_ci_failures
+++ b/script/report_out_of_hours_ci_failures
@@ -1,0 +1,372 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "rubygems"
+require "bundler"
+Bundler.setup(:default, :development)
+
+require "json"
+require "optparse"
+require "pathname"
+require "time"
+require "yaml"
+require "httpx"
+require "active_support/all"
+
+require_relative "support/github_actions_failures"
+
+GITHUB_API_OPENPROJECT_PREFIX = "https://api.github.com/repos/opf/openproject"
+RAILS_ROOT = Pathname.new(__dir__).dirname
+TEST_WORKFLOW_FILE = "test-core.yml"
+PRIMARY_BRANCH_PATTERN = /\A(?:dev|release\/.+)\z/
+TEST_STEP_NAMES = ["Unit tests", "Feature tests"].freeze
+DEFAULT_TIMEZONE = "Europe/Berlin"
+DEFAULT_LOOKBACK_DAYS = 30
+
+module OutOfHoursCiFailures
+  RunSummary = Data.define(:run_id, :run_number, :html_url, :head_branch, :event, :created_at, :failed_steps, :errors)
+  SpecSummary = Data.define(
+    :location,
+    :test_types,
+    :out_of_hours_count,
+    :in_hours_count,
+    :branches,
+    :first_seen_at,
+    :last_seen_at,
+    :out_of_hours_runs,
+    :in_hours_runs,
+    :classification
+  )
+
+  class Options
+    DEFAULTS = {
+      days: DEFAULT_LOOKBACK_DAYS,
+      include_pr_runs: false,
+      json: false,
+      timezone: DEFAULT_TIMEZONE,
+      workflow: TEST_WORKFLOW_FILE
+    }.freeze
+
+    class << self
+      # rubocop:disable Metrics/AbcSize
+      def parse!(argv)
+        options = DEFAULTS.dup
+
+        OptionParser.new do |parser|
+          parser.banner = "Usage: script/report_out_of_hours_ci_failures [options]"
+
+          parser.on("--days DAYS", Integer, "Look back this many days (default: #{DEFAULT_LOOKBACK_DAYS})") do |value|
+            options[:days] = value
+          end
+
+          parser.on("--include-pr-runs", "Include pull_request runs in the report") do
+            options[:include_pr_runs] = true
+          end
+
+          parser.on("--json", "Output JSON instead of a table") do
+            options[:json] = true
+          end
+
+          parser.on(
+            "--timezone NAME",
+            "Timezone for the in-hours/out-of-hours classification (default: #{DEFAULT_TIMEZONE})"
+          ) do |value|
+            options[:timezone] = value
+          end
+
+          parser.on("--workflow FILE", "Workflow file name to inspect (default: #{TEST_WORKFLOW_FILE})") do |value|
+            options[:workflow] = value
+          end
+
+          parser.on("-h", "--help", "Print this help") do
+            puts parser
+            exit
+          end
+        end.parse!(argv)
+
+        options
+      end
+      # rubocop:enable Metrics/AbcSize
+    end
+  end
+
+  class GithubClient
+    def initialize(cache_dir:)
+      @cache_dir = cache_dir
+    end
+
+    def workflow_runs(workflow_file:, page:)
+      get_json("actions/workflows/#{workflow_file}/runs?status=completed&per_page=100&page=#{page}")
+    end
+
+    def jobs(run_id)
+      get_json("actions/runs/#{run_id}/jobs")
+    end
+
+    def log(job_id)
+      cached("job_#{job_id}.log") do
+        get_http("actions/jobs/#{job_id}/logs")
+      end
+    end
+
+    private
+
+    def http
+      @http ||= HTTPX
+        .plugin(:follow_redirects)
+        .plugin(:basic_auth)
+        .basic_auth(ENV.fetch("GITHUB_USERNAME"), ENV.fetch("GITHUB_TOKEN"))
+    end
+
+    def github_url(path)
+      path.start_with?("http") ? path : "#{GITHUB_API_OPENPROJECT_PREFIX}/#{path}"
+    end
+
+    def get_http(path)
+      response = http.get(github_url(path))
+      response.raise_for_status
+      response.to_s
+    end
+
+    def get_json(path)
+      JSON.parse(get_http(path))
+    rescue HTTPX::HTTPError => e
+      body = e.response.json
+      raise "#{body['message']} (see #{body['documentation_url']})"
+    end
+
+    def cached(name)
+      path = @cache_dir.join(name)
+      return path.read if path.file?
+
+      content = yield
+      path.dirname.mkpath
+      path.write(content)
+      content
+    end
+  end
+
+  class ReportBuilder
+    def initialize(options:, client:)
+      @options = options
+      @client = client
+      @timezone = ActiveSupport::TimeZone[options[:timezone]] || raise("Unknown timezone #{options[:timezone]}")
+      @since = Time.current - options[:days].days
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def build
+      spec_runs = Hash.new { |hash, key| hash[key] = [] }
+
+      each_relevant_run do |workflow_run, failed_jobs|
+        logs = failed_jobs.map { |job| @client.log(job.fetch("id")) }
+        scan_result = GithubActionsFailures::JobErrorsFinder.scan_logs(logs)
+        next if scan_result.errors.empty?
+
+        failed_steps = failed_jobs.flat_map { failing_test_steps(it) }.uniq.sort
+        summary = RunSummary.new(
+          run_id: workflow_run.fetch("id"),
+          run_number: workflow_run.fetch("run_number"),
+          html_url: workflow_run.fetch("html_url"),
+          head_branch: workflow_run.fetch("head_branch"),
+          event: workflow_run.fetch("event"),
+          created_at: parse_time(workflow_run.fetch("created_at")),
+          failed_steps:,
+          errors: scan_result.errors.map(&:location).sort
+        )
+
+        summary.errors.each do |location|
+          spec_runs[location] << summary
+        end
+      end
+
+      spec_runs
+        .sort_by { |location, _| location }
+        .map { |location, runs| summarize(location, runs) }
+        .sort_by { |summary| [-summary.out_of_hours_count, -summary.in_hours_count, summary.location] }
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    private
+
+    # rubocop:disable Metrics/AbcSize
+    def each_relevant_run
+      page = 1
+      done = false
+
+      loop do
+        response = @client.workflow_runs(workflow_file: @options[:workflow], page:)
+        runs = response.fetch("workflow_runs")
+        break if runs.empty?
+
+        runs.each do |workflow_run|
+          created_at = parse_time(workflow_run.fetch("created_at"))
+          if created_at < @since
+            done = true
+            break
+          end
+
+          next unless include_run?(workflow_run)
+
+          jobs = @client.jobs(workflow_run.fetch("id")).fetch("jobs")
+          failed_jobs = jobs.select { test_job_failure?(it) }
+          next if failed_jobs.empty?
+
+          yield workflow_run, failed_jobs
+        end
+
+        page += 1
+        break if done
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def include_run?(workflow_run)
+      branch = workflow_run.fetch("head_branch")
+      return false unless branch.match?(PRIMARY_BRANCH_PATTERN) || @options[:include_pr_runs]
+      return false if workflow_run.fetch("event") == "pull_request" && !@options[:include_pr_runs]
+
+      true
+    end
+
+    def test_job_failure?(job)
+      job.fetch("conclusion") == "failure" && failing_test_steps(job).any?
+    end
+
+    def failing_test_steps(job)
+      job
+        .fetch("steps")
+        .filter_map { |step| step["name"] if step["conclusion"] == "failure" && TEST_STEP_NAMES.include?(step["name"]) }
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def summarize(location, runs)
+      out_of_hours_runs, in_hours_runs = runs.partition { out_of_hours?(it.created_at) }
+      branches = runs.map(&:head_branch).uniq.sort
+      test_types = runs.flat_map(&:failed_steps).uniq.sort
+
+      SpecSummary.new(
+        location:,
+        test_types:,
+        out_of_hours_count: out_of_hours_runs.count,
+        in_hours_count: in_hours_runs.count,
+        branches:,
+        first_seen_at: runs.min_by(&:created_at).created_at,
+        last_seen_at: runs.max_by(&:created_at).created_at,
+        out_of_hours_runs: out_of_hours_runs.map(&:html_url),
+        in_hours_runs: in_hours_runs.map(&:html_url),
+        classification: classify(out_of_hours_runs:, in_hours_runs:, branches:)
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def classify(out_of_hours_runs:, in_hours_runs:, branches:)
+      total = out_of_hours_runs.count + in_hours_runs.count
+      return "needs manual review" if total < 2
+      return "likely regression" if branches.one?
+      return "likely datetime-sensitive" if in_hours_runs.empty?
+
+      ratio = out_of_hours_runs.count.to_f / total
+      return "likely datetime-sensitive" if ratio >= 0.75 && branches.many?
+
+      "likely generic flaky"
+    end
+
+    def out_of_hours?(time)
+      local = time.in_time_zone(@timezone)
+      local.saturday? || local.sunday? || local.hour < 9 || local.hour >= 18
+    end
+
+    def parse_time(value)
+      Time.iso8601(value)
+    end
+  end
+
+  class Formatter
+    def initialize(timezone:)
+      @timezone = timezone
+    end
+
+    def print(spec_summaries, json: false)
+      json ? print_json(spec_summaries) : print_table(spec_summaries)
+    end
+
+    private
+
+    # rubocop:disable Metrics/AbcSize
+    def print_json(spec_summaries)
+      puts JSON.pretty_generate(
+        spec_summaries.map do |summary|
+          {
+            location: summary.location,
+            test_types: summary.test_types,
+            out_of_hours_count: summary.out_of_hours_count,
+            in_hours_count: summary.in_hours_count,
+            branches: summary.branches,
+            first_seen_at: summary.first_seen_at.in_time_zone(@timezone).iso8601,
+            last_seen_at: summary.last_seen_at.in_time_zone(@timezone).iso8601,
+            classification: summary.classification,
+            out_of_hours_runs: summary.out_of_hours_runs,
+            in_hours_runs: summary.in_hours_runs
+          }
+        end
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    # rubocop:disable Metrics/AbcSize
+    def print_table(spec_summaries)
+      puts [
+        "Classification".ljust(26),
+        "OOH".rjust(3),
+        "IN".rjust(3),
+        "Type".ljust(16),
+        "Branches".ljust(18),
+        "First seen".ljust(17),
+        "Last seen".ljust(17),
+        "Spec"
+      ].join("  ")
+
+      spec_summaries.each do |summary|
+        puts [
+          summary.classification.ljust(26),
+          summary.out_of_hours_count.to_s.rjust(3),
+          summary.in_hours_count.to_s.rjust(3),
+          summary.test_types.join(",").ljust(16),
+          truncate(summary.branches.join(","), 18).ljust(18),
+          summary.first_seen_at.in_time_zone(@timezone).strftime("%F %H:%M"),
+          summary.last_seen_at.in_time_zone(@timezone).strftime("%F %H:%M"),
+          summary.location
+        ].join("  ")
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def truncate(value, length)
+      return value if value.length <= length
+
+      "#{value[0, length - 3]}..."
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  if !ENV["GITHUB_USERNAME"]
+    raise "Missing GITHUB_USERNAME env"
+  elsif !ENV["GITHUB_TOKEN"]
+    raise "Missing GITHUB_TOKEN env, go to https://github.com/settings/tokens and create one with 'repo' access"
+  end
+
+  # workaround an openssl 3.6.0 issue
+  # https://github.com/ruby/openssl/issues/949#issuecomment-3367944960
+  s = OpenSSL::X509::Store.new.tap(&:set_default_paths)
+  OpenSSL::SSL::SSLContext.send(:remove_const, :DEFAULT_CERT_STORE) rescue nil # rubocop:disable Style/RescueModifier
+  OpenSSL::SSL::SSLContext.const_set(:DEFAULT_CERT_STORE, s.freeze)
+
+  options = OutOfHoursCiFailures::Options.parse!(ARGV)
+  client = OutOfHoursCiFailures::GithubClient.new(cache_dir: RAILS_ROOT.join("tmp/report_out_of_hours_ci_failures"))
+  builder = OutOfHoursCiFailures::ReportBuilder.new(options:, client:)
+  formatter = OutOfHoursCiFailures::Formatter.new(timezone: options[:timezone])
+
+  formatter.print(builder.build, json: options[:json])
+end

--- a/script/support/github_actions_failures.rb
+++ b/script/support/github_actions_failures.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "json"
+
+module GithubActionsFailures
+  Result = Data.define(:errors, :failures_explanation, :merge_branch_sha)
+
+  class Error
+    attr_accessor :location, :page_html, :page_screenshot, :tests_group, :loading_error
+  end
+
+  class TestsGroup
+    attr_accessor :test_env_number, :seed, :files
+
+    def initialize
+      @files = []
+    end
+
+    def include_error?(error)
+      return false if error.location.nil?
+
+      files.any? { |file| error.location.include?(file) }
+    end
+
+    def inspect
+      "#<#{self.class} @test_env_number=#{test_env_number} @seed=#{seed} (#{files.count} files)>"
+    end
+  end
+
+  class JobErrorsFinder
+    SPEC_FAILURES_PATTERN = %r{^\S+ rspec (\S+) #.+$}
+    SPEC_LOADING_ERRORS_PATTERN = %r{^\S+ An error occurred while loading (\S+)\.\r?$}
+    SCREENSHOT_PATTERN = /\{"message":"Screenshot captured for failed feature test"[^\n]+$/
+    # Looks like this in the job log:
+    # rubocop:disable Layout/LineLength
+    # Process 28: TEST_ENV_NUMBER=28 RUBYOPT=-I/usr/local/bundle/bundler/gems/turbo_tests-3148ae6c3482/lib -r/usr/local/bundle/gems/bundler-2.5.23/lib/bundler/setup -W0 RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1 /usr/local/bundle/gems/bundler-2.5.23/exe/bundle exec rspec --seed 52674 --format TurboTests::JsonRowsFormatter --out tmp/test-pipes/subprocess-28 --format ParallelTests::RSpec::RuntimeLogger --out spec/support/turbo_runtime_features.log spec/features/api_docs/index_spec.rb spec/features/custom_fields/reorder_options_spec.rb spec/features/projects/projects_portfolio_spec.rb spec/features/projects/template_spec.rb spec/features/versions/edit_spec.rb spec/features/work_packages/details/markdown/description_editor_spec.rb spec/features/work_packages/table/hierarchy/hierarchy_parent_below_spec.rb spec/features/work_packages/table/inline_create/inline_create_refresh_spec.rb spec/features/work_packages/table/invalid_query_spec.rb spec/features/work_packages/tabs/activity_revisions_spec.rb
+    # rubocop:enable Layout/LineLength
+    TESTS_GROUP_PATTERN = /Process \d+: TEST_ENV_NUMBER=\d+ [^\n]+$/
+    BRANCH_MERGE_PATTERN = /Merge \w{40} into (\w{40})$/
+
+    def self.scan_logs(logs)
+      finder = new
+      logs.each do |log|
+        finder.scan_log(log)
+      end
+
+      Result.new(
+        errors: finder.errors,
+        failures_explanation: finder.failures_explanation,
+        merge_branch_sha: finder.merge_branch_sha
+      )
+    end
+
+    attr_reader :failures_explanation, :merge_branch_sha
+
+    def scan_log(log)
+      find_failures(log)
+      find_failures_explanation(log)
+      find_loading_errors(log)
+      find_screenshots(log)
+      find_tests_groups(log)
+      find_merge_branch_info(log)
+    end
+
+    def errors
+      @errors.values
+    end
+
+    private
+
+    def initialize
+      @errors = {}
+    end
+
+    def create_error(location)
+      return if location.nil?
+
+      error = Error.new
+      error.location = location
+      @errors[location] ||= error
+    end
+
+    def with_matching_error(location: nil, id: nil)
+      error = @errors[id] || @errors[location]
+      yield error if error && block_given?
+      error
+    end
+
+    def find_failures(log)
+      log.scan(SPEC_FAILURES_PATTERN)
+         .flatten
+         .uniq
+         .sort
+         .each do |rerun_location|
+        create_error(rerun_location)
+      end
+    end
+
+    def find_failures_explanation(log)
+      explanations = []
+      log.split("\n").each do |line|
+        if line.end_with?("Failures:") .. line.end_with?("Failed examples:")
+          explanations << line
+        end
+      end
+      explanations.map! { it[29..] } # Remove leading GitHub Actions log timestamp (e.g. "2024-02-05T08:37:54.5175930Z ")
+      explanations.reject! do |line|
+        line == "Failures:" ||
+          line == "Failed examples:" ||
+          line.include?("gems/rspec-retry-") ||
+          line.include?("gems/webmock-")
+      end
+      @failures_explanation = explanations.join("\n")
+    end
+
+    def find_loading_errors(log)
+      log.scan(SPEC_LOADING_ERRORS_PATTERN)
+         .flatten
+         .uniq
+         .sort
+         .each do |location|
+        error = create_error(location)
+        error.loading_error = true
+      end
+    end
+
+    def find_screenshots(log)
+      log.scan(SCREENSHOT_PATTERN)
+         .map { JSON.parse(it) }
+         .each do |screenshot_info|
+        id = screenshot_info["test_id"]
+        location = screenshot_info["test_location"]
+        with_matching_error(location:, id:) do |error|
+          error.page_html = screenshot_info["html"]
+          error.page_screenshot = screenshot_info["image"]
+        end
+      end
+    end
+
+    def find_tests_groups(log)
+      tests_groups = log
+        .scan(TESTS_GROUP_PATTERN)
+        .flatten
+        .map { build_tests_group_from_command(it) }
+
+      errors.each do |error|
+        error.tests_group = tests_groups.find { it.include_error?(error) }
+      end
+    end
+
+    def find_merge_branch_info(log)
+      merge_branch_sha = log.scan(BRANCH_MERGE_PATTERN).flatten.first
+      @merge_branch_sha = merge_branch_sha if merge_branch_sha
+    end
+
+    def build_tests_group_from_command(line)
+      tests_group = TestsGroup.new
+      parts = line.split
+      while parts.any?
+        case part = parts.shift
+        when /^TEST_ENV_NUMBER=/
+          tests_group.test_env_number = part.delete_prefix("TEST_ENV_NUMBER=")
+        when "--seed"
+          tests_group.seed = parts.shift
+        when /_spec.rb$/
+          tests_group.files << part
+        end
+      end
+      tests_group
+    end
+  end
+end

--- a/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_date_alert_mention_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Notification center date alert and mention",
     create(:user,
            member_with_permissions: { project => %w[view_work_packages] })
   end
-  shared_let(:work_package) { create(:work_package, project:, due_date: 1.day.ago) }
-
-  shared_let(:notification_mention) do
+  let(:reference_time) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
+  let(:work_package) { create(:work_package, project:, due_date: 1.day.ago.to_date) }
+  let!(:notification_mention) do
     create(:notification,
            reason: :mentioned,
            recipient: user,
@@ -22,7 +22,7 @@ RSpec.describe "Notification center date alert and mention",
            actor:)
   end
 
-  shared_let(:notification_date_alert) do
+  let!(:notification_date_alert) do
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
@@ -32,9 +32,14 @@ RSpec.describe "Notification center date alert and mention",
   let(:center) { Pages::Notifications::Center.new }
 
   before do
+    travel_to(reference_time)
     login_as user
     visit notifications_center_path
     wait_for_reload
+  end
+
+  after do
+    travel_back
   end
 
   context "with date alerts ee", with_ee: %i[date_alerts] do

--- a/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
+++ b/spec/features/notifications/notification_center/notification_center_reminder_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe "Notification center reminder, mention and date alert",
     create(:user,
            member_with_permissions: { project => %w[view_work_packages] })
   end
-  shared_let(:work_package) { create(:work_package, project:, due_date: 1.day.ago) }
-  shared_let(:work_package2) { create(:work_package, project:) }
+  let(:reference_time) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
+  let(:work_package) { create(:work_package, project:, due_date: 1.day.ago.to_date) }
+  let(:work_package2) { create(:work_package, project:) }
 
-  shared_let(:notification_mentions) do
+  let!(:notification_mentions) do
     [create(:notification,
             reason: :mentioned,
             recipient: user,
@@ -29,27 +30,32 @@ RSpec.describe "Notification center reminder, mention and date alert",
             actor: actor)]
   end
 
-  shared_let(:notification_date_alert) do
+  let!(:notification_date_alert) do
     create(:notification,
            reason: :date_alert_due_date,
            recipient: user,
            resource: work_package)
   end
 
-  shared_let(:notification_reminder) do
+  let!(:notification_reminder) do
     create_reminder_notification_for(work_package: work_package, user: user)
   end
 
-  shared_let(:notification_reminder2) do
+  let!(:notification_reminder2) do
     create_reminder_notification_for(work_package: work_package2, user: user)
   end
 
   let(:center) { Pages::Notifications::Center.new }
 
   before do
+    travel_to(reference_time)
     login_as user
     visit notifications_center_path
     wait_for_reload
+  end
+
+  after do
+    travel_back
   end
 
   context "with a reminder, mention and date alert" do

--- a/spec/features/work_packages/reminders_spec.rb
+++ b/spec/features/work_packages/reminders_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Work package reminder modal",
                :js do
+  let(:reference_time) { Time.find_zone!("Europe/Berlin").local(2025, 1, 8, 12, 0, 0) }
   let!(:project) { create(:project) }
   let!(:work_package) { create(:work_package, project:) }
   let!(:role_that_allows_managing_own_reminders) do
@@ -53,6 +54,14 @@ RSpec.describe "Work package reminder modal",
 
   let(:work_package_page) { Pages::FullWorkPackage.new(work_package) }
   let(:center) { Pages::Notifications::Center.new }
+
+  before do
+    travel_to(reference_time)
+  end
+
+  after do
+    travel_back
+  end
 
   context "with permissions to manage own reminders" do
     current_user { user_with_permissions }

--- a/spec/features/work_packages/table/queries/filter_spec.rb
+++ b/spec/features/work_packages/table/queries/filter_spec.rb
@@ -556,26 +556,36 @@ RSpec.describe "filter work packages", :js do
   end
 
   describe "datetime filters" do
+    shared_let(:business_day_at_noon) { Time.find_zone!("Europe/Kyiv").local(2025, 1, 8, 12, 0, 0) }
+
+    before do
+      travel_to(business_day_at_noon)
+    end
+
+    after do
+      travel_back
+    end
+
     shared_let(:wp_updated_today) do
       create(:work_package,
              subject: "Created today",
              project:,
-             created_at: Time.current.change(hour: 12),
-             updated_at: Time.current.change(hour: 12))
+             created_at: business_day_at_noon,
+             updated_at: business_day_at_noon)
     end
     shared_let(:wp_updated_3d_ago) do
       create(:work_package,
              subject: "Created 3d ago",
              project:,
-             created_at: 3.days.ago,
-             updated_at: 3.days.ago)
+             created_at: business_day_at_noon - 3.days,
+             updated_at: business_day_at_noon - 3.days)
     end
     shared_let(:wp_updated_5d_ago) do
       create(:work_package,
              subject: "Created 5d ago",
              project:,
-             created_at: 5.days.ago,
-             updated_at: 5.days.ago)
+             created_at: business_day_at_noon - 5.days,
+             updated_at: business_day_at_noon - 5.days)
     end
 
     it "filters on date by created_at (Regression #28459)" do

--- a/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
+++ b/spec/features/work_packages/table/queries/mobile_date_filter_spec.rb
@@ -36,15 +36,21 @@ RSpec.describe "mobile date filter work packages", :js do
   shared_let(:wp_table) { Pages::WorkPackagesTable.new(project) }
   shared_let(:wp_cards) { Pages::WorkPackageCards.new(project) }
   shared_let(:filters) { Components::WorkPackages::Filters.new }
-  shared_let(:work_package_with_due_date) { create(:work_package, project:, due_date: Date.current) }
-  shared_let(:work_package_without_due_date) { create(:work_package, project:, due_date: 5.days.from_now) }
+  shared_let(:business_day_at_noon) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
+  shared_let(:work_package_with_due_date) { create(:work_package, project:, due_date: business_day_at_noon.to_date) }
+  shared_let(:work_package_without_due_date) { create(:work_package, project:, due_date: business_day_at_noon.to_date + 5.days) }
 
   current_user { user }
 
   include_context "with mobile screen size"
 
   before do
+    travel_to(business_day_at_noon)
     wp_table.visit!
+  end
+
+  after do
+    travel_back
   end
 
   context "when filtering between finish date" do
@@ -59,9 +65,9 @@ RSpec.describe "mobile date filter work packages", :js do
       clear_input_field_contents(start_field)
       clear_input_field_contents(end_field)
 
-      start_field.set 1.day.ago.to_date
+      start_field.set business_day_at_noon.to_date - 1.day
       start_field.send_keys :tab
-      end_field.set Date.current
+      end_field.set business_day_at_noon.to_date
       end_field.send_keys :tab
 
       wait_for_reload
@@ -76,7 +82,7 @@ RSpec.describe "mobile date filter work packages", :js do
 
       last_query = Query.last
       date_filter = last_query.filters.last
-      expect(date_filter.values).to eq [1.day.ago.to_date.iso8601, Date.current.iso8601]
+      expect(date_filter.values).to eq [(business_day_at_noon.to_date - 1.day).iso8601, business_day_at_noon.to_date.iso8601]
     end
   end
 
@@ -90,7 +96,7 @@ RSpec.describe "mobile date filter work packages", :js do
       expect(date_field["type"]).to eq "date"
 
       clear_input_field_contents(date_field)
-      date_field.set Date.current
+      date_field.set business_day_at_noon.to_date
 
       wait_for_reload
       loading_indicator_saveguard
@@ -104,7 +110,7 @@ RSpec.describe "mobile date filter work packages", :js do
 
       last_query = Query.last
       date_filter = last_query.filters.last
-      expect(date_filter.values).to eq [Date.current.iso8601]
+      expect(date_filter.values).to eq [business_day_at_noon.to_date.iso8601]
     end
   end
 end

--- a/spec/scripts/out_of_hours_ci_failures/report_builder_spec.rb
+++ b/spec/scripts/out_of_hours_ci_failures/report_builder_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module OutOfHoursCiFailures
+end
+
+load Rails.root.join("script/report_out_of_hours_ci_failures")
+
+RSpec.describe OutOfHoursCiFailures::ReportBuilder do
+  let(:options) do
+    {
+      days: 30,
+      include_pr_runs: false,
+      json: false,
+      timezone: "Europe/Berlin",
+      workflow: "test-core.yml"
+    }
+  end
+
+  let(:client) { instance_spy(OutOfHoursCiFailures::GithubClient) }
+  let(:builder) { described_class.new(options:, client:) }
+  let(:run_id) { 1001 }
+
+  before do
+    allow(Time).to receive(:current).and_return(Time.zone.parse("2026-03-08 12:00:00 UTC"))
+  end
+
+  it "classifies boundary times using the configured timezone" do
+    stub_runs(
+      workflow(run_id:, created_at: "2026-03-03T07:59:00Z")
+    )
+    stub_jobs(run_id => failed_jobs("Feature tests"))
+    stub_logs("spec/features/example_spec.rb:10")
+
+    summary = builder.build.first
+
+    expect(summary.out_of_hours_count).to eq(1)
+    expect(summary.in_hours_count).to eq(0)
+  end
+
+  it "ignores build failures and keeps only unit and feature test failures" do
+    stub_runs(
+      workflow(run_id:, created_at: "2026-03-03T08:00:00Z"),
+      workflow(run_id: 1002, created_at: "2026-03-03T09:00:00Z")
+    )
+    stub_jobs(
+      run_id => build_failure_jobs,
+      1002 => failed_jobs("Unit tests")
+    )
+    stub_logs("spec/models/example_spec.rb:12")
+
+    summaries = builder.build
+
+    expect(summaries.map(&:location)).to eq(["spec/models/example_spec.rb:12"])
+  end
+
+  it "classifies repeated out-of-hours failures on multiple branches as likely datetime-sensitive" do
+    stub_runs(
+      workflow(run_id:, branch: "dev", created_at: "2026-03-03T07:59:00Z"),
+      workflow(
+        run_id: 1002,
+        branch: "release/17.2",
+        created_at: "2026-03-04T18:00:00Z"
+      )
+    )
+    stub_jobs(
+      run_id => failed_jobs("Feature tests"),
+      1002 => failed_jobs("Feature tests")
+    )
+    stub_logs("spec/features/example_spec.rb:10")
+
+    summary = builder.build.first
+
+    expect(summary.classification).to eq("likely datetime-sensitive")
+  end
+
+  it "classifies failures seen in and out of hours as likely generic flaky" do
+    stub_runs(
+      workflow(run_id:, branch: "dev", created_at: "2026-03-03T07:59:00Z"),
+      workflow(
+        run_id: 1002,
+        branch: "release/17.2",
+        created_at: "2026-03-04T10:00:00Z"
+      )
+    )
+    stub_jobs(
+      run_id => failed_jobs("Feature tests"),
+      1002 => failed_jobs("Feature tests")
+    )
+    stub_logs("spec/features/example_spec.rb:10")
+
+    summary = builder.build.first
+
+    expect(summary.classification).to eq("likely generic flaky")
+  end
+
+  it "classifies repeated failures on a single branch as likely regression" do
+    stub_runs(
+      workflow(
+        run_id:,
+        created_at: "2026-03-03T07:59:00Z",
+        branch: "feature/foo",
+        event: "push"
+      ),
+      workflow(
+        run_id: 1002,
+        created_at: "2026-03-04T08:30:00Z",
+        branch: "feature/foo",
+        event: "push"
+      )
+    )
+    stub_jobs(
+      run_id => failed_jobs("Unit tests"),
+      1002 => failed_jobs("Unit tests")
+    )
+    stub_logs("spec/models/example_spec.rb:12")
+
+    summaries = described_class.new(options: options.merge(include_pr_runs: true), client:).build
+
+    expect(summaries.first.classification).to eq("likely regression")
+  end
+
+  def stub_runs(*runs)
+    allow(client).to receive(:workflow_runs).and_return(
+      { "workflow_runs" => runs },
+      { "workflow_runs" => [] }
+    )
+  end
+
+  def stub_jobs(jobs_by_run_id)
+    allow(client).to receive(:jobs) do |id|
+      jobs_by_run_id.fetch(id)
+    end
+  end
+
+  def stub_logs(location)
+    allow(client).to receive(:log).and_return(job_log(location))
+  end
+
+  def workflow(run_id:, created_at:, branch: "dev", event: "push")
+    {
+      "id" => run_id,
+      "run_number" => run_id,
+      "html_url" => "https://github.com/opf/openproject/actions/runs/#{run_id}",
+      "head_branch" => branch,
+      "event" => event,
+      "created_at" => created_at
+    }
+  end
+
+  def failed_jobs(step_name)
+    {
+      "jobs" => [
+        {
+          "id" => 9001,
+          "conclusion" => "failure",
+          "steps" => [
+            { "name" => step_name, "conclusion" => "failure" }
+          ]
+        }
+      ]
+    }
+  end
+
+  def build_failure_jobs
+    {
+      "jobs" => [
+        {
+          "id" => 9002,
+          "conclusion" => "failure",
+          "steps" => [
+            { "name" => "Build", "conclusion" => "failure" }
+          ]
+        }
+      ]
+    }
+  end
+
+  def job_log(location)
+    "2026-03-03T08:00:00.0000000Z rspec #{location} # example failure\n"
+  end
+end

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -198,6 +198,8 @@ module Components
       end
 
       def open_filters
+        return if filters_expanded?
+
         retry_block do
           toggle_filters_section
           expect(page).to have_css(".op-filters-form.-expanded")
@@ -211,6 +213,13 @@ module Components
 
       def toggle_filters_section
         filters_toggle.click
+      end
+
+      def filters_expanded?
+        # wait for widgets to be loaded (filters button should be visible)
+        filters_toggle
+
+        page.has_css?(".op-filters-form.-expanded", wait: 0)
       end
 
       def autocomplete_filter?(filter)

--- a/spec/support_spec/table_helpers/column_type/schedule_spec.rb
+++ b/spec/support_spec/table_helpers/column_type/schedule_spec.rb
@@ -50,6 +50,10 @@ module TableHelpers::ColumnType
       travel_to(fake_today)
     end
 
+    after do
+      travel_back
+    end
+
     describe "origin day" do
       it "is identified by the 'M' in 'MTWTFSS' in the header and corresponds to the next monday" do
         expect(parsed_attributes(<<~TABLE))

--- a/spec/support_spec/table_helpers/example_methods_spec.rb
+++ b/spec/support_spec/table_helpers/example_methods_spec.rb
@@ -45,6 +45,10 @@ module TableHelpers
         travel_to(fake_today)
       end
 
+      after do
+        travel_back
+      end
+
       it "applies attribute changes to a group of work packages from a visual table representation" do
         main = build_stubbed(:work_package, subject: "main")
         second = build_stubbed(:work_package, subject: "second")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72882

# What are you trying to accomplish?
Stabilize CI failures that correlate with out-of-hours runs and add tooling to analyze them more systematically.

This PR does two things:
- adds a reusable report for recent `test-core.yml` failures, classifying specs by whether they fail mostly out-of-hours or across both time buckets
- hardens a first pass of clearly time-sensitive specs by removing reliance on wall-clock time and by cleaning up leaked `travel_to` state

# What approach did you choose and why?
I treated out-of-hours failures as a triage signal, not proof of a datetime bug.

For the reporting side, the new helper and script reuse the existing GitHub Actions log parsing flow so we can group recent failing specs by branch, failed test step, and Europe/Berlin business-hours buckets without inventing a second parser.

For the spec fixes, I focused first on examples with strong evidence of time sensitivity and direct use of relative time helpers in setup. Those specs were changed to use deterministic timestamps or correctly scoped time travel so they no longer depend on the current weekday, hour, or leaked process time state.

I kept broader or weakly evidenced candidates out of the branch unless they had a clear out-of-hours pattern and a verified local fix.

# Merge checklist

- [x] Added/updated tests
- [X] Added/updated documentation
