### PR TITLE
Fix `./script/docs/check_links` failure on CI 

### DIFF
--- a/docs/user-guide/project-home/project-widgets/README.md
+++ b/docs/user-guide/project-home/project-widgets/README.md
@@ -31,6 +31,7 @@ Click the **+** icon and choose which kind of widget you want to add.
 
 You can add various widgets to your project dashboard. Available widgets in OpenProject include:
 
+- Budget
 - Calendar
 - Custom text
 - Description
@@ -43,6 +44,14 @@ You can add various widgets to your project dashboard. Available widgets in Open
 - Work packages graph
 - Work packages overview
 - Work packages table
+
+### Budget widget
+
+The budget widget helps you monitor the financial health of a project directly from the project home page. It displays key figures such as total planned budget, total actual costs, spent ratio, and remaining budget. It also includes a visual breakdown of planned budget by cost type.
+
+To use budget widgets, the **Budgets** and **Time and costs** modules need to be enabled for the project. You also need the relevant permissions to view budgets and cost information.
+
+If your project contains subprojects, budget data can be aggregated across subitems so you get a consolidated overview. From the widget, you can navigate directly to the detailed [Budgets](../../budgets/) view.
 
 ### Calendar widget
 


### PR DESCRIPTION
## Ticket

n/a 

## Summary

- Fix `./script/docs/check_links` failures on CI ([example here](https://github.com/opf/openproject/actions/runs/22817126363/job/66183806736?pr=22251)).
- Add Budget widget entry to project widgets `README` (AI-generated, still needs human-review)

## Testing

n/a