### PR TITLE
Implementation/72878 reset the project sharing settings when disabling the backlogs module

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,7 +77,7 @@ class Project < ApplicationRecord
   has_many :principals, through: :member_principals, source: :principal
   has_many :calculated_value_errors, dependent: :delete_all, as: :customized
 
-  has_many :enabled_modules, dependent: :delete_all
+  has_many :enabled_modules, dependent: :delete_all, after_remove: :module_disabled
   has_and_belongs_to_many :types, -> {
     order("#{::Type.table_name}.position")
   }
@@ -349,5 +349,11 @@ class Project < ApplicationRecord
     @allowed_actions ||= allowed_permissions.flat_map do |permission|
       OpenProject::AccessControl.allowed_actions(permission)
     end
+  end
+
+  def module_disabled(disabled_module)
+    OpenProject::Notifications.send(
+      OpenProject::Events::MODULE_DISABLED, disabled_module:
+    )
   end
 end

--- a/lib/open_project/events.rb
+++ b/lib/open_project/events.rb
@@ -80,6 +80,8 @@ module OpenProject
     WATCHER_ADDED = "watcher_added"
     WATCHER_DESTROYED = "watcher_destroyed"
 
+    MODULE_DISABLED = "module_disabled"
+
     WORK_PACKAGE_SHARED = "work_package_shared"
   end
 end

--- a/modules/backlogs/app/models/projects/sprint_sharing.rb
+++ b/modules/backlogs/app/models/projects/sprint_sharing.rb
@@ -79,6 +79,12 @@ module Projects::SprintSharing
     sprint_sharing == NO_SHARING
   end
 
+  def not_sharing_sprints!
+    return if not_sharing_sprints?
+
+    update_column(:settings, settings.merge("sprint_sharing" => NO_SHARING))
+  end
+
   def sprint_source
     # Senders and non-sharing projects only see their own sprints.
     # Receivers see external sprints from the closest ancestor sharing

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -185,6 +185,21 @@ module OpenProject::Backlogs
       OpenProject::Backlogs::Hooks::UserSettingsHook
     end
 
+    initializer "openproject_backlogs.event_subscriptions" do
+      Rails.application.config.after_initialize do
+        OpenProject::Notifications.subscribe(OpenProject::Events::MODULE_DISABLED) do |payload|
+          disabled_module = payload[:disabled_module]
+          next unless disabled_module.name == "backlogs"
+
+          disabled_module.project.not_sharing_sprints!
+        end
+
+        OpenProject::Notifications.subscribe(OpenProject::Events::PROJECT_ARCHIVED) do |payload|
+          payload[:project].not_sharing_sprints!
+        end
+      end
+    end
+
     config.to_prepare do
       ::Type.add_constraint :position, ->(type, project: nil) do
         if project.present?

--- a/modules/backlogs/spec/lib/open_project/backlogs/event_subscriptions_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/event_subscriptions_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::Notifications, "backlogs event subscriptions" do # rubocop:disable RSpec/SpecFilePathFormat
+  describe "MODULE_DISABLED" do
+    subject do
+      described_class.send(
+        OpenProject::Events::MODULE_DISABLED,
+        disabled_module:
+      )
+    end
+
+    Projects::SprintSharing::SPRINT_SHARING_MODES.each do |sharing_mode|
+      context "when the backlogs module is disabled on a project with #{sharing_mode}" do
+        let(:project) { create(:project, sprint_sharing: sharing_mode) }
+        let(:disabled_module) { instance_double(EnabledModule, name: "backlogs", project:) }
+
+        it "sets sprint sharing to no_sharing" do
+          subject
+
+          expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::NO_SHARING)
+        end
+      end
+    end
+
+    context "when a different module is disabled" do
+      let(:project) do
+        create(:project, sprint_sharing: Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      end
+      let(:disabled_module) { instance_double(EnabledModule, name: "wiki", project:) }
+
+      it "does not reset sprint sharing" do
+        subject
+
+        expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::SHARE_ALL_PROJECTS)
+      end
+    end
+  end
+
+  describe "PROJECT_ARCHIVED" do
+    subject do
+      described_class.send(
+        OpenProject::Events::PROJECT_ARCHIVED,
+        project:
+      )
+    end
+
+    Projects::SprintSharing::SPRINT_SHARING_MODES.each do |sharing_mode|
+      context "when a project with #{sharing_mode} is archived" do
+        let(:project) { create(:project, sprint_sharing: sharing_mode) }
+
+        it "sets sprint sharing to no_sharing" do
+          subject
+
+          expect(project.reload.sprint_sharing).to eq(Projects::SprintSharing::NO_SHARING)
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/models/projects/sprint_sharing_spec.rb
+++ b/modules/backlogs/spec/models/projects/sprint_sharing_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Projects::SprintSharing do
-  let(:project) { create(:project) }
+  let(:sprint_sharing) { "no_sharing" }
+  let(:active) { true }
+  let!(:project) { create(:project, sprint_sharing:, active:) }
 
   describe "SPRINT_SHARING_MODES" do
     it "defines all supported sprint sharing options" do
@@ -18,6 +20,8 @@ RSpec.describe Projects::SprintSharing do
   end
 
   describe "#sprint_sharing" do
+    let(:sprint_sharing) { nil }
+
     it "defaults to no_sharing" do
       expect(project.sprint_sharing).to eq("no_sharing")
     end
@@ -58,15 +62,41 @@ RSpec.describe Projects::SprintSharing do
     end
   end
 
+  describe "#not_sharing_sprints!" do
+    context "when the project is already set to no_sharing" do
+      let(:sprint_sharing) { "no_sharing" }
+
+      it "does not update the database" do
+        allow(project).to receive(:update_column)
+
+        subject
+
+        expect(project).not_to have_received(:update_column)
+      end
+    end
+
+    context "when the project has an active sharing mode" do
+      let(:sprint_sharing) { "share_all_projects" }
+
+      it "resets sprint_sharing to no_sharing" do
+        project.not_sharing_sprints!
+
+        expect(project.reload.sprint_sharing).to eq("no_sharing")
+      end
+    end
+  end
+
   describe ".global_sprint_sharer" do
     context "when no project shares with all projects" do
+      let(:sprint_sharing) { "no_sharing" }
+
       it "returns nil" do
         expect(Project.global_sprint_sharer).to be_nil
       end
     end
 
     context "when a project shares with all projects" do
-      before { project.update!(sprint_sharing: "share_all_projects") }
+      let(:sprint_sharing) { "share_all_projects" }
 
       it "returns that project" do
         expect(Project.global_sprint_sharer).to eq(project)
@@ -74,7 +104,8 @@ RSpec.describe Projects::SprintSharing do
     end
 
     context "when the sharing project is archived" do
-      before { project.update!(sprint_sharing: "share_all_projects", active: false) }
+      let(:sprint_sharing) { "share_all_projects" }
+      let(:active) { false }
 
       it "returns nil" do
         expect(Project.global_sprint_sharer).to be_nil

--- a/spec/models/enabled_module_spec.rb
+++ b/spec/models/enabled_module_spec.rb
@@ -34,6 +34,37 @@ RSpec.describe EnabledModule do
   # Force reload, as association is not always(?) showing
   let(:project) { create(:project, enabled_module_names: modules).reload }
 
+  describe "MODULE_DISABLED event" do
+    let(:modules) { %w[wiki] }
+
+    it "fires the event when a module is removed from the collection" do
+      disabled_module = project.enabled_modules.find_by(name: "wiki")
+
+      allow(OpenProject::Notifications)
+        .to receive(:send)
+        .with(OpenProject::Events::MODULE_DISABLED, disabled_module:)
+
+      project.enabled_module_names = []
+
+      expect(OpenProject::Notifications)
+        .to have_received(:send)
+        .with(OpenProject::Events::MODULE_DISABLED, disabled_module:)
+        .once
+    end
+
+    it "does not fire the event when creating a module" do
+      project.enabled_module_names = []
+
+      allow(OpenProject::Notifications)
+        .to receive(:send)
+        .with(OpenProject::Events::MODULE_DISABLED, disabled_module: anything)
+
+      project.enabled_module_names = ["wiki"]
+
+      expect(OpenProject::Notifications).not_to have_received(:send)
+    end
+  end
+
   describe "#wiki" do
     let(:modules) { %w[wiki] }
 
@@ -48,11 +79,11 @@ RSpec.describe EnabledModule do
       expect do
         project.enabled_module_names = []
         project.reload
-      end.not_to change { Wiki.count }
+      end.not_to change(Wiki, :count)
 
       expect do
         project.enabled_module_names = ["wiki"]
-      end.not_to change { Wiki.count }
+      end.not_to change(Wiki, :count)
 
       expect(project.wiki).not_to be_nil
     end
@@ -91,11 +122,11 @@ RSpec.describe EnabledModule do
         expect do
           project.enabled_module_names = []
           project.reload
-        end.not_to change { Repository.count }
+        end.not_to change(Repository, :count)
 
         expect do
           project.enabled_module_names = ["repository"]
-        end.not_to change { Repository.count }
+        end.not_to change(Repository, :count)
 
         expect(project.repository).not_to be_nil
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72878

# What are you trying to accomplish?
Reset the project sharing settings to `no_sharing` when disabling the backlogs module, or archiving the project.

# What approach did you choose and why?
- Trigger an `OpenProject::Events::MODULE_DISABLED` event when a module is disabled for a project.
- Trigger an `OpenProject::Events::PROJECT_ARCHIVED` event when the project is archived.
- Set the `Project#sprint_sharing` to `"no_sharing"` when the above events are triggered.

ℹ️ Instead of resetting the setting, clearing was also considered, however the setting already has a default value, so clearing does not make sense.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
