### PR TITLE
[73403] Broken back navigation from board page

### DIFF
--- a/modules/boards/app/components/boards/row_component.rb
+++ b/modules/boards/app/components/boards/row_component.rb
@@ -35,7 +35,7 @@ module Boards
     end
 
     def name
-      link_to model.name, project_work_package_board_path(model.project, model)
+      link_to model.name, project_work_package_board_path(model.project, model), data: { turbo: false }
     end
 
     def created_at


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73403

# What are you trying to accomplish?
Use `turbo: false` to allow correct rendering on browser back

