### PR TITLE
Implementation/72849 make drag and drop work between sprints and version backlogs

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_component.rb
@@ -73,7 +73,7 @@ module Backlogs
       {
         generic_drag_and_drop_target: "container",
         target_container_accessor: ":scope > ul",
-        target_id: backlog.sprint_id,
+        target_id: "version:#{backlog.sprint_id}",
         target_allowed_drag_type: "story"
       }
     end
@@ -82,7 +82,6 @@ module Backlogs
       {
         draggable_id: story.id,
         draggable_type: "story",
-        # TODO: this URL is called must be called for agile_sprint instead!
         drop_url: move_legacy_backlogs_project_sprint_story_path(project, sprint, story)
       }
     end

--- a/modules/backlogs/app/components/backlogs/backlog_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_component.rb
@@ -82,7 +82,8 @@ module Backlogs
       {
         draggable_id: story.id,
         draggable_type: "story",
-        drop_url: move_backlogs_project_sprint_story_path(project, sprint, story)
+        # TODO: this URL is called must be called for agile_sprint instead!
+        drop_url: move_legacy_backlogs_project_sprint_story_path(project, sprint, story)
       }
     end
   end

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -85,7 +85,7 @@ module Backlogs
       {
         draggable_id: story.id,
         draggable_type: "story",
-        drop_url: project_sprint_story_move_path(project, sprint, story)
+        drop_url: move_project_sprint_story_path(project, sprint, story)
       }
     end
   end

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -76,7 +76,7 @@ module Backlogs
       {
         generic_drag_and_drop_target: "container",
         target_container_accessor: ":scope > ul",
-        target_id: sprint.id,
+        target_id: "sprint:#{sprint.id}",
         target_allowed_drag_type: "story"
       }
     end
@@ -85,7 +85,7 @@ module Backlogs
       {
         draggable_id: story.id,
         draggable_type: "story",
-        drop_url: move_backlogs_project_sprint_story_path(project, sprint, story)
+        drop_url: project_sprint_story_move_path(project, sprint, story)
       }
     end
   end

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -41,13 +41,17 @@ class RbApplicationController < ApplicationController
   # Loads the project to be used by the authorize filter to determine if
   # User.current has permission to invoke the method in question.
   def load_sprint_and_project
-    @project = Project.visible.find(params[:project_id])
+    load_project
 
     # because of strong params, we want to pluck this variable out right now,
     # otherwise it causes issues where we are doing `attributes=`.
     if (@sprint_id = params.delete(:sprint_id))
       @sprint = Sprint.visible.apply_to(@project).find(@sprint_id)
     end
+  end
+
+  def load_project
+    @project = Project.visible.find(params[:project_id])
   end
 
   def check_if_plugin_is_configured

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -176,10 +176,6 @@ class RbSprintsController < RbApplicationController
     load_project
   end
 
-  def load_project
-    @project = Project.visible.find(params[:project_id])
-  end
-
   def sprint_params
     params.expect(sprint: %i[name start_date effective_date])
   end

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -101,6 +101,7 @@ class RbStoriesController < RbApplicationController
       render_error_flash_message_via_turbo_stream(
         message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       )
+      return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
     replace_sprint_component_via_turbo_stream(sprint: @sprint)

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -156,7 +156,7 @@ class RbStoriesController < RbApplicationController
       # if it is used as a backlog. We will keep a "regular" version reference.
       # Otherwise, moving a story to a sprint would delete it from any version it is
       # assigned to.
-      if version_is_backlog?(@story.version)
+      if @story.version&.used_as_backlog?
         { version_id: nil, sprint_id: target_id }
       else
         { sprint_id: target_id }
@@ -164,14 +164,6 @@ class RbStoriesController < RbApplicationController
     else
       raise ArgumentError, "target_type must include one of: version, sprint."
     end
-  end
-
-  def version_is_backlog?(version)
-    return false unless version
-
-    settings = version.version_settings&.where(project: @project)&.first
-
-    settings&.display_right?
   end
 
   def target_version?(move_attributes)

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -36,7 +36,7 @@ class RbStoriesController < RbApplicationController
   skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS
 
   before_action :legacy_load_story, except: NEW_SPRINT_ACTIONS
-  before_action :load_project, :load_sprint, :load_story, only: NEW_SPRINT_ACTIONS
+  prepend_before_action :load_sprint, :load_project, :load_story, only: NEW_SPRINT_ACTIONS
 
   # Move a story from a Sprint to another Sprint or an Agile::Sprint.
   def move_legacy
@@ -45,7 +45,7 @@ class RbStoriesController < RbApplicationController
     version_id_was = @story.version_id
 
     move_attributes = infer_attributes_from_target
-    unless move_story(move_attributes)
+    unless move_story(move_attributes).success?
       return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
@@ -65,7 +65,7 @@ class RbStoriesController < RbApplicationController
     sprint_id_was = @story.sprint_id
 
     move_attributes = infer_attributes_from_target
-    unless move_story(move_attributes)
+    unless move_story(move_attributes).success?
       return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
@@ -100,15 +100,16 @@ class RbStoriesController < RbApplicationController
   def move_story(move_attributes)
     call = update_story_with_target_and_position(attributes: move_attributes)
 
-    unless call.success?
+    if call.success?
+      # Update source component so that the moved story disappears
+      replace_typed_component_via_turbo_stream(sprint: @sprint)
+    else
       render_error_flash_message_via_turbo_stream(
         message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       )
-      return false
     end
 
-    # Update source component so that the moved story disappears
-    replace_typed_component_via_turbo_stream(sprint: @sprint)
+    call
   end
 
   def update_story_with_target_and_position(attributes:)

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -191,7 +191,7 @@ class RbStoriesController < RbApplicationController
   end
 
   def load_story
-    @story = WorkPackage.visible.find(params[:story_id])
+    @story = WorkPackage.visible.find(params[:id])
   end
 
   def load_sprint

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -152,10 +152,26 @@ class RbStoriesController < RbApplicationController
     when "version"
       { version_id: target_id, sprint_id: nil }
     when "sprint"
-      { version_id: nil, sprint_id: target_id }
+      # If the story is assigned to a version, we will only nullify the version
+      # if it is used as a backlog. We will keep a "regular" version reference.
+      # Otherwise, moving a story to a sprint would delete it from any version it is
+      # assigned to.
+      if version_is_backlog?(@story.version)
+        { version_id: nil, sprint_id: target_id }
+      else
+        { sprint_id: target_id }
+      end
     else
-      raise ArgumentError, "target_id must include one of: version, sprint."
+      raise ArgumentError, "target_type must include one of: version, sprint."
     end
+  end
+
+  def version_is_backlog?(version)
+    return false unless version
+
+    settings = version.version_settings&.where(project: @project)&.first
+
+    settings&.display_right?
   end
 
   def target_version?(move_attributes)

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -39,89 +39,40 @@ class RbStoriesController < RbApplicationController
   before_action :load_project, :load_sprint, :load_story, only: NEW_SPRINT_ACTIONS
 
   # Move a story from a Sprint to another Sprint or an Agile::Sprint.
-  def move_legacy # rubocop:disable Metrics/AbcSize
-    move_attributes = infer_attributes_from_target
-
+  def move_legacy
     # The update service reloads the story internally (via #move_after),
     # so we memoize the previous version_id before the call.
     version_id_was = @story.version_id
 
-    call = Stories::UpdateService
-      .new(user: current_user, story: @story)
-      .call(
-        attributes: move_attributes,
-        position: move_params[:position].to_i
-      )
-
-    unless call.success?
-      render_error_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
-      )
+    move_attributes = infer_attributes_from_target
+    unless move_story(move_attributes)
       return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
-    replace_backlog_component_via_turbo_stream(sprint: @sprint)
-
     if target_sprint?(move_attributes)
-      new_sprint = @story.sprint.becomes(Agile::Sprint)
-
-      render_success_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
-      )
-
-      replace_sprint_component_via_turbo_stream(sprint: new_sprint)
+      moved_to_sprint
     elsif target_version?(move_attributes) && @story.version_id != version_id_was
-      new_sprint = @story.version.becomes(Sprint)
-
-      render_success_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
-      )
-      replace_backlog_component_via_turbo_stream(sprint: new_sprint)
+      moved_to_version
     end
 
     respond_with_turbo_streams
   end
 
   # Move a story from an Agile::Sprint to another Agile::Sprint or a Sprint.
-  def move # rubocop:disable Metrics/AbcSize
-    move_attributes = infer_attributes_from_target
-
+  def move
     # The update service reloads the story internally (via #move_after),
     # so we memoize the previous sprint_id before the call.
     sprint_id_was = @story.sprint_id
 
-    call = Stories::UpdateService
-             .new(user: current_user, story: @story)
-             .call(
-               attributes: move_attributes,
-               position: move_params[:position].to_i
-             )
-
-    unless call.success?
-      render_error_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
-      )
+    move_attributes = infer_attributes_from_target
+    unless move_story(move_attributes)
       return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
-    replace_sprint_component_via_turbo_stream(sprint: @sprint)
-
     if target_version?(move_attributes)
-      new_sprint = @story.version.becomes(Sprint)
-
-      render_success_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
-      )
-
-      replace_backlog_component_via_turbo_stream(sprint: new_sprint)
+      moved_to_version
     elsif target_sprint?(move_attributes) && @story.sprint_id != sprint_id_was
-      new_sprint = @story.sprint.becomes(Agile::Sprint)
-
-      render_success_flash_message_via_turbo_stream(
-        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
-      )
-
-      replace_sprint_component_via_turbo_stream(sprint: new_sprint)
+      moved_to_sprint
     end
 
     respond_with_turbo_streams
@@ -145,6 +96,54 @@ class RbStoriesController < RbApplicationController
   end
 
   private
+
+  def move_story(move_attributes)
+    call = update_story_with_target_and_position(attributes: move_attributes)
+
+    unless call.success?
+      render_error_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
+      )
+      return false
+    end
+
+    # Update source component so that the moved story disappears
+    replace_typed_component_via_turbo_stream(sprint: @sprint)
+  end
+
+  def update_story_with_target_and_position(attributes:)
+    Stories::UpdateService
+      .new(user: current_user, story: @story)
+      .call(
+        attributes:,
+        position: move_params[:position].to_i
+      )
+  end
+
+  def replace_typed_component_via_turbo_stream(sprint:)
+    if sprint.is_a?(Agile::Sprint)
+      replace_sprint_component_via_turbo_stream(sprint:)
+    else
+      replace_backlog_component_via_turbo_stream(sprint:)
+    end
+  end
+
+  def moved_to_version
+    moved_to(new_sprint: @story.version.becomes(Sprint))
+  end
+
+  def moved_to_sprint
+    moved_to(new_sprint: @story.sprint.becomes(Agile::Sprint))
+  end
+
+  def moved_to(new_sprint:)
+    render_success_flash_message_via_turbo_stream(
+      message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
+    )
+
+    # Update the target component so that the moved story shows up
+    replace_typed_component_via_turbo_stream(sprint: new_sprint)
+  end
 
   def infer_attributes_from_target
     target_type, target_id = move_params[:target_id].split(":")

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -31,9 +31,17 @@
 class RbStoriesController < RbApplicationController
   include OpTurbo::ComponentStream
 
-  before_action :load_story
+  NEW_SPRINT_ACTIONS = %i[move].freeze
 
+  skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS
+
+  before_action :legacy_load_story, except: NEW_SPRINT_ACTIONS
+  before_action :load_project, :load_sprint, :load_story, only: NEW_SPRINT_ACTIONS
+
+  # Move a story from a Sprint to another Sprint or an Agile::Sprint.
   def move_legacy # rubocop:disable Metrics/AbcSize
+    move_attributes = infer_attributes_from_target
+
     # The update service reloads the story internally (via #move_after),
     # so we memoize the previous version_id before the call.
     version_id_was = @story.version_id
@@ -41,7 +49,7 @@ class RbStoriesController < RbApplicationController
     call = Stories::UpdateService
       .new(user: current_user, story: @story)
       .call(
-        attributes: { version_id: move_params[:target_id] },
+        attributes: move_attributes,
         position: move_params[:position].to_i
       )
 
@@ -54,13 +62,65 @@ class RbStoriesController < RbApplicationController
 
     replace_backlog_component_via_turbo_stream(sprint: @sprint)
 
-    if @story.version_id != version_id_was
+    if target_sprint?(move_attributes)
+      new_sprint = @story.sprint.becomes(Agile::Sprint)
+
+      render_success_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
+      )
+
+      replace_sprint_component_via_turbo_stream(sprint: new_sprint)
+    elsif target_version?(move_attributes) && @story.version_id != version_id_was
       new_sprint = @story.version.becomes(Sprint)
 
       render_success_flash_message_via_turbo_stream(
         message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
       )
       replace_backlog_component_via_turbo_stream(sprint: new_sprint)
+    end
+
+    respond_with_turbo_streams
+  end
+
+  # Move a story from an Agile::Sprint to another Agile::Sprint or a Sprint.
+  def move # rubocop:disable Metrics/AbcSize
+    move_attributes = infer_attributes_from_target
+
+    # The update service reloads the story internally (via #move_after),
+    # so we memoize the previous sprint_id before the call.
+    sprint_id_was = @story.sprint_id
+
+    call = Stories::UpdateService
+             .new(user: current_user, story: @story)
+             .call(
+               attributes: move_attributes,
+               position: move_params[:position].to_i
+             )
+
+    unless call.success?
+      render_error_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
+      )
+    end
+
+    replace_sprint_component_via_turbo_stream(sprint: @sprint)
+
+    if target_version?(move_attributes)
+      new_sprint = @story.version.becomes(Sprint)
+
+      render_success_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
+      )
+
+      replace_backlog_component_via_turbo_stream(sprint: new_sprint)
+    elsif target_sprint?(move_attributes) && @story.sprint_id != sprint_id_was
+      new_sprint = @story.sprint.becomes(Agile::Sprint)
+
+      render_success_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_successful_move, from: @sprint.name, to: new_sprint.name)
+      )
+
+      replace_sprint_component_via_turbo_stream(sprint: new_sprint)
     end
 
     respond_with_turbo_streams
@@ -85,6 +145,27 @@ class RbStoriesController < RbApplicationController
 
   private
 
+  def infer_attributes_from_target
+    target_type, target_id = move_params[:target_id].split(":")
+
+    case target_type
+    when "version"
+      { version_id: target_id, sprint_id: nil }
+    when "sprint"
+      { version_id: nil, sprint_id: target_id }
+    else
+      raise ArgumentError, "target_id must include one of: version, sprint."
+    end
+  end
+
+  def target_version?(move_attributes)
+    move_attributes[:version_id].present?
+  end
+
+  def target_sprint?(move_attributes)
+    move_attributes[:sprint_id].present?
+  end
+
   def replace_backlog_component_via_turbo_stream(sprint:)
     @backlog = Backlog.for(sprint:, project: @project)
     replace_via_turbo_stream(
@@ -93,8 +174,20 @@ class RbStoriesController < RbApplicationController
     )
   end
 
-  def load_story
+  def replace_sprint_component_via_turbo_stream(sprint:)
+    replace_via_turbo_stream(component: Backlogs::SprintComponent.new(sprint: sprint))
+  end
+
+  def legacy_load_story
     @story = Story.visible.find(params[:id])
+  end
+
+  def load_story
+    @story = WorkPackage.visible.find(params[:story_id])
+  end
+
+  def load_sprint
+    @sprint = Agile::Sprint.for_project(@project).visible.find(params[:sprint_id])
   end
 
   def move_params

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -33,7 +33,7 @@ class RbStoriesController < RbApplicationController
 
   before_action :load_story
 
-  def move # rubocop:disable Metrics/AbcSize
+  def move_legacy # rubocop:disable Metrics/AbcSize
     # The update service reloads the story internally (via #move_after),
     # so we memoize the previous version_id before the call.
     version_id_was = @story.version_id

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
       end
 
       resources :stories, controller: :rb_stories, only: [] do
-        put :move
+        member do
+          put :move
+        end
       end
     end
   end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -71,7 +71,7 @@ Rails.application.routes.draw do
 
         resources :stories, controller: :rb_stories, only: [] do
           member do
-            put :move
+            put :move_legacy
             post :reorder
           end
         end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -40,6 +40,10 @@ Rails.application.routes.draw do
         get :edit_dialog
         put :update_agile_sprint
       end
+
+      resources :stories, controller: :rb_stories, only: [] do
+        put :move
+      end
     end
   end
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -100,7 +100,7 @@ module OpenProject::Backlogs
                    visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
 
         permission :manage_sprint_items,
-                   { rb_stories: %i[move reorder] },
+                   { rb_stories: %i[move move_legacy reorder] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
@@ -42,7 +42,7 @@ module OpenProject::Backlogs::Patches::VersionPatch
 
       settings = version_settings&.where(project:)&.first
 
-      settings&.display_right?
+      !!settings&.display_right?
     end
 
     def rebuild_story_positions(project = self.project)

--- a/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/version_patch.rb
@@ -37,6 +37,14 @@ module OpenProject::Backlogs::Patches::VersionPatch
   end
 
   module InstanceMethods
+    def used_as_backlog?(project = self.project)
+      return false unless project.backlogs_enabled?
+
+      settings = version_settings&.where(project:)&.first
+
+      settings&.display_right?
+    end
+
     def rebuild_story_positions(project = self.project)
       return unless project.backlogs_enabled?
 

--- a/modules/backlogs/spec/components/backlogs/backlog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_component_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Backlogs::BacklogComponent, type: :component do
         box = page.find(".Box")
         expect(box["data-generic-drag-and-drop-target"]).to eq("container")
         expect(box["data-target-container-accessor"]).to eq(":scope > ul")
-        expect(box["data-target-id"]).to eq(sprint.id.to_s)
+        expect(box["data-target-id"]).to eq("version:#{sprint.id}")
         expect(box["data-target-allowed-drag-type"]).to eq("story")
       end
 
@@ -129,7 +129,7 @@ RSpec.describe Backlogs::BacklogComponent, type: :component do
         story_row = page.find(".Box-row[id='story_#{story1.id}']")
         expect(story_row["data-draggable-id"]).to eq(story1.id.to_s)
         expect(story_row["data-draggable-type"]).to eq("story")
-        expect(story_row["data-drop-url"]).to end_with(move_backlogs_project_sprint_story_path(project, sprint, story1))
+        expect(story_row["data-drop-url"]).to end_with(move_legacy_backlogs_project_sprint_story_path(project, sprint, story1))
       end
 
       it "renders story rows with proper classes" do

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         box = page.find(".Box")
         expect(box["data-generic-drag-and-drop-target"]).to eq("container")
         expect(box["data-target-container-accessor"]).to eq(":scope > ul")
-        expect(box["data-target-id"]).to eq(sprint.id.to_s)
+        expect(box["data-target-id"]).to eq("sprint:#{sprint.id}")
         expect(box["data-target-allowed-drag-type"]).to eq("story")
       end
 
@@ -126,7 +126,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         story_row = page.find(".Box-row[id='work_package_#{story1.id}']")
         expect(story_row["data-draggable-id"]).to eq(story1.id.to_s)
         expect(story_row["data-draggable-type"]).to eq("story")
-        expect(story_row["data-drop-url"]).to end_with(move_backlogs_project_sprint_story_path(project, sprint, story1))
+        expect(story_row["data-drop-url"]).to end_with(move_project_sprint_story_path(project, sprint, story1))
       end
 
       it "renders story rows with proper classes" do

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe RbStoriesController do
   current_user { user }
 
   let(:project) { create(:project) }
-  let(:status)  { create(:status, name: "status 1", is_default: true) }
-  let(:sprint)  { create(:sprint, project:) }
-  let(:story)   { create(:story, status:, version: sprint, project:) }
+  let(:status) { create(:status, name: "status 1", is_default: true) }
+  let(:version_sprint) { create(:sprint, project:) }
+  let(:story) { create(:story, status:, version: version_sprint, project:) }
 
   before do
     allow(Setting)
@@ -49,27 +49,27 @@ RSpec.describe RbStoriesController do
 
   describe "PUT #move_legacy" do
     context "with a version from the same project" do
-      let(:other_sprint) { create(:sprint, name: "Sprint 2", project:) }
+      let(:other_version_sprint) { create(:sprint, name: "Sprint 2", project:) }
 
       it "responds with success", :aggregate_failures do
         put :move_legacy, params: {
                             project_id: project.id,
-                            sprint_id: sprint.id,
+                            sprint_id: version_sprint.id,
                             id: story.id,
-                            target_id: "version:#{other_sprint.id}",
+                            target_id: "version:#{other_version_sprint.id}",
                             position: 1
                           },
                           format: :turbo_stream
 
         expect(response).to be_successful
         expect(response).to have_http_status :ok
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{other_sprint.id}"
-        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{sprint.id}"][method="morph"])
-        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{other_sprint.id}"][method="morph"])
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{other_version_sprint.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{other_version_sprint.id}"][method="morph"]) # rubocop:disable Layout/LineLength
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(assigns(:project)).to eq(project)
-        expect(assigns(:sprint)).to eq(sprint)
+        expect(assigns(:sprint)).to eq(version_sprint)
         expect(assigns(:story)).to eq(story)
         expect(assigns(:backlog)).to be_a(Backlog)
       end
@@ -77,35 +77,35 @@ RSpec.describe RbStoriesController do
 
     context "with a version from another project" do
       let(:other_project) { create(:project) }
-      let(:other_sprint) { create(:sprint, name: "Sprint 2", project: other_project, sharing: "system") }
-      let(:story) { create(:story, status:, version: other_sprint, project:) }
+      let(:other_version_sprint) { create(:sprint, name: "Sprint 2", project: other_project, sharing: "system") }
+      let(:story) { create(:story, status:, version: other_version_sprint, project:) }
 
       it "responds with success", :aggregate_failures do
         put :move_legacy, params: {
                             project_id: project.id,
-                            sprint_id: other_sprint.id,
+                            sprint_id: other_version_sprint.id,
                             id: story.id,
-                            target_id: "version:#{sprint.id}",
+                            target_id: "version:#{version_sprint.id}",
                             position: 1
                           },
                           format: :turbo_stream
 
         expect(response).to be_successful
         expect(response).to have_http_status :ok
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{other_sprint.id}"
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
-        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{other_sprint.id}"][method="morph"])
-        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{sprint.id}"][method="morph"])
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{other_version_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{other_version_sprint.id}"][method="morph"]) # rubocop:disable Layout/LineLength
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(assigns(:project)).to eq(project)
-        expect(assigns(:sprint)).to eq(other_sprint)
+        expect(assigns(:sprint)).to eq(other_version_sprint)
         expect(assigns(:story)).to eq(story)
         expect(assigns(:backlog)).to be_a(Backlog)
       end
     end
 
     context "when service call fails" do
-      let(:other_sprint) { create(:sprint, name: "Sprint 2", project:) }
+      let(:other_version_sprint) { create(:sprint, name: "Sprint 2", project:) }
       let(:service_result) { ServiceResult.failure(message: "Something went wrong") }
 
       before do
@@ -119,31 +119,31 @@ RSpec.describe RbStoriesController do
       it "renders an error flash with 422", :aggregate_failures do
         put :move_legacy, params: {
                             project_id: project.id,
-                            sprint_id: sprint.id,
+                            sprint_id: version_sprint.id,
                             id: story.id,
-                            target_id: "version:#{other_sprint.id}",
+                            target_id: "version:#{other_version_sprint.id}",
                             position: 1
                           },
                           format: :turbo_stream
 
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
       end
     end
   end
 
   describe "POST #reorder" do
     it "responds with success", :aggregate_failures do
-      post :reorder, params: { project_id: project.id, sprint_id: sprint.id, id: story.id, direction: "highest" },
+      post :reorder, params: { project_id: project.id, sprint_id: version_sprint.id, id: story.id, direction: "highest" },
                      format: :turbo_stream
 
       expect(response).to be_successful
       expect(response).to have_http_status :ok
-      expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
-      assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{sprint.id}"][method="morph"])
+      expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+      assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
       expect(assigns(:project)).to eq(project)
-      expect(assigns(:sprint)).to eq(sprint)
+      expect(assigns(:sprint)).to eq(version_sprint)
       expect(assigns(:story)).to eq(story)
       expect(assigns(:backlog)).to be_a(Backlog)
     end
@@ -160,12 +160,12 @@ RSpec.describe RbStoriesController do
       end
 
       it "renders an error flash with 422", :aggregate_failures do
-        post :reorder, params: { project_id: project.id, sprint_id: sprint.id, id: story.id, direction: "highest" },
+        post :reorder, params: { project_id: project.id, sprint_id: version_sprint.id, id: story.id, direction: "highest" },
                        format: :turbo_stream
 
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{sprint.id}"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
       end
     end
   end

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -33,9 +33,10 @@ require "rails_helper"
 RSpec.describe RbStoriesController do
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:type_task) { create(:type_task) }
-  shared_let(:user) { create(:admin) }
+
   current_user { user }
 
+  let(:user) { create(:admin) }
   let(:project) { create(:project) }
   let(:status) { create(:status, name: "status 1", is_default: true) }
   let(:version_sprint) { create(:sprint, project:) }
@@ -51,6 +52,24 @@ RSpec.describe RbStoriesController do
   end
 
   describe "PUT #move_legacy" do
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+
+      it "responds with 403" do
+        put :move_legacy, params: {
+                            project_id: project.id,
+                            sprint_id: version_sprint.id,
+                            id: story.id,
+                            target_id: "foo",
+                            position: 1
+                          },
+                          format: :turbo_stream
+
+        expect(response).not_to be_successful
+        expect(response).to have_http_status :not_found
+      end
+    end
+
     context "with a version from the same project" do
       let(:other_version_sprint) { create(:sprint, name: "Sprint 2", project:) }
 

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -41,10 +41,13 @@ RSpec.describe RbStoriesController do
   let(:version_sprint) { create(:sprint, project:) }
   let(:story) { create(:story, status:, version: version_sprint, project:) }
 
+  # Via this setting, version_sprint is used as backlog:
+  let!(:version_setting) { create(:version_setting, version: version_sprint, project:, display: VersionSetting::DISPLAY_RIGHT) }
+
   before do
     allow(Setting)
       .to receive(:plugin_openproject_backlogs)
-      .and_return({ "story_types" => [type_feature.id], "task_type" => type_task.id })
+            .and_return({ "story_types" => [type_feature.id], "task_type" => type_task.id })
   end
 
   describe "PUT #move_legacy" do
@@ -101,6 +104,35 @@ RSpec.describe RbStoriesController do
         expect(assigns(:sprint)).to eq(other_version_sprint)
         expect(assigns(:story)).to eq(story)
         expect(assigns(:backlog)).to be_a(Backlog)
+      end
+    end
+
+    context "with an Agile::Sprint as target" do
+      let(:agile_sprint) { create(:agile_sprint, name: "Agile Sprint 1", project:) }
+
+      it "responds with success and moves story to Agile::Sprint, removing the association to the version", :aggregate_failures do
+        put :move_legacy, params: {
+                            project_id: project.id,
+                            sprint_id: version_sprint.id,
+                            id: story.id,
+                            target_id: "sprint:#{agile_sprint.id}",
+                            position: 1
+                          },
+                          format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(version_sprint)
+        expect(assigns(:story)).to eq(story)
+
+        # It will remove the association to the version since the version is used as backlog:
+        expect(story.reload.version).to be_nil
       end
     end
 
@@ -166,6 +198,121 @@ RSpec.describe RbStoriesController do
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+      end
+    end
+  end
+
+  describe "PUT #move" do
+    let(:agile_sprint) { create(:agile_sprint, name: "Agile Sprint 1", project:) }
+    let(:story_in_agile_sprint) { create(:work_package, status:, sprint: agile_sprint, project:) }
+
+    context "with another Agile::Sprint as target" do
+      let(:other_agile_sprint) { create(:agile_sprint, name: "Agile Sprint 2", project:) }
+
+      it "responds with success and moves story to another Agile::Sprint", :aggregate_failures do
+        put :move, params: {
+                     project_id: project.id,
+                     sprint_id: agile_sprint.id,
+                     id: story_in_agile_sprint.id,
+                     target_id: "sprint:#{other_agile_sprint.id}",
+                     position: 1
+                   },
+                   format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{other_agile_sprint.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{other_agile_sprint.id}"])
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(agile_sprint)
+        expect(assigns(:story)).to eq(story_in_agile_sprint)
+      end
+
+      context "when the story has a version that is not used as backlog" do
+        let(:story_in_agile_sprint) { create(:work_package, status:, sprint: agile_sprint, version: version_sprint, project:) }
+        # Via this setting, version_sprint is NOT used as backlog:
+        let!(:version_setting) { create(:version_setting, version: version_sprint, project:, display: VersionSetting::DISPLAY_NONE) }
+
+        it "responds with success and moves story to Agile::Sprint, keeping the version", :aggregate_failures do
+          put :move, params: {
+                       project_id: project.id,
+                       sprint_id: agile_sprint.id,
+                       id: story_in_agile_sprint.id,
+                       target_id: "sprint:#{other_agile_sprint.id}",
+                       position: 1
+                     },
+                     format: :turbo_stream
+
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+          expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{other_agile_sprint.id}"
+          assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
+          assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{other_agile_sprint.id}"])
+          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:sprint)).to eq(agile_sprint)
+          expect(assigns(:story)).to eq(story_in_agile_sprint)
+
+          # It will preserve the version since it is not used as backlog/sprint.
+          expect(story_in_agile_sprint.reload.version).to eq(version_sprint)
+        end
+      end
+    end
+
+    context "with a Sprint (Version) as target" do
+      it "responds with success and moves story to Sprint", :aggregate_failures do
+        put :move, params: {
+                     project_id: project.id,
+                     sprint_id: agile_sprint.id,
+                     id: story_in_agile_sprint.id,
+                     target_id: "version:#{version_sprint.id}",
+                     position: 1
+                   },
+                   format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(agile_sprint)
+        expect(assigns(:story)).to eq(story_in_agile_sprint)
+        expect(assigns(:backlog)).to be_a(Backlog)
+      end
+    end
+
+    context "when service call fails" do
+      let(:other_agile_sprint) { create(:agile_sprint, name: "Agile Sprint 2", project:) }
+      let(:service_result) { ServiceResult.failure(message: "Something went wrong") }
+
+      before do
+        update_service = instance_double(Stories::UpdateService, call: service_result)
+
+        allow(Stories::UpdateService)
+          .to receive(:new)
+          .and_return(update_service)
+      end
+
+      it "renders an error flash with 422", :aggregate_failures do
+        put :move, params: {
+                     project_id: project.id,
+                     sprint_id: agile_sprint.id,
+                     id: story_in_agile_sprint.id,
+                     target_id: "sprint:#{other_agile_sprint.id}",
+                     position: 1
+                   },
+                   format: :turbo_stream
+
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
       end
     end
   end

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -47,19 +47,19 @@ RSpec.describe RbStoriesController do
       .and_return({ "story_types" => [type_feature.id], "task_type" => type_task.id })
   end
 
-  describe "PUT #move" do
+  describe "PUT #move_legacy" do
     context "with a version from the same project" do
       let(:other_sprint) { create(:sprint, name: "Sprint 2", project:) }
 
       it "responds with success", :aggregate_failures do
-        put :move, params: {
-                     project_id: project.id,
-                     sprint_id: sprint.id,
-                     id: story.id,
-                     target_id: other_sprint.id,
-                     position: 1
-                   },
-                   format: :turbo_stream
+        put :move_legacy, params: {
+                            project_id: project.id,
+                            sprint_id: sprint.id,
+                            id: story.id,
+                            target_id: "version:#{other_sprint.id}",
+                            position: 1
+                          },
+                          format: :turbo_stream
 
         expect(response).to be_successful
         expect(response).to have_http_status :ok
@@ -81,14 +81,14 @@ RSpec.describe RbStoriesController do
       let(:story) { create(:story, status:, version: other_sprint, project:) }
 
       it "responds with success", :aggregate_failures do
-        put :move, params: {
-                     project_id: project.id,
-                     sprint_id: other_sprint.id,
-                     id: story.id,
-                     target_id: sprint.id,
-                     position: 1
-                   },
-                   format: :turbo_stream
+        put :move_legacy, params: {
+                            project_id: project.id,
+                            sprint_id: other_sprint.id,
+                            id: story.id,
+                            target_id: "version:#{sprint.id}",
+                            position: 1
+                          },
+                          format: :turbo_stream
 
         expect(response).to be_successful
         expect(response).to have_http_status :ok
@@ -117,14 +117,14 @@ RSpec.describe RbStoriesController do
       end
 
       it "renders an error flash with 422", :aggregate_failures do
-        put :move, params: {
-                     project_id: project.id,
-                     sprint_id: sprint.id,
-                     id: story.id,
-                     target_id: other_sprint.id,
-                     position: 1
-                   },
-                   format: :turbo_stream
+        put :move_legacy, params: {
+                            project_id: project.id,
+                            sprint_id: sprint.id,
+                            id: story.id,
+                            target_id: "version:#{other_sprint.id}",
+                            position: 1
+                          },
+                          format: :turbo_stream
 
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"

--- a/modules/backlogs/spec/models/version_spec.rb
+++ b/modules/backlogs/spec/models/version_spec.rb
@@ -31,6 +31,95 @@ require "spec_helper"
 RSpec.describe Version do
   it { is_expected.to have_many :version_settings }
 
+  describe "#used_as_backlog?" do
+    let(:project) { create(:project) }
+    let(:version) { create(:version, project:) }
+
+    context "when backlogs is not enabled" do
+      before do
+        project.enabled_module_names = project.enabled_module_names - ["backlogs"]
+      end
+
+      it "returns false" do
+        expect(version.used_as_backlog?(project)).to be false
+      end
+    end
+
+    context "when backlogs is enabled" do
+      before do
+        project.enabled_module_names = project.enabled_module_names + ["backlogs"]
+      end
+
+      context "when no version_settings exist" do
+        it "returns false" do
+          expect(version.used_as_backlog?(project)).to be false
+        end
+      end
+
+      context "when version_settings exist with display_right" do
+        before do
+          create(:version_setting, version:, project:, display: VersionSetting::DISPLAY_RIGHT)
+        end
+
+        it "returns true" do
+          expect(version.used_as_backlog?(project)).to be true
+        end
+      end
+
+      context "when version_settings exist with display_left" do
+        before do
+          create(:version_setting, version:, project:, display: VersionSetting::DISPLAY_LEFT)
+        end
+
+        it "returns false" do
+          expect(version.used_as_backlog?(project)).to be false
+        end
+      end
+
+      context "when version_settings exist with display_none" do
+        before do
+          create(:version_setting, version:, project:, display: VersionSetting::DISPLAY_NONE)
+        end
+
+        it "returns false" do
+          expect(version.used_as_backlog?(project)).to be false
+        end
+      end
+
+      context "when multiple version_settings exist for different projects" do
+        let(:other_project) { create(:project) }
+
+        before do
+          project.enabled_module_names = project.enabled_module_names + ["backlogs"]
+          other_project.enabled_module_names = other_project.enabled_module_names + ["backlogs"]
+          create(:version_setting, version:, project:, display: VersionSetting::DISPLAY_RIGHT)
+          create(:version_setting, version:, project: other_project, display: VersionSetting::DISPLAY_LEFT)
+        end
+
+        it "returns true for the project with display_right" do
+          expect(version.used_as_backlog?(project)).to be true
+        end
+
+        it "returns false for the project with display_left" do
+          expect(version.used_as_backlog?(other_project)).to be false
+        end
+      end
+
+      context "when project parameter is not provided" do
+        context "and version has a project" do
+          before do
+            project.enabled_module_names = project.enabled_module_names + ["backlogs"]
+            create(:version_setting, version:, project:, display: VersionSetting::DISPLAY_RIGHT)
+          end
+
+          it "uses the version's project" do
+            expect(version.used_as_backlog?).to be true
+          end
+        end
+      end
+    end
+  end
+
   describe "rebuild positions" do
     def build_work_package(options = {})
       build(:work_package, options.reverse_merge(version_id: version.id,

--- a/modules/backlogs/spec/routing/rb_stories_routing_spec.rb
+++ b/modules/backlogs/spec/routing/rb_stories_routing_spec.rb
@@ -31,6 +31,16 @@ require "spec_helper"
 RSpec.describe RbStoriesController do
   describe "routing" do
     it {
+      expect(put("/projects/project_42/sprints/21/stories/85/move_legacy")).to route_to(
+        controller: "rb_stories",
+        action: "move_legacy",
+        project_id: "project_42",
+        sprint_id: "21",
+        id: "85"
+      )
+    }
+
+    it {
       expect(put("/projects/project_42/sprints/21/stories/85/move")).to route_to(
         controller: "rb_stories",
         action: "move",


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72849

**Note**: We have a name clash. With Sprint, I mean the legacy Sprint inheriting from Version. For the new style sprint, I will explicitly write Agile::Sprint.

Drag and drop works:

* From one Sprint to another
* From one Agile::Sprint to another
* From Agile::Sprint to Sprint
* From Sprint to Agile::Sprint

When moving a Story from any sprint type to another, we try to retain the Version assigned to the Work Package. The rule is: if the assigned Version is not configured to be `used_as_backlog?`, we can keep the Version association. However, if the Version poses as backlog, we must remove the association, or else the Story would exist in an Agile::Sprint and a Sprint at the same time.

The feature flag is not checked within the stories controller. As you can only move a Story to an already existing Agile::Sprint, I think this is acceptable. Having the feature enabled is required to create an Agile::Sprint. Modifying one should be allowed even without the flag.

## Caveats

Work Packages **do not** consider and update their `position` with Agile::Sprint in mind. Hence, you can drag and drop to an Agile::Sprint - but once the Work Package is in an Agile::Sprint, the position will not work as expected. This issue is out of scope for the current PR and will be handled in WP [73093](https://community.openproject.org/wp/73093)
