### PR TITLE
[#73129] Rework sprint blankslate

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -49,7 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% if work_packages.empty? %>
       <% border_box.with_row(data: { empty_list_item: true }) do %>
         <%=
-          render Primer::Beta::Blankslate.new(role: "status", aria: { live: "polite" }) do |blankslate|
+          render Primer::Beta::Blankslate.new(spacious: true, role: "status", aria: { live: "polite" }) do |blankslate|
             blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
             blankslate.with_description_content(t(".blankslate_description"))
           end

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -28,69 +28,94 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= turbo_frame_tag "backlogs_container", refresh: :morph, class: "op-backlogs-page" do %>
-  <% if @owner_backlogs.empty? && @sprints.empty? %>
-    <%=
-      render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
-        blankslate.with_visual_icon(icon: :versions)
-        blankslate.with_heading(tag: :h2).with_content(t(:backlogs_empty_title))
+  <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
+    <div id="owner_backlogs_container" class="op-sprint-planning-lists">
+      <%= render Backlogs::InboxComponent.new(
+            work_packages: @inbox_work_packages,
+            project: @project,
+            show_all: params[:all].present?
+          ) %>
+    </div>
+    <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
+      <%=
+        render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+          head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }
 
-        if current_user.allowed_in_project?(:manage_versions, @project)
-          blankslate.with_description_content(t(:backlogs_empty_action_text))
-        end
-      end
-    %>
-  <% else %>
-    <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
-      <div id="owner_backlogs_container" class="op-sprint-planning-lists">
-        <%= render Backlogs::InboxComponent.new(
-              work_packages: @inbox_work_packages,
-              project: @project,
-              show_all: params[:all].present?
-            ) %>
-      </div>
-      <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
-        <%=
-          render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-            head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }
-
-            if allow_sprint_creation?(@project)
-              head.with_actions do
-                render Primer::Beta::Button.new(
-                  tag: :a,
-                  label: Agile::Sprint.human_model_name,
-                  href: new_dialog_project_sprints_path(@project),
-                  data: {
-                    controller: "async-dialog",
-                    test_selector: "op-sprints--new-sprint-button"
-                  }
-                ) do |button|
-                  button.with_leading_visual_icon(icon: :plus)
-                  Agile::Sprint.human_model_name
-                end
-              end
-            end
-          end
-        %>
-
-        <%#= render(Primer::OpenProject::SubHeader.new) do |subheader|
-            if allow_sprint_creation?(@project)
-              subheader.with_action_button(
-                leading_icon: :plus,
-                label: Agile::Sprint.human_model_name,
+          if allow_sprint_creation?(@project)
+            head.with_actions do
+              render Primer::Beta::Button.new(
                 tag: :a,
+                label: Agile::Sprint.human_model_name,
                 href: new_dialog_project_sprints_path(@project),
                 data: {
                   controller: "async-dialog",
                   test_selector: "op-sprints--new-sprint-button"
                 }
-              ) do
+              ) do |button|
+                button.with_leading_visual_icon(icon: :plus)
                 Agile::Sprint.human_model_name
               end
             end
-          end %>
+          end
+        end
+      %>
 
+      <%#= render(Primer::OpenProject::SubHeader.new) do |subheader|
+          if allow_sprint_creation?(@project)
+            subheader.with_action_button(
+              leading_icon: :plus,
+              label: Agile::Sprint.human_model_name,
+              tag: :a,
+              href: new_dialog_project_sprints_path(@project),
+              data: {
+                controller: "async-dialog",
+                test_selector: "op-sprints--new-sprint-button"
+              }
+            ) do
+              Agile::Sprint.human_model_name
+            end
+          end
+        end %>
+
+      <% if @sprints.empty? %>
+        <% can_create_sprints = current_user.allowed_in_project?(:create_sprints, @project) %>
+        <% can_manage_sprint_sharing = current_user.allowed_in_project?(:share_sprint, @project) %>
+        <% description_key =
+             if @project.receive_shared_sprints?
+               can_manage_sprint_sharing ? "backlogs.sprint_planning.blankslate.receive_shared_description_html" :
+                 "backlogs.sprint_planning.blankslate.receive_shared_no_actions_description_text"
+             elsif can_create_sprints && can_manage_sprint_sharing
+               "backlogs.sprint_planning.blankslate.description_html"
+             elsif can_create_sprints
+               "backlogs.sprint_planning.blankslate.create_sprint_description_text"
+             elsif can_manage_sprint_sharing
+               "backlogs.sprint_planning.blankslate.share_sprint_description_html"
+             else
+               "backlogs.sprint_planning.blankslate.no_actions_description_text"
+             end %>
+        <% description_content =
+             if can_manage_sprint_sharing
+               t(
+                 description_key,
+                 settings_link: link_to(
+                   t("backlogs.sprint_planning.blankslate.settings_link_text"),
+                   project_settings_backlog_sharing_path(@project)
+                 )
+               )
+             else
+               t(description_key)
+             end %>
+
+        <%=
+          render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
+            blankslate.with_visual_icon(icon: :versions)
+            blankslate.with_heading(tag: :h4).with_content(t("backlogs.sprint_planning.blankslate.title"))
+            blankslate.with_description_content(description_content)
+          end
+        %>
+      <% else %>
         <%= render(Backlogs::SprintComponent.with_collection(@sprints, project: @project, active_sprint_ids: @active_sprint_ids)) %>
-      </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -164,6 +164,17 @@ en:
         copy_work_package_id: "Copy work package ID"
         move_menu: "Move"
 
+    sprint_planning:
+      blankslate:
+        title: "No sprints present yet"
+        description_html: "To start planning your sprint, create one here or go to the %{settings_link} to receive sprints from a different project."
+        create_sprint_description_text: "To start planning your sprint, create one here."
+        share_sprint_description_html: "To start planning your sprint, go to the %{settings_link} to receive sprints from a different project."
+        no_actions_description_text: "No sprints are available for this project yet."
+        receive_shared_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
+        receive_shared_no_actions_description_text: "This project receives shared sprints from a different project, but none are available right now."
+        settings_link_text: "project settings"
+
     sprint_header_component:
       label_toggle_backlog: "Collapse/Expand %{name}"
       label_story_count:

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -32,23 +32,28 @@ require "spec_helper"
 require_relative "../support/pages/sprint_planning"
 
 RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_projects: true } do
+  let(:sprint_sharing) { nil }
   let!(:project) do
     create(:project,
            types: [type],
-           enabled_module_names: %w[work_package_tracking backlogs])
+           enabled_module_names: %w[work_package_tracking backlogs],
+           sprint_sharing:)
   end
   let!(:type) { create(:type) }
-  let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+  let(:base_permissions) do
+    %i[
+      view_project
+      view_sprints
+      manage_sprint_items
+      add_work_packages
+      view_work_packages
+      edit_work_packages
+    ]
+  end
+  let(:additional_permissions) { [] }
+  let(:permissions) { base_permissions + additional_permissions }
   let!(:role) do
-    create(:project_role,
-           permissions: %i[
-             view_project
-             view_sprints
-             manage_sprint_items
-             add_work_packages
-             view_work_packages
-             edit_work_packages
-           ])
+    create(:project_role, permissions:)
   end
   let!(:current_user) { create(:user, member_with_roles: { project => role }) }
 
@@ -59,6 +64,8 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
   end
 
   context "when the inbox has no work packages" do
+    let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+
     before { planning_page.visit! }
 
     it "shows the blankslate" do
@@ -66,7 +73,134 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
     end
   end
 
+  context "when there are no sprints" do
+    before { planning_page.visit! }
+
+    context "when the user can create sprints and manage sprint sharing" do
+      let(:additional_permissions) { %i[create_sprints share_sprint] }
+
+      it "shows the sprint blankslate with settings link and sprint button" do
+        planning_page.expect_inbox_blankslate
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "To start planning your sprint, create one here or go to the project settings to receive sprints from a different project."
+        )
+        planning_page.expect_sprint_planning_settings_link
+        planning_page.expect_new_sprint_button
+      end
+    end
+
+    context "when the user cannot manage sprint sharing" do
+      let(:additional_permissions) { %i[create_sprints] }
+
+      it "shows the sprint blankslate without the settings link" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_no_sprint_planning_settings_link
+        planning_page.expect_sprint_planning_blankslate_description(
+          "To start planning your sprint, create one here."
+        )
+        planning_page.expect_new_sprint_button
+      end
+    end
+
+    context "when the user can manage sprint sharing but cannot create sprints" do
+      let(:additional_permissions) { %i[share_sprint] }
+
+      it "shows the sprint blankslate with settings link but no sprint button" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "To start planning your sprint, go to the project settings to receive sprints from a different project."
+        )
+        planning_page.expect_sprint_planning_settings_link
+        planning_page.expect_no_new_sprint_button
+      end
+    end
+
+    context "when the user cannot create sprints or manage sprint sharing" do
+      it "shows the sprint blankslate without action copy, settings link, or sprint button" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "No sprints are available for this project yet."
+        )
+        planning_page.expect_no_sprint_planning_settings_link
+        planning_page.expect_no_new_sprint_button
+      end
+    end
+  end
+
+  context "when the project receives shared sprints" do
+    let(:sprint_sharing) { "receive_shared" }
+
+    before { planning_page.visit! }
+
+    context "when the user can manage sprint sharing" do
+      let(:additional_permissions) { %i[create_sprints share_sprint] }
+
+      it "shows the sprint blankslate without a sprint button and keeps the settings link" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "This project receives sprints from a different project. Manage this in the project settings."
+        )
+        planning_page.expect_sprint_planning_settings_link
+        planning_page.expect_no_new_sprint_button
+      end
+    end
+
+    context "when the user cannot manage sprint sharing" do
+      it "shows the sprint blankslate without settings link or sprint button" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "This project receives shared sprints from a different project, but none are available right now."
+        )
+        planning_page.expect_no_sprint_planning_settings_link
+        planning_page.expect_no_new_sprint_button
+      end
+    end
+
+    context "when the user can create sprints but cannot manage sprint sharing" do
+      let(:additional_permissions) { %i[create_sprints] }
+
+      it "shows the sprint blankslate without settings link or sprint button" do
+        planning_page.expect_sprint_planning_blankslate
+        planning_page.expect_sprint_planning_blankslate_description(
+          "This project receives shared sprints from a different project, but none are available right now."
+        )
+        planning_page.expect_no_sprint_planning_settings_link
+        planning_page.expect_no_new_sprint_button
+      end
+    end
+
+    context "when a shared sprint is available" do
+      let!(:source_project) do
+        create(:project,
+               sprint_sharing: "share_all_projects",
+               types: [type],
+               enabled_module_names: %w[work_package_tracking backlogs])
+      end
+      let!(:shared_sprint) { create(:agile_sprint, name: "Shared Sprint", project: source_project) }
+
+      before { planning_page.visit! }
+
+      it "renders the shared sprint instead of the blankslate" do
+        planning_page.expect_no_sprint_planning_blankslate
+        planning_page.expect_sprint_names_in_order("Shared Sprint")
+      end
+    end
+  end
+
+  context "when a sprint is present" do
+    let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
+
+    before { planning_page.visit! }
+
+    it "renders the sprint and hides the sprint blankslate" do
+      planning_page.expect_no_sprint_planning_blankslate
+      planning_page.expect_sprint_names_in_order("Sprint 1")
+    end
+  end
+
   context "with work packages in the inbox" do
+    let!(:sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
     let!(:inbox_wp1) { create(:work_package, project:) }
     let!(:inbox_wp2) { create(:work_package, project:) }
     let!(:inbox_wp3) { create(:work_package, project:) }

--- a/modules/backlogs/spec/features/sprints/create_spec.rb
+++ b/modules/backlogs/spec/features/sprints/create_spec.rb
@@ -157,8 +157,6 @@ RSpec.describe "Create", :js do
         end
 
         it "prefilled with 'Sprint 1' if there are no previous sprints" do
-          pending "Currently broken since the blankslate renders without any sprint or version present. " +
-                  "Fix at a later time when backlog items are there #72198"
           planning_page.visit!
 
           planning_page.open_create_sprint_dialog

--- a/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
+++ b/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
           expect(response).to have_turbo_frame "backlogs_container"
           expect(response).to have_no_turbo_frame "content-bodyRight"
         end
+
+        context "with no sprints available" do
+          before do
+            allow(Backlog)
+              .to receive(:owner_backlogs)
+              .with(project)
+              .and_return([])
+
+            allow(Agile::Sprint)
+              .to receive(:for_project)
+              .with(project)
+              .and_return(Agile::Sprint.none)
+          end
+
+          it "still renders the sprint planning container for turbo-frame requests" do
+            get "/projects/#{project.identifier}/backlogs/sprint_planning",
+                headers: { "Turbo-Frame" => "backlogs_container" }
+
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include('id="owner_backlogs_container"')
+            expect(response.body).to include('id="sprint_backlogs_container"')
+          end
+        end
       end
     end
   end

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -146,6 +146,60 @@ module Pages
       end
     end
 
+    def expect_sprint_planning_blankslate
+      within_sprint_backlogs do
+        expect(page).to have_css("h4", text: "No sprints present yet")
+      end
+    end
+
+    def expect_sprint_planning_blankslate_description(text)
+      within_sprint_backlogs do
+        expect(page).to have_text(text)
+      end
+    end
+
+    def expect_no_sprint_planning_blankslate
+      within_sprint_backlogs do
+        expect(page).to have_no_css("h4", text: "No sprints present yet")
+      end
+    end
+
+    def expect_sprint_planning_settings_link
+      within_sprint_backlogs do
+        expect(page).to have_link(
+          "project settings",
+          href: project_settings_backlog_sharing_path(project)
+        )
+      end
+    end
+
+    def expect_no_sprint_planning_settings_link
+      within_sprint_backlogs do
+        expect(page).to have_no_link(
+          "project settings",
+          href: project_settings_backlog_sharing_path(project)
+        )
+      end
+    end
+
+    def expect_new_sprint_button
+      within_sprint_backlogs do
+        expect(page).to have_css(
+          test_selector("op-sprints--new-sprint-button"),
+          text: Agile::Sprint.human_model_name
+        )
+      end
+    end
+
+    def expect_no_new_sprint_button
+      within_sprint_backlogs do
+        expect(page).to have_no_css(
+          test_selector("op-sprints--new-sprint-button"),
+          text: Agile::Sprint.human_model_name
+        )
+      end
+    end
+
     def expect_inbox_item(work_package)
       within_inbox do
         expect(page).to have_css(inbox_item_selector(work_package))
@@ -393,6 +447,10 @@ module Pages
 
     def within_inbox(&)
       within("#inbox_#{project.id}", &)
+    end
+
+    def within_sprint_backlogs(&)
+      within("#sprint_backlogs_container", &)
     end
 
     def sprint_selector(sprint)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73129

# What are you trying to accomplish?

Keep sprint planning in a two-column layout when no sprints are available, add permission-aware blankslate copy, and cover the behavior with request and feature specs.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Previously, when both `@owner_backlogs` and `@sprints` were empty the entire two-column layout was replaced by a single full-width blankslate. This meant that the inbox column (with its own blankslate) disappeared, losing context.

Now the two-column layout always renders. The sprint blankslate is scoped to the sprint column only, alongside the "Sprints" heading and "New Sprint" button. The blankslate copy is permission-aware:

| Condition | Copy |
|-----------|------|
| Can create sprints + manage sharing | Create here or go to project settings |
| Can create sprints only | Create here |
| Can manage sharing only | Go to project settings |
| No relevant permissions | "No sprints are available for this project yet." |
| Project receives shared sprints + can manage sharing | Manage in project settings |
| Project receives shared sprints + no manage permission | "None are available right now." |

The `allow_sprint_creation?` helper already returns `false` for `receive_shared_sprints?` projects, so the "New Sprint" button is hidden in all receive-shared scenarios.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)