### PR TITLE
[72916] DPA email: comma missing after the name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4352,7 +4352,7 @@ en:
       center: "To notification center"
       see_in_center: "See comment in notification center"
       settings: "Change email settings"
-    salutation: "Hello %{user}"
+    salutation: "Hello %{user},"
     salutation_full_name: "Full name"
     work_packages:
       created_at: "Created at %{timestamp} by %{user} "


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72916

# What are you trying to accomplish?
Add a comma after the mail salutation


