### PR TITLE
[73111] Backlogs page looks broken on mobile

### DIFF
--- a/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_list.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag :backlogs_container, refresh: :morph, class: "op-backlogs-page" do %>
+<%= turbo_frame_tag :backlogs_container, refresh: :morph do %>
   <% if @owner_backlogs.empty? && @sprint_backlogs.empty? %>
     <%=
       render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% content_for :content_body do %>
-  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: backlogs_project_backlogs_path(@project) %>
+  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: backlogs_project_backlogs_path(@project), class: "op-backlogs-page" %>
 <% end %>
 
 <% content_for :content_body_right do %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73111

# What are you trying to accomplish?
Set class on the turboTag that remains in Dom instead of the one that is replacing only the content
