### PR TITLE
Feature/73220 migrate existing positions to scope of project id sprint

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -63,7 +63,8 @@ OpenProject::FeatureDecisions.add :jira_import,
 
 OpenProject::FeatureDecisions.add :scrum_projects,
                                   description: "Enables an overhauled version of the backlogs module to " \
-                                               "support Scrum projects with a new sprint planning experience. "
+                                               "support Scrum projects with a new sprint planning experience. ",
+                                  force_active: true
 
 OpenProject::FeatureDecisions.add :user_working_times,
                                   description: "Enables tracking of user working hours and non-working days."

--- a/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
+++ b/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RepositionWorkPackages < ActiveRecord::Migration[8.1]
+  def change
+    reversible do |direction|
+      direction.up do
+        # Copied 1:1 from modules/backlogs/app/services/work_packages/rebuild_positions_service.rb.
+        # The service could also have been called. But this way, there is no dependency between the two.
+        execute <<~SQL.squish
+          UPDATE work_packages
+          SET position = mapping.new_position
+          FROM (
+            SELECT
+              id,
+              ROW_NUMBER() OVER (
+                PARTITION BY project_id, sprint_id
+                ORDER BY position, created_at
+              ) AS new_position
+            FROM work_packages
+          ) AS mapping
+          WHERE work_packages.id = mapping.id
+        SQL
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73220

# What are you trying to accomplish?

Creates a migration to reposition existing work packages. 

The attempt to add a unique constraint by `project_id, sprint_id, position` on `work_packages` was given up on as multiple specs failed. This is not ideal and has the potential to cause problems later on.

Since the repositioning will lead to order changing in the non feature flag views, the feature flag is forced to be active after this. 