### PR TITLE
Remove unused translation key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,7 +292,7 @@ en:
             confirm_button: "Start import"
             description: >
               This importer is an alpha feature. It is not yet able to import all data from Jira and might leave incomplete data on this OpenProject instance.
-              
+
               <b>Do not use a production environment and create a backup of your OpenProject data before starting.</b>
             confirm: "I understand and made the necessary preparations"
           revert_dialog:


### PR DESCRIPTION
Usage was removed in PR #9665. Some i18n keys were removed back then in this PR, but this one was missed.
