### PR TITLE
[#73227] Validate the sprint start contract to not allow starting sprints without dates

### DIFF
--- a/modules/backlogs/app/contracts/sprints/start_contract.rb
+++ b/modules/backlogs/app/contracts/sprints/start_contract.rb
@@ -32,6 +32,7 @@ module Sprints
   class StartContract < ::BaseContract
     validate :validate_permission
     validate :validate_status_in_planning
+    validate :validate_dates_present
     validate :validate_no_other_active_sprint
 
     def self.can_start_or_finish?(user:, sprint:)
@@ -55,6 +56,13 @@ module Sprints
       return if model.in_planning?
 
       errors.add :status, :must_be_in_planning
+    end
+
+    def validate_dates_present
+      return unless model.in_planning?
+      return if model.start_date? && model.finish_date?
+
+      errors.add :base, :dates_required
     end
 
     def validate_no_other_active_sprint

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -58,6 +58,7 @@ en:
       messages:
         must_be_in_planning: "must be in planning to start."
         only_one_active_sprint_allowed: "only one active sprint is allowed per project."
+        dates_required: "Start and finish dates are required in order to start the sprint."
       models:
         project:
           receiving_sprints: "is receiving shared sprints. Own sprints cannot be created."

--- a/modules/backlogs/spec/contracts/sprints/start_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/sprints/start_contract_spec.rb
@@ -83,6 +83,24 @@ RSpec.describe Sprints::StartContract do
       end
     end
 
+    context "when the sprint has no start date" do
+      let(:sprint) { create(:agile_sprint, project:, status: sprint_status, start_date: nil) }
+
+      it "is invalid" do
+        expect(contract.validate).to be(false)
+        expect(contract.errors.symbols_for(:base)).to include(:dates_required)
+      end
+    end
+
+    context "when the sprint has no finish date" do
+      let(:sprint) { create(:agile_sprint, project:, status: sprint_status, finish_date: nil) }
+
+      it "is invalid" do
+        expect(contract.validate).to be(false)
+        expect(contract.errors.symbols_for(:base)).to include(:dates_required)
+      end
+    end
+
     context "when another active sprint exists in the project" do
       before do
         create(:agile_sprint,

--- a/modules/backlogs/spec/services/sprints/start_service_spec.rb
+++ b/modules/backlogs/spec/services/sprints/start_service_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe Sprints::StartService do
     end
   end
 
+  context "when the sprint has no start date" do
+    let(:sprint) { create(:agile_sprint, project:, start_date: nil) }
+
+    it "fails contract validation without activating the sprint", :aggregate_failures do
+      expect(result).not_to be_success
+      expect(result.errors.symbols_for(:base)).to include(:dates_required)
+      expect(sprint.reload).to be_in_planning
+    end
+  end
+
+  context "when the sprint has no finish date" do
+    let(:sprint) { create(:agile_sprint, project:, finish_date: nil) }
+
+    it "fails contract validation without activating the sprint", :aggregate_failures do
+      expect(result).not_to be_success
+      expect(result.errors.symbols_for(:base)).to include(:dates_required)
+      expect(sprint.reload).to be_in_planning
+    end
+  end
+
   context "when another active sprint exists in the project" do
     let!(:active_sprint) { create(:agile_sprint, project:, status: "active") }
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73227

# What are you trying to accomplish?
- Follow up to validate the sprint starting contract as well.
- See https://github.com/opf/openproject/pull/22504#discussion_r2989506920

## Screenshots
<img width="1086" height="709" alt="image" src="https://github.com/user-attachments/assets/c0710a84-f65f-4c82-9fda-426d206eed73" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
