### PR TITLE
[#72939] Jira import: status that doesn't exist on OP doesn't get assigned to the work package. Empty Group/Project required custom fields error.

### DIFF
--- a/app/workers/import/jira_fetch_and_import_projects_job.rb
+++ b/app/workers/import/jira_fetch_and_import_projects_job.rb
@@ -189,7 +189,7 @@ module Import
 
       jira_user_groups.each do |group_name|
         call = Groups::CreateService
-                 .new(user: User.system)
+                 .new(user: User.system, contract_class: EmptyContract)
                  .call(name: group_name)
         call.on_success do |result|
           group = result.result

--- a/app/workers/import/jira_import_projects_job.rb
+++ b/app/workers/import/jira_import_projects_job.rb
@@ -70,7 +70,7 @@ module Import
           ### PROJECT
           identifier = jira_project.payload.fetch("key").downcase
           service_call = Projects::CreateService
-                           .new(user:)
+                           .new(user:, contract_class: EmptyContract)
                            .call(
                              name: jira_project.payload.fetch("name"),
                              identifier:,
@@ -151,6 +151,19 @@ module Import
                 jira_import:,
                 uses_existing:
               )
+
+              ### Modify workfows for given role and type
+              statuses = Status.all
+              row = statuses.to_h do |status|
+                [status.id.to_s, ["always"]]
+              end
+              status_params = statuses.to_h do |status|
+                [status.id.to_s, row]
+              end
+              call = Workflows::BulkUpdateService
+                       .new(role: project_role, type:, tab: "always")
+                       .call(status_params)
+              raise call.message if call.failure?
 
               ### PRIORITY
               issue_priority = jira_issue.payload["fields"]["priority"]

--- a/spec/workers/import/jira_import_projects_job_spec.rb
+++ b/spec/workers/import/jira_import_projects_job_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe Import::JiraImportProjectsJob, :webmock do
            payload: jira_project_payload)
   end
 
+  let!(:default_status) { create(:default_status) }
+
   describe "#perform" do
     context "when a project with the same identifier already exists" do
       let!(:existing_project) { create(:project, identifier: "dyx", name: "Existing Project") }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->
https://community.openproject.org/work_packages/72939

# What is inside?

- Modify workflows of JiraMember role to allow all status transition for every type used during migration.
- Use EmptyContract for Group and Project creation to avoid errors about empty required fields.