### PR TITLE
Wikis module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,11 @@ PATH
     openproject-webhooks (1.0.0)
 
 PATH
+  remote: modules/wikis
+  specs:
+    openproject-wikis (1.0.0)
+
+PATH
   remote: modules/xls_export
   specs:
     openproject-xls_export (1.0.0)
@@ -1687,6 +1692,7 @@ DEPENDENCIES
   openproject-token (~> 8.8.0)
   openproject-two_factor_authentication!
   openproject-webhooks!
+  openproject-wikis!
   openproject-xls_export!
   opentelemetry-exporter-otlp (~> 0.31.0)
   opentelemetry-instrumentation-all (~> 0.90.0)
@@ -2068,6 +2074,7 @@ CHECKSUMS
   openproject-token (8.8.0) sha256=832a493e05dcce806134faf63ae8011cc5a48422fbed9ebb552f8028912954d4
   openproject-two_factor_authentication (1.0.0)
   openproject-webhooks (1.0.0)
+  openproject-wikis (1.0.0)
   openproject-xls_export (1.0.0)
   openssl (4.0.1) sha256=e27974136b7b02894a1bce46c5397ee889afafe704a839446b54dc81cb9c5f7d
   openssl-signature_algorithm (1.3.0) sha256=a3b40b5e8276162d4a6e50c7c97cdaf1446f9b2c3946a6fa2c14628e0c957e80

--- a/Gemfile.modules
+++ b/Gemfile.modules
@@ -40,6 +40,7 @@ group :opf_plugins do
   gem 'openproject-gantt',                     path: 'modules/gantt'
   gem 'openproject-calendar',                  path: 'modules/calendar'
   gem 'openproject-storages',                  path: 'modules/storages'
+  gem 'openproject-wikis',                     path: 'modules/wikis'
   gem 'openproject-documents',                 path: 'modules/documents'
 
   gem 'openproject-bim',                       path: 'modules/bim'

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -161,7 +161,7 @@ class WikiPage < ApplicationRecord
     content_to = journals.find_by(version: version_to)
     content_from = journals.find_by(version: version_from)
 
-    content_to && content_from ? Wikis::Diff.new(content_to, content_from) : nil
+    content_to && content_from ? WikiPage::Diff.new(content_to, content_from) : nil
   end
 
   def version
@@ -171,7 +171,7 @@ class WikiPage < ApplicationRecord
   def annotate(compare_version = nil)
     compare_version = compare_version ? compare_version.to_i : version
     c = journals.find_by(version: compare_version)
-    c ? Wikis::Annotate.new(c) : nil
+    c ? WikiPage::Annotate.new(c) : nil
   end
 
   # Returns true if usr is allowed to edit the page, otherwise false

--- a/app/models/wiki_page/annotate.rb
+++ b/app/models/wiki_page/annotate.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Wikis::Annotate
+class WikiPage::Annotate
   attr_reader :lines, :content
 
   def initialize(content)

--- a/app/models/wiki_page/diff.rb
+++ b/app/models/wiki_page/diff.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Wikis::Diff < Redmine::Helpers::Diff
+class WikiPage::Diff < Redmine::Helpers::Diff
   attr_reader :content_to, :content_from
 
   def initialize(content_to, content_from)

--- a/modules/wikis/README.md
+++ b/modules/wikis/README.md
@@ -1,0 +1,7 @@
+# OpenProject Wikis Plugin
+
+FIXME Add description and check issue tracker link below
+
+## Issue Tracker
+
+https://community.openproject.org/projects/wikis/work_packages

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  activerecord:
+    attributes: {}
+    errors: {}
+    models: {}
+  wikis: {}

--- a/modules/wikis/lib/open_project/wikis.rb
+++ b/modules/wikis/lib/open_project/wikis.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "open_project/wikis/engine"
+
+module OpenProject
+  module Wikis
+  end
+end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Prevent load-order problems in case openproject-plugins is listed after a plugin in the Gemfile
+# or not at all
+require "open_project/plugins"
+
+module OpenProject::Wikis
+  class Engine < ::Rails::Engine
+    engine_name :openproject_wikis
+
+    include OpenProject::Plugins::ActsAsOpEngine
+
+    register "openproject-wikis",
+             :author_url => "https://openproject.org",
+             :requires_openproject => ">= 17.0.0"
+
+  end
+end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Prevent load-order problems in case openproject-plugins is listed after a plugin in the Gemfile
+# Prevent load-order problems in case openproject-plugins is listed after a plugin in the Gemfile
 # or not at all
 require "open_project/plugins"
 
@@ -39,8 +39,7 @@ module OpenProject::Wikis
     include OpenProject::Plugins::ActsAsOpEngine
 
     register "openproject-wikis",
-             :author_url => "https://openproject.org",
-             :requires_openproject => ">= 17.0.0"
-
+             author_url: "https://openproject.org",
+             requires_openproject: ">= 17.0.0"
   end
 end

--- a/modules/wikis/lib/openproject-wikis.rb
+++ b/modules/wikis/lib/openproject-wikis.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "open_project/wikis"

--- a/modules/wikis/openproject-wikis.gemspec
+++ b/modules/wikis/openproject-wikis.gemspec
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = "openproject-wikis"
+  s.version     = "1.0.0"
+
+  s.authors     = "OpenProject GmbH"
+  s.email       = "info@openproject.org"
+  s.homepage    = "https://community.openproject.org/projects/wikis"  # TODO check this URL
+  s.summary     = "OpenProject Wikis"
+  s.description = "Allows linking work packages to pages in wikis, such as XWiki or the internal OpenProject wiki."
+  s.license     = "GPLv3"
+
+  s.files = Dir["{app,config,db,lib}/**/*"] + %w(CHANGELOG.md README.md)
+end

--- a/modules/wikis/openproject-wikis.gemspec
+++ b/modules/wikis/openproject-wikis.gemspec
@@ -35,10 +35,10 @@ Gem::Specification.new do |s|
 
   s.authors     = "OpenProject GmbH"
   s.email       = "info@openproject.org"
-  s.homepage    = "https://community.openproject.org/projects/wikis"  # TODO check this URL
   s.summary     = "OpenProject Wikis"
   s.description = "Allows linking work packages to pages in wikis, such as XWiki or the internal OpenProject wiki."
   s.license     = "GPLv3"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + %w(CHANGELOG.md README.md)
+  s.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
Begin introducing the basic scaffold for the wikis module.

This includes the renaming of two existing classes that currently occupy the `::Wikis` namespace, which will soon be used by classes defined in the new module.