### PR TITLE
Feature/72198 move to sprint menu

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
@@ -74,14 +74,29 @@ See COPYRIGHT and LICENSE files for more details.
       item.with_leading_visual_icon(icon: :hash)
     end
 
-    if show_move_items?
+    if show_move_submenu?
       menu.with_divider
 
       menu.with_sub_menu_item(label: t(".action_menu.move_menu")) do |move_menu|
         move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 
         with_item_group(move_menu) do
-          build_move_menu(move_menu)
+          if show_move_items?
+            build_move_menu(move_menu)
+          end
+
+          if show_move_to_sprint?
+            move_menu.with_divider if show_move_items?
+
+            move_menu.with_item(
+              id: dom_target(work_package, :menu, :move_to_sprint),
+              label: t(".label_move_to_sprint"),
+              href: move_to_sprint_dialog_project_inbox_path(project, work_package),
+              content_arguments: { data: { controller: "async-dialog" } }
+            ) do |item|
+              item.with_leading_visual_icon(icon: :zap)
+            end
+          end
         end
       end
     end

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.html.erb
@@ -81,13 +81,11 @@ See COPYRIGHT and LICENSE files for more details.
         move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 
         with_item_group(move_menu) do
-          if show_move_items?
-            build_move_menu(move_menu)
-          end
+          build_move_menu(move_menu)
+        end
 
+        with_item_group(move_menu) do
           if show_move_to_sprint?
-            move_menu.with_divider if show_move_items?
-
             move_menu.with_item(
               id: dom_target(work_package, :menu, :move_to_sprint),
               label: t(".label_move_to_sprint"),

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -53,9 +53,18 @@ module Backlogs
 
     private
 
+    def show_move_submenu?
+      show_move_items? || show_move_to_sprint?
+    end
+
     def show_move_items?
       allowed_to_manage_sprint_items? &&
       !(first_item? && last_item?)
+    end
+
+    def show_move_to_sprint?
+      allowed_to_manage_sprint_items? &&
+        Agile::Sprint.for_project(project).not_completed.exists?
     end
 
     def allowed_to_manage_sprint_items?

--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
@@ -1,0 +1,69 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(Primer::Alpha::Dialog.new(title: t(".title"), id: DIALOG_ID)) do |d|
+    d.with_header(variant: :large)
+
+    d.with_body do
+      form_with(
+        url: move_project_inbox_path(project, work_package),
+        method: :put,
+        id: FORM_ID,
+        data: { turbo_stream: true }
+      ) do
+        render(
+          Primer::Alpha::Select.new(
+            name: "target_id",
+            label: t(".label_sprint"),
+            input_width: :large
+          )
+        ) do |select|
+          sprints.each do |sprint|
+            select.option(label: sprint.name, value: "sprint:#{sprint.id}")
+          end
+        end
+      end
+    end
+
+    d.with_footer do
+      component_collection do |buttons|
+        buttons.with_component(Primer::Beta::Button.new(data: { close_dialog_id: DIALOG_ID })) do
+          t("button_cancel")
+        end
+
+        buttons.with_component(
+          Primer::Beta::Button.new(scheme: :primary, form: FORM_ID, data: { turbo: true }, type: :submit)
+        ) do
+          t("button_save")
+        end
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
@@ -28,11 +28,11 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  render(Primer::Alpha::Dialog.new(title: t(".title"), id: DIALOG_ID)) do |d|
+  render(Primer::Alpha::Dialog.new(title: t(".title"), id: DIALOG_ID, size: :medium)) do |d|
     d.with_header(variant: :large)
 
     d.with_body do
-      form_with(
+      primer_form_with(
         url: move_project_inbox_path(project, work_package),
         method: :put,
         id: FORM_ID,
@@ -41,8 +41,8 @@ See COPYRIGHT and LICENSE files for more details.
         render(
           Primer::Alpha::Select.new(
             name: "target_id",
-            label: t(".label_sprint"),
-            input_width: :large
+            label: Agile::Sprint.human_model_name,
+            visually_hide_label: true
           )
         ) do |select|
           sprints.each do |sprint|
@@ -52,16 +52,16 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    d.with_footer do
+    d.with_footer(show_divider: true) do
       component_collection do |buttons|
         buttons.with_component(Primer::Beta::Button.new(data: { close_dialog_id: DIALOG_ID })) do
-          t("button_cancel")
+          t(:button_cancel)
         end
 
         buttons.with_component(
           Primer::Beta::Button.new(scheme: :primary, form: FORM_ID, data: { turbo: true }, type: :submit)
         ) do
-          t("button_save")
+          t(:button_save)
         end
       end
     end

--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class MoveToSprintDialogComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    DIALOG_ID = "move-to-sprint-dialog"
+    FORM_ID = "move-to-sprint-dialog-form"
+
+    attr_reader :work_package, :project, :sprints
+
+    def initialize(work_package:, project:, sprints:)
+      super()
+
+      @work_package = work_package
+      @project = project
+      @sprints = sprints
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
@@ -38,12 +38,12 @@ module Backlogs
 
     attr_reader :work_package, :project, :sprints
 
-    def initialize(work_package:, project:, sprints:)
+    def initialize(work_package:, project:)
       super()
 
       @work_package = work_package
       @project = project
-      @sprints = sprints
+      @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
     end
   end
 end

--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -36,6 +36,11 @@ class InboxController < RbApplicationController
   before_action :not_authorized_on_feature_flag_inactive
   prepend_before_action :load_work_package, :load_project
 
+  def move_to_sprint_dialog
+    sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+    respond_with_dialog Backlogs::MoveToSprintDialogComponent.new(work_package: @work_package, project: @project, sprints:)
+  end
+
   def reorder
     call = Stories::UpdateService
       .new(user: current_user, story: @work_package)
@@ -54,7 +59,7 @@ class InboxController < RbApplicationController
 
     call = Stories::UpdateService
       .new(user: current_user, story: @work_package)
-      .call(attributes:, position: move_params[:position].to_i)
+      .call(attributes:, **position_attributes)
 
     return failure_response(call.message) unless call.success?
 
@@ -96,8 +101,12 @@ class InboxController < RbApplicationController
   end
 
   def move_params
-    params.require(%i[position target_id])
+    params.require(%i[target_id])
     params.permit(:position, :target_id)
+  end
+
+  def position_attributes
+    move_params[:position].present? ? { position: move_params[:position].to_i } : {}
   end
 
   def reorder_param

--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -37,8 +37,10 @@ class InboxController < RbApplicationController
   prepend_before_action :load_work_package, :load_project
 
   def move_to_sprint_dialog
-    sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
-    respond_with_dialog Backlogs::MoveToSprintDialogComponent.new(work_package: @work_package, project: @project, sprints:)
+    respond_with_dialog Backlogs::MoveToSprintDialogComponent.new(
+      work_package: @work_package,
+      project: @project
+    )
   end
 
   def reorder
@@ -106,7 +108,7 @@ class InboxController < RbApplicationController
   end
 
   def position_attributes
-    move_params[:position].present? ? { position: move_params[:position].to_i } : {}
+    { position: move_params[:position]&.to_i }.compact
   end
 
   def reorder_param

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -163,6 +163,11 @@ en:
         copy_url_to_clipboard: "Copy URL to clipboard"
         copy_work_package_id: "Copy work package ID"
         move_menu: "Move"
+      label_move_to_sprint: "Move to sprint"
+
+    move_to_sprint_dialog_component:
+      title: "Move to sprint"
+      label_sprint: "Sprint"
 
     sprint_header_component:
       label_toggle_backlog: "Collapse/Expand %{name}"

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
         member do
           put :move
           post :reorder
+          get :move_to_sprint_dialog
         end
       end
     end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -103,7 +103,7 @@ module OpenProject::Backlogs
 
         permission :manage_sprint_items,
                    { rb_stories: %i[move move_legacy reorder],
-                     inbox: %i[move reorder] },
+                     inbox: %i[move reorder move_to_sprint_dialog] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::MoveToSprintDialogComponent, type: :component do
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+  let(:move_path) { Rails.application.routes.url_helpers.move_project_inbox_path(project, work_package) }
+
+  def render_component
+    render_inline(described_class.new(work_package:, project:))
+  end
+
+  it "renders the dialog with the correct title" do
+    render_component
+
+    expect(page).to have_text(I18n.t(:"backlogs.move_to_sprint_dialog_component.title"))
+  end
+
+  it "renders a form targeting the move path via PUT" do
+    render_component
+
+    expect(page).to have_element(:form, action: move_path, method: "post")
+    expect(page).to have_css("form[action='#{move_path}'] input[name='_method'][value='put']", visible: :all)
+  end
+
+  it "renders Cancel and Save buttons" do
+    render_component
+
+    expect(page).to have_button(I18n.t(:button_cancel))
+    expect(page).to have_button(I18n.t(:button_save))
+  end
+
+  context "when in_planning and active sprints exist" do
+    let!(:planning_sprint) { create(:agile_sprint, project:, name: "Planning Sprint", status: "in_planning") }
+    let!(:active_sprint) { create(:agile_sprint, project:, name: "Active Sprint", status: "active") }
+
+    it "lists them as select options with sprint: prefix values" do
+      render_component
+
+      expect(page).to have_css("option[value='sprint:#{planning_sprint.id}']", text: "Planning Sprint")
+      expect(page).to have_css("option[value='sprint:#{active_sprint.id}']", text: "Active Sprint")
+    end
+  end
+
+  context "when a completed sprint exists" do
+    let!(:completed_sprint) { create(:agile_sprint, project:, name: "Old Sprint", status: "completed") }
+
+    it "does not list the completed sprint" do
+      render_component
+
+      expect(page).to have_no_css("option", text: "Old Sprint")
+    end
+  end
+
+  context "when a sprint belongs to a different project" do
+    let!(:other_sprint) { create(:agile_sprint, project: create(:project), name: "Other Sprint") }
+
+    it "does not list sprints from other projects" do
+      render_component
+
+      expect(page).to have_no_css("option", text: "Other Sprint")
+    end
+  end
+end

--- a/modules/backlogs/spec/controllers/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/inbox_controller_spec.rb
@@ -141,6 +141,18 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
       end
     end
 
+    context "when no position is provided" do
+      let!(:work_packages) { create_list(:work_package, 5, project:, sprint: agile_sprint) }
+      let(:position) { nil }
+
+      it "places the work package at the last position in the sprint" do
+        expect { work_package.reload }
+          .to change(work_package, :position).from(1).to(6)
+        expect { work_packages.each(&:reload) }
+          .not_to change { work_packages.map(&:position) }
+      end
+    end
+
     context "when service call fails" do
       let(:service_result) { ServiceResult.failure(message: "Move failed") }
 
@@ -149,6 +161,39 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace",
                                                   target: "backlogs-inbox-component-#{project.id}"
+      end
+    end
+
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
+  describe "GET #move_to_sprint_dialog" do
+    let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+
+    subject do
+      get :move_to_sprint_dialog,
+          params: { project_id: project.id, id: work_package.id },
+          format: :turbo_stream
+    end
+
+    context "when user has manage_sprint_items permission" do
+      it "responds with a dialog turbo stream", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dialog"
+      end
+    end
+
+    context "with a user lacking manage_sprint_items permission" do
+      let(:user) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+      it "responds with 403" do
+        expect(response).to have_http_status :forbidden
       end
     end
 

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -82,13 +82,8 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
     end
 
     it "allows reordering items via the kebab menu", :aggregate_failures do
-      items_in_visual_order = planning_page.inbox_items_in_visual_order(inbox_wp1, inbox_wp2, inbox_wp3)
-      top_item = items_in_visual_order[0]
-      middle_item = items_in_visual_order[1]
-      bottom_item = items_in_visual_order[2]
-
       # First item has no upward actions
-      planning_page.within_inbox_menu(top_item) do |menu|
+      planning_page.within_inbox_menu(inbox_wp1) do |menu|
         planning_page.within_move_submenu(menu) do |submenu|
           expect(submenu).to have_no_selector(:menuitem, text: "Move to top")
           expect(submenu).to have_no_selector(:menuitem, text: "Move up")
@@ -98,7 +93,7 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
       end
 
       # Last item has no downward actions
-      planning_page.within_inbox_menu(bottom_item) do |menu|
+      planning_page.within_inbox_menu(inbox_wp3) do |menu|
         planning_page.within_move_submenu(menu) do |submenu|
           expect(submenu).to have_selector(:menuitem, text: "Move to top")
           expect(submenu).to have_selector(:menuitem, text: "Move up")
@@ -107,20 +102,20 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
         end
       end
 
-      planning_page.click_in_inbox_move_menu(top_item, "Move down")
-      planning_page.expect_inbox_items_in_order(middle_item, top_item, bottom_item)
+      planning_page.click_in_inbox_move_menu(inbox_wp1, "Move down")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
 
-      planning_page.click_in_inbox_move_menu(top_item, "Move down")
-      planning_page.expect_inbox_items_in_order(middle_item, bottom_item, top_item)
+      planning_page.click_in_inbox_move_menu(inbox_wp1, "Move down")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
 
-      planning_page.click_in_inbox_move_menu(middle_item, "Move to bottom")
-      planning_page.expect_inbox_items_in_order(bottom_item, top_item, middle_item)
+      planning_page.click_in_inbox_move_menu(inbox_wp2, "Move to bottom")
+      planning_page.expect_inbox_items_in_order(inbox_wp3, inbox_wp1, inbox_wp2)
 
-      planning_page.click_in_inbox_move_menu(middle_item, "Move to top")
-      planning_page.expect_inbox_items_in_order(middle_item, bottom_item, top_item)
+      planning_page.click_in_inbox_move_menu(inbox_wp2, "Move to top")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp3, inbox_wp1)
 
-      planning_page.click_in_inbox_move_menu(top_item, "Move up")
-      planning_page.expect_inbox_items_in_order(middle_item, top_item, bottom_item)
+      planning_page.click_in_inbox_move_menu(inbox_wp1, "Move up")
+      planning_page.expect_inbox_items_in_order(inbox_wp2, inbox_wp1, inbox_wp3)
     end
 
     describe "moving backlog items to a sprint via the 'Move to sprint' menu item" do

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -123,6 +123,30 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
       planning_page.expect_inbox_items_in_order(middle_item, top_item, bottom_item)
     end
 
+    describe "moving backlog items to a sprint via the 'Move to sprint' menu item" do
+      let!(:sprint2) { create(:agile_sprint, name: "Sprint 2", project:) }
+      let!(:sprint_wp) { create(:work_package, project:, sprint:) }
+
+      before { planning_page.visit! }
+
+      it "moves the item to the bottom of the selected sprint" do
+        planning_page.click_in_inbox_move_menu(inbox_wp1, "Move to sprint")
+
+        within("#move-to-sprint-dialog") do
+          # Expect to have all sprints listed
+          expect(page).to have_select("target_id", with_options: ["Sprint 1", "Sprint 2"])
+
+          select sprint.name, from: "target_id"
+          click_button I18n.t("button_save")
+        end
+
+        planning_page.expect_no_inbox_item(inbox_wp1)
+        expect_and_dismiss_flash(message: "Successful move from Inbox to Sprint 1.")
+        planning_page.expect_story_in_sprint(inbox_wp1, sprint)
+        planning_page.expect_work_packages_in_sprint_in_order(sprint, work_packages: [sprint_wp, inbox_wp1])
+      end
+    end
+
     describe "moving backlog items to a sprint via drag-and-drop" do
       it "moves multiple items into the sprint one by one" do
         planning_page.drag_inbox_item_to_sprint(inbox_wp1, sprint)

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
           expect(page).to have_select("target_id", with_options: ["Sprint 1", "Sprint 2"])
 
           select sprint.name, from: "target_id"
-          click_button I18n.t("button_save")
+          click_button "Save"
         end
 
         planning_page.expect_no_inbox_item(inbox_wp1)

--- a/modules/backlogs/spec/features/projects/settings/backlog_sharing_settings_spec.rb
+++ b/modules/backlogs/spec/features/projects/settings/backlog_sharing_settings_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Backlogs project settings sprint sharing", :js, with_flag: { scr
       expect(page).to have_no_text(I18n.t("projects.settings.backlog_sharing.options.share_subprojects.info"))
 
       # persists receive_shared
-      click_button I18n.t("button_save")
+      click_button "Save"
 
       expect_and_dismiss_flash(type: :success, message: I18n.t(:notice_successful_update))
       expect(page).to have_checked_field("Receive shared sprints")
@@ -88,7 +88,7 @@ RSpec.describe "Backlogs project settings sprint sharing", :js, with_flag: { scr
       expect(page).to have_no_text(I18n.t("projects.settings.backlog_sharing.options.receive_shared.warning"))
 
       # persists no_sharing
-      click_button I18n.t("button_save")
+      click_button "Save"
 
       expect_and_dismiss_flash(type: :success, message: I18n.t(:notice_successful_update))
       expect(page).to have_checked_field("Don't share")

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -167,18 +167,6 @@ module Pages
       wait_for_network_idle
     end
 
-    def inbox_items_in_visual_order(*work_packages)
-      tops = within_inbox do
-        work_packages.index_with do |wp|
-          page.evaluate_script(
-            "document.querySelector('#{inbox_item_selector(wp)}').getBoundingClientRect().top"
-          )
-        end
-      end
-
-      work_packages.sort_by { |wp| tops.fetch(wp) }
-    end
-
     def within_inbox_menu(work_package, &)
       within(inbox_item_selector(work_package)) do
         button = find(:button, accessible_name: "Work package actions")


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72198

# What are you trying to accomplish?
- Add "Move to sprint" dropdown item to backlog items.

# What approach did you choose and why?
- Add a new dialog to show the available sprints
- Submit the dialog to the existing `InboxController#move` action.

# Screensots
<details><summary>1. Move to Sprint dropdown menu</summary>
<p>

<img width="896" height="680" alt="image" src="https://github.com/user-attachments/assets/6eddcd30-4027-4ed9-990a-6e5ecebb4a92" />


</p>
</details> 

<details><summary>2. Sprint selector dialog</summary>
<p>

<img width="889" height="686" alt="image" src="https://github.com/user-attachments/assets/0c37f829-dd2c-457d-8554-1bd2c64cb33c" />

</p>
</details> 

<details><summary>3. Story moved to the bottom of the sprint</summary>
<p>

<img width="979" height="557" alt="image" src="https://github.com/user-attachments/assets/8354dd9c-8749-4a68-b94d-8af37b5cd387" />

</p>
</details> 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
