### PR TITLE
[#72918] Redirect routes with old project identifiers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,6 +56,7 @@ class ApplicationController < ActionController::Base
   include Security::DefaultUrlOptions
   include OpModalFlashable
   include DynamicContentSecurityPolicy
+  include Projects::HistoricalIdentifierRedirect
 
   layout "base"
 
@@ -246,45 +247,18 @@ class ApplicationController < ActionController::Base
   # Note: find() is Project.friendly.find()
   def find_project
     @project = Project.visible.find(params[:id])
-    redirect_if_historical_project_identifier(:id)
   end
 
   # Find project of id params[:project_id]
   # Note: find() is Project.friendly.find()
   def find_project_by_project_id
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
-  end
-
-  # Redirects to the project's current identifier if the request used a historical slug.
-  # friendly_id's :history extension records old identifiers in friendly_id_slugs; if the
-  # param is a slug (param.friendly_id? is truthy) that no longer matches the current
-  # identifier, it must be a historical slug. Numeric IDs are passed through without redirect.
-  # Only redirects HTML requests; turbo_stream and other formats are left as-is.
-  def redirect_if_historical_project_identifier(identifier_param_key)
-    param = params[identifier_param_key]
-    if request.get? && request.format.symbol == :html && param.friendly_id? && param != @project.identifier
-      # Reconstruct the URL from path + query parameters, and prevent user-supplied
-      # options such as :host or :protocol from influencing the redirect target.
-      safe_path_params  = request.path_parameters.symbolize_keys
-      safe_query_params = request.query_parameters.symbolize_keys
-
-      # Ensure the identifier in the path matches the current project identifier.
-      safe_path_params[identifier_param_key] = @project.identifier
-
-      # Remove any URL option keys that could affect the redirect target.
-      safe_query_params.except!(:host, :protocol, :subdomain, :domain, :port)
-
-      redirect_to url_for(safe_path_params.merge(safe_query_params).merge(only_path: true)),
-                  status: :moved_permanently
-    end
   end
 
   # Find project by project_id if given
   def find_optional_project
     if params[:project_id].present?
       @project = Project.visible.find(params[:project_id])
-      redirect_if_historical_project_identifier(:project_id)
       nil if performed?
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -257,10 +257,7 @@ class ApplicationController < ActionController::Base
 
   # Find project by project_id if given
   def find_optional_project
-    if params[:project_id].present?
-      @project = Project.visible.find(params[:project_id])
-      nil if performed?
-    end
+    @project = Project.visible.find(params[:project_id]) if params[:project_id].present?
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -263,7 +263,7 @@ class ApplicationController < ActionController::Base
   # Only redirects HTML requests; turbo_stream and other formats are left as-is.
   def redirect_if_historical_project_identifier(identifier_param_key)
     param = params[identifier_param_key]
-    if request.get? && request.format.html? && param.friendly_id? && param != @project.identifier
+    if request.get? && request.format.symbol == :html && param.friendly_id? && param != @project.identifier
       # Reconstruct the URL from path + query parameters, and prevent user-supplied
       # options such as :host or :protocol from influencing the redirect target.
       safe_path_params  = request.path_parameters.symbolize_keys

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -246,17 +246,47 @@ class ApplicationController < ActionController::Base
   # Note: find() is Project.friendly.find()
   def find_project
     @project = Project.visible.find(params[:id])
+    redirect_if_historical_project_identifier(:id)
   end
 
   # Find project of id params[:project_id]
   # Note: find() is Project.friendly.find()
   def find_project_by_project_id
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
+  end
+
+  # Redirects to the project's current identifier if the request used a historical slug.
+  # friendly_id's :history extension records old identifiers in friendly_id_slugs; if the
+  # param is a slug (param.friendly_id? is truthy) that no longer matches the current
+  # identifier, it must be a historical slug. Numeric IDs are passed through without redirect.
+  # Only redirects HTML requests; turbo_stream and other formats are left as-is.
+  def redirect_if_historical_project_identifier(identifier_param_key)
+    param = params[identifier_param_key]
+    if request.get? && request.format.html? && param.friendly_id? && param != @project.identifier
+      # Reconstruct the URL from path + query parameters, and prevent user-supplied
+      # options such as :host or :protocol from influencing the redirect target.
+      safe_path_params  = request.path_parameters.symbolize_keys
+      safe_query_params = request.query_parameters.symbolize_keys
+
+      # Ensure the identifier in the path matches the current project identifier.
+      safe_path_params[identifier_param_key] = @project.identifier
+
+      # Remove any URL option keys that could affect the redirect target.
+      safe_query_params.except!(:host, :protocol, :subdomain, :domain, :port)
+
+      redirect_to url_for(safe_path_params.merge(safe_query_params).merge(only_path: true)),
+                  status: :moved_permanently
+    end
   end
 
   # Find project by project_id if given
   def find_optional_project
-    @project = Project.visible.find(params[:project_id]) if params[:project_id].present?
+    if params[:project_id].present?
+      @project = Project.visible.find(params[:project_id])
+      redirect_if_historical_project_identifier(:project_id)
+      nil if performed?
+    end
   rescue ActiveRecord::RecordNotFound
     render_404
   end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -32,7 +32,7 @@ class CategoriesController < ApplicationController
   menu_item :settings_categories
 
   before_action :find_category_and_project, except: %i[new create]
-  before_action :find_project, only: %i[new create]
+  before_action :find_project_by_project_id, only: %i[new create]
   before_action :authorize
   redirect_historical_project_identifier param_key: :project_id, only: %i[new create]
 
@@ -84,9 +84,5 @@ class CategoriesController < ApplicationController
   def find_category_and_project
     @category = Category.find(params[:id])
     @project = @category.project
-  end
-
-  def find_project
-    @project = Project.visible.find(params[:project_id])
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -34,6 +34,7 @@ class CategoriesController < ApplicationController
   before_action :find_category_and_project, except: %i[new create]
   before_action :find_project, only: %i[new create]
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id, only: %i[new create]
 
   def new
     @category = @project.categories.build
@@ -87,6 +88,5 @@ class CategoriesController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -87,5 +87,6 @@ class CategoriesController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
   end
 end

--- a/app/controllers/concerns/projects/historical_identifier_redirect.rb
+++ b/app/controllers/concerns/projects/historical_identifier_redirect.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  # Provides controller helpers for redirecting requests with historical (outdated)
+  # project identifiers to URLs with the current identifier.
+  #
+  # When a project's identifier changes, friendly_id's :history extension records
+  # the old identifier. This module checks if a request uses an old identifier and
+  # issues a 301 redirect to the same URL with the current identifier.
+  #
+  # Usage in controllers:
+  #
+  #   class SomeController < ApplicationController
+  #     before_action :find_project_by_project_id
+  #     before_action :authorize
+  #     redirect_historical_project_identifier param_key: :project_id
+  #   end
+  #
+  # The redirect_historical_project_identifier declaration should:
+  # - Come AFTER the finder that sets @project
+  # - Come AFTER any authorization checks
+  # - Use the same action scope (only/except) as the finder
+  #
+  # The redirect logic automatically:
+  # - Only redirects GET requests (skips POST/PUT/PATCH/DELETE)
+  # - Only redirects HTML format requests (skips turbo_stream, JSON, etc.)
+  # - Only redirects when @project is present
+  # - Only redirects when the param is a friendly_id slug (not numeric ID)
+  # - Only redirects when the slug differs from current identifier
+  module HistoricalIdentifierRedirect
+    extend ActiveSupport::Concern
+
+    included do
+      # Declares a before_action to check and redirect historical project identifiers.
+      #
+      # @param param_key [Symbol] The parameter name containing the project identifier
+      #   (default: :project_id, use :id for ProjectsController and similar)
+      # @param options [Hash] Standard before_action options (only, except, if, unless, etc.)
+      #
+      # @example
+      #   redirect_historical_project_identifier param_key: :project_id, only: %i[show edit]
+      def self.redirect_historical_project_identifier(param_key: :project_id, **options)
+        before_action(**options) do
+          check_and_redirect_historical_project_identifier(param_key)
+        end
+      end
+    end
+
+    # Can be called directly from action methods if needed (for edge cases).
+    # Typically you should use the redirect_historical_project_identifier class method instead.
+    #
+    # @param param_key [Symbol] The parameter name containing the project identifier
+    def redirect_if_historical_project_identifier(param_key)
+      check_and_redirect_historical_project_identifier(param_key)
+    end
+
+    private
+
+    def check_and_redirect_historical_project_identifier(param_key)
+      return unless should_redirect_historical_identifier?
+
+      param_value = params[param_key]
+
+      return unless param_value.friendly_id?
+      return if param_value == @project.identifier
+
+      redirect_to_current_identifier(param_key)
+    end
+
+    def should_redirect_historical_identifier?
+      request.get? &&
+        request.format.symbol == :html &&
+        @project.present?
+    end
+
+    def redirect_to_current_identifier(param_key)
+      safe_path_params = request.path_parameters.symbolize_keys
+      safe_query_params = request.query_parameters.symbolize_keys
+
+      # Replace the old identifier with the current one
+      safe_path_params[param_key] = @project.identifier
+
+      # Remove any URL option keys that could affect the redirect target (security)
+      safe_query_params.except!(:host, :protocol, :subdomain, :domain, :port)
+
+      redirect_to url_for(safe_path_params.merge(safe_query_params).merge(only_path: true)),
+                  status: :moved_permanently
+    end
+  end
+end

--- a/app/controllers/concerns/projects/historical_identifier_redirect.rb
+++ b/app/controllers/concerns/projects/historical_identifier_redirect.rb
@@ -67,8 +67,8 @@ module Projects
       #
       # @example
       #   redirect_historical_project_identifier param_key: :project_id, only: %i[show edit]
-      def self.redirect_historical_project_identifier(param_key: :project_id, **options)
-        before_action(**options) do
+      def self.redirect_historical_project_identifier(param_key: :project_id, **)
+        before_action(**) do
           check_and_redirect_historical_project_identifier(param_key)
         end
       end

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -35,6 +35,7 @@ class ForumsController < ApplicationController
   before_action :find_forum, only: %i[show edit update move destroy]
 
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   accept_key_auth :show
 

--- a/app/controllers/members/menus_controller.rb
+++ b/app/controllers/members/menus_controller.rb
@@ -31,6 +31,7 @@ module Members
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @sidebar_menu_items = Members::Menu.new(project: @project, params:).menu_items

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -34,6 +34,7 @@ class MembersController < ApplicationController
   before_action :find_project_by_project_id
   before_action :find_member, except: %i[index create autocomplete_for_member destroy_by_principal]
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def index
     set_index_data!

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -159,6 +159,9 @@ class MessagesController < ApplicationController
 
   def find_project_and_forum
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
+    return if performed?
+
     @forum = @project.forums.find(params[:forum_id])
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -36,6 +36,7 @@ class MessagesController < ApplicationController
   before_action :authorize, except: %i[edit update destroy]
   # Checked inside the method.
   no_authorization_required! :edit, :update, :destroy
+  redirect_historical_project_identifier param_key: :project_id
 
   include AttachmentsHelper
   include PaginationHelper
@@ -159,7 +160,6 @@ class MessagesController < ApplicationController
 
   def find_project_and_forum
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
     return if performed?
 
     @forum = @project.forums.find(params[:forum_id])

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -160,8 +160,6 @@ class MessagesController < ApplicationController
 
   def find_project_and_forum
     @project = Project.visible.find(params[:project_id])
-    return if performed?
-
     @forum = @project.forums.find(params[:forum_id])
   end
 

--- a/app/controllers/news/comments_controller.rb
+++ b/app/controllers/news/comments_controller.rb
@@ -58,6 +58,9 @@ class News::CommentsController < ApplicationController
 
   def find_news_and_project
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
+    return if performed?
+
     @news = @project.news.visible.find(params[:news_id])
   end
 end

--- a/app/controllers/news/comments_controller.rb
+++ b/app/controllers/news/comments_controller.rb
@@ -34,6 +34,7 @@ class News::CommentsController < ApplicationController
   before_action :find_news_and_project
   before_action :find_comment, only: [:destroy]
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def create
     @comment = Comment.new(permitted_params.comment)
@@ -58,7 +59,6 @@ class News::CommentsController < ApplicationController
 
   def find_news_and_project
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
     return if performed?
 
     @news = @project.news.visible.find(params[:news_id])

--- a/app/controllers/news/comments_controller.rb
+++ b/app/controllers/news/comments_controller.rb
@@ -59,8 +59,6 @@ class News::CommentsController < ApplicationController
 
   def find_news_and_project
     @project = Project.visible.find(params[:project_id])
-    return if performed?
-
     @news = @project.news.visible.find(params[:news_id])
   end
 end

--- a/app/controllers/projects/archive_controller.rb
+++ b/app/controllers/projects/archive_controller.rb
@@ -50,9 +50,11 @@ class Projects::ArchiveController < ApplicationController
   private
 
   def find_project_including_archived
-    # The visible scope filters out archived projects, but here we want to explicitly unarchive them.
-    # The contracts do proper permission checks, so we can skip the visible scope here.
+    # Skips the visible scope so archived projects are accessible.
+    # The contracts do proper permission checks. Project admins (regular users with admin role)
+    # may reach these actions via an old identifier, so redirect if needed.
     @project = Project.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
   end
 
   def change_status_action(status)

--- a/app/controllers/projects/archive_controller.rb
+++ b/app/controllers/projects/archive_controller.rb
@@ -51,9 +51,8 @@ class Projects::ArchiveController < ApplicationController
   private
 
   def find_project_including_archived
-    # Skips the visible scope so archived projects are accessible.
-    # The contracts do proper permission checks. Project admins (regular users with admin role)
-    # may reach these actions via an old identifier, so redirect if needed.
+    # The visible scope filters out archived projects, but here we want to explicitly unarchive them.
+    # The contracts do proper permission checks, so we can skip the visible scope here.
     @project = Project.find(params[:project_id])
   end
 

--- a/app/controllers/projects/archive_controller.rb
+++ b/app/controllers/projects/archive_controller.rb
@@ -34,6 +34,7 @@ class Projects::ArchiveController < ApplicationController
   before_action :find_project_including_archived
   before_action :authorize, only: %i[create dialog]
   before_action :require_admin, only: [:destroy]
+  redirect_historical_project_identifier param_key: :project_id
 
   def create
     change_status_action(:archive)
@@ -54,7 +55,6 @@ class Projects::ArchiveController < ApplicationController
     # The contracts do proper permission checks. Project admins (regular users with admin role)
     # may reach these actions via an old identifier, so redirect if needed.
     @project = Project.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
   end
 
   def change_status_action(status)

--- a/app/controllers/projects/identifier_controller.rb
+++ b/app/controllers/projects/identifier_controller.rb
@@ -31,6 +31,7 @@
 class Projects::IdentifierController < ApplicationController
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def show; end
 

--- a/app/controllers/projects/settings_controller.rb
+++ b/app/controllers/projects/settings_controller.rb
@@ -31,6 +31,7 @@
 class Projects::SettingsController < ApplicationController
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def show; end
 end

--- a/app/controllers/projects/status_controller.rb
+++ b/app/controllers/projects/status_controller.rb
@@ -34,6 +34,7 @@ class Projects::StatusController < ApplicationController
 
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def update
     change_status_action(params.fetch(:status_code).presence)

--- a/app/controllers/projects/templated_controller.rb
+++ b/app/controllers/projects/templated_controller.rb
@@ -31,6 +31,7 @@
 class Projects::TemplatedController < ApplicationController
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def create
     change_templated_action(true)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -183,9 +183,10 @@ class ProjectsController < ApplicationController
   private
 
   def find_project_including_archived
-    # The actions that use this method are only accessible to admins, so we can show them archived projects as well and
-    # can skip the visible scope here.
+    # Skips the visible scope so archived projects are accessible.
+    # Project admins (regular users with admin role) may reach these actions via an old identifier.
     @project = Project.find(params[:id])
+    redirect_if_historical_project_identifier(:id)
   end
 
   def from_template? = @template.present?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,6 +43,7 @@ class ProjectsController < ApplicationController
   before_action :require_admin, only: %i[destroy destroy_info]
   before_action :find_optional_parent, only: :new
   before_action :find_optional_template, only: %i[new create]
+  redirect_historical_project_identifier param_key: :id, except: %i[index new create destroy destroy_info]
 
   no_authorization_required! :index
 
@@ -186,7 +187,6 @@ class ProjectsController < ApplicationController
     # Skips the visible scope so archived projects are accessible.
     # Project admins (regular users with admin role) may reach these actions via an old identifier.
     @project = Project.find(params[:id])
-    redirect_if_historical_project_identifier(:id)
   end
 
   def from_template? = @template.present?

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -48,6 +48,7 @@ class RepositoriesController < ApplicationController
 
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
   before_action :find_repository, except: %i[update create destroy destroy_info]
   accept_key_auth :revisions
 

--- a/app/controllers/users/invite_controller.rb
+++ b/app/controllers/users/invite_controller.rb
@@ -134,7 +134,10 @@ class Users::InviteController < ApplicationController
   end
 
   def set_project
-    @project = Project.find(params[:project_id]) if params[:project_id].present?
+    if params[:project_id].present?
+      @project = Project.find(params[:project_id])
+      redirect_if_historical_project_identifier(:project_id)
+    end
   end
 
   def dialog_title

--- a/app/controllers/users/invite_controller.rb
+++ b/app/controllers/users/invite_controller.rb
@@ -33,6 +33,7 @@ class Users::InviteController < ApplicationController
 
   authorize_with_permission :manage_members, global: true
   before_action :set_project, only: :start_dialog
+  redirect_historical_project_identifier param_key: :project_id, only: :start_dialog
 
   def start_dialog
     respond_with_dialog(
@@ -136,7 +137,6 @@ class Users::InviteController < ApplicationController
   def set_project
     if params[:project_id].present?
       @project = Project.find(params[:project_id])
-      redirect_if_historical_project_identifier(:project_id)
     end
   end
 

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -35,6 +35,7 @@ class VersionsController < ApplicationController
   before_action :find_version, except: %i[index new create close_completed]
   before_action :find_project, only: %i[index new create close_completed]
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id, only: %i[index new create close_completed]
 
   def index
     @types = @project.types.order(Arel.sql("position"))
@@ -139,7 +140,6 @@ class VersionsController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
   end
 
   def retrieve_selected_type_ids(selectable_types, default_types = nil)

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -139,6 +139,7 @@ class VersionsController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
   end
 
   def retrieve_selected_type_ids(selectable_types, default_types = nil)

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -33,7 +33,7 @@ class VersionsController < ApplicationController
   menu_item :settings_versions
 
   before_action :find_version, except: %i[index new create close_completed]
-  before_action :find_project, only: %i[index new create close_completed]
+  before_action :find_project_by_project_id, only: %i[index new create close_completed]
   before_action :authorize
   redirect_historical_project_identifier param_key: :project_id, only: %i[index new create close_completed]
 
@@ -136,10 +136,6 @@ class VersionsController < ApplicationController
 
   def redirect_back_or_version_settings
     redirect_back_or_default(project_settings_versions_path(@project))
-  end
-
-  def find_project
-    @project = Project.visible.find(params[:project_id])
   end
 
   def retrieve_selected_type_ids(selectable_types, default_types = nil)

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -372,8 +372,6 @@ class WikiController < ApplicationController
 
   def find_wiki
     @project = Project.visible.find(params[:project_id])
-    return if performed?
-
     @wiki = @project.wiki
     render_404 unless @wiki
   end

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -56,6 +56,7 @@ class WikiController < ApplicationController
   before_action :find_wiki_page, only: %i[show]
   before_action :handle_new_wiki_page, only: %i[show]
   before_action :build_wiki_page, only: %i[new]
+  redirect_historical_project_identifier param_key: :project_id
 
   include AttachableServiceCall
   include AttachmentsHelper
@@ -371,7 +372,6 @@ class WikiController < ApplicationController
 
   def find_wiki
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
     return if performed?
 
     @wiki = @project.wiki

--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -371,6 +371,9 @@ class WikiController < ApplicationController
 
   def find_wiki
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
+    return if performed?
+
     @wiki = @project.wiki
     render_404 unless @wiki
   end

--- a/app/controllers/wiki_menu_items_controller.rb
+++ b/app/controllers/wiki_menu_items_controller.rb
@@ -60,6 +60,7 @@ class WikiMenuItemsController < ApplicationController
 
   before_action :find_project_by_project_id
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def edit
     get_data_from_params(params)

--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -36,6 +36,7 @@ class WorkPackages::DialogsController < ApplicationController
   before_action :build_work_package, only: %i[new]
 
   authorize_with_permission :add_work_packages
+  redirect_historical_project_identifier param_key: :project_id
 
   def new
     respond_with_dialog WorkPackages::Dialogs::CreateDialogComponent.new(work_package: @work_package, project: @project)

--- a/app/controllers/work_packages/reports_controller.rb
+++ b/app/controllers/work_packages/reports_controller.rb
@@ -31,6 +31,7 @@
 class WorkPackages::ReportsController < ApplicationController
   menu_item :work_packages
   before_action :find_project_by_project_id, :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def report
     reports_service = Reports::ReportsService.new(@project)

--- a/lib/api/helpers/historical_identifier_redirect.rb
+++ b/lib/api/helpers/historical_identifier_redirect.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module Helpers
+    module HistoricalIdentifierRedirect
+      # Redirects API requests using a historical project identifier to the canonical URL
+      # with the project's current identifier.
+      #
+      # Returns a 301 Moved Permanently response when the request uses a historical
+      # (retired) project identifier. This ensures API responses always use canonical URLs.
+      #
+      # @param identifier_param [Symbol] The route parameter name (e.g., :id, :project, :of)
+      # @param project [Project] The loaded project instance
+      #
+      # @example In a Grape API endpoint
+      #   route_param :id do
+      #     after_validation do
+      #       helpers ::API::Helpers::HistoricalIdentifierRedirect
+      #       @project = Project.find(params[:id])
+      #       redirect_if_historical_identifier(:id, @project)
+      #     end
+      #   end
+      def redirect_if_historical_identifier(identifier_param, project)
+        param_value = params[identifier_param]
+
+        # Only redirect if:
+        # 1. The parameter is a friendly_id slug (not numeric ID)
+        # 2. The parameter doesn't match the project's current identifier
+        if request.get? && param_value.friendly_id? && param_value != project.identifier
+          # Reconstruct only the path and query string, not the full URL
+          # This prevents Host header injection and open redirect attacks
+          path = request.path
+          query_string = request.query_string
+
+          # Replace the old identifier in the path
+          new_path = path.sub(
+            %r{(/)#{Regexp.escape(param_value)}(/|$)},
+            "\\1#{project.identifier}\\2"
+          )
+
+          # Replace the old identifier in query parameters if present
+          if query_string.present?
+            new_query_string = query_string.gsub(
+              /(\A|&)#{Regexp.escape(identifier_param.to_s)}=#{Regexp.escape(param_value)}(&|\z)/,
+              "\\1#{identifier_param}=#{CGI.escape(project.identifier)}\\2"
+            )
+            new_path += "?#{new_query_string}"
+          end
+
+          # Return 301 Moved Permanently with path-only redirect
+          redirect new_path, permanent: true
+        end
+      end
+    end
+  end
+end

--- a/lib/api/helpers/historical_identifier_redirect.rb
+++ b/lib/api/helpers/historical_identifier_redirect.rb
@@ -31,52 +31,21 @@
 module API
   module Helpers
     module HistoricalIdentifierRedirect
-      # Redirects API requests using a historical project identifier to the canonical URL
-      # with the project's current identifier.
+      # Issues a 301 redirect to the canonical URL when the request uses a historical
+      # project identifier. The canonical URL is provided by the caller via a block,
+      # which is only evaluated when a redirect is actually needed.
       #
-      # Returns a 301 Moved Permanently response when the request uses a historical
-      # (retired) project identifier. This ensures API responses always use canonical URLs.
-      #
-      # @param identifier_param [Symbol] The route parameter name (e.g., :id, :project, :of)
+      # @param param_value [String] The identifier value from the request params
       # @param project [Project] The loaded project instance
+      # @yieldreturn [String] The canonical URL to redirect to
       #
-      # @example In a Grape API endpoint
-      #   route_param :id do
-      #     after_validation do
-      #       helpers ::API::Helpers::HistoricalIdentifierRedirect
-      #       @project = Project.find(params[:id])
-      #       redirect_if_historical_identifier(:id, @project)
-      #     end
+      # @example
+      #   redirect_if_historical_project_identifier(params[:id], @project) do
+      #     api_v3_paths.project(@project.identifier)
       #   end
-      def redirect_if_historical_identifier(identifier_param, project)
-        param_value = params[identifier_param]
-
-        # Only redirect if:
-        # 1. The parameter is a friendly_id slug (not numeric ID)
-        # 2. The parameter doesn't match the project's current identifier
+      def redirect_if_historical_project_identifier(param_value, project)
         if request.get? && param_value.friendly_id? && param_value != project.identifier
-          # Reconstruct only the path and query string, not the full URL
-          # This prevents Host header injection and open redirect attacks
-          path = request.path
-          query_string = request.query_string
-
-          # Replace the old identifier in the path
-          new_path = path.sub(
-            %r{(/)#{Regexp.escape(param_value)}(/|$)},
-            "\\1#{project.identifier}\\2"
-          )
-
-          # Replace the old identifier in query parameters if present
-          if query_string.present?
-            new_query_string = query_string.gsub(
-              /(\A|&)#{Regexp.escape(identifier_param.to_s)}=#{Regexp.escape(param_value)}(&|\z)/,
-              "\\1#{identifier_param}=#{CGI.escape(project.identifier)}\\2"
-            )
-            new_path += "?#{new_query_string}"
-          end
-
-          # Return 301 Moved Permanently with path-only redirect
-          redirect new_path, permanent: true
+          redirect yield, permanent: true
         end
       end
     end

--- a/lib/api/v3/projects/available_parents_api.rb
+++ b/lib/api/v3/projects/available_parents_api.rb
@@ -33,9 +33,17 @@ module API
     module Projects
       class AvailableParentsAPI < ::API::OpenProjectAPI
         resource :available_parent_projects do
+          helpers ::API::Helpers::HistoricalIdentifierRedirect
+
           after_validation do
             authorize_globally(:add_project) do
               authorize_in_any_project(%i[add_subprojects edit_project])
+            end
+
+            # Handle redirect for historical identifier in :of query param
+            if params[:of]
+              @of_project = Project.find(params[:of])
+              redirect_if_historical_identifier(:of, @of_project)
             end
           end
 
@@ -43,7 +51,8 @@ module API
             model: Project,
             scope: -> do
               project = if params[:of]
-                          Project.find(params[:of])
+                          # Reuse @of_project if available (already found in after_validation)
+                          @of_project || Project.find(params[:of])
                         else
                           Project.new(workspace_type: params[:workspace_type] || "project")
                         end

--- a/lib/api/v3/projects/available_parents_api.rb
+++ b/lib/api/v3/projects/available_parents_api.rb
@@ -43,7 +43,9 @@ module API
             # Handle redirect for historical identifier in :of query param
             if params[:of]
               @of_project = Project.find(params[:of])
-              redirect_if_historical_identifier(:of, @of_project)
+              redirect_if_historical_project_identifier(params[:of], @of_project) do
+                api_v3_paths.projects_available_parents(of: @of_project.identifier)
+              end
             end
           end
 

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -71,7 +71,9 @@ module API
                            Project.visible(current_user)
                          end.find(params[:id])
 
-              redirect_if_historical_identifier(:id, @project)
+              redirect_if_historical_project_identifier(params[:id], @project) do
+                api_v3_paths.project(@project.identifier)
+              end
             end
 
             mount API::V3::Projects::Copy::CopyAPI

--- a/lib/api/v3/projects/projects_api.rb
+++ b/lib/api/v3/projects/projects_api.rb
@@ -58,6 +58,8 @@ module API
             requires :id, desc: "Project id"
           end
           route_param :id do
+            helpers ::API::Helpers::HistoricalIdentifierRedirect
+
             after_validation do
               # TODO: This should be scoped to only allow actual projects.
               # But since it and especially the NestedAPIs are established routes,
@@ -68,6 +70,8 @@ module API
                          else
                            Project.visible(current_user)
                          end.find(params[:id])
+
+              redirect_if_historical_identifier(:id, @project)
             end
 
             mount API::V3::Projects::Copy::CopyAPI

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -96,6 +96,8 @@ module API
               requires :type, desc: "Work package schema id"
             end
             namespace ":project-:type" do
+              helpers ::API::Helpers::HistoricalIdentifierRedirect
+
               after_validation do
                 begin
                   @project = Project.find(params[:project])
@@ -103,6 +105,8 @@ module API
                 rescue ActiveRecord::RecordNotFound
                   raise404
                 end
+
+                redirect_if_historical_identifier(:project, @project)
 
                 authorize_in_any_work_package(:view_work_packages, in_project: @project) do
                   raise404

--- a/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schemas_api.rb
@@ -106,7 +106,9 @@ module API
                   raise404
                 end
 
-                redirect_if_historical_identifier(:project, @project)
+                redirect_if_historical_project_identifier(params[:project], @project) do
+                  api_v3_paths.work_package_schema(@project.identifier, params[:type])
+                end
 
                 authorize_in_any_work_package(:view_work_packages, in_project: @project) do
                   raise404

--- a/lib/api/v3/workspaces/workspaces_api.rb
+++ b/lib/api/v3/workspaces/workspaces_api.rb
@@ -52,7 +52,9 @@ module API
                            Project.visible(current_user)
                          end.find(params[:id])
 
-              redirect_if_historical_identifier(:id, @project)
+              redirect_if_historical_project_identifier(params[:id], @project) do
+                api_v3_paths.project(@project.identifier)
+              end
             end
 
             mount ::API::V3::Workspaces::InstanceApis

--- a/lib/api/v3/workspaces/workspaces_api.rb
+++ b/lib/api/v3/workspaces/workspaces_api.rb
@@ -43,12 +43,16 @@ module API
           mount ::API::V3::Workspaces::Schemas::WorkspaceSchemaAPI
 
           route_param :id do
+            helpers ::API::Helpers::HistoricalIdentifierRedirect
+
             after_validation do
               @project = if current_user.admin?
                            Project
                          else
                            Project.visible(current_user)
                          end.find(params[:id])
+
+              redirect_if_historical_identifier(:id, @project)
             end
 
             mount ::API::V3::Workspaces::InstanceApis

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -42,6 +42,8 @@ class RbApplicationController < ApplicationController
   # User.current has permission to invoke the method in question.
   def load_sprint_and_project
     load_project
+    redirect_if_historical_project_identifier(:project_id)
+    return if performed?
 
     # because of strong params, we want to pluck this variable out right now,
     # otherwise it causes issues where we are doing `attributes=`.

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -35,6 +35,7 @@ class RbApplicationController < ApplicationController
   before_action :load_sprint_and_project,
                 :check_if_plugin_is_configured,
                 :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   private
 
@@ -42,7 +43,6 @@ class RbApplicationController < ApplicationController
   # User.current has permission to invoke the method in question.
   def load_sprint_and_project
     load_project
-    redirect_if_historical_project_identifier(:project_id)
     return if performed?
 
     # because of strong params, we want to pluck this variable out right now,

--- a/modules/backlogs/app/controllers/rb_application_controller.rb
+++ b/modules/backlogs/app/controllers/rb_application_controller.rb
@@ -43,7 +43,6 @@ class RbApplicationController < ApplicationController
   # User.current has permission to invoke the method in question.
   def load_sprint_and_project
     load_project
-    return if performed?
 
     # because of strong params, we want to pluck this variable out right now,
     # otherwise it causes issues where we are doing `attributes=`.

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -42,6 +42,7 @@ class RbSprintsController < RbApplicationController
   before_action :not_authorized_on_feature_flag_inactive,
                 :load_project,
                 only: NEW_SPRINT_ACTIONS
+  redirect_historical_project_identifier param_key: :project_id, only: NEW_SPRINT_ACTIONS
 
   def new_dialog
     call = Sprints::SetAttributesService.new(
@@ -178,7 +179,6 @@ class RbSprintsController < RbApplicationController
 
   def load_project
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
   end
 
   def sprint_params

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -176,6 +176,11 @@ class RbSprintsController < RbApplicationController
     load_project
   end
 
+  def load_project
+    @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
+  end
+
   def sprint_params
     params.expect(sprint: %i[name start_date effective_date])
   end

--- a/modules/backlogs/lib/open_project/backlogs/patches/versions_controller_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/versions_controller_patch.rb
@@ -30,6 +30,7 @@ module OpenProject::Backlogs::Patches::VersionsControllerPatch
   def self.included(base) # rubocop:disable Metrics/AbcSize
     base.class_eval do
       before_action :override_project_from_id, only: %i[edit update]
+      redirect_historical_project_identifier param_key: :project_id, only: %i[edit update]
 
       append_before_action :add_project_to_version_settings_attributes, only: %i[update create]
       append_before_action :whitelist_update_params, only: :update
@@ -41,7 +42,6 @@ module OpenProject::Backlogs::Patches::VersionsControllerPatch
         # here we want to add that we always set it to the project from params if present
         if params[:project_id].present?
           @project = Project.visible.find(params[:project_id])
-          redirect_if_historical_project_identifier(:project_id)
         end
       end
 

--- a/modules/backlogs/lib/open_project/backlogs/patches/versions_controller_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/versions_controller_patch.rb
@@ -41,6 +41,7 @@ module OpenProject::Backlogs::Patches::VersionsControllerPatch
         # here we want to add that we always set it to the project from params if present
         if params[:project_id].present?
           @project = Project.visible.find(params[:project_id])
+          redirect_if_historical_project_identifier(:project_id)
         end
       end
 

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -389,4 +389,144 @@ RSpec.describe RbSprintsController do
       end
     end
   end
+
+  describe "legacy actions" do
+    shared_let(:type_feature) { create(:type_feature) }
+    shared_let(:type_task) { create(:type_task) }
+    shared_let(:user) { create(:admin) }
+    current_user { user }
+
+    let(:visible_projects_scope) { instance_double(ActiveRecord::Relation) }
+    let(:visible_sprints_scope) { instance_double(ActiveRecord::Relation) }
+
+    before do
+      allow(Setting)
+        .to receive(:plugin_openproject_backlogs)
+              .and_return({ "story_types" => [type_feature.id], "task_type" => type_task.id })
+
+      allow(Project)
+        .to receive(:visible)
+              .and_return(visible_projects_scope)
+
+      allow(visible_projects_scope)
+        .to receive(:find)
+              .with(project.identifier)
+              .and_return(project)
+
+      allow(Sprint)
+        .to receive(:visible)
+              .and_return(visible_sprints_scope)
+
+      allow(visible_sprints_scope)
+        .to receive(:find)
+              .with(sprint.id.to_s)
+              .and_return(sprint)
+    end
+
+    describe "GET #edit_name" do
+      let(:project) { build_stubbed(:project) }
+      let(:sprint) { build_stubbed(:sprint) }
+
+      it "responds with success", :aggregate_failures do
+        get :edit_name, params: { project_id: project.identifier, id: sprint.id }, format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(sprint)
+        expect(assigns(:backlog)).to be_a(Backlog)
+      end
+    end
+
+    describe "GET #show_name" do
+      let(:project) { build_stubbed(:project) }
+      let(:sprint) { build_stubbed(:sprint) }
+
+      it "responds with success", :aggregate_failures do
+        get :show_name, params: { project_id: project.identifier, id: sprint.id }, format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(sprint)
+        expect(assigns(:backlog)).to be_a(Backlog)
+      end
+    end
+
+    describe "PATCH #update" do
+      let(:project) { build_stubbed(:project) }
+      let(:sprint) { build_stubbed(:sprint) }
+
+      before do
+        update_service = instance_double(Versions::UpdateService, call: service_result)
+
+        allow(Versions::UpdateService)
+          .to receive(:new)
+                .with(user:, model: sprint)
+                .and_return(update_service)
+      end
+
+      context "when service call succeeds" do
+        let(:service_result) { ServiceResult.success(result: sprint) }
+
+        it "responds with success", :aggregate_failures do
+          patch :update,
+                params: { project_id: project.identifier, id: sprint.id, sprint: { name: "Updated Sprint" } },
+                format: :turbo_stream
+
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
+          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:sprint)).to eq(sprint)
+          expect(assigns(:backlog)).to be_a(Backlog)
+        end
+      end
+
+      context "when service call fails" do
+        let(:service_result) { ServiceResult.failure(result: sprint) }
+
+        before do
+          project.name = ""
+        end
+
+        it "responds with 422", :aggregate_failures do
+          patch :update,
+                params: { project_id: project.identifier, id: sprint.id, sprint: { name: "" } },
+                format: :turbo_stream
+
+          expect(response).not_to be_successful
+          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
+          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:sprint)).to eq(sprint)
+          expect(assigns(:backlog)).to be_a(Backlog)
+        end
+      end
+    end
+  end
+
+  describe "historic identifier handling" do
+    let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints create_sprints] }) }
+    let(:project) { create(:project) }
+    let!(:old_identifier) { project.identifier }
+
+    before do
+      login_as(user)
+      project.update!(identifier: "current-identifier")
+      allow(Setting)
+        .to receive(:plugin_openproject_backlogs)
+              .and_return({ "story_types" => [1], "task_type" => 2 })
+    end
+
+    it "does not redirect turbo_stream requests with historical identifier" do
+      get :new_dialog, params: { project_id: old_identifier }, format: :turbo_stream
+      expect(response).to be_successful
+      expect(response).not_to have_http_status(:moved_permanently)
+    end
+  end
 end

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -510,7 +510,7 @@ RSpec.describe RbSprintsController do
     end
   end
 
-  describe "historic identifier handling" do
+  describe "historic identifier handling", with_flag: { scrum_projects: true } do
     let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints create_sprints] }) }
     let(:project) { create(:project) }
     let!(:old_identifier) { project.identifier }

--- a/modules/backlogs/spec/controllers/rb_taskboards_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_taskboards_controller_spec.rb
@@ -85,4 +85,12 @@ RSpec.describe RbTaskboardsController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+    let(:sprint) { create(:sprint, project:) }
+
+    it_behaves_like "redirects GET requests using a historical project identifier",
+                    :show, { sprint_id: -> { sprint.id } }
+  end
 end

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/projects_api.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/projects_api.rb
@@ -48,7 +48,9 @@ module Bim::Bcf::API::V2_1
           @project = visible_projects
                      .find(params[:id])
 
-          redirect_if_historical_identifier(:id, @project)
+          redirect_if_historical_project_identifier(params[:id], @project) do
+            bcf_v2_1_paths.project(@project.identifier)
+          end
         end
 
         get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount

--- a/modules/bim/app/controllers/bim/bcf/api/v2_1/projects_api.rb
+++ b/modules/bim/app/controllers/bim/bcf/api/v2_1/projects_api.rb
@@ -43,6 +43,7 @@ module Bim::Bcf::API::V2_1
 
       route_param :id do
         helpers ::API::Helpers::HistoricalIdentifierRedirect
+        helpers ::API::Bim::Utilities::PathHelper
 
         after_validation do
           @project = visible_projects

--- a/modules/bim/app/controllers/bim/bcf/issues_controller.rb
+++ b/modules/bim/app/controllers/bim/bcf/issues_controller.rb
@@ -33,6 +33,7 @@ module Bim
 
       before_action :find_project_by_project_id
       before_action :authorize
+      redirect_historical_project_identifier param_key: :project_id
       before_action :import_canceled?
 
       before_action :check_file_param, only: %i[prepare_import]

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -37,6 +37,8 @@ module Bim
       # Callback done by AWS so can't be authenticated. Don't have to be either, though.
       # It only actually does anything if there is a pending upload with the key passed by AWS.
       before_action :authorize, except: %i[direct_upload_finished set_direct_upload_file_name]
+      redirect_historical_project_identifier param_key: :project_id,
+                                             only: %i[index new create show defaults edit update destroy direct_upload_finished]
       before_action :require_login, only: [:set_direct_upload_file_name]
       skip_before_action :verify_authenticity_token, only: [:set_direct_upload_file_name] # AJAX request in page, so skip authenticity token
       no_authorization_required! :set_direct_upload_file_name,

--- a/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_viewer_controller.rb
@@ -31,6 +31,7 @@ module Bim
     class IfcViewerController < BaseController
       before_action :find_project_by_project_id
       before_action :authorize
+      redirect_historical_project_identifier param_key: :project_id
       before_action :find_all_ifc_models
       before_action :set_default_models
       before_action :parse_showing_models

--- a/modules/bim/app/controllers/bim/menus_controller.rb
+++ b/modules/bim/app/controllers/bim/menus_controller.rb
@@ -29,6 +29,7 @@ module ::Bim
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @submenu_menu_items = ::Bim::Menu.new(project: @project, params:).menu_items

--- a/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
+++ b/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
@@ -35,6 +35,13 @@ module API
 
           resources :projects do
             route_param :id do
+              helpers ::API::Helpers::HistoricalIdentifierRedirect
+
+              after_validation do
+                @project = Project.find(params[:id])
+                redirect_if_historical_identifier(:id, @project)
+              end
+
               namespace "bcf_xml" do
                 helpers do
                   # Global helper to set allowed content_types
@@ -56,7 +63,7 @@ module API
                   end
 
                   def find_project
-                    Project.find(params[:id])
+                    @project || Project.find(params[:id])
                   end
                 end
 

--- a/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
+++ b/modules/bim/lib/api/bim/bcf_xml/v1/bcf_xml_api.rb
@@ -39,7 +39,9 @@ module API
 
               after_validation do
                 @project = Project.find(params[:id])
-                redirect_if_historical_identifier(:id, @project)
+                redirect_if_historical_project_identifier(params[:id], @project) do
+                  "/api/bcf_xml_api/projects/#{@project.identifier}"
+                end
               end
 
               namespace "bcf_xml" do

--- a/modules/bim/spec/requests/api/bcf/v2_1/projects_historical_identifier_redirect_spec.rb
+++ b/modules/bim/spec/requests/api/bcf/v2_1/projects_historical_identifier_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "BCF 2.1 projects historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project, enabled_module_names: [:bim]) }
+  shared_let(:role) { create(:project_role, permissions: [:view_work_packages]) }
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-
-          redirect_if_historical_identifier(:id, @project)
-        end
-
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
-    end
+  describe "GET /api/bcf/2.1/projects/:id" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/bcf/2.1/projects/:id"
   end
 end

--- a/modules/bim/spec/requests/api/bcf_xml/v1/historical_identifier_redirect_spec.rb
+++ b/modules/bim/spec/requests/api/bcf_xml/v1/historical_identifier_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "API BCF XML historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project, enabled_module_names: %w[bim work_package_tracking]) }
+  shared_let(:role) { create(:project_role, permissions: [:view_linked_issues]) }
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-
-          redirect_if_historical_identifier(:id, @project)
-        end
-
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
-    end
+  describe "GET /api/bcf_xml_api/v1/projects/:id/bcf_xml" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/bcf_xml_api/v1/projects/:id/bcf_xml"
   end
 end

--- a/modules/boards/app/controllers/boards/menus_controller.rb
+++ b/modules/boards/app/controllers/boards/menus_controller.rb
@@ -29,6 +29,7 @@ module ::Boards
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @submenu_menu_items = ::Boards::Menu.new(project: @project, params:).menu_items

--- a/modules/budgets/app/controllers/budgets_controller.rb
+++ b/modules/budgets/app/controllers/budgets_controller.rb
@@ -41,6 +41,8 @@ class BudgetsController < ApplicationController
     :update_material_budget_item,
     :update_labor_budget_item
   ]
+  redirect_historical_project_identifier param_key: :project_id,
+                                         only: %i[new create update_material_budget_item update_labor_budget_item]
 
   no_authorization_required! :update_material_budget_item,
                              :update_labor_budget_item

--- a/modules/budgets/spec/controllers/budgets_controller_spec.rb
+++ b/modules/budgets/spec/controllers/budgets_controller_spec.rb
@@ -201,11 +201,13 @@ RSpec.describe BudgetsController do
   end
 
   describe "historic identifier redirect" do
-    let(:project) { create(:project) }
-    let(:user) { create(:user, member_with_permissions: { project => %i[view_budgets] }) }
+    let(:redirect_project) { create(:project, enabled_module_names: %i[budgets]) }
+    let(:redirect_user) { create(:user, member_with_permissions: { redirect_project => %i[view_budgets edit_budgets] }) }
 
-    before { allow(User).to receive(:current).and_return user }
+    before { allow(User).to receive(:current).and_return redirect_user }
 
-    it_behaves_like "redirects GET requests using a historical project identifier", :new
+    it_behaves_like "redirects GET requests using a historical project identifier", :new do
+      let(:project) { redirect_project }
+    end
   end
 end

--- a/modules/budgets/spec/controllers/budgets_controller_spec.rb
+++ b/modules/budgets/spec/controllers/budgets_controller_spec.rb
@@ -199,4 +199,13 @@ RSpec.describe BudgetsController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+    let(:user) { create(:user, member_with_permissions: { project => %i[view_budgets] }) }
+
+    before { allow(User).to receive(:current).and_return user }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :new
+  end
 end

--- a/modules/calendar/app/controllers/calendar/menus_controller.rb
+++ b/modules/calendar/app/controllers/calendar/menus_controller.rb
@@ -29,6 +29,7 @@ module ::Calendar
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @submenu_menu_items = ::Calendar::Menu.new(project: @project, params:).menu_items

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -106,7 +106,6 @@ class CostlogController < ApplicationController
       @project = @work_package.project
     elsif params[:project_id]
       @project = Project.visible.find(params[:project_id])
-      nil if performed?
     else
       render_404
     end

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -105,6 +105,8 @@ class CostlogController < ApplicationController
       @project = @work_package.project
     elsif params[:project_id]
       @project = Project.visible.find(params[:project_id])
+      redirect_if_historical_project_identifier(:project_id)
+      nil if performed?
     else
       render_404
     end

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -32,6 +32,7 @@ class CostlogController < ApplicationController
   menu_item :work_packages
   before_action :find_cost_entry_work_package_or_project, :authorize, only: %i[edit new create update destroy]
   before_action :find_associated_objects, only: %i[create update]
+  redirect_historical_project_identifier param_key: :project_id, only: %i[edit new create update destroy]
 
   helper :work_packages
   include CostlogHelper
@@ -105,7 +106,6 @@ class CostlogController < ApplicationController
       @project = @work_package.project
     elsif params[:project_id]
       @project = Project.visible.find(params[:project_id])
-      redirect_if_historical_project_identifier(:project_id)
       nil if performed?
     else
       render_404

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -42,6 +42,7 @@ class HourlyRatesController < ApplicationController
 
   # #show, #edit and #update have their own authorization
   before_action :authorize, except: %i[show edit update]
+  redirect_historical_project_identifier param_key: :project_id, only: %i[show]
   no_authorization_required! :show,
                              :edit,
                              :update
@@ -141,7 +142,6 @@ class HourlyRatesController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
-    redirect_if_historical_project_identifier(:project_id)
   end
 
   def find_user

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -141,6 +141,7 @@ class HourlyRatesController < ApplicationController
 
   def find_project
     @project = Project.visible.find(params[:project_id])
+    redirect_if_historical_project_identifier(:project_id)
   end
 
   def find_user

--- a/modules/costs/app/controllers/hourly_rates_controller.rb
+++ b/modules/costs/app/controllers/hourly_rates_controller.rb
@@ -37,7 +37,7 @@ class HourlyRatesController < ApplicationController
   include HourlyRatesHelper
 
   before_action :find_optional_project, only: %i[edit update]
-  before_action :find_project, only: %i[show]
+  before_action :find_project_by_project_id, only: %i[show]
   before_action :find_user, only: %i[show edit update]
 
   # #show, #edit and #update have their own authorization
@@ -138,10 +138,6 @@ class HourlyRatesController < ApplicationController
     else
       user.default_rates.delete_all
     end
-  end
-
-  def find_project
-    @project = Project.visible.find(params[:project_id])
   end
 
   def find_user

--- a/modules/costs/spec/controllers/costlog_controller_spec.rb
+++ b/modules/costs/spec/controllers/costlog_controller_spec.rb
@@ -753,4 +753,15 @@ RSpec.describe CostlogController do
       it_behaves_like "forbidden update"
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project_with_types) }
+    let(:user) { create(:user, member_with_permissions: { project => [:log_costs] }) }
+
+    before do
+      login_as(user)
+    end
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :new
+  end
 end

--- a/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
+++ b/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
@@ -250,14 +250,19 @@ RSpec.describe HourlyRatesController do
   end
 
   describe "historic identifier redirect" do
-    let(:project) { create(:project) }
-    let(:rate_user) { create(:user) }
+    let(:redirect_project) { create(:project) }
+    let(:rate_user) { create(:user, member_with_permissions: { redirect_project => [] }) }
+    let(:redirect_admin) { create(:admin, member_with_permissions: { redirect_project => [:view_hourly_rates] }) }
 
     before do
-      login_as(admin)
+      # Ensure rate_user is a member so the project has data
+      rate_user
+      login_as(redirect_admin)
     end
 
     it_behaves_like "redirects GET requests using a historical project identifier",
-                    :show, { id: -> { rate_user.id } }
+                    :show, { id: -> { rate_user.id } } do
+      let(:project) { redirect_project }
+    end
   end
 end

--- a/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
+++ b/modules/costs/spec/controllers/hourly_rates_controller_spec.rb
@@ -248,4 +248,16 @@ RSpec.describe HourlyRatesController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+    let(:rate_user) { create(:user) }
+
+    before do
+      login_as(admin)
+    end
+
+    it_behaves_like "redirects GET requests using a historical project identifier",
+                    :show, { id: -> { rate_user.id } }
+  end
 end

--- a/modules/costs/spec/controllers/time_entries_controller_spec.rb
+++ b/modules/costs/spec/controllers/time_entries_controller_spec.rb
@@ -290,4 +290,21 @@ RSpec.describe TimeEntriesController do
       end
     end
   end
+
+  describe "historic identifier handling" do
+    let(:project) { create(:project) }
+    let(:user) { create(:user, member_with_permissions: { project => [:log_time] }) }
+    let!(:old_identifier) { project.identifier }
+
+    before do
+      login_as(user)
+      project.update!(identifier: "current-identifier")
+    end
+
+    it "does not redirect turbo_stream requests with historical identifier" do
+      get :dialog, params: { project_id: old_identifier }, format: :turbo_stream
+      expect(response).to be_successful
+      expect(response).not_to have_http_status(:moved_permanently)
+    end
+  end
 end

--- a/modules/documents/app/controllers/documents/menus_controller.rb
+++ b/modules/documents/app/controllers/documents/menus_controller.rb
@@ -32,6 +32,7 @@ module Documents
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @sidebar_menu_items = Documents::Menu.new(project: @project, params:).menu_items

--- a/modules/documents/app/controllers/documents/refresh_tokens_controller.rb
+++ b/modules/documents/app/controllers/documents/refresh_tokens_controller.rb
@@ -33,6 +33,7 @@ module Documents
     before_action :find_project_by_project_id
     before_action :find_document
     before_action :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def create
       token_result = Documents::OAuth::TokenWithMetadataService.new(

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -39,6 +39,7 @@ class DocumentsController < ApplicationController
   before_action :find_project_by_project_id, only: %i[index search new create]
   before_action :find_document, except: %i[index search new create]
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id, only: %i[index search new create]
 
   def index
     @documents = list_documents_query

--- a/modules/grids/app/controllers/grids/base_in_project_controller.rb
+++ b/modules/grids/app/controllers/grids/base_in_project_controller.rb
@@ -2,6 +2,7 @@ module ::Grids
   class BaseInProjectController < ::ApplicationController
     before_action :find_project_by_project_id
     before_action :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       render

--- a/modules/grids/app/controllers/grids/widgets/news_controller.rb
+++ b/modules/grids/app/controllers/grids/widgets/news_controller.rb
@@ -34,6 +34,7 @@ class Grids::Widgets::NewsController < Grids::WidgetController
   # 403 error page.
   skip_before_action :load_and_authorize_in_optional_project
   before_action :find_optional_project
+  redirect_historical_project_identifier param_key: :project_id
 
   def show
     render_widget Grids::Widgets::News.new(@project, current_user:)

--- a/modules/overviews/app/controllers/overviews/project_custom_fields_controller.rb
+++ b/modules/overviews/app/controllers/overviews/project_custom_fields_controller.rb
@@ -34,6 +34,7 @@ class Overviews::ProjectCustomFieldsController < ApplicationController
   before_action :find_project_by_project_id
   before_action :find_project_custom_field
   before_action :authorize
+  redirect_historical_project_identifier param_key: :project_id
 
   def show
     respond_with_dialog(

--- a/modules/storages/app/controllers/storages/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/project_storages_controller.rb
@@ -37,6 +37,7 @@ class Storages::ProjectStoragesController < ApplicationController
   before_action :find_project_by_project_id
   before_action :find_project_storage
   before_action :render_403, unless: -> { User.current.allowed_in_project?(:view_file_links, @project) }
+  redirect_historical_project_identifier param_key: :project_id
   no_authorization_required! :open
 
   before_action :ensure_remote_identity, only: :open

--- a/modules/team_planner/app/controllers/team_planner/menus_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/menus_controller.rb
@@ -29,6 +29,7 @@ module ::TeamPlanner
   class MenusController < ApplicationController
     before_action :find_project_by_project_id,
                   :authorize
+    redirect_historical_project_identifier param_key: :project_id
 
     def show
       @submenu_menu_items = ::TeamPlanner::Menu.new(project: @project, params:).menu_items

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -259,4 +259,10 @@ RSpec.describe CategoriesController do
       it_behaves_like "redirect"
     end
   end
+
+  describe "historic identifier redirect" do
+    before { allow(User).to receive(:current).and_return user }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :new
+  end
 end

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -265,4 +265,10 @@ RSpec.describe ForumsController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    before { allow(User).to receive(:current).and_return user }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :index
+  end
 end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -439,4 +439,12 @@ RSpec.describe MembersController do
       expect(response).to redirect_to "/projects/pet_project/members"
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+
+    before { allow(User).to receive(:current).and_return user }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :index
+  end
 end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -441,10 +441,13 @@ RSpec.describe MembersController do
   end
 
   describe "historic identifier redirect" do
-    let(:project) { create(:project) }
+    let(:redirect_project) { create(:project) }
+    let(:redirect_user) { create(:user, member_with_permissions: { redirect_project => %i[view_members] }) }
 
-    before { allow(User).to receive(:current).and_return user }
+    before { allow(User).to receive(:current).and_return redirect_user }
 
-    it_behaves_like "redirects GET requests using a historical project identifier", :index
+    it_behaves_like "redirects GET requests using a historical project identifier", :index do
+      let(:project) { redirect_project }
+    end
   end
 end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe MessagesController, with_settings: { journal_aggregation_time_min
   end
 
   describe "historic identifier redirect" do
-    let(:permissions) { %i[view_messages] }
+    let(:permissions) { %i[view_messages add_messages] }
 
     it_behaves_like "redirects GET requests using a historical project identifier",
                     :new,

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -136,4 +136,12 @@ RSpec.describe MessagesController, with_settings: { journal_aggregation_time_min
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:permissions) { %i[view_messages] }
+
+    it_behaves_like "redirects GET requests using a historical project identifier",
+                    :new,
+                    { forum_id: -> { forum.id } }
+  end
 end

--- a/spec/controllers/projects/archive_controller_spec.rb
+++ b/spec/controllers/projects/archive_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe Projects::ArchiveController do
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  before do
+    login_as(user)
+  end
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
+  describe "historic identifier handling" do
+    let!(:old_identifier) { project.identifier }
 
-          redirect_if_historical_identifier(:id, @project)
-        end
+    before { project.update!(identifier: "current-identifier") }
 
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
+    it "does not redirect turbo_stream requests with historical identifier" do
+      get :dialog, params: { project_id: old_identifier }, format: :turbo_stream
+      expect(response).to be_successful
+      expect(response).not_to have_http_status(:moved_permanently)
     end
   end
 end

--- a/spec/controllers/projects/identifier_controller_spec.rb
+++ b/spec/controllers/projects/identifier_controller_spec.rb
@@ -36,6 +36,27 @@ RSpec.describe Projects::IdentifierController do
   current_user { create(:admin) }
   render_views
 
+  describe "show" do
+    context "when accessing an old identifier" do
+      let!(:old_identifier) { project.identifier }
+
+      before { project.update!(identifier: "new-identifier") }
+
+      it "redirects GET to the current identifier with 301" do
+        get :show, params: { project_id: old_identifier }
+        expect(response).to redirect_to(project_identifier_path("new-identifier"))
+        expect(response).to have_http_status(:moved_permanently)
+      end
+    end
+
+    context "when accessing via numeric project id" do
+      it "does not redirect" do
+        get :show, params: { project_id: project.id.to_s }
+        expect(response).not_to have_http_status(:moved_permanently)
+      end
+    end
+  end
+
   describe "update" do
     it "sets the project identifier to the provided value" do
       put :update, params: { project_id: project.id, project: { identifier: "new-identifier" } }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -558,6 +558,21 @@ RSpec.describe ProjectsController do
     end
   end
 
+  describe "#copy_form with a historical identifier" do
+    let(:project) { create(:project, identifier: "blog") }
+
+    before do
+      old_identifier = project.identifier
+      project.update!(identifier: "new-blog")
+      get "copy_form", params: { id: old_identifier }
+    end
+
+    it "redirects to the current identifier with 301" do
+      expect(response).to redirect_to(copy_project_path("new-blog"))
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
   describe "#copy" do
     let(:project) { create(:project, identifier: "blog") }
 
@@ -607,5 +622,11 @@ RSpec.describe ProjectsController do
         expect(response).to render_template "copy_form"
       end
     end
+  end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+
+    it_behaves_like "redirects GET requests using a historical project :id", :destroy_info
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -627,6 +627,6 @@ RSpec.describe ProjectsController do
   describe "historic identifier redirect" do
     let(:project) { create(:project) }
 
-    it_behaves_like "redirects GET requests using a historical project :id", :destroy_info
+    it_behaves_like "redirects GET requests using a historical project :id", :copy_form
   end
 end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -344,4 +344,16 @@ RSpec.describe RepositoriesController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    let(:project) { create(:project) }
+    let(:repository) { create(:repository_subversion, project:) }
+
+    before do
+      allow(User).to receive(:current).and_return(user)
+      allow(Setting).to receive(:enabled_scm).and_return(["subversion"])
+    end
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :show
+  end
 end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -348,6 +348,7 @@ RSpec.describe RepositoriesController do
   describe "historic identifier redirect" do
     let(:project) { create(:project) }
     let(:repository) { create(:repository_subversion, project:) }
+    let(:permissions) { [:browse_repository] }
 
     before do
       allow(User).to receive(:current).and_return(user)

--- a/spec/controllers/users/invite_controller_spec.rb
+++ b/spec/controllers/users/invite_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe Users::InviteController do
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  before do
+    login_as(user)
+  end
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
+  describe "historic identifier handling" do
+    let!(:old_identifier) { project.identifier }
 
-          redirect_if_historical_identifier(:id, @project)
-        end
+    before { project.update!(identifier: "current-identifier") }
 
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
+    it "does not redirect turbo_stream requests with historical identifier" do
+      get :start_dialog, params: { project_id: old_identifier }, format: :turbo_stream
+      expect(response).to be_successful
+      expect(response).not_to have_http_status(:moved_permanently)
     end
   end
 end

--- a/spec/controllers/versions_controller_spec.rb
+++ b/spec/controllers/versions_controller_spec.rb
@@ -360,4 +360,10 @@ RSpec.describe VersionsController do
       expect { Version.find(@deleted) }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe "historic identifier redirect" do
+    before { login_as(user) }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :index
+  end
 end

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -33,6 +33,16 @@ require "spec_helper"
 RSpec.describe WikiController do
   shared_let(:admin) { create(:admin) }
 
+  describe "historic identifier redirect" do
+    # Use a local let (not shared_let) so we can mutate the identifier without
+    # affecting the shared project used by the rest of the suite.
+    let(:project) { create(:project).tap { |p| create(:wiki, project: p) } }
+
+    current_user { admin }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :index
+  end
+
   shared_let(:project) do
     create(:project).tap(&:reload)
   end

--- a/spec/controllers/work_packages/reports_controller_spec.rb
+++ b/spec/controllers/work_packages/reports_controller_spec.rb
@@ -183,4 +183,10 @@ RSpec.describe WorkPackages::ReportsController do
       end
     end
   end
+
+  describe "historic identifier redirect" do
+    before { allow(User).to receive(:current).and_return user }
+
+    it_behaves_like "redirects GET requests using a historical project identifier", :report
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -674,6 +674,44 @@ RSpec.describe Project do
     end
   end
 
+  describe "identifier history" do
+    let!(:project) { create(:project, identifier: "sc") }
+
+    it "records old identifier in friendly_id_slugs when identifier changes" do
+      project.update!(identifier: "scp")
+      expect(FriendlyId::Slug.where(sluggable: project).pluck(:slug)).to include("sc")
+    end
+
+    it "can still find the project via its old identifier" do
+      project.update!(identifier: "scp")
+      expect(described_class.friendly.find("sc")).to eq(project)
+    end
+
+    it "returns the project with its current identifier when found via old identifier" do
+      project.update!(identifier: "scp")
+      found = described_class.friendly.find("sc")
+      expect(found.identifier).to eq("scp")
+    end
+
+    it "locks old identifier to the original project (not reusable by others)" do
+      project.update!(identifier: "scp")
+      slug = FriendlyId::Slug.find_by(slug: "sc")
+      expect(slug.sluggable_id).to eq(project.id)
+    end
+
+    it "allows the project to revert to a previously used identifier" do
+      project.update!(identifier: "scp")
+      expect { project.update!(identifier: "sc") }.not_to raise_error
+      expect(project.identifier).to eq("sc")
+    end
+
+    it "is valid when reverting to own historical identifier" do
+      project.update!(identifier: "scp")
+      project.identifier = "sc"
+      expect(project).to be_valid
+    end
+  end
+
   describe "#allowed_parent_workspace_types" do
     {
       project: %i[portfolio program project],

--- a/spec/requests/api/v3/projects/available_parents_historical_identifier_spec.rb
+++ b/spec/requests/api/v3/projects/available_parents_historical_identifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "API v3 Available Parents historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-
-          redirect_if_historical_identifier(:id, @project)
-        end
-
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
-    end
+  describe "GET /api/v3/projects/available_parent_projects?of=:id" do
+    it_behaves_like "API redirects GET requests using a historical project identifier in query param",
+                    "/api/v3/projects/available_parent_projects", "of"
   end
 end

--- a/spec/requests/api/v3/projects/historical_identifier_redirect_spec.rb
+++ b/spec/requests/api/v3/projects/historical_identifier_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,17 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "API v3 Projects historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-
-          redirect_if_historical_identifier(:id, @project)
-        end
-
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
-    end
+  describe "GET /api/v3/projects/:id" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/v3/projects/:id"
   end
 end

--- a/spec/requests/api/v3/work_packages/schema/historical_identifier_redirect_spec.rb
+++ b/spec/requests/api/v3/work_packages/schema/historical_identifier_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,23 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "API v3 WorkPackage Schema historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project, :with_types) }
+  shared_let(:type) { project.types.first }
+  shared_let(:user) do
+    create(:user,
+           member_with_roles: { project => create(:project_role, permissions: [:view_work_packages]) })
+  end
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
-
-          redirect_if_historical_identifier(:id, @project)
-        end
-
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
+  describe "GET /api/v3/work_packages/schemas/:project-:type" do
+    it_behaves_like "API redirects GET requests using a historical project identifier with dynamic path" do
+      let(:path_with_old_id) { "/api/v3/work_packages/schemas/#{old_identifier}-#{type.id}" }
+      let(:current_identifier_pattern) { "#{project.identifier}-#{type.id}" }
     end
   end
 end

--- a/spec/requests/api/v3/workspaces/historical_identifier_redirect_spec.rb
+++ b/spec/requests/api/v3/workspaces/historical_identifier_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,39 +28,28 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Bim::Bcf::API::V2_1
-  class ProjectsAPI < ::API::OpenProjectAPI
-    resources :projects do
-      helpers do
-        def visible_projects
-          Project
-            .visible(current_user)
-            .has_module(:bim)
-        end
-      end
+require "spec_helper"
+require "rack/test"
 
-      get &::Bim::Bcf::API::V2_1::Endpoints::Index.new(model: Project,
-                                                       scope: -> { visible_projects })
-                                             .mount
+RSpec.describe "API v3 Workspace historical identifier redirect", content_type: :json do
+  shared_let(:project) { create(:project) }
+  shared_let(:role) { create(:project_role, permissions: [:view_work_packages]) }
+  shared_let(:user) { create(:user, member_with_roles: { project => role }) }
 
-      route_param :id do
-        helpers ::API::Helpers::HistoricalIdentifierRedirect
+  current_user { user }
 
-        after_validation do
-          @project = visible_projects
-                     .find(params[:id])
+  describe "GET /api/v3/workspaces/:id" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/v3/workspaces/:id"
+  end
 
-          redirect_if_historical_identifier(:id, @project)
-        end
+  describe "GET /api/v3/workspaces/:id/work_packages" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/v3/workspaces/:id/work_packages"
+  end
 
-        get &::Bim::Bcf::API::V2_1::Endpoints::Show.new(model: Project).mount
-        put &::Bim::Bcf::API::V2_1::Endpoints::Update
-               .new(model: Project)
-               .mount
-
-        mount ::Bim::Bcf::API::V2_1::TopicsAPI
-        mount ::Bim::Bcf::API::V2_1::ProjectExtensions::API
-      end
-    end
+  describe "GET /api/v3/workspaces/:id/categories" do
+    it_behaves_like "API redirects GET requests using a historical project identifier",
+                    "/api/v3/workspaces/:id/categories"
   end
 end

--- a/spec/services/projects/set_attributes_service_integration_spec.rb
+++ b/spec/services/projects/set_attributes_service_integration_spec.rb
@@ -68,8 +68,22 @@ RSpec.describe Projects::SetAttributesService, "integration", type: :model do
       let(:project) { Project.new name: "My new project", identifier: "my-new-project" }
 
       it "results in an error" do
-        expect(service_result).not_to be_success
+        expect(service_result).to be_a_failure
         expect(service_result.result.identifier).to eq "my-new-project"
+
+        errors = service_result.errors.full_messages
+        expect(errors).to eq ["Identifier has already been taken."]
+      end
+    end
+
+    context "and a new project with an identifier formerly used by the existing project" do
+      let(:project) { Project.new name: "My new project", identifier: existing_identifier }
+
+      before { existing.update!(identifier: "my-renamed-project") }
+
+      it "results in an error — retired identifiers remain reserved" do
+        expect(service_result).to be_a_failure
+        expect(service_result.result.identifier).to eq existing_identifier
 
         errors = service_result.errors.full_messages
         expect(errors).to eq ["Identifier has already been taken."]

--- a/spec/support/shared/controllers/historic_project_identifier_redirect.rb
+++ b/spec/support/shared/controllers/historic_project_identifier_redirect.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Shared example for controller specs that verify GET requests using a
+# historical (stale) project identifier are redirected 301 to the same
+# URL with the project's current identifier.
+#
+# Requires `project` to be defined in the enclosing context (via let).
+#
+# Usage:
+#   it_behaves_like "redirects GET requests using a historical project identifier",
+#                   :index, { project_id: :injected_by_shared_example }
+#
+#   # With extra required params (e.g. forum_id):
+#   it_behaves_like "redirects GET requests using a historical project identifier",
+#                   :index, { forum_id: -> { forum.id } }
+#
+# The param key for the project is always :project_id.
+# To test with :id instead, use the "...via :id" variant below.
+RSpec.shared_examples "redirects GET requests using a historical project identifier" do |action, extra_params = {}|
+  let!(:old_identifier) { project.identifier }
+
+  before { project.update!(identifier: "current-identifier") }
+
+  it "redirects to the same action with the current identifier (301)" do
+    resolved = extra_params.transform_values { |v| v.respond_to?(:call) ? instance_exec(&v) : v }
+    get action, params: { project_id: old_identifier }.merge(resolved)
+    expect(response).to have_http_status(:moved_permanently)
+    expect(response.location).to include("current-identifier")
+  end
+end
+
+# Variant for controllers that use :id instead of :project_id for the project param.
+RSpec.shared_examples "redirects GET requests using a historical project :id" do |action, extra_params = {}|
+  let!(:old_identifier) { project.identifier }
+
+  before { project.update!(identifier: "current-identifier") }
+
+  it "redirects to the same action with the current identifier (301)" do
+    resolved = extra_params.transform_values { |v| v.respond_to?(:call) ? instance_exec(&v) : v }
+    get action, params: { id: old_identifier }.merge(resolved)
+    expect(response).to have_http_status(:moved_permanently)
+    expect(response.location).to include("current-identifier")
+  end
+end

--- a/spec/support/shared/controllers/historic_project_identifier_redirect.rb
+++ b/spec/support/shared/controllers/historic_project_identifier_redirect.rb
@@ -8,11 +8,14 @@
 #
 # Usage:
 #   it_behaves_like "redirects GET requests using a historical project identifier",
-#                   :index, { project_id: :injected_by_shared_example }
+#                   :index
 #
 #   # With extra required params (e.g. forum_id):
 #   it_behaves_like "redirects GET requests using a historical project identifier",
 #                   :index, { forum_id: -> { forum.id } }
+#
+#   Attention: If you manually set a param for the project id it will be overwritten
+#              by the example.
 #
 # The param key for the project is always :project_id.
 # To test with :id instead, use the "...via :id" variant below.
@@ -23,7 +26,7 @@ RSpec.shared_examples "redirects GET requests using a historical project identif
 
   it "redirects to the same action with the current identifier (301)" do
     resolved = extra_params.transform_values { |v| v.respond_to?(:call) ? instance_exec(&v) : v }
-    get action, params: { project_id: old_identifier }.merge(resolved)
+    get action, params: { project_id: old_identifier }.reverse_merge(resolved)
     expect(response).to have_http_status(:moved_permanently)
     expect(response.location).to include("current-identifier")
   end
@@ -37,7 +40,7 @@ RSpec.shared_examples "redirects GET requests using a historical project :id" do
 
   it "redirects to the same action with the current identifier (301)" do
     resolved = extra_params.transform_values { |v| v.respond_to?(:call) ? instance_exec(&v) : v }
-    get action, params: { id: old_identifier }.merge(resolved)
+    get action, params: { id: old_identifier }.reverse_merge(resolved)
     expect(response).to have_http_status(:moved_permanently)
     expect(response.location).to include("current-identifier")
   end

--- a/spec/support/shared/requests/api/historic_project_identifier_redirect.rb
+++ b/spec/support/shared/requests/api/historic_project_identifier_redirect.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# Shared example for API request specs that verify GET requests using a
+# historical (stale) project identifier are redirected 301 to the same
+# URL with the project's current identifier.
+#
+# Requires `project` and `current_user` to be defined in the enclosing context (via let).
+#
+# Usage:
+#   it_behaves_like "API redirects GET requests using a historical project identifier",
+#                   "/api/v3/workspaces/:id"
+#
+#   # With path that includes the identifier in a different position:
+#   it_behaves_like "API redirects GET requests using a historical project identifier",
+#                   "/api/v3/work_packages/schemas/:id-#{type.id}"
+#
+# The :id in the path will be replaced with old_identifier for testing.
+RSpec.shared_examples "API redirects GET requests using a historical project identifier" do |path_template|
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let!(:old_identifier) { project.identifier }
+
+  before { project.update!(identifier: "current-identifier") }
+
+  it "redirects to the same path with the current identifier (301)" do
+    # Replace :id in template with old_identifier
+    test_path = path_template.gsub(":id", old_identifier)
+
+    get test_path
+
+    expect(last_response).to have_http_status(301)
+    expect(last_response.location).to include("current-identifier")
+    expect(last_response.location).not_to include(old_identifier)
+  end
+
+  it "does not redirect when using current identifier" do
+    test_path = path_template.gsub(":id", "current-identifier")
+
+    get test_path
+
+    expect(last_response).to have_http_status(200)
+  end
+
+  it "does not redirect when using numeric ID" do
+    test_path = path_template.gsub(":id", project.id.to_s)
+
+    get test_path
+
+    expect(last_response).to have_http_status(200)
+  end
+end
+
+# Variant for API endpoints with dynamic paths that need let variables
+# Requires `path_with_old_id` and `current_identifier_pattern` to be defined via let.
+RSpec.shared_examples "API redirects GET requests using a historical project identifier with dynamic path" do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let!(:old_identifier) { project.identifier }
+
+  before { project.update!(identifier: "current-identifier") }
+
+  it "redirects to the same path with the current identifier (301)" do
+    get path_with_old_id
+
+    expect(last_response).to have_http_status(301)
+    expect(last_response.location).to include(current_identifier_pattern)
+    expect(last_response.location).not_to include(old_identifier)
+  end
+
+  it "does not redirect when using current identifier" do
+    path_with_current_id = path_with_old_id.gsub(old_identifier, "current-identifier")
+    get path_with_current_id
+
+    expect(last_response).to have_http_status(200)
+  end
+
+  it "does not redirect when using numeric ID" do
+    path_with_numeric_id = path_with_old_id.gsub(old_identifier, project.id.to_s)
+    get path_with_numeric_id
+
+    expect(last_response).to have_http_status(200)
+  end
+end
+
+# Variant for API endpoints that use query parameters for the project identifier
+RSpec.shared_examples "API redirects GET requests using a historical project identifier in query param" do |base_path, param_name|
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let!(:old_identifier) { project.identifier }
+
+  before { project.update!(identifier: "current-identifier") }
+
+  it "redirects to the same path with the current identifier (301)" do
+    get "#{base_path}?#{param_name}=#{old_identifier}"
+
+    expect(last_response).to have_http_status(301)
+    expect(last_response.location).to include("#{param_name}=current-identifier")
+    expect(last_response.location).not_to include(old_identifier)
+  end
+
+  it "does not redirect when using current identifier" do
+    get "#{base_path}?#{param_name}=current-identifier"
+
+    expect(last_response).to have_http_status(200)
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72918

# What are you trying to accomplish?
Redirect all routes that include an outdated project identifier (to the identical route but with the current identifier)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
