### PR TITLE
[73401] Hierarchy/WIL project attributes do not open with tree expanded

### DIFF
--- a/app/helpers/custom_field_hierarchy_tree_view_helper.rb
+++ b/app/helpers/custom_field_hierarchy_tree_view_helper.rb
@@ -71,7 +71,7 @@ module CustomFieldHierarchyTreeViewHelper
       checked: options[:checked_fn]&.call(item) || false,
       current: options[:current] == item,
       disabled: options[:disabled]&.include?(item) || false,
-      expanded: options[:expanded]&.include?(item) || false,
+      expanded: options[:expanded_fn]&.call(item) || options[:expanded]&.include?(item) || false,
       href: options[:href_fn]&.call(item)
     }
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73401

# What are you trying to accomplish?
Expand the filterableTreeView in the inplaceEditFields per default. We will have to test whether very long lists may cause problems in production