### PR TITLE
hide story/task/wiki setting in backlogs and ensure new code doesn't rely on it

### DIFF
--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -51,6 +51,8 @@ class RbApplicationController < ApplicationController
   end
 
   def check_if_plugin_is_configured
+    return if OpenProject::FeatureDecisions.scrum_projects_active?
+
     settings = Setting.plugin_openproject_backlogs
     if settings["story_types"].blank? || settings["task_type"].blank?
       respond_to do |format|

--- a/modules/backlogs/app/forms/admin/settings/backlogs_settings_form.rb
+++ b/modules/backlogs/app/forms/admin/settings/backlogs_settings_form.rb
@@ -34,60 +34,62 @@ module Admin
       include ::Settings::FormHelper
 
       form do |f|
-        f.autocompleter(
-          name: :story_types,
-          label: I18n.t(:backlogs_story_type),
-          caption: setting_caption(:plugin_openproject_backlogs, :story_types),
-          autocomplete_options: {
-            multiple: true,
-            closeOnSelect: false,
-            clearable: false,
-            decorated: true,
-            data: {
-              admin__backlogs_settings_target: "storyTypes",
-              test_selector: "story_type_autocomplete"
+        unless scrum_projects_active?
+          f.autocompleter(
+            name: :story_types,
+            label: I18n.t(:backlogs_story_type),
+            caption: setting_caption(:plugin_openproject_backlogs, :story_types),
+            autocomplete_options: {
+              multiple: true,
+              closeOnSelect: false,
+              clearable: false,
+              decorated: true,
+              data: {
+                admin__backlogs_settings_target: "storyTypes",
+                test_selector: "story_type_autocomplete"
+              }
             }
-          }
-        ) do |list|
-          available_types.each do |label, value|
-            active = value.in?(Story.types)
-            in_use = Task.type == value
+          ) do |list|
+            available_types.each do |label, value|
+              active = value.in?(Story.types)
+              in_use = Task.type == value
 
-            list.option(
-              label:,
-              value:,
-              selected: active,
-              disabled: in_use
-            )
+              list.option(
+                label:,
+                value:,
+                selected: active,
+                disabled: in_use
+              )
+            end
           end
-        end
 
-        f.autocompleter(
-          name: :task_type,
-          label: I18n.t(:backlogs_task_type),
-          caption: setting_caption(:plugin_openproject_backlogs, :task_type),
-          input_width: :small,
-          autocomplete_options: {
-            multiple: false,
-            closeOnSelect: true,
-            clearable: false,
-            decorated: true,
-            data: {
-              admin__backlogs_settings_target: "taskType",
-              test_selector: "task_type_autocomplete"
+          f.autocompleter(
+            name: :task_type,
+            label: I18n.t(:backlogs_task_type),
+            caption: setting_caption(:plugin_openproject_backlogs, :task_type),
+            input_width: :small,
+            autocomplete_options: {
+              multiple: false,
+              closeOnSelect: true,
+              clearable: false,
+              decorated: true,
+              data: {
+                admin__backlogs_settings_target: "taskType",
+                test_selector: "task_type_autocomplete"
+              }
             }
-          }
-        ) do |list|
-          available_types.each do |label, value|
-            active = Task.type == value
-            in_use = value.in?(Story.types)
+          ) do |list|
+            available_types.each do |label, value|
+              active = Task.type == value
+              in_use = value.in?(Story.types)
 
-            list.option(
-              label:,
-              value:,
-              selected: active,
-              disabled: in_use
-            )
+              list.option(
+                label:,
+                value:,
+                selected: active,
+                disabled: in_use
+              )
+            end
           end
         end
 
@@ -105,11 +107,13 @@ module Admin
           )
         end
 
-        f.text_field(
-          name: :wiki_template,
-          label: I18n.t(:backlogs_wiki_template),
-          input_width: :medium
-        )
+        unless scrum_projects_active?
+          f.text_field(
+            name: :wiki_template,
+            label: I18n.t(:backlogs_wiki_template),
+            input_width: :medium
+          )
+        end
 
         f.submit(scheme: :primary, name: :apply, label: I18n.t(:button_save))
       end
@@ -118,6 +122,10 @@ module Admin
 
       def available_types
         Type.pluck(:name, :id)
+      end
+
+      def scrum_projects_active?
+        OpenProject::FeatureDecisions.scrum_projects_active?
       end
     end
   end

--- a/modules/backlogs/app/helpers/rb_common_helper.rb
+++ b/modules/backlogs/app/helpers/rb_common_helper.rb
@@ -156,6 +156,8 @@ module RbCommonHelper
   end
 
   def backlogs_types
+    return [] if scrum_projects_enabled?
+
     @backlogs_types ||= begin
       backlogs_ids = Setting.plugin_openproject_backlogs["story_types"]
       backlogs_ids << Setting.plugin_openproject_backlogs["task_type"]
@@ -165,6 +167,8 @@ module RbCommonHelper
   end
 
   def story_types
+    return [] if scrum_projects_enabled?
+
     @story_types ||= begin
       backlogs_type_ids = Setting.plugin_openproject_backlogs["story_types"].map(&:to_i)
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/type_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/type_patch.rb
@@ -39,10 +39,14 @@ module OpenProject::Backlogs::Patches::TypePatch
 
   module InstanceMethods
     def story?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       Story.types.include?(id)
     end
 
     def task?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       Task.type.present? && id == Task.type
     end
   end

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -50,6 +50,8 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
 
   module ClassMethods
     def backlogs_types
+      return [] if OpenProject::FeatureDecisions.scrum_projects_active?
+
       # Unfortunately, this is not cachable so the following line would be wrong
       # @backlogs_types ||= Story.types << Task.type
       # Caching like in the line above would prevent the types selected
@@ -72,6 +74,8 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     end
 
     def is_story?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       backlogs_enabled? && Story.types.include?(type_id)
     end
 
@@ -80,10 +84,14 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     end
 
     def is_task?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       backlogs_enabled? && (parent_id && type_id == Task.type && Task.type.present?)
     end
 
     def is_impediment?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       backlogs_enabled? && (parent_id.nil? && type_id == Task.type && Task.type.present?)
     end
 
@@ -117,6 +125,8 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     end
 
     def in_backlogs_type?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       backlogs_enabled? && WorkPackage.backlogs_types.include?(type.try(:id))
     end
   end

--- a/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
+++ b/modules/backlogs/lib/open_project/backlogs/work_package_filter.rb
@@ -80,6 +80,8 @@ module OpenProject::Backlogs
     private
 
     def backlogs_configured?
+      return false if OpenProject::FeatureDecisions.scrum_projects_active?
+
       Story.types.present? && Task.type.present?
     end
 

--- a/modules/backlogs/spec/features/admin/backlogs_settings_spec.rb
+++ b/modules/backlogs/spec/features/admin/backlogs_settings_spec.rb
@@ -125,4 +125,11 @@ RSpec.describe "Backlogs Admin Settings", :js do
 
     expect(page).to have_field "Template for sprint wiki page", with: "my_sprint_wiki_page"
   end
+
+  it "hides wiki and types selection on scrum projects feature flag active", with_flag: { scrum_projects: true } do
+    expect(page).to have_no_field "Template for sprint wiki page"
+    expect(page).to have_no_css "[data-test-selector='story_type_autocomplete']"
+    expect(page).to have_no_css "[data-test-selector='task_type_autocomplete']"
+    expect(page).to have_css "fieldset", text: "Points burn up/down"
+  end
 end

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -112,11 +112,6 @@ RSpec.describe "Backlogs", :js do
       # TODO: removed in OP #57688, to be reimplemented
       # fill_in "Story Points", with: "5"
 
-      # inactive types should not be selectable but the user can choose from the
-      # active types
-      # TODO: removed in OP #57688, to be reimplemented
-      # expect(page).to have_no_css("option", text: inactive_story_type.name)
-
       select_combo_box_option story_type2.name, from: "Type"
 
       # saving the new story

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -72,14 +72,6 @@ RSpec.describe "Create", :js do
   before do
     login_as(user)
 
-    # Legacy backlogs module requires type configuration
-    allow(Setting)
-      .to receive(:plugin_openproject_backlogs)
-            .and_return("story_types" => [story_type.id.to_s,
-                                          story_type2.id.to_s,
-                                          inactive_story_type.id.to_s],
-                        "task_type" => task_type.id.to_s)
-
     backlogs_page.visit!
   end
 

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -94,14 +94,6 @@ RSpec.describe "Edit", :js do
   before do
     login_as(user)
 
-    # Legacy backlogs module requires type configuration
-    allow(Setting)
-      .to receive(:plugin_openproject_backlogs)
-            .and_return("story_types" => [story_type.id.to_s,
-                                          story_type2.id.to_s,
-                                          inactive_story_type.id.to_s],
-                        "task_type" => task_type.id.to_s)
-
     backlogs_page.visit!
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73101

# What are you trying to accomplish?

Start to turn the backlogs plugin independent of the settings on what constitutes a story/task. 

The Settings are hidden in the instance administration

<img width="315" height="313" alt="image" src="https://github.com/user-attachments/assets/9df7891b-24f9-4d54-8a0c-56abc82b6a18" />

Since it was convenient to do it, the setting for the wiki page template has been removed as well.

To ensure that the setting is not used, methods returning story/task types have been short circuited and return nothing. If the system runs even without those returning anything, it has become independent of the setting.

All of this is only done if the feature flag for the new view is turned on.

There where not many tests where the settings could already be removed but for those it could, the setting has been removed.

# Merge checklist

- [x] Added/updated tests
