### PR TITLE
Only show wikis tab when there are wikis

### DIFF
--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -147,6 +147,10 @@ export class ConfigurationService {
     return moment.localeData(I18n.locale).firstDayOfWeek();
   }
 
+  public get wikisAvailable():boolean {
+    return this.systemPreference('wikisAvailable');
+  }
+
   public get hostName():string {
     return this.systemPreference('hostName');
   }

--- a/modules/wikis/app/models/wikis/internal_provider.rb
+++ b/modules/wikis/app/models/wikis/internal_provider.rb
@@ -30,6 +30,10 @@
 
 module Wikis
   class InternalProvider < Provider
+    class << self
+      def registry_prefix = "internal"
+    end
+
     def name
       model_name.human
     end

--- a/modules/wikis/app/models/wikis/provider.rb
+++ b/modules/wikis/app/models/wikis/provider.rb
@@ -33,5 +33,15 @@ module Wikis
     self.table_name = "wiki_providers"
 
     has_many :page_links, dependent: :destroy
+
+    scope :enabled, -> { where(enabled: true) }
+
+    class << self
+      def registry_prefix = raise NotImplementedError, "SubclassResponsibility"
+    end
+
+    def resolve(registry_path)
+      Adapters::Registry["#{self.class.registry_prefix}.#{registry_path}"].new(self)
+    end
   end
 end

--- a/modules/wikis/app/models/wikis/xwiki_provider.rb
+++ b/modules/wikis/app/models/wikis/xwiki_provider.rb
@@ -39,5 +39,9 @@ module Wikis
     store_attribute :options, :authentication_method, :string, default: "two_way_oauth2"
     store_attribute :options, :wiki_audience, :string
     store_attribute :options, :token_exchange_scope, :string
+
+    class << self
+      def registry_prefix = "xwiki"
+    end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/queries/test.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/queries/test.rb
@@ -23,46 +23,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
+# This query is only intended for demo purposes and can be deleted once we have real queries
+module Wikis::Adapters::Providers::Internal::Queries
+  class Test
+    def initialize(provider)
+      @provider = provider
+    end
 
-module Storages
-  module Adapters
-    class Registry
-      extend Dry::Container::Mixin
-
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
-      def self.known_providers
-        keys.map { it.split(".").first }.uniq
-      end
-
-      class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
-        def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
-            super
-          end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
-
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
-          raise error
-        end
-      end
-
-      config.resolver = Resolver.new
-
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
+    def call(*args, **opts)
+      puts "#{args} and #{opts} passed to internal test query for #{@provider}" # rubocop:disable Rails/Output
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
@@ -23,46 +23,37 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
-
-module Storages
+module Wikis
   module Adapters
-    class Registry
-      extend Dry::Container::Mixin
-
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
-      def self.known_providers
-        keys.map { it.split(".").first }.uniq
-      end
-
-      class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
-        def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
-            super
+    module Providers
+      module Internal
+        Registry = Dry::Container::Namespace.new("internal") do
+          namespace("authentication") do
+            # ...
           end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
 
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
-          raise error
+          namespace("commands") do
+            # ...
+          end
+
+          namespace("components") do
+            # ...
+          end
+
+          namespace("contracts") do
+            # ...
+          end
+
+          namespace("queries") do
+            register(:test, Queries::Test)
+          end
         end
       end
-
-      config.resolver = Resolver.new
-
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/test.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/test.rb
@@ -23,46 +23,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
+# This query is only intended for demo purposes and can be deleted once we have real queries
+module Wikis::Adapters::Providers::XWiki::Queries
+  class Test
+    def initialize(provider)
+      @provider = provider
+    end
 
-module Storages
-  module Adapters
-    class Registry
-      extend Dry::Container::Mixin
-
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
-      def self.known_providers
-        keys.map { it.split(".").first }.uniq
-      end
-
-      class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
-        def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
-            super
-          end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
-
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
-          raise error
-        end
-      end
-
-      config.resolver = Resolver.new
-
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
+    def call(*args, **opts)
+      puts "#{args} and #{opts} passed to internal test query for #{@provider}" # rubocop:disable Rails/Output
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
@@ -23,46 +23,37 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
-
-module Storages
+module Wikis
   module Adapters
-    class Registry
-      extend Dry::Container::Mixin
-
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
-      def self.known_providers
-        keys.map { it.split(".").first }.uniq
-      end
-
-      class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
-        def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
-            super
+    module Providers
+      module XWiki
+        Registry = Dry::Container::Namespace.new("xwiki") do
+          namespace("authentication") do
+            # ...
           end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
 
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
-          raise error
+          namespace("commands") do
+            # ...
+          end
+
+          namespace("components") do
+            # ...
+          end
+
+          namespace("contracts") do
+            # ...
+          end
+
+          namespace("queries") do
+            register(:test, Queries::Test)
+          end
         end
       end
-
-      config.resolver = Resolver.new
-
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/registry.rb
@@ -23,46 +23,69 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
 require "dry/container"
 
-module Storages
+module Wikis
   module Adapters
     class Registry
       extend Dry::Container::Mixin
 
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
+      class Error < StandardError
+      end
+
+      class MissingContract < Error
+      end
+
+      class OperationNotSupported < Error
+      end
+
+      class UnknownProvider < Error
+      end
+
       def self.known_providers
         keys.map { it.split(".").first }.uniq
       end
 
       class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
         def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
+          Rails.logger.tagged("Wikis::Adapters::Registry") do
+            Rails.logger.info "Resolving #{key}"
             super
           end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
+        rescue Dry::Container::KeyError => e
+          error = registry_error_for(key)
 
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
+          Rails.logger.tagged("Wikis::Adapters::Registry") { Rails.logger.error (error || e).message }
+          raise if error.nil?
+
           raise error
+        end
+
+        private
+
+        def registry_error_for(key)
+          case key.split(".")
+          in [provider, *] if Registry.known_providers.exclude?(provider)
+            UnknownProvider.new(provider)
+          in [provider, "contracts", model]
+            MissingContract.new("No #{model} contract defined for provider: #{provider.camelize}")
+          in [provider, "commands" | "queries" => type, operation]
+            OperationNotSupported.new(
+              "#{type.singularize.capitalize} #{operation} not supported by provider: #{provider.camelize}"
+            )
+          end
         end
       end
 
       config.resolver = Resolver.new
 
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
+      import Providers::Internal::Registry
+      import Providers::XWiki::Registry
     end
   end
 end

--- a/modules/wikis/db/migrate/20260325133701_add_providers_enabled.rb
+++ b/modules/wikis/db/migrate/20260325133701_add_providers_enabled.rb
@@ -23,46 +23,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
-
-module Storages
-  module Adapters
-    class Registry
-      extend Dry::Container::Mixin
-
-      # Extracts the known_providers from the registered keys
-      # @return [Array<String>]
-      def self.known_providers
-        keys.map { it.split(".").first }.uniq
-      end
-
-      class Resolver < Dry::Container::Resolver
-        include TaggedLogging
-
-        def call(container, key)
-          with_tagged_logger("Storages::Adapters::Registry") do
-            info "Resolving #{key}"
-            super
-          end
-        rescue Dry::Container::KeyError
-          error = Errors.registry_error_for(key)
-
-          with_tagged_logger("Storages::Adapters::Registry") { error error.message }
-          raise error
-        end
-      end
-
-      config.resolver = Resolver.new
-
-      # Need to make this dynamic to ease new providers to be registered
-      import Providers::Nextcloud::NextcloudRegistry
-      import Providers::OneDrive::OneDriveRegistry
-      import Providers::Sharepoint::SharepointRegistry
-    end
+class AddProvidersEnabled < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wiki_providers, :enabled, :boolean, null: false, default: true
   end
 end

--- a/modules/wikis/frontend/module/main.ts
+++ b/modules/wikis/frontend/module/main.ts
@@ -44,8 +44,7 @@ export function initializeWikiPlugin(injector:Injector) {
       component: WikisTabComponent,
       name: I18n.t('js.work_packages.tabs.wikis'),
       id: 'wikis',
-      // TODO: only display if there are wiki providers available
-      displayable: (workPackage) => configService.activeFeatureFlags.includes("wikiEnhancements"),
+      displayable: (workPackage) => configService.wikisAvailable && configService.activeFeatureFlags.includes("wikiEnhancements"),
     },
   );
 }

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -46,8 +46,8 @@ module OpenProject::Wikis
                     skip_permissions_check: true,
                     after: :relations,
                     if: ->(_project) {
-                      # TODO: only display if there are wiki providers available
-                      OpenProject::FeatureDecisions.wiki_enhancements_active?
+                      Wikis::Provider.enabled.exists? &&
+                        OpenProject::FeatureDecisions.wiki_enhancements_active?
                     }
              end
 
@@ -64,6 +64,13 @@ module OpenProject::Wikis
           "XWiki#{default_inflect($1, abspath)}"
         end
       end
+    end
+
+    config.to_prepare do
+      API::V3::Configuration::ConfigurationRepresenter.property(
+        :wikisAvailable,
+        getter: ->(*) { ::Wikis::Provider.enabled.exists? }
+      )
     end
 
     replace_principal_references "Wikis::PageLink" => %i[author_id]

--- a/modules/wikis/spec/factories/wiki_provider_factory.rb
+++ b/modules/wikis/spec/factories/wiki_provider_factory.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
   factory :wiki_provider, class: "Wikis::Provider" do
     sequence(:name) { |i| "The Wiki Provider ##{i}" }
     universal_identifier { SecureRandom.uuid }
+    enabled { true }
   end
 
   factory :internal_wiki_provider, class: "Wikis::InternalProvider", parent: :wiki_provider do

--- a/modules/wikis/spec/lib/api/v3/configuration/configuration_representer_spec.rb
+++ b/modules/wikis/spec/lib/api/v3/configuration/configuration_representer_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe API::V3::Configuration::ConfigurationRepresenter do
+  include API::V3::Utilities::PathHelper
+
+  let(:represented) { Setting }
+  let(:current_user) do
+    build_stubbed(:user).tap do |user|
+      allow(user)
+        .to receive(:preference)
+        .and_return(build_stubbed(:user_preference))
+    end
+  end
+  let(:embed_links) { false }
+  let(:representer) do
+    described_class.new(represented, current_user:, embed_links:)
+  end
+
+  subject { representer.to_json }
+
+  describe "wikisAvailable" do
+    context "when there is at least one enabled wiki" do
+      before do
+        create(:internal_wiki_provider, enabled: false)
+        create(:xwiki_provider)
+      end
+
+      it "is true" do
+        expect(subject).to be_json_eql(true.to_json).at_path("wikisAvailable")
+      end
+    end
+
+    context "when there is no enabled wiki" do
+      before do
+        create(:internal_wiki_provider, enabled: false)
+      end
+
+      it "is false" do
+        expect(subject).to be_json_eql(false.to_json).at_path("wikisAvailable")
+      end
+    end
+
+    context "when only the internal wiki provider exists and is enabled (default database state)" do
+      before do
+        create(:internal_wiki_provider)
+      end
+
+      it "is true" do
+        expect(subject).to be_json_eql(true.to_json).at_path("wikisAvailable")
+      end
+    end
+
+    context "when there are no wikis at all (unexpected database state)" do
+      it "is false" do
+        expect(subject).to be_json_eql(false.to_json).at_path("wikisAvailable")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Effectively we only want to allow disabling the internal wiki for now, but we'll have to answer certain usability questions on what happens when a provider is deleted/disabled anyways, so we'll make it technically possible to disable any provider, even if we might not offer it for all of them out of the box.

The most likely starting scenario to have no wikis tab is that the internal wikis are disabled and no external wiki is configured.

### Ticket
https://community.openproject.org/wp/72969