### PR TITLE
Implementation/73433 poc explore compute on read finder methods for project based work package identifiers

### DIFF
--- a/app/models/work_package_move.rb
+++ b/app/models/work_package_move.rb
@@ -28,35 +28,8 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages::Identifier
-  extend ActiveSupport::Concern
-
-  included do
-    extend FriendlyId
-
-    # Configures FriendlyId with finders (but not history — no slug writes).
-    # All historical resolution is handled by compute-on-read FinderMethods
-    # which structurally parses identifiers and resolves via project history.
-    friendly_id :identifier, use: :finders do |config|
-      config.finder_methods = WorkPackages::Identifier::FinderMethods
-      FriendlyId::Finders.setup(WorkPackage)
-    end
-
-    scope :identified, -> { where.not(sequence_number: nil).where.not(identifier: nil) }
-
-    after_create :allocate_identifier!, if: -> { Setting::WorkPackageIdentifier.alphanumeric? && identifier.blank? }
-  end
-
-  private
-
-  # Allocates a project-scoped sequence number and composes the semantic identifier.
-  # Uses an advisory lock to serialize concurrent allocations on the same project.
-  def allocate_identifier!
-    OpenProject::Mutex.with_advisory_lock_transaction(project, "wp_sequence") do
-      next_seq = project.increment_wp_sequence!
-
-      update_columns(sequence_number: next_seq,
-                     identifier: "#{project.identifier}-#{next_seq}")
-    end
-  end
+# Records cross-project work package moves so that old identifiers
+# remain resolvable via compute-on-read finder methods.
+class WorkPackageMove < ApplicationRecord
+  belongs_to :work_package
 end

--- a/app/models/work_packages/identifier.rb
+++ b/app/models/work_packages/identifier.rb
@@ -32,15 +32,11 @@ module WorkPackages::Identifier
   extend ActiveSupport::Concern
 
   included do
-    extend FriendlyId
-
-    # Configures FriendlyId with finders (but not history — no slug writes).
-    # All historical resolution is handled by compute-on-read FinderMethods
-    # which structurally parses identifiers and resolves via project history.
-    friendly_id :identifier, use: :finders do |config|
-      config.finder_methods = WorkPackages::Identifier::FinderMethods
-      FriendlyId::Finders.setup(WorkPackage)
-    end
+    # Wire finder methods into both the model class and its relation class
+    # so that WorkPackage.find("SC-1") and WorkPackage.visible.find("SC-1")
+    # both resolve semantic identifiers structurally.
+    extend WorkPackages::Identifier::FinderMethods
+    relation.class.include(WorkPackages::Identifier::FinderMethods)
 
     scope :identified, -> { where.not(sequence_number: nil).where.not(identifier: nil) }
 

--- a/app/models/work_packages/identifier/finder_methods.rb
+++ b/app/models/work_packages/identifier/finder_methods.rb
@@ -30,27 +30,35 @@
 
 # Compute-on-read identifier resolution for work packages.
 #
-# All historical resolution is structural — no slug history table is used
-# for work packages. Instead, identifiers are parsed into prefix + sequence
-# and resolved via Project's own FriendlyId history.
+# Overrides find and exists? to support semantic identifiers ("SC-123").
+# Numeric IDs pass through to ActiveRecord. Identifiers are resolved
+# structurally: parse prefix + sequence → resolve project (via Project's
+# FriendlyId history) → find WP by (project_id, sequence_number).
+#
+# Uses FriendlyId's Object#friendly_id? for dispatch (already available
+# globally via FriendlyId::ObjectUtils, loaded for Project).
 #
 # Resolution chain:
-#   1. Primary column match (via FriendlyId base)
-#   2. Structural resolution: parse prefix + sequence, resolve prefix to
-#      project (via Project FriendlyId history), find WP by sequence_number
-#   3. Move resolution: check work_package_moves for WPs that left a project
+#   1. Structural: parse "PREFIX-SEQ", resolve prefix to project, find WP
+#   2. Move fallback: check work_package_moves for WPs that left a project
+#   3. Numeric fallback: delegate to ActiveRecord (primary key lookup)
 module WorkPackages::Identifier::FinderMethods
-  include FriendlyId::FinderMethods
+  def find(*args)
+    return super if args.length != 1
 
-  def exists_by_friendly_id?(id)
-    super || resolve_identifier(id).present?
+    id = args.first
+    return super unless id.friendly_id?
+
+    resolve_identifier(id) || super
+  end
+
+  def exists?(id = :none, **)
+    return super if id == :none || !id.friendly_id?
+
+    resolve_identifier(id).present? || super
   end
 
   private
-
-  def first_by_friendly_id(id)
-    super || resolve_identifier(id)
-  end
 
   def resolve_identifier(id)
     prefix, seq = id.to_s.match(/\A(.+)-(\d+)\z/)&.captures
@@ -67,10 +75,7 @@ module WorkPackages::Identifier::FinderMethods
 
   # Finds a WP that was moved FROM the given project with the given sequence.
   def find_moved_work_package(source_project_id, sequence_number)
-    move = WorkPackageMove.find_by(
-      source_project_id:,
-      sequence_number:
-    )
+    move = WorkPackageMove.find_by(source_project_id:, sequence_number:)
     find_by(id: move.work_package_id) if move
   end
 end

--- a/app/models/work_packages/identifier/finder_methods.rb
+++ b/app/models/work_packages/identifier/finder_methods.rb
@@ -28,37 +28,49 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Extends FriendlyId's history-aware finder with "ghost" identifier resolution.
+# Compute-on-read identifier resolution for work packages.
 #
-# A ghost identifier is one that was never actually assigned to a work package
-# but is intuitively valid — e.g. after renaming project "PROJ" to "BETTER",
-# a new WP gets "BETTER-11", but users may still look up "PROJ-11".
+# All historical resolution is structural — no slug history table is used
+# for work packages. Instead, identifiers are parsed into prefix + sequence
+# and resolved via Project's own FriendlyId history.
 #
 # Resolution chain:
 #   1. Primary column match (via FriendlyId base)
-#   2. Slug history match (via FriendlyId::History)
-#   3. Ghost resolution: parse prefix + sequence, resolve prefix to project
-#      (via Project's own FriendlyId history), find WP by sequence_number
+#   2. Structural resolution: parse prefix + sequence, resolve prefix to
+#      project (via Project FriendlyId history), find WP by sequence_number
+#   3. Move resolution: check work_package_moves for WPs that left a project
 module WorkPackages::Identifier::FinderMethods
-  include FriendlyId::History::FinderMethods
+  include FriendlyId::FinderMethods
 
   def exists_by_friendly_id?(id)
-    super || resolve_ghost_identifier(id).present?
+    super || resolve_identifier(id).present?
   end
 
   private
 
   def first_by_friendly_id(id)
-    super || resolve_ghost_identifier(id)
+    super || resolve_identifier(id)
   end
 
-  def resolve_ghost_identifier(id)
+  def resolve_identifier(id)
     prefix, seq = id.to_s.match(/\A(.+)-(\d+)\z/)&.captures
     return unless prefix && seq
 
+    seq = seq.to_i
     project = Project.friendly.find(prefix)
-    find_by(project_id: project.id, sequence_number: seq.to_i)
+
+    find_by(project_id: project.id, sequence_number: seq) ||
+      find_moved_work_package(project.id, seq)
   rescue ActiveRecord::RecordNotFound
     nil
+  end
+
+  # Finds a WP that was moved FROM the given project with the given sequence.
+  def find_moved_work_package(source_project_id, sequence_number)
+    move = WorkPackageMove.find_by(
+      source_project_id:,
+      sequence_number:
+    )
+    find_by(id: move.work_package_id) if move
   end
 end

--- a/app/models/work_packages/identifier/finder_methods.rb
+++ b/app/models/work_packages/identifier/finder_methods.rb
@@ -52,10 +52,10 @@ module WorkPackages::Identifier::FinderMethods
     resolve_identifier(id) || super
   end
 
-  def exists?(id = :none, **)
-    return super if id == :none || !id.friendly_id?
+  def exists?(*args)
+    return super unless args.length == 1 && args.first.friendly_id?
 
-    resolve_identifier(id).present? || super
+    resolve_identifier(args.first).present? || super
   end
 
   private

--- a/app/services/work_packages/reallocate_identifiers_on_move_service.rb
+++ b/app/services/work_packages/reallocate_identifiers_on_move_service.rb
@@ -31,38 +31,64 @@
 # Reallocates semantic identifiers when work packages move between projects.
 #
 # Uses 3 bulk SQL statements (regardless of work package count):
-#   1. Reserves a block of sequence numbers from the target project's counter cache
-#   2. Records old identifiers in FriendlyId slug history (so they remain resolvable)
+#   1. Records moves in work_package_moves (so old identifiers remain resolvable)
+#   2. Reserves a block of sequence numbers from the target project's counter cache
 #   3. Bulk-updates all work packages with new identifiers in a single CTE-based UPDATE
 #
-# Old identifiers are recorded manually because bulk SQL bypasses ActiveRecord
-# callbacks, so FriendlyId's automatic slug history tracking does not fire.
+# Old identifiers are resolved at read time via compute-on-read finder methods
+# that check the work_package_moves table as a fallback.
 #
 # All operations run within a single advisory lock on the target project
 # to serialize sequence allocation.
 class WorkPackages::ReallocateIdentifiersOnMoveService
-  attr_reader :target_project
+  attr_reader :target_project, :source_project_id
 
-  def initialize(target_project:)
+  # @param target_project [Project] the project being moved into
+  # @param source_project_id [Integer] the project being moved from (passed explicitly
+  #   because descendants loaded fresh in cleanup have no dirty tracking)
+  def initialize(target_project:, source_project_id:)
     @target_project = target_project
+    @source_project_id = source_project_id
   end
 
   def call(moved_work_packages)
     return unless Setting::WorkPackageIdentifier.alphanumeric?
 
     wp_data = moved_work_packages
-                .select { |wp| wp.identifier.present? }
-                .map { |wp| [wp.id, wp.identifier] }
+                .select { it.identifier.present? }
+                .map { [it.id, sequence_number_from(it)] }
+                .select { it[1] }
     return if wp_data.empty?
 
     OpenProject::Mutex.with_advisory_lock_transaction(target_project, "wp_sequence") do
+      record_moves(wp_data)
       base_seq = reserve_sequence_block!(wp_data.size)
-      record_old_slugs(wp_data)
       bulk_update_identifiers(wp_data.map(&:first), base_seq)
     end
   end
 
   private
+
+  # Extracts the old sequence number from dirty tracking or the identifier string.
+  # Descendants loaded fresh from DB after bulk-update don't have dirty tracking,
+  # so we fall back to parsing the identifier (format: "PREFIX-SEQ").
+  def sequence_number_from(work_package)
+    work_package.sequence_number_before_last_save || parse_sequence_from_identifier(work_package.identifier)
+  end
+
+  def parse_sequence_from_identifier(identifier)
+    identifier&.match(/-(\d+)\z/) { it[1].to_i }
+  end
+
+  def record_moves(wp_data)
+    now = Time.current
+    WorkPackageMove.insert_all(
+      wp_data.map do |wp_id, seq|
+        { work_package_id: wp_id, source_project_id:, sequence_number: seq, created_at: now }
+      end,
+      unique_by: %i[source_project_id sequence_number]
+    )
+  end
 
   def reserve_sequence_block!(count)
     final_seq = connection.select_value(<<~SQL.squish)
@@ -73,16 +99,6 @@ class WorkPackages::ReallocateIdentifiersOnMoveService
     SQL
 
     final_seq - count
-  end
-
-  def record_old_slugs(wp_data)
-    now = Time.current
-    FriendlyId::Slug.insert_all(
-      wp_data.map do |wp_id, old_identifier|
-        { sluggable_type: WorkPackage.name, sluggable_id: wp_id, slug: old_identifier, scope: nil, created_at: now }
-      end,
-      unique_by: %i[slug sluggable_type scope]
-    )
   end
 
   # Assigns sequential identifiers to moved work packages in a single SQL statement.

--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -280,7 +280,7 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
   # reject the save if the target project already has a WP with the same
   # sequence_number. The identifier is intentionally preserved so that
   # ReallocateIdentifiersOnMoveService (which runs post-save) can detect
-  # which WPs need reallocation and record old slugs in FriendlyId history.
+  # which WPs need reallocation and record moves for old identifier resolution.
   def clear_sequence_number_on_move
     return unless Setting::WorkPackageIdentifier.alphanumeric?
 

--- a/app/services/work_packages/update_identifiers_on_rename_service.rb
+++ b/app/services/work_packages/update_identifiers_on_rename_service.rb
@@ -30,12 +30,10 @@
 
 # Updates work package identifiers when a project is renamed.
 #
-# Uses 2 bulk SQL statements (regardless of work package count):
-#   1. Records old identifiers in FriendlyId slug history (so they remain resolvable)
-#   2. Bulk-updates all identifiers to use the new project identifier prefix
-#
-# Old identifiers are recorded manually because bulk SQL bypasses ActiveRecord
-# callbacks, so FriendlyId's automatic slug history tracking does not fire.
+# Uses a single bulk UPDATE (regardless of work package count).
+# No slug history recording needed — old identifiers are resolved
+# at read time via compute-on-read finder methods that parse the
+# identifier structurally and resolve via Project's FriendlyId history.
 class WorkPackages::UpdateIdentifiersOnRenameService
   attr_reader :project
 
@@ -46,28 +44,8 @@ class WorkPackages::UpdateIdentifiersOnRenameService
   def call
     return unless Setting::WorkPackageIdentifier.alphanumeric?
 
-    wp_data = project.work_packages.identified.pluck(:id, :identifier)
-    return if wp_data.empty?
-
-    record_old_identifiers_in_slug_history(wp_data)
-    bulk_update_identifiers
-  end
-
-  private
-
-  def bulk_update_identifiers
     project.work_packages.identified.update_all(
       ["identifier = ? || '-' || CAST(sequence_number AS text)", project.identifier]
-    )
-  end
-
-  def record_old_identifiers_in_slug_history(wp_data)
-    now = Time.current
-    FriendlyId::Slug.insert_all(
-      wp_data.map do |wp_id, old_id|
-        { sluggable_type: "WorkPackage", sluggable_id: wp_id, slug: old_id, scope: nil, created_at: now }
-      end,
-      unique_by: %i[slug sluggable_type scope]
     )
   end
 end

--- a/app/services/work_packages/update_service.rb
+++ b/app/services/work_packages/update_service.rb
@@ -102,7 +102,9 @@ class WorkPackages::UpdateService < BaseServices::Update
       delete_relations(moved_work_packages)
       move_time_entries(moved_work_packages, work_package.project_id)
       move_work_package_memberships(moved_work_packages, work_package.project_id)
-      reallocate_identifiers_on_move(moved_work_packages, work_package.project)
+      reallocate_identifiers_on_move(moved_work_packages,
+                                     work_package.project,
+                                     work_package.project_id_before_last_save)
     end
     if work_package.saved_change_to_type_id?
       reset_custom_values(work_package)
@@ -129,9 +131,9 @@ class WorkPackages::UpdateService < BaseServices::Update
       .update_all(project_id:)
   end
 
-  def reallocate_identifiers_on_move(moved_work_packages, target_project)
+  def reallocate_identifiers_on_move(moved_work_packages, target_project, source_project_id)
     WorkPackages::ReallocateIdentifiersOnMoveService
-      .new(target_project:)
+      .new(target_project:, source_project_id:)
       .call(moved_work_packages)
   end
 

--- a/db/migrate/20260326120000_create_work_package_moves.rb
+++ b/db/migrate/20260326120000_create_work_package_moves.rb
@@ -28,35 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages::Identifier
-  extend ActiveSupport::Concern
-
-  included do
-    extend FriendlyId
-
-    # Configures FriendlyId with finders (but not history — no slug writes).
-    # All historical resolution is handled by compute-on-read FinderMethods
-    # which structurally parses identifiers and resolves via project history.
-    friendly_id :identifier, use: :finders do |config|
-      config.finder_methods = WorkPackages::Identifier::FinderMethods
-      FriendlyId::Finders.setup(WorkPackage)
+# Tracks cross-project work package moves so that old identifiers
+# (e.g. "SRC-5" after a WP moved to TGT and became "TGT-3") remain resolvable
+# via compute-on-read finder methods.
+class CreateWorkPackageMoves < ActiveRecord::Migration[8.1]
+  def change
+    create_table :work_package_moves do |t|
+      t.references :work_package, null: false, foreign_key: true, index: true
+      t.bigint :source_project_id, null: false
+      t.integer :sequence_number, null: false
+      t.datetime :created_at, null: false
     end
 
-    scope :identified, -> { where.not(sequence_number: nil).where.not(identifier: nil) }
-
-    after_create :allocate_identifier!, if: -> { Setting::WorkPackageIdentifier.alphanumeric? && identifier.blank? }
-  end
-
-  private
-
-  # Allocates a project-scoped sequence number and composes the semantic identifier.
-  # Uses an advisory lock to serialize concurrent allocations on the same project.
-  def allocate_identifier!
-    OpenProject::Mutex.with_advisory_lock_transaction(project, "wp_sequence") do
-      next_seq = project.increment_wp_sequence!
-
-      update_columns(sequence_number: next_seq,
-                     identifier: "#{project.identifier}-#{next_seq}")
-    end
+    add_index :work_package_moves, %i[source_project_id sequence_number], unique: true
   end
 end

--- a/spec/models/work_packages/identifier/finder_methods_spec.rb
+++ b/spec/models/work_packages/identifier/finder_methods_spec.rb
@@ -54,12 +54,8 @@ RSpec.describe WorkPackages::Identifier::FinderMethods do
       expect(WorkPackage.find(identifier)).to eq(expected_wp)
     end
 
-    it "via .friendly.find" do
-      expect(WorkPackage.friendly.find(identifier)).to eq(expected_wp)
-    end
-
-    it "via .find_by_friendly_id" do
-      expect(WorkPackage.friendly.find_by_friendly_id(identifier)).to eq(expected_wp) # rubocop:disable Rails/DynamicFindBy
+    it "via scoped .find" do
+      expect(WorkPackage.where(nil).find(identifier)).to eq(expected_wp)
     end
 
     it "via .exists?" do
@@ -70,14 +66,6 @@ RSpec.describe WorkPackages::Identifier::FinderMethods do
   shared_examples "raises RecordNotFound" do
     it "via .find" do
       expect { WorkPackage.find(identifier) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "via .friendly.find" do
-      expect { WorkPackage.friendly.find(identifier) }.to raise_error(ActiveRecord::RecordNotFound)
-    end
-
-    it "via .find_by_friendly_id" do
-      expect { WorkPackage.friendly.find_by_friendly_id(identifier) }.to raise_error(ActiveRecord::RecordNotFound) # rubocop:disable Rails/DynamicFindBy
     end
 
     it "via .exists?" do

--- a/spec/models/work_packages/identifier/finder_methods_spec.rb
+++ b/spec/models/work_packages/identifier/finder_methods_spec.rb
@@ -114,11 +114,7 @@ RSpec.describe WorkPackages::Identifier::FinderMethods do
       include_examples "resolves to the expected work package"
     end
 
-    context "with an old identifier recorded in slug history" do
-      before do
-        FriendlyId::Slug.create!(slug: "sc-1", sluggable: work_package, sluggable_type: "WorkPackage")
-      end
-
+    context "with the original identifier (still resolves via structural lookup)" do
       let(:identifier) { "sc-1" }
       let(:expected_wp) { work_package }
 
@@ -171,6 +167,33 @@ RSpec.describe WorkPackages::Identifier::FinderMethods do
       let(:identifier) { "sc" }
 
       include_examples "raises RecordNotFound"
+    end
+  end
+
+  describe "move resolution" do
+    let(:target_project) { create(:project, identifier: "tgt") }
+
+    let!(:moved_wp) do
+      wp = create(:work_package, project:)
+      wp.update_columns(identifier: "sc-2", sequence_number: 2)
+      # Record move, then reassign to target project with new identifier
+      WorkPackageMove.create!(work_package: wp, source_project_id: project.id, sequence_number: 2)
+      wp.update_columns(project_id: target_project.id, identifier: "tgt-1", sequence_number: 1)
+      wp
+    end
+
+    context "with the old identifier from the source project" do
+      let(:identifier) { "sc-2" }
+      let(:expected_wp) { moved_wp }
+
+      include_examples "resolves to the expected work package"
+    end
+
+    context "with the new identifier in the target project" do
+      let(:identifier) { "tgt-1" }
+      let(:expected_wp) { moved_wp }
+
+      include_examples "resolves to the expected work package"
     end
   end
 

--- a/spec/models/work_packages/identifier_spec.rb
+++ b/spec/models/work_packages/identifier_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe WorkPackages::Identifier do
   end
 
   describe "FriendlyId configuration" do
-    it "uses the identifier column as the FriendlyId slug" do
+    it "uses the identifier column as the query field" do
       config = WorkPackage.friendly_id_config
-      expect(config.slug_column).to eq(:identifier)
+      expect(config.query_field).to eq("identifier")
     end
 
     it "includes the finders module" do
@@ -132,67 +132,7 @@ RSpec.describe WorkPackages::Identifier do
     end
   end
 
-  describe "historical identifier resolution" do
-    let!(:work_package) do
-      wp = create(:work_package, project:)
-      wp.update!(identifier: "SC-1", sequence_number: 1)
-      wp
-    end
-
-    it "records the old identifier in friendly_id_slugs when identifier changes" do
-      work_package.update!(identifier: "INFRA-42")
-
-      expect(FriendlyId::Slug.where(slug: "SC-1", sluggable_type: "WorkPackage")).to exist
-    end
-
-    it "finds a work package by a previous identifier" do
-      work_package.update!(identifier: "INFRA-42")
-
-      expect(WorkPackage.friendly.find("SC-1")).to eq(work_package)
-    end
-
-    it "finds a work package by its current identifier after a change" do
-      work_package.update!(identifier: "INFRA-42")
-
-      expect(WorkPackage.friendly.find("INFRA-42")).to eq(work_package)
-    end
-
-    it "resolves the latest work package when multiple identifiers have been used" do
-      work_package.update!(identifier: "INFRA-42")
-      work_package.update!(identifier: "DEV-7")
-
-      # All three identifiers resolve to the same work package
-      expect(WorkPackage.friendly.find("SC-1")).to eq(work_package)
-      expect(WorkPackage.friendly.find("INFRA-42")).to eq(work_package)
-      expect(WorkPackage.friendly.find("DEV-7")).to eq(work_package)
-    end
-
-    it "accumulates slug history entries for each identifier change" do
-      work_package.update!(identifier: "INFRA-42")
-      work_package.update!(identifier: "DEV-7")
-
-      slugs = FriendlyId::Slug.where(sluggable_id: work_package.id, sluggable_type: "WorkPackage").pluck(:slug)
-      # FriendlyId records a slug for each value (including the current one)
-      expect(slugs).to include("SC-1", "INFRA-42")
-    end
-
-    it "cleans up all slug history when work package is destroyed" do
-      work_package.update!(identifier: "INFRA-42")
-
-      slug_count = FriendlyId::Slug.where(
-        sluggable_id: work_package.id, sluggable_type: "WorkPackage"
-      ).count
-      expect(slug_count).to be >= 1
-
-      expect do
-        work_package.destroy!
-      end.to change {
-        FriendlyId::Slug.where(sluggable_id: work_package.id, sluggable_type: "WorkPackage").count
-      }.to(0)
-    end
-  end
-
-  describe "unset_slug_if_invalid override" do
+  describe "identifier stability on validation failure" do
     it "does not revert the identifier when validation fails" do
       wp = create(:work_package, project:)
       wp.update!(identifier: "SC-1", sequence_number: 1)

--- a/spec/models/work_packages/identifier_spec.rb
+++ b/spec/models/work_packages/identifier_spec.rb
@@ -40,46 +40,41 @@ RSpec.describe WorkPackages::Identifier do
     it { is_expected.to have_db_index(:identifier).unique(true) }
   end
 
-  describe "FriendlyId configuration" do
-    it "uses the identifier column as the query field" do
-      config = WorkPackage.friendly_id_config
-      expect(config.query_field).to eq("identifier")
+  describe "FinderMethods wiring" do
+    it "extends the model class with FinderMethods" do
+      expect(WorkPackage.singleton_class.ancestors).to include(WorkPackages::Identifier::FinderMethods)
     end
 
-    it "includes the finders module" do
-      expect(WorkPackage.respond_to?(:friendly)).to be true
+    it "includes FinderMethods in the relation class" do
+      expect(WorkPackage.all.class.ancestors).to include(WorkPackages::Identifier::FinderMethods)
     end
   end
 
   describe "finding by identifier" do
     let!(:work_package) do
       wp = create(:work_package, project:)
-      wp.update!(identifier: "SC-1", sequence_number: 1)
+      wp.update_columns(identifier: "sc-1", sequence_number: 1)
       wp
     end
 
-    it "finds by semantic identifier via .friendly.find" do
-      expect(WorkPackage.friendly.find("SC-1")).to eq(work_package)
-    end
-
-    it "finds by semantic identifier via .find (FriendlyId proxies it)" do
-      expect(WorkPackage.find("SC-1")).to eq(work_package)
+    it "finds by semantic identifier via .find" do
+      expect(WorkPackage.find("sc-1")).to eq(work_package)
     end
 
     it "finds by numeric ID (integer)" do
-      expect(WorkPackage.friendly.find(work_package.id)).to eq(work_package)
+      expect(WorkPackage.find(work_package.id)).to eq(work_package)
     end
 
     it "finds by numeric ID (string)" do
-      expect(WorkPackage.friendly.find(work_package.id.to_s)).to eq(work_package)
+      expect(WorkPackage.find(work_package.id.to_s)).to eq(work_package)
     end
 
     it "raises RecordNotFound for a non-existent identifier" do
-      expect { WorkPackage.friendly.find("NONEXISTENT-999") }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { WorkPackage.find("NONEXISTENT-999") }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "raises RecordNotFound for a non-existent numeric ID" do
-      expect { WorkPackage.friendly.find(0) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { WorkPackage.find(0) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "still finds a work package without an identifier by its numeric ID" do
@@ -141,7 +136,7 @@ RSpec.describe WorkPackages::Identifier do
       wp.subject = ""
       wp.valid?
 
-      # Identifier should NOT be reverted to nil by FriendlyId
+      # Identifier should remain stable across validation failures
       expect(wp.identifier).to eq("SC-1")
     end
   end

--- a/spec/services/work_packages/create_service_integration_spec.rb
+++ b/spec/services/work_packages/create_service_integration_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe WorkPackages::CreateService, "integration", type: :model do
       it "makes the work package findable by its identifier" do
         expect(service_result).to be_success
 
-        found = WorkPackage.friendly.find(new_work_package.identifier)
+        found = WorkPackage.find(new_work_package.identifier)
         expect(found).to eq(new_work_package)
       end
     end

--- a/spec/services/work_packages/reallocate_identifiers_on_move_service_spec.rb
+++ b/spec/services/work_packages/reallocate_identifiers_on_move_service_spec.rb
@@ -31,18 +31,18 @@
 require "spec_helper"
 
 RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
-  subject(:service) { described_class.new(target_project:) }
+  subject(:service) { described_class.new(target_project:, source_project_id: source_project.id) }
 
   let(:source_project) { create(:project, identifier: "SRC") }
   let(:target_project) { create(:project, identifier: "TGT") }
 
   # Simulate a WP that was created in source_project (callback allocates "SRC-N")
-  # and then moved to target_project (UpdateService changes project_id first).
-  # sequence_number is nilled out to avoid unique index collisions with the
-  # new allocation — the service is responsible for setting it on target.
+  # and then moved to target_project via UpdateService (which nils sequence_number
+  # to avoid unique index collisions, then saves with the new project_id).
+  # We use update! to preserve dirty tracking so project_id_before_last_save works.
   let(:work_package) do
     create(:work_package, project: source_project).tap do |wp|
-      wp.update_columns(project_id: target_project.id, sequence_number: nil)
+      wp.update!(project: target_project, sequence_number: nil)
     end
   end
 
@@ -62,13 +62,16 @@ RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
       expect(target_project.reload.wp_sequence_counter).to eq(1)
     end
 
-    it "records the old identifier in FriendlyId slug history" do
+    it "records the move in work_package_moves" do
       service.call([work_package])
 
-      expect(FriendlyId::Slug.where(slug: "SRC-1", sluggable_type: "WorkPackage")).to exist
+      move = WorkPackageMove.find_by(work_package_id: work_package.id)
+      expect(move).to be_present
+      expect(move.source_project_id).to eq(source_project.id)
+      expect(move.sequence_number).to eq(1)
     end
 
-    it "makes the old identifier resolvable" do
+    it "makes the old identifier resolvable via move resolution" do
       service.call([work_package])
 
       expect(WorkPackage.friendly.find("SRC-1")).to eq(work_package)
@@ -86,7 +89,7 @@ RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
 
     it "allocates sequential numbers for multiple work packages" do
       wp2 = create(:work_package, project: source_project).tap do |wp|
-        wp.update_columns(project_id: target_project.id, sequence_number: nil)
+        wp.update!(project: target_project, sequence_number: nil)
       end
 
       service.call([work_package, wp2])
@@ -97,7 +100,8 @@ RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
 
     it "skips work packages without identifiers" do
       wp_without_id = create(:work_package, project: source_project)
-      wp_without_id.update_columns(project_id: target_project.id, identifier: nil, sequence_number: nil)
+      wp_without_id.update_columns(identifier: nil, sequence_number: nil)
+      wp_without_id.update!(project: target_project)
 
       expect { service.call([wp_without_id]) }
         .not_to change { target_project.reload.wp_sequence_counter }
@@ -111,7 +115,7 @@ RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
 
     let(:work_package) do
       create(:work_package, project: source_project).tap do |wp|
-        wp.update_columns(project_id: target_project.id)
+        wp.update!(project: target_project)
       end
     end
 

--- a/spec/services/work_packages/reallocate_identifiers_on_move_service_spec.rb
+++ b/spec/services/work_packages/reallocate_identifiers_on_move_service_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe WorkPackages::ReallocateIdentifiersOnMoveService do
     it "makes the old identifier resolvable via move resolution" do
       service.call([work_package])
 
-      expect(WorkPackage.friendly.find("SRC-1")).to eq(work_package)
-      expect(WorkPackage.friendly.find("TGT-1")).to eq(work_package)
+      expect(WorkPackage.find("SRC-1")).to eq(work_package)
+      expect(WorkPackage.find("TGT-1")).to eq(work_package)
     end
 
     it "continues from the target project's existing counter" do

--- a/spec/services/work_packages/update_identifiers_on_rename_service_spec.rb
+++ b/spec/services/work_packages/update_identifiers_on_rename_service_spec.rb
@@ -63,16 +63,18 @@ RSpec.describe WorkPackages::UpdateIdentifiersOnRenameService do
       expect(wp2.reload.sequence_number).to eq(2)
     end
 
-    it "records old identifiers in FriendlyId slug history" do
-      service.call
-
-      expect(FriendlyId::Slug.where(slug: "SC-1", sluggable_type: "WorkPackage")).to exist
-      expect(FriendlyId::Slug.where(slug: "SC-2", sluggable_type: "WorkPackage")).to exist
+    it "does not write any FriendlyId slugs for work packages" do
+      expect { service.call }
+        .not_to change { FriendlyId::Slug.where(sluggable_type: "WorkPackage").count }
     end
 
-    it "makes old identifiers resolvable via FriendlyId" do
+    it "makes old identifiers resolvable via structural resolution" do
+      # Record the old project identifier in FriendlyId slug history (as Projects::SetAttributesService does)
+      FriendlyId::Slug.create!(slug: "SC", sluggable: project, sluggable_type: "Project")
+
       service.call
 
+      # Old prefix resolves via Project FriendlyId history + structural lookup
       expect(WorkPackage.friendly.find("SC-1")).to eq(wp1)
       expect(WorkPackage.friendly.find("SCO-1")).to eq(wp1)
     end

--- a/spec/services/work_packages/update_identifiers_on_rename_service_spec.rb
+++ b/spec/services/work_packages/update_identifiers_on_rename_service_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe WorkPackages::UpdateIdentifiersOnRenameService do
       service.call
 
       # Old prefix resolves via Project FriendlyId history + structural lookup
-      expect(WorkPackage.friendly.find("SC-1")).to eq(wp1)
-      expect(WorkPackage.friendly.find("SCO-1")).to eq(wp1)
+      expect(WorkPackage.find("SC-1")).to eq(wp1)
+      expect(WorkPackage.find("SCO-1")).to eq(wp1)
     end
   end
 

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -453,8 +453,8 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
         it "makes the old identifier resolvable" do
           subject
 
-          expect(WorkPackage.friendly.find("SRC-1")).to eq(work_package)
-          expect(WorkPackage.friendly.find("TGT-1")).to eq(work_package)
+          expect(WorkPackage.find("SRC-1")).to eq(work_package)
+          expect(WorkPackage.find("TGT-1")).to eq(work_package)
         end
 
         it "increments the target project's wp_sequence_counter" do

--- a/spec/services/work_packages/update_service_integration_spec.rb
+++ b/spec/services/work_packages/update_service_integration_spec.rb
@@ -441,10 +441,13 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
           expect(work_package.sequence_number).to eq(1)
         end
 
-        it "records the old identifier in FriendlyId slug history" do
+        it "records the move in work_package_moves" do
           subject
 
-          expect(FriendlyId::Slug.where(slug: "SRC-1", sluggable_type: "WorkPackage")).to exist
+          move = WorkPackageMove.find_by(work_package_id: work_package.id)
+          expect(move).to be_present
+          expect(move.source_project_id).to eq(source_project.id)
+          expect(move.sequence_number).to eq(1)
         end
 
         it "makes the old identifier resolvable" do
@@ -497,11 +500,11 @@ RSpec.describe WorkPackages::UpdateService, "integration", type: :model do
             expect(child_wp.reload.identifier).to eq("TGT-2")
           end
 
-          it "records old identifiers for all moved work packages" do
+          it "records moves for all moved work packages" do
             subject
 
-            expect(FriendlyId::Slug.where(slug: "SRC-1", sluggable_type: "WorkPackage")).to exist
-            expect(FriendlyId::Slug.where(slug: "SRC-2", sluggable_type: "WorkPackage")).to exist
+            expect(WorkPackageMove.where(source_project_id: source_project.id).pluck(:sequence_number))
+              .to contain_exactly(1, 2)
           end
         end
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/73433

# What are you trying to accomplish?

This is the compute-on-read alternative to the [FriendlyId tracking POC (PR #22474)](https://github.com/opf/openproject/pull/22474). Both branches share the same data layer — `work_packages.identifier`, `work_packages.sequence_number`, counter cache allocation — but differ in how old identifiers are resolved after renames and moves.

Where the tracking POC pre-stores every historical identifier in `friendly_id_slugs`, this branch derives resolution at query time by structurally parsing identifiers and delegating to Project's own FriendlyId history. No slug rows are ever written for work packages.

The feature is gated behind `Setting::WorkPackageIdentifier` and is a no-op when the system is in numeric mode (the default).

# What approach did you choose and why?

The core insight is that a work package identifier like `SC-3` is structurally decomposable: `SC` is a project identifier and `3` is a sequence number. Since Project already has FriendlyId with `:history` tracking old identifiers, we can resolve any historical work package identifier by parsing it, resolving the project prefix (current or historical), and looking up by `(project_id, sequence_number)`.

This means the `identifier` column on `work_packages` is a denormalized cache for display and API responses — never a lookup key. FriendlyId is not used on WorkPackage at all. Instead, a standalone `FinderMethods` module overrides `find` and `exists?` directly, wired into both the model class and its relation class so `WorkPackage.find("SC-3")` and `WorkPackage.visible.find("SC-3")` both work transparently. The module reuses FriendlyId's `Object#friendly_id?` (already globally available for Project) for numeric vs string dispatch.

Resolution chain:
1. **Structural**: parse `PREFIX-SEQ` → `Project.friendly.find(prefix)` → `find_by(project_id:, sequence_number:)`
2. **Move fallback**: check `work_package_moves` for WPs that left a project with that sequence number
3. **Numeric fallback**: delegate to ActiveRecord (primary key lookup)

Cross-project moves are the one case that can't be resolved purely from project history — if WP `SRC-5` moves to `TGT-1`, there's no structural link from `SRC-5` to the new location. A lightweight `work_package_moves` table records `(work_package_id, source_project_id, sequence_number)` at move time, giving the finder a fallback path. This table grows only with moves (O(m)), not with renames.

Project renames need just a single bulk `UPDATE` to refresh the cached `identifier` column — no slug recording, no history table writes. Old identifiers resolve automatically through Project's FriendlyId history.

## Trade-offs vs the tracking POC

| | Tracking (PR #22474) | Compute-on-read (this PR) |
|---|---|---|
| **Write amplification** | O(n) slug inserts on rename/move | Zero on rename, O(m) move records on move |
| **Storage** | `friendly_id_slugs` grows with every rename × WP count | `work_package_moves` grows only with actual moves |
| **Read path** | Single index lookup on `friendly_id_slugs` | Parse + project lookup + sequence lookup (2-3 queries) |
| **Dependency** | FriendlyId `:finders` + `:history` on WorkPackage | No FriendlyId on WorkPackage (standalone FinderMethods) |
| **Complexity** | More machinery on writes | More machinery on reads |

# Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~ N/A — no UI changes
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~ N/A — backend only
