### PR TITLE
Fix sprint menu permissions

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    if user_allowed?(:create_sprints)
+    if show_edit_sprint_action?
       menu.with_item(
         id: dom_target(sprint, :menu, :edit_sprint),
         label: t(".action_menu.edit_sprint"),

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -62,11 +62,19 @@ module Backlogs
     end
 
     def show_start_sprint_action?
-      sprint.in_planning? && ::Sprints::StartContract.can_start?(user: current_user, sprint:, project:)
+      mutable_sprint_in_project? &&
+        sprint.in_planning? &&
+        ::Sprints::StartContract.can_start?(user: current_user, sprint:, project:)
     end
 
     def show_finish_sprint_action?
-      sprint.active? && ::Sprints::StartContract.can_start_or_finish?(user: current_user, sprint:)
+      mutable_sprint_in_project? &&
+        sprint.active? &&
+        ::Sprints::StartContract.can_start_or_finish?(user: current_user, sprint:)
+    end
+
+    def show_edit_sprint_action?
+      mutable_sprint_in_project? && user_allowed?(:create_sprints)
     end
 
     def disable_start_sprint_action?
@@ -97,6 +105,12 @@ module Backlogs
 
     def resolved_active_sprint_ids
       active_sprint_ids || Agile::Sprint.for_project(sprint.project).active.pluck(:id)
+    end
+
+    def mutable_sprint_in_project?
+      return @mutable_sprint_in_project if defined?(@mutable_sprint_in_project)
+
+      @mutable_sprint_in_project = project.sprint_source.exists?(id: sprint.project_id)
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -305,5 +305,54 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         end
       end
     end
+
+    context "when the sprint is only visible through work package references" do
+      let(:source_project) { create(:project, types: [type_feature, type_task]) }
+      let(:project) { create(:project, types: [type_feature, type_task]) }
+      let(:sprint) do
+        create(:agile_sprint,
+               project: source_project,
+               name: "Referenced Sprint",
+               start_date: Date.yesterday,
+               finish_date: Date.tomorrow,
+               status: "active")
+      end
+      let(:permissions) do
+        %i[view_sprints view_work_packages show_board_views create_sprints manage_sprint_items start_complete_sprint]
+      end
+
+      before do
+        create(:member,
+               project: source_project,
+               principal: user,
+               roles: [create(:project_role, permissions: %i[view_sprints create_sprints start_complete_sprint])])
+        create(:work_package, project:, type: type_feature, sprint:)
+      end
+
+      it "hides Finish sprint and Edit sprint for an active sprint" do
+        render_component
+
+        expect(page).to have_no_selector(:menuitem, text: "Finish sprint")
+        expect(page).to have_no_selector(:menuitem, text: "Edit sprint")
+      end
+
+      context "when the sprint is in planning" do
+        let(:sprint) do
+          create(:agile_sprint,
+                 project: source_project,
+                 name: "Referenced Sprint",
+                 start_date: Date.yesterday,
+                 finish_date: Date.tomorrow,
+                 status: "in_planning")
+        end
+
+        it "hides Start sprint and Edit sprint" do
+          render_component
+
+          expect(page).to have_no_selector(:menuitem, text: "Start sprint")
+          expect(page).to have_no_selector(:menuitem, text: "Edit sprint")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
> [!NOTE]
> This fix has been extracted from #22478 



# Ticket

n/a

# What are you trying to accomplish?

Align sprint menu permissions with controller mutability rules.

This hides sprint mutation actions when a sprint is only visible through work package references - thus ensuring the UI no longer advertises operations the controllers will reject.

## Screenshots

n/a

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
