### PR TITLE
Fix series and occurrence sequence numbers not matching

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -141,7 +141,7 @@ module Meetings
 
         e.created = meeting.created_at.utc
         e.last_modified = meeting.updated_at.utc
-        e.sequence = meeting.lock_version
+        e.sequence = [meeting.lock_version, recurring_meeting.template.lock_version].max
 
         e.recurrence_id = ical_datetime(scheduled_meeting.start_time, timezone: recurring_meeting.time_zone)
         e.dtstart = ical_datetime(meeting.start_time, timezone: recurring_meeting.time_zone)

--- a/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_spec.rb
@@ -403,6 +403,18 @@ RSpec.describe Meetings::IcalendarBuilder,
         end
       end
 
+      it "sets occurrence override SEQUENCE >= series SEQUENCE" do
+        builder.add_series_event(recurring_meeting:)
+
+        master = parsed_calendar.events.find { |e| e.rrule.present? && e.recurrence_id.blank? }
+        overrides = parsed_calendar.events.select { |e| e.recurrence_id.present? }
+
+        expect(master.sequence).to be >= 0
+        overrides.each do |override_event|
+          expect(override_event.sequence).to be >= master.sequence
+        end
+      end
+
       it "sets created and last_modified timestamps correctly for recurring series when accepted" do
         builder.add_series_event(recurring_meeting:)
 


### PR DESCRIPTION
Open-Xchange (correctly) complains when an occurrence has an older sequence number from the series.

The recurring series has SEQUENCE:1, but the occurrence override (identified by RECURRENCE-ID) has SEQUENCE:0. The occurrence override's SEQUENCE must be >= the series SEQUENCE.

The series template gets its lock_version incremented when the occurrence meeting is created (because the template is touched/updated), so template.lock_version becomes 1. But the newly created occurrence meeting starts with lock_version = 0.

https://community.openproject.org/work_packages/72865