### PR TITLE
[#73227] Disable "start" button on sprint on lacking dates

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -70,13 +70,17 @@ module Backlogs
     end
 
     def disable_start_sprint_action?
-      sprint.in_planning? && project_has_another_active_sprint?
+      sprint.in_planning? && (!sprint.date_range_set? || project_has_another_active_sprint?)
     end
 
     def start_sprint_action_description
       return unless disable_start_sprint_action?
 
-      t(".action_menu.start_sprint_disabled_description")
+      if sprint.date_range_set?
+        t(".action_menu.start_sprint_disabled_description")
+      else
+        t(".action_menu.start_sprint_missing_dates_description")
+      end
     end
 
     def user_allowed?(permission)

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -174,6 +174,7 @@ en:
         start_sprint: "Start sprint"
         finish_sprint: "Finish sprint"
         start_sprint_disabled_description: "Another sprint is already active."
+        start_sprint_missing_dates_description: "Start and finish dates are required in order to start the sprint."
         edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
         task_board: "Task board"

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -174,6 +174,36 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         end
       end
 
+      context "when the sprint has no start date" do
+        let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: nil, finish_date: Date.tomorrow) }
+
+        it "shows Start sprint disabled with a missing dates description" do
+          render_component
+
+          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: true)
+          expect(page).to have_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.start_sprint_missing_dates_description"))
+        end
+      end
+
+      context "when the sprint has no finish date" do
+        let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: nil) }
+
+        it "shows Start sprint disabled with a missing dates description" do
+          render_component
+
+          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: true)
+          expect(page).to have_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.start_sprint_missing_dates_description"))
+        end
+      end
+
+      context "when the sprint has both start and finish dates" do
+        it "shows Start sprint enabled" do
+          render_component
+
+          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: false)
+        end
+      end
+
       context "when the sprint is in planning and the user cannot start it" do
         let(:permissions) { %i[view_sprints view_work_packages] }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/73227

# What are you trying to accomplish?
- Disable the start sprint button, when sprint start or finish date is missing

## Screenshots
<img width="456" height="329" alt="image" src="https://github.com/user-attachments/assets/87c17bd5-1b72-49e3-bd8a-db7779007258" />

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
