### PR TITLE
[72678] Screenshot overlaps with CKeditor tool bar when scrolling

### DIFF
--- a/frontend/src/global_styles/content/editor/_ckeditor.sass
+++ b/frontend/src/global_styles/content/editor/_ckeditor.sass
@@ -94,7 +94,7 @@ opce-ckeditor-augmented-textarea .op-ckeditor--attachments
   .document-editor__toolbar
     position: sticky
     top: 0
-    z-index: 2
+    z-index: 3
 
     // Reset these styles explicitly when the editor is opened inside a Dialog, as position: sticky opens a separate stacking context.
     // In case the dialog has multiple editors below each other, these different context interfere and the paragraph dropdown of an editor will be behind the editor below it.


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72678

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
This bug happens because CKEditor raises the z-index of selected widgets to 2 (e.g., images with `.ck-widget_selected`), causing them to render above the toolbar.

To ensure the toolbar remains visible and usable, the z-index of the sticky CK Editor toolbar is increased to 3.
