### PR TITLE
[#73188] Remove EE guards from boards

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -92,28 +92,18 @@ function workPackageFullViewTour() {
   });
 }
 
-function ganttTour(configuration:ConfigurationService) {
+function ganttTour(_configuration:ConfigurationService) {
   initializeTour('ganttTourFinished');
 
   const boardsDemoDataAvailable = getMetaContent('boards_demo_data_available') === 'true';
   const teamPlannerDemoDataAvailable = getMetaContent('demo_view_of_type_team_planner_seeded') === 'true';
-  const eeTokenAvailable = configuration.availableFeatures.includes('board_view');
 
   waitForElement('.work-package--results-tbody', '#content', () => {
     let steps:OnboardingStep[] = ganttOnboardingTourSteps();
-    // Check for EE edition
-    if (eeTokenAvailable) {
-      // ... and available seed data of boards.
-      // Then add boards to the tour, otherwise skip it.
-      if (boardsDemoDataAvailable && moduleVisible('boards')) {
-        steps = steps.concat(navigateToBoardStep('enterprise'));
-      } else if (teamPlannerDemoDataAvailable && moduleVisible('team-planner-view')) {
-        steps = steps.concat(navigateToTeamPlannerStep());
-      } else {
-        steps = steps.concat(menuTourSteps());
-      }
-    } else if (boardsDemoDataAvailable && moduleVisible('boards')) {
-      steps = steps.concat(navigateToBoardStep('basic'));
+    if (boardsDemoDataAvailable && moduleVisible('boards')) {
+      steps = steps.concat(navigateToBoardStep('enterprise'));
+    } else if (teamPlannerDemoDataAvailable && moduleVisible('team-planner-view')) {
+      steps = steps.concat(navigateToTeamPlannerStep());
     } else {
       steps = steps.concat(menuTourSteps());
     }
@@ -122,14 +112,13 @@ function ganttTour(configuration:ConfigurationService) {
   });
 }
 
-function boardTour(configuration:ConfigurationService) {
+function boardTour(_configuration:ConfigurationService) {
   initializeTour('boardsTourFinished');
 
   const teamPlannerDemoDataAvailable = getMetaContent('demo_view_of_type_team_planner_seeded') === 'true';
-  const eeTokenAvailable = configuration.availableFeatures.includes('board_view');
 
   waitForElement('wp-single-card', '#content', () => {
-    let steps:OnboardingStep[] = eeTokenAvailable ? boardTourSteps('enterprise') : boardTourSteps('basic');
+    let steps:OnboardingStep[] = boardTourSteps('enterprise');
 
     // Available seed data of team planner.
     // Then add Team planner to the tour, otherwise skip it.

--- a/frontend/src/app/features/boards/board/board-actions/board-actions-registry.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/board-actions-registry.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { BoardActionService } from 'core-app/features/boards/board/board-actions/board-action.service';
-import { BannersService } from 'core-app/core/enterprise/banners.service';
 
 export interface ITileViewEntry {
   text:string;
@@ -13,10 +12,6 @@ export interface ITileViewEntry {
 
 @Injectable({ providedIn: 'root' })
 export class BoardActionsRegistryService {
-  constructor(
-    private bannersService:BannersService,
-  ) {}
-
   private mapping:Record<string, BoardActionService> = {};
 
   public add(attribute:string, service:BoardActionService):void {
@@ -30,7 +25,6 @@ export class BoardActionsRegistryService {
       icon: '',
       description: '',
       image: '',
-      disabled: !this.bannersService.allowsTo('board_view'),
     }));
   }
 

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -1,57 +1,49 @@
 @if ((board$ | async); as board) {
-  @if (!board.isFree) {
-    <op-enterprise-banner-frame class="boards-list--enterprise-banner"
-      feature="board_view"
-      [dismissable]="true"
-     />
-  }
-  @if (available) {
-    <div
-      class="boards-list--container"
-      [ngClass]="{ '-free' : board.isFree }"
-      #container
-      cdkDropList
-      [cdkDropListDisabled]="!board.editable"
-      cdkDropListOrientation="horizontal"
-      (cdkDropListDropped)="moveList(board, $event)"
-      >
-      @for (boardWidget of boardWidgets; track trackByQueryId($index, boardWidget)) {
-        <div
-          class="boards-list--item"
-          cdkDrag
-          [cdkDragData]="boardWidget"
-          >
-          @if (board.editable) {
-            <span
-              class="boards-list-item-handle icon icon-drag-handle"
-            cdkDragHandle></span>
-          }
-          <board-list [resource]="boardWidget"
-            [board]="board"
-            (onRemove)="removeList(board, boardWidget)"
-            (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)" />
+  <div
+    class="boards-list--container"
+    [ngClass]="{ '-free' : board.isFree }"
+    #container
+    cdkDropList
+    [cdkDropListDisabled]="!board.editable"
+    cdkDropListOrientation="horizontal"
+    (cdkDropListDropped)="moveList(board, $event)"
+    >
+    @for (boardWidget of boardWidgets; track trackByQueryId($index, boardWidget)) {
+      <div
+        class="boards-list--item"
+        cdkDrag
+        [cdkDragData]="boardWidget"
+        >
+        @if (board.editable) {
+          <span
+            class="boards-list-item-handle icon icon-drag-handle"
+          cdkDragHandle></span>
+        }
+        <board-list [resource]="boardWidget"
+          [board]="board"
+          (onRemove)="removeList(board, boardWidget)"
+          (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)" />
+      </div>
+    }
+    @if (showHiddenListWarning) {
+      <span
+        class="boards-list--tooltip tooltip--right"
+        [attr.data-tooltip]="text.hiddenListWarning">
+        <i class="icon icon-attention"></i>
+      </span>
+    }
+    @if (board.editable) {
+      <div class="boards-list--add-item -no-text-select"
+        role="button"
+        tabindex="0"
+        (click)="addList(board)"
+        (keydown.enter)="addList(board)"
+        (keydown.space)="addList(board)">
+        <div class="boards-list--add-item-text">
+          <op-icon icon-classes="icon-add icon-context" />
+          <span [textContent]="text.addList"></span>
         </div>
-      }
-      @if (showHiddenListWarning) {
-        <span
-          class="boards-list--tooltip tooltip--right"
-          [attr.data-tooltip]="text.hiddenListWarning">
-          <i class="icon icon-attention"></i>
-        </span>
-      }
-      @if (board.editable) {
-        <div class="boards-list--add-item -no-text-select"
-          role="button"
-          tabindex="0"
-          (click)="addList(board)"
-          (keydown.enter)="addList(board)"
-          (keydown.space)="addList(board)">
-          <div class="boards-list--add-item-text">
-            <op-icon icon-classes="icon-add icon-context" />
-            <span [textContent]="text.addList"></span>
-          </div>
-        </div>
-      }
-    </div>
-  }
+      </div>
+    }
+  </div>
 }

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -17,7 +17,6 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
 import { BoardListsService } from 'core-app/features/boards/board/board-list/board-lists.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { BoardService } from 'core-app/features/boards/board/board.service';
-import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { DragAndDropService } from 'core-app/shared/helpers/drag-and-drop/drag-and-drop.service';
 import { QueryUpdatedService } from 'core-app/features/boards/board/query-updated/query-updated.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -40,7 +39,6 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import {
   WorkPackageStatesInitializationService,
 } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
-import { enterpriseDocsUrl } from 'core-app/core/setup/globals/constants.const';
 
 @Component({
   templateUrl: './board-list-container.component.html',
@@ -89,8 +87,6 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
 
   showHiddenListWarning = false;
 
-  available = this.Banner.allowsTo('board_view');
-
   private currentQueryUpdatedMonitoring:Subscription;
 
   constructor(
@@ -105,7 +101,6 @@ readonly I18n:I18nService,
     readonly injector:Injector,
     readonly apiV3Service:ApiV3Service,
     readonly Boards:BoardService,
-    readonly Banner:BannersService,
     readonly boardListCrossSelectionService:BoardListCrossSelectionService,
     readonly wpStatesInitialization:WorkPackageStatesInitializationService,
     readonly Drag:DragAndDropService,
@@ -125,10 +120,6 @@ readonly I18n:I18nService,
       .pipe(
         tap((board) => this.setupQueryUpdatedMonitoring(board)),
       );
-
-    this.board$.subscribe((board) => {
-      this.available = this.Banner.allowsTo('board_view') || board.isFree;
-    });
 
     this.Boards.currentBoard$.next(id);
 

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ::Boards
   class BoardsController < BaseController
     include Layout
@@ -11,7 +13,6 @@ module ::Boards
 
     before_action :build_board_grid, only: %i[new]
     before_action :load_query, only: %i[index]
-    before_action :ensure_board_type_not_restricted, only: %i[create]
 
     menu_item :boards
 
@@ -85,14 +86,6 @@ module ::Boards
       @board_grid = Boards::Grid.new
     end
 
-    def ensure_board_type_not_restricted
-      render_403 if restricted_board_type?
-    end
-
-    def restricted_board_type?
-      !EnterpriseToken.allows_to?(:board_view) && board_grid_params[:attribute] != "basic"
-    end
-
     def service_call
       service_class.new(user: User.current)
                    .call(
@@ -114,7 +107,7 @@ module ::Boards
     end
 
     def board_grid_params
-      params.require(:boards_grid).permit(%i[name attribute])
+      params.expect(boards_grid: %i[name attribute])
     end
   end
 end

--- a/modules/boards/app/helpers/boards_helper.rb
+++ b/modules/boards/app/helpers/boards_helper.rb
@@ -4,12 +4,11 @@ module BoardsHelper
   BoardTypeAttributes = Struct.new(:radio_button_value,
                                    :title,
                                    :description,
-                                   :image_path,
-                                   :disabled?)
+                                   :image_path)
 
   def board_types
     [
-      build_board_type_attributes("basic", "lists", false),
+      build_board_type_attributes("basic", "lists"),
       build_board_type_attributes("status", "status"),
       build_board_type_attributes("assignee", "assignees"),
       build_board_type_attributes("version", "version"),
@@ -18,12 +17,11 @@ module BoardsHelper
     ]
   end
 
-  def build_board_type_attributes(type_name, image_name, disabled = !EnterpriseToken.allows_to?(:board_view))
+  def build_board_type_attributes(type_name, image_name)
     BoardTypeAttributes.new(type_name,
                             I18n.t("boards.board_type_attributes.#{type_name}"),
                             I18n.t("boards.board_type_descriptions.#{type_name}"),
-                            "assets/images/board_creation_modal/#{image_name}.svg",
-                            disabled)
+                            "assets/images/board_creation_modal/#{image_name}.svg")
   end
 
   def global_board_create_context?
@@ -35,6 +33,6 @@ module BoardsHelper
   end
 
   def global_board_create_action?
-    request.path == work_package_boards_path && @project.nil?
+    request.path == work_package_boards_path && controller.params[:project_id].blank?
   end
 end

--- a/modules/boards/app/views/boards/boards/_form.html.erb
+++ b/modules/boards/app/views/boards/boards/_form.html.erb
@@ -59,14 +59,10 @@ See COPYRIGHT and LICENSE files for more details.
 
   <div class="form--field -required -align-start">
     <label class="form--label" for="board_type"><%= t("boards.label_board_type") %></label>
-    <div class="form--field-container -enterprise-restricted">
-      <%=
-        render(EnterpriseEdition::BannerComponent.new(:board_view))
-      %>
-
+    <div class="form--field-container">
       <div class="op-tile-block">
         <% board_types.each_with_index do |board_type, tile_number| %>
-          <label class="op-tile-block--tile form--radio-button-container -wide <%= "-disabled" if board_type.disabled? %>"
+          <label class="op-tile-block--tile form--radio-button-container -wide"
                  for="boards_grid_attribute_<%= board_type.radio_button_value %>"
                  data-test-selector="op-tile-block">
             <div class="op-tile-block--content">
@@ -74,7 +70,6 @@ See COPYRIGHT and LICENSE files for more details.
                                           board_type.radio_button_value,
                                           tile_number == 0,
                                           no_label: true,
-                                          disabled: board_type.disabled?,
                                           class: "radio-button" %>
               <div>
                 <span data-test-selector="op-tile-block-title" class="op-tile-block--title">
@@ -84,7 +79,7 @@ See COPYRIGHT and LICENSE files for more details.
               </div>
             </div>
 
-            <img src="<%= frontend_asset_path board_type.image_path%>"
+            <img src="<%= frontend_asset_path board_type.image_path %>"
                  alt=""
                  class="op-tile-block--image">
           </label>

--- a/modules/boards/spec/features/action_boards/assignee_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/assignee_board_spec.rb
@@ -32,8 +32,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Assignee action board",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:bobself_user) do
     create(:user,
            firstname: "Bob",

--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -34,8 +34,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Custom field filter in boards",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/action_boards/status_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_board_spec.rb
@@ -32,8 +32,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Status action board",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/status_type_moving_board_spec.rb
@@ -34,8 +34,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Status action board",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/action_boards/subproject_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subproject_board_spec.rb
@@ -32,8 +32,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Subproject action board",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/subtasks_board_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 require_relative "../support//board_index_page"
 require_relative "../support/board_page"
 
-RSpec.describe "Subtasks action board", :js, :selenium, with_ee: %i[board_view] do
+RSpec.describe "Subtasks action board", :js, :selenium do
   let(:type) { create(:type_standard) }
   let(:project) { create(:project, types: [type], enabled_module_names: %i[work_package_tracking board_view]) }
   let(:role) { create(:project_role, permissions:) }

--- a/modules/boards/spec/features/action_boards/version_board_spec.rb
+++ b/modules/boards/spec/features/action_boards/version_board_spec.rb
@@ -32,8 +32,7 @@ require_relative "../support/board_page"
 
 RSpec.describe "Version action board",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user, member_with_roles: { project => role, second_project => role })
   end

--- a/modules/boards/spec/features/board_conflicts_spec.rb
+++ b/modules/boards/spec/features/board_conflicts_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_relative "support/board_index_page"
 require_relative "support/board_page"
 
-RSpec.describe "Board remote changes resolution", :js, with_ee: %i[board_view] do
+RSpec.describe "Board remote changes resolution", :js do
   let(:user1) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/board_enterprise_spec.rb
+++ b/modules/boards/spec/features/board_enterprise_spec.rb
@@ -32,15 +32,10 @@ require "spec_helper"
 require_relative "support/board_index_page"
 require_relative "support/board_page"
 
-RSpec.describe "Boards enterprise spec", :js do
+RSpec.describe "Boards availability", :js do
   shared_let(:admin) { create(:admin) }
 
   shared_let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
-  shared_let(:priority) { create(:default_priority) }
-  shared_let(:status) { create(:default_status) }
-
-  let(:board_index) { Pages::BoardIndex.new(project) }
-
   shared_let(:manual_board) { create(:board_grid_with_query, name: "My board", project:) }
   shared_let(:action_board) do
     create(:subproject_board,
@@ -49,61 +44,31 @@ RSpec.describe "Boards enterprise spec", :js do
            projects_columns: [])
   end
 
-  context "when EE inactive" do
-    before do
-      login_as(admin)
-      board_index.visit!
-    end
+  let(:board_index) { Pages::BoardIndex.new(project) }
 
-    it "disabled all action boards" do
-      page.find('[data-test-selector="add-board-button"]', text: "Board").click
-
-      expect(page).to have_css("#{test_selector('op-tile-block')}:not(.-disabled)", text: "Basic")
-      expect(page).to have_css("#{test_selector('op-tile-block')}.-disabled", count: 5)
-    end
-
-    it "shows a banner on the action board" do
-      # Expect both existing boards to show
-      expect(page).to have_content "My board"
-      expect(page).to have_content "Subproject board"
-
-      board_page = board_index.open_board(manual_board)
-      board_page.expect_query "My board"
-      wait_for_network_idle # wait for the banner to be loaded
-      expect(page).not_to have_enterprise_banner
-
-      board_index.visit!
-      board_page = board_index.open_board(action_board)
-      board_page.expect_query "Subproject board"
-      expect(page).to have_enterprise_banner
-    end
+  before do
+    login_as(admin)
+    board_index.visit!
   end
 
-  context "when EE active", with_ee: %i[board_view] do
-    before do
-      login_as(admin)
-      board_index.visit!
-    end
+  it "enables all board types" do
+    page.find('[data-test-selector="add-board-button"]', text: "Board").click
 
-    it "enables all options" do
-      page.find('[data-test-selector="add-board-button"]', text: "Board").click
+    expect(page).to have_css("[data-test-selector='op-tile-block']", count: 6)
+    expect(page).to have_no_css("[data-test-selector='op-tile-block'].-disabled")
+  end
 
-      expect(page).to have_css("#{test_selector('op-tile-block')}:not(.-disabled)", count: 6)
-    end
+  it "renders action boards without an enterprise banner" do
+    expect(page).to have_content "My board"
+    expect(page).to have_content "Subproject board"
 
-    it "shows the action board" do
-      # Expect both existing boards to show
-      expect(page).to have_content "My board"
-      expect(page).to have_content "Subproject board"
+    board_page = board_index.open_board(manual_board)
+    board_page.expect_query "My board"
+    expect(page).not_to have_enterprise_banner
 
-      board_page = board_index.open_board(manual_board)
-      board_page.expect_query "My board"
-      expect(page).not_to have_enterprise_banner
-
-      board_index.visit!
-      board_page = board_index.open_board(action_board)
-      board_page.expect_query "Subproject board"
-      expect(page).not_to have_enterprise_banner
-    end
+    board_index.visit!
+    board_page = board_index.open_board(action_board)
+    board_page.expect_query "Subproject board"
+    expect(page).not_to have_enterprise_banner
   end
 end

--- a/modules/boards/spec/features/board_highlighting_spec.rb
+++ b/modules/boards/spec/features/board_highlighting_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 require_relative "support/board_index_page"
 require_relative "support/board_page"
 
-RSpec.describe "Work Package boards spec", :js, :selenium, with_ee: %i[board_view] do
+RSpec.describe "Work Package boards spec", :js, :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/board_index_spec.rb
+++ b/modules/boards/spec/features/board_index_spec.rb
@@ -29,8 +29,7 @@
 require "spec_helper"
 require_relative "support/board_index_page"
 
-RSpec.describe "Work Package Project Boards Index Page",
-               with_ee: %i[board_view] do
+RSpec.describe "Work Package Project Boards Index Page" do
   # The identifier is important to test https://community.openproject.com/wp/29754
   shared_let(:project) { create(:project, identifier: "boards", enabled_module_names: %i[work_package_tracking board_view]) }
 

--- a/modules/boards/spec/features/board_management_spec.rb
+++ b/modules/boards/spec/features/board_management_spec.rb
@@ -30,7 +30,7 @@ require "spec_helper"
 require_relative "support/board_index_page"
 require_relative "support/board_page"
 
-RSpec.describe "Board management spec", :js, :selenium, with_ee: %i[board_view] do
+RSpec.describe "Board management spec", :js, :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/board_navigation_spec.rb
+++ b/modules/boards/spec/features/board_navigation_spec.rb
@@ -32,8 +32,7 @@ require_relative "support/board_page"
 
 RSpec.describe "Work Package boards spec",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/board_overview_spec.rb
+++ b/modules/boards/spec/features/board_overview_spec.rb
@@ -30,8 +30,7 @@ require "spec_helper"
 require_relative "support/board_overview_page"
 
 RSpec.describe "Work Package Boards Overview",
-               :js,
-               with_ee: %i[board_view] do
+               :js do
   # The identifier is important to test https://community.openproject.com/wp/29754
   shared_let(:project) do
     create(:project,

--- a/modules/boards/spec/features/board_reference_work_package_spec.rb
+++ b/modules/boards/spec/features/board_reference_work_package_spec.rb
@@ -32,8 +32,7 @@ require_relative "support/board_page"
 
 RSpec.describe "Board reference work package spec",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:user) do
     create(:user,
            member_with_roles: { project => role })

--- a/modules/boards/spec/features/board_update_spec.rb
+++ b/modules/boards/spec/features/board_update_spec.rb
@@ -32,8 +32,7 @@ require_relative "support/board_page"
 
 RSpec.describe "Work Package boards updating spec",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:admin) { create(:admin) }
 
   let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }

--- a/modules/boards/spec/features/boards_global_create_spec.rb
+++ b/modules/boards/spec/features/boards_global_create_spec.rb
@@ -5,8 +5,7 @@ require_relative "support/board_new_page"
 
 RSpec.describe "Boards",
                "Creating a view from a Global Context",
-               :js,
-               with_ee: %i[board_view] do
+               :js do
   shared_let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   shared_let(:other_project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   shared_let(:admin) { create(:admin) }
@@ -48,157 +47,158 @@ RSpec.describe "Boards",
       new_board_page.visit!
     end
 
-    context "with a Community Edition", with_ee: %i[] do
-      it "renders an enterprise banner and disables all restricted board types", :aggregate_failures do
-        expect(page).to have_enterprise_banner
-        expect(page).to have_selector(:radio_button, "Basic")
+    it "enables all board types" do
+      %w[Basic Kanban Assignee Version Subproject Parent-child].each do |board_type|
+        expect(page).to have_css("[data-test-selector='op-tile-block-title']", text: board_type)
+      end
 
-        %w[Kanban Assignee Version Subproject Parent-child].each do |restricted_board_type|
-          expect(page).to have_selector(:radio_button, restricted_board_type, disabled: true)
+      expect(page).to have_css("[data-test-selector='op-tile-block']", count: 6)
+      expect(page).to have_no_css("[data-test-selector='op-tile-block'].-disabled")
+      expect(page).to have_no_css("input.radio-button[disabled]")
+    end
+
+    it "does not render an enterprise banner" do
+      expect(page).not_to have_enterprise_banner
+    end
+
+    context "with all fields set" do
+      before do
+        wait_for_reload # Halt until the project autocompleter is ready
+
+        new_board_page.set_title "Gotham Renewal Board"
+        new_board_page.set_project project
+      end
+
+      context 'when creating a "Basic" board' do
+        before do
+          new_board_page.set_board_type "Basic"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it" do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
+        end
+      end
+
+      context 'when creating a "Status" board' do
+        before do
+          new_board_page.set_board_type "Kanban"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it" do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
+          expect(page).to have_css("[data-query-name='#{status.name}']")
+        end
+      end
+
+      context 'when creating an "Assignee" board' do
+        before do
+          new_board_page.set_board_type "Assignee"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it" do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
+        end
+      end
+
+      context 'when creating a "Version" board' do
+        before do
+          new_board_page.set_board_type "Version"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it", :aggregate_failures do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
+          versions.each do |version|
+            expect(page).to have_css("[data-query-name='#{version.name}']")
+          end
+          excluded_versions.each do |version|
+            expect(page).to have_no_css("[data-query-name='#{version.name}']")
+          end
+        end
+      end
+
+      context 'when creating a "Subproject" board' do
+        before do
+          new_board_page.set_board_type "Subproject"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it" do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
+        end
+      end
+
+      context 'when creating a "Parent-child" board' do
+        before do
+          new_board_page.set_board_type "Parent-child"
+          new_board_page.click_on_submit
+
+          wait_for_reload
+        end
+
+        it "creates the board and redirects me to it" do
+          expect(page).to have_text(I18n.t(:notice_successful_create))
+          expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
+          expect(page).to have_text "Gotham Renewal Board"
         end
       end
     end
 
-    context "with an Enterprise Edition" do
-      context "with all fields set" do
+    context "when missing a required field" do
+      describe "title" do
         before do
           wait_for_reload # Halt until the project autocompleter is ready
 
-          new_board_page.set_title "Gotham Renewal Board"
-          new_board_page.set_project project
+          new_board_page.set_project(project)
+          new_board_page.click_on_submit
         end
 
-        context 'when creating a "Basic" board' do
-          before do
-            new_board_page.set_board_type "Basic"
-            new_board_page.click_on_submit
+        it "renders a required attribute validation error" do
+          expect(Boards::Grid.all).to be_empty
 
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it" do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-          end
-        end
-
-        context 'when creating a "Status" board' do
-          before do
-            new_board_page.set_board_type "Kanban"
-            new_board_page.click_on_submit
-
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it" do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-            expect(page).to have_css("[data-query-name='#{status.name}']")
-          end
-        end
-
-        context 'when creating an "Assignee" board' do
-          before do
-            new_board_page.set_board_type "Assignee"
-            new_board_page.click_on_submit
-
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it" do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-          end
-        end
-
-        context 'when creating a "Version" board' do
-          before do
-            new_board_page.set_board_type "Version"
-            new_board_page.click_on_submit
-
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it", :aggregate_failures do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-            versions.each do |version|
-              expect(page).to have_css("[data-query-name='#{version.name}'")
-            end
-            excluded_versions.each do |version|
-              expect(page).to have_no_css("[data-query-name='#{version.name}'")
-            end
-          end
-        end
-
-        context 'when creating a "Subproject" board' do
-          before do
-            new_board_page.set_board_type "Subproject"
-            new_board_page.click_on_submit
-
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it" do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-          end
-        end
-
-        context 'when creating a "Parent-child" board' do
-          before do
-            new_board_page.set_board_type "Parent-child"
-            new_board_page.click_on_submit
-
-            wait_for_reload
-          end
-
-          it "creates the board and redirects me to it" do
-            expect(page).to have_text(I18n.t(:notice_successful_create))
-            expect(page).to have_current_path("/projects/#{project.identifier}/boards/#{Boards::Grid.last.id}")
-            expect(page).to have_text "Gotham Renewal Board"
-          end
+          # Required HTML attribute just warns
+          expect(page).to have_current_path(new_work_package_board_path)
         end
       end
 
-      context "when missing a required field" do
-        describe "title" do
-          before do
-            wait_for_reload # Halt until the project autocompleter is ready
+      describe "project_id" do
+        before do
+          new_board_page.set_title("Batman's Itinerary")
+          new_board_page.click_on_submit
 
-            new_board_page.set_project(project)
-            new_board_page.click_on_submit
-          end
-
-          it "renders a required attribute validation error" do
-            expect(Boards::Grid.all).to be_empty
-
-            # Required HTML attribute just warns
-            expect(page).to have_current_path(new_work_package_board_path)
-          end
+          wait_for_reload
         end
 
-        describe "project_id" do
-          before do
-            new_board_page.set_title("Batman's Itinerary")
-            new_board_page.click_on_submit
+        it "renders a required attribute validation error" do
+          expect(Boards::Grid.all).to be_empty
 
-            wait_for_reload
-          end
+          expect_flash message: "Project #{I18n.t('activerecord.errors.messages.blank')}",
+                       type: :error
 
-          it "renders a required attribute validation error" do
-            expect(Boards::Grid.all).to be_empty
-
-            expect_flash message: "Project #{I18n.t('activerecord.errors.messages.blank')}",
-                         type: :error
-
-            new_board_page.expect_project_dropdown
-          end
+          new_board_page.expect_project_dropdown
         end
       end
     end

--- a/modules/boards/spec/features/boards_sorting_spec.rb
+++ b/modules/boards/spec/features/boards_sorting_spec.rb
@@ -32,8 +32,7 @@ require_relative "support/board_page"
 
 RSpec.describe "Work Package boards sorting spec",
                :js,
-               :selenium,
-               with_ee: %i[board_view] do
+               :selenium do
   let(:admin) { create(:admin) }
   let(:project) { create(:project, enabled_module_names: %i[work_package_tracking board_view]) }
   let(:board_index) { Pages::BoardIndex.new(project) }

--- a/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
+++ b/modules/boards/spec/features/onboarding/boards_onboarding_tour_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -58,16 +60,15 @@ RSpec.describe "boards onboarding tour",
            public: true,
            enabled_module_names: %w[work_package_tracking gantt wiki board_view])
   end
-  let!(:wp_1) { create(:work_package, project: demo_project) }
+  let!(:wp1) { create(:work_package, project: demo_project) }
 
   let!(:demo_board_view) { create(:board_grid_with_query, project: demo_project, name: "Kanban", query:) }
   let!(:demo_basic_board_view) { create(:board_grid_with_query, project: demo_project, name: "Basic board", query:) }
   let(:query) { create(:query, user:, project: demo_project) }
 
   before do
-    OrderedWorkPackage.create(query:, work_package: wp_1, position: 0)
-    allow(Setting).to receive(:demo_projects_available).and_return(true)
-    allow(Setting).to receive(:boards_demo_data_available).and_return(true)
+    OrderedWorkPackage.create!(query:, work_package: wp1, position: 0)
+    allow(Setting).to receive_messages(demo_projects_available: true, boards_demo_data_available: true)
   end
 
   after do
@@ -76,38 +77,19 @@ RSpec.describe "boards onboarding tour",
   end
 
   context "as a new user" do
-    context "with an EE token", with_ee: %i[board_view] do
-      before do
-        login_as user
-      end
-
-      it "I see the board onboarding tour in the demo project" do
-        # Set the tour parameter so that we can start on the wp page
-        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
-
-        step_through_onboarding_wp_tour demo_project, wp_1
-
-        step_through_onboarding_board_tour
-
-        step_through_onboarding_main_menu_tour has_full_capabilities: true
-      end
+    before do
+      login_as user
     end
 
-    context "without an EE token" do
-      before do
-        login_as user
-      end
+    it "I see the board onboarding tour in the demo project" do
+      # Set the tour parameter so that we can start on the wp page
+      visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
 
-      it "I see the board onboarding tour in the demo project" do
-        # Set the tour parameter so that we can start on the wp page
-        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
+      step_through_onboarding_wp_tour demo_project, wp1
 
-        step_through_onboarding_wp_tour demo_project, wp_1
+      step_through_onboarding_board_tour
 
-        step_through_onboarding_board_tour with_ee_token: false
-
-        step_through_onboarding_main_menu_tour has_full_capabilities: true
-      end
+      step_through_onboarding_main_menu_tour has_full_capabilities: true
     end
   end
 end

--- a/modules/boards/spec/features/support/onboarding_steps.rb
+++ b/modules/boards/spec/features/support/onboarding_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -27,18 +29,13 @@
 #++
 
 module OnboardingSteps
-  def step_through_onboarding_board_tour(with_ee_token: true)
+  def step_through_onboarding_board_tour
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t("js.onboarding.steps.boards.overview")), normalize_ws: true
 
     next_button.click
-    if with_ee_token
-      expect(page)
-        .to have_text sanitize_string(I18n.t("js.onboarding.steps.boards.lists_kanban")), normalize_ws: true, wait: 20
-    else
-      expect(page)
-        .to have_text sanitize_string(I18n.t("js.onboarding.steps.boards.lists_basic")), normalize_ws: true, wait: 20
-    end
+    expect(page)
+      .to have_text sanitize_string(I18n.t("js.onboarding.steps.boards.lists_kanban")), normalize_ws: true, wait: 20
 
     next_button.click
     expect(page).to have_text sanitize_string(I18n.t("js.onboarding.steps.boards.add")), normalize_ws: true


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based off #22086. Please review/merge that PR first. 

# Ticket
https://community.openproject.org/wp/73188

# What are you trying to accomplish?

Make boards fully available in Community Edition by removing the remaining Boards-specific EE guards.

This changes the boards experience so action boards are no longer disabled or hidden behind an enterprise banner when no board_view EE token is present. It also updates the boards creation flow and onboarding coverage to reflect that action boards are now available by default in CE.

There are no route, API, permission, or schema changes in this PR. The existing board_view project module and the show_board_views / manage_board_views permissions stay unchanged.

# What approach did you choose and why?

I treated this as a frontend/runtime availability change rather than a permissions rewrite.

Boards were already modeled as a normal project module with normal permissions on the backend. The remaining CE-vs-EE split was in the frontend behavior and the boards feature specs:
- action board types were disabled in the create flow
- non-free boards rendered an enterprise banner instead of the lists
- onboarding branched on EE token presence
- feature specs encoded those old CE/EE expectations

So I removed the board_view EE checks from the Angular boards UI and aligned the affected feature specs with the new default behavior.

I deliberately did not broaden this into a full rename sweep of board_view / "Advanced Boards" wording or static docs links. This PR is limited to removing the runtime guards and the boards-specific upsell behavior.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
