### PR TITLE
Simplify `ProjectIdentifierSuggestionGenerator` interface

### DIFF
--- a/app/services/work_packages/identifier_autofix/preview_query.rb
+++ b/app/services/work_packages/identifier_autofix/preview_query.rb
@@ -43,8 +43,7 @@ module WorkPackages
 
         suggestions = WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator.call(
           preview,
-          in_use_identifiers:,
-          reserved_identifiers:
+          exclude: reserved_identifiers | in_use_identifiers
         )
 
         projects_data = suggestions.map do |entry|

--- a/app/services/work_packages/identifier_autofix/project_identifier_suggestion_generator.rb
+++ b/app/services/work_packages/identifier_autofix/project_identifier_suggestion_generator.rb
@@ -64,35 +64,34 @@ module WorkPackages
       FALLBACK_IDENTIFIER = "PROJ"
       SUFFIX_LIMIT = 10_000
 
-      def self.call(projects, reserved_identifiers: Set.new, in_use_identifiers: Set.new)
-        new.call(projects, reserved_identifiers:, in_use_identifiers:)
+      def self.call(projects, exclude: Set.new)
+        new.call(projects, exclude:)
       end
 
       # Returns a single suggested identifier string for the given project name.
       #
-      def self.suggest_identifier(name, reserved_identifiers: Set.new, in_use_identifiers: Set.new)
-        new.suggest_identifier(name, reserved_identifiers:, in_use_identifiers:)
+      def self.suggest_identifier(name, exclude: Set.new)
+        new.suggest_identifier(name, exclude:)
       end
 
-      def call(projects, reserved_identifiers:, in_use_identifiers:)
-        generate_suggestions(projects, reserved_identifiers:, in_use_identifiers:)
+      def call(projects, exclude:)
+        generate_suggestions(projects, exclude:)
       end
 
-      def suggest_identifier(name, reserved_identifiers: Set.new, in_use_identifiers: Set.new)
-        used = reserved_identifiers | in_use_identifiers
+      def suggest_identifier(name, exclude: Set.new)
         candidates = identifier_candidates(name)
-        find_unique(candidates, used)
+        find_unique(candidates, exclude)
       end
 
       private
 
-      def generate_suggestions(projects, reserved_identifiers:, in_use_identifiers:)
-        used_identifiers = reserved_identifiers | in_use_identifiers
+      def generate_suggestions(projects, exclude:)
+        excluded = exclude.dup
 
         projects.map do |project|
           candidates = identifier_candidates(project.name)
-          identifier = find_unique(candidates, used_identifiers)
-          used_identifiers << identifier
+          identifier = find_unique(candidates, excluded)
+          excluded << identifier
 
           {
             project:,

--- a/spec/services/work_packages/identifier_autofix/project_identifier_suggestion_generator_spec.rb
+++ b/spec/services/work_packages/identifier_autofix/project_identifier_suggestion_generator_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGener
 
     it "does not suggest an identifier that is already in use (pre-seeded collision)" do
       project = create(:project, identifier: "sc-app", name: "Stream Communicator")
-      result = described_class.call([project], in_use_identifiers: Set["SC"])
+      result = described_class.call([project], exclude: Set["SC"])
       # "SC" is taken, so it widens to "STC" (Stream → ST, Communicator → C)
       expect(result.first[:suggested_identifier]).to eq("STC")
     end
@@ -170,7 +170,7 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGener
     it "falls back to numeric suffix only when all expansion candidates are exhausted" do
       # Reserve all expansion candidates for "Go" (a 2-char word)
       project = create(:project, identifier: "bad-id", name: "Go")
-      result = described_class.call([project], in_use_identifiers: Set["GO"])
+      result = described_class.call([project], exclude: Set["GO"])
       # "GO" is taken, no further expansion possible, so numeric suffix
       expect(result.first[:suggested_identifier]).to eq("GO2")
     end


### PR DESCRIPTION
Replace the separate `reserved_identifiers` and `in_use_identifiers` keyword arguments with a single `exclude` parameter.

The generator immediately merged these two sets on every call path -- the distinction only matters to `PreviewQuery` for error classification, which it already handles independently. Collapsing them into one parameter removes unnecessary coupling.