### PR TITLE
Add empty wikis tab to work package view

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -72,6 +72,9 @@ OpenProject::FeatureDecisions.add :scrum_projects,
 OpenProject::FeatureDecisions.add :user_working_times,
                                   description: "Enables tracking of user working hours and non-working days."
 
+OpenProject::FeatureDecisions.add :wiki_enhancements,
+                                  description: "Enables Wiki enhancements, such as the Wikis tab and XWiki integration."
+
 OpenProject::FeatureDecisions.add :semantic_work_package_ids,
                                   description: "Enables the use of semantic work package IDs, " \
                                                "in the schema <project identifier>-<sequence number>. " \

--- a/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
+++ b/modules/wikis/app/components/wikis/work_package_wikis_tab_component.html.erb
@@ -1,0 +1,36 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  content_tag("turbo-frame", id: "work-package-wikis-tab-content") do
+    component_wrapper do
+      render(Primer::Beta::Text.new) { "Hi 👋" }
+    end
+  end
+%>

--- a/modules/wikis/app/components/wikis/work_package_wikis_tab_component.rb
+++ b/modules/wikis/app/components/wikis/work_package_wikis_tab_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  class WorkPackageWikisTabComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+  end
+end

--- a/modules/wikis/app/controllers/work_package_wikis_tab_controller.rb
+++ b/modules/wikis/app/controllers/work_package_wikis_tab_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class WorkPackageWikisTabController < ApplicationController
+  include OpTurbo::ComponentStream
+
+  load_and_authorize_with_permission_in_project :view_work_packages
+
+  before_action :set_work_package
+
+  def index
+    render(Wikis::WorkPackageWikisTabComponent.new, layout: false)
+  end
+
+  private
+
+  def set_work_package
+    @work_package = @project.work_packages.visible.find(params[:work_package_id])
+  end
+end

--- a/modules/wikis/config/locales/js-en.yml
+++ b/modules/wikis/config/locales/js-en.yml
@@ -1,0 +1,33 @@
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+en:
+  js:
+    work_packages:
+      tabs:
+        wikis: 'Wikis'

--- a/modules/wikis/config/routes.rb
+++ b/modules/wikis/config/routes.rb
@@ -28,44 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Prevent load-order problems in case openproject-plugins is listed after a plugin in the Gemfile
-# or not at all
-require "open_project/plugins"
-
-module OpenProject::Wikis
-  class Engine < ::Rails::Engine
-    engine_name :openproject_wikis
-
-    include OpenProject::Plugins::ActsAsOpEngine
-
-    register "openproject-wikis",
-             author_url: "https://openproject.org" do
-               menu :work_package_split_view,
-                    :wikis,
-                    { tab: :wikis },
-                    skip_permissions_check: true,
-                    after: :relations,
-                    if: ->(_project) {
-                      # TODO: only display if there are wiki providers available
-                      OpenProject::FeatureDecisions.wiki_enhancements_active?
-                    }
-             end
-
-    initializer "openproject_wikis.inflections" do
-      ActiveSupport::Inflector.inflections(:en) do |inflect|
-        inflect.acronym "XWiki"
-      end
-
-      OpenProject::Inflector.rule do |basename, abspath|
-        case basename
-        when "xwiki"
-          "XWiki"
-        when /\Axwiki_(.*)\z/
-          "XWiki#{default_inflect($1, abspath)}"
+Rails.application.routes.draw do
+  resources :projects, only: %i[] do
+    resources :work_packages, only: %i[] do
+      resources :wikis, only: %i[] do
+        collection do
+          resources :tab, only: %i[index], controller: "work_package_wikis_tab", as: "wikis_tab"
         end
       end
     end
-
-    replace_principal_references "Wikis::PageLink" => %i[author_id]
   end
 end

--- a/modules/wikis/frontend/module/main.ts
+++ b/modules/wikis/frontend/module/main.ts
@@ -1,0 +1,70 @@
+// -- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+
+import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+import { OpSharedModule } from 'core-app/shared/shared.module';
+import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import {
+  WorkPackageTabsService,
+} from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
+import { WikisTabComponent } from './wikis-tab/wikis-tab.component';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+
+export function initializeWikiPlugin(injector:Injector) {
+  const wpTabService = injector.get(WorkPackageTabsService);
+  const configService = injector.get(ConfigurationService);
+  const I18n = injector.get(I18nService);
+  wpTabService.registerAfter(
+    'relations',
+    {
+      component: WikisTabComponent,
+      name: I18n.t('js.work_packages.tabs.wikis'),
+      id: 'wikis',
+      // TODO: only display if there are wiki providers available
+      displayable: (workPackage) => configService.activeFeatureFlags.includes("wikiEnhancements"),
+    },
+  );
+}
+
+@NgModule({
+  imports: [
+    OpSharedModule,
+    OpenprojectTabsModule,
+  ],
+  declarations: [
+    WikisTabComponent,
+  ],
+  exports: [
+    WikisTabComponent,
+  ],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class PluginModule {
+  constructor(injector:Injector) {
+    initializeWikiPlugin(injector);
+  }
+}

--- a/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
+++ b/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
@@ -1,0 +1,54 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { TabComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+
+@Component({
+  selector: 'op-wikis-tab',
+  templateUrl: './wikis-tab.template.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class WikisTabComponent implements OnInit, TabComponent {
+  @Input() public workPackage:WorkPackageResource;
+  turboFrameSrc:string;
+
+  constructor(
+    private elementRef:ElementRef,
+    readonly PathHelper:PathHelperService,
+    readonly I18n:I18nService,
+  ) {}
+
+  ngOnInit():void {
+    this.turboFrameSrc = `${this.PathHelper.projectWorkPackagePath(this.workPackage.project.id as string, this.workPackage.id as string)}/wikis/tab`;
+  }
+}

--- a/modules/wikis/frontend/module/wikis-tab/wikis-tab.template.html
+++ b/modules/wikis/frontend/module/wikis-tab/wikis-tab.template.html
@@ -1,0 +1,11 @@
+<turbo-frame [src]="turboFrameSrc" id="work-package-wikis-tab-content">
+  <op-content-loader viewBox="0 0 100 100">
+    <svg:rect x="0" y="0" width="70" height="5" rx="1" />
+
+    <svg:rect x="75" y="0" width="25" height="5" rx="1" />
+
+    <svg:rect x="0" y="10" width="100" height="8" rx="1" />
+
+    <svg:rect x="0" y="25" width="100" height="12" rx="1" />
+  </op-content-loader>
+</turbo-frame>


### PR DESCRIPTION
This PR mostly adds the relevant glue code to render a Wikis tab in the work packages view (both split screen and full screen).

It's noteworthy that the decision to render the tab has to be performed once in Javascript (for the full screen view) and in Ruby (for the split screen view). As far as I can tell, this is a sign of us moving away from Angular slowly, but for the time being it means there's two places to keep synced up.

# Ticket
https://community.openproject.org/wp/72969