### PR TITLE
Feature/72198 Fix InboxController unauthenticated before filters.

### DIFF
--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -31,10 +31,8 @@
 class InboxController < RbApplicationController
   include OpTurbo::ComponentStream
 
-  skip_before_action :load_sprint_and_project
-
   before_action :not_authorized_on_feature_flag_inactive
-  prepend_before_action :load_work_package, :load_project
+  before_action :load_work_package
 
   def reorder
     call = Stories::UpdateService


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73416

# What are you trying to accomplish?
- Fix drag and drop issues for private projects

# What approach did you choose and why?
Prepending before actions in the controller cause them to be executed even before the user is authenticated. This can lead to situations where ie: a `Project.visible.find` will return no results, even if the user has access to the project. The solution is to avoid using prepend before filters, ensuring that every before filter has the user authenticated.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
