### PR TITLE
Only warn on version mismatch

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator.rb
@@ -72,7 +72,7 @@ module Storages
               dependency = I18n.t("storages.dependencies.nextcloud.integration_app")
 
               if capabilities_result.app_version < min_app_version
-                fail_check(:dependencies_versions, :nc_dependency_version_mismatch, context: { dependency: })
+                warn_check(:dependencies_versions, :nc_dependency_version_mismatch, context: { dependency: })
               else
                 pass_check(:dependencies_versions)
               end

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator_spec.rb
@@ -73,7 +73,7 @@ module Storages
                 allow(subject).to receive(:nextcloud_dependencies).and_return(absurd_version)
 
                 results = validator.call
-                expect(results[:dependencies_versions]).to be_a_failure
+                expect(results[:dependencies_versions]).to be_a_warning
                 expect(results[:dependencies_versions].code).to eq(:nc_dependency_version_mismatch)
                 expect(results[:dependencies_versions].context[:dependency]).to eq("Integration OpenProject")
               end


### PR DESCRIPTION
We already did this for the check of the team folders app, but apparently forgot to do it for other dependencies too.

The main motivation is that an error would prevent all other health checks from running, even if we are just behind by one patch level.

It should be enough to show a warning to users when the version does not match expectations, but it's not a hard error that should prevent further health checks.