### PR TITLE
Experiment: Get rid of retries

### DIFF
--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -769,9 +769,7 @@ module Pages::Meetings
 
     # still a bit ambiguous, but better than nothing
     def expect_focused_ckeditor
-      retry_block do
-        expect(page.evaluate_script("document.activeElement.classList.contains('ck-focused')")).to be true
-      end
+      expect(page).to have_css(".ck-focused", wait: 10)
     end
 
     def expect_notes(text)

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -246,10 +246,8 @@ module Pages::Meetings
       select_action(item, "Move to next meeting")
       expect_modal("Move to next meeting?")
 
-      retry_block do
-        page.within_modal "Move to next meeting?" do
-          click_on "Move"
-        end
+      page.within_modal "Move to next meeting?" do
+        click_on "Move"
       end
     end
 
@@ -260,30 +258,22 @@ module Pages::Meetings
       end
       expect_modal("Duplicate in next meeting?")
 
-      retry_block do
-        page.within_modal "Duplicate in next meeting?" do
-          click_on "Duplicate"
-        end
+      page.within_modal "Duplicate in next meeting?" do
+        click_on "Duplicate"
       end
     end
 
     def open_menu(item, &)
-      retry_block do
-        page.within("#meeting-agenda-item-#{item.id}") do
-          page.find_test_selector("op-meeting-agenda-actions").click
-        end
-        page.find(".Overlay")
-        page.within(".Overlay", &)
+      page.within("#meeting-agenda-item-#{item.id}") do
+        page.find_test_selector("op-meeting-agenda-actions").click
       end
+      page.within(".Overlay", wait: 5, &)
     end
 
     def select_outcome_action(action)
-      retry_block do
-        page.find_test_selector("op-meeting-outcome-actions").click
-        page.find(".Overlay")
-      end
+      page.find_test_selector("op-meeting-outcome-actions").click
 
-      page.within(".Overlay") do
+      page.within(".Overlay", wait: 5) do
         click_on action
       end
     end
@@ -293,25 +283,19 @@ module Pages::Meetings
     end
 
     def expect_no_outcome_action(item)
-      retry_block do
-        page.within("#meeting-agenda-item-#{item.id}") do
-          page.find_test_selector("op-meeting-agenda-actions").trigger("click")
-        end
-        page.find(".Overlay")
+      page.within("#meeting-agenda-item-#{item.id}") do
+        page.find_test_selector("op-meeting-agenda-actions").trigger("click")
       end
 
-      page.within(".Overlay") do
+      page.within(".Overlay", wait: 5) do
         expect(page).to have_no_text("Add outcome")
       end
     end
 
     def select_section_action(section, action)
-      retry_block do
-        click_on_section_menu(section)
-        page.find(".Overlay")
-      end
+      click_on_section_menu(section)
 
-      page.within(".Overlay") do
+      page.within(".Overlay", wait: 5) do
         click_on action
       end
     end
@@ -399,10 +383,8 @@ module Pages::Meetings
 
     def expect_empty_backlog
       within_backlog do
-        retry_block do
-          expect(page).to have_text("Drag items here or create a new one")
-          expect(page).to have_button("Add")
-        end
+        expect(page).to have_text("Drag items here or create a new one")
+        expect(page).to have_button("Add")
       end
     end
 
@@ -444,12 +426,10 @@ module Pages::Meetings
     end
 
     def select_backlog_action(action)
-      retry_block do
-        click_on_backlog_menu
-        page.find(".Overlay")
-        page.within(".Overlay") do
-          click_on action
-        end
+      click_on_backlog_menu
+
+      page.within(".Overlay", wait: 5) do
+        click_on action
       end
     end
 
@@ -506,13 +486,10 @@ module Pages::Meetings
     end
 
     def expect_item_edit_field_error(item, text)
-      # retry because the #meeting-agenda-items-form-component-<id> may not be
-      # updated yet and then becomes stale while checking for field error.
-      retry_block do
-        page.within("#meeting-agenda-items-form-component-#{item.id}") do
-          expect(page).to have_css(".FormControl-inlineValidation", text:)
-        end
-      end
+      expect(page).to have_css(
+        "#meeting-agenda-items-form-component-#{item.id} .FormControl-inlineValidation",
+        text:, wait: 10
+      )
     end
 
     def clear_item_edit_work_package_title
@@ -522,9 +499,7 @@ module Pages::Meetings
 
     def open_participant_form
       page.find_test_selector("manage-participants-button").click
-      retry_block do
-        expect_modal("Manage participants")
-      end
+      expect_modal("Manage participants")
     end
 
     def in_participant_form(&)
@@ -555,10 +530,8 @@ module Pages::Meetings
 
     def invite_participant(participant)
       id = "checkbox_invited_#{participant.id}"
-      retry_block do
-        check(id:)
-        raise "Expected #{participant.id} to be invited now" unless page.has_checked_field?(id:)
-      end
+      check(id:)
+      expect(page).to have_checked_field(id:)
     end
 
     def toggle_attendance(participant)
@@ -591,12 +564,9 @@ module Pages::Meetings
     end
 
     def close_meeting
-      retry_block do
-        click_on("Open")
-        page.find(".Overlay")
-      end
+      click_on("Open")
 
-      page.within(".Overlay") do
+      page.within(".Overlay", wait: 5) do
         click_on("Closed")
       end
       expect(page).to have_link("Reopen meeting")
@@ -661,12 +631,10 @@ module Pages::Meetings
     end
 
     def add_section(&)
-      retry_block do
+      wait_for_turbo_stream do
         page.within("#meeting-agenda-items-new-button-component") do
           click_on I18n.t(:button_add)
           click_on "Section"
-          # wait for the disabled button, indicating the turbo streams are applied
-          expect(page).to have_css("#meeting-agenda-items-new-button-component button[disabled='disabled']")
         end
       end
 
@@ -700,15 +668,13 @@ module Pages::Meetings
     end
 
     def check_add_section_path(meeting)
-      retry_block do
-        page.within("#meeting-agenda-items-new-button-component") do
-          click_on I18n.t(:button_add)
+      page.within("#meeting-agenda-items-new-button-component") do
+        click_on I18n.t(:button_add)
 
-          add_section_link = find_link("Section")
-          url = add_section_link[:href]
+        add_section_link = find_link("Section")
+        url = add_section_link[:href]
 
-          expect(URI.parse(url).path).to eq(project_meeting_sections_path(meeting.project, meeting))
-        end
+        expect(URI.parse(url).path).to eq(project_meeting_sections_path(meeting.project, meeting))
       end
     end
 
@@ -762,9 +728,7 @@ module Pages::Meetings
     end
 
     def expect_focused_input(input_id)
-      retry_block do
-        expect(page.evaluate_script("document.activeElement.id")).to eq(input_id)
-      end
+      expect(page).to have_css("##{input_id}:focus", wait: 10)
     end
 
     # still a bit ambiguous, but better than nothing

--- a/spec/features/admin/enterprise/enterprise_trial_spec.rb
+++ b/spec/features/admin/enterprise/enterprise_trial_spec.rb
@@ -176,10 +176,8 @@ RSpec.describe "Enterprise trial management",
     fill_in "Last name", with: "Bar"
     fill_in "Email", with: mail
 
-    retry_block do
-      check "general_consent", allow_label_click: true
-      expect(page).to have_checked_field("general_consent")
-    end
+    check "general_consent", allow_label_click: true
+    expect(page).to have_checked_field("general_consent")
   end
 
   it "does not send a request when an internal validation fails" do

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -125,10 +125,8 @@ RSpec.describe "invite user via email", :js do
       it "does not allow finding that user" do
         members_page.visit!
 
-        retry_block do
-          members_page.open_new_member!
-          find_by_id("members_add_form")
-        end
+        members_page.open_new_member!
+        find_by_id("members_add_form")
 
         dropdown = members_page.search_principal! "hugo@openproject.com"
         expect(dropdown).to have_no_text "Hugo Hurried"
@@ -142,10 +140,8 @@ RSpec.describe "invite user via email", :js do
       it "user lookup by email" do
         members_page.visit!
 
-        retry_block do
-          members_page.open_new_member!
-          find_by_id("members_add_form")
-        end
+        members_page.open_new_member!
+        find_by_id("members_add_form")
 
         members_page.search_and_select_principal! "hugo@openproject.com",
                                                   "Hugo Hurriedhugo@openproject.com"

--- a/spec/features/projects/settings/toggle_public_spec.rb
+++ b/spec/features/projects/settings/toggle_public_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe "Project public/private toggle", :js do
 
     expect(page).to have_text I18n.t("projects.settings.public_confirmation.title")
 
-    retry_block do
-      check I18n.t("projects.settings.public_confirmation.checkbox")
-      click_button "Confirm"
-    end
+    check I18n.t("projects.settings.public_confirmation.checkbox")
+    click_button "Confirm"
 
     expect(page).to have_test_selector("op-projects-public-warning")
     expect(page).to have_text(I18n.t("projects.settings.public_warning"))

--- a/spec/features/users/user_memberships_spec.rb
+++ b/spec/features/users/user_memberships_spec.rb
@@ -53,14 +53,12 @@ RSpec.describe "user memberships through user page", :js, :selenium do
         principal_page.expect_global_roles([GlobalRole.standard.name, global_role.name])
 
         # Remove the global role from the user
-        principal_page.remove_global_role!(global_role.id)
-
-        wait_for_network_idle
+        wait_for_turbo do
+          principal_page.remove_global_role!(global_role.id)
+        end
 
         # Verify that it is gone
-        retry_block do
-          principal_page.expect_global_roles([GlobalRole.standard.name])
-        end
+        principal_page.expect_global_roles([GlobalRole.standard.name])
       end
     end
   end

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -200,11 +200,9 @@ module Components
       def open_filters
         return if filters_expanded?
 
-        retry_block do
-          toggle_filters_section
-          expect(page).to have_css(".op-filters-form.-expanded")
-          page.find_field("Add filter", visible: true)
-        end
+        toggle_filters_section
+        expect(page).to have_css(".op-filters-form.-expanded", wait: 5)
+        page.find_field("Add filter", visible: true)
       end
 
       def filters_toggle

--- a/spec/support/components/sharing/share_modal.rb
+++ b/spec/support/components/sharing/share_modal.rb
@@ -264,15 +264,8 @@ module Components
 
       def filter(filter_name, value)
         within(shares_header) do
-          retry_block do
-            # The button's text changes dynamically based on the currently selected option
-            # Hence the spec's readability is hindered by using something like
-            # `click_button filter_name.capitalize`
-            find("[data-test-selector='op-share-dialog-filter-#{filter_name}-button']").click
-
-            # Open the ActionMenu
-            find(".ActionListContent", text: value).click
-          end
+          find("[data-test-selector='op-share-dialog-filter-#{filter_name}-button']").click
+          find(".ActionListContent", text: value, wait: 5).click
         end
 
         wait_for_network_idle # Ensures filtering is done

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -84,9 +84,7 @@ module Components
       end
 
       def within_journal_entry(journal, &)
-        retry_block(screenshot: true) do
-          expect(page).to have_test_selector("op-wp-journal-entry-#{journal.id}")
-        end
+        expect(page).to have_test_selector("op-wp-journal-entry-#{journal.id}", wait: 10)
 
         page.within_test_selector("op-wp-journal-entry-#{journal.id}", &)
       end

--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -369,9 +369,9 @@ module Components
       end
 
       def filter_journals(filter, default_sorting: User.current.preference&.comments_sorting || "desc")
-        retry_block do
-          page.find_test_selector("op-wp-journals-filter-menu").click
+        page.find_test_selector("op-wp-journals-filter-menu").click
 
+        wait_for_turbo_stream do
           case filter
           when :all
             page.find_test_selector("op-wp-journals-filter-show-all").click
@@ -382,19 +382,17 @@ module Components
           end
         end
 
-        # Ensure the journals are reloaded
-        wait_for { page }.to have_test_selector("op-wp-journals-#{filter}-#{default_sorting}")
-        # the wait_for will not work on its own as the selector will be switched to the target filter before the page is updated
-        # so we still need to wait statically unfortunately to avoid flakyness
-        sleep 1
+        expect(page).to have_test_selector("op-wp-journals-#{filter}-#{default_sorting}", wait: 10)
       end
 
       def set_journal_sorting(sorting, default_filter: :all)
-        retry_block do
-          page.find_test_selector("op-wp-journals-sorting-menu").click
+        page.find_test_selector("op-wp-journals-sorting-menu").click
+
+        wait_for_turbo_stream do
           page.find_test_selector("op-wp-journals-sorting-#{sorting}").click
-          expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}")
         end
+
+        expect(page).to have_test_selector("op-wp-journals-#{default_filter}-#{sorting}", wait: 10)
       end
 
       def trigger_update_streams_poll

--- a/spec/support/components/work_packages/filters.rb
+++ b/spec/support/components/work_packages/filters.rb
@@ -43,11 +43,8 @@ module Components
       def open
         SeleniumHubWaiter.wait
         expect_loaded
-        retry_block do
-          # Run in retry block because filters do nothing if not yet loaded
-          filter_button.click
-          find(filters_selector, visible: true)
-        end
+        filter_button.click
+        find(filters_selector, visible: true, wait: 5)
       end
 
       def open!

--- a/spec/support/components/work_packages/settings_menu.rb
+++ b/spec/support/components/work_packages/settings_menu.rb
@@ -49,10 +49,8 @@ module Components
       end
 
       def open_and_choose(name)
-        retry_block do
-          open!
-          choose(name)
-        end
+        open!
+        choose(name)
       end
 
       def open!

--- a/spec/support/components/work_packages/table_configuration/highlighting.rb
+++ b/spec/support/components/work_packages/table_configuration/highlighting.rb
@@ -83,9 +83,7 @@ module Components
         @opened = true
         ::Components::WorkPackages::SettingsMenu.new.open_and_choose "Configure view"
 
-        retry_block do
-          find(".op-tab-row--link", text: "HIGHLIGHTING", wait: 10).click
-        end
+        find(".op-tab-row--link", text: "HIGHLIGHTING", wait: 10).click
       end
 
       def assume_opened

--- a/spec/support/components/work_packages/table_configuration_modal.rb
+++ b/spec/support/components/work_packages/table_configuration_modal.rb
@@ -60,12 +60,10 @@ module Components
 
       def open!
         SeleniumHubWaiter.wait
-        retry_block do
-          next if open?
+        return if open?
 
-          scroll_to_and_click trigger
-          expect_open
-        end
+        scroll_to_and_click trigger
+        expect_open
       end
 
       def set_display_sums(enable: true)
@@ -109,14 +107,10 @@ module Components
       end
 
       def switch_to(target)
-        # Switching too fast may result in the click handler not yet firing
-        # so wait a bit initially
         SeleniumHubWaiter.wait unless using_cuprite?
 
-        retry_block do
-          find("#{selector} .op-tab-row--link", text: target.upcase, wait: 2).click
-          selected_tab(target)
-        end
+        find("#{selector} .op-tab-row--link", text: target.upcase, wait: 5).click
+        selected_tab(target)
       end
 
       def selector


### PR DESCRIPTION
We have quite a few places in our Feature specs that we assume to sometimes go wrong. This is an AI assisted attempt to remove as many `retry_block`s and replace them with proper waits.