### PR TITLE
[70183] Work Package Export dialog resizes on switching format

### DIFF
--- a/app/components/work_packages/exports/modal_dialog_component.html.erb
+++ b/app/components/work_packages/exports/modal_dialog_component.html.erb
@@ -1,7 +1,9 @@
 <%= render(
       Primer::Alpha::Dialog.new(
         title: I18n.t("export.dialog.title"),
-        size: :xlarge,
+        size: :large,
+        position: :right,
+        position_narrow: :fullscreen,
         id: MODAL_ID,
         data: {
           controller: "work-packages--export--dialog"


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70183

# What are you trying to accomplish?
Move export dialog to the right to grant it more vertical space

## Screenshots

<img width="2150" height="741" alt="Bildschirmfoto 2026-03-23 um 13 21 52" src="https://github.com/user-attachments/assets/f51d7680-b7b2-400d-b686-35c217345db2" />
