### PR TITLE
Fix env name SSRF by using the actual defined value

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -111,8 +111,10 @@ class AdminController < ApplicationController
     @smtp_addr = ActionMailer::Base.smtp_settings[:address]
     @safe_ip = OpenProject::SsrfProtection.safe_ip?(@smtp_addr)
 
-    if !@safe_ip
-      flash[:error] = I18n.t :notice_smtp_address_unsafe, address: @smtp_addr
+    unless @safe_ip
+      flash[:error] = I18n.t :notice_smtp_address_unsafe_env_hint,
+                             address: @smtp_addr,
+                             env_name: Settings::Definition[:ssrf_protection_ip_allowlist].env_name
 
       redirect_to admin_settings_mail_notifications_path, status: :see_other
     end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1400,6 +1400,14 @@ module Settings
       end
     end
 
+    def env_name
+      self.class.env_name(self)
+    end
+
+    def possible_env_names
+      self.class.possible_env_names(self)
+    end
+
     def derive_default(default)
       @default = default.is_a?(Hash) ? default.deep_stringify_keys : default
       @default.freeze
@@ -1689,8 +1697,6 @@ module Settings
         ].compact
       end
 
-      public :possible_env_names
-
       def env_name_nested(definition)
         "#{ENV_PREFIX}#{definition.name.upcase.gsub('_', '__')}"
       end
@@ -1708,6 +1714,8 @@ module Settings
 
         definition.env_alias.upcase
       end
+
+      public :possible_env_names, :env_name
 
       ##
       # Extract the configuration value from the given environment variable

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4388,7 +4388,7 @@ en:
   notice_parent_item_not_found: "Parent item not found."
   notice_project_not_deleted: "The project wasn't deleted."
   notice_project_not_found: "Project not found."
-  notice_smtp_address_unsafe: "SMTP address %{address} is not safe. Please add it to OPENPROJECT_SSRF_PROTECTION_ALLOWLIST."
+  notice_smtp_address_unsafe_env_hint: "SMTP address %{address} is not safe. Please add it to the whitelist using the %{env_name} environment variable."
   notice_successful_connection: "Successful connection."
   notice_successful_create: "Successful creation."
   notice_successful_delete: "Successful deletion."

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe AdminController do
 
       it "redirects back, showing an error" do
         expect(response).to redirect_to admin_settings_mail_notifications_path
-        expect(flash[:error]).to match /OPENPROJECT_SSRF_PROTECTION_ALLOWLIST/
+        expect(flash[:error]).to match /OPENPROJECT_SSRF_PROTECTION_IP_ALLOWLIST/
       end
     end
 


### PR DESCRIPTION
The env key in the flash message for SSRF test mail was incorrect