### PR TITLE
[#72928] Fix backlogs to use Turbo morphing (dev follow-up)

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= component_wrapper(tag: :section) do %>
   <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
-    <% border_box.with_header do %>
+    <% border_box.with_header(id: dom_target(sprint, :header)) do %>
       <%= render(Backlogs::SprintHeaderComponent.new(sprint:, folded: folded?)) %>
     <% end %>
     <% if stories.empty? %>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%=
-  render(Primer::Alpha::ActionMenu.new(anchor_align: :end, classes: "hide-when-print")) do |menu|
+  render(Primer::Alpha::ActionMenu.new(**@system_arguments)) do |menu|
     menu.with_show_button(
       scheme: :invisible,
       icon: :"kebab-horizontal",
@@ -38,6 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
 
     if user_allowed?(:create_sprints)
       menu.with_item(
+        id: dom_target(sprint, :menu, :edit_sprint),
         label: t(".action_menu.edit_sprint"),
         href: edit_dialog_project_sprint_path(project, sprint),
         content_arguments: { data: { controller: "async-dialog" } }
@@ -48,6 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
 
     if user_allowed?(:manage_sprint_items)
       menu.with_item(
+        id: dom_target(sprint, :menu, :new_story),
         label: t(".action_menu.new_story"),
         href: new_project_work_packages_dialog_path(
           project,
@@ -66,6 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
 
     menu.with_item(
       # TODO: sprint_id filter does not exist for work packages. Add?
+      id: dom_target(sprint, :menu, :stories_tasks),
       scheme: :danger,
       label: t(".action_menu.stories_tasks"),
       tag: :a,

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -34,12 +34,20 @@ module Backlogs
 
     attr_reader :sprint, :project, :current_user
 
-    def initialize(sprint:, project:, current_user: User.current)
+    def initialize(sprint:, project:, current_user: User.current, **system_arguments)
       super()
 
       @sprint = sprint
       @project = project
       @current_user = current_user
+
+      @system_arguments = system_arguments
+      @system_arguments[:menu_id] = dom_target(sprint, :menu)
+      @system_arguments[:anchor_align] = :end
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "hide-when-print"
+      )
     end
 
     def stories

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -154,7 +154,10 @@ class RbSprintsController < RbApplicationController
   end
 
   def update_sprint_header_component_via_turbo_stream(sprint:)
-    update_via_turbo_stream(component: Backlogs::SprintHeaderComponent.new(sprint:))
+    update_via_turbo_stream(
+      component: Backlogs::SprintHeaderComponent.new(sprint:),
+      method: :morph
+    )
   end
 
   def update_new_sprint_form_component_via_turbo_stream(sprint:, base_errors: nil)

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         expect(page).to have_css(".Box-header h3", text: "Sprint 1")
       end
 
+      it "renders a stable id on the sprint header" do
+        render_component
+
+        expect(page).to have_element(:div, class: "Box-header", id: /\Aagile_sprint_#{sprint.id}_header\z/)
+      end
+
       it "renders StoryComponent for each story" do
         render_component
 

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
 
         expect(page).to have_css("action-menu")
       end
+
+      it "renders a stable id on the sprint menu trigger" do
+        render_component
+
+        expect(page).to have_element(:button, id: /\Aagile_sprint_#{sprint.id}_menu-button\z/)
+      end
     end
 
     context "with no stories" do

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
   describe "always-visible items" do
     let(:permissions) { [:view_sprints] }
 
+    it "renders stable ids on the action menu and stories/tasks item" do
+      render_component
+
+      expect(page).to have_element(:button, id: /\Aagile_sprint_#{sprint.id}_menu-button\z/)
+      expect(page).to have_element(:ul, id: /\Aagile_sprint_#{sprint.id}_menu-list\z/)
+      expect(page).to have_element(:a, id: /\Aagile_sprint_#{sprint.id}_menu_stories_tasks\z/)
+    end
+
     it "shows Stories/Tasks link" do
       render_component
 

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -312,6 +312,8 @@ RSpec.describe RbSprintsController do
           expect(response).to be_successful
           expect(response).to have_http_status :ok
           expect(response.body).to have_turbo_stream action: "flash"
+          expect(response.body).to have_turbo_stream action: "update", target: "backlogs-sprint-header-component-#{sprint.id}"
+          assert_select %(turbo-stream[action="update"][target="backlogs-sprint-header-component-#{sprint.id}"][method="morph"])
           expect(response.body).to include("Successful update.")
           expect(sprint.reload.name).to eq("Changed sprint name")
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72928

# What are you trying to accomplish?

Port the `#72928` Turbo morphing follow-up to the newer sprint-based backlogs components on `dev`.

This updates the agile sprint header Turbo Stream refresh to use `method: :morph`, and adds stable ids to the new sprint header and sprint menu elements so Turbo can reconcile the DOM reliably.

# What approach did you choose and why?

I mirrored the original `#72928` change in the new sprint-based implementation in two parts:

1. Use Turbo morphing when `update_agile_sprint` refreshes the sprint header.
2. Add deterministic ids to the sprint header and sprint menu elements that need to survive morphing.

I kept the stable-id tests intentionally narrow. The component specs verify representative stable ids that matter for morphing without asserting every generated menu item id, which would make the suite more brittle than useful.

I did not recreate the page-level request-spec work from the original PR because that coverage already exists on `dev`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

Tested with:

```zsh
source /opt/homebrew/opt/chruby/share/chruby/chruby.sh
chruby ruby-3.4.7
bundle exec rspec \
  modules/backlogs/spec/components/backlogs/sprint_component_spec.rb \
  modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb \
  modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb \
  modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb \
  modules/backlogs/spec/requests/rb_master_backlogs_spec.rb \
  modules/backlogs/spec/components/backlogs/backlog_component_spec.rb \
  modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb \
  modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
```

Result: `93 examples, 0 failures`
