### PR TITLE
Always show message about missing AMPF, when it's missing

### DIFF
--- a/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.ts
@@ -173,7 +173,7 @@ export abstract class FilePickerBaseModalComponent extends OpModalComponent impl
       return of('/');
     }
 
-    if (this.locals.projectFolderMode === 'automatic' && this.locals.projectFolderHref === null) {
+    if (this.locals.projectFolderMode === 'automatic' && !this.locals.projectFolderHref) {
       this.showAlert.next('managedFolderNotFound');
       return of('/');
     }


### PR DESCRIPTION
The previous check was overly specific. In case when the projectFolderHref was not null, but undefined, it would not correctly recognize the missing project folder.

This caused the corresponding alert to be properly shown in the file-picker-modal, but not in the location-picker-modal.

# Ticket
https://community.openproject.org/wp/73122

# Note

We are now also offering the user to upload the file to a location outside the AMPF. At first this surprised me, but I verified in a healthy project, that we never limit the location where a user can upload a file. The AMPF is just the default selection. Thus it's only consistent to also behave the same here and allow an upload anywhere, while showing a warning message.