### PR TITLE
[#72924] Workflows UX improvement: Make saving changes more straightforward and less error-prone  

### DIFF
--- a/app/components/workflows/confirmation_dialog_component.html.erb
+++ b/app/components/workflows/confirmation_dialog_component.html.erb
@@ -48,7 +48,8 @@ See COPYRIGHT and LICENSE files for more details.
         footer.with_component(
           Primer::Beta::Button.new(
             scheme: :primary, type: :submit, form: "workflow_form",
-            name: :next_role_id, value: @next_role_id
+            name: @next_tab ? :next_tab : :next_role_id,
+            value: @next_tab || @next_role_id
           )
         ) { t("admin.workflows.leave_confirmation.save") }
       end

--- a/app/components/workflows/confirmation_dialog_component.html.erb
+++ b/app/components/workflows/confirmation_dialog_component.html.erb
@@ -1,0 +1,57 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(
+    Primer::OpenProject::FeedbackDialog.new(
+      id: DIALOG_ID,
+      title: t("admin.workflows.leave_confirmation.title")
+    )
+  ) do |dialog|
+    dialog.with_feedback_message(icon_arguments: { icon: :none }) do |message|
+      message.with_heading(tag: :h2) { t("admin.workflows.leave_confirmation.title") }
+      message.with_description_content(t("admin.workflows.leave_confirmation.description"))
+    end
+
+    dialog.with_footer do
+      component_collection do |footer|
+        footer.with_component(
+          Primer::Beta::Button.new(scheme: :danger, tag: :a, href: @redirect_url)
+        ) { t("admin.workflows.leave_confirmation.ignore") }
+
+        footer.with_component(
+          Primer::Beta::Button.new(
+            scheme: :primary, type: :submit, form: "workflow_form",
+            name: :next_role_id, value: @next_role_id
+          )
+        ) { t("admin.workflows.leave_confirmation.save") }
+      end
+    end
+  end
+%>

--- a/app/components/workflows/confirmation_dialog_component.rb
+++ b/app/components/workflows/confirmation_dialog_component.rb
@@ -35,10 +35,11 @@ module Workflows
 
     DIALOG_ID = "workflows-confirmation-dialog"
 
-    def initialize(redirect_url:, next_role_id:)
+    def initialize(redirect_url:, next_role_id: nil, next_tab: nil)
       super()
       @redirect_url = redirect_url
       @next_role_id = next_role_id
+      @next_tab = next_tab
     end
   end
 end

--- a/app/components/workflows/confirmation_dialog_component.rb
+++ b/app/components/workflows/confirmation_dialog_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# -- copyright
+#-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,21 +26,19 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
 module Workflows
-  class EditSubHeaderComponent < ApplicationComponent
+  class ConfirmationDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(tab:, current_role: nil, type: nil, available_roles: [], status_ids: [], dirty: false)
-      super
-      @tab = tab
-      @current_role = current_role
-      @type = type
-      @available_roles = available_roles
-      @status_ids = status_ids
-      @dirty = dirty
+    DIALOG_ID = "workflows-confirmation-dialog"
+
+    def initialize(redirect_url:, next_role_id:)
+      super()
+      @redirect_url = redirect_url
+      @next_role_id = next_role_id
     end
   end
 end

--- a/app/components/workflows/edit_sub_header_component.html.erb
+++ b/app/components/workflows/edit_sub_header_component.html.erb
@@ -27,37 +27,47 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%=
-  render Primer::OpenProject::SubHeader.new do |subheader|
-    if @type && @available_roles.any?
-      subheader.with_filter_component do
-        render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
-          menu.with_show_button(scheme: :secondary) do |button|
-            button.with_trailing_visual_icon(icon: :"triangle-down")
-            @current_role ? t("admin.workflows.role_selector.label", role: @current_role.name) : t("admin.workflows.role_selector.no_role")
-          end
-          @available_roles.each do |role|
-            menu.with_item(
-              label: role.name,
-              tag: :a,
-              href: helpers.edit_workflow_path(@type, role_id: role.id, tab: @tab || "always"),
-              active: role == @current_role,
-              data: { turbo_frame: "_top" }
-            )
+<%= component_wrapper do %>
+  <%=
+    render Primer::OpenProject::SubHeader.new do |subheader|
+      if @type && @available_roles.any?
+        subheader.with_filter_component do
+          render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
+            menu.with_show_button(scheme: :secondary) do |button|
+              button.with_trailing_visual_icon(icon: :"triangle-down")
+              @current_role ? t("admin.workflows.role_selector.label", role: @current_role.name) : t("admin.workflows.role_selector.no_role")
+            end
+            @available_roles.each do |role|
+              menu.with_item(
+                label: role.name,
+                active: role == @current_role,
+                href: helpers.confirmation_dialog_workflows_path(
+                  type_id: @type.id,
+                  role_id: @current_role&.id,
+                  next_role_id: role.id,
+                  tab: @tab || "always",
+                  dirty: @dirty
+                ),
+                form_arguments: {
+                  method: :post,
+                  data: { turbo_stream: true, workflow_role_form: true }
+                }
+              )
+            end
           end
         end
       end
-    end
 
-    subheader.with_action_button(
-      tag: :a,
-      scheme: :secondary,
-      leading_icon: :plus,
-      label: t("admin.workflows.status_button"),
-      href: helpers.status_dialog_workflows_path(role_id: @current_role&.id, type_id: @type&.id, tab: @tab, status_ids: @status_ids.presence),
-      data: { controller: "async-dialog" }
-    ) do
-      t("admin.workflows.status_button")
+      subheader.with_action_button(
+        tag: :a,
+        scheme: :secondary,
+        leading_icon: :plus,
+        label: t("admin.workflows.status_button"),
+        href: helpers.status_dialog_workflows_path(role_id: @current_role&.id, type_id: @type&.id, tab: @tab, status_ids: @status_ids.presence),
+        data: { controller: "async-dialog" }
+      ) do
+        t("admin.workflows.status_button")
+      end
     end
-  end
-%>
+  %>
+<% end %>

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -38,8 +38,8 @@ class WorkflowsController < ApplicationController
   before_action :find_roles, except: :update
   before_action :find_types, except: %i[edit update]
 
-  before_action :find_role, only: :update
-  before_action :find_type, only: %i[edit update]
+  before_action :find_role, only: %i[update confirmation_dialog]
+  before_action :find_type, only: %i[edit update confirmation_dialog]
 
   before_action :find_optional_role, only: %i[edit status_dialog confirm_statuses]
   before_action :find_optional_type, only: %i[edit status_dialog confirm_statuses]
@@ -68,7 +68,8 @@ class WorkflowsController < ApplicationController
 
     if call.success?
       flash[:notice] = I18n.t(:notice_successful_update)
-      redirect_to edit_workflow_path(@type, role_id: @role.id, tab:)
+      next_role_id = params[:next_role_id].presence
+      redirect_to edit_workflow_path(@type, role_id: next_role_id || @role.id, tab:)
     end
   end
 
@@ -97,6 +98,31 @@ class WorkflowsController < ApplicationController
         flash[:notice] = I18n.t(:notice_successful_update)
         redirect_to action: "copy", source_type_id: @source_type, source_role_id: @source_role
       end
+    end
+  end
+
+  def confirmation_dialog # rubocop:disable Metrics/AbcSize
+    if params[:dirty] == "true"
+      # Necessary because the ActionMenu updates even when the confirmation dialog
+      # is closed via "X". This update ensures the correct option is shown as selected
+      # with a preceding checkbox at all times.
+      update_via_turbo_stream(
+        component: Workflows::EditSubHeaderComponent.new(
+          tab: current_tab,
+          current_role: @role,
+          type: @type,
+          available_roles: @roles,
+          status_ids: [],
+          dirty: true
+        )
+      )
+      respond_with_dialog Workflows::ConfirmationDialogComponent.new(
+        redirect_url: edit_workflow_path(@type, role_id: params[:next_role_id], tab: current_tab),
+        next_role_id: params[:next_role_id]
+      )
+    else
+      redirect_to edit_workflow_path(@type, role_id: params[:next_role_id], tab: current_tab),
+                  status: :see_other
     end
   end
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -52,6 +52,7 @@ class WorkflowsController < ApplicationController
   end
 
   def edit
+    @current_tab = current_tab
     statuses_for_form
 
     if @type && @role && @statuses.any?
@@ -69,7 +70,8 @@ class WorkflowsController < ApplicationController
     if call.success?
       flash[:notice] = I18n.t(:notice_successful_update)
       next_role_id = params[:next_role_id].presence
-      redirect_to edit_workflow_path(@type, role_id: next_role_id || @role.id, tab:)
+      next_tab = params[:next_tab].presence
+      redirect_to edit_workflow_path(@type, role_id: next_role_id || @role.id, tab: next_tab || tab)
     end
   end
 
@@ -102,6 +104,10 @@ class WorkflowsController < ApplicationController
   end
 
   def confirmation_dialog # rubocop:disable Metrics/AbcSize
+    destination_role_id = params[:next_role_id].presence || @role.id
+    destination_tab = params[:next_tab].presence || current_tab
+    destination_url = edit_workflow_path(@type, role_id: destination_role_id, tab: destination_tab)
+
     if params[:dirty] == "true"
       # Necessary because the ActionMenu updates even when the confirmation dialog
       # is closed via "X". This update ensures the correct option is shown as selected
@@ -117,12 +123,12 @@ class WorkflowsController < ApplicationController
         )
       )
       respond_with_dialog Workflows::ConfirmationDialogComponent.new(
-        redirect_url: edit_workflow_path(@type, role_id: params[:next_role_id], tab: current_tab),
-        next_role_id: params[:next_role_id]
+        redirect_url: destination_url,
+        next_role_id: params[:next_role_id].presence,
+        next_tab: params[:next_tab].presence
       )
     else
-      redirect_to edit_workflow_path(@type, role_id: params[:next_role_id], tab: current_tab),
-                  status: :see_other
+      redirect_to destination_url, status: :see_other
     end
   end
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -60,7 +60,7 @@ class WorkflowsController < ApplicationController
     end
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     tab = params[:tab] || "always"
 
     call = Workflows::BulkUpdateService

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -111,7 +111,7 @@ class WorkflowsController < ApplicationController
     if params[:dirty] == "true"
       # Necessary because the ActionMenu updates even when the confirmation dialog
       # is closed via "X". This update ensures the correct option is shown as selected
-      # with a preceding checkbox at all times.
+      # with a preceding checkbox at all times
       update_via_turbo_stream(
         component: Workflows::EditSubHeaderComponent.new(
           tab: current_tab,

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -44,7 +44,7 @@ module TabsHelper
 
     header.with_tab_nav(label: nil, test_selector:) do |tab_nav|
       tabs.each do |tab|
-        tab_nav.with_tab(selected: selected_tab(tabs) == tab, href: tab[:path]) do |t|
+        tab_nav.with_tab(selected: selected_tab(tabs) == tab, href: tab[:path], data: tab[:data]) do |t|
           feature = tab[:enterprise_feature]
 
           if feature && !EnterpriseToken.allows_to?(feature)

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -29,26 +29,29 @@
 #++
 
 module WorkflowHelper
-  def workflow_tabs(type)
+  def workflow_tabs(type, current_role: nil, current_tab: nil)
     [
-      {
-        name: "always",
+      { name: "always", label: I18n.t(:"admin.workflows.tabs.default_transitions") },
+      { name: "author", label: I18n.t(:"admin.workflows.tabs.user_author") },
+      { name: "assignee", label: I18n.t(:"admin.workflows.tabs.user_assignee") }
+    ].map do |tab|
+      tab.merge(
         partial: "workflows/form",
-        path: edit_workflow_path(type, { tab: :always }.merge(params.permit(:role_id))),
-        label: I18n.t(:"admin.workflows.tabs.default_transitions")
-      },
-      {
-        name: "author",
-        partial: "workflows/form",
-        path: edit_workflow_path(type, { tab: :author }.merge(params.permit(:role_id))),
-        label: I18n.t(:"admin.workflows.tabs.user_author")
-      },
-      {
-        name: "assignee",
-        partial: "workflows/form",
-        path: edit_workflow_path(type, { tab: :assignee }.merge(params.permit(:role_id))),
-        label: I18n.t(:"admin.workflows.tabs.user_assignee")
-      }
-    ]
+        path: edit_workflow_path(type, { tab: tab[:name] }.merge(params.permit(:role_id))),
+        data: if current_role
+                {
+                  workflow_tab_link: true,
+                  workflow_tab_current: tab[:name] == current_tab,
+                  confirmation_url: confirmation_dialog_workflows_path(
+                    type_id: type.id,
+                    role_id: current_role.id,
+                    next_tab: tab[:name],
+                    tab: current_tab || "always",
+                    dirty: true
+                  )
+                }
+              end
+      )
+    end
   end
 end

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -29,12 +29,12 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_administration), t(:label_workflow_plural), @type.name -%>
 
 <% content_for :content_header do %>
-  <%= render Workflows::EditPageHeaderComponent.new(@type, tabs: workflow_tabs(@type)) %>
+  <%= render Workflows::EditPageHeaderComponent.new(@type, tabs: workflow_tabs(@type, current_role: @role, current_tab: @current_tab)) %>
 <% end %>
 
 <% if @type && @role %>
   <%= turbo_frame_tag "workflow-table" do %>
-    <%= render Workflows::EditSubHeaderComponent.new(tab: params[:tab], current_role: @role, type: @type, available_roles: @roles, status_ids: @statuses.pluck(:id)) %>
+    <%= render Workflows::EditSubHeaderComponent.new(tab: @current_tab, current_role: @role, type: @type, available_roles: @roles, status_ids: @statuses.pluck(:id)) %>
 
     <% if @statuses.any? %>
       <%= form_tag(
@@ -45,7 +45,7 @@ See COPYRIGHT and LICENSE files for more details.
           ) do %>
           <%= hidden_field_tag "type_id", @type.id %>
           <%= hidden_field_tag "role_id", @role.id %>
-          <%= hidden_field_tag "tab", params[:tab] || "always" %>
+          <%= hidden_field_tag "tab", @current_tab %>
 
     <%= render_tabs workflow_tabs(@type) %>
 
@@ -58,7 +58,7 @@ See COPYRIGHT and LICENSE files for more details.
           </div>
         <% end %>
     <% else %>
-      <%= render Workflows::BlankslateComponent.new(role: @role, type: @type, tab: params[:tab]) %>
+      <%= render Workflows::BlankslateComponent.new(role: @role, type: @type, tab: @current_tab) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -51,7 +51,7 @@ See COPYRIGHT and LICENSE files for more details.
 
           <div class="workflow-save-bar">
             <%=
-              render Primer::Beta::Button.new(scheme: :primary, type: :submit, mt: 2, ml: 3, mb: 4) do
+              render Primer::Beta::Button.new(scheme: :primary, type: :submit, mt: 3, ml: 3, mb: 4) do
                 t(:button_save)
               end
             %>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -49,11 +49,13 @@ See COPYRIGHT and LICENSE files for more details.
 
     <%= render_tabs workflow_tabs(@type) %>
 
-          <%=
-            render Primer::Beta::Button.new(scheme: :primary, type: :submit, id: "work-flow-save-button") do
-              t(:button_save)
-            end
-          %>
+          <div class="workflow-save-bar">
+            <%=
+              render Primer::Beta::Button.new(scheme: :primary, type: :submit, mt: 2, ml: 3, mb: 4) do
+                t(:button_save)
+              end
+            %>
+          </div>
         <% end %>
     <% else %>
       <%= render Workflows::BlankslateComponent.new(role: @role, type: @type, tab: params[:tab]) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,6 +418,11 @@ en:
           other: "Remove %{count} statuses?"
         description: "Removing these statuses will make them unavailable to this type and delete existing workflows. Are you sure you want to proceed?"
         confirm: "Remove"
+      leave_confirmation:
+        title: "Save changes before continuing?"
+        description: "You are about to leave this page but you have unsaved changes. Would you like to save them before continuing?"
+        ignore: "Ignore changes"
+        save: "Save changes and continue"
       role_selector:
         label: "Role: %{role}"
         no_role: "Select role"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -803,6 +803,7 @@ Rails.application.routes.draw do
       get "summarized"
       get :status_dialog
       post :confirm_statuses
+      post :confirmation_dialog
     end
   end
 

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,7 +1,15 @@
 .controller-workflows
   #content-body
     overflow-x: scroll
-    padding-bottom: 50px
+    margin-bottom: 68px
+
+  turbo-frame#workflow-table
+    width: 100%
+
+  sub-header.SubHeader
+    position: sticky
+    left: 0
+    background: var(--body-background)
 
 #workflow_form
   .generic-table--results-container

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,7 +1,10 @@
 .controller-workflows
   #content-body
     overflow-x: scroll
-    margin-bottom: 72px
+
+  &.action-edit
+    #content-body
+      margin-bottom: 72px // 16px (mt: 3) + 32px (button) + 24px (mb: 4)
 
   turbo-frame#workflow-table
     width: 100%

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,7 +1,7 @@
 .controller-workflows
   #content-body
     overflow-x: scroll
-    margin-bottom: 68px
+    margin-bottom: 72px
 
   turbo-frame#workflow-table
     width: 100%

--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -1,6 +1,7 @@
 .controller-workflows
   #content-body
     overflow-x: scroll
+    padding-bottom: 50px
 
 #workflow_form
   .generic-table--results-container
@@ -60,6 +61,10 @@
   th:first-child
     z-index: 3
 
-#work-flow-save-button
-  position: sticky
-  left: 0
+.workflow-save-bar
+  position: fixed
+  bottom: 0
+  left: var(--main-menu-width)
+  right: 0
+  background: var(--body-background)
+  z-index: 100

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -29,6 +29,7 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
+import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 
 const SAVED_STATE_KEY = 'workflow-saved-state';
 
@@ -39,8 +40,13 @@ interface SavedState {
 
 export default class WorkflowCheckboxStateController extends Controller<HTMLFormElement> {
   private initialCheckboxState:Record<string, boolean> = {};
+  private turboRequests:TurboRequestsService;
 
   connect() {
+    void window.OpenProject.getPluginContext().then((context) => {
+      this.turboRequests = context.services.turboRequests;
+    });
+
     const frame = this.element.closest<HTMLElement>('turbo-frame');
     frame?.addEventListener('turbo:before-frame-render', this.onBeforeFrameRender);
 
@@ -53,12 +59,15 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
 
     this.initialCheckboxState = this.captureState();
     this.element.addEventListener('change', this.onCheckboxChange);
+
+    document.addEventListener('click', this.onTabLinkClick, true);
   }
 
   disconnect() {
     this.element.closest('turbo-frame')?.removeEventListener('turbo:before-frame-render', this.onBeforeFrameRender);
     this.element.removeEventListener('submit', this.onFormSubmit);
     this.element.removeEventListener('change', this.onCheckboxChange);
+    document.removeEventListener('click', this.onTabLinkClick, true);
   }
 
   private onBeforeFrameRender = () => {
@@ -76,6 +85,21 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     const dirty = Object.keys(current).some((key) => current[key] !== this.initialCheckboxState[key]);
     this.element.dataset.dirty = dirty ? 'true' : 'false';
     this.updateRoleFormDirtyParam(dirty);
+  };
+
+  private onTabLinkClick = (event:Event) => {
+    const target = (event.target as HTMLElement).closest<HTMLAnchorElement>('[data-workflow-tab-link]');
+    if (!target) return;
+    if (target.dataset.workflowTabCurrent === 'true') return;
+    if (this.element.dataset.dirty !== 'true') return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    void this.turboRequests.request(target.dataset.confirmationUrl!, {
+      method: 'POST',
+      headers: { Accept: 'text/vnd.turbo-stream.html' },
+    });
   };
 
   private updateRoleFormDirtyParam(dirty:boolean):void {

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -38,6 +38,8 @@ interface SavedState {
 }
 
 export default class WorkflowCheckboxStateController extends Controller<HTMLFormElement> {
+  private initialCheckboxState:Record<string, boolean> = {};
+
   connect() {
     const frame = this.element.closest<HTMLElement>('turbo-frame');
     frame?.addEventListener('turbo:before-frame-render', this.onBeforeFrameRender);
@@ -48,26 +50,50 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     }
 
     this.element.addEventListener('submit', this.onFormSubmit);
+
+    this.initialCheckboxState = this.captureState();
+    this.element.addEventListener('change', this.onCheckboxChange);
   }
 
   disconnect() {
     this.element.closest('turbo-frame')?.removeEventListener('turbo:before-frame-render', this.onBeforeFrameRender);
     this.element.removeEventListener('submit', this.onFormSubmit);
+    this.element.removeEventListener('change', this.onCheckboxChange);
   }
 
   private onBeforeFrameRender = () => {
-    const checkboxes:Record<string, boolean> = {};
-    this.element.querySelectorAll<HTMLInputElement>('input[type="checkbox"]').forEach((cb) => {
-      checkboxes[`${cb.dataset.oldStatus}:${cb.dataset.newStatus}:${cb.value}`] = cb.checked;
-    });
-
-    const state:SavedState = { formKey: this.formKey, checkboxes };
+    const state:SavedState = { formKey: this.formKey, checkboxes: this.captureState() };
     sessionStorage.setItem(SAVED_STATE_KEY, JSON.stringify(state));
   };
 
   private onFormSubmit = () => {
     sessionStorage.removeItem(SAVED_STATE_KEY);
+    this.element.dataset.dirty = 'false';
   };
+
+  private onCheckboxChange = () => {
+    const current = this.captureState();
+    const dirty = Object.keys(current).some((key) => current[key] !== this.initialCheckboxState[key]);
+    this.element.dataset.dirty = dirty ? 'true' : 'false';
+    this.updateRoleFormDirtyParam(dirty);
+  };
+
+  private updateRoleFormDirtyParam(dirty:boolean):void {
+    const frame = this.element.closest('turbo-frame');
+    frame?.querySelectorAll<HTMLFormElement>('[data-workflow-role-form]').forEach((form) => {
+      const url = new URL(form.action);
+      url.searchParams.set('dirty', dirty ? 'true' : 'false');
+      form.action = url.toString();
+    });
+  }
+
+  private captureState():Record<string, boolean> {
+    const checkboxes:Record<string, boolean> = {};
+    this.element.querySelectorAll<HTMLInputElement>('input[type="checkbox"]').forEach((cb) => {
+      checkboxes[`${cb.dataset.oldStatus}:${cb.dataset.newStatus}:${cb.value}`] = cb.checked;
+    });
+    return checkboxes;
+  }
 
   private get formKey():string {
     return `${this.formValue('type_id')}-${this.formValue('role_id')}`;

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -38,6 +38,21 @@ interface SavedState {
   checkboxes:Record<string, boolean>;
 }
 
+/**
+ * Handles two things:
+ * 1) Saving and restoring checked state of each checkbox when updating statuses,
+ * since this refreshes the turbo frame and the checked state is not directly saved
+ * to the DB
+ *
+ * 2) Marking the checkbox matrix as dirty when changes are made but not saved, and
+ * passing this info along when roles/tabs are changed to trigger a confirmation
+ * dialog when necessary:
+ *   - Roles are handled by setting an attribute on each ActionMenu item when dirty.
+ *   This param decides if the controller responds with a confirmation dialog,
+ *   or simply redirects
+ *   - Tabs are handled by listening for clicks on the tab headers, and directly
+ * calling the confirmation dialog from here when dirty
+ */
 export default class WorkflowCheckboxStateController extends Controller<HTMLFormElement> {
   private initialCheckboxState:Record<string, boolean> = {};
   private turboRequests:TurboRequestsService;

--- a/spec/features/roles/create_spec.rb
+++ b/spec/features/roles/create_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Role creation", :js do
     click_link type.name
 
     click_button existing_role.name
-    click_link "New role name"
+    click_button "New role name"
 
     old_status = existing_workflow.old_status.name
     new_status = existing_workflow.new_status.name

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -223,6 +223,11 @@ RSpec.describe "Workflow edit" do
       end
 
       click_link "User is author"
+
+      within_dialog "Save changes before continuing?" do
+        click_link "Ignore changes"
+      end
+
       click_link "Default transitions"
 
       within "#workflow_form_always" do

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe "Workflow edit" do
 
     it "loads the matrix for a different role after switching" do
       click_button role.name
-      click_link other_role.name
+      click_button other_role.name
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 2)
@@ -266,14 +266,18 @@ RSpec.describe "Workflow edit" do
       end
 
       click_button role.name
-      click_link other_role.name
+      click_button other_role.name
+
+      within_dialog "Save changes before continuing?" do
+        click_link "Ignore changes"
+      end
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 2)
       end
 
       click_button other_role.name
-      click_link role.name
+      click_button role.name
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 0), checked: false

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "Workflow edit" do
       end
     end
 
-    it "loses unsaved checkbox changes when switching tabs" do
+    it "loses unsaved checkbox changes when switching tabs and ignoring" do
       within "#workflow_form_always" do
         check workflow_checkbox(1, 0)
       end
@@ -232,6 +232,45 @@ RSpec.describe "Workflow edit" do
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 0), checked: false
+      end
+    end
+
+    it "saves changes and switches to the new tab when clicking 'Save changes and continue'" do
+      within "#workflow_form_always" do
+        check workflow_checkbox(1, 0)
+      end
+
+      click_link "User is author"
+
+      within_dialog "Save changes before continuing?" do
+        click_button "Save changes and continue"
+      end
+
+      expect_flash(message: "Successful update.")
+
+      expect(page).to have_css("#workflow_form_author")
+
+      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
+                              old_status_id: statuses[1].id, new_status_id: statuses[0].id,
+                              author: false, assignee: false)).to be true
+    end
+
+    it "keeps unsaved changes and stays on the same tab when closing the dialog via 'X'" do
+      within "#workflow_form_always" do
+        check workflow_checkbox(1, 0)
+      end
+
+      click_link "User is author"
+
+      within_dialog "Save changes before continuing?" do
+        find(".close-button").click
+      end
+
+      expect(page).to have_no_dialog("Save changes before continuing?")
+      expect(page).to have_css("#workflow_form_always")
+
+      within "#workflow_form_always" do
+        expect(page).to have_field workflow_checkbox(1, 0), checked: true
       end
     end
   end
@@ -265,7 +304,7 @@ RSpec.describe "Workflow edit" do
       end
     end
 
-    it "loses unsaved checkbox changes when switching roles" do
+    it "loses unsaved checkbox changes when switching roles and ignoring" do
       within "#workflow_form_always" do
         check workflow_checkbox(1, 0)
       end
@@ -286,6 +325,49 @@ RSpec.describe "Workflow edit" do
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 0), checked: false
+      end
+    end
+
+    it "saves changes and switches to the new role when clicking 'Save changes and continue'" do
+      within "#workflow_form_always" do
+        check workflow_checkbox(1, 0)
+      end
+
+      click_button role.name
+      click_button other_role.name
+
+      within_dialog "Save changes before continuing?" do
+        click_button "Save changes and continue"
+      end
+
+      expect_flash(message: "Successful update.")
+
+      within "#workflow_form_always" do
+        expect(page).to have_field workflow_checkbox(1, 2)
+      end
+
+      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
+                              old_status_id: statuses[1].id, new_status_id: statuses[0].id,
+                              author: false, assignee: false)).to be true
+    end
+
+    it "keeps unsaved changes and stays on the same role when closing the dialog via 'X'" do
+      within "#workflow_form_always" do
+        check workflow_checkbox(1, 0)
+      end
+
+      click_button role.name
+      click_button other_role.name
+
+      within_dialog "Save changes before continuing?" do
+        find(".close-button").click
+      end
+
+      expect(page).to have_no_dialog("Save changes before continuing?")
+
+      within "#workflow_form_always" do
+        expect(page).to have_field workflow_checkbox(0, 1)
+        expect(page).to have_field workflow_checkbox(1, 0), checked: true
       end
     end
   end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72924

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- The save button bar is now fixed and with a higher z-index so that the table scrolls under it and it appears stuck to the bottom of the view. There is also a margin-bottom on the remaining content to make the horizontal scroll bar appear properly
- Add dirty tracking to the `workflow-checkbox-state` controller to decide when to show a confirmation dialog. This is a comparison of the current state and the saved state that is initially loaded
   - For role changes, the stimulus controller sets a param on each ActionMenu item. When clicked, if this param is set, the controller responds with a confirmation dialog. Otherwise, it redirects as usual
   - For tab changes, the stimulus controller checks dirty state on each click of a tab header. If dirty, it calls the confirmation dialog directly

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
