### PR TITLE
Revert primer primitives bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@openproject/octicons"
       - dependency-name: "@openproject/primer-view-components"
+      - dependency-name: "@primer/primitives"
+      - dependency-name: "@primer/css"
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,7 @@
         "@openproject/reactivestates": "^3.0.1",
         "@primer/css": "^22.1.0",
         "@primer/live-region-element": "^0.8.0",
-        "@primer/primitives": "^11.5.0",
+        "@primer/primitives": "^11.3.2",
         "@primer/view-components": "npm:@openproject/primer-view-components@^0.82.0",
         "@rails/request.js": "^0.0.13",
         "@stimulus-components/auto-submit": "^6.0.0",
@@ -7823,9 +7823,10 @@
       }
     },
     "node_modules/@primer/primitives": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.5.0.tgz",
-      "integrity": "sha512-vYx9IJeCEZLluZh7Q+sZZXZU8vY2mY9t699AYc7Z2XA6BrVwdcbLbINIS7vjusxb+kQsIK2FshAGJujpV5OMLw=="
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.3.2.tgz",
+      "integrity": "sha512-/8EDh3MmF9cbmrLETFmIuNFIdvpSCkvBlx6zzD8AZ4dZ5UYExQzFj8QAtIrRtCFJ2ZmW5QrtrPR3+JVb8KEDpg==",
+      "license": "MIT"
     },
     "node_modules/@primer/view-components": {
       "name": "@openproject/primer-view-components",
@@ -30582,9 +30583,9 @@
       "integrity": "sha512-KMWYYEIDKNIY0N3fMmNGPWJGHgoJF5NHkJllpOM3upDXuLtAe26Riogp1cfYdhp+sVjGZMt32DxcUhTX7ZhLOQ=="
     },
     "@primer/primitives": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.5.0.tgz",
-      "integrity": "sha512-vYx9IJeCEZLluZh7Q+sZZXZU8vY2mY9t699AYc7Z2XA6BrVwdcbLbINIS7vjusxb+kQsIK2FshAGJujpV5OMLw=="
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.3.2.tgz",
+      "integrity": "sha512-/8EDh3MmF9cbmrLETFmIuNFIdvpSCkvBlx6zzD8AZ4dZ5UYExQzFj8QAtIrRtCFJ2ZmW5QrtrPR3+JVb8KEDpg=="
     },
     "@primer/view-components": {
       "version": "npm:@openproject/primer-view-components@0.82.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,7 +115,7 @@
     "@openproject/reactivestates": "^3.0.1",
     "@primer/css": "^22.1.0",
     "@primer/live-region-element": "^0.8.0",
-    "@primer/primitives": "^11.5.0",
+    "@primer/primitives": "^11.3.2",
     "@primer/view-components": "npm:@openproject/primer-view-components@^0.82.0",
     "@rails/request.js": "^0.0.13",
     "@stimulus-components/auto-submit": "^6.0.0",


### PR DESCRIPTION
The bump to primer/primitives 11.5.0 broke the UI because the borderRadius variable was missing. This PR reverts that change and adds both repos to the ignore list.
