### PR TITLE
Sort MCP things by name

### DIFF
--- a/app/controllers/admin/mcp_configurations_controller.rb
+++ b/app/controllers/admin/mcp_configurations_controller.rb
@@ -40,9 +40,9 @@ module Admin
 
     def index
       @server_config = McpConfiguration.server_config
-      @tool_configs = McpConfiguration.where(identifier: McpTools.tools_by_name.keys)
+      @tool_configs = McpConfiguration.where(identifier: McpTools.tools_by_name.keys).order(identifier: :asc)
 
-      @resource_configs = McpConfiguration.where(identifier: McpResources.resources_by_name.keys)
+      @resource_configs = McpConfiguration.where(identifier: McpResources.resources_by_name.keys).order(identifier: :asc)
     end
 
     def update


### PR DESCRIPTION
Previously there was no defined order for tools and resources.

This made it harder than necessary to find something in the lists and even worse, the order could change after updating tools/resources or whenever the database felt like returning rows in a different order.

Now sorting them by the "Name" column, since this seems to be the most expectable sort order from a user's perspective.

# Ticket
https://community.openproject.org/wp/72920