### PR TITLE
[#72909] User is not redirected to the Template index page after deleting a template  

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -221,6 +221,8 @@ class MeetingsController < ApplicationController
 
     if recurring
       redirect_to project_recurring_meeting_path(@project, recurring), status: :see_other
+    elsif @meeting.onetime_template?
+      redirect_to templates_project_meetings_path(@project), status: :see_other
     else
       redirect_back_or_default project_meetings_path(@project), status: :see_other
     end

--- a/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe "Onetime templates CRUD", :js do
 
       wait_for_network_idle
 
+      expect(page).to have_current_path(templates_project_meetings_path(project))
       expect(page).to have_no_text("Template to delete")
       expect(Meeting.exists?(template_to_delete.id)).to be false
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72909

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
