### PR TITLE
fix https webhooks again

### DIFF
--- a/lib/open_project/ssrf_protection.rb
+++ b/lib/open_project/ssrf_protection.rb
@@ -30,6 +30,35 @@
 
 module OpenProject
   class SsrfProtection < ::SsrfFilter
+    # ssrf_filter works by resolving the hostname to a public IP, then connecting to that IP
+    # directly (to prevent DNS-rebinding attacks). For HTTPS, Net::HTTP must set the SNI hostname
+    # so the server knows which certificate to serve.
+    #
+    # However, modern Net::HTTP (net-http gem) explicitly skips setting SNI when the address is
+    # an IP (correctly per RFC 6066 §3 — IP literals are not valid in SNI). ssrf_filter 1.0.x
+    # patches SSLSocket#hostname= to inject the original hostname, but that patch never fires
+    # because Net::HTTP never calls hostname= for IP addresses.
+    #
+    # This patch targets SSLSocket#connect instead, which IS called regardless of address type.
+    # It sets the SNI hostname from ssrf_filter's thread-local just before the TLS handshake,
+    # making HTTPS work for SNI-dependent servers (e.g. Cloudflare-hosted webhooks).
+    #
+    # This patch can be removed once release/17.2 is retired — on dev we use ssrf_filter ~> 1.3
+    # which resolves this differently.
+    ::OpenSSL::SSL::SSLSocket.class_eval do
+      # Net::Protocol#ssl_socket_connect uses connect_nonblock when a timeout is set (the common
+      # case), falling back to connect only when timeout is nil. Patch both to be safe.
+      %i[connect connect_nonblock].each do |meth|
+        original = instance_method(meth)
+        define_method(meth) do |**kwargs|
+          if (hostname = ::Thread.current[::SsrfFilter::FIBER_LOCAL_KEY])
+            self.hostname = hostname
+          end
+          original.bind(self).call(**kwargs)
+        end
+      end
+    end
+
     class << self
       ##
       # Performs an SSRF-safe HTTP POST request to the given URL.


### PR DESCRIPTION
It seems that with ssrf_filter 1.0.8 SNI doesn't actually work correctly. So posting to https fails.

```
> OpenProject::SsrfProtection.post(url, body: '{"foo": "buzz"}', headers: { "Content-Type": "application/json" })
/app/vendor/bundle/ruby/3.4.0/gems/irb-1.17.0/lib/irb.rb:428:in 'full_message': SSL_connect returned=1 errno=0 peeraddr=104.21.24.177:443 state=error: sslv3 alert handshake failure (SSL alert number 40) (OpenSSL::SSL::SSLError)
OpenSSL error queue reported 1 errors:
error:0A000410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure (SSL alert number 40)
```

This PR fixes that. The fix can be removed with OpenProject 17.3 where we are using ssrf_filter 1.3.0 which has fixed that issue. We cannot update to 1.3.0 on 17.2 because the old carrierwave version still used here pins it to a lower version.