### PR TITLE
[72931] Project description caption appears for work packages description as well

### DIFF
--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -33,7 +33,7 @@ class AttributeHelpText < ApplicationRecord
 
   def self.cached(user)
     RequestStore.fetch(name) do
-      visible(user).select(:id, :attribute_name, :caption).index_by(&:attribute_name)
+      visible_condition(user).where(type: name).select(:id, :type, :attribute_name, :caption).index_by(&:attribute_name)
     end
   end
 
@@ -83,7 +83,7 @@ class AttributeHelpText < ApplicationRecord
     raise NotImplementedError
   end
 
-  def self.visible_condition
+  def self.visible_condition(_user = nil)
     raise NotImplementedError
   end
 

--- a/spec/models/attribute_help_text/project_spec.rb
+++ b/spec/models/attribute_help_text/project_spec.rb
@@ -94,6 +94,24 @@ RSpec.describe AttributeHelpText::Project do
     end
   end
 
+  describe ".cached" do
+    let(:user) { create(:user) }
+    let!(:project_help_text) { create(:project_help_text, attribute_name: "status") }
+    let!(:wp_help_text) { create(:work_package_help_text, attribute_name: "status") }
+
+    subject { described_class.cached(user) }
+
+    it "returns only Project help texts, not WorkPackage help texts with the same attribute name" do
+      expect(subject["status"]).to eq(project_help_text)
+      expect(subject["status"]).not_to eq(wp_help_text)
+      expect(subject["status"]).to be_a(described_class)
+    end
+
+    it "does not include help texts of other types" do
+      expect(subject.values).to all(be_a(described_class))
+    end
+  end
+
   describe "validations" do
     subject { build(:project_help_text) }
 

--- a/spec/models/attribute_help_text/work_package_spec.rb
+++ b/spec/models/attribute_help_text/work_package_spec.rb
@@ -154,6 +154,24 @@ RSpec.describe AttributeHelpText::WorkPackage do
     end
   end
 
+  describe ".cached" do
+    let(:user) { create(:user) }
+    let!(:wp_help_text) { create(:work_package_help_text, attribute_name: "status") }
+    let!(:project_help_text) { create(:project_help_text, attribute_name: "status") }
+
+    subject { described_class.cached(user) }
+
+    it "returns only WorkPackage help texts, not Project help texts with the same attribute name" do
+      expect(subject["status"]).to eq(wp_help_text)
+      expect(subject["status"]).not_to eq(project_help_text)
+      expect(subject["status"]).to be_a(described_class)
+    end
+
+    it "does not include help texts of other types" do
+      expect(subject.values).to all(be_a(described_class))
+    end
+  end
+
   describe "validations" do
     before do
       allow(described_class).to receive(:available_attributes).and_return(status: "Status")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72931

# What are you trying to accomplish?
Cache the AttributeHelpTexts type dependent to avoid that the wrong help text is returned

