### PR TITLE
Implementation/72943 page overhaul: swap backlogs and sprint position around

### DIFF
--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -79,6 +79,11 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   flex-direction: row
   gap: var(--stack-gap-normal)
 
+  // Line that separates left side of sprint planning from right side of sprint planning
+  .op-backlogs-lists:first-child
+    border-right: 1px solid var(--borderColor-default)
+    padding-right: var(--stack-gap-normal)
+
 .op-backlogs-lists
   display: flex
   flex-direction: column

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -74,22 +74,24 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   container-name: backlogsListsContainer
   container-type: inline-size
 
-.op-backlogs-container
+.op-backlogs-container, .op-sprint-planning-container
   display: flex
   flex-direction: row
   gap: var(--stack-gap-normal)
 
   // Line that separates left side of sprint planning from right side of sprint planning
-  .op-backlogs-lists:first-child
+  .op-sprint-planning-lists:first-child
     border-right: 1px solid var(--borderColor-default)
     padding-right: var(--stack-gap-normal)
 
-.op-backlogs-lists
+.op-backlogs-lists, .op-sprint-planning-lists
   display: flex
   flex-direction: column
   gap: var(--stack-gap-normal)
   flex: 1 1 100%
   overflow: hidden
+
+.op-sprint-planning-lists
   padding-top: var(--base-size-16)
 
 //------------------ Header form responsive styling -----------------------

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -90,6 +90,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   gap: var(--stack-gap-normal)
   flex: 1 1 100%
   overflow: hidden
+  padding-top: var(--base-size-16)
 
 //------------------ Header form responsive styling -----------------------
 // Note: Using hardcoded values because Sass doesn't interpolate variables in

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -50,7 +50,7 @@ See COPYRIGHT and LICENSE files for more details.
     if user_allowed?(:manage_sprint_items)
       menu.with_item(
         id: dom_target(sprint, :menu, :new_story),
-        label: t(".action_menu.new_story"),
+        label: t(".action_menu.add_work_package"),
         href: new_project_work_packages_dialog_path(
           project,
           sprint_id: sprint.id,
@@ -58,24 +58,13 @@ See COPYRIGHT and LICENSE files for more details.
         ),
         content_arguments: { data: { turbo_stream: true } }
       ) do |item|
-        item.with_leading_visual_icon(icon: :compose)
+        item.with_leading_visual_icon(icon: :plus)
       end
     end
 
-    if user_allowed?(:create_sprints) || user_allowed?(:add_work_packages)
-      menu.with_divider
-    end
-
-    menu.with_item(
-      # TODO: sprint_id filter does not exist for work packages. Add?
-      id: dom_target(sprint, :menu, :stories_tasks),
-      scheme: :danger,
-      label: t(".action_menu.stories_tasks"),
-      tag: :a,
-      href: project_work_packages_path(project, sprint_id: sprint.id)
-    ) do |item|
-      item.with_leading_visual_icon(icon: :"op-view-list")
-    end
+    # if user_allowed?(:create_sprints) || user_allowed?(:add_work_packages)
+    #   menu.with_divider
+    # end
 
     # menu.with_item(
     #   # TODO: what to do with the task board?

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -64,4 +64,8 @@ class RbApplicationController < ApplicationController
       end
     end
   end
+
+  def not_authorized_on_feature_flag_inactive
+    render_403 unless OpenProject::FeatureDecisions.scrum_projects_active?
+  end
 end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -31,12 +31,12 @@
 class RbMasterBacklogsController < RbApplicationController
   include WorkPackages::WithSplitView
 
-  if OpenProject::FeatureDecisions.scrum_projects_active?
-    current_menu_item [:sprint_planning] do
-      :sprint_planning
-    end
-  else
-    menu_item :backlogs
+  # Without the feature flag, there is only the top level menu item, select it
+  menu_item :backlogs_legacy
+
+  # With the feature flag, we have a proper menu, select the correct sub entry
+  current_menu_item [:sprint_planning] do
+    :sprint_planning
   end
 
   before_action :not_authorized_on_feature_flag_inactive, only: :sprint_planning

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -33,23 +33,22 @@ class RbMasterBacklogsController < RbApplicationController
 
   menu_item :backlogs
 
-  before_action :load_backlogs, only: :index
+  before_action :not_authorized_on_feature_flag_inactive, only: :sprint_planning
+  before_action :load_backlogs, only: %i[index sprint_planning]
+
+  def sprint_planning
+    if turbo_frame_request?
+      render partial: "sprint_planning_list", layout: false
+    else
+      render :sprint_planning
+    end
+  end
 
   def index
-    if OpenProject::FeatureDecisions.scrum_projects_active?
-      # Feature flag is active, render the new views
-      if turbo_frame_request?
-        render partial: "agile_list", layout: false
-      else
-        render :agile_index
-      end
+    if turbo_frame_request?
+      render partial: "list", layout: false
     else
-      # Feature flag is not active, render legacy views
-      if turbo_frame_request? # rubocop:disable Style/IfInsideElse
-        render partial: "list", layout: false
-      else
-        render :index
-      end
+      render :index
     end
   end
 
@@ -60,14 +59,20 @@ class RbMasterBacklogsController < RbApplicationController
       load_backlogs
 
       if OpenProject::FeatureDecisions.scrum_projects_active?
-        render :agile_index
+        render :sprint_planning
       else
         render :index
       end
     end
   end
 
-  def split_view_base_route = backlogs_project_backlogs_path(request.query_parameters)
+  def split_view_base_route
+    if OpenProject::FeatureDecisions.scrum_projects_active?
+      sprint_planning_backlogs_project_backlogs_path(@project)
+    else
+      backlogs_project_backlogs_path(request.query_parameters)
+    end
+  end
 
   private
 

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -51,6 +51,8 @@ class RbMasterBacklogsController < RbApplicationController
   end
 
   def index
+    return redirect_to action: :sprint_planning if OpenProject::FeatureDecisions.scrum_projects_active?
+
     if turbo_frame_request?
       render partial: "list", layout: false
     else

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -31,7 +31,13 @@
 class RbMasterBacklogsController < RbApplicationController
   include WorkPackages::WithSplitView
 
-  menu_item :backlogs
+  if OpenProject::FeatureDecisions.scrum_projects_active?
+    current_menu_item [:sprint_planning] do
+      :sprint_planning
+    end
+  else
+    menu_item :backlogs
+  end
 
   before_action :not_authorized_on_feature_flag_inactive, only: :sprint_planning
   before_action :load_backlogs, only: %i[index sprint_planning]

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -76,7 +76,7 @@ class RbMasterBacklogsController < RbApplicationController
 
   def split_view_base_route
     if OpenProject::FeatureDecisions.scrum_projects_active?
-      sprint_planning_backlogs_project_backlogs_path(@project)
+      sprint_planning_backlogs_project_backlogs_path(request.query_parameters)
     else
       backlogs_project_backlogs_path(request.query_parameters)
     end

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -81,7 +81,7 @@ class RbSprintsController < RbApplicationController
 
     if call.success?
       flash[:notice] = I18n.t(:notice_successful_create)
-      render turbo_stream: turbo_stream.redirect_to(backlogs_project_backlogs_path(@project))
+      render turbo_stream: turbo_stream.redirect_to(sprint_planning_backlogs_project_backlogs_path(@project))
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
       respond_with_turbo_streams
@@ -194,9 +194,5 @@ class RbSprintsController < RbApplicationController
     converted_sprint_params[:project] = @project
 
     converted_sprint_params
-  end
-
-  def not_authorized_on_feature_flag_inactive
-    render_403 unless OpenProject::FeatureDecisions.scrum_projects_active?
   end
 end

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
 
-<turbo-frame id="backlogs_container" refresh="morph" class="op-backlogs-page">
+<%= turbo_frame_tag "backlogs_container", refresh: :morph, class: "op-backlogs-page" do %>
   <% if @owner_backlogs.empty? && @sprints.empty? %>
     <%=
       render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
@@ -104,4 +104,4 @@ See COPYRIGHT and LICENSE files for more details.
       </div>
     </div>
   <% end %>
-</turbo-frame>
+<% end %>

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -43,10 +43,17 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
       <div id="owner_backlogs_container" class="op-sprint-planning-lists">
         <%=
-          # `margin bottom` of 8 is needed to push the content down enough so that it is level
-          # with the "Sprints" content section:
-          render(Primer::Beta::Subhead.new(hide_border: true, mb: 8)) do |head|
+          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
             head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { t(:label_backlog) }
+
+            if allow_sprint_creation?(@project)
+              # Ugly hack:
+              # This button will not be rendered, but still takes up space to push the left side down a bit.
+              # Remove as soon as the `+ Sprint` button moves from the Subhead into a SubHeader.
+              head.with_actions do
+                render(Primer::Beta::Button.new(tag: :a, visibility: :hidden)) { "spacer" }
+              end
+            end
           end
         %>
 
@@ -56,11 +63,27 @@ See COPYRIGHT and LICENSE files for more details.
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
             head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }
+
+            if allow_sprint_creation?(@project)
+              head.with_actions do
+                render Primer::Beta::Button.new(
+                  tag: :a,
+                  label: Agile::Sprint.human_model_name,
+                  href: new_dialog_project_sprints_path(@project),
+                  data: {
+                    controller: "async-dialog",
+                    test_selector: "op-sprints--new-sprint-button"
+                  }
+                ) do |button|
+                  button.with_leading_visual_icon(icon: :plus)
+                  Agile::Sprint.human_model_name
+                end
+              end
+            end
           end
         %>
 
-        <%=
-          render(Primer::OpenProject::SubHeader.new) do |subheader|
+        <%#= render(Primer::OpenProject::SubHeader.new) do |subheader|
             if allow_sprint_creation?(@project)
               subheader.with_action_button(
                 leading_icon: :plus,
@@ -75,8 +98,7 @@ See COPYRIGHT and LICENSE files for more details.
                 Agile::Sprint.human_model_name
               end
             end
-          end
-        %>
+          end %>
 
         <%= render(Backlogs::SprintComponent.with_collection(@sprints)) %>
       </div>

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -1,0 +1,83 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<turbo-frame id="backlogs_container" refresh="morph" class="op-backlogs-page">
+  <% if @owner_backlogs.empty? && @sprints.empty? %>
+    <%=
+      render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
+        blankslate.with_visual_icon(icon: :versions)
+        blankslate.with_heading(tag: :h2).with_content(t(:backlogs_empty_title))
+
+        if current_user.allowed_in_project?(:manage_versions, @project)
+          blankslate.with_description_content(t(:backlogs_empty_action_text))
+        end
+      end
+    %>
+  <% else %>
+    <div class="op-backlogs-container" data-controller="generic-drag-and-drop">
+      <div id="owner_backlogs_container" class="op-backlogs-lists">
+        <%=
+          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+            head.with_heading(tag: :h3, size: :medium) { t(:label_backlogs) }
+          end
+        %>
+
+        <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>
+      </div>
+      <div id="sprint_backlogs_container" class="op-backlogs-lists">
+        <%=
+          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+            head.with_heading(tag: :h3, size: :medium) { Agile::Sprint.human_model_name.pluralize }
+          end
+        %>
+
+        <%=
+          render(Primer::OpenProject::SubHeader.new) do |subheader|
+            if allow_sprint_creation?(@project)
+              subheader.with_action_button(
+                leading_icon: :plus,
+                label: Agile::Sprint.human_model_name,
+                tag: :a,
+                href: new_dialog_project_sprints_path(@project),
+                data: {
+                  controller: "async-dialog",
+                  test_selector: "op-sprints--new-sprint-button"
+                }
+              ) do
+                Agile::Sprint.human_model_name
+              end
+            end
+          end
+        %>
+
+        <%= render(Backlogs::SprintComponent.with_collection(@sprints)) %>
+      </div>
+    </div>
+  <% end %>
+</turbo-frame>

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -40,8 +40,8 @@ See COPYRIGHT and LICENSE files for more details.
       end
     %>
   <% else %>
-    <div class="op-backlogs-container" data-controller="generic-drag-and-drop">
-      <div id="owner_backlogs_container" class="op-backlogs-lists">
+    <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
+      <div id="owner_backlogs_container" class="op-sprint-planning-lists">
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
             head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { t(:label_backlog) }
@@ -50,7 +50,7 @@ See COPYRIGHT and LICENSE files for more details.
 
         <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>
       </div>
-      <div id="sprint_backlogs_container" class="op-backlogs-lists">
+      <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
             head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -44,7 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div id="owner_backlogs_container" class="op-backlogs-lists">
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-            head.with_heading(tag: :h3, size: :medium) { t(:label_backlogs) }
+            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { t(:label_backlog) }
           end
         %>
 
@@ -53,7 +53,7 @@ See COPYRIGHT and LICENSE files for more details.
       <div id="sprint_backlogs_container" class="op-backlogs-lists">
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-            head.with_heading(tag: :h3, size: :medium) { Agile::Sprint.human_model_name.pluralize }
+            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }
           end
         %>
 

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -43,7 +43,9 @@ See COPYRIGHT and LICENSE files for more details.
     <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
       <div id="owner_backlogs_container" class="op-sprint-planning-lists">
         <%=
-          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+          # `margin bottom` of 8 is needed to push the content down enough so that it is level
+          # with the "Sprints" content section:
+          render(Primer::Beta::Subhead.new(hide_border: true, mb: 8)) do |head|
             head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { t(:label_backlog) }
           end
         %>

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -45,41 +45,14 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%=
     render(Primer::OpenProject::SubHeader.new) do |subheader|
-      if allow_sprint_creation?(@project)
-        # Scrum sprints are available, show an action menu to create Sprints and Versions
-        subheader.with_action_menu(
-          leading_icon: :plus,
-          trailing_icon: :"triangle-down",
-          label: t(:button_create),
-          button_arguments: { scheme: :primary }
-        ) do |menu|
-          menu.with_item(
-            label: Version.human_model_name,
-            href: new_project_version_path(@project)
-          )
-
-          menu.with_item(
-            label: Agile::Sprint.human_model_name,
-            href: new_dialog_project_sprints_path(@project),
-            content_arguments: {
-              data: {
-                controller: "async-dialog",
-                test_selector: "op-sprints--new-sprint-button"
-              }
-            }
-          )
-        end
-      else
-        # No scrum sprints, we only show a "+ Version" button
-        subheader.with_action_button(
-          scheme: :primary,
-          leading_icon: :plus,
-          label: I18n.t(:label_version_new),
-          tag: :a,
-          href: new_project_version_path(@project)
-        ) do
-          Version.human_model_name
-        end
+      subheader.with_action_button(
+        scheme: :primary,
+        leading_icon: :plus,
+        label: I18n.t(:label_version_new),
+        tag: :a,
+        href: new_project_version_path(@project)
+      ) do
+        Version.human_model_name
       end
     end
   %>

--- a/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
@@ -36,10 +36,11 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_for :content_header do %>
   <%=
     render Primer::OpenProject::PageHeader.new do |header|
-      header.with_title { t(:label_backlogs) }
+      header.with_title { t(:label_sprint_planning) }
       header.with_breadcrumbs(
         [{ href: project_overview_path(@project), text: @project.name },
-         t(:label_backlogs)]
+         { href: sprint_planning_backlogs_project_backlogs_path(@project), text: t(:label_backlogs) },
+         t(:label_sprint_planning)]
       )
     end
   %>

--- a/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
@@ -43,51 +43,10 @@ See COPYRIGHT and LICENSE files for more details.
       )
     end
   %>
-
-  <%=
-    render(Primer::OpenProject::SubHeader.new) do |subheader|
-      if allow_sprint_creation?(@project)
-        # Scrum sprints are available, show an action menu to create Sprints and Versions
-        subheader.with_action_menu(
-          leading_icon: :plus,
-          trailing_icon: :"triangle-down",
-          label: t(:button_create),
-          button_arguments: { scheme: :primary }
-        ) do |menu|
-          menu.with_item(
-            label: Version.human_model_name,
-            href: new_project_version_path(@project)
-          )
-
-          menu.with_item(
-            label: Agile::Sprint.human_model_name,
-            href: new_dialog_project_sprints_path(@project),
-            content_arguments: {
-              data: {
-                controller: "async-dialog",
-                test_selector: "op-sprints--new-sprint-button"
-              }
-            }
-          )
-        end
-      else
-        # No scrum sprints, we only show a "+ Version" button
-        subheader.with_action_button(
-          scheme: :primary,
-          leading_icon: :plus,
-          label: I18n.t(:label_version_new),
-          tag: :a,
-          href: new_project_version_path(@project)
-        ) do
-          Version.human_model_name
-        end
-      end
-    end
-  %>
 <% end %>
 
 <% content_for :content_body do %>
-  <%= render partial: "agile_list" %>
+  <%= render partial: "sprint_planning_list" %>
 <% end %>
 
 <% content_for :content_body_right do %>

--- a/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% content_for :content_body do %>
-  <%= render partial: "sprint_planning_list" %>
+  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: sprint_planning_backlogs_project_backlogs_path(@project) %>
 <% end %>
 
 <% content_for :content_body_right do %>

--- a/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% content_for :content_header do %>
   <%=
-    render Primer::OpenProject::PageHeader.new do |header|
+    render Primer::OpenProject::PageHeader.new(mb: 0) do |header|
       header.with_title { t(:label_sprint_planning) }
       header.with_breadcrumbs(
         [{ href: project_overview_path(@project), text: @project.name },

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
   label_sprint_edit: "Edit sprint"
   label_sprint_impediments: "Sprint Impediments"
   label_sprint_new: "New sprint"
+  label_sprint_planning: "Sprint planning"
   label_task_board: "Task board"
 
   permission_create_sprints: "Create sprints"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -149,10 +149,7 @@ en:
       label_actions: "Sprint actions"
       action_menu:
         edit_sprint: "Edit sprint"
-        new_story: "New story"
-        stories_tasks: "Stories/Tasks"
-        task_board: "Task board"
-        burndown_chart: "Burndown chart"
+        add_work_package: "Add work package"
 
     story_component:
       label_drag_story: "Move %{name}"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -183,6 +183,7 @@ en:
       task_type:
         cannot_be_story_type: "can not also be a story type"
 
+  label_backlog: "Backlog"
   label_backlogs: "Backlogs"
   label_backlogs_unconfigured: "You have not configured Backlogs yet. Please go to %{administration} > %{plugins}, then click on the %{configure} link for this plugin. Once you have set the fields, come back to this page to start using the tool."
   label_blocks_ids: "IDs of blocked work packages"

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
               as: :details,
               work_package_split_view: true,
               defaults: { tab: :overview }
+
+          get :sprint_planning
         end
       end
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -66,7 +66,7 @@ module OpenProject::Backlogs
 
       project_module :backlogs, dependencies: :work_package_tracking do
         permission :view_sprints,
-                   { rb_master_backlogs: %i[index details],
+                   { rb_master_backlogs: %i[index sprint_planning details],
                      rb_sprints: %i[index show show_name],
                      rb_wikis: :show,
                      rb_stories: %i[index show],

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -113,16 +113,36 @@ module OpenProject::Backlogs
                    visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
       end
 
+      # Menu items that are there when feature flag is active
       menu :project_menu,
            :backlogs,
-           { controller: "/rb_master_backlogs", action: :index },
+           { controller: "/rb_master_backlogs", action: :sprint_planning },
+           if: Proc.new { |project| project.module_enabled?(:backlogs) && OpenProject::FeatureDecisions.scrum_projects_active? },
            caption: :project_module_backlogs,
            after: :work_packages,
            icon: "op-backlogs"
 
       menu :project_menu,
+           :sprint_planning,
+           { controller: "/rb_master_backlogs", action: :sprint_planning },
+           if: Proc.new { |project| project.module_enabled?(:backlogs) && OpenProject::FeatureDecisions.scrum_projects_active? },
+           caption: :label_sprint_planning,
+           parent: :backlogs
+
+      # Menu items that are there when feature flag is inactive
+      menu :project_menu,
+           :backlogs_legacy,
+           { controller: "/rb_master_backlogs", action: :index },
+           if: Proc.new { |project| project.module_enabled?(:backlogs) && !OpenProject::FeatureDecisions.scrum_projects_active? },
+           caption: :project_module_backlogs,
+           after: :work_packages,
+           icon: "op-backlogs"
+
+      # Menu items that are always present
+      menu :project_menu,
            :settings_backlogs,
            { controller: "/projects/settings/backlogs", action: :show },
+           if: Proc.new { |project| project.module_enabled?(:backlogs) },
            caption: :label_backlogs,
            parent: :settings,
            before: :settings_storage

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -61,21 +61,21 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
     context "with :manage_sprint_items permission" do
       let(:permissions) { %i[view_sprints manage_sprint_items] }
 
-      it "shows Add new story item with compose icon" do
+      it "shows Add new work package item with plus icon" do
         render_component
 
-        expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.new_story"))
-        expect(page).to have_octicon(:compose)
+        expect(page).to have_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.add_work_package"))
+        expect(page).to have_octicon(:plus)
       end
     end
 
     context "without :manage_sprint_items permission" do
       let(:permissions) { [:view_sprints] }
 
-      it "does not show Add new story item" do
+      it "does not show Add work package item" do
         render_component
 
-        expect(page).to have_no_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.new_story"))
+        expect(page).to have_no_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.add_work_package"))
       end
     end
 
@@ -86,7 +86,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         render_component
 
         expect(page).to have_css("action-menu")
-        expect(page).to have_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
+        expect(page).to have_text(I18n.t("backlogs.sprint_menu_component.action_menu.edit_sprint"))
         expect(page).to have_octicon(:pencil)
       end
     end
@@ -97,26 +97,8 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
       it "does not show Edit item" do
         render_component
 
-        expect(page).to have_no_text(I18n.t("backlogs.backlog_menu_component.action_menu.edit_sprint"))
+        expect(page).to have_no_text(I18n.t("backlogs.sprint_menu_component.action_menu.edit_sprint"))
       end
-    end
-  end
-
-  describe "always-visible items" do
-    let(:permissions) { [:view_sprints] }
-
-    it "renders stable ids on the action menu and stories/tasks item" do
-      render_component
-
-      expect(page).to have_element(:button, id: /\Aagile_sprint_#{sprint.id}_menu-button\z/)
-      expect(page).to have_element(:ul, id: /\Aagile_sprint_#{sprint.id}_menu-list\z/)
-      expect(page).to have_element(:a, id: /\Aagile_sprint_#{sprint.id}_menu_stories_tasks\z/)
-    end
-
-    it "shows Stories/Tasks link" do
-      render_component
-
-      expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.stories_tasks"))
     end
   end
 end

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -85,8 +85,6 @@ RSpec.describe "Create", :js do
     end
 
     it "renders the menu" do
-      pending "flaky spec, for whatever reason"
-
       within "#main-menu" do
         expect(page).to have_css(".selected", text: "Sprint planning")
       end

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -29,7 +29,7 @@
 #++
 
 require "spec_helper"
-require_relative "../../support/pages/backlogs"
+require_relative "../../support/pages/sprint_planning"
 
 RSpec.describe "Create", :js do
   let(:project) { create(:project) }
@@ -38,7 +38,7 @@ RSpec.describe "Create", :js do
   let(:user) do
     create(:user, member_with_permissions: { project => permissions })
   end
-  let(:backlogs_page) { Pages::Backlogs.new(project) }
+  let(:planning_page) { Pages::SprintPlanning.new(project) }
 
   let!(:initial_sprint) do
     create(:agile_sprint,
@@ -72,7 +72,7 @@ RSpec.describe "Create", :js do
   before do
     login_as(user)
 
-    backlogs_page.visit!
+    planning_page.visit!
   end
 
   context "with the feature flag active", with_flag: { scrum_projects: true } do
@@ -83,9 +83,9 @@ RSpec.describe "Create", :js do
       let(:finish_date_fmt) { finish_date.strftime("%Y-%m-%d") }
 
       it "allows creating a new sprint" do
-        backlogs_page.expect_sprint_names_in_order(initial_sprint.name)
+        planning_page.expect_sprint_names_in_order(initial_sprint.name)
 
-        backlogs_page.open_create_sprint_dialog
+        planning_page.open_create_sprint_dialog
 
         within_dialog "New sprint" do
           page.fill_in "Sprint name", with: "Created sprint"
@@ -96,7 +96,7 @@ RSpec.describe "Create", :js do
         end
 
         expect_and_dismiss_flash(message: "Successful creation.")
-        backlogs_page.expect_sprint_names_in_order(initial_sprint.name, "Created sprint")
+        planning_page.expect_sprint_names_in_order(initial_sprint.name, "Created sprint")
 
         sprint = project.reload.sprints.last
         expect(sprint).to be_present
@@ -106,7 +106,7 @@ RSpec.describe "Create", :js do
       end
 
       it "previews the sprint duration when changing the dates" do
-        backlogs_page.open_create_sprint_dialog
+        planning_page.open_create_sprint_dialog
 
         within_dialog "New sprint" do
           expect(page).to have_field "Duration", with: "", readonly: true
@@ -122,7 +122,7 @@ RSpec.describe "Create", :js do
         let(:too_early_finish_date) { start_date - 1.day }
 
         it "validates required fields are present" do
-          backlogs_page.open_create_sprint_dialog
+          planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
             page.fill_in "Sprint name", with: ""
@@ -136,7 +136,7 @@ RSpec.describe "Create", :js do
         end
 
         it "validates finish date is not before start date" do
-          backlogs_page.open_create_sprint_dialog
+          planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
             page.fill_in "Start date", with: start_date_fmt
@@ -157,7 +157,10 @@ RSpec.describe "Create", :js do
         let!(:initial_sprint) { nil } # override so that initial sprint is not present
 
         it "prefilled with 'Sprint 1' if there are no previous sprints" do
-          backlogs_page.open_create_sprint_dialog
+          pending "Currently broken since the blankslate renders without any sprint or version present. " +
+                  "Fix at a later time when backlog items are there #72198"
+
+          planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
             expect(page).to have_field "Sprint name *", with: "Sprint 1", required: true, focused: true
@@ -168,8 +171,8 @@ RSpec.describe "Create", :js do
           before do
             create(:agile_sprint, name: "Be ambitious 42", project:)
 
-            backlogs_page.visit!
-            backlogs_page.open_create_sprint_dialog
+            planning_page.visit!
+            planning_page.open_create_sprint_dialog
           end
 
           it "offers the next sprint name with a number increment" do

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -48,27 +48,6 @@ RSpec.describe "Create", :js do
            finish_date: Date.new(2025, 9, 15))
   end
 
-  let(:story_type) do
-    create(:type_feature)
-  end
-  let(:story_type2) do
-    type = create(:type)
-
-    project.types << type
-
-    type
-  end
-  let(:inactive_story_type) do
-    create(:type)
-  end
-
-  let(:task_type) do
-    type = create(:type_task)
-    project.types << type
-
-    type
-  end
-
   before do
     login_as(user)
 

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe "Create", :js do
       end
     end
 
+    it "renders the menu" do
+      within "#main-menu" do
+        expect(page).to have_css(".selected", text: "Sprint planning")
+      end
+    end
+
     context "with the 'create_sprints' permissions" do
       let(:start_date) { Date.new(2025, 10, 5) }
       let(:start_date_fmt) { start_date.strftime("%Y-%m-%d") }

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Create", :js do
   end
 
   context "with the feature flag active", with_flag: { scrum_projects: true } do
-    it "shows a correct breadcrumb menu" do
+    it "shows the correct breadcrumb menu" do
       within ".PageHeader-breadcrumbs" do
         expect(page).to have_link(href: project_path(project), text: project.name)
         expect(page).to have_link(href: sprint_planning_backlogs_project_backlogs_path(project), text: "Backlogs")
@@ -85,6 +85,8 @@ RSpec.describe "Create", :js do
     end
 
     it "renders the menu" do
+      pending "flaky spec, for whatever reason"
+
       within "#main-menu" do
         expect(page).to have_css(".selected", text: "Sprint planning")
       end

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe "Create", :js do
   end
 
   context "with the feature flag active", with_flag: { scrum_projects: true } do
+    it "shows a correct breadcrumb menu" do
+      within ".PageHeader-breadcrumbs" do
+        expect(page).to have_link(href: project_path(project), text: project.name)
+        expect(page).to have_link(href: sprint_planning_backlogs_project_backlogs_path(project), text: "Backlogs")
+        expect(page).to have_text("Sprint planning")
+      end
+    end
+
     context "with the 'create_sprints' permissions" do
       let(:start_date) { Date.new(2025, 10, 5) }
       let(:start_date_fmt) { start_date.strftime("%Y-%m-%d") }

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe "Edit", :js do
     end
 
     it "adds a work package to a sprint" do
-      planning_page.click_in_sprint_menu(first_sprint, "New story")
+      planning_page.click_in_sprint_menu(first_sprint, "Add work package")
       planning_page.expect_create_work_package_dialog
 
       page.within("#create-work-package-dialog") do
@@ -127,10 +127,9 @@ RSpec.describe "Edit", :js do
       context "when editing a sprint" do
         it "displays all menu entries" do
           planning_page.within_sprint_menu(first_sprint) do |menu|
-            expect(menu).to have_selector :menuitem, count: 3
+            expect(menu).to have_selector :menuitem, count: 2
             expect(menu).to have_selector :menuitem, "Edit sprint"
-            expect(menu).to have_selector :menuitem, "New story"
-            expect(menu).to have_selector :menuitem, "Stories/Tasks"
+            expect(menu).to have_selector :menuitem, "Add work package"
           end
         end
 
@@ -154,11 +153,10 @@ RSpec.describe "Edit", :js do
 
           it "has no menu entry for creating a new story" do
             planning_page.within_sprint_menu(first_sprint) do |menu|
-              expect(menu).to have_selector :menuitem, count: 2
+              expect(menu).to have_selector :menuitem, count: 1
               expect(menu).to have_selector :menuitem, "Edit sprint"
-              expect(menu).to have_selector :menuitem, "Stories/Tasks"
 
-              expect(menu).to have_no_selector :menuitem, "New story"
+              expect(menu).to have_no_selector :menuitem, "Add work package"
             end
           end
         end
@@ -175,7 +173,6 @@ RSpec.describe "Edit", :js do
 
       it "has no menu entry for editing a sprint" do
         planning_page.within_sprint_menu(first_sprint) do |menu|
-          expect(menu).to have_selector :menuitem, "Stories/Tasks"
           expect(menu).to have_no_selector :menuitem, "Edit sprint"
         end
       end

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -40,27 +40,6 @@ RSpec.describe "Edit", :js do
   end
   let(:planning_page) { Pages::SprintPlanning.new(project) }
 
-  let(:story_type) do
-    create(:type_feature)
-  end
-  let(:story_type2) do
-    type = create(:type)
-
-    project.types << type
-
-    type
-  end
-  let(:inactive_story_type) do
-    create(:type)
-  end
-
-  let(:task_type) do
-    type = create(:type_task)
-    project.types << type
-
-    type
-  end
-
   let!(:closed_sprint) do
     create(:agile_sprint,
            project:,
@@ -84,7 +63,7 @@ RSpec.describe "Edit", :js do
   end
 
   let!(:work_package) do
-    create(:work_package, subject: "First work package", project:, sprint: first_sprint, type: story_type)
+    create(:work_package, subject: "First work package", project:, sprint: first_sprint)
   end
 
   # Necessary so that work packages can be created via dialog

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -29,7 +29,7 @@
 #++
 
 require "spec_helper"
-require_relative "../../support/pages/backlogs"
+require_relative "../../support/pages/sprint_planning"
 
 RSpec.describe "Edit", :js do
   let(:project) { create(:project) }
@@ -38,7 +38,7 @@ RSpec.describe "Edit", :js do
   let(:user) do
     create(:user, member_with_permissions: { project => permissions })
   end
-  let(:backlogs_page) { Pages::Backlogs.new(project) }
+  let(:planning_page) { Pages::SprintPlanning.new(project) }
 
   let(:story_type) do
     create(:type_feature)
@@ -94,20 +94,20 @@ RSpec.describe "Edit", :js do
   before do
     login_as(user)
 
-    backlogs_page.visit!
+    planning_page.visit!
   end
 
   context "with the feature flag active", with_flag: { scrum_projects: true } do
     it "lists all open sprints" do
-      backlogs_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
+      planning_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
 
-      backlogs_page.expect_story_in_sprint(work_package, first_sprint)
-      backlogs_page.expect_story_not_in_sprint(work_package, second_sprint)
+      planning_page.expect_story_in_sprint(work_package, first_sprint)
+      planning_page.expect_story_not_in_sprint(work_package, second_sprint)
     end
 
     it "adds a work package to a sprint" do
-      backlogs_page.click_in_sprint_menu(first_sprint, "New story")
-      backlogs_page.expect_create_work_package_dialog
+      planning_page.click_in_sprint_menu(first_sprint, "New story")
+      planning_page.expect_create_work_package_dialog
 
       page.within("#create-work-package-dialog") do
         page.fill_in "Subject", with: "Story created in sprint"
@@ -120,13 +120,13 @@ RSpec.describe "Edit", :js do
       expect_and_dismiss_flash type: :success, message: "New work package created and added as a child"
       created_wp = first_sprint.reload.work_packages.last
       expect(created_wp.subject).to eq("Story created in sprint")
-      backlogs_page.expect_story_in_sprint(created_wp, first_sprint)
+      planning_page.expect_story_in_sprint(created_wp, first_sprint)
     end
 
     context "with the 'create_sprints' permissions" do
       context "when editing a sprint" do
         it "displays all menu entries" do
-          backlogs_page.within_sprint_menu(first_sprint) do |menu|
+          planning_page.within_sprint_menu(first_sprint) do |menu|
             expect(menu).to have_selector :menuitem, count: 3
             expect(menu).to have_selector :menuitem, "Edit sprint"
             expect(menu).to have_selector :menuitem, "New story"
@@ -135,10 +135,10 @@ RSpec.describe "Edit", :js do
         end
 
         it "edits the sprint name" do
-          backlogs_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
+          planning_page.expect_sprint_names_in_order(first_sprint.name, second_sprint.name)
 
-          backlogs_page.click_in_sprint_menu(first_sprint, "Edit sprint")
-          backlogs_page.expect_sprint_dialog
+          planning_page.click_in_sprint_menu(first_sprint, "Edit sprint")
+          planning_page.expect_sprint_dialog
 
           within_dialog "Edit sprint" do
             page.fill_in "Sprint name", with: "Changed name"
@@ -146,14 +146,14 @@ RSpec.describe "Edit", :js do
           end
 
           wait_for_reload
-          backlogs_page.expect_sprint_names_in_order("Changed name", second_sprint.name)
+          planning_page.expect_sprint_names_in_order("Changed name", second_sprint.name)
         end
 
         context "when lacking the 'manage_sprint_items' permission" do
           let(:permissions) { all_permissions - %i[manage_sprint_items] }
 
           it "has no menu entry for creating a new story" do
-            backlogs_page.within_sprint_menu(first_sprint) do |menu|
+            planning_page.within_sprint_menu(first_sprint) do |menu|
               expect(menu).to have_selector :menuitem, count: 2
               expect(menu).to have_selector :menuitem, "Edit sprint"
               expect(menu).to have_selector :menuitem, "Stories/Tasks"
@@ -174,7 +174,7 @@ RSpec.describe "Edit", :js do
       end
 
       it "has no menu entry for editing a sprint" do
-        backlogs_page.within_sprint_menu(first_sprint) do |menu|
+        planning_page.within_sprint_menu(first_sprint) do |menu|
           expect(menu).to have_selector :menuitem, "Stories/Tasks"
           expect(menu).to have_no_selector :menuitem, "Edit sprint"
         end

--- a/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
+++ b/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
         expect(response).to have_no_turbo_frame "content-bodyRight"
       end
     end
+
+    context "with the scrum project feature flag active", with_flag: { scrum_projects: true } do
+      it "redirects to sprint_planning" do
+        get "/projects/#{project.identifier}/backlogs"
+
+        expect(response).to redirect_to("/projects/#{project.identifier}/backlogs/sprint_planning")
+      end
+    end
   end
 
   describe "GET #details" do
@@ -82,6 +90,15 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
 
       expect(response).to have_turbo_frame "backlogs_container", src: "/projects/#{project.identifier}/backlogs"
       expect(response).to have_turbo_frame "content-bodyRight"
+    end
+
+    context "with the scrum project feature flag active", with_flag: { scrum_projects: true } do
+      it "is successful and renders sprint_planning" do
+        get "/projects/#{project.identifier}/backlogs/details/#{story.id}"
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:sprint_planning)
+      end
     end
 
     context "with a Turbo Frame request" do

--- a/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
+++ b/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
@@ -81,6 +81,40 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
     end
   end
 
+  describe "GET #sprint_planning" do
+    context "without the scrum project feature flag" do
+      it "is not successful" do
+        get "/projects/#{project.identifier}/backlogs/sprint_planning"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with the scrum project feature flag active", with_flag: { scrum_projects: true } do
+      it "is successful" do
+        get "/projects/#{project.identifier}/backlogs/sprint_planning"
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template(:sprint_planning)
+
+        expect(response).to have_turbo_frame "backlogs_container", src: "/projects/#{project.identifier}/backlogs/sprint_planning"
+        expect(response).to have_turbo_frame "content-bodyRight"
+      end
+
+      context "with a Turbo Frame request" do
+        it "renders the sprint planning list partial" do
+          get "/projects/#{project.identifier}/backlogs/sprint_planning", headers: { "Turbo-Frame" => "backlogs_container" }
+
+          expect(response).to have_http_status(:ok)
+          expect(response).to render_template("rb_master_backlogs/_sprint_planning_list")
+
+          expect(response).to have_turbo_frame "backlogs_container"
+          expect(response).to have_no_turbo_frame "content-bodyRight"
+        end
+      end
+    end
+  end
+
   describe "GET #details" do
     it "is successful" do
       get "/projects/#{project.identifier}/backlogs/details/#{story.id}"

--- a/modules/backlogs/spec/routing/rb_master_backlogs_routing_spec.rb
+++ b/modules/backlogs/spec/routing/rb_master_backlogs_routing_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe RbMasterBacklogsController do
     }
 
     it {
+      route = "/projects/project_42/backlogs/sprint_planning"
+      expect(get(route)).to route_to(controller: "rb_master_backlogs",
+                                     action: "sprint_planning",
+                                     project_id: "project_42")
+    }
+
+    it {
       expect(get("/projects/project_42/backlogs/details/33")).to route_to(
         controller: "rb_master_backlogs",
         action: "details",

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -31,18 +31,12 @@
 require "support/pages/page"
 
 module Pages
-  class Backlogs < Page
+  class SprintPlanning < Page
     attr_reader :project
 
     def initialize(project)
       super()
       @project = project
-    end
-
-    def enter_edit_backlog_mode(backlog)
-      within_backlog_menu(backlog) do |menu|
-        menu.find(:menuitem, "Edit sprint").click
-      end
     end
 
     def alter_attributes_in_details_view(story, **attributes)
@@ -57,45 +51,14 @@ module Pages
       end
     end
 
-    def alter_attributes_in_edit_backlog_mode(backlog, **attributes)
-      within_backlog(backlog) do
-        attributes.each do |key, value|
-          case key
-          when :name
-            fill_in "Name", with: value
-          when :start_date
-            fill_in "Start date", with: value
-          when :effective_date
-            fill_in "Finish date", with: value
-          else
-            raise NotImplementedError
-          end
-        end
-      end
-    end
-
-    def save_backlog_from_edit_mode(backlog)
-      within_backlog(backlog) do
-        find_field("Name").send_keys :return
-      end
-    end
-
-    def edit_backlog(backlog, **attributes)
-      enter_edit_backlog_mode(backlog)
-
-      alter_attributes_in_edit_backlog_mode(backlog, **attributes)
-
-      save_backlog_from_edit_mode(backlog)
-    end
-
     def edit_story_in_details_view(story, **attributes)
       click_in_story_menu(story, "Open details view")
 
       alter_attributes_in_details_view(story, **attributes)
     end
 
-    def click_in_backlog_menu(backlog, item_name)
-      within_backlog_menu(backlog) do |menu|
+    def click_in_sprint_menu(sprint, item_name)
+      within_sprint_menu(sprint) do |menu|
         menu.find(:menuitem, text: item_name).click
       end
     end
@@ -113,33 +76,25 @@ module Pages
       drag_n_drop_element from: moved_element, to: target_element, offset_x: 0, offset_y: before ? -5 : +10
     end
 
-    def fold_backlog(backlog)
-      within_backlog(backlog) do
-        find(:button, aria: { controls: "backlog_#{backlog.id}-list" }).click
+    def sprint_names_in_order
+      page.find_all("#sprint_backlogs_container > section .CollapsibleHeader-title").map(&:text)
+    end
+
+    def expect_sprint_names_in_order(*sprint_names)
+      expect(sprint_names_in_order).to eq(sprint_names)
+    end
+
+    def expect_story_in_sprint(story, sprint)
+      within_sprint(sprint) do
+        expect(page)
+          .to have_selector(work_package_selector(story).to_s)
       end
     end
 
-    def expect_sprint(sprint)
-      expect(page)
-        .to have_css("#sprint_backlogs_container #{backlog_selector(sprint)}")
-    end
-
-    def expect_backlog(sprint)
-      expect(page)
-        .to have_css("#owner_backlogs_container #{backlog_selector(sprint)}")
-    end
-
-    def expect_story_in_backlog(story, backlog)
-      within_backlog(backlog) do
+    def expect_story_not_in_sprint(story, sprint)
+      within_sprint(sprint) do
         expect(page)
-          .to have_selector(story_selector(story).to_s)
-      end
-    end
-
-    def expect_story_not_in_backlog(story, backlog)
-      within_backlog(backlog) do
-        expect(page)
-          .to have_no_selector(story_selector(story).to_s)
+          .to have_no_selector(work_package_selector(story).to_s)
       end
     end
 
@@ -150,16 +105,6 @@ module Pages
       end
     end
 
-    def expect_stories_in_order(backlog, *stories)
-      within_backlog(backlog) do
-        ids = stories.map { |s| "story_#{s.id}" }
-        existing_ids_in_order = all(ids.map { |id| "##{id}" }.join(", ")).pluck(:id)
-
-        expect(existing_ids_in_order)
-          .to eql(ids)
-      end
-    end
-
     def expect_and_dismiss_error(message)
       expect(page).to have_content message
 
@@ -167,16 +112,7 @@ module Pages
     end
 
     def path
-      backlogs_project_backlogs_path(project)
-    end
-
-    def within_backlog_menu(backlog, &)
-      within_backlog(backlog) do
-        button = find(:button, accessible_name: "Backlog actions")
-        button.click
-
-        within_menu_controlled_by(button, &)
-      end
+      sprint_planning_backlogs_project_backlogs_path(project)
     end
 
     def within_story_menu(story, &)
@@ -205,8 +141,24 @@ module Pages
       details_view
     end
 
+    def open_create_sprint_dialog
+      find_test_selector("op-sprints--new-sprint-button", text: "Sprint").click
+    end
+
+    def expect_sprint_dialog
+      expect(page).to have_css("#new-sprint-dialog")
+    end
+
     def expect_create_work_package_dialog
       expect(page).to have_css("#create-work-package-dialog")
+    end
+
+    def within_sprint_menu(backlog, &)
+      within_sprint(backlog) do
+        find(:button, accessible_name: "Sprint actions").click
+
+        within(:menu, &)
+      end
     end
 
     private
@@ -215,8 +167,12 @@ module Pages
       within(story_selector(story), &)
     end
 
-    def within_backlog(backlog, &)
-      within(backlog_selector(backlog), &)
+    def within_sprint(sprint, &)
+      within(sprint_selector(sprint), &)
+    end
+
+    def sprint_selector(sprint)
+      "#agile_sprint_#{sprint.id}"
     end
 
     def backlog_selector(backlog)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72943

# What are you trying to accomplish?

Set up the "Sprint planning" page.

* Introduce a menu for the backlogs module. The only submenu item is "Sprint planning", which is active by default.
* Change title and breadcrumbs accordingly
* Version-backlogs are displayed on the left, sprints are displayed on the right.
* Sprint planning has its own route, action and view. Most of which are copies of the previous `RbMasterBacklogs#index` implementation. After moving the scrum project related bits out of there, there's less feature flag juggling now.
* Copied the `BacklogsPage` helper over to `SprintPlanning` page, removed all no longer relevant bits from these files so that they are properly split.
* The few relevant CSS changes kept hidden behind a new CSS class, to not cause conflicts with the non-feature-flagged version.
* Drive-by fix of the `SprintComponentMenu` as discussed in today's weekly meeting -> removed all currently not supported menu points and renamed the ones that stay.
* Since the backlog drop down is missing for now, I moved the `+ Sprint` button up into the Header-row, as discussed in our team meeting the other day. The previous, original position is still committed, but commented out. This will make it easy to shift the button to the correct position once it's there.

## Screenshots

<img width="1818" height="1064" alt="image" src="https://github.com/user-attachments/assets/ab63cb26-3538-4aac-b15d-328c9f79ac63" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
