### PR TITLE
[72548] Insufficient space between action buttons on Invite user screen

### DIFF
--- a/app/components/users/invitation/principal_step/footer_component.html.erb
+++ b/app/components/users/invitation/principal_step/footer_component.html.erb
@@ -10,7 +10,8 @@
             data: {
               turbo_method: :post
             }
-          )) do
+          )
+        ) do
           I18n.t(:button_back)
         end
       end
@@ -20,6 +21,7 @@
           buttons.with_component(
             Primer::Beta::Button.new(
               data: { "close-dialog-id": Users::Invitation::DialogComponent::DIALOG_ID },
+              mr: 1
             )
           ) do
             I18n.t(:button_cancel)

--- a/app/components/users/invitation/project_step/footer_component.rb
+++ b/app/components/users/invitation/project_step/footer_component.rb
@@ -44,7 +44,8 @@ module Users::Invitation::ProjectStep
         component_collection do |modal_footer|
           modal_footer.with_component(
             Primer::Beta::Button.new(
-              data: { "close-dialog-id": Users::Invitation::DialogComponent::DIALOG_ID }
+              data: { "close-dialog-id": Users::Invitation::DialogComponent::DIALOG_ID },
+              mr: 1
             )
           ) do
             I18n.t(:button_cancel)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72548

# What are you trying to accomplish?
Add spacing between the footer buttons. This spacing was not added automatically because of the component_wrapper around it which catches the `flex-gap`

