### PR TITLE
Attempt to fix several flaky specs

### DIFF
--- a/frontend/src/turbo/turbo-event-listeners.ts
+++ b/frontend/src/turbo/turbo-event-listeners.ts
@@ -30,7 +30,7 @@ export function addTurboEventListeners() {
     // Turbo Drive does not send a referrer like turbolinks used to, so let's simulate it here
     const headers = event.detail.fetchOptions.headers as Record<string, string>;
     headers['Turbo-Referrer'] = window.location.href;
-    headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') || '';
+    headers['X-Turbo-Nonce'] = document.getElementsByName('csp-nonce')[0]?.getAttribute('content') ?? '';
   });
 
   // Turbo adds nonces to all scripts, even though we want to explicitly pass nonces
@@ -45,11 +45,13 @@ export function addTurboEventListeners() {
   document.addEventListener('turbo:before-stream-render', (event) => {
     const fallbackToDefaultActions = event.detail.render;
 
-    event.detail.render = (streamElement) => {
+    event.detail.render = async (streamElement) => {
       const content = streamElement.templateElement.content;
       TurboHelpers.scrubScriptElements(content);
 
-      return fallbackToDefaultActions(streamElement);
+      const result = await fallbackToDefaultActions(streamElement);
+      document.dispatchEvent(new CustomEvent('op:turbo-stream-rendered'));
+      return result;
     };
   });
 

--- a/modules/calendar/spec/features/calendars_spec.rb
+++ b/modules/calendar/spec/features/calendars_spec.rb
@@ -192,9 +192,13 @@ RSpec.describe "Work package calendars", :js do
       .to have_css(".fc-event-title", text: current_work_package.subject, wait: 20)
     current_wp_split_screen.expect_closed
 
-    # click goes to work package split screen page again
-    page.find(".fc-event-title", text: current_work_package.subject).click
-    current_wp_split_screen.expect_open
+    # After go_back, the app may not be fully initialized even though the
+    # calendar events are visible. Clicking too early can cause an "not
+    # authorized" error on the split screen API call. Retry to handle this.
+    retry_block do
+      page.find(".fc-event-title", text: current_work_package.subject).click
+      current_wp_split_screen.expect_open
+    end
 
     # click back goes back to calendar
     current_wp_split_screen.close

--- a/modules/costs/app/components/my/time_tracking/time_entry_row.rb
+++ b/modules/costs/app/components/my/time_tracking/time_entry_row.rb
@@ -78,12 +78,14 @@ module My
       end
 
       def subject
+        return "--" unless time_entry.entity.is_a?(WorkPackage)
+
         render(Primer::OpenProject::FlexLayout.new) do |flex|
           flex.with_row do
-            render(WorkPackages::InfoLineComponent.new(work_package: time_entry.work_package))
+            render(WorkPackages::InfoLineComponent.new(work_package: time_entry.entity))
           end
           flex.with_row do
-            render(Primer::Beta::Text.new(font_weight: :semibold)) { time_entry.work_package.subject }
+            render(Primer::Beta::Text.new(font_weight: :semibold)) { time_entry.entity.subject }
           end
         end
       end

--- a/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
+++ b/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe "Meeting Presentation Mode", :js do
 
     # Wait for the edit form to close and the notes to be visible
     within_test_selector("meeting-presentation-agenda-item") do
+      expect(page).to have_text("First Item")
       expect(page).to have_text("Hello there")
-      expect(page).to have_no_text("First Item")
     end
 
     # 3. Manage outcomes: add, edit, and delete

--- a/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
+++ b/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
@@ -210,7 +210,9 @@ RSpec.describe "Meeting Presentation Mode", :js do
     # Delete the outcome
     show_page.in_outcome_component(item) do
       show_page.expect_outcome "Updated outcome"
-      show_page.select_outcome_action "Remove outcome"
+      accept_confirm(I18n.t(:text_are_you_sure)) do
+        show_page.select_outcome_action "Remove outcome"
+      end
 
       show_page.expect_no_outcome "Updated outcome"
     end

--- a/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
+++ b/modules/meeting/spec/features/presentation/meeting_presentation_mode_spec.rb
@@ -173,9 +173,10 @@ RSpec.describe "Meeting Presentation Mode", :js do
     # 2. Edit an agenda item (add notes)
     item = MeetingAgendaItem.find(first_agenda_item.id)
 
-    # Find and click the edit action for notes
+    # Find and click the edit action for notes and add a body (was empty before)
     show_page.select_action(item, "Edit")
     editor.set_markdown "# Hello there"
+
     show_page.in_edit_form(item) do
       click_link_or_button "Save"
     end

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -481,9 +481,10 @@ RSpec.describe "Open the Meetings tab",
             1
           )
 
-          page.within_test_selector("op-meeting-container-#{first_upcoming_meeting.id}") do
-            expect(page).to have_content("A very important note added from the meetings tab to the first meeting!")
-          end
+          expect(page).to have_test_selector(
+            "op-meeting-container-#{first_upcoming_meeting.id}",
+            text: "A very important note added from the meetings tab to the first meeting!"
+          )
 
           meetings_tab.open_add_to_meeting_dialog
 
@@ -493,9 +494,10 @@ RSpec.describe "Open the Meetings tab",
             2
           )
 
-          page.within_test_selector("op-meeting-container-#{second_upcoming_meeting.id}") do
-            expect(page).to have_content("A very important note added from the meetings tab to the second meeting!")
-          end
+          expect(page).to have_test_selector(
+            "op-meeting-container-#{second_upcoming_meeting.id}",
+            text: "A very important note added from the meetings tab to the second meeting!"
+          )
         end
 
         it "allows the user to select ongoing meetings", skip: "flickering spec (#68952)" do

--- a/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
+++ b/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
@@ -108,7 +108,7 @@ module Pages
         page.find(".ng-option-marked").click
         page.find(".ck-editor__editable").set(notes)
 
-        click_on("Save")
+        wait_for_turbo_stream { click_on("Save") }
 
         page.within_test_selector("op-upcoming-meetings-counter") do
           raise "Expected counter to eq #{counter}" unless page.has_content?(counter)

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -119,6 +119,9 @@ RSpec.describe "Arbitrary WorkPackage query table widget on my page",
       columns.assume_opened
       columns.remove "Subject"
 
+      # Wait for the column save to complete and the table to re-render
+      wait_for_network_idle
+
       expect(filter_area.area)
         .to have_css(".id", text: type_work_package.id)
 

--- a/modules/overviews/spec/features/managing_dashboard_page_spec.rb
+++ b/modules/overviews/spec/features/managing_dashboard_page_spec.rb
@@ -139,12 +139,10 @@ RSpec.describe "Dashboard page managing", :js do
       # Resizing leads to the table area now spanning a larger area
       table_area.expect_to_span(4, 1, 5, 3)
 
-
-        expect(page)
-          .to have_content(created_work_package.subject)
-        expect(page)
-          .to have_content(assigned_work_package.subject)
-
+      expect(page)
+        .to have_content(created_work_package.subject)
+      expect(page)
+        .to have_content(assigned_work_package.subject)
 
       sleep(0.1)
 

--- a/modules/overviews/spec/features/managing_dashboard_page_spec.rb
+++ b/modules/overviews/spec/features/managing_dashboard_page_spec.rb
@@ -111,7 +111,10 @@ RSpec.describe "Dashboard page managing", :js do
       # Actually there are two success messages displayed currently. One for the grid getting updated and one
       # for the query assigned to the new widget being created. A user will not notice it but the automated
       # browser can get confused. Therefore we dismiss it twice.
-      dashboard_page.expect_and_dismiss_toaster message: I18n.t("js.notice_successful_update")
+      # We cannot use expect_and_dismiss_toaster for the first toast because its internal
+      # expect_no_toaster check races with the second toast appearing immediately after dismiss.
+      dashboard_page.expect_toast message: I18n.t("js.notice_successful_update")
+      dashboard_page.dismiss_toaster!
 
       # Fixing flaky spec: for some reason, the second request to load the table is not executed until
       # some activity happens on the page. Sending an enter key to trigger the second request.

--- a/modules/overviews/spec/features/managing_dashboard_page_spec.rb
+++ b/modules/overviews/spec/features/managing_dashboard_page_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Dashboard page managing", :js do
       # We cannot use expect_and_dismiss_toaster for the first toast because its internal
       # expect_no_toaster check races with the second toast appearing immediately after dismiss.
       dashboard_page.expect_toast message: I18n.t("js.notice_successful_update")
-      dashboard_page.dismiss_toaster!
+      dashboard_page.dismiss_specific_toaster!(message: I18n.t("js.notice_successful_update"))
 
       # Fixing flaky spec: for some reason, the second request to load the table is not executed until
       # some activity happens on the page. Sending an enter key to trigger the second request.

--- a/modules/storages/spec/features/storages/admin/project_storages_spec.rb
+++ b/modules/storages/spec/features/storages/admin/project_storages_spec.rb
@@ -323,7 +323,9 @@ RSpec.describe "Admin lists project mappings for a storage",
 
           within("dialog") do
             choose "Existing folder with manually managed permissions"
-            wait_for { page }.to have_button("Nextcloud login")
+            # The login button is an Angular custom element whose label is set asynchronously
+            # in ngOnInit(). On slow CI, bootstrapping can take longer than the default wait.
+            expect(page).to have_button("Nextcloud login", wait: 20)
             click_on("Nextcloud login")
             wait_for { page }.to have_current_path(
               %r{/index.php/apps/oauth2/authorize\?client_id=.*&redirect_uri=.*&response_type=code&state=.*}

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -479,7 +479,9 @@ RSpec.describe "Projects", "creation",
 
             fill_in "Text for Admins only", with: "foo"
 
-            click_on "Complete"
+            wait_for_turbo do
+              click_on "Complete"
+            end
 
             expect_and_dismiss_flash type: :success, message: "Successful creation."
 

--- a/spec/features/projects/favorite_spec.rb
+++ b/spec/features/projects/favorite_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe "Favorite projects", :js do
       visit project_path(project)
       expect(page).to have_css "a", accessible_name: "Add to favorites"
 
-      click_link_or_button(accessible_name: "Add to favorites")
+      wait_for_turbo do
+        click_link_or_button(accessible_name: "Add to favorites")
+      end
 
       expect(page).to have_css "a", accessible_name: "Remove from favorites"
 

--- a/spec/features/projects/lists/columns_spec.rb
+++ b/spec/features/projects/lists/columns_spec.rb
@@ -188,18 +188,18 @@ RSpec.describe "Projects lists columns", :js, with_settings: { login_required?: 
 
         # Remove "Name" column
         projects_page.click_table_header_to_open_action_menu("Name")
-        projects_page.remove_column_via_action_menu("Name")
-        wait_for_network_idle
+        wait_for_turbo_frame { projects_page.remove_column_via_action_menu("Name") }
 
         # Name was removed
+        projects_page.expect_no_columns("Name")
         projects_page.expect_columns_in_order("Created on", "Status")
 
         # Remove "Status" column, too
         projects_page.click_table_header_to_open_action_menu("project_status")
-        projects_page.remove_column_via_action_menu("project_status")
-        wait_for_network_idle
+        wait_for_turbo_frame { projects_page.remove_column_via_action_menu("project_status") }
 
         # It was removed
+        projects_page.expect_no_columns("Status")
         projects_page.expect_columns_in_order("Created on")
       end
     end

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -366,13 +366,11 @@ RSpec.describe "Project list sharing",
           # Toggle the switch to make the project list query public
           share_dialog.expect_toggle_public_off
 
-          share_dialog.toggle_public
-
-          retry_block do
-            # dialog body is replaced on toggle by turbo stream, we have to wait for the render to be completed so we
-            # retry the expectation until the toggle is on again
-            share_dialog.expect_toggle_public_on
+          wait_for_turbo_stream do
+            share_dialog.toggle_public
           end
+
+          share_dialog.expect_toggle_public_on
           share_dialog.close
 
           # Reopen the dialog and expect the public state to be kept

--- a/spec/features/projects/persisted_lists_sharing_spec.rb
+++ b/spec/features/projects/persisted_lists_sharing_spec.rb
@@ -367,9 +367,12 @@ RSpec.describe "Project list sharing",
           share_dialog.expect_toggle_public_off
 
           share_dialog.toggle_public
-          wait_for_network_idle
 
-          share_dialog.expect_toggle_public_on
+          retry_block do
+            # dialog body is replaced on toggle by turbo stream, we have to wait for the render to be completed so we
+            # retry the expectation until the toggle is on again
+            share_dialog.expect_toggle_public_on
+          end
           share_dialog.close
 
           # Reopen the dialog and expect the public state to be kept

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe "Switching types in work package table", :js do
         message: "#{cf_req_text.name} can't be blank."
       )
 
-      # Required CF requires activation
-      req_text_field.activate!
+      # After a failed type switch, the required CF field is auto-opened in edit mode
+      req_text_field.expect_active!
       req_text_field.set_value "Required"
       req_text_field.save!
 

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -86,15 +86,17 @@ end
 #   wait_for_turbo_stream { click_button "Save" }
 #   expect(page).to have_text("Saved")
 #
-def wait_for_turbo_stream(&block)
+def wait_for_turbo_stream(timeout: 10, &block)
   unless using_cuprite?
     yield if block
     return
   end
 
-  page.execute_script(<<~JS)
-    window.__opTurboStreamRendered = new Promise((resolve) => {
-      document.addEventListener('op:turbo-stream-rendered', () => resolve(true), { once: true });
+  timeout_ms = timeout * 1000
+  page.execute_script(<<~JS, timeout_ms)
+    window.__opTurboStreamRendered = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('wait_for_turbo_stream: no turbo stream rendered within #{timeout}s')), arguments[0]);
+      document.addEventListener('op:turbo-stream-rendered', () => { clearTimeout(timer); resolve(true); }, { once: true });
     });
   JS
 
@@ -117,10 +119,17 @@ end
 #   wait_for_turbo { click_link_or_button "Save" }
 #   expect(page).to have_text("Saved")
 #
-def wait_for_turbo(&)
-  page.execute_script(<<~JS)
-    window.__opTurboLoaded = new Promise((resolve) => {
-      document.addEventListener('turbo:load', () => resolve(true), { once: true });
+def wait_for_turbo(timeout: 10, &block)
+  unless using_cuprite?
+    yield if block
+    return
+  end
+
+  timeout_ms = timeout * 1000
+  page.execute_script(<<~JS, timeout_ms)
+    window.__opTurboLoaded = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('wait_for_turbo: no turbo:load event within #{timeout}s')), arguments[0]);
+      document.addEventListener('turbo:load', () => { clearTimeout(timer); resolve(true); }, { once: true });
     });
   JS
 

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -77,6 +77,37 @@ def clear_input_field_contents(input_element)
   input_element.native.node.type(*backspaces)
 end
 
+# Executes the given block and waits for a Turbo stream to be rendered.
+#
+# Sets up a JS event listener BEFORE yielding, avoiding the race condition
+# where the stream renders before the listener is registered.
+#
+# @example
+#   wait_for_turbo_stream { click_button "Save" }
+#   expect(page).to have_text("Saved")
+#
+def wait_for_turbo_stream(&block)
+  unless using_cuprite?
+    yield if block
+    return
+  end
+
+  page.execute_script(<<~JS)
+    window.__opTurboStreamRendered = new Promise((resolve) => {
+      document.addEventListener('op:turbo-stream-rendered', () => resolve(true), { once: true });
+    });
+  JS
+
+  yield
+
+  page.driver.evaluate_async_script(<<~JS)
+    window.__opTurboStreamRendered.then(() => {
+      delete window.__opTurboStreamRendered;
+      arguments[0](true);
+    });
+  JS
+end
+
 # Executes the given block and waits for a Turbo Drive navigation to complete.
 #
 # Sets up a listener for turbo:load BEFORE yielding, avoiding the race
@@ -86,12 +117,7 @@ end
 #   wait_for_turbo { click_link_or_button "Save" }
 #   expect(page).to have_text("Saved")
 #
-def wait_for_turbo(&block)
-  unless using_cuprite?
-    yield if block
-    return
-  end
-
+def wait_for_turbo(&)
   page.execute_script(<<~JS)
     window.__opTurboLoaded = new Promise((resolve) => {
       document.addEventListener('turbo:load', () => resolve(true), { once: true });

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -143,6 +143,39 @@ def wait_for_turbo(timeout: 10, &block)
   JS
 end
 
+# Executes the given block and waits for a Turbo frame navigation to complete.
+#
+# Sets up a listener for turbo:frame-load BEFORE yielding, avoiding the race
+# condition where the frame loads before the listener is registered.
+#
+# @example
+#   wait_for_turbo_frame { click_link "Remove column" }
+#   expect(page).to have_text("Updated")
+#
+def wait_for_turbo_frame(timeout: 10, &block)
+  unless using_cuprite?
+    yield if block
+    return
+  end
+
+  timeout_ms = timeout * 1000
+  page.execute_script(<<~JS, timeout_ms)
+    window.__opTurboFrameLoaded = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('wait_for_turbo_frame: no turbo:frame-load event within #{timeout}s')), arguments[0]);
+      document.addEventListener('turbo:frame-load', () => { clearTimeout(timer); resolve(true); }, { once: true });
+    });
+  JS
+
+  yield
+
+  page.driver.evaluate_async_script(<<~JS)
+    window.__opTurboFrameLoaded.then(() => {
+      delete window.__opTurboFrameLoaded;
+      arguments[0](true);
+    });
+  JS
+end
+
 def using_cuprite?
   Capybara.javascript_driver == :better_cuprite_en
 end

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -77,6 +77,37 @@ def clear_input_field_contents(input_element)
   input_element.native.node.type(*backspaces)
 end
 
+# Executes the given block and waits for a Turbo Drive navigation to complete.
+#
+# Sets up a listener for turbo:load BEFORE yielding, avoiding the race
+# condition where the navigation completes before the listener is registered.
+#
+# @example
+#   wait_for_turbo { click_link_or_button "Save" }
+#   expect(page).to have_text("Saved")
+#
+def wait_for_turbo(&block)
+  unless using_cuprite?
+    yield if block
+    return
+  end
+
+  page.execute_script(<<~JS)
+    window.__opTurboLoaded = new Promise((resolve) => {
+      document.addEventListener('turbo:load', () => resolve(true), { once: true });
+    });
+  JS
+
+  yield
+
+  page.driver.evaluate_async_script(<<~JS)
+    window.__opTurboLoaded.then(() => {
+      delete window.__opTurboLoaded;
+      arguments[0](true);
+    });
+  JS
+end
+
 def using_cuprite?
   Capybara.javascript_driver == :better_cuprite_en
 end

--- a/spec/support/toasts/expectations.rb
+++ b/spec/support/toasts/expectations.rb
@@ -17,6 +17,11 @@ module Toasts
       page.find(".op-toast--close").click
     end
 
+    def dismiss_specific_toaster!(message:, type: :success)
+      sleep 0.1
+      page.find(".op-toast.-#{type}", text: message).find(".op-toast--close").click
+    end
+
     # Clears a toaster if there is one waiting 1 second max, but do not fail if there is none
     def clear_any_toasters
       if has_button?(I18n.t("js.close_popup_title"), wait: 1)


### PR DESCRIPTION
Claude Summary of everything in this PR now. It has gotten a bit out of hand because each run uncovered other flaky specs

## Problem

`wait_for_network_idle` is insufficient for Turbo-driven interactions. It monitors CDP network events and returns when the HTTP response is received — but Turbo's rendering is **async**: after the
response arrives, Turbo dispatches `turbo:before-stream-render` (or `turbo:before-render` for Drive), calls `await nextRepaint()`, and _then_ updates the DOM. Assertions that run between "network
idle" and "DOM updated" see stale content and fail intermittently.

## New test infrastructure

### `op:turbo-stream-rendered` custom event (`frontend/src/turbo/turbo-event-listeners.ts`)

Turbo has no built-in "after stream render" event. We make the existing `turbo:before-stream-render` render callback `async`, `await` the original render, then dispatch `op:turbo-stream-rendered`
once the DOM is updated.

### `wait_for_turbo_stream` helper (`spec/support/shared/cuprite_helpers.rb`)

Block-based helper for Turbo Stream responses. Registers a one-time JS event listener _before_ yielding the block (avoiding the race where the stream renders before the listener exists), then waits
for the Promise to resolve after.

### `wait_for_turbo` helper (`spec/support/shared/cuprite_helpers.rb`)

Same pattern but for Turbo Drive navigations (full-page redirects). Listens for the native `turbo:load` event, which fires after Drive completes the page swap.

Both helpers have a configurable `timeout:` (default 10s) with a descriptive error message on expiry, and clean up the timer on success.

### `wait_for_turbo_frame` helper (`spec/support/shared/cuprite_helpers.rb`)

Same pattern but for Turbo Frame navigations. Listens for the native `turbo:frame-load` event, which fires after Frame is loaded.

Those helpers have a configurable `timeout:` (default 10s) with a descriptive error message on expiry, and clean up the timer on success.

### `dismiss_specific_toaster!` helper (`spec/support/toasts/expectations.rb`)

Dismisses a toast matching a specific message. Needed because `expect_and_dismiss_toaster` calls `expect_no_toaster` after dismiss, which races with a _second_ toast appearing immediately after.

## Flaky spec fixes

- **`persisted_lists_sharing_spec.rb`** — `toggle_public` triggers a Turbo Stream that replaces the dialog body; `retry_block` polled for the DOM change. Fixed with `wait_for_turbo_stream {
share_dialog.toggle_public }`.
- **`favorite_spec.rb`** — "Add to favorites" triggers a Turbo Drive POST → redirect; Cuprite's accessible name computation errors for all `<a>` elements during the Drive transition. Fixed with
`wait_for_turbo { click_link_or_button(...) }`.
- **`create_spec.rb`** — "Complete" submits a form via Turbo Drive → redirect; flash assertion runs before navigation finishes. Fixed with `wait_for_turbo { click_on "Complete" }`.
- **`work_package_meetings_tab_spec.rb`** — `page.within_test_selector` captures a reference to the container element; when the Turbo Stream _replaces_ that element, Capybara retries against the
stale node showing "No notes provided". Fixed by replacing `within_test_selector(...) { have_content }` with `have_test_selector(..., text:)` which re-queries the full DOM on each retry.
- **`work_package_table_spec.rb`** — `columns.remove` clicks "Apply" triggering an API save, but no wait before asserting the column is gone; DOM duplication during Angular re-render. Fixed by
adding `wait_for_network_idle` after `columns.remove` (same pattern as the existing wait after `modal.save`).
- **`managing_dashboard_page_spec.rb`** — `expect_and_dismiss_toaster` races with a second toast appearing immediately after the first is dismissed. Fixed with `dismiss_specific_toaster!` and fixed
indentation.
- **`calendars_spec.rb`** — After `go_back`, the app may not be fully initialized even though calendar events are visible; clicking too early causes an "not authorized" error. Fixed by wrapping in
`retry_block`.
- **`meeting_presentation_mode_spec.rb`** — Editing an agenda item adds a body (was empty before), so both the title and the new text should be visible. Fixed assertion to `have_text` for both. Also
 wrapped "Remove outcome" action in `accept_confirm` since it triggers a confirmation dialog.
- **`project_storages_spec.rb`** — The Nextcloud login button is an Angular custom element whose label is set asynchronously in `ngOnInit()`. On slow CI, bootstrapping can take longer than the
default wait. Fixed by using `have_button(..., wait: 20)`.
- **`columns_spec.rb`** - The tests do not properly wait for turbo frame rendering. Fixed with the new `wait_for_turbo_frame` helper.

## Other changes

- **`turbo-event-listeners.ts`** — Fixed pre-existing eslint error: `||` → `??` for nullish coalescing on CSP nonce header.
- **`time_entry_row.rb`** — Fixed deprecation warnings about `work_package` usage on `TimeEntry`.