### PR TITLE
[67643] Wiki menu visible when using the browser's print function/print dialog

### DIFF
--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -10,7 +10,8 @@
   .other-formats,
   .toolbar-items,
   .ui-helper-hidden-accessible,
-  #wiki_add_attachment
+  #wiki_add_attachment,
+  action-list
     display: none !important
 
   .op-toast:not(.show-when-print)

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -11,7 +11,7 @@
   .toolbar-items,
   .ui-helper-hidden-accessible,
   #wiki_add_attachment,
-  action-list
+  .Overlay action-list
     display: none !important
 
   .op-toast:not(.show-when-print)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67643

# What are you trying to accomplish?
Hide the action list while printing

## Screenshots
Before:
<img width="1448" height="578" alt="Screenshot 2026-03-17 at 11 30 00" src="https://github.com/user-attachments/assets/65fc3c9a-57fa-4586-8bf0-df85af74481b" />

After:
<img width="1711" height="591" alt="Screenshot 2026-03-17 at 11 29 07" src="https://github.com/user-attachments/assets/4c21fbd8-71a6-4c84-93b9-8c700ba6b980" />

