### PR TITLE
Rework scrum project feature guards as routing constraints

### DIFF
--- a/modules/backlogs/app/controllers/projects/settings/backlog_sharings_controller.rb
+++ b/modules/backlogs/app/controllers/projects/settings/backlog_sharings_controller.rb
@@ -31,8 +31,6 @@
 class Projects::Settings::BacklogSharingsController < Projects::SettingsController
   menu_item :settings_backlogs
 
-  before_action :check_scrum_projects_feature_flag
-
   def show; end
 
   def update
@@ -50,10 +48,6 @@ class Projects::Settings::BacklogSharingsController < Projects::SettingsControll
   end
 
   private
-
-  def check_scrum_projects_feature_flag
-    render_404 unless OpenProject::FeatureDecisions.scrum_projects_active?
-  end
 
   def backlog_settings_params
     params.expect(project: %i[sprint_sharing])

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -40,9 +40,7 @@ class RbSprintsController < RbApplicationController
 
   skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS
 
-  before_action :not_authorized_on_feature_flag_inactive,
-                :load_project,
-                only: NEW_SPRINT_ACTIONS + SPRINT_STATE_ACTIONS
+  before_action :load_project, only: NEW_SPRINT_ACTIONS + SPRINT_STATE_ACTIONS
 
   def new_dialog
     call = Sprints::SetAttributesService.new(
@@ -108,7 +106,6 @@ class RbSprintsController < RbApplicationController
   end
 
   def start
-    return render_403 unless OpenProject::FeatureDecisions.scrum_projects_active?
     return render_404 unless @sprint.in_planning?
 
     result = start_sprint
@@ -123,7 +120,6 @@ class RbSprintsController < RbApplicationController
   end
 
   def finish
-    return render_403 unless OpenProject::FeatureDecisions.scrum_projects_active?
     return render_404 unless @sprint.active?
 
     result = finish_sprint
@@ -204,8 +200,7 @@ class RbSprintsController < RbApplicationController
   def load_sprint_and_project
     load_project
 
-    @sprint = if OpenProject::FeatureDecisions.scrum_projects_active? &&
-                 (NEW_SPRINT_ACTIONS + SPRINT_STATE_ACTIONS).include?(action_name.to_sym)
+    @sprint = if (NEW_SPRINT_ACTIONS + SPRINT_STATE_ACTIONS).include?(action_name.to_sym)
                 Agile::Sprint.for_project(@project).visible.find(params[:id])
               else
                 Sprint.visible.find(params[:id])
@@ -278,9 +273,5 @@ class RbSprintsController < RbApplicationController
     else
       I18n.t(:notice_unsuccessful_finish)
     end
-  end
-
-  def not_authorized_on_feature_flag_inactive
-    render_403 unless OpenProject::FeatureDecisions.scrum_projects_active?
   end
 end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -29,26 +29,34 @@
 #++
 
 Rails.application.routes.draw do
-  # Routes for the new Agile::Sprint
-  # Scoped under projects for permissions:
-  resources :projects, only: [] do
-    resources :sprints, controller: :rb_sprints, only: %i[create] do
-      collection do
-        get :new_dialog
-        get :refresh_form
-      end
-
-      member do
-        patch :start
-        patch :finish
-        get :edit_dialog
-        put :update_agile_sprint
-      end
-
-      resources :stories, controller: :rb_stories, only: [] do
-        member do
-          put :move
+  constraints(Constraints::FeatureDecision.new(:scrum_projects)) do
+    # Routes for the new Agile::Sprint
+    # Scoped under projects for permissions:
+    resources :projects, only: [] do
+      resources :sprints, controller: :rb_sprints, only: %i[create] do
+        collection do
+          get :new_dialog
+          get :refresh_form
         end
+
+        member do
+          patch :start
+          patch :finish
+          get :edit_dialog
+          put :update_agile_sprint
+        end
+
+        resources :stories, controller: :rb_stories, only: [] do
+          member do
+            put :move
+          end
+        end
+      end
+    end
+
+    scope "projects/:project_id", as: "project", module: "projects" do
+      namespace "settings" do
+        resource :backlog_sharing, only: %i[show update]
       end
     end
   end
@@ -98,8 +106,6 @@ Rails.application.routes.draw do
 
   scope "projects/:project_id", as: "project", module: "projects" do
     namespace "settings" do
-      resource :backlog_sharing, only: %i[show update]
-
       resource :backlogs, only: %i[show update] do
         member do
           post "rebuild_positions" => "backlogs#rebuild_positions"

--- a/modules/backlogs/spec/controllers/projects/settings/backlog_sharings_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/projects/settings/backlog_sharings_controller_spec.rb
@@ -50,20 +50,4 @@ RSpec.describe Projects::Settings::BacklogSharingsController, with_flag: { scrum
       end
     end
   end
-
-  context "when scrum_projects feature flag is inactive", with_flag: { scrum_projects: false } do
-    let(:project) { build_stubbed(:project) }
-
-    it "returns 404 for show" do
-      get :show, params: { project_id: project.identifier }
-
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "returns 404 for update" do
-      patch :update, params: { project_id: project.identifier, project: { sprint_sharing: "no_sharing" } }
-
-      expect(response).to have_http_status(:not_found)
-    end
-  end
 end

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -174,15 +174,6 @@ RSpec.describe RbSprintsController do
     end
 
     describe "GET #new_dialog" do
-      context "with the feature flag inactive" do
-        it "responds with forbidden" do
-          get :new_dialog, params: { project_id: project.id }, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :forbidden
-        end
-      end
-
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         it "responds with success", :aggregate_failures do
           get :new_dialog, params: { project_id: project.id }, format: :turbo_stream
@@ -209,15 +200,6 @@ RSpec.describe RbSprintsController do
     describe "GET #edit_dialog" do
       let!(:sprint) { create(:agile_sprint, project:) }
 
-      context "with the feature flag inactive" do
-        it "responds with forbidden" do
-          get :edit_dialog, params: { project_id: project.id, id: sprint.id }, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :forbidden
-        end
-      end
-
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         it "responds with success", :aggregate_failures do
           get :edit_dialog, params: { project_id: project.id, id: sprint.id }, format: :turbo_stream
@@ -243,15 +225,6 @@ RSpec.describe RbSprintsController do
     end
 
     describe "POST #create" do
-      context "with the feature flag inactive" do
-        it "responds with forbidden" do
-          post :create, params: { project_id: project.id }, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :forbidden
-        end
-      end
-
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         let(:params) do
           {
@@ -287,15 +260,6 @@ RSpec.describe RbSprintsController do
 
     describe "PUT #update_agile_sprint" do
       let!(:sprint) { create(:agile_sprint, name: "Original sprint name", project:) }
-
-      context "with the feature flag inactive" do
-        it "responds with forbidden" do
-          put :update_agile_sprint, params: { id: sprint.id, project_id: project.id }, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :forbidden
-        end
-      end
 
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         let(:params) do
@@ -342,15 +306,6 @@ RSpec.describe RbSprintsController do
           .to receive(:new)
           .with(user:, model: sprint)
           .and_return(service)
-      end
-
-      context "with the feature flag inactive" do
-        it "responds with not found" do
-          patch :start, params: request_params, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status(:not_found)
-        end
       end
 
       context "with the feature flag active", with_flag: { scrum_projects: true } do
@@ -473,15 +428,6 @@ RSpec.describe RbSprintsController do
           .and_return(service)
       end
 
-      context "with the feature flag inactive" do
-        it "responds with not found" do
-          patch :finish, params: request_params
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status(:not_found)
-        end
-      end
-
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         it "finishes the sprint and redirects to the backlog", :aggregate_failures do
           patch :finish, params: request_params
@@ -542,15 +488,6 @@ RSpec.describe RbSprintsController do
     end
 
     describe "GET #refresh_form" do
-      context "with the feature flag inactive" do
-        it "responds with forbidden" do
-          get :refresh_form, params: { project_id: project.id }, format: :turbo_stream
-
-          expect(response).not_to be_successful
-          expect(response).to have_http_status :forbidden
-        end
-      end
-
       context "with the feature flag active", with_flag: { scrum_projects: true } do
         let(:params) do
           {

--- a/modules/backlogs/spec/features/projects/settings/backlog_sharing_settings_spec.rb
+++ b/modules/backlogs/spec/features/projects/settings/backlog_sharing_settings_spec.rb
@@ -143,15 +143,11 @@ RSpec.describe "Backlogs project settings sprint sharing", :js, with_flag: { scr
   end
 
   context "when scrum_projects feature flag is inactive", with_flag: { scrum_projects: false } do
-    it "does not show the sharing tab and returns 404 on direct access" do
+    it "does not show the sharing tab" do
       visit project_settings_backlogs_path(project)
 
       expect(page).to have_heading(I18n.t(:label_backlogs))
       expect(page).to have_no_link(I18n.t("backlogs.sharing"))
-
-      visit project_settings_backlog_sharing_path(project)
-
-      expect(page).to have_text(I18n.t(:notice_file_not_found))
     end
   end
 end

--- a/modules/backlogs/spec/routing/projects/settings/backlog_sharings_routing_spec.rb
+++ b/modules/backlogs/spec/routing/projects/settings/backlog_sharings_routing_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Projects::Settings::BacklogSharingsController do
+  describe "routing" do
+    context "with the feature flag active", with_flag: { scrum_projects: true } do
+      it {
+        expect(get("/projects/project_42/settings/backlog_sharing")).to route_to(
+          controller: "projects/settings/backlog_sharings",
+          action: "show",
+          project_id: "project_42"
+        )
+      }
+
+      it {
+        expect(patch("/projects/project_42/settings/backlog_sharing")).to route_to(
+          controller: "projects/settings/backlog_sharings",
+          action: "update",
+          project_id: "project_42"
+        )
+      }
+    end
+
+    context "with the feature flag inactive", with_flag: { scrum_projects: false } do
+      it { expect(get("/projects/project_42/settings/backlog_sharing")).not_to be_routable }
+      it { expect(patch("/projects/project_42/settings/backlog_sharing")).not_to be_routable }
+    end
+  end
+end

--- a/modules/backlogs/spec/routing/rb_sprints_routing_spec.rb
+++ b/modules/backlogs/spec/routing/rb_sprints_routing_spec.rb
@@ -57,22 +57,76 @@ RSpec.describe RbSprintsController do
                                                                  id: "21")
     }
 
-    it {
-      expect(patch("/projects/project_42/sprints/21/start")).to route_to(
-        controller: "rb_sprints",
-        action: "start",
-        project_id: "project_42",
-        id: "21"
-      )
-    }
+    context "with the feature flag active", with_flag: { scrum_projects: true } do
+      it {
+        expect(get("/projects/project_42/sprints/new_dialog")).to route_to(
+          controller: "rb_sprints",
+          action: "new_dialog",
+          project_id: "project_42"
+        )
+      }
 
-    it {
-      expect(patch("/projects/project_42/sprints/21/finish")).to route_to(
-        controller: "rb_sprints",
-        action: "finish",
-        project_id: "project_42",
-        id: "21"
-      )
-    }
+      it {
+        expect(get("/projects/project_42/sprints/refresh_form")).to route_to(
+          controller: "rb_sprints",
+          action: "refresh_form",
+          project_id: "project_42"
+        )
+      }
+
+      it {
+        expect(post("/projects/project_42/sprints")).to route_to(
+          controller: "rb_sprints",
+          action: "create",
+          project_id: "project_42"
+        )
+      }
+
+      it {
+        expect(get("/projects/project_42/sprints/21/edit_dialog")).to route_to(
+          controller: "rb_sprints",
+          action: "edit_dialog",
+          project_id: "project_42",
+          id: "21"
+        )
+      }
+
+      it {
+        expect(put("/projects/project_42/sprints/21/update_agile_sprint")).to route_to(
+          controller: "rb_sprints",
+          action: "update_agile_sprint",
+          project_id: "project_42",
+          id: "21"
+        )
+      }
+
+      it {
+        expect(patch("/projects/project_42/sprints/21/start")).to route_to(
+          controller: "rb_sprints",
+          action: "start",
+          project_id: "project_42",
+          id: "21"
+        )
+      }
+
+      it {
+        expect(patch("/projects/project_42/sprints/21/finish")).to route_to(
+          controller: "rb_sprints",
+          action: "finish",
+          project_id: "project_42",
+          id: "21"
+        )
+      }
+    end
+
+    context "with the feature flag inactive", with_flag: { scrum_projects: false } do
+      it { expect(get("/projects/project_42/sprints/new_dialog")).not_to be_routable }
+      it { expect(get("/projects/project_42/sprints/refresh_form")).not_to be_routable }
+      it { expect(post("/projects/project_42/sprints")).not_to be_routable }
+      it { expect(get("/projects/project_42/sprints/21/edit_dialog")).not_to be_routable }
+      it { expect(put("/projects/project_42/sprints/21/update_agile_sprint")).not_to be_routable }
+      it { expect(patch("/projects/project_42/sprints/21/start")).not_to be_routable }
+      it { expect(patch("/projects/project_42/sprints/21/finish")).not_to be_routable }
+    end
   end
 end

--- a/modules/backlogs/spec/routing/rb_stories_routing_spec.rb
+++ b/modules/backlogs/spec/routing/rb_stories_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -40,15 +42,21 @@ RSpec.describe RbStoriesController do
       )
     }
 
-    it {
-      expect(put("/projects/project_42/sprints/21/stories/85/move")).to route_to(
-        controller: "rb_stories",
-        action: "move",
-        project_id: "project_42",
-        sprint_id: "21",
-        id: "85"
-      )
-    }
+    context "with the feature flag active", with_flag: { scrum_projects: true } do
+      it {
+        expect(put("/projects/project_42/sprints/21/stories/85/move")).to route_to(
+          controller: "rb_stories",
+          action: "move",
+          project_id: "project_42",
+          sprint_id: "21",
+          id: "85"
+        )
+      }
+    end
+
+    context "with the feature flag inactive", with_flag: { scrum_projects: false } do
+      it { expect(put("/projects/project_42/sprints/21/stories/85/move")).not_to be_routable }
+    end
 
     it {
       expect(post("/projects/project_42/sprints/21/stories/85/reorder")).to route_to(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based off #22086. Please review/merge that PR first. 


# Ticket

n/a

# What are you trying to accomplish?

Use `Constraints::FeatureDecision` for the scrum-only sprint and backlog sharing routes, and move the inactive-flag expectations from controller specs into routing specs.

# What approach did you choose and why?

routing constraints are a cleaner and more concise way of adding guards for functionality behind feature flags

# Merge checklist

- [X] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
