### PR TITLE
[#73137] Add active sprint per project database constraint

### DIFF
--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -66,8 +66,13 @@ module Agile
     validates :finish_date,
               comparison: { greater_than_or_equal_to: :start_date },
               if: :start_date?
-
-    validate :validate_only_one_active_sprint_per_project
+    validates :status,
+              uniqueness: {
+                scope: :project_id,
+                conditions: -> { active },
+                message: :only_one_active_sprint_allowed
+              },
+              if: :active?
 
     def date_range_set?
       start_date? && finish_date?
@@ -85,24 +90,6 @@ module Agile
 
     def task_board?
       task_board.present?
-    end
-
-    private
-
-    # TODO: consider moving this validation to the database level to ensure data integrity.
-    # Doing this in Rails can lead to race conditions. Revisit this topic once the sharing
-    # logic has been fully specified.
-    def validate_only_one_active_sprint_per_project
-      return if !active? || project_id.blank?
-
-      existing_active_sprint = self.class
-                                   .where(project_id:, status: "active")
-                                   .where.not(id:)
-                                   .exists?
-
-      if existing_active_sprint
-        errors.add(:status, :only_one_active_sprint_allowed)
-      end
     end
   end
 end

--- a/modules/backlogs/app/services/sprints/start_service.rb
+++ b/modules/backlogs/app/services/sprints/start_service.rb
@@ -58,6 +58,9 @@ class Sprints::StartService < BaseServices::BaseCallable
     ServiceResult.success(result: model)
   rescue ActiveRecord::RecordInvalid
     unsuccessful_start_result
+  rescue ActiveRecord::RecordNotUnique
+    add_only_one_active_sprint_error
+    unsuccessful_start_result
   end
 
   def unsuccessful_start_result
@@ -76,5 +79,11 @@ class Sprints::StartService < BaseServices::BaseCallable
 
   def unsuccessful_start_message
     model.errors.full_messages.to_sentence if model.errors.any?
+  end
+
+  def add_only_one_active_sprint_error
+    return if model.errors.added?(:status, :only_one_active_sprint_allowed)
+
+    model.errors.add(:status, :only_one_active_sprint_allowed)
   end
 end

--- a/modules/backlogs/db/migrate/20260313170000_add_uniqueness_for_active_sprints.rb
+++ b/modules/backlogs/db/migrate/20260313170000_add_uniqueness_for_active_sprints.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddUniquenessForActiveSprints < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    add_index :sprints, :project_id, unique: true,
+                                     where: "status = 'active'",
+                                     algorithm: :concurrently,
+                                     name: "index_sprints_on_project_id_when_active"
+  end
+
+  def down
+    remove_index :sprints, name: "index_sprints_on_project_id_when_active", algorithm: :concurrently
+  end
+end

--- a/modules/backlogs/spec/services/sprints/start_service_spec.rb
+++ b/modules/backlogs/spec/services/sprints/start_service_spec.rb
@@ -99,6 +99,22 @@ RSpec.describe Sprints::StartService do
     end
   end
 
+  context "when the database unique constraint rejects sprint activation" do
+    before do
+      allow(sprint)
+        .to receive(:active!)
+        .and_raise(ActiveRecord::RecordNotUnique)
+    end
+
+    it "returns failure with the active sprint error", :aggregate_failures do
+      expect(result).not_to be_success
+      expect(result.errors[:status]).to include("only one active sprint is allowed per project.")
+      expect(result.message).to eq(sprint.errors.full_messages.to_sentence)
+      expect(sprint.reload).to be_in_planning
+      expect(sprint.task_board).to be_nil
+    end
+  end
+
   context "when the sprint is already active" do
     let(:status) { "active" }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based off #22086. Please review/merge that PR first. 

# Ticket

https://community.openproject.org/wp/73137

# What are you trying to accomplish?

Adds a database-level guarantee that a project can only have one active sprint.

# What approach did you choose and why?

I added a partial unique index on active sprints per project and kept the model validation for user-facing errors. `Sprints::StartService` also rescues `ActiveRecord::RecordNotUnique` so races still surface as a normal validation failure.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
