### PR TITLE
Remove superfluous code already run in the wrapped textarea

### DIFF
--- a/lib/open_project/text_formatting/formats/markdown/helper.rb
+++ b/lib/open_project/text_formatting/formats/markdown/helper.rb
@@ -38,17 +38,6 @@ module OpenProject::TextFormatting::Formats
       end
 
       def wikitoolbar_for(field_id, **context)
-        # Hide the original textarea
-        view_context.content_for(:additional_js_dom_ready) do
-          js = <<-JAVASCRIPT
-            var field = document.getElementById('#{field_id}');
-            field.style.display = 'none';
-            field.removeAttribute('required');
-          JAVASCRIPT
-
-          js.html_safe
-        end
-
         # Pass an optional resource to the CKEditor instance
         resource = context.fetch(:resource, {})
         helpers.angular_component_tag "opce-ckeditor-augmented-textarea",


### PR DESCRIPTION
Already done in https://github.com/opf/openproject/blob/3d68c1b4962560d4bb4cc27cfc772b64e0db46c6/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts#L160-L161