### PR TITLE
[#72947] Add additional story menu items

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
@@ -93,13 +93,7 @@ export default class StoryController extends Controller<HTMLElement> implements 
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
-    if (
-      target.closest('a') ||
-      target.closest('button') ||
-      target.closest('[data-drag-handle]')
-    ) {
-      return;
-    }
+    if (this.shouldIgnoreMouseTarget(target)) return;
 
     if (this.clickTimeout !== null) return;
 
@@ -113,13 +107,7 @@ export default class StoryController extends Controller<HTMLElement> implements 
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
-    if (
-      target.closest('a') ||
-      target.closest('button') ||
-      target.closest('[data-drag-handle]')
-    ) {
-      return;
-    }
+    if (this.shouldIgnoreMouseTarget(target)) return;
 
     if (this.clickTimeout !== null) {
       clearTimeout(this.clickTimeout);
@@ -135,16 +123,7 @@ export default class StoryController extends Controller<HTMLElement> implements 
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
-    if (
-      target.closest('a') ||
-      target.closest('button') ||
-      target.closest('input') ||
-      target.closest('textarea') ||
-      target.closest('select') ||
-      target.closest("[contenteditable='true']")
-    ) {
-      return;
-    }
+    if (this.shouldIgnoreKeyboardTarget(target)) return;
 
     event.preventDefault();
     if (event.shiftKey) {
@@ -160,5 +139,23 @@ export default class StoryController extends Controller<HTMLElement> implements 
 
   private openFullPane():void {
     Turbo.visit(this.fullUrlValue, { frame: '_top' });
+  }
+
+  private shouldIgnoreMouseTarget(target:HTMLElement):boolean {
+    return [
+      'a',
+      'button',
+      'clipboard-copy',
+      '[data-drag-handle]',
+    ].some((selector) => target.closest(selector) !== null);
+  }
+
+  private shouldIgnoreKeyboardTarget(target:HTMLElement):boolean {
+    return this.shouldIgnoreMouseTarget(target) || [
+      'input',
+      'textarea',
+      'select',
+      "[contenteditable='true']",
+    ].some((selector) => target.closest(selector) !== null);
   }
 }

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
@@ -56,9 +56,34 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :"screen-full")
     end
 
-    if show_move_items?
-      menu.with_divider
-      build_move_menu(menu)
+    menu.with_item(
+      id: dom_target(work_package, :menu, :copy_url_to_clipboard),
+      tag: :"clipboard-copy",
+      label: t(".action_menu.copy_url_to_clipboard"),
+      content_arguments: { value: work_package_url(work_package) }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :copy)
+    end
+
+    menu.with_item(
+      id: dom_target(work_package, :menu, :copy_work_package_id),
+      tag: :"clipboard-copy",
+      label: t(".action_menu.copy_work_package_id"),
+      content_arguments: { value: work_package.id }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :hash)
+    end
+
+    menu.with_divider
+
+    menu.with_sub_menu_item(label: t(".action_menu.move_menu"), disabled: !show_move_items?) do |move_menu|
+      move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
+
+      if show_move_items?
+        with_item_group(move_menu) do
+          build_move_menu(move_menu)
+        end
+      end
     end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
@@ -74,12 +74,12 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :hash)
     end
 
-    menu.with_divider
+    if show_move_items?
+      menu.with_divider
 
-    menu.with_sub_menu_item(label: t(".action_menu.move_menu"), disabled: !show_move_items?) do |move_menu|
-      move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
+      menu.with_sub_menu_item(label: t(".action_menu.move_menu")) do |move_menu|
+        move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 
-      if show_move_items?
         with_item_group(move_menu) do
           build_move_menu(move_menu)
         end

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -30,6 +30,8 @@
 
 module Backlogs
   class InboxMenuComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
     attr_reader :work_package, :project, :max_position, :current_user
 
     def initialize(work_package:, project:, max_position:, current_user: User.current, **system_arguments)

--- a/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
@@ -74,13 +74,15 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :hash)
     end
 
-    menu.with_divider
+    if show_move_items?
+      menu.with_divider
 
-    menu.with_sub_menu_item(label: t(".action_menu.move_menu"), disabled: !show_move_items?) do |move_menu|
-      move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
+      menu.with_sub_menu_item(label: t(".action_menu.move_menu")) do |move_menu|
+        move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 
-      with_item_group(move_menu) do
-        build_move_menu(move_menu)
+        with_item_group(move_menu) do
+          build_move_menu(move_menu)
+        end
       end
     end
   end

--- a/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_menu_component.html.erb
@@ -56,9 +56,32 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :"screen-full")
     end
 
-    if show_move_items?
-      menu.with_divider
-      build_move_menu(menu)
+    menu.with_item(
+      id: dom_target(story, :menu, :copy_url_to_clipboard),
+      tag: :"clipboard-copy",
+      label: t(".action_menu.copy_url_to_clipboard"),
+      content_arguments: { value: work_package_url(story) }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :copy)
+    end
+
+    menu.with_item(
+      id: dom_target(story, :menu, :copy_work_package_id),
+      tag: :"clipboard-copy",
+      label: t(".action_menu.copy_work_package_id"),
+      content_arguments: { value: story.id }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :hash)
+    end
+
+    menu.with_divider
+
+    menu.with_sub_menu_item(label: t(".action_menu.move_menu"), disabled: !show_move_items?) do |move_menu|
+      move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
+
+      with_item_group(move_menu) do
+        build_move_menu(move_menu)
+      end
     end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/story_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/story_menu_component.rb
@@ -30,6 +30,8 @@
 
 module Backlogs
   class StoryMenuComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
     attr_reader :story, :sprint, :project, :max_position, :current_user
 
     def initialize(story:, sprint:, project:, max_position:, current_user: User.current, **system_arguments)

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -159,6 +159,10 @@ en:
 
     inbox_menu_component:
       label_actions: "Work package actions"
+      action_menu:
+        copy_url_to_clipboard: "Copy URL to clipboard"
+        copy_work_package_id: "Copy work package ID"
+        move_menu: "Move"
 
     sprint_header_component:
       label_toggle_backlog: "Collapse/Expand %{name}"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -204,6 +204,10 @@ en:
 
     story_menu_component:
       label_actions: "Story actions"
+      action_menu:
+        copy_url_to_clipboard: "Copy URL to clipboard"
+        copy_work_package_id: "Copy work package ID"
+        move_menu: "Move"
 
   backlogs_points_burn_direction: "Points burn up/down"
   backlogs_product_backlog: "Product backlog"

--- a/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
@@ -118,17 +118,17 @@ RSpec.describe Backlogs::InboxMenuComponent, type: :component do
         text: I18n.t("backlogs.inbox_menu_component.action_menu.copy_work_package_id")
       )
     end
-
-    it "shows a divider before the Move submenu" do
-      render_component
-
-      expect(page).to have_css(".ActionList-sectionDivider")
-    end
   end
 
   describe "move menu" do
     context "with :manage_sprint_items permission" do
       let(:permissions) { [:manage_sprint_items] }
+
+      it "shows a divider before the Move submenu" do
+        render_component
+
+        expect(page).to have_css(".ActionList-sectionDivider")
+      end
 
       it "shows the Move submenu with incoming-arrow icon" do
         render_component
@@ -164,33 +164,23 @@ RSpec.describe Backlogs::InboxMenuComponent, type: :component do
         expect(page).to have_no_text(I18n.t(:label_sort_lowest))
       end
 
-      it "shows the Move submenu disabled when there is only one item" do
+      it "hides the Move submenu when there is only one item" do
         render_component(position: 1, max_position: 1)
 
-        expect(page).to have_no_text(I18n.t(:label_sort_highest))
-        expect(page).to have_no_text(I18n.t(:label_sort_higher))
-        expect(page).to have_no_text(I18n.t(:label_sort_lower))
-        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
-        expect(page).to have_selector(
+        expect(page).to have_no_selector(
           :menuitem,
-          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu"),
-          disabled: true
+          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu")
         )
       end
     end
 
     context "without :manage_sprint_items permission" do
-      it "shows the Move submenu disabled" do
+      it "hides the Move submenu" do
         render_component
 
-        expect(page).to have_no_text(I18n.t(:label_sort_highest))
-        expect(page).to have_no_text(I18n.t(:label_sort_higher))
-        expect(page).to have_no_text(I18n.t(:label_sort_lower))
-        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
-        expect(page).to have_selector(
+        expect(page).to have_no_selector(
           :menuitem,
-          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu"),
-          disabled: true
+          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu")
         )
       end
     end

--- a/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::InboxMenuComponent, type: :component do
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:user) { create(:user) }
+  current_user { user }
+
+  let(:permissions) { [] }
+  let(:project) { create(:project) }
+  let(:position) { 2 }
+  let(:max_position) { 3 }
+  let(:work_package) do
+    create(:work_package,
+           subject: "Inbox Work Package",
+           project:,
+           status: default_status,
+           priority: default_priority,
+           position:)
+  end
+
+  before do
+    create(:member,
+           project:,
+           principal: user,
+           roles: [create(:project_role, permissions:)])
+  end
+
+  def render_component(position: 2, max_position: 3)
+    work_package.update!(position:)
+    render_inline(described_class.new(work_package:, project:, max_position:, current_user: user))
+  end
+
+  describe "standard items" do
+    it "renders stable ids for the action menu and primary actions" do
+      render_component
+
+      expect(page).to have_element(:button, id: /\Awork_package_#{work_package.id}_menu-button\z/)
+      expect(page).to have_element(:ul, id: /\Awork_package_#{work_package.id}_menu-list\z/)
+      expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_details\z/)
+      expect(page).to have_element(:a, id: /\Awork_package_#{work_package.id}_menu_open_fullscreen\z/)
+      expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_url_to_clipboard\z/)
+      expect(page).to have_element(:"clipboard-copy", id: /\Awork_package_#{work_package.id}_menu_copy_work_package_id\z/)
+    end
+
+    it "shows Open details link (split view)" do
+      render_component
+
+      expect(page).to have_text(I18n.t(:"js.button_open_details"))
+      expect(page).to have_octicon(:"op-view-split")
+      expect(page).to have_css(
+        "a[data-turbo-frame='content-bodyRight'][data-turbo-action='advance']",
+        text: I18n.t(:"js.button_open_details")
+      )
+    end
+
+    it "shows Open fullscreen link (full page)" do
+      render_component
+
+      expect(page).to have_text(I18n.t(:"js.button_open_fullscreen"))
+      expect(page).to have_octicon(:"screen-full")
+      expect(page).to have_css(
+        "a[data-turbo-frame='_top']",
+        text: I18n.t(:"js.button_open_fullscreen")
+      )
+    end
+
+    it "shows Copy URL to clipboard action" do
+      render_component
+
+      expect(page).to have_octicon(:copy)
+      expect(page).to have_element(
+        :"clipboard-copy",
+        id: "work_package_#{work_package.id}_menu_copy_url_to_clipboard",
+        value: /\/work_packages\/#{work_package.id}\z/,
+        text: I18n.t("backlogs.inbox_menu_component.action_menu.copy_url_to_clipboard")
+      )
+    end
+
+    it "shows Copy work package ID action" do
+      render_component
+
+      expect(page).to have_octicon(:hash)
+      expect(page).to have_element(
+        :"clipboard-copy",
+        id: "work_package_#{work_package.id}_menu_copy_work_package_id",
+        value: work_package.id.to_s,
+        text: I18n.t("backlogs.inbox_menu_component.action_menu.copy_work_package_id")
+      )
+    end
+
+    it "shows a divider before the Move submenu" do
+      render_component
+
+      expect(page).to have_css(".ActionList-sectionDivider")
+    end
+  end
+
+  describe "move menu" do
+    context "with :manage_sprint_items permission" do
+      let(:permissions) { [:manage_sprint_items] }
+
+      it "shows the Move submenu with incoming-arrow icon" do
+        render_component
+
+        expect(page).to have_selector(:menuitem, text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu"))
+        expect(page).to have_octicon(:"op-arrow-in")
+      end
+
+      it "shows all move options when item is in the middle" do
+        render_component(position: 2, max_position: 3)
+
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
+      end
+
+      it "shows only downward move options when item is first" do
+        render_component(position: 1, max_position: 3)
+
+        expect(page).to have_no_text(I18n.t(:label_sort_highest))
+        expect(page).to have_no_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
+      end
+
+      it "shows only upward move options when item is last" do
+        render_component(position: 3, max_position: 3)
+
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_no_text(I18n.t(:label_sort_lower))
+        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
+      end
+
+      it "shows the Move submenu disabled when there is only one item" do
+        render_component(position: 1, max_position: 1)
+
+        expect(page).to have_no_text(I18n.t(:label_sort_highest))
+        expect(page).to have_no_text(I18n.t(:label_sort_higher))
+        expect(page).to have_no_text(I18n.t(:label_sort_lower))
+        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_selector(
+          :menuitem,
+          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu"),
+          disabled: true
+        )
+      end
+    end
+
+    context "without :manage_sprint_items permission" do
+      it "shows the Move submenu disabled" do
+        render_component
+
+        expect(page).to have_no_text(I18n.t(:label_sort_highest))
+        expect(page).to have_no_text(I18n.t(:label_sort_higher))
+        expect(page).to have_no_text(I18n.t(:label_sort_lower))
+        expect(page).to have_no_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_selector(
+          :menuitem,
+          text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu"),
+          disabled: true
+        )
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
@@ -221,13 +221,12 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
         expect(page).to have_no_text(I18n.t(:label_sort_lowest))
       end
 
-      it "shows the Move submenu disabled" do
+      it "hides the Move submenu" do
         render_component(position: 1, max_position: 1)
 
-        expect(page).to have_selector(
+        expect(page).to have_no_selector(
           :menuitem,
-          text: I18n.t("backlogs.story_menu_component.action_menu.move_menu"),
-          disabled: true
+          text: I18n.t("backlogs.story_menu_component.action_menu.move_menu")
         )
       end
     end

--- a/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_menu_component_spec.rb
@@ -66,13 +66,15 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
   end
 
   describe "standard items" do
-    it "renders stable ids for the action menu and primary links" do
+    it "renders stable ids for the action menu and primary actions" do
       render_component
 
       expect(page).to have_element(:button, id: /\Astory_#{story.id}_menu-button\z/)
       expect(page).to have_element(:ul, id: /\Astory_#{story.id}_menu-list\z/)
       expect(page).to have_element(:a, id: /\Astory_#{story.id}_menu_open_details\z/)
       expect(page).to have_element(:a, id: /\Astory_#{story.id}_menu_open_fullscreen\z/)
+      expect(page).to have_element(:"clipboard-copy", id: /\Astory_#{story.id}_menu_copy_url_to_clipboard\z/)
+      expect(page).to have_element(:"clipboard-copy", id: /\Astory_#{story.id}_menu_copy_work_package_id\z/)
     end
 
     it "shows Open details link (split view)" do
@@ -97,10 +99,41 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
       )
     end
 
-    it "shows a divider before move options" do
+    it "shows Copy URL to clipboard action" do
+      render_component
+
+      expect(page).to have_octicon(:copy)
+      expect(page).to have_element(
+        :"clipboard-copy",
+        id: "story_#{story.id}_menu_copy_url_to_clipboard",
+        value: /\/work_packages\/#{story.id}\z/,
+        text: I18n.t("backlogs.story_menu_component.action_menu.copy_url_to_clipboard")
+      )
+    end
+
+    it "shows Copy work package ID action" do
+      render_component
+
+      expect(page).to have_octicon(:hash)
+      expect(page).to have_element(
+        :"clipboard-copy",
+        id: "story_#{story.id}_menu_copy_work_package_id",
+        value: story.id.to_s,
+        text: I18n.t("backlogs.story_menu_component.action_menu.copy_work_package_id")
+      )
+    end
+
+    it "shows a divider before the Move submenu" do
       render_component
 
       expect(page).to have_css(".ActionList-sectionDivider")
+    end
+
+    it "shows the Move submenu with incoming-arrow icon" do
+      render_component
+
+      expect(page).to have_selector(:menuitem, text: I18n.t("backlogs.story_menu_component.action_menu.move_menu"))
+      expect(page).to have_octicon(:"op-arrow-in")
     end
   end
 
@@ -188,10 +221,14 @@ RSpec.describe Backlogs::StoryMenuComponent, type: :component do
         expect(page).to have_no_text(I18n.t(:label_sort_lowest))
       end
 
-      it "hides the divider" do
+      it "shows the Move submenu disabled" do
         render_component(position: 1, max_position: 1)
 
-        expect(page).to have_no_css(".ActionList-sectionDivider")
+        expect(page).to have_selector(
+          :menuitem,
+          text: I18n.t("backlogs.story_menu_component.action_menu.move_menu"),
+          disabled: true
+        )
       end
     end
   end

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -82,36 +82,45 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
     end
 
     it "allows reordering items via the kebab menu", :aggregate_failures do
+      items_in_visual_order = planning_page.inbox_items_in_visual_order(inbox_wp1, inbox_wp2, inbox_wp3)
+      top_item = items_in_visual_order[0]
+      middle_item = items_in_visual_order[1]
+      bottom_item = items_in_visual_order[2]
+
       # First item has no upward actions
-      planning_page.within_inbox_menu(inbox_wp1) do |menu|
-        expect(menu).to have_no_selector(:menuitem, text: "Move to top")
-        expect(menu).to have_no_selector(:menuitem, text: "Move up")
-        expect(menu).to have_selector(:menuitem, text: "Move down")
-        expect(menu).to have_selector(:menuitem, text: "Move to bottom")
+      planning_page.within_inbox_menu(top_item) do |menu|
+        planning_page.within_move_submenu(menu) do |submenu|
+          expect(submenu).to have_no_selector(:menuitem, text: "Move to top")
+          expect(submenu).to have_no_selector(:menuitem, text: "Move up")
+          expect(submenu).to have_selector(:menuitem, text: "Move down")
+          expect(submenu).to have_selector(:menuitem, text: "Move to bottom")
+        end
       end
 
       # Last item has no downward actions
-      planning_page.within_inbox_menu(inbox_wp3) do |menu|
-        expect(menu).to have_selector(:menuitem, text: "Move to top")
-        expect(menu).to have_selector(:menuitem, text: "Move up")
-        expect(menu).to have_no_selector(:menuitem, text: "Move down")
-        expect(menu).to have_no_selector(:menuitem, text: "Move to bottom")
+      planning_page.within_inbox_menu(bottom_item) do |menu|
+        planning_page.within_move_submenu(menu) do |submenu|
+          expect(submenu).to have_selector(:menuitem, text: "Move to top")
+          expect(submenu).to have_selector(:menuitem, text: "Move up")
+          expect(submenu).to have_no_selector(:menuitem, text: "Move down")
+          expect(submenu).to have_no_selector(:menuitem, text: "Move to bottom")
+        end
       end
 
-      planning_page.click_in_inbox_menu(inbox_wp1, "Move down")
-      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
+      planning_page.click_in_inbox_move_menu(top_item, "Move down")
+      planning_page.expect_inbox_items_in_order(middle_item, top_item, bottom_item)
 
-      planning_page.click_in_inbox_menu(inbox_wp1, "Move down")
-      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
+      planning_page.click_in_inbox_move_menu(top_item, "Move down")
+      planning_page.expect_inbox_items_in_order(middle_item, bottom_item, top_item)
 
-      planning_page.click_in_inbox_menu(inbox_wp2, "Move to bottom")
-      planning_page.expect_inbox_items_in_order(inbox_wp3, inbox_wp1, inbox_wp2)
+      planning_page.click_in_inbox_move_menu(middle_item, "Move to bottom")
+      planning_page.expect_inbox_items_in_order(bottom_item, top_item, middle_item)
 
-      planning_page.click_in_inbox_menu(inbox_wp2, "Move to top")
-      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
+      planning_page.click_in_inbox_move_menu(middle_item, "Move to top")
+      planning_page.expect_inbox_items_in_order(middle_item, bottom_item, top_item)
 
-      planning_page.click_in_inbox_menu(inbox_wp1, "Move up")
-      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
+      planning_page.click_in_inbox_move_menu(top_item, "Move up")
+      planning_page.expect_inbox_items_in_order(middle_item, top_item, bottom_item)
     end
 
     describe "moving backlog items to a sprint via drag-and-drop" do
@@ -143,36 +152,45 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
       before { planning_page.visit! }
 
       it "allows reordering items", :aggregate_failures do
+        items_in_visual_order = planning_page.sprint_items_in_visual_order(sprint, sprint_wp1, sprint_wp2, sprint_wp3)
+        top_item = items_in_visual_order[0]
+        middle_item = items_in_visual_order[1]
+        bottom_item = items_in_visual_order[2]
+
         # First item has no upward actions
-        planning_page.within_sprint_story_menu(sprint_wp1) do |menu|
-          expect(menu).to have_no_selector(:menuitem, text: "Move to top")
-          expect(menu).to have_no_selector(:menuitem, text: "Move up")
-          expect(menu).to have_selector(:menuitem, text: "Move down")
-          expect(menu).to have_selector(:menuitem, text: "Move to bottom")
+        planning_page.within_sprint_story_menu(top_item) do |menu|
+          planning_page.within_move_submenu(menu) do |submenu|
+            expect(submenu).to have_no_selector(:menuitem, text: "Move to top")
+            expect(submenu).to have_no_selector(:menuitem, text: "Move up")
+            expect(submenu).to have_selector(:menuitem, text: "Move down")
+            expect(submenu).to have_selector(:menuitem, text: "Move to bottom")
+          end
         end
 
         # Last item has no downward actions
-        planning_page.within_sprint_story_menu(sprint_wp3) do |menu|
-          expect(menu).to have_selector(:menuitem, text: "Move to top")
-          expect(menu).to have_selector(:menuitem, text: "Move up")
-          expect(menu).to have_no_selector(:menuitem, text: "Move down")
-          expect(menu).to have_no_selector(:menuitem, text: "Move to bottom")
+        planning_page.within_sprint_story_menu(bottom_item) do |menu|
+          planning_page.within_move_submenu(menu) do |submenu|
+            expect(submenu).to have_selector(:menuitem, text: "Move to top")
+            expect(submenu).to have_selector(:menuitem, text: "Move up")
+            expect(submenu).to have_no_selector(:menuitem, text: "Move down")
+            expect(submenu).to have_no_selector(:menuitem, text: "Move to bottom")
+          end
         end
 
-        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move down")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp1, sprint_wp3])
+        planning_page.click_in_sprint_story_move_menu(top_item, "Move down")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
 
-        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move down")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp3, sprint_wp1])
+        planning_page.click_in_sprint_story_move_menu(top_item, "Move down")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
 
-        planning_page.click_in_sprint_story_menu(sprint_wp2, "Move to bottom")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp3, sprint_wp1, sprint_wp2])
+        planning_page.click_in_sprint_story_move_menu(middle_item, "Move to bottom")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [bottom_item, top_item, middle_item])
 
-        planning_page.click_in_sprint_story_menu(sprint_wp2, "Move to top")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp3, sprint_wp1])
+        planning_page.click_in_sprint_story_move_menu(middle_item, "Move to top")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, bottom_item, top_item])
 
-        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move up")
-        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp1, sprint_wp3])
+        planning_page.click_in_sprint_story_move_menu(top_item, "Move up")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [middle_item, top_item, bottom_item])
       end
     end
 

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -97,9 +97,21 @@ module Pages
       raise ArgumentError, "work_packages should not be empty" if work_packages.empty?
 
       selectors = work_packages.map { |wp| work_package_selector(wp) }
-
       expect(page)
         .to have_css(selectors.join(" + "))
+      wait_for_network_idle
+    end
+
+    def sprint_items_in_visual_order(sprint, *work_packages)
+      tops = within_sprint(sprint) do
+        work_packages.index_with do |wp|
+          page.evaluate_script(
+            "document.querySelector('#{work_package_selector(wp)}').getBoundingClientRect().top"
+          )
+        end
+      end
+
+      work_packages.sort_by { |wp| tops.fetch(wp) }
     end
 
     def drag_work_package(moved, before: nil, into: nil)
@@ -151,15 +163,28 @@ module Pages
         selectors = work_packages.map { |wp| inbox_item_selector(wp) }
         expect(page).to have_css(selectors.join(" + "))
       end
+
+      wait_for_network_idle
+    end
+
+    def inbox_items_in_visual_order(*work_packages)
+      tops = within_inbox do
+        work_packages.index_with do |wp|
+          page.evaluate_script(
+            "document.querySelector('#{inbox_item_selector(wp)}').getBoundingClientRect().top"
+          )
+        end
+      end
+
+      work_packages.sort_by { |wp| tops.fetch(wp) }
     end
 
     def within_inbox_menu(work_package, &)
       within(inbox_item_selector(work_package)) do
         button = find(:button, accessible_name: "Work package actions")
-        button.click
-        within_menu_controlled_by(button, &)
+        within(open_controlled_menu(button), &)
       end
-      page.send_keys(:escape)
+      dismiss_menu
     end
 
     def click_in_inbox_menu(work_package, item_name)
@@ -168,19 +193,36 @@ module Pages
       end
     end
 
+    def click_in_inbox_move_menu(work_package, item_name)
+      button = within(inbox_item_selector(work_package)) do
+        find(:button, accessible_name: "Work package actions")
+      end
+      menu = open_controlled_menu(button)
+      submenu = open_move_submenu(menu)
+      submenu.find(:menuitem, text: item_name).click
+    end
+
     def within_sprint_story_menu(story, &)
       within(work_package_selector(story)) do
         button = find(:button, accessible_name: "Story actions")
-        button.click
-        within_menu_controlled_by(button, &)
+        within(open_controlled_menu(button), &)
       end
-      page.send_keys(:escape)
+      dismiss_menu
     end
 
     def click_in_sprint_story_menu(story, item_name)
       within_sprint_story_menu(story) do |menu|
         menu.find(:menuitem, text: item_name).click
       end
+    end
+
+    def click_in_sprint_story_move_menu(story, item_name)
+      button = within(work_package_selector(story)) do
+        find(:button, accessible_name: "Story actions")
+      end
+      menu = open_controlled_menu(button)
+      submenu = open_move_submenu(menu)
+      submenu.find(:menuitem, text: item_name).click
     end
 
     def drag_inbox_item_to_sprint(work_package, sprint)
@@ -250,9 +292,7 @@ module Pages
     def within_story_menu(story, &)
       within_story(story) do
         button = find(:button, accessible_name: "Story actions")
-        button.click
-
-        within_menu_controlled_by(button, &)
+        within(open_controlled_menu(button), &)
       end
     end
 
@@ -298,9 +338,7 @@ module Pages
     def within_sprint_menu(sprint, &)
       within_sprint(sprint) do
         button = find(:button, accessible_name: "Sprint actions")
-        button.click
-
-        within_menu_controlled_by(button, &)
+        within(open_controlled_menu(button), &)
       end
     end
 
@@ -337,6 +375,10 @@ module Pages
 
         click_button "Close sprint"
       end
+    end
+
+    def within_move_submenu(menu, &)
+      within(open_move_submenu(menu), &)
     end
 
     private
@@ -377,13 +419,19 @@ module Pages
       "#work_package_#{work_package.id}"
     end
 
-    def within_menu_controlled_by(button)
-      menu_id = button[:controls] || button["aria-controls"]
-      menu = page.find(:menu, id: menu_id)
+    def open_controlled_menu(button)
+      button.click
+      page.find(:menu, id: button[:controls] || button["aria-controls"])
+    end
 
-      within(menu) do
-        yield page
-      end
+    def open_move_submenu(menu)
+      move_item = menu.find(:menuitem, text: "Move")
+      move_item.click
+      page.find(:menu, id: move_item["aria-controls"])
+    end
+
+    def dismiss_menu
+      page.find("body").click
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72947

# What are you trying to accomplish?

Add the new backlog work package action menu items from the sprint/backlog redesign.

This updates both story and inbox menus to:
- add `Copy URL to clipboard`
- add `Copy work package ID`
- move the reorder actions into a dedicated `Move` submenu

It also updates the story row Stimulus controller so clicking `clipboard-copy` does not open the details view.

# What approach did you choose and why?

This keeps the new actions aligned across story and inbox rows, uses the same Primer action menu patterns, and makes the reorder actions easier to scan by grouping them under a dedicated submenu.

## Screenshots

<img width="255" height="262" alt="Screenshot 2026-03-25 at 13 55 24" src="https://github.com/user-attachments/assets/4e4546ee-e85a-44ad-a3a4-89066ed2d33a" />

<img width="435" height="334" alt="Screenshot 2026-03-25 at 13 55 38" src="https://github.com/user-attachments/assets/f6dd6f3c-f36d-4b96-a419-d7239d6f087b" />

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
