### PR TITLE
Feature/72198 inbox backlog bucket

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,7 +461,7 @@ en:
         no_role: "Select role"
       blankslate:
         title: "No status transitions configured"
-        description: "Add statuses to start configuring workflows for this role"    
+        description: "Add statuses to start configuring workflows for this role"
     info:
       database_deprecation_html: >
         Starting with OpenProject 16.0, PostgreSQL 16 is required to use OpenProject.

--- a/frontend/src/global_styles/openproject.sass
+++ b/frontend/src/global_styles/openproject.sass
@@ -20,6 +20,7 @@
 
 // Module specific Styles
 @import "../../../modules/auth_saml/app/components/_index.sass"
+@import "../../../modules/backlogs/app/components/_index.sass"
 @import "../../../modules/costs/app/components/_index.sass"
 @import "../../../modules/documents/app/assets/stylesheets/_index.sass"
 @import "../../../modules/documents/app/components/_index.sass"

--- a/modules/backlogs/app/components/_index.sass
+++ b/modules/backlogs/app/components/_index.sass
@@ -1,0 +1,1 @@
+@import "backlogs/inbox_component"

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -26,8 +26,25 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
+<%= component_wrapper(tag: "turbo-frame", refresh: :morph) do %>
+  <%=
+    render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+      head.with_heading(tag: :h3, font_weight: :bold, size: :medium) do
+        concat t(:label_backlog)
+        concat render(Primer::Beta::Counter.new(count: total, scheme: :default, ml: 1))
+      end
 
-<%= component_wrapper(tag: :section) do %>
+      if allow_sprint_creation?(project)
+        # Ugly hack:
+        # This button will not be rendered, but still takes up space to push the left side down a bit.
+        # Remove as soon as the `+ Sprint` button moves from the Subhead into a SubHeader.
+        head.with_actions do
+          render(Primer::Beta::Button.new(tag: :a, visibility: :hidden)) { "spacer" }
+        end
+      end
+    end
+  %>
+
   <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
     <% if work_packages.empty? %>
       <% border_box.with_row(data: { empty_list_item: true }) do %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -65,10 +65,23 @@ See COPYRIGHT and LICENSE files for more details.
         ) %>
 
     <% if paginate? %>
-      <% border_box.with_row(id: "inbox-more-row-#{project.id}") do %>
-        <%= link_to t(".show_more", count: middle_count),
-                    sprint_planning_backlogs_project_backlogs_path(project, all: 1),
-                    class: "btn-transparent width-full text-center" %>
+      <% border_box.with_row(
+           id: "inbox-more-row-#{project.id}", scheme: :neutral,
+           classes: "backlogs-inbox-component--show-more-row"
+         ) do %>
+        <%=
+          render(
+            Primer::Beta::Button.new(
+              scheme: :link,
+              tag: :a,
+              size: :large,
+              block: true,
+              align_content: :start,
+              underline: true,
+              href: sprint_planning_backlogs_project_backlogs_path(project, all: 1)
+            )
+          ) { t(".show_more", count: middle_count) }
+        %>
       <% end %>
 
       <%= render Backlogs::InboxItemComponent.with_collection(

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -1,0 +1,65 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= component_wrapper(tag: :section) do %>
+  <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
+    <% if work_packages.empty? %>
+      <% border_box.with_row(data: { empty_list_item: true }) do %>
+        <%=
+          render Primer::Beta::Blankslate.new(role: "status", aria: { live: "polite" }) do |blankslate|
+            blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
+            blankslate.with_description_content(t(".blankslate_description"))
+          end
+        %>
+      <% end %>
+    <% end %>
+
+    <%= render Backlogs::InboxItemComponent.with_collection(
+          paginate? ? first_page : work_packages,
+          container: border_box,
+          project:,
+          max_position:
+        ) %>
+
+    <% if paginate? %>
+      <% border_box.with_row(id: "inbox-more-row-#{project.id}") do %>
+        <%= link_to t(".show_more", count: middle_count),
+                    sprint_planning_backlogs_project_backlogs_path(project, all: 1),
+                    class: "btn-transparent width-full text-center" %>
+      <% end %>
+
+      <%= render Backlogs::InboxItemComponent.with_collection(
+            last_page,
+            container: border_box,
+            project:,
+            max_position:
+          ) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class InboxComponent < ApplicationComponent
+    include Primer::AttributesHelper
+    include OpTurbo::Streamable
+    include RbCommonHelper
+
+    PAGINATION_THRESHOLD = 70
+    FIRST_PAGE_SIZE = 50
+    LAST_PAGE_SIZE = 10
+
+    attr_reader :work_packages, :project, :current_user, :show_all
+
+    def initialize(work_packages:, project:, show_all: false, current_user: User.current, **system_arguments)
+      super()
+
+      @work_packages = work_packages
+      @project = project
+      @show_all = show_all
+      @current_user = current_user
+
+      @system_arguments = system_arguments
+      @system_arguments[:id] = inbox_dom_id
+      @system_arguments[:padding] = :condensed
+      @system_arguments[:data] = merge_data(
+        @system_arguments,
+        { data: drop_target_config }
+      )
+    end
+
+    def wrapper_uniq_by
+      project
+    end
+
+    private
+
+    def total
+      @total ||= work_packages.count
+    end
+
+    def inbox_dom_id
+      "inbox_#{project.id}"
+    end
+
+    def paginate?
+      !show_all && total > PAGINATION_THRESHOLD
+    end
+
+    def first_page
+      work_packages.limit(FIRST_PAGE_SIZE)
+    end
+
+    def last_page
+      work_packages.last(LAST_PAGE_SIZE)
+    end
+
+    def middle_count
+      total - FIRST_PAGE_SIZE - LAST_PAGE_SIZE
+    end
+
+    def drop_target_config
+      {
+        generic_drag_and_drop_target: "container",
+        target_container_accessor: ":scope > ul",
+        target_id: "inbox",
+        target_allowed_drag_type: "story"
+      }
+    end
+
+    def max_position
+      work_packages.maximum(:position)
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/inbox_component.sass
+++ b/modules/backlogs/app/components/backlogs/inbox_component.sass
@@ -1,0 +1,4 @@
+.backlogs-inbox-component
+  &--show-more-row
+    border-top: var(--borderWidth-thick) solid var(--borderColor-default)
+    border-bottom: var(--borderWidth-thick) solid var(--borderColor-default)

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
@@ -30,17 +30,23 @@ See COPYRIGHT and LICENSE files for more details.
 <% container.with_row(**row_options) do %>
   <%= grid_layout("op-backlogs-story", tag: :article) do |grid| %>
     <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
-      <%=
-        render(
-          Primer::OpenProject::DragHandle.new(
-            classes: "op-backlogs-story--drag_handle_button",
-            label: t(".label_drag_work_package", name: work_package.subject)
-          )
-        )
-      %>
+      <%= if draggable?
+            render(
+              Primer::OpenProject::DragHandle.new(
+                classes: "op-backlogs-story--drag_handle_button",
+                label: t(".label_drag_work_package", name: work_package.subject)
+              )
+            )
+          end %>
     <% end %>
     <% grid.with_area(:info_line) do %>
       <%= render(WorkPackages::InfoLineComponent.new(work_package:)) %>
+    <% end %>
+    <% grid.with_area(:points) do %>
+      <%= render(Primer::Beta::Text.new(color: :subtle)) do %>
+        <%= story_points %>
+        <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
+      <% end %>
     <% end %>
     <% grid.with_area(:menu) do %>
       <%= render(Backlogs::InboxMenuComponent.new(work_package:, project:, max_position:)) %>

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
@@ -1,0 +1,52 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<% container.with_row(**row_options) do %>
+  <%= grid_layout("op-backlogs-story", tag: :article) do |grid| %>
+    <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
+      <%=
+        render(
+          Primer::OpenProject::DragHandle.new(
+            classes: "op-backlogs-story--drag_handle_button",
+            label: t(".label_drag_work_package", name: work_package.subject)
+          )
+        )
+      %>
+    <% end %>
+    <% grid.with_area(:info_line) do %>
+      <%= render(WorkPackages::InfoLineComponent.new(work_package:)) %>
+    <% end %>
+    <% grid.with_area(:menu) do %>
+      <%= render(Backlogs::InboxMenuComponent.new(work_package:, project:, max_position:)) %>
+    <% end %>
+    <% grid.with_area(:subject) do %>
+      <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { work_package.subject } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.rb
@@ -46,6 +46,18 @@ module Backlogs
 
     private
 
+    def story_points
+      work_package.story_points || 0
+    end
+
+    def wrapper_uniq_by
+      "inbox-frame-#{project.id}"
+    end
+
+    def draggable?
+      current_user.allowed_in_project?(:manage_sprint_items, project)
+    end
+
     def row_options
       {
         id: dom_id(work_package),

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class InboxItemComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :work_package, :project, :container, :max_position, :current_user
+
+    def initialize(inbox_item:, project:, container:, max_position:, current_user: User.current)
+      super()
+
+      @work_package = inbox_item
+      @project = project
+      @container = container
+      @max_position = max_position
+      @current_user = current_user
+    end
+
+    private
+
+    def row_options
+      {
+        id: dom_id(work_package),
+        classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
+        data: {
+          draggable_id: work_package.id,
+          draggable_type: "story",
+          drop_url: move_from_inbox_project_story_path(project, work_package),
+          story: true,
+          controller: "backlogs--story",
+          backlogs__story_id_value: work_package.id,
+          backlogs__story_split_url_value: details_backlogs_project_backlogs_path(project, work_package),
+          backlogs__story_full_url_value: work_package_path(work_package),
+          backlogs__story_selected_class: "Box-row--blue"
+        },
+        tabindex: 0
+      }
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
@@ -1,0 +1,64 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%=
+  render(Primer::Alpha::ActionMenu.new(**@system_arguments)) do |menu|
+    menu.with_show_button(
+      scheme: :invisible,
+      icon: :"kebab-horizontal",
+      "aria-label": t(".label_actions"),
+      tooltip_direction: :se
+    )
+
+    menu.with_item(
+      id: dom_target(work_package, :menu, :open_details),
+      tag: :a,
+      label: t(:"js.button_open_details"),
+      href: details_backlogs_project_backlogs_path(project, work_package),
+      content_arguments: { data: { turbo_frame: "content-bodyRight", turbo_action: "advance" } }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :"op-view-split")
+    end
+
+    menu.with_item(
+      id: dom_target(work_package, :menu, :open_fullscreen),
+      tag: :a,
+      label: t(:"js.button_open_fullscreen"),
+      href: work_package_path(work_package),
+      content_arguments: { data: { turbo_frame: "_top" } }
+    ) do |item|
+      item.with_leading_visual_icon(icon: :"screen-full")
+    end
+
+    if show_move_items?
+      menu.with_divider
+      build_move_menu(menu)
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class InboxMenuComponent < ApplicationComponent
+    attr_reader :work_package, :project, :max_position, :current_user
+
+    def initialize(work_package:, project:, max_position:, current_user: User.current, **system_arguments)
+      super()
+
+      @work_package = work_package
+      @project = project
+      @max_position = max_position
+      @current_user = current_user
+
+      @system_arguments = system_arguments
+      @system_arguments[:menu_id] = dom_target(work_package, :menu)
+      @system_arguments[:anchor_align] = :end
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "hide-when-print"
+      )
+    end
+
+    private
+
+    def show_move_items?
+      !(first_item? && last_item?)
+    end
+
+    def build_move_menu(menu)
+      unless first_item?
+        build_move_item(menu, label: I18n.t(:label_sort_highest), direction: "highest", icon: :"move-to-top")
+        build_move_item(menu, label: I18n.t(:label_sort_higher), direction: "higher", icon: :"chevron-up")
+      end
+      unless last_item?
+        build_move_item(menu, label: I18n.t(:label_sort_lower), direction: "lower", icon: :"chevron-down")
+        build_move_item(menu, label: I18n.t(:label_sort_lowest), direction: "lowest", icon: :"move-to-bottom")
+      end
+    end
+
+    def build_move_item(menu, label:, direction:, icon:)
+      menu.with_item(
+        id: dom_target(work_package, :menu, direction),
+        label:,
+        tag: :button,
+        href: reorder_inbox_project_story_path(project, work_package),
+        form_arguments: { method: :post, inputs: [{ name: "direction", value: direction }] }
+      ) do |item|
+        item.with_leading_visual_icon(icon:)
+      end
+    end
+
+    def first_item?
+      work_package.position == 1
+    end
+
+    def last_item?
+      work_package.position == max_position
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -71,7 +71,7 @@ module Backlogs
         id: dom_target(work_package, :menu, direction),
         label:,
         tag: :button,
-        href: reorder_inbox_project_story_path(project, work_package),
+        href: reorder_project_inbox_path(project, work_package),
         form_arguments: { method: :post, inputs: [{ name: "direction", value: direction }] }
       ) do |item|
         item.with_leading_visual_icon(icon:)

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -52,7 +52,12 @@ module Backlogs
     private
 
     def show_move_items?
+      allowed_to_manage_sprint_items? &&
       !(first_item? && last_item?)
+    end
+
+    def allowed_to_manage_sprint_items?
+      current_user.allowed_in_project?(:manage_sprint_items, project)
     end
 
     def build_move_menu(menu)

--- a/modules/backlogs/app/components/backlogs/story_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/story_menu_component.rb
@@ -53,7 +53,12 @@ module Backlogs
     private
 
     def show_move_items?
+      allowed_to_manage_sprint_items? &&
       !(first_item? && last_item?)
+    end
+
+    def allowed_to_manage_sprint_items?
+      current_user.allowed_in_project?(:manage_sprint_items, project)
     end
 
     def build_move_menu(menu)

--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class InboxController < RbApplicationController
+  include OpTurbo::ComponentStream
+
+  skip_before_action :load_sprint_and_project
+
+  before_action :not_authorized_on_feature_flag_inactive
+  prepend_before_action :load_work_package, :load_project
+
+  def reorder
+    call = Stories::UpdateService
+      .new(user: current_user, story: @work_package)
+      .call(attributes: { move_to: reorder_param })
+
+    return failure_response(call.message) unless call.success?
+
+    replace_inbox_component_via_turbo_stream
+    respond_with_turbo_streams
+  end
+
+  # Move a work package from the Inbox to a Sprint, or reorder it within the Inbox.
+  def move
+    target_type, sprint_id = move_params[:target_id].split(":", 2)
+    attributes = target_type == "sprint" ? { sprint_id: } : {}
+
+    call = Stories::UpdateService
+      .new(user: current_user, story: @work_package)
+      .call(attributes:, position: move_params[:position].to_i)
+
+    return failure_response(call.message) unless call.success?
+
+    replace_inbox_component_via_turbo_stream
+    replace_sprint_component_via_turbo_stream(sprint_id) if target_type == "sprint"
+    respond_with_turbo_streams
+  end
+
+  private
+
+  def load_work_package
+    @work_package = WorkPackage.visible.find(params[:id])
+  end
+
+  def replace_inbox_component_via_turbo_stream
+    inbox_work_packages = Backlog.inbox_for(project: @project)
+    replace_via_turbo_stream(
+      component: Backlogs::InboxComponent.new(work_packages: inbox_work_packages, project: @project),
+      method: :morph
+    )
+  end
+
+  def replace_sprint_component_via_turbo_stream(sprint_id)
+    sprint = Agile::Sprint.for_project(@project).visible.find(sprint_id)
+    render_success_flash_message_via_turbo_stream(
+      message: I18n.t(:notice_successful_move, from: I18n.t(:label_inbox), to: sprint.name)
+    )
+    replace_via_turbo_stream(
+      component: Backlogs::SprintComponent.new(sprint: sprint, project: @project),
+      method: :morph
+    )
+  end
+
+  def failure_response(reason)
+    render_error_flash_message_via_turbo_stream(
+      message: I18n.t(:notice_unsuccessful_update_with_reason, reason:)
+    )
+    respond_with_turbo_streams(status: :unprocessable_entity)
+  end
+
+  def move_params
+    params.require(%i[position target_id])
+    params.permit(:position, :target_id)
+  end
+
+  def reorder_param
+    params.expect(:direction)
+  end
+end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -90,6 +90,7 @@ class RbMasterBacklogsController < RbApplicationController
     if OpenProject::FeatureDecisions.scrum_projects_active?
       @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
       @active_sprint_ids = @sprints.select(&:active?).map(&:id)
+      @inbox_work_packages = Backlog.inbox_for(project: @project)
     else
       @sprint_backlogs = Backlog.sprint_backlogs(@project)
     end

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -31,13 +31,7 @@
 class RbStoriesController < RbApplicationController
   include OpTurbo::ComponentStream
 
-  NEW_SPRINT_ACTIONS = %i[move].freeze
-  LEGACY_SPRINT_ACTIONS = %i[move_legacy reorder].freeze
-
-  skip_before_action :load_sprint_and_project, only: NEW_SPRINT_ACTIONS + LEGACY_SPRINT_ACTIONS
-
-  prepend_before_action :load_legacy_project_sprint_and_story, only: LEGACY_SPRINT_ACTIONS
-  prepend_before_action :load_new_project_sprint_and_story, only: NEW_SPRINT_ACTIONS
+  before_action :load_story
 
   # Move a story from a Sprint to another Sprint or an Agile::Sprint.
   def move_legacy
@@ -209,32 +203,12 @@ class RbStoriesController < RbApplicationController
                              method: :morph)
   end
 
-  def legacy_load_story
-    @story = Story.visible.find(params[:id])
-  end
-
-  def load_legacy_project_sprint_and_story
-    load_project
-    legacy_load_sprint
-    legacy_load_story
-  end
-
-  def load_new_project_sprint_and_story
-    load_project
-    load_sprint
-    load_story
-  end
-
-  def legacy_load_sprint
-    @sprint = Sprint.visible.apply_to(@project).find(params[:sprint_id])
-  end
-
   def load_story
-    @story = WorkPackage.visible.find(params[:id])
-  end
-
-  def load_sprint
-    @sprint = Agile::Sprint.for_project(@project).visible.find(params[:sprint_id])
+    @story = if OpenProject::FeatureDecisions.scrum_projects_active?
+               WorkPackage.visible.find(params[:id])
+             else
+               Story.visible.find(params[:id])
+             end
   end
 
   def move_params

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -59,7 +59,7 @@ class RbStoriesController < RbApplicationController
     respond_with_turbo_streams
   end
 
-  # Move a story from an Agile::Sprint to another Agile::Sprint or a Sprint.
+  # Move a story from an Agile::Sprint to another Agile::Sprint, or the Inbox.
   def move
     # The update service reloads the story internally (via #move_after),
     # so we memoize the previous sprint_id before the call.
@@ -70,7 +70,9 @@ class RbStoriesController < RbApplicationController
       return respond_with_turbo_streams(status: :unprocessable_entity)
     end
 
-    if target_version?(move_attributes)
+    if target_inbox?(move_attributes)
+      moved_to_inbox
+    elsif target_version?(move_attributes)
       moved_to_version
     elsif target_sprint?(move_attributes) && @story.sprint_id != sprint_id_was
       moved_to_sprint
@@ -130,6 +132,17 @@ class RbStoriesController < RbApplicationController
     end
   end
 
+  def moved_to_inbox
+    render_success_flash_message_via_turbo_stream(
+      message: I18n.t(:notice_successful_move, from: @sprint.name, to: I18n.t(:label_inbox))
+    )
+    inbox_work_packages = Backlog.inbox_for(project: @project)
+    replace_via_turbo_stream(
+      component: Backlogs::InboxComponent.new(work_packages: inbox_work_packages, project: @project),
+      method: :morph
+    )
+  end
+
   def moved_to_version
     moved_to(new_sprint: @story.version.becomes(Sprint))
   end
@@ -163,8 +176,10 @@ class RbStoriesController < RbApplicationController
       else
         { sprint_id: target_id }
       end
+    when "inbox"
+      { sprint_id: nil }
     else
-      raise ArgumentError, "target_type must include one of: version, sprint."
+      raise ArgumentError, "target_type must include one of: version, sprint, inbox."
     end
   end
 
@@ -174,6 +189,11 @@ class RbStoriesController < RbApplicationController
 
   def target_sprint?(move_attributes)
     move_attributes[:sprint_id].present?
+  end
+
+  def target_inbox?(move_attributes)
+    move_attributes.key?(:sprint_id) && move_attributes[:sprint_id].nil? &&
+      !move_attributes.key?(:version_id)
   end
 
   def replace_backlog_component_via_turbo_stream(sprint:)

--- a/modules/backlogs/app/models/backlog.rb
+++ b/modules/backlogs/app/models/backlog.rb
@@ -41,9 +41,8 @@ class Backlog
   def self.inbox_for(project:)
     WorkPackage
       .visible
-      .where(project:)
       .with_status_open
-      .where(sprint_id: nil)
+      .where(project:, sprint_id: nil)
       .order(Arel.sql(Story::ORDER))
   end
 

--- a/modules/backlogs/app/models/backlog.rb
+++ b/modules/backlogs/app/models/backlog.rb
@@ -38,6 +38,15 @@ class Backlog
     new(sprint:, stories: sprint.stories(project), owner_backlog:)
   end
 
+  def self.inbox_for(project:)
+    WorkPackage
+      .visible
+      .where(project:)
+      .with_status_open
+      .where(sprint_id: nil)
+      .order(Arel.sql(Story::ORDER))
+  end
+
   def self.owner_backlogs(project)
     backlogs = Sprint.apply_to(project).with_status_open.displayed_right(project).order(:name)
 

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -42,31 +42,11 @@ See COPYRIGHT and LICENSE files for more details.
   <% else %>
     <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
       <div id="owner_backlogs_container" class="op-sprint-planning-lists">
-        <%=
-          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) do
-              concat t(:label_backlog)
-              concat render(Primer::Beta::Counter.new(count: @inbox_work_packages.count, scheme: :default, ml: 1))
-            end
-
-            if allow_sprint_creation?(@project)
-              # Ugly hack:
-              # This button will not be rendered, but still takes up space to push the left side down a bit.
-              # Remove as soon as the `+ Sprint` button moves from the Subhead into a SubHeader.
-              head.with_actions do
-                render(Primer::Beta::Button.new(tag: :a, visibility: :hidden)) { "spacer" }
-              end
-            end
-          end
-        %>
-
-        <%= turbo_frame_tag "inbox-frame-#{@project.id}" do %>
-          <%= render Backlogs::InboxComponent.new(
-                work_packages: @inbox_work_packages,
-                project: @project,
-                show_all: params[:all].present?
-              ) %>
-        <% end %>
+        <%= render Backlogs::InboxComponent.new(
+              work_packages: @inbox_work_packages,
+              project: @project,
+              show_all: params[:all].present?
+            ) %>
       </div>
       <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
         <%=

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -60,13 +60,13 @@ See COPYRIGHT and LICENSE files for more details.
           end
         %>
 
-        <turbo-frame id="inbox-frame-<%= @project.id %>">
+        <%= turbo_frame_tag "inbox-frame-#{@project.id}" do %>
           <%= render Backlogs::InboxComponent.new(
                 work_packages: @inbox_work_packages,
                 project: @project,
                 show_all: params[:all].present?
               ) %>
-        </turbo-frame>
+        <% end %>
       </div>
       <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
         <%=

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -44,7 +44,10 @@ See COPYRIGHT and LICENSE files for more details.
       <div id="owner_backlogs_container" class="op-sprint-planning-lists">
         <%=
           render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { t(:label_backlog) }
+            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) do
+              concat t(:label_backlog)
+              concat render(Primer::Beta::Counter.new(count: @inbox_work_packages.count, scheme: :default, ml: 1))
+            end
 
             if allow_sprint_creation?(@project)
               # Ugly hack:
@@ -57,7 +60,13 @@ See COPYRIGHT and LICENSE files for more details.
           end
         %>
 
-        <%= render(Backlogs::BacklogComponent.with_collection(@owner_backlogs, project: @project)) %>
+        <turbo-frame id="inbox-frame-<%= @project.id %>">
+          <%= render Backlogs::InboxComponent.new(
+                work_packages: @inbox_work_packages,
+                project: @project,
+                show_all: params[:all].present?
+              ) %>
+        </turbo-frame>
       </div>
       <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
         <%=

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -136,8 +136,8 @@ en:
         other: "%{count} stories in backlog"
 
     inbox_component:
-      blankslate_title: "Inbox is empty"
-      blankslate_description: "No open work packages without a sprint assignment."
+      blankslate_title: "Backlog inbox is empty"
+      blankslate_description: "All open work packages in this project will automatically appear here."
       label_drag_work_package: "Move %{name}"
       show_more:
         one: "Show 1 more item"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -135,6 +135,12 @@ en:
         one: "%{count} story in backlog"
         other: "%{count} stories in backlog"
 
+    inbox_item_component:
+      label_drag_work_package: "Move %{name}"
+
+    inbox_menu_component:
+      label_actions: "Work package actions"
+
     sprint_header_component:
       label_toggle_backlog: "Collapse/Expand %{name}"
       label_story_count:

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -207,6 +207,7 @@ en:
         cannot_be_story_type: "can not also be a story type"
 
   label_backlog: "Backlog"
+  label_inbox: "Inbox"
   label_backlogs: "Backlogs"
   label_backlogs_unconfigured: "You have not configured Backlogs yet. Please go to %{administration} > %{plugins}, then click on the %{configure} link for this plugin. Once you have set the fields, come back to this page to start using the tool."
   label_blocks_ids: "IDs of blocked work packages"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -135,6 +135,14 @@ en:
         one: "%{count} story in backlog"
         other: "%{count} stories in backlog"
 
+    inbox_component:
+      blankslate_title: "Inbox is empty"
+      blankslate_description: "No open work packages without a sprint assignment."
+      label_drag_work_package: "Move %{name}"
+      show_more:
+        one: "Show 1 more item"
+        other: "Show %{count} more items"
+
     inbox_item_component:
       label_drag_work_package: "Move %{name}"
 

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -52,18 +52,18 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      resources :inbox, only: [] do
+        member do
+          put :move
+          post :reorder
+        end
+      end
     end
 
     scope "projects/:project_id", as: "project", module: "projects" do
       namespace "settings" do
         resource :backlog_sharing, only: %i[show update]
-      end
-    end
-
-    resources :inbox, only: [] do
-      member do
-        put :move
-        post :reorder
       end
     end
   end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -60,10 +60,10 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :stories, controller: :rb_stories, only: [] do
+    resources :inbox, only: [] do
       member do
-        put :move_from_inbox
-        post :reorder_inbox
+        put :move
+        post :reorder
       end
     end
   end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -59,6 +59,13 @@ Rails.application.routes.draw do
         resource :backlog_sharing, only: %i[show update]
       end
     end
+
+    resources :stories, controller: :rb_stories, only: [] do
+      member do
+        put :move_from_inbox
+        post :reorder_inbox
+      end
+    end
   end
 
   # Legacy routes

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -102,7 +102,7 @@ module OpenProject::Backlogs
                    visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
 
         permission :manage_sprint_items,
-                   { rb_stories: %i[move move_legacy reorder] },
+                   { rb_stories: %i[move move_legacy reorder move_from_inbox reorder_inbox] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -102,7 +102,8 @@ module OpenProject::Backlogs
                    visible: -> { OpenProject::FeatureDecisions.scrum_projects_active? }
 
         permission :manage_sprint_items,
-                   { rb_stories: %i[move move_legacy reorder move_from_inbox reorder_inbox] },
+                   { rb_stories: %i[move move_legacy reorder],
+                     inbox: %i[move reorder] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     let(:work_packages) { WorkPackage.none }
 
     it "shows the blankslate heading and description" do
-      expect(page).to have_css("h4", text: "Inbox is empty")
-      expect(page).to have_text("No open work packages without a sprint assignment.")
+      expect(page).to have_css("h4", text: "Backlog inbox is empty")
+      expect(page).to have_text("All open work packages in this project will automatically appear here.")
     end
   end
 
@@ -81,7 +81,7 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       expect(page).to have_text("Second item")
 
       # does not show the blankslate
-      expect(page).to have_no_css("h4", text: "Inbox is empty")
+      expect(page).to have_no_css("h4", text: "Backlog inbox is empty")
     end
   end
 

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::InboxComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+
+  current_user { user }
+
+  let(:work_packages) { WorkPackage.none }
+  let(:show_all) { false }
+
+  def render_component(**)
+    render_inline(described_class.new(work_packages:, project:, current_user: user, **))
+  end
+
+  def create_inbox_work_package(subject: "WP", position: nil)
+    create(:work_package, subject:, project:, position:)
+  end
+
+  before do
+    render_component(show_all:)
+  end
+
+  describe "container" do
+    it "renders a Primer::Beta::BorderBox with the inbox DOM id" do
+      expect(page).to have_css(".Box#inbox_#{project.id}")
+    end
+  end
+
+  describe "empty state" do
+    let(:work_packages) { WorkPackage.none }
+
+    it "shows the blankslate heading and description" do
+      expect(page).to have_css("h4", text: "Inbox is empty")
+      expect(page).to have_text("No open work packages without a sprint assignment.")
+    end
+  end
+
+  describe "with work packages" do
+    let(:wp1) { create_inbox_work_package(subject: "First item", position: 1) }
+    let(:wp2) { create_inbox_work_package(subject: "Second item", position: 2) }
+    let(:work_packages) { WorkPackage.where(id: [wp1.id, wp2.id]).order(:position) }
+
+    it "renders a row for each work package", :aggregate_failures do
+      expect(page).to have_css(".Box-row", count: 2)
+
+      # renders the subject of each work package
+      expect(page).to have_text("First item")
+      expect(page).to have_text("Second item")
+
+      # does not show the blankslate
+      expect(page).to have_no_css("h4", text: "Inbox is empty")
+    end
+  end
+
+  describe "pagination" do
+    let(:threshold) { described_class::PAGINATION_THRESHOLD }
+    let(:first_page_size) { described_class::FIRST_PAGE_SIZE }
+    let(:last_page_size) { described_class::LAST_PAGE_SIZE }
+
+    context "when work packages do not exceed the threshold" do
+      let(:work_packages) do
+        wps = create_list(:work_package, threshold, project:)
+        WorkPackage.where(id: wps.map(&:id))
+      end
+
+      it "renders all items without pagination" do
+        expect(page).to have_css(".Box-row", count: threshold)
+        # does not show a 'show more' link
+        expect(page).to have_no_css("#inbox-more-row-#{project.id}")
+      end
+    end
+
+    context "when work packages exceed the threshold" do
+      let(:total) { threshold + 8 }
+      let(:middle_count) { total - first_page_size - last_page_size }
+      let(:work_packages) do
+        wps = create_list(:work_package, total, project:)
+        WorkPackage.where(id: wps.map(&:id)).order(:id)
+      end
+
+      it "renders only the first page and last page items (not all)" do
+        expect(page).to have_css(".Box-row", count: first_page_size + last_page_size + 1) # +1 for "show more" row
+        # shows a 'show more' link with the count of hidden items
+        expect(page).to have_css("#inbox-more-row-#{project.id}")
+        expect(page).to have_text("Show #{middle_count} more items")
+      end
+    end
+
+    context "when show_all: true and work packages exceed threshold" do
+      let(:show_all) { true }
+      let(:total) { threshold + 3 }
+      let(:work_packages) do
+        wps = create_list(:work_package, total, project:)
+        WorkPackage.where(id: wps.map(&:id))
+      end
+
+      it "renders all items without pagination" do
+        expect(page).to have_css(".Box-row", count: total)
+        # does not show a 'show more' link
+        expect(page).to have_no_css("#inbox-more-row-#{project.id}")
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+# InboxItemComponent renders into a Primer::Beta::BorderBox container slot,
+# so it is tested through InboxComponent which provides the container.
+RSpec.describe Backlogs::InboxItemComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:user) { create(:admin) }
+  current_user { user }
+
+  let(:project) { create(:project) }
+  let(:work_package) do
+    create(:work_package,
+           subject: "Inbox Work Package",
+           project:,
+           status: default_status,
+           priority: default_priority,
+           position: 1)
+  end
+  let(:work_packages) { WorkPackage.where(id: work_package.id).order(Arel.sql(Story::ORDER)) }
+
+  before do
+    render_inline(Backlogs::InboxComponent.new(work_packages:, project:, current_user: user))
+  end
+
+  it "rendering renders the Inbox Component", :aggregate_failures do
+    # renders the work package subject
+    expect(page).to have_text("Inbox Work Package")
+    # renders a drag handle
+    expect(page).to have_octicon(:grabber)
+    # renders WorkPackages::InfoLineComponent with type and ID
+    expect(page).to have_text("##{work_package.id}")
+    # renders an InboxMenuComponent action menu
+    expect(page).to have_css("action-menu")
+  end
+
+  describe "row data attributes" do
+    subject(:row) { page.find(".Box-row#work_package_#{work_package.id}") }
+
+    it "sets the work package DOM id on the row" do
+      expect(page).to have_css(".Box-row#work_package_#{work_package.id}")
+    end
+
+    it "sets the backlogs--story Stimulus controller" do
+      expect(row["data-controller"]).to eq("backlogs--story")
+    end
+
+    it "sets the split-view and full-view URLs for the story controller" do
+      expect(row["data-backlogs--story-split-url-value"])
+        .to end_with(details_backlogs_project_backlogs_path(project, work_package))
+      expect(row["data-backlogs--story-full-url-value"])
+        .to end_with(work_package_path(work_package))
+    end
+
+    it "applies the correct row CSS classes" do
+      expect(row[:class]).to include("Box-row--hover-blue", "Box-row--focus-gray",
+                                     "Box-row--clickable", "Box-row--draggable")
+    end
+  end
+end

--- a/modules/backlogs/spec/controllers/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/inbox_controller_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
+  current_user { user }
+
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+  let!(:work_packages) { create_list(:work_package, 5, project:) }
+  let(:work_package) { create(:work_package, project:) }
+  let(:setup_service_result) do
+    allow(Stories::UpdateService)
+      .to receive(:new)
+      .and_return(instance_double(Stories::UpdateService, call: service_result))
+  end
+
+  before do
+    setup_service_result if defined?(service_result)
+    subject
+  end
+
+  describe "POST #reorder" do
+    subject do
+      post :reorder,
+           params: { project_id: project.id, id: work_package.id, direction: "highest" },
+           format: :turbo_stream
+    end
+
+    context "when service call succeeds" do
+      it "replaces the inbox component and responds with turbo streams", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-inbox-component-#{project.id}"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:work_package)).to eq(work_package)
+      end
+
+      it "moves the work package to the first place" do
+        expect { work_package.reload }
+          .to change(work_package, :position).from(6).to(1)
+        expect { work_packages.each(&:reload) }
+          .to change { work_packages.map(&:position) }
+          .from([1, 2, 3, 4, 5])
+          .to([2, 3, 4, 5, 6])
+      end
+    end
+
+    context "when service call fails" do
+      let(:service_result) { ServiceResult.failure(message: "Something went wrong") }
+
+      it "renders an error flash with 422", :aggregate_failures do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace",
+                                                  target: "backlogs-inbox-component-#{project.id}"
+      end
+    end
+
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
+  describe "PUT #move" do
+    let(:agile_sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+    let(:target_id) { "sprint:#{agile_sprint.id}" }
+    let(:position) { 1 }
+
+    subject do
+      put :move,
+          params: {
+            project_id: project.id,
+            id: work_package.id,
+            target_id:,
+            position:
+          },
+          format: :turbo_stream
+    end
+
+    context "when moving to an Agile::Sprint" do
+      it "replaces both the inbox and target sprint components", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-inbox-component-#{project.id}"
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-sprint-component-#{agile_sprint.id}"
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      end
+    end
+
+    context "when reordering within the Inbox" do
+      let(:target_id) { "inbox" }
+      let(:position) { 2 }
+
+      it "replaces only the inbox component without a flash", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-inbox-component-#{project.id}"
+        expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      end
+
+      it "moves the work package to position 2" do
+        expect { work_package.reload }
+          .to change(work_package, :position).from(6).to(2)
+        expect { work_packages.each(&:reload) }
+          .to change { work_packages.map(&:position) }
+          .from([1, 2, 3, 4, 5])
+          .to([1, 3, 4, 5, 6])
+      end
+    end
+
+    context "when service call fails" do
+      let(:service_result) { ServiceResult.failure(message: "Move failed") }
+
+      it "renders an error flash with 422 and does not replace components", :aggregate_failures do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace",
+                                                  target: "backlogs-inbox-component-#{project.id}"
+      end
+    end
+
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -307,6 +307,34 @@ RSpec.describe RbStoriesController do
       end
     end
 
+    context "with Inbox as target" do
+      let!(:existing_inbox_item) { create(:work_package, project:, status:, position: 1) }
+
+      it "responds with success and moves story to Inbox at the given position", :aggregate_failures do
+        put :move, params: {
+                     project_id: project.id,
+                     sprint_id: agile_sprint.id,
+                     id: story_in_agile_sprint.id,
+                     target_id: "inbox",
+                     position: 2
+                   },
+                   format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-inbox-component-#{project.id}"
+        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-inbox-component-#{project.id}"][method="morph"])
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(assigns(:project)).to eq(project)
+        expect(assigns(:sprint)).to eq(agile_sprint)
+        expect(assigns(:story)).to eq(story_in_agile_sprint)
+        expect(story_in_agile_sprint.reload.sprint).to be_nil
+        expect(story_in_agile_sprint.reload.position).to eq(2)
+      end
+    end
+
     context "when service call fails" do
       let(:other_agile_sprint) { create(:agile_sprint, name: "Agile Sprint 2", project:) }
       let(:service_result) { ServiceResult.failure(message: "Something went wrong") }

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -126,35 +126,6 @@ RSpec.describe RbStoriesController do
       end
     end
 
-    context "with an Agile::Sprint as target", with_flag: { scrum_projects: true } do
-      let(:agile_sprint) { create(:agile_sprint, name: "Agile Sprint 1", project:) }
-
-      it "responds with success and moves story to Agile::Sprint, removing the association to the version", :aggregate_failures do
-        put :move_legacy, params: {
-                            project_id: project.id,
-                            sprint_id: version_sprint.id,
-                            id: story.id,
-                            target_id: "sprint:#{agile_sprint.id}",
-                            position: 1
-                          },
-                          format: :turbo_stream
-
-        expect(response).to be_successful
-        expect(response).to have_http_status :ok
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-component-#{version_sprint.id}"
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
-        assert_select %(turbo-stream[action="replace"][target="backlogs-backlog-component-#{version_sprint.id}"][method="morph"])
-        assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
-        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-        expect(assigns(:project)).to eq(project)
-        expect(assigns(:sprint)).to eq(version_sprint)
-        expect(assigns(:story)).to eq(story)
-
-        # It will remove the association to the version since the version is used as backlog:
-        expect(story.reload.version).to be_nil
-      end
-    end
-
     context "when service call fails" do
       let(:other_version_sprint) { create(:sprint, name: "Sprint 2", project:) }
       let(:service_result) { ServiceResult.failure(message: "Something went wrong") }

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../support/pages/sprint_planning"
+
+RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_projects: true } do
+  let!(:project) do
+    create(:project,
+           types: [type],
+           enabled_module_names: %w[work_package_tracking backlogs])
+  end
+  let!(:type) { create(:type) }
+  let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+  let!(:role) do
+    create(:project_role,
+           permissions: %i[
+             view_project
+             view_sprints
+             manage_sprint_items
+             add_work_packages
+             view_work_packages
+             edit_work_packages
+           ])
+  end
+  let!(:current_user) { create(:user, member_with_roles: { project => role }) }
+
+  let(:planning_page) { Pages::SprintPlanning.new(project) }
+
+  before do
+    login_as current_user
+  end
+
+  context "when the inbox has no work packages" do
+    before { planning_page.visit! }
+
+    it "shows the blankslate" do
+      planning_page.expect_inbox_blankslate
+    end
+  end
+
+  context "with work packages in the inbox" do
+    let!(:inbox_wp1) { create(:work_package, project:) }
+    let!(:inbox_wp2) { create(:work_package, project:) }
+    let!(:inbox_wp3) { create(:work_package, project:) }
+
+    before { planning_page.visit! }
+
+    it "displays all items in position order and hides the blankslate" do
+      planning_page.expect_inbox_item(inbox_wp1)
+      planning_page.expect_inbox_item(inbox_wp2)
+      planning_page.expect_inbox_item(inbox_wp3)
+      planning_page.expect_inbox_items_in_order(inbox_wp1, inbox_wp2, inbox_wp3)
+      planning_page.expect_no_inbox_blankslate
+    end
+
+    it "allows reordering items via the kebab menu", :aggregate_failures do
+      # First item has no upward actions
+      planning_page.within_inbox_menu(inbox_wp1) do |menu|
+        expect(menu).to have_no_selector(:menuitem, text: "Move to top")
+        expect(menu).to have_no_selector(:menuitem, text: "Move up")
+        expect(menu).to have_selector(:menuitem, text: "Move down")
+        expect(menu).to have_selector(:menuitem, text: "Move to bottom")
+      end
+
+      # Last item has no downward actions
+      planning_page.within_inbox_menu(inbox_wp3) do |menu|
+        expect(menu).to have_selector(:menuitem, text: "Move to top")
+        expect(menu).to have_selector(:menuitem, text: "Move up")
+        expect(menu).to have_no_selector(:menuitem, text: "Move down")
+        expect(menu).to have_no_selector(:menuitem, text: "Move to bottom")
+      end
+
+      planning_page.click_in_inbox_menu(inbox_wp1, "Move down")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
+
+      planning_page.click_in_inbox_menu(inbox_wp1, "Move down")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
+
+      planning_page.click_in_inbox_menu(inbox_wp2, "Move to bottom")
+      planning_page.expect_inbox_items_in_order(inbox_wp3, inbox_wp1, inbox_wp2)
+
+      planning_page.click_in_inbox_menu(inbox_wp2, "Move to top")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
+
+      planning_page.click_in_inbox_menu(inbox_wp1, "Move up")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
+    end
+
+    describe "moving backlog items to a sprint via drag-and-drop" do
+      it "moves multiple items into the sprint one by one" do
+        planning_page.drag_inbox_item_to_sprint(inbox_wp1, sprint)
+        planning_page.expect_no_inbox_item(inbox_wp1)
+        expect_and_dismiss_flash(message: "Successful move from Inbox to Sprint 1.")
+
+        planning_page.drag_inbox_item_to_sprint(inbox_wp2, sprint)
+        planning_page.expect_no_inbox_item(inbox_wp2)
+        expect_and_dismiss_flash(message: "Successful move from Inbox to Sprint 1.")
+
+        planning_page.drag_inbox_item_to_sprint(inbox_wp3, sprint)
+        planning_page.expect_no_inbox_item(inbox_wp3)
+        expect_and_dismiss_flash(message: "Successful move from Inbox to Sprint 1.")
+
+        planning_page.expect_inbox_blankslate
+        planning_page.expect_story_in_sprint(inbox_wp1, sprint)
+        planning_page.expect_story_in_sprint(inbox_wp2, sprint)
+        planning_page.expect_story_in_sprint(inbox_wp3, sprint)
+      end
+    end
+
+    describe "reordering sprint items via the kebab menu" do
+      let!(:sprint_wp1) { create(:work_package, project:, sprint:) }
+      let!(:sprint_wp2) { create(:work_package, project:, sprint:) }
+      let!(:sprint_wp3) { create(:work_package, project:, sprint:) }
+
+      before { planning_page.visit! }
+
+      it "allows reordering items", :aggregate_failures do
+        # First item has no upward actions
+        planning_page.within_sprint_story_menu(sprint_wp1) do |menu|
+          expect(menu).to have_no_selector(:menuitem, text: "Move to top")
+          expect(menu).to have_no_selector(:menuitem, text: "Move up")
+          expect(menu).to have_selector(:menuitem, text: "Move down")
+          expect(menu).to have_selector(:menuitem, text: "Move to bottom")
+        end
+
+        # Last item has no downward actions
+        planning_page.within_sprint_story_menu(sprint_wp3) do |menu|
+          expect(menu).to have_selector(:menuitem, text: "Move to top")
+          expect(menu).to have_selector(:menuitem, text: "Move up")
+          expect(menu).to have_no_selector(:menuitem, text: "Move down")
+          expect(menu).to have_no_selector(:menuitem, text: "Move to bottom")
+        end
+
+        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move down")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp1, sprint_wp3])
+
+        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move down")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp3, sprint_wp1])
+
+        planning_page.click_in_sprint_story_menu(sprint_wp2, "Move to bottom")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp3, sprint_wp1, sprint_wp2])
+
+        planning_page.click_in_sprint_story_menu(sprint_wp2, "Move to top")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp3, sprint_wp1])
+
+        planning_page.click_in_sprint_story_menu(sprint_wp1, "Move up")
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp2, sprint_wp1, sprint_wp3])
+      end
+    end
+
+    describe "moving sprint items back to the inbox via drag-and-drop" do
+      let!(:sprint_wp1) { create(:work_package, project:, sprint:) }
+      let!(:sprint_wp2) { create(:work_package, project:, sprint:) }
+
+      before { planning_page.visit! }
+
+      it "moves all sprint items back to the inbox" do
+        planning_page.drag_sprint_item_to_inbox(sprint_wp1)
+        expect_and_dismiss_flash(message: "Successful move from Sprint 1 to Inbox.")
+
+        planning_page.drag_sprint_item_to_inbox(sprint_wp2)
+        expect_and_dismiss_flash(message: "Successful move from Sprint 1 to Inbox.")
+
+        planning_page.expect_story_not_in_sprint(sprint_wp1, sprint)
+        planning_page.expect_story_not_in_sprint(sprint_wp2, sprint)
+        planning_page.expect_inbox_item(sprint_wp1)
+        planning_page.expect_inbox_item(sprint_wp2)
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/models/backlog_spec.rb
+++ b/modules/backlogs/spec/models/backlog_spec.rb
@@ -39,6 +39,42 @@ RSpec.describe Backlog do
   end
 
   describe "Class Methods" do
+    describe ".inbox_for" do
+      let(:project) { create(:project) }
+      let(:open_status) { create(:status, is_closed: false) }
+      let(:closed_status) { create(:status, is_closed: true) }
+      let(:agile_sprint) { create(:agile_sprint, project:) }
+
+      before { login_as create(:admin) }
+
+      subject(:inbox) { described_class.inbox_for(project:) }
+
+      it "returns work packages with no sprint assigned and open status" do
+        inbox_wp = create(:work_package, project:, status: open_status)
+        create(:work_package, project:, status: closed_status)
+        create(:work_package, project:, status: open_status, sprint: agile_sprint)
+
+        expect(inbox).to contain_exactly(inbox_wp)
+      end
+
+      it "excludes work packages from other projects" do
+        create(:work_package, status: open_status)
+        own_wp = create(:work_package, project:, status: open_status)
+
+        expect(inbox).to contain_exactly(own_wp)
+      end
+
+      it "orders by position ascending, falling back to id for unpositioned items" do
+        wp1 = create(:work_package, project:, status: open_status, position: 2)
+        wp2 = create(:work_package, project:, status: open_status, position: 1)
+        wp3 = create(:work_package, project:, status: open_status, position: nil)
+
+        wp3.update_column(:position, nil)
+
+        expect(inbox).to eq([wp2, wp1, wp3])
+      end
+    end
+
     describe "#owner_backlogs" do
       describe "WITH one open version defined in the project" do
         before do

--- a/modules/backlogs/spec/models/backlog_spec.rb
+++ b/modules/backlogs/spec/models/backlog_spec.rb
@@ -68,10 +68,12 @@ RSpec.describe Backlog do
         wp1 = create(:work_package, project:, status: open_status, position: 2)
         wp2 = create(:work_package, project:, status: open_status, position: 1)
         wp3 = create(:work_package, project:, status: open_status, position: nil)
+        wp4 = create(:work_package, project:, status: open_status, position: nil)
 
         wp3.update_column(:position, nil)
+        wp4.update_column(:position, nil)
 
-        expect(inbox).to eq([wp2, wp1, wp3])
+        expect(inbox).to eq([wp2, wp1, wp3, wp4])
       end
     end
 

--- a/modules/backlogs/spec/routing/inbox_routing_spec.rb
+++ b/modules/backlogs/spec/routing/inbox_routing_spec.rb
@@ -28,41 +28,26 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Backlogs
-  class InboxItemComponent < ApplicationComponent
-    include OpPrimer::ComponentHelpers
+require "spec_helper"
 
-    attr_reader :work_package, :project, :container, :max_position, :current_user
+RSpec.describe InboxController do
+  describe "routing" do
+    it {
+      expect(put("/projects/project_42/inbox/85/move")).to route_to(
+        controller: "inbox",
+        action: "move",
+        project_id: "project_42",
+        id: "85"
+      )
+    }
 
-    def initialize(inbox_item:, project:, container:, max_position:, current_user: User.current)
-      super()
-
-      @work_package = inbox_item
-      @project = project
-      @container = container
-      @max_position = max_position
-      @current_user = current_user
-    end
-
-    private
-
-    def row_options
-      {
-        id: dom_id(work_package),
-        classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
-        data: {
-          draggable_id: work_package.id,
-          draggable_type: "story",
-          drop_url: move_project_inbox_path(project, work_package),
-          story: true,
-          controller: "backlogs--story",
-          backlogs__story_id_value: work_package.id,
-          backlogs__story_split_url_value: details_backlogs_project_backlogs_path(project, work_package),
-          backlogs__story_full_url_value: work_package_path(work_package),
-          backlogs__story_selected_class: "Box-row--blue"
-        },
-        tabindex: 0
-      }
-    end
+    it {
+      expect(post("/projects/project_42/inbox/85/reorder")).to route_to(
+        controller: "inbox",
+        action: "reorder",
+        project_id: "project_42",
+        id: "85"
+      )
+    }
   end
 end

--- a/modules/backlogs/spec/routing/inbox_routing_spec.rb
+++ b/modules/backlogs/spec/routing/inbox_routing_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe InboxController do
+RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
   describe "routing" do
     it {
       expect(put("/projects/project_42/inbox/85/move")).to route_to(

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -114,13 +114,13 @@ module Pages
 
     def expect_inbox_blankslate
       within_inbox do
-        expect(page).to have_css("h4", text: "Inbox is empty")
+        expect(page).to have_css("h4", text: "Backlog inbox is empty")
       end
     end
 
     def expect_no_inbox_blankslate
       within_inbox do
-        expect(page).to have_no_css("h4", text: "Inbox is empty")
+        expect(page).to have_no_css("h4", text: "Backlog inbox is empty")
       end
     end
 

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -112,6 +112,83 @@ module Pages
         .to have_no_css("#{work_package_selector(work_package)} .DragHandle")
     end
 
+    def expect_inbox_blankslate
+      within_inbox do
+        expect(page).to have_css("h4", text: "Inbox is empty")
+      end
+    end
+
+    def expect_no_inbox_blankslate
+      within_inbox do
+        expect(page).to have_no_css("h4", text: "Inbox is empty")
+      end
+    end
+
+    def expect_inbox_item(work_package)
+      within_inbox do
+        expect(page).to have_css(inbox_item_selector(work_package))
+      end
+    end
+
+    def expect_no_inbox_item(work_package)
+      within_inbox do
+        expect(page).to have_no_css(inbox_item_selector(work_package))
+      end
+    end
+
+    def expect_inbox_items_in_order(*work_packages)
+      within_inbox do
+        selectors = work_packages.map { |wp| inbox_item_selector(wp) }
+        expect(page).to have_css(selectors.join(" + "))
+      end
+    end
+
+    def within_inbox_menu(work_package, &)
+      within(inbox_item_selector(work_package)) do
+        button = find(:button, accessible_name: "Work package actions")
+        button.click
+        within_menu_controlled_by(button, &)
+      end
+      page.send_keys(:escape)
+    end
+
+    def click_in_inbox_menu(work_package, item_name)
+      within_inbox_menu(work_package) do |menu|
+        menu.find(:menuitem, text: item_name).click
+      end
+    end
+
+    def within_sprint_story_menu(story, &)
+      within(work_package_selector(story)) do
+        button = find(:button, accessible_name: "Story actions")
+        button.click
+        within_menu_controlled_by(button, &)
+      end
+      page.send_keys(:escape)
+    end
+
+    def click_in_sprint_story_menu(story, item_name)
+      within_sprint_story_menu(story) do |menu|
+        menu.find(:menuitem, text: item_name).click
+      end
+    end
+
+    def drag_inbox_item_to_sprint(work_package, sprint)
+      moved_element = find("#{inbox_item_selector(work_package)} .DragHandle")
+      target_element = find(sprint_selector(sprint))
+      moved_element.native.drag_to(target_element.native, delay: 0.1)
+    rescue Capybara::Cuprite::ObsoleteNode
+      retry
+    end
+
+    def drag_sprint_item_to_inbox(work_package)
+      moved_element = find("#{work_package_selector(work_package)} .DragHandle")
+      target_element = find("#inbox_#{project.id}")
+      moved_element.native.drag_to(target_element.native, delay: 0.1)
+    rescue Capybara::Cuprite::ObsoleteNode
+      retry
+    end
+
     def expect_no_sprint_menu(sprint)
       within_sprint(sprint) do
         expect(page).to have_no_button(accessible_name: "Sprint actions")
@@ -221,6 +298,10 @@ module Pages
       within(sprint_selector(sprint), &)
     end
 
+    def within_inbox(&)
+      within("#inbox_#{project.id}", &)
+    end
+
     def sprint_selector(sprint)
       test_selector("sprint-#{sprint.id}")
     end
@@ -235,6 +316,10 @@ module Pages
 
     def work_package_selector(work_package)
       test_selector("work-package-#{work_package.id}")
+    end
+
+    def inbox_item_selector(work_package)
+      "#work_package_#{work_package.id}"
     end
 
     def within_menu_controlled_by(button)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72198

# What are you trying to accomplish?
- Add the Backlogs Inbox column.
- This column should contain all the work packages inside the project that are open and not assigned to any sprints.
- It should be possible to reorder elements inside the Inbox via drag & drop and dropdown menu as well.
## Screenshots
  
<details><summary>Backlogs blank slate</summary>
<p>

<img width="889" height="460" alt="image" src="https://github.com/user-attachments/assets/c2319d9d-f9da-4193-a2e9-cc5dcaef535b" />


</p>
</details> 

<details><summary>Backlogs page</summary>
<p>

<img width="1229" height="681" alt="image" src="https://github.com/user-attachments/assets/03cd1d12-0515-4715-ac5e-e5d90af3e3ea" />


</p>
</details> 

<details><summary>Backlog item dropdown menu</summary>
<p>

<img width="444" height="355" alt="image" src="https://github.com/user-attachments/assets/685c85c2-5cc6-49a0-90b8-ac458a5dd30b" />

</p>
</details> 

<details><summary>Drag & drop</summary>
<p>

<img width="1763" height="1252" alt="image" src="https://github.com/user-attachments/assets/80128359-c107-485b-b2c0-c6466c265dd7" />


</p>
</details> 

# What approach did you choose and why?
- Use the existing acts as list plugin on the work packages implementation to build the backlog
- Add `Backlogs::InboxComponent` to display the list.
- Add `Backlogs::InboxItemComponent` to display individual inbox entries.
- Add `Backlogs::InboxMenuComponent` to display inbox entries dropdown menu.

## Known issues (out of scope)
> [!CAUTION]
> Not having position attributes for all the work packages, will make drag & drop and menu sorting behave unexpectedly.
- The menu sorting can be solved by fixing the condition `acts_as_list_list.all?(position: nil)`. The condition probably should be `acts_as_list_list.all?{ it.position.nil? }` or `acts_as_list_list.none?(&:position)`. https://github.com/opf/openproject/blob/2bdb79bb5f80a8a315171ca891f8a0ac2e039361/modules/backlogs/lib/open_project/backlogs/list.rb#L99-L105
- The drag & drop sorting should be fixed by applying the `set_default_prev_positions_silently` when a position is assigned.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
