### PR TITLE
[#72927] Fix drag and drop error handling

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -29,10 +29,9 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import * as Turbo from '@hotwired/turbo';
+import { FetchRequest } from '@rails/request.js';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import dragula, { Drake } from 'dragula';
-import { useMeta } from 'stimulus-use';
 import invariant from 'tiny-invariant';
 
 interface TargetConfig {
@@ -46,19 +45,16 @@ export default class GenericDragAndDropController extends Controller {
 
   containerTargets:HTMLElement[];
 
-  static metaNames = ['csrf-token'];
-  declare readonly csrfToken:string;
-
   static values = { handleSelector: { type: String, default: '.DragHandle' } };
   declare readonly handleSelectorValue:string;
 
   private drake:Drake|null = null;
   private containers:HTMLElement[] = [];
   private targetConfigs:TargetConfig[] = [];
+  private dragOriginSource:Element|null = null;
+  private dragOriginNextSibling:Element|null = null;
 
   connect() {
-    useMeta(this, { suffix: false });
-
     this.drake?.destroy();
     this.initDrake();
   }
@@ -91,8 +87,18 @@ export default class GenericDragAndDropController extends Controller {
     }
   }
 
-  cancel() {
+  cancelDrag() {
     this.drake?.cancel(true);
+  }
+
+  private revertDrop(el:Element) {
+    if (this.dragOriginSource) {
+      if (this.dragOriginNextSibling?.parentNode === this.dragOriginSource) {
+        this.dragOriginSource.insertBefore(el, this.dragOriginNextSibling);
+      } else {
+        this.dragOriginSource.appendChild(el);
+      }
+    }
   }
 
   initDrake() {
@@ -106,7 +112,10 @@ export default class GenericDragAndDropController extends Controller {
         revertOnSpill: true, // enable reverting of elements if they are dropped outside of a valid target
       },
     )
-      .on('drag', (el) => {
+      .on('drag', (el, source) => {
+        this.dragOriginSource = source;
+        this.dragOriginNextSibling = el.nextElementSibling;
+
         const handle = el.querySelector(this.handleSelectorValue)!;
         handle.setAttribute('aria-pressed', 'true');
       })
@@ -152,25 +161,14 @@ export default class GenericDragAndDropController extends Controller {
     const data = this.buildData(el, target);
 
     if (dropUrl) {
-      const response = await fetch(dropUrl, {
-        method: 'PUT',
-        body: data,
-        headers: {
-          'X-CSRF-Token': this.csrfToken,
-          Accept: 'text/vnd.turbo-stream.html',
-        },
-        credentials: 'same-origin',
-      });
+      const request = new FetchRequest('put', dropUrl, { body: data, responseKind: 'turbo-stream' });
+      const response = await request.perform();
 
       if (!response.ok) {
+        this.revertDrop(el);
         debugLog('Failed to sort item');
-      } else {
-        const text = await response.text();
-        Turbo.renderStreamMessage(text);
       }
     }
-
-    this.cancel();
   }
 
   protected buildData(el:Element, target:Element):FormData {

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -160,14 +160,24 @@ export default class GenericDragAndDropController extends Controller {
     const dropUrl = el.getAttribute('data-drop-url');
     const data = this.buildData(el, target);
 
-    if (dropUrl) {
+    if (!dropUrl) {
+      return;
+    }
+
+    try {
       const request = new FetchRequest('put', dropUrl, { body: data, responseKind: 'turbo-stream' });
       const response = await request.perform();
 
       if (!response.ok) {
         this.revertDrop(el);
-        debugLog('Failed to sort item');
+        debugLog(`Failed to sort item: ${response.statusCode}`);
       }
+    } catch (error) {
+      this.revertDrop(el);
+      debugLog('Failed to sort item due to request error', error);
+    } finally {
+      this.dragOriginSource = null;
+      this.dragOriginNextSibling = null;
     }
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/meetings/drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/drag-and-drop.controller.ts
@@ -44,7 +44,7 @@ export default class extends GenericDragAndDropController {
   override async drop(el:Element, target:Element, source:Element|null, sibling:Element|null) {
     if (hasUnsavedChanges()) {
       if (!window.confirm(I18n.t('js.text_are_you_sure_to_cancel'))) {
-        this.cancel();
+        this.cancelDrag();
         return;
       }
     }

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -49,6 +49,7 @@ class RbStoriesController < RbApplicationController
       render_error_flash_message_via_turbo_stream(
         message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       )
+      return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
     replace_backlog_component_via_turbo_stream(sprint: @sprint)
@@ -74,6 +75,7 @@ class RbStoriesController < RbApplicationController
       render_error_flash_message_via_turbo_stream(
         message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       )
+      return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
     replace_backlog_component_via_turbo_stream(sprint: @sprint)

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe RbStoriesController do
           .and_return(update_service)
       end
 
-      it "renders an error flash", :aggregate_failures do
+      it "renders an error flash with 422", :aggregate_failures do
         put :move, params: {
                      project_id: project.id,
                      sprint_id: sprint.id,
@@ -122,9 +122,9 @@ RSpec.describe RbStoriesController do
                    },
                    format: :turbo_stream
 
-        expect(response).to be_successful
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
+        expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
       end
     end
   end
@@ -154,13 +154,13 @@ RSpec.describe RbStoriesController do
           .and_return(update_service)
       end
 
-      it "renders an error flash", :aggregate_failures do
+      it "renders an error flash with 422", :aggregate_failures do
         post :reorder, params: { project_id: project.id, sprint_id: sprint.id, id: story.id, direction: "highest" },
                        format: :turbo_stream
 
-        expect(response).to be_successful
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
+        expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72927

# What are you trying to accomplish?

> [!NOTE]
> Addresses an issue flagged by [@ulferts](https://github.com/ulferts) in previous drag and drop bug PR #22161

Fixes two issues with drag and drop error handling in the Backlogs module:

1. `RbStoriesController#move` and `#reorder` always returned HTTP 200, even on failure. The `unless call.success?` block did not return early, so the success path (backlog re-render, version-change flash) ran unconditionally.
2. The generic drag-and-drop Stimulus controller used raw `fetch` with manual CSRF/Turbo handling, and had no working mechanism to revert a failed drop.

# What approach did you choose and why?

**Controller fix:** Added early `return respond_with_turbo_streams(status: :unprocessable_entity)` in the failure branch for both actions, following the pattern used elsewhere (e.g. `RbSprintsController`).

**Frontend fix:** Replaced raw `fetch` with `FetchRequest` from `@rails/request.js`, which handles CSRF tokens and Turbo Stream rendering automatically. For DOM revert on failure, the original source container and next sibling are captured synchronously during the `drag` event, then used to `insertBefore` the element back on async failure. This avoids relying on `drake.cancel()`, which is a no-op after the drag lifecycle ends.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)