### PR TITLE
[73398] Long Text Project Attribute is showing CF ID on click

### DIFF
--- a/app/components/open_project/common/inplace_edit_fields/display_fields/rich_text_area_component.rb
+++ b/app/components/open_project/common/inplace_edit_fields/display_fields/rich_text_area_component.rb
@@ -43,8 +43,9 @@ module OpenProject
                                                classes: "op-uc-container op-uc-container_reduced-headings -multiline")) do
                 if field_value.present?
                   if truncated
+                    name = custom_field? ? custom_field.name : attribute.to_s.humanize
                     render OpenProject::Common::AttributeComponent.new("#{attribute}-truncated-display-field",
-                                                                       attribute,
+                                                                       name,
                                                                        field_value,
                                                                        lines: 3)
                   else


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73398

# What are you trying to accomplish?
Correctly set the name for the atrribute label dialog


