### PR TITLE
[67643] Wiki menu visible when using the browser's print function

### DIFF
--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -11,7 +11,8 @@
   .toolbar-items,
   .ui-helper-hidden-accessible,
   #wiki_add_attachment,
-  .Overlay action-list
+  .Overlay action-list,
+  anchored-position
     display: none !important
 
   .op-toast:not(.show-when-print)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67643

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
On windows and browser Edge, while printing, in 30 or less than 30 percent scale, there is a line visible which is the anchor position element. We will hide this element while printing.
## Screenshots
Before:
<img width="972" height="596" alt="Screenshot 2026-03-25 at 15 22 39" src="https://github.com/user-attachments/assets/3aa89887-8a28-4103-ba50-63f5448c4e46" />
After:
<img width="987" height="272" alt="Screenshot 2026-03-25 at 15 24 24" src="https://github.com/user-attachments/assets/77fb031d-19e1-4d6c-89f7-fb6d2ed4cc1d" />

