### PR TITLE
Seed default bug/task description templates

### DIFF
--- a/app/seeders/basic_data/type_seeder.rb
+++ b/app/seeders/basic_data/type_seeder.rb
@@ -40,7 +40,7 @@ module BasicData
     def model_attributes(type_data)
       {
         name: type_data["name"],
-        description: "",
+        description: type_data["description"] || "",
         is_default: true?(type_data["is_default"]),
         color_id: color_id(type_data["color_name"]),
         is_in_roadmap: true?(type_data["is_in_roadmap"]),

--- a/app/seeders/standard.yml
+++ b/app/seeders/standard.yml
@@ -914,6 +914,23 @@ time_entry_activities:
 types:
   - reference: :default_type_task
     t_name: Task
+    t_description: |-
+      ## Summary
+      (What needs to be done)
+
+      ## Goal / Expected outcome
+      (Definition of done)
+
+      ## Scope
+      - In scope:
+      - Out of scope:
+
+      ## Acceptance criteria
+      - [ ]
+      - [ ]
+
+      ## Dependencies / Links
+      (Related work packages, docs, blockers)
     is_default: true
     color_name: :default_color_blue
     is_in_roadmap: true
@@ -946,6 +963,39 @@ types:
     position: 6
   - reference: :default_type_bug
     t_name: Bug
+    t_description: |-
+      ## Summary
+      (One-sentence defect summary and impact)
+
+      ## Environment
+      - Product/app version:
+      - Browser + version:
+      - OS/device + version:
+      - Project:
+
+      ## Steps to reproduce
+      1.
+      2.
+      3.
+
+      ## Expected behavior
+      (What should happen)
+
+      ## Actual behavior
+      (What actually happens)
+
+      ## Reproducibility
+      - [ ] Always
+      - [ ] Intermittent
+      - [ ] Could not reproduce reliably
+
+      ## Evidence
+      (Logs, screenshots, links, crash IDs)
+
+      ## Impact
+      - Severity:
+      - Priority:
+      - Affected users/workflow:
     color_name: 'red-7'
     is_in_roadmap: true
     position: 7

--- a/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
+++ b/docs/system-admin-guide/manage-work-packages/work-package-types/README.md
@@ -35,6 +35,97 @@ Click the green **+ Type** button to add a new work package type in the system, 
 
 ![Create a new work package type in OpenProject administration](openproject_system_guide_new_work_package_typ.png)
 
+## Bug and task template runbook
+
+Use this runbook to roll out consistent bug/task intake templates in a configuration-first way.
+OpenProject applies the **type description** as the default description when a new work package of that type is created.
+In fresh standard seeding, Task and Bug starter templates are provided by default.
+For existing installations, use the rollout steps below to apply them.
+
+### Copy/paste template for **Bug** type description
+
+```md
+## Summary
+(One-sentence defect summary and impact)
+
+## Environment
+- Product/app version:
+- Browser + version:
+- OS/device + version:
+- Project:
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+(What should happen)
+
+## Actual behavior
+(What actually happens)
+
+## Reproducibility
+- [ ] Always
+- [ ] Intermittent
+- [ ] Could not reproduce reliably
+
+## Evidence
+(Logs, screenshots, links, crash IDs)
+
+## Impact
+- Severity:
+- Priority:
+- Affected users/workflow:
+```
+
+### Copy/paste template for **Task** type description
+
+```md
+## Summary
+(What needs to be done)
+
+## Goal / Expected outcome
+(Definition of done)
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Acceptance criteria
+- [ ]
+- [ ]
+
+## Dependencies / Links
+(Related work packages, docs, blockers)
+```
+
+### Rollout steps
+
+1. Pilot in 1-2 projects first:
+   1. Go to **Administration -> Work packages -> Types -> Bug** and paste the Bug template into **Description**.
+   2. Repeat for **Task** with the Task template.
+2. Validate in both creation paths:
+   1. Global create (`/work_packages/new`)
+   2. Project create (`/projects/:project_id/work_packages/new`)
+3. Confirm behavior:
+   1. Template is prefilled for new Bug/Task.
+   2. Switching type replaces only untouched default text.
+   3. User-edited descriptions are not overwritten on type switch.
+4. Roll out globally to all projects using Bug/Task types.
+5. Revisit after adoption and decide whether to add required custom fields for stricter intake.
+
+### Project-specific variants
+
+Type descriptions are global per type. If a specific project needs a different template (for example, extra iOS version/device fields), create a dedicated type variant such as **iOS Bug** and enable it only for that project under the type's **Projects** tab.
+
+### Industry references
+
+- [Google Chrome extension bug filing guidance](https://developer.chrome.com/docs/extensions/support/file-a-bug)
+- [Mozilla Bugzilla bug-writing guidelines](https://bugzilla.mozilla.org/page.cgi?id=bug-writing.html)
+- [Microsoft Azure DevOps bug work item guidance](https://learn.microsoft.com/en-us/azure/devops/boards/backlogs/manage-bugs)
+- [GitLab issue/description templates](https://docs.gitlab.com/user/project/description_templates/)
+
 ## Work package form configuration (Enterprise add-on)
 
 You can freely **configure the attributes shown** for each work package type to decide which attributes are shown in the form and how they are grouped.
@@ -118,4 +209,3 @@ Under the **Generate PDF** tab of  *Administration -> Work packages -> Types* yo
 The template determines the design and attributes visible in the exported PDF of a work package using this type. The first  template on the list is selected by default.
 
 ![Generate PDF tab under work package types settings in OpenProject administration](openproject_system_guide_work_package_types_pdf_tab.png)
-

--- a/spec/seeders/basic_data/type_seeder_spec.rb
+++ b/spec/seeders/basic_data/type_seeder_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe BasicData::TypeSeeder do
+  include_context "with basic seed data"
+
+  subject(:seeder) { described_class.new(seed_data) }
+
+  let(:seed_data) { basic_seed_data.merge(Source::SeedData.new(data_hash)) }
+
+  before do
+    seeder.seed!
+  end
+
+  context "with type descriptions defined" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        types:
+        - reference: :type_task
+          name: Task
+          description: "## Summary\\nTask template"
+          color_name: :default_color_blue
+          is_default: true
+          is_in_roadmap: true
+          position: 1
+        - reference: :type_bug
+          name: Bug
+          description: "## Summary\\nBug template"
+          color_name: red-7
+          is_default: false
+          is_in_roadmap: true
+          position: 2
+      SEEDING_DATA_YAML
+    end
+
+    it "creates types with the seeded descriptions", :aggregate_failures do
+      expect(Type.count).to eq(2)
+      expect(Type.find_by(name: "Task")).to have_attributes(
+        description: "## Summary\nTask template",
+        is_default: true,
+        position: 1
+      )
+      expect(Type.find_by(name: "Bug")).to have_attributes(
+        description: "## Summary\nBug template",
+        is_default: false,
+        position: 2
+      )
+    end
+  end
+
+  context "when type description is omitted" do
+    let(:data_hash) do
+      YAML.load <<~SEEDING_DATA_YAML
+        types:
+        - reference: :type_task
+          name: Task
+          color_name: :default_color_blue
+          is_default: true
+          is_in_roadmap: true
+          position: 1
+      SEEDING_DATA_YAML
+    end
+
+    it "defaults the description to an empty string" do
+      expect(Type.find_by(name: "Task")).to have_attributes(description: "")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow `BasicData::TypeSeeder` to consume seeded `description` values instead of always forcing `""`
- seed default description templates for `Task` and `Bug` types in `app/seeders/standard.yml`
- add system-admin runbook docs for rolling out bug/task templates (including project-specific variant guidance)
- add `BasicData::TypeSeeder` spec coverage for description seeding and fallback behavior

## Why
OpenProject already supports applying a type description as the default description for new work packages. This change ships practical bug/task templates out of the box for fresh standard seeding and documents rollout for existing installations.

## Validation
- ✅ `ruby -e "require 'yaml'; YAML.load_file('app/seeders/standard.yml'); puts 'standard.yml OK'"`
- ⚠️ `bundle exec rspec spec/seeders/basic_data/type_seeder_spec.rb` fails in this environment due to missing locally installed gems on `upstream/dev` (Bundler::GemNotFound). The spec itself is included and expected to run in CI.
