### PR TITLE
[73365] Fields with AttributehHelpTexts are jumping

### DIFF
--- a/app/components/open_project/common/attribute_label_component.sass
+++ b/app/components/open_project/common/attribute_label_component.sass
@@ -30,5 +30,4 @@
   display: inline-flex
 
   > .op-attribute-help-text
-    align-self: baseline
     margin-left: var(--base-size-6)


### PR DESCRIPTION

# Ticket
https://community.openproject.org/wp/73365


# What are you trying to accomplish?
Remove baseline alignment as it cause misalignment and inplaceEditFields to jump

