### PR TITLE
[#72927] Fix drag and drop error handling (dev follow-up)

### DIFF
--- a/modules/backlogs/spec/components/backlogs/backlog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::BacklogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:type_task) { create(:type_task) }
   shared_let(:default_status) { create(:default_status) }
@@ -115,6 +117,8 @@ RSpec.describe Backlogs::BacklogComponent, type: :component do
         render_component
 
         box = page.find(".Box")
+        expect(box["data-generic-drag-and-drop-target"]).to eq("container")
+        expect(box["data-target-container-accessor"]).to eq(":scope > ul")
         expect(box["data-target-id"]).to eq(sprint.id.to_s)
         expect(box["data-target-allowed-drag-type"]).to eq("story")
       end
@@ -125,7 +129,7 @@ RSpec.describe Backlogs::BacklogComponent, type: :component do
         story_row = page.find(".Box-row[id='story_#{story1.id}']")
         expect(story_row["data-draggable-id"]).to eq(story1.id.to_s)
         expect(story_row["data-draggable-type"]).to eq("story")
-        expect(story_row["data-drop-url"]).to include("move")
+        expect(story_row["data-drop-url"]).to end_with(move_backlogs_project_sprint_story_path(project, sprint, story1))
       end
 
       it "renders story rows with proper classes" do

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -31,6 +31,8 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::SprintComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:type_task) { create(:type_task) }
   shared_let(:default_status) { create(:default_status) }
@@ -106,6 +108,8 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         render_component
 
         box = page.find(".Box")
+        expect(box["data-generic-drag-and-drop-target"]).to eq("container")
+        expect(box["data-target-container-accessor"]).to eq(":scope > ul")
         expect(box["data-target-id"]).to eq(sprint.id.to_s)
         expect(box["data-target-allowed-drag-type"]).to eq("story")
       end
@@ -116,7 +120,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         story_row = page.find(".Box-row[id='work_package_#{story1.id}']")
         expect(story_row["data-draggable-id"]).to eq(story1.id.to_s)
         expect(story_row["data-draggable-type"]).to eq("story")
-        expect(story_row["data-drop-url"]).to include("move")
+        expect(story_row["data-drop-url"]).to end_with(move_backlogs_project_sprint_story_path(project, sprint, story1))
       end
 
       it "renders story rows with proper classes" do

--- a/modules/backlogs/spec/components/backlogs/story_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_component_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe Backlogs::StoryComponent, type: :component do
 
       expect(page).to have_css("action-menu")
     end
+
+    it "renders a drag handle compatible with GenericDragAndDropController" do
+      render_component
+
+      expect(page).to have_css(".DragHandle[role='button'][tabindex='0']")
+      expect(page).to have_css(".DragHandle[aria-label='Move Test Story Subject']")
+    end
   end
 
   describe "story points handling" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72927

# What are you trying to accomplish?

Bring the intent of PR #22277 over to `dev`'s newer `modules/backlogs` componentized UI by tightening coverage around the drag-and-drop contract.

The runtime fixes are already present on `dev`, but the newer backlog and sprint components did not explicitly prove the DOM/data-attribute wiring expected by `generic-drag-and-drop.controller.ts`.

# What approach did you choose and why?

Extended the component specs for the new backlogs UI to assert:

1. Drop targets expose the expected Stimulus metadata (`generic_drag_and_drop_target`, `target_container_accessor`, `target_id`, `target_allowed_drag_type`).
2. Story rows expose stable draggable metadata and the `move` endpoint used for drag-and-drop persistence.
3. The story component still renders a `.DragHandle` button with the expected accessible label so the generic controller can discover and operate on it.

The existing `RbStoriesController` spec remains the source of truth for the 422/no-re-render failure semantics on `dev`, so this follow-up keeps runtime code unchanged and closes the coverage gap in the componentized rendering path.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
