### PR TITLE
Add button to trigger AMPF sync

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -58,15 +58,12 @@ search:
   ## Paths or `Find.find` patterns to search in:
   paths:
   #  - app/
-   - modules/storages/app/
+    - modules/storages/app/
 
   ## Root directories for relative keys resolution.
-  # relative_roots:
-  #   - app/controllers
-  #   - app/helpers
-  #   - app/mailers
-  #   - app/presenters
-  #   - app/views
+  relative_roots:
+    - modules/storages/app/components
+    - modules/storages/app/views
 
   ## Directories where method names which should not be part of a relative key resolution.
   # By default, if a relative translation is used inside a method, the name of the method will be considered part of the resolved key.

--- a/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.html.erb
+++ b/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.html.erb
@@ -59,6 +59,22 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
         end
+
+        notifications_container.with_row(mt: 2) do
+          if sync_pending?
+            render(Primer::OpenProject::InlineMessage.new(scheme: :success)) { t(".sync_queued") }
+          else
+            render(Primer::Beta::Button.new(
+              tag: :a,
+              scheme: :link,
+              data: { turbo_method: :post },
+              href: ampf_sync_now_admin_settings_storage_path(@storage)
+            )) do |button|
+              button.with_leading_visual_icon(icon: :sync)
+              t(".sync_now")
+            end
+          end
+        end
       end
     end
   end

--- a/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.rb
+++ b/modules/storages/app/components/storages/admin/side_panel/health_notifications_component.rb
@@ -35,9 +35,10 @@ module Storages
       include OpTurbo::Streamable
       include OpPrimer::ComponentHelpers
 
-      def initialize(storage:)
+      def initialize(storage:, sync_pending: false)
         super
         @storage = storage
+        @sync_pending = sync_pending
       end
 
       def render?
@@ -55,6 +56,10 @@ module Storages
         else
           { scheme: :attention, label: I18n.t("storages.health.label_pending") }
         end
+      end
+
+      def sync_pending?
+        @sync_pending
       end
 
       # This method returns the health identifier, description and the time since when the error occurs in a

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -46,7 +46,7 @@ module Storages
       before_action :require_admin
       before_action :find_storage,
                     only: %i[show_oauth_application destroy edit edit_host edit_storage_audience confirm_destroy update
-                             change_health_notifications_enabled replace_oauth_application]
+                             change_health_notifications_enabled replace_oauth_application ampf_sync_now]
       before_action :ensure_valid_wizard_parameters, only: [:new]
       before_action :require_ee_token, only: [:new]
 
@@ -209,6 +209,15 @@ module Storages
           # FIXME: This should be a partial stream update
           render :edit
         end
+      end
+
+      def ampf_sync_now
+        ::Storages::AutomaticallyManagedStorageSyncJob.perform_later(@storage)
+
+        update_via_turbo_stream(
+          component: ::Storages::Admin::SidePanel::HealthNotificationsComponent.new(storage: @storage, sync_pending: true)
+        )
+        respond_with_turbo_streams
       end
 
       private

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -204,6 +204,11 @@ en:
         upload_link_service:
           not_found: The destination folder %{folder} could not be found on %{storage_name}.
   storages:
+    admin:
+      side_panel:
+        health_notifications_component:
+          sync_now: Sync now
+          sync_queued: Synchronization queued.
     buttons:
       done_continue: Done, continue
       open_storage: Open file storage

--- a/modules/storages/config/routes.rb
+++ b/modules/storages/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
           patch :change_health_notifications_enabled
           get :confirm_destroy
           delete :replace_oauth_application
+          post :ampf_sync_now
         end
 
         get :upsell, on: :collection


### PR DESCRIPTION
This is mostly intended for debugging purposes,
when something with AMPF goes wrong. Under normal
operation this button should not be necessary.

# Ticket
https://community.openproject.org/wp/69320

# Screenshots

<img width="320" height="379" alt="image" src="https://github.com/user-attachments/assets/c7c36549-a712-42db-851c-7c0a13b260c0" />

<img width="320" height="379" alt="image" src="https://github.com/user-attachments/assets/81188544-8a2f-49ac-bc56-673cd6644be5" />

