### PR TITLE
fix: last name requirement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,7 +144,6 @@ class User < Principal
 
   validates :login,
             :firstname,
-            :lastname,
             :mail,
             presence: { unless: Proc.new { |user| user.builtin? } }
 

--- a/app/views/account/_register.html.erb
+++ b/app/views/account/_register.html.erb
@@ -54,8 +54,8 @@ See COPYRIGHT and LICENSE files for more details.
         <div class="form--field -required -wide-label">
           <%= f.text_field :firstname, required: true %>
         </div>
-        <div class="form--field -required -wide-label">
-          <%= f.text_field :lastname, required: true %>
+        <div class="form--field -wide-label">
+          <%= f.text_field :lastname %>
         </div>
         <% if registration_show_email? %>
           <div class="form--field -required -wide-label">

--- a/docs/api/apiv3/components/schemas/user_create_model.yml
+++ b/docs/api/apiv3/components/schemas/user_create_model.yml
@@ -6,7 +6,6 @@ required:
   - email
   - login
   - firstName
-  - lastName
   - language
 properties:
   admin:

--- a/lib/api/v3/users/schemas/user_schema_representer.rb
+++ b/lib/api/v3/users/schemas/user_schema_representer.rb
@@ -65,7 +65,7 @@ module API
           schema :lastname,
                  as: :lastName,
                  type: "String",
-                 min_length: 1,
+                 required: false,
                  max_length: 255
 
           schema :avatar,

--- a/lib/open_project_scimitar/name_schema.rb
+++ b/lib/open_project_scimitar/name_schema.rb
@@ -35,7 +35,7 @@ module OpenProjectScimitar
         Scimitar::Schema::Attribute.new(name: "familyName",
                                         caseExact: false,
                                         type: "string",
-                                        required: true),
+                                        required: false),
         Scimitar::Schema::Attribute.new(name: "givenName",
                                         caseExact: false,
                                         type: "string",

--- a/spec/requests/api/v3/user/create_form_resource_spec.rb
+++ b/spec/requests/api/v3/user/create_form_resource_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe API::V3::Users::CreateFormAPI, content_type: :json do
                 .at_path("_embedded/payload/status")
 
         expect(body)
-          .to have_json_size(5)
+          .to have_json_size(4)
                 .at_path("_embedded/validationErrors")
 
         expect(body)
@@ -91,8 +91,6 @@ RSpec.describe API::V3::Users::CreateFormAPI, content_type: :json do
           .to have_json_path("_embedded/validationErrors/email")
         expect(body)
           .to have_json_path("_embedded/validationErrors/firstName")
-        expect(body)
-          .to have_json_path("_embedded/validationErrors/lastName")
 
         expect(body)
           .not_to have_json_path("_links/commit")

--- a/spec/requests/api/v3/user/create_user_common_examples.rb
+++ b/spec/requests/api/v3/user/create_user_common_examples.rb
@@ -68,9 +68,9 @@ RSpec.shared_examples "create user request flow" do
 
       expect(last_response).to have_http_status(:unprocessable_entity)
 
-      expect(errors.count).to eq(5)
+      expect(errors.count).to eq(4)
       expect(errors.collect { |el| el["_embedded"]["details"]["attribute"] })
-        .to contain_exactly("password", "login", "firstName", "lastName", "email")
+        .to contain_exactly("password", "login", "firstName", "email")
 
       expect(last_response.body)
         .to be_json_eql("urn:openproject-org:api:v3:errors:MultipleErrors".to_json)
@@ -128,10 +128,10 @@ RSpec.shared_examples "create user request flow" do
           .to be_json_eql("urn:openproject-org:api:v3:errors:MultipleErrors".to_json)
                 .at_path("errorIdentifier")
 
-        expect(errors.count).to eq 4
+        expect(errors.count).to eq 3
 
         attributes = errors.map { |error| error.dig("_embedded", "details", "attribute") }
-        expect(attributes).to contain_exactly("login", "firstName", "lastName", "email")
+        expect(attributes).to contain_exactly("login", "firstName", "email")
       end
     end
   end


### PR DESCRIPTION
Using for example OpenID (OIDC) login, some (like us) do not use last names, making the signing in/up impossible and asks to make an account manually instead.

This makes Last name optional.