### PR TITLE
[#70213] Stabilize out-of-hours unit specs

### DIFF
--- a/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/create_service_integration_spec.rb
@@ -35,12 +35,21 @@ RSpec.describe RecurringMeetings::CreateService, "integration", type: :model do
   shared_let(:user) do
     create(:user, member_with_permissions: { project => %i(view_meetings create_meetings) })
   end
+  let(:business_day_at_noon) { Time.zone.parse("2025-01-08T12:00:00Z") }
   let(:instance) { described_class.new(user:) }
   let(:service_result) { subject }
   let(:series) { service_result.result }
   let(:params) { {} }
 
   subject { instance.call(**params) }
+
+  before do
+    travel_to(business_day_at_noon)
+  end
+
+  after do
+    travel_back
+  end
 
   shared_examples "creates the series" do
     it "creates the series and template" do

--- a/spec/components/portfolios/details_component_spec.rb
+++ b/spec/components/portfolios/details_component_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
     render_inline(described_class.new(...))
   end
 
+  let(:reference_time) { Time.zone.local(2025, 2, 1, 12, 0, 0) }
   let(:user) { create(:admin) }
   let(:status_code_a) { "on_track" }
   let(:status_code_b) { "at_risk" }
@@ -51,6 +52,8 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
   end
 
   before do
+    travel_to(reference_time)
+
     create(:program, parent: portfolio, status_code: status_code_a).tap do |program_a|
       create(:project, parent: program_a, status_code: status_code_a).tap do |project_a|
         create(:project, parent: project_a, status_code: status_code_b)
@@ -67,6 +70,10 @@ RSpec.describe Portfolios::DetailsComponent, type: :component do
     portfolio.reload
 
     def portfolio.favorited?; false; end
+  end
+
+  after do
+    travel_back
   end
 
   shared_examples "having a description and last update time" do

--- a/spec/requests/api/v3/work_packages/show_resource_spec.rb
+++ b/spec/requests/api/v3/work_packages/show_resource_spec.rb
@@ -412,7 +412,16 @@ RSpec.describe "API v3 Work package resource",
           end
 
           context "when the timestamps are relative date keywords" do
+            let(:business_day_at_noon) { Time.zone.parse("2025-01-08T12:00:00Z") }
             let(:timestamps) { [Timestamp.new("oneWeekAgo@12:00+00:00"), Timestamp.now] }
+
+            before do
+              travel_to(business_day_at_noon)
+            end
+
+            after do
+              travel_back
+            end
 
             it "has an embedded link to the baseline work package" do
               expect(subject)
@@ -421,11 +430,9 @@ RSpec.describe "API v3 Work package resource",
             end
 
             it "has the absolute timestamps within the self link" do
-              Timecop.freeze do
-                expect(subject)
-                  .to be_json_eql(api_v3_paths.work_package(work_package.id, timestamps: timestamps.map(&:absolute)).to_json)
-                  .at_path("_links/self/href")
-              end
+              expect(subject)
+                .to be_json_eql(api_v3_paths.work_package(work_package.id, timestamps: timestamps.map(&:absolute)).to_json)
+                .at_path("_links/self/href")
             end
 
             describe "attributesByTimestamp" do
@@ -456,7 +463,7 @@ RSpec.describe "API v3 Work package resource",
                       # Travel 1 day to test the href not being cached, because the
                       # relative date keyword has a fixed hour part, which means the timestamp
                       # will change its value only in 1 day units
-                      Timecop.travel 1.day do
+                      travel 1.day do
                         get get_path
                       end
                     end.to change {
@@ -468,7 +475,7 @@ RSpec.describe "API v3 Work package resource",
                   it "does not cache the attributes" do
                     get get_path
                     expect do
-                      Timecop.travel 2.days do
+                      travel 2.days do
                         get get_path
                       end
                     end.to change {
@@ -486,7 +493,7 @@ RSpec.describe "API v3 Work package resource",
                     it "is not cached" do
                       get get_path
                       expect do
-                        Timecop.travel 2.days do
+                        travel 2.days do
                           get get_path
                         end
                       end.to change {

--- a/spec/services/reminders/set_attributes_service_spec.rb
+++ b/spec/services/reminders/set_attributes_service_spec.rb
@@ -31,6 +31,7 @@
 require "spec_helper"
 
 RSpec.describe Reminders::SetAttributesService do
+  let(:business_day_at_noon) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
   let(:user) { build_stubbed(:user) }
   let(:model_instance) { Reminder.new }
   let(:remindable) { build_stubbed(:work_package) }
@@ -42,6 +43,14 @@ RSpec.describe Reminders::SetAttributesService do
     described_class.new(user: user,
                         model: model_instance,
                         contract_class:)
+  end
+
+  before do
+    travel_to(business_day_at_noon)
+  end
+
+  after do
+    travel_back
   end
 
   describe "building remind_at timestamp" do

--- a/spec/services/reminders/update_service_spec.rb
+++ b/spec/services/reminders/update_service_spec.rb
@@ -39,16 +39,22 @@ RSpec.describe Reminders::UpdateService do
   describe "remind_at changed" do
     subject { described_class.new(user:, model: model_instance).call(call_attributes) }
 
+    let(:business_day_at_noon) { Time.zone.local(2025, 1, 8, 12, 0, 0) }
     let(:model_instance) { create(:reminder, :scheduled, :with_unread_notifications, creator: user) }
     let(:user) { create(:admin) }
-    let(:remind_at) { 2.days.from_now.change(hour: 12, min: 0) }
+    let(:remind_at) { business_day_at_noon + 2.days }
     let(:call_attributes) { { remind_at_date: remind_at.to_date, remind_at_time: remind_at.strftime("%H:%M") } }
 
     before do
-      model_instance.update(job_id: 1)
+      travel_to(business_day_at_noon)
+      model_instance.update!(job_id: 1)
       allow(Reminders::ScheduleReminderJob).to receive(:schedule)
         .with(model_instance)
         .and_return(instance_double(Reminders::ScheduleReminderJob, job_id: 2))
+    end
+
+    after do
+      travel_back
     end
 
     context "with an existing unfinished scheduled job" do
@@ -101,7 +107,7 @@ RSpec.describe Reminders::UpdateService do
     end
 
     context "with remind_at attribute in non-utc timezone" do
-      let(:call_attributes) { { remind_at: 2.days.from_now.in_time_zone("Africa/Nairobi") } }
+      let(:call_attributes) { { remind_at: remind_at.in_time_zone("Africa/Nairobi") } }
 
       it "reschedules the reminder" do
         expect { subject }.to change(model_instance, :job_id).from("1").to("2")


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based off #22251. Please review/merge first.

# Ticket
https://community.openproject.org/wp/70213

# What are you trying to accomplish?
Stabilize unit specs that are susceptible to out-of-hours or wall-clock-sensitive failures.

This branch currently contains only unit-spec fixes on top of the feature-spec branch it is based on.

Example failed run:

- https://github.com/opf/openproject/actions/runs/22880794198/job/66382848520?pr=22086

# What approach did you choose and why?
I kept this follow-up branch focused on unit-side stabilization only.

The current concrete changes are:
- a speculative hardening of a component spec with a relative-time assertion by freezing the clock and using a deterministic `updated_at` value, so the rendered "Updated about 1 month ago" text no longer depends on the actual date the suite is run
- deterministic reminder service specs that no longer depend on the real current date/time for future/past validation and timezone conversion paths

The branch is intentionally based on #22251 because the broader out-of-hours investigation and reporting work lives there, but the changes in this PR should read as unit-spec-only follow-up fixes.

# Merge checklist

- [x] Added/updated tests
