### PR TITLE
show blankslate on backlogs administration

### DIFF
--- a/modules/backlogs/app/forms/admin/settings/backlogs_settings_form.rb
+++ b/modules/backlogs/app/forms/admin/settings/backlogs_settings_form.rb
@@ -34,62 +34,60 @@ module Admin
       include ::Settings::FormHelper
 
       form do |f|
-        unless scrum_projects_active?
-          f.autocompleter(
-            name: :story_types,
-            label: I18n.t(:backlogs_story_type),
-            caption: setting_caption(:plugin_openproject_backlogs, :story_types),
-            autocomplete_options: {
-              multiple: true,
-              closeOnSelect: false,
-              clearable: false,
-              decorated: true,
-              data: {
-                admin__backlogs_settings_target: "storyTypes",
-                test_selector: "story_type_autocomplete"
-              }
+        f.autocompleter(
+          name: :story_types,
+          label: I18n.t(:backlogs_story_type),
+          caption: setting_caption(:plugin_openproject_backlogs, :story_types),
+          autocomplete_options: {
+            multiple: true,
+            closeOnSelect: false,
+            clearable: false,
+            decorated: true,
+            data: {
+              admin__backlogs_settings_target: "storyTypes",
+              test_selector: "story_type_autocomplete"
             }
-          ) do |list|
-            available_types.each do |label, value|
-              active = value.in?(Story.types)
-              in_use = Task.type == value
+          }
+        ) do |list|
+          available_types.each do |label, value|
+            active = value.in?(Story.types)
+            in_use = Task.type == value
 
-              list.option(
-                label:,
-                value:,
-                selected: active,
-                disabled: in_use
-              )
-            end
+            list.option(
+              label:,
+              value:,
+              selected: active,
+              disabled: in_use
+            )
           end
+        end
 
-          f.autocompleter(
-            name: :task_type,
-            label: I18n.t(:backlogs_task_type),
-            caption: setting_caption(:plugin_openproject_backlogs, :task_type),
-            input_width: :small,
-            autocomplete_options: {
-              multiple: false,
-              closeOnSelect: true,
-              clearable: false,
-              decorated: true,
-              data: {
-                admin__backlogs_settings_target: "taskType",
-                test_selector: "task_type_autocomplete"
-              }
+        f.autocompleter(
+          name: :task_type,
+          label: I18n.t(:backlogs_task_type),
+          caption: setting_caption(:plugin_openproject_backlogs, :task_type),
+          input_width: :small,
+          autocomplete_options: {
+            multiple: false,
+            closeOnSelect: true,
+            clearable: false,
+            decorated: true,
+            data: {
+              admin__backlogs_settings_target: "taskType",
+              test_selector: "task_type_autocomplete"
             }
-          ) do |list|
-            available_types.each do |label, value|
-              active = Task.type == value
-              in_use = value.in?(Story.types)
+          }
+        ) do |list|
+          available_types.each do |label, value|
+            active = Task.type == value
+            in_use = value.in?(Story.types)
 
-              list.option(
-                label:,
-                value:,
-                selected: active,
-                disabled: in_use
-              )
-            end
+            list.option(
+              label:,
+              value:,
+              selected: active,
+              disabled: in_use
+            )
           end
         end
 
@@ -107,13 +105,11 @@ module Admin
           )
         end
 
-        unless scrum_projects_active?
-          f.text_field(
-            name: :wiki_template,
-            label: I18n.t(:backlogs_wiki_template),
-            input_width: :medium
-          )
-        end
+        f.text_field(
+          name: :wiki_template,
+          label: I18n.t(:backlogs_wiki_template),
+          input_width: :medium
+        )
 
         f.submit(scheme: :primary, name: :apply, label: I18n.t(:button_save))
       end
@@ -122,10 +118,6 @@ module Admin
 
       def available_types
         Type.pluck(:name, :id)
-      end
-
-      def scrum_projects_active?
-        OpenProject::FeatureDecisions.scrum_projects_active?
       end
     end
   end

--- a/modules/backlogs/app/views/backlogs_settings/show.html.erb
+++ b/modules/backlogs/app/views/backlogs_settings/show.html.erb
@@ -40,15 +40,22 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <%=
-  settings_primer_form_with(
-    url: admin_backlogs_settings_path,
-    method: :put,
-    model: @settings,
-    scope: :settings,
-    data: {
-      controller: "admin--backlogs-settings"
-    }
-  ) do |f|
+  if OpenProject::FeatureDecisions.scrum_projects_active?
+    render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
+      blankslate.with_heading(tag: :h2).with_content(t("backlogs.administration_blankslate.title"))
+      blankslate.with_description_content(t("backlogs.administration_blankslate.text"))
+    end
+  else
+    settings_primer_form_with(
+      url: admin_backlogs_settings_path,
+      method: :put,
+      model: @settings,
+      scope: :settings,
+      data: {
+        controller: "admin--backlogs-settings"
+      }
+    ) do |f|
+      render Admin::Settings::BacklogsSettingsForm.new(f)
+    end
+  end
 %>
-  <%= render Admin::Settings::BacklogsSettingsForm.new(f) %>
-<% end %>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -111,6 +111,11 @@ en:
     task: "Task"
     task_color: "Task color"
     unassigned: "Unassigned"
+
+    administration_blankslate:
+      title: "Backlog admin settings are evolving"
+      text: "We are currently redesigning the Backlogs module. Admin settings for sprints and backlogs will be visible here in the near future. Project-level settings remain available."
+
     user_preference:
       header_backlogs: "Backlogs module"
       button_update_backlogs: "Update backlogs module"

--- a/modules/backlogs/spec/features/admin/backlogs_settings_spec.rb
+++ b/modules/backlogs/spec/features/admin/backlogs_settings_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe "Backlogs Admin Settings", :js do
     story_autocompleter.expect_selected "Feature", "Story"
   end
 
-
   scenario "updating task type" do
     expect(page).to have_heading "Backlogs"
 
@@ -126,10 +125,12 @@ RSpec.describe "Backlogs Admin Settings", :js do
     expect(page).to have_field "Template for sprint wiki page", with: "my_sprint_wiki_page"
   end
 
-  it "hides wiki and types selection on scrum projects feature flag active", with_flag: { scrum_projects: true } do
+  it "hides configuration on scrum projects feature flag active", with_flag: { scrum_projects: true } do
     expect(page).to have_no_field "Template for sprint wiki page"
     expect(page).to have_no_css "[data-test-selector='story_type_autocomplete']"
     expect(page).to have_no_css "[data-test-selector='task_type_autocomplete']"
-    expect(page).to have_css "fieldset", text: "Points burn up/down"
+    expect(page).to have_no_css "fieldset", text: "Points burn up/down"
+
+    expect(page).to have_content "Backlog admin settings are evolving"
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73226

# What are you trying to accomplish?

Show a blankslate on backlogs admin page.

<img width="784" height="370" alt="image" src="https://github.com/user-attachments/assets/044c48d6-4a5f-48e2-868c-63ed0979571d" />

