### PR TITLE
[#73254] Jira Import: request for an user by key fails and stops the import

### DIFF
--- a/app/workers/import/jira_fetch_and_import_projects_job.rb
+++ b/app/workers/import/jira_fetch_and_import_projects_job.rb
@@ -153,9 +153,15 @@ module Import
         created_at:,
         updated_at:
       }
-    rescue StandardError => e
-      Rails.logger.error "Error fetching user data for user key #{jira_user_key}: #{e.message}"
-      nil
+    rescue JiraClient::ApiError => e
+      if e.status == 404
+        # The user for jira_user_key was not found, this may happen for a user in the Jira issue history
+        # no longer available in the Jira instance
+        Rails.logger.error "Error fetching user data for user key #{jira_user_key}: #{e.message}"
+        nil
+      else
+        raise "Error fetching user data for user key #{jira_user_key}: #{e.message}"
+      end
     end
 
     def import_users(jira_import)

--- a/app/workers/import/jira_fetch_and_import_projects_job.rb
+++ b/app/workers/import/jira_fetch_and_import_projects_job.rb
@@ -130,19 +130,32 @@ module Import
       jira_client = jira_import.client
       updated_at = Time.zone.now
       created_at = updated_at
-      user_keys.compact.map do |jira_user_key|
-        # here we send a direct user request to get group memberships
-        # which are not returned by users_search endpoint
-        jira_user_by_key = jira_client.user_by_key(key: jira_user_key)
-        {
-          payload: jira_user_by_key,
-          jira_id: jira_import.jira_id,
-          jira_import_id: jira_import.id,
-          jira_user_key:,
-          created_at:,
-          updated_at:
-        }
+      user_keys.compact.filter_map do |jira_user_key|
+        build_user_upsert_data(
+          jira_user_key,
+          created_at,
+          updated_at,
+          jira_import,
+          jira_client
+        )
       end
+    end
+
+    def build_user_upsert_data(jira_user_key, created_at, updated_at, jira_import, jira_client)
+      # here we send a direct user request to get group memberships
+      # which are not returned by users_search endpoint
+      jira_user_by_key = jira_client.user_by_key(key: jira_user_key)
+      {
+        payload: jira_user_by_key,
+        jira_id: jira_import.jira_id,
+        jira_import_id: jira_import.id,
+        jira_user_key:,
+        created_at:,
+        updated_at:
+      }
+    rescue StandardError => e
+      Rails.logger.error "Error fetching user data for user key #{jira_user_key}: #{e.message}"
+      nil
     end
 
     def import_users(jira_import)


### PR DESCRIPTION

# Ticket
https://community.openproject.org/work_packages/73254

# What are you trying to achieve?

The data Jira is sending is not clean. E.g. in this case it contains a user key which is not available in the Jira instance: Jira API returning 404. This stops the import.

# What approach did you choose and why?

If we can't retrieve a user for a Jira user key, we just log the error but continue as we have no other option.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
