### PR TITLE
Remove feature flag for MCP server

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -49,10 +49,6 @@ OpenProject::FeatureDecisions.add :calculated_value_project_attribute,
                                   description: "Allows the use of calculated values as a project attribute.",
                                   force_active: true
 
-OpenProject::FeatureDecisions.add :mcp_server,
-                                  description: "Enables the experimental MCP API.",
-                                  force_active: true
-
 OpenProject::FeatureDecisions.add :minutes_styling_meeting_pdf,
                                   description: "Allow exporting a meeting with FITKO styling. " \
                                                "See #65124 for details."

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -489,13 +489,13 @@ Redmine::MenuManager.map :admin_menu do |menu|
 
   menu.push :ai,
             { controller: "/admin/mcp_configurations", action: :index },
-            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.mcp_server_active? },
+            if: ->(_) { User.current.admin? },
             caption: I18n.t("menus.admin.ai"),
             icon: :sparkle
 
   menu.push :mcp_configurations,
             { controller: "/admin/mcp_configurations", action: :index },
-            if: ->(_) { User.current.admin? && OpenProject::FeatureDecisions.mcp_server_active? },
+            if: ->(_) { User.current.admin? },
             caption: I18n.t("menus.admin.mcp_configurations"),
             enterprise_feature: "mcp_server",
             parent: :ai

--- a/lib/api/mcp.rb
+++ b/lib/api/mcp.rb
@@ -44,7 +44,7 @@ module API
     end
 
     post "/" do
-      if !OpenProject::FeatureDecisions.mcp_server_active? || !EnterpriseToken.allows_to?(:mcp_server) || !server_config.enabled?
+      if !EnterpriseToken.allows_to?(:mcp_server) || !server_config.enabled?
         status 404
         return "MCP server is not available."
       end

--- a/spec/features/menu_items/admin_menu_item_spec.rb
+++ b/spec/features/menu_items/admin_menu_item_spec.rb
@@ -31,8 +31,7 @@
 require "spec_helper"
 
 RSpec.describe "Admin menu items",
-               :js,
-               with_flag: { mcp_server: true } do
+               :js do
   shared_let(:user) { create(:admin) }
 
   before do

--- a/spec/requests/mcp/mcp_resources/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/current_user_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::CurrentUser, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::CurrentUser do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/project_spec.rb
+++ b/spec/requests/mcp/mcp_resources/project_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::Project, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::Project do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/status_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_list_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::StatusList, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::StatusList do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/status_spec.rb
+++ b/spec/requests/mcp/mcp_resources/status_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::Status, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::Status do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/type_list_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_list_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::TypeList, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::TypeList do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/type_spec.rb
+++ b/spec/requests/mcp/mcp_resources/type_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::Type, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::Type do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/user_spec.rb
+++ b/spec/requests/mcp/mcp_resources/user_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::User, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::User do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/version_spec.rb
+++ b/spec/requests/mcp/mcp_resources/version_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::Version, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::Version do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_resources/work_package_spec.rb
+++ b/spec/requests/mcp/mcp_resources/work_package_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpResources::WorkPackage, with_flag: { mcp_server: true } do
+RSpec.describe McpResources::WorkPackage do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/current_user_spec.rb
+++ b/spec/requests/mcp/mcp_tools/current_user_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::CurrentUser, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::CurrentUser do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_statuses_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::ListStatuses, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::ListStatuses do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/list_types_spec.rb
+++ b/spec/requests/mcp/mcp_tools/list_types_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::ListTypes, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::ListTypes do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_portfolios_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchPortfolios, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchPortfolios do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"

--- a/spec/requests/mcp/mcp_tools/search_programs_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_programs_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchPrograms, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchPrograms do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"

--- a/spec/requests/mcp/mcp_tools/search_projects_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_projects_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchProjects, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchProjects do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/search_users_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_users_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchUsers, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchUsers do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/mcp_tools/search_versions_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_versions_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchVersions, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchVersions do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "X-Authentication-Scheme", "Bearer"

--- a/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
+++ b/spec/requests/mcp/mcp_tools/search_work_packages_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe McpTools::SearchWorkPackages, with_flag: { mcp_server: true } do
+RSpec.describe McpTools::SearchWorkPackages do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/resource_templates_list_spec.rb
+++ b/spec/requests/mcp/resource_templates_list_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "MCP resources/templates/list", with_flag: { mcp_server: true } do
+RSpec.describe "MCP resources/templates/list" do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/resources_list_spec.rb
+++ b/spec/requests/mcp/resources_list_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "MCP resources/list", with_flag: { mcp_server: true } do
+RSpec.describe "MCP resources/list" do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"

--- a/spec/requests/mcp/tools_list_spec.rb
+++ b/spec/requests/mcp/tools_list_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe "MCP tools/list", with_flag: { mcp_server: true } do
+RSpec.describe "MCP tools/list" do
   subject do
     header "Authorization", "Bearer #{access_token.plaintext_token}"
     header "Content-Type", "application/json"


### PR DESCRIPTION
The MCP server was introduced officially with 17.2, using a forced feature flag. Thus we should now remove the feature flag entirely, since there is no intent to disable it anymore.