### PR TITLE
Disable `RSpecRails/TravelAround` cop for project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -226,6 +226,10 @@ Rails/SkipsModelValidations:
 RSpecRails/HttpStatus:
   Enabled: false
 
+# The block form of `travel_to` is often the tighter and safer option in our Rails specs.
+RSpecRails/TravelAround:
+  Enabled: false
+
 # expect not_to change is not working as expected
 # if you chain it with multiple expected changes
 RSpec/ChangeByZero:

--- a/modules/costs/spec/features/my_time_tracking_spec.rb
+++ b/modules/costs/spec/features/my_time_tracking_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "my time tracking", :js do
   end
 
   around do |example|
-    travel_to "2025-04-09T12:00:00Z" do # rubocop:disable RSpecRails/TravelAround
+    travel_to "2025-04-09T12:00:00Z" do
       example.run
     end
   end


### PR DESCRIPTION
# Ticket
None

# What are you trying to accomplish?
Disable `RSpecRails/TravelAround` project-wide and remove the now-redundant inline suppression from the existing spec.

This keeps the project from erroring when using the block form of `travel_to` with `after`, which is often the tighter-scoped option in Rails feature specs.

See upstream conversation: https://github.com/rubocop/rubocop-rspec_rails/issues/68


# What approach did you choose and why?
I disabled the cop centrally in `.rubocop.yml` instead of keeping file-level suppressions.

That gives us one explicit project policy instead of repeating local `rubocop:disable` comments in specs. I also removed the remaining inline suppression from the time tracking feature spec so the codebase matches the new configuration.

## Screenshots
Not applicable.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
