### PR TITLE
[#72885] Fix Turbo attrs in story menu

### DIFF
--- a/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
@@ -40,7 +40,7 @@ See COPYRIGHT and LICENSE files for more details.
       tag: :a,
       label: t(:"js.button_open_details"),
       href: details_backlogs_project_backlogs_path(project, story),
-      content_arguments: { turbo_frame: "content-bodyRight", turbo_action: "advance" }
+      content_arguments: { data: { turbo_frame: "content-bodyRight", turbo_action: "advance" } }
     ) do |item|
       item.with_leading_visual_icon(icon: :"op-view-split")
     end
@@ -49,7 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
       tag: :a,
       label: t(:"js.button_open_fullscreen"),
       href: work_package_path(story),
-      content_arguments: { turbo_frame: "_top" }
+      content_arguments: { data: { turbo_frame: "_top" } }
     ) do |item|
       item.with_leading_visual_icon(icon: :"screen-full")
     end

--- a/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
 
       expect(page).to have_text(I18n.t(:"js.button_open_details"))
       expect(page).to have_octicon(:"op-view-split")
+      expect(page).to have_css(
+        "a[data-turbo-frame='content-bodyRight'][data-turbo-action='advance']",
+        text: I18n.t(:"js.button_open_details")
+      )
     end
 
     it "shows Open fullscreen link (full page)" do
@@ -78,6 +82,10 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
 
       expect(page).to have_text(I18n.t(:"js.button_open_fullscreen"))
       expect(page).to have_octicon(:"screen-full")
+      expect(page).to have_css(
+        "a[data-turbo-frame='_top']",
+        text: I18n.t(:"js.button_open_fullscreen")
+      )
     end
 
     it "shows a divider before move options" do

--- a/modules/backlogs/spec/features/stories_in_backlog_spec.rb
+++ b/modules/backlogs/spec/features/stories_in_backlog_spec.rb
@@ -186,6 +186,20 @@ RSpec.describe "Stories in backlog", :js, :settings_reset do
     backlogs_page.expect_story_in_sprint(sprint_story1, backlog)
   end
 
+  it "switches the details view from one story to another" do
+    backlogs_page
+      .click_in_story_menu(sprint_story1, "Open details view")
+
+    backlogs_page.expect_details_view(sprint_story1)
+    backlogs_page.expect_story_in_sprint(sprint_story2, sprint)
+
+    backlogs_page
+      .click_in_story_menu(sprint_story2, "Open details view")
+
+    backlogs_page.expect_details_view(sprint_story2)
+    backlogs_page.expect_story_in_sprint(sprint_story1, sprint)
+  end
+
   it "removes story from sprint when type is changed to non-story type via details view" do
     backlogs_page
       .edit_story_in_details_view(sprint_story2, type: task.name)

--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -187,13 +187,19 @@ module Pages
     end
 
     def within_details_view(story, &)
+      details_view = expect_details_view(story)
+
+      yield details_view
+    end
+
+    def expect_details_view(story)
       details_view = Pages::PrimerizedSplitWorkPackage.new(story)
       details_view.expect_tab :overview
       details_view.expect_subject
 
       expect(page).to have_current_path details_backlogs_project_backlogs_path(story.project, story)
 
-      yield details_view
+      details_view
     end
 
     private


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72885

# What are you trying to accomplish?

Render the backlogs story action menu links with the expected data-turbo-* attributes so split-view and fullscreen navigation use Turbo correctly.

Add component and feature coverage for the regression where opening one story in details view and then another could trigger a full page refresh and leave stale DOM state behind.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
