### PR TITLE
Fix flaky spec in WP table

### DIFF
--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -110,6 +110,10 @@ RSpec.describe "Arbitrary WorkPackage query table widget on my page",
       filters.add_filter_by("Type", "is (OR)", type.name)
       modal.save
 
+      # Wait for the filter save to complete before opening the column configuration,
+      # otherwise the two saves can race and only one change gets persisted.
+      wait_for_network_idle
+
       filter_area.configure_wp_table
       modal.switch_to("Columns")
       columns.assume_opened


### PR DESCRIPTION
Fixes flaky spec in `modules/my_page/spec/features/my/work_package_table_spec.rb` because two saves race.