### PR TITLE
[72807] Attribute help text not shown on project home page (overview tab)

### DIFF
--- a/app/components/projects/status_button_component.html.erb
+++ b/app/components/projects/status_button_component.html.erb
@@ -32,7 +32,7 @@
         end
       end
 
-      unless hide_help_text?
+      unless hide_help_text_caption?
         container.with_row do
           render(
             OpenProject::Common::AttributeHelpTextCaptionComponent.new(

--- a/app/components/projects/status_button_component.rb
+++ b/app/components/projects/status_button_component.rb
@@ -34,16 +34,18 @@ class Projects::StatusButtonComponent < ApplicationComponent
   include OpPrimer::ComponentHelpers
   include ProjectStatusHelper
 
-  attr_reader :project, :user, :hide_help_text
+  attr_reader :project, :user, :hide_help_text, :hide_help_text_caption
   alias :hide_help_text? :hide_help_text
+  alias :hide_help_text_caption? :hide_help_text_caption
 
-  def initialize(project:, user:, size: :medium, hide_help_text: false)
+  def initialize(project:, user:, size: :medium, hide_help_text: false, hide_help_text_caption: false)
     super
 
     @project = project
     @user = user
     @size = size
     @hide_help_text = hide_help_text
+    @hide_help_text_caption = hide_help_text_caption
 
     @status = find_status(project.status_code)
   end

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.html
@@ -10,12 +10,12 @@
       class="grid--area-drag-handle hidden-for-mobile"></svg>
     }
 
-    <ng-content select="[slot=prepend]" />
-
     <editable-toolbar-title [title]="name"
       (onSave)="renamed($event)"
       [editable]="isRenameable"
       class="op-widget-box--header-title" />
+
+    <ng-content select="[slot=append]" />
   </h3>
 
   <ng-content select="[slot=menu]" />

--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.html
@@ -2,9 +2,9 @@
   [name]="widgetName"
   [editable]="isEditable">
 
-  <attribute-help-text slot="prepend"
-    attribute="members"
-  [attributeScope]="'Project'" />
+  <attribute-help-text slot="append"
+                       attribute="members"
+                       [attributeScope]="'Project'" />
 
   <widget-menu slot="menu"
     [resource]="resource" />

--- a/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-description/project-description.component.html
@@ -2,9 +2,9 @@
   [name]="widgetName"
   [editable]="isEditable">
 
-  <attribute-help-text slot="prepend"
-    attribute="description"
-  [attributeScope]="'Project'" />
+  <attribute-help-text slot="append"
+                       attribute="description"
+                       [attributeScope]="'Project'" />
 
   <widget-menu slot="menu"
     [resource]="resource" />

--- a/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/project-status/project-status.component.html
@@ -2,7 +2,7 @@
   [name]="widgetName"
   [editable]="isEditable">
 
-  <attribute-help-text slot="prepend"
+  <attribute-help-text slot="append"
                        attribute="status"
                        [attributeScope]="'Project'" />
 

--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -180,7 +180,7 @@ $widget-box--enumeration-width: 20px
 
   .help-text--entry
     vertical-align: -1px
-    margin-right: 4px
+    margin-left: 4px
 
 .op-widget-box--header-title
   vertical-align: middle

--- a/modules/grids/app/components/grids/widget_box_component.rb
+++ b/modules/grids/app/components/grids/widget_box_component.rb
@@ -33,10 +33,10 @@ module Grids
   class WidgetBoxComponent < ApplicationComponent
     attr_reader :title, :content_padding
 
-    renders_one :header, lambda { |title:, **system_arguments|
+    renders_one :header, lambda { |title:, attribute_label: nil, **system_arguments|
       system_arguments[:id] = @header_id
 
-      Header.new(title:, **system_arguments)
+      Header.new(title:, attribute_label:, **system_arguments)
     }
 
     renders_one :body, Body
@@ -56,12 +56,14 @@ module Grids
       full_width: false,
       half_width: false,
       border: true,
+      attribute_label: nil,
       **system_arguments
     )
       super()
 
       @key = key
       @title = title
+      @attribute_label = attribute_label
       @content_padding = content_padding
       @header_id = "#{key}-header"
 
@@ -90,7 +92,7 @@ module Grids
     end
 
     def default_header
-      Header.new(title:, id: @header_id)
+      Header.new(title:, id: @header_id, attribute_label: @attribute_label)
     end
 
     def default_body

--- a/modules/grids/app/components/grids/widget_box_component/header.html.erb
+++ b/modules/grids/app/components/grids/widget_box_component/header.html.erb
@@ -30,7 +30,15 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
   <div class="op-widget-box--header-title title-container">
-    <h3 class="editable-toolbar-title--fixed"><%= title %></h3>
+    <h3 class="editable-toolbar-title--fixed">
+      <% if @attribute_label_args %>
+        <%= render OpenProject::Common::AttributeLabelComponent.new(**@attribute_label_args) do %>
+          <%= title %>
+        <% end %>
+      <% else %>
+        <%= title %>
+      <% end %>
+    </h3>
   </div>
   <%= action %>
 <% end %>

--- a/modules/grids/app/components/grids/widget_box_component/header.rb
+++ b/modules/grids/app/components/grids/widget_box_component/header.rb
@@ -49,10 +49,12 @@ module Grids
         }
       }
 
+      # @param attribute_label [Hash, nil] Optional args for AttributeLabelComponent (model:, attribute:, current_user:)
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(title:, **system_arguments)
+      def initialize(title:, attribute_label: nil, **system_arguments)
         super()
         @title = title
+        @attribute_label_args = attribute_label
         @system_arguments = system_arguments
         @system_arguments[:tag] = :header
         @system_arguments[:id] ||= self.class.generate_id

--- a/modules/grids/app/components/grids/widgets/description.rb
+++ b/modules/grids/app/components/grids/widgets/description.rb
@@ -38,6 +38,10 @@ module Grids
       def title
         Project.human_attribute_name(:description)
       end
+
+      def wrapper_arguments
+        { attribute_label: { model: project, attribute: :description, current_user: } }
+      end
     end
   end
 end

--- a/modules/grids/app/components/grids/widgets/project_status.html.erb
+++ b/modules/grids/app/components/grids/widgets/project_status.html.erb
@@ -32,14 +32,13 @@ See COPYRIGHT and LICENSE files for more details.
     component_wrapper do
       flex_layout do |flex|
         flex.with_row(mb: 3) do
-          render(Projects::StatusButtonComponent.new(project:, user: current_user))
+          render(Projects::StatusButtonComponent.new(project:, user: current_user, hide_help_text: true))
         end
 
         flex.with_row do
           render OpenProject::Common::InplaceEditFieldComponent.new(
             model: project,
             attribute: :status_explanation,
-            visually_hide_label: true,
             rich_text_options: {
               showAttachments: false,
               editorType: "constrained",

--- a/modules/grids/app/components/grids/widgets/project_status.rb
+++ b/modules/grids/app/components/grids/widgets/project_status.rb
@@ -39,6 +39,10 @@ module Grids
       def title
         Project.human_attribute_name(:status)
       end
+
+      def wrapper_arguments
+        { attribute_label: { model: project, attribute: :status, current_user: } }
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72807

# What are you trying to accomplish?
* Allow AttributeHelpTexts within widgetHeaders
* Harmonize the positioning and display of AttributeHelpTexts within widgets on Overview and Dashboard tab

## Screenshots
**Overview**
<img width="1552" height="566" alt="Bildschirmfoto 2026-03-23 um 14 13 02" src="https://github.com/user-attachments/assets/fa750ce8-2348-4d33-a960-0345011e20f0" />

**Dashboard**
<img width="1464" height="628" alt="Bildschirmfoto 2026-03-23 um 14 13 29" src="https://github.com/user-attachments/assets/43575d0b-a6ed-45b5-8c87-a4d4d51be92a" />
