### PR TITLE
include `add work package attachments` to capabilities api

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -399,7 +399,8 @@ Rails.application.reloader.to_prepare do
       wpt.permission :add_work_package_attachments,
                      {},
                      permissible_on: %i[work_package project],
-                     dependencies: :view_work_packages
+                     dependencies: :view_work_packages,
+                     contract_actions: { work_package_attachments: %i[create] }
 
       # WorkPackage categories
       wpt.permission :manage_categories,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72984

# What are you trying to accomplish?

Add the add_work_package_attachments permission to the ones included in the capabilities API.

## Screenshots

<img width="666" height="345" alt="image" src="https://github.com/user-attachments/assets/fa655ed9-ab7a-4bb0-8e89-2057a15e2761" />

