### PR TITLE
Fix flaky stories in backlog feature spec

### DIFF
--- a/modules/backlogs/spec/support/pages/backlogs.rb
+++ b/modules/backlogs/spec/support/pages/backlogs.rb
@@ -172,17 +172,19 @@ module Pages
 
     def within_backlog_menu(backlog, &)
       within_backlog(backlog) do
-        find(:button, accessible_name: "Backlog actions").click
+        button = find(:button, accessible_name: "Backlog actions")
+        button.click
 
-        within(:menu, &)
+        within_menu_controlled_by(button, &)
       end
     end
 
     def within_story_menu(story, &)
       within_story(story) do
-        find(:button, accessible_name: "Story actions").click
+        button = find(:button, accessible_name: "Story actions")
+        button.click
 
-        within(:menu, &)
+        within_menu_controlled_by(button, &)
       end
     end
 
@@ -198,6 +200,7 @@ module Pages
       details_view.expect_subject
 
       expect(page).to have_current_path details_backlogs_project_backlogs_path(story.project, story)
+      wait_for_network_idle
 
       details_view
     end
@@ -218,6 +221,14 @@ module Pages
 
     def story_selector(story)
       "#story_#{story.id}"
+    end
+
+    def within_menu_controlled_by(button)
+      menu_id = button[:controls] || button["aria-controls"]
+
+      within(:menu, id: menu_id) do
+        yield page
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket

follow up to https://github.com/opf/openproject/pull/22264

# What are you trying to accomplish?

Mitigate the flaky backlogs feature spec that switches the split details view from one story to another.

## Screenshots

N/A

# What approach did you choose and why?

Harden the backlogs feature helper used by the spec so it interacts with the menu controlled by the clicked action button and waits for the details view request to settle before continuing.

The flaky spec was introduced in [#22264](https://github.com/opf/openproject/pull/22264).

# Merge checklist

- [x] Added/updated tests