### PR TITLE
Add logo to logo_only layout

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -74,7 +74,7 @@ See COPYRIGHT and LICENSE files for more details.
         </a>
         <%= render_top_menu_left %>
       </div>
-      <div class="op-app-header--center">
+      <div class="op-app-header--center op-app-header--center_mobile-end">
         <%= render_top_menu_center %>
       </div>
       <div class="op-app-header--end">

--- a/app/views/layouts/only_logo.html.erb
+++ b/app/views/layouts/only_logo.html.erb
@@ -39,8 +39,13 @@ See COPYRIGHT and LICENSE files for more details.
                 data: body_data_attributes(local_assigns) do %>
   <div id="wrapper">
     <header class="op-app-header<%= " op-app-header_development" if OpenProject::Configuration.development_highlight_enabled? %>">
-      <div class="op-app-header--center op-logo">
-        <%= link_to(I18n.t("label_home"), home_url, class: "op-logo--link") %>
+      <div class="op-app-header--center">
+        <div class="op-logo">
+          <%= link_to(I18n.t("label_home"), home_url, class: "op-logo--link") %>
+        </div>
+        <% if CustomStyle.current&.logo_mobile.present? || !custom_logo? %>
+          <%= link_to(I18n.t("label_home"), home_url, class: ["op-logo--icon", "op-logo--link"].compact) %>
+        <% end %>
       </div>
     </header>
     <main id="content-wrapper">

--- a/app/views/layouts/only_logo.html.erb
+++ b/app/views/layouts/only_logo.html.erb
@@ -41,10 +41,10 @@ See COPYRIGHT and LICENSE files for more details.
     <header class="op-app-header<%= " op-app-header_development" if OpenProject::Configuration.development_highlight_enabled? %>">
       <div class="op-app-header--center">
         <div class="op-logo">
-          <%= link_to(I18n.t("label_home"), home_url, class: "op-logo--link") %>
+          <%= link_to(I18n.t("label_home"), configurable_home_url, class: "op-logo--link") %>
         </div>
         <% if CustomStyle.current&.logo_mobile.present? || !custom_logo? %>
-          <%= link_to(I18n.t("label_home"), home_url, class: ["op-logo--icon", "op-logo--link"].compact) %>
+          <%= link_to(I18n.t("label_home"), configurable_home_url, class: ["op-logo--icon", "op-logo--link"].compact) %>
         <% end %>
       </div>
     </header>

--- a/frontend/src/global_styles/common/header/app-header.sass
+++ b/frontend/src/global_styles/common/header/app-header.sass
@@ -45,6 +45,7 @@
     grid-area: center
     justify-content: center
 
+  &--center_mobile-end
     @media screen and (max-width: $breakpoint-md)
       justify-content: flex-end
 


### PR DESCRIPTION
Updating the `no_logo` layout to receive some features that have been forgotten before:

* "mobile" logos
* custom home urls

The fact that the regular logo is now hidden below a certain resolution, made the logo disappear entirely due to the omission.

# Ticket
https://community.openproject.org/wp/72369

# Screenshots

**before**
<img width="701" height="528" alt="image" src="https://github.com/user-attachments/assets/e8f602a5-236b-4cbf-a810-42add5e973e2" />

**after**
<img width="701" height="528" alt="image" src="https://github.com/user-attachments/assets/951a9d3a-dd7e-4a2b-80d7-37264d95943b" />
