### PR TITLE
Documentation: Fix command for running tests in docker

### DIFF
--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -63,10 +63,10 @@ You can run tests inside the `backend-test` container. You can run specific test
 
 ```shell
 # Run all tests (not recommended)
-docker compose run --rm backend-test bundle exec rspec
+bin/compose rspec
 
 # Run the specified test
-docker compose run --rm backend-test bundle exec rspec spec/features/work_package_show_spec.rb
+bin/compose rspec spec/features/work_package_show_spec.rb
 ```
 
 ***


### PR DESCRIPTION
This is the command the backend-test container itself promotes in its logs. 
The output of the replaced command is not usable:

```
docker compose run --rm backend-test bundle exec rspec spec/models/project_spec.rb
[+]  8/8t 8/88
 ✔ Network openproject-no-tls_testing             Created                                                                                                                                                                                 0.0s
 ✔ Container openproject-no-tls-db-test-1         Started                                                                                                                                                                                 0.2s
 ✔ Container openproject-no-tls-cuprite-chrome-1  Started                                                                                                                                                                                 0.2s
 ✔ Container openproject-no-tls-chrome-1          Started                                                                                                                                                                                 0.2s
 ✔ Container openproject-no-tls-hocuspocus-test-1 Started                                                                                                                                                                                 0.3s
 ✔ Container openproject-no-tls-frontend-test-1   Started                                                                                                                                                                                 0.3s
 ✔ Container openproject-no-tls-firefox-1         Started                                                                                                                                                                                 0.2s
 ✔ Container selenium-hub                         Started                                                                                                                                                                                 0.3s
Container openproject-no-tls-frontend-test-1 Waiting
Container openproject-no-tls-frontend-test-1 Healthy
Container openproject-no-tls-backend-test-run-8cf0273581eb Creating
Container openproject-no-tls-backend-test-run-8cf0273581eb Created
Waiting for the Grid...
In a future version of Bundler, running `bundle` without argument will no longer run `bundle install`.
Instead, the `cli_help` command will be displayed. Please use `bundle install` explicitly for scripts like CI/CD.
You can use the future behavior now with `bundle config set default_cli_command cli_help --global`,
or you can continue to use the current behavior with `bundle config set default_cli_command install --global`.
This message will be removed after a default_cli_command value is set.

Bundle complete! 222 Gemfile dependencies, 494 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
13 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
```

With `bin/compose` the output looks like this:

```
bin/compose exec backend-test bundle exec rspec spec/models/project_spec.rb
DEPRECATION WARNING: Setting action_controller.escape_json_responses = true is deprecated and will have no effect in Rails 8.2. Set it to `false`, or remove the config. (called from block (2 levels) in <top (required)> at /home/dev/openproject/config/initializers/doorkeeper.rb:241)

Randomized with seed 18555

Project
  when the wiki module is enabled
    creates a wiki menu item named like the default start page
    creates a wiki
  #active?
    if active
      is true
    if not active
      is false
  #parent_allowed?
    for a project
      is truthy
    for a program
...
```
