### PR TITLE
Rename "last check" to "last sync"

### DIFF
--- a/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.html.erb
+++ b/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
         notifications_container.with_row do
           concat(
             render(Primer::Beta::Text.new(pr: 2, test_selector: "storage-health-checked-at")) do
-              I18n.t("storages.health.checked", datetime: helpers.format_time(@storage.health_checked_at))
+              I18n.t("storages.health.synced", datetime: helpers.format_time(@storage.health_checked_at))
             end
           )
 

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -373,6 +373,7 @@ en:
         failure: Some checks failed and the system does not work as expected.
         success: All connections and systems are working as expected.
         warning: Some checks returned a warning. This can lead to unexpected behaviour.
+      synced: 'Last sync: %{datetime}'
       title: Health status report
     health_email_notifications:
       description_disabled: Admins will not receive updates by email when there are important updates.

--- a/modules/storages/spec/components/storages/admin/side_panel/health_notifications_component_spec.rb
+++ b/modules/storages/spec/components/storages/admin/side_panel/health_notifications_component_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Storages::Admin::SidePanel::HealthNotificationsComponent, type: :
 
         it "shows a healthy status" do
           expect(page).to have_test_selector("storage-health-status", text: "Healthy")
-          expect(page).to have_test_selector("storage-health-checked-at", text: "Last check: 11/28/2023 01:02 AM")
+          expect(page).to have_test_selector("storage-health-checked-at", text: "Last sync: 11/28/2023 01:02 AM")
         end
       end
 


### PR DESCRIPTION
This affects the section for "automatically managed project folders", which actually does not indicate the time at which a dedicated health CHECK was performed, but rather indicates the last time that an AMPF sync was attempted and whether that succeeded or not.

This is confusing to users, because seemingly we have two health checks, when in fact there's just a single health check. The AMPF job is a job that performs a task and it can do so successfully or not. Hopefully this change makes it more clear to users that if an error occurs during AMPF sync, that something went wrong.

# Screenshots

<img width="396" height="520" alt="image" src="https://github.com/user-attachments/assets/8016fb77-138d-460d-a6e2-7925da39e4a8" />
