### PR TITLE
Cleanup crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -81,8 +81,9 @@ jobs:
           OPENPROJECT_CROWDIN_PROJECT: ${{ secrets.OPENPROJECT_CROWDINV2_PROJECT }}
           OPENPROJECT_CROWDIN_API_KEY: ${{ secrets.OPENPROJECT_CROWDINV2_API_KEY }}
       - name: "Fix root key in Portuguese crowdin translation files"
-        run: |
-          script/i18n/fix_crowdin_pt_language_root_key
+        run: script/i18n/fix_crowdin_pt_language_root_key
+      - name: "Rewrite crowdin translation files using ruby yaml library"
+        run: script/i18n/rewrite_crowdin_yml_files
       - name: "Commit translations"
         env:
           BRANCH: ${{ matrix.branch }}

--- a/script/i18n/fix_crowdin_pt_language_root_key
+++ b/script/i18n/fix_crowdin_pt_language_root_key
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-echo "Fixing language root key in pt-BR and pt-PT crowdin files to match the filename"
 if [ "$(uname -s)" = "Darwin" ]; then
-  sed -i '' 's/^pt:/pt-BR:/' config/locales/crowdin/*pt-BR*.yml modules/*/config/locales/crowdin/*pt-BR*.yml
-  sed -i '' 's/^pt:/pt-PT:/' config/locales/crowdin/*pt-PT*.yml modules/*/config/locales/crowdin/*pt-PT*.yml
+  sed_inplace() { sed -i '' "$@"; }
 else
-  sed -i 's/^pt:/pt-BR:/' config/locales/crowdin/*pt-BR*.yml modules/*/config/locales/crowdin/*pt-BR*.yml
-  sed -i 's/^pt:/pt-PT:/' config/locales/crowdin/*pt-PT*.yml modules/*/config/locales/crowdin/*pt-PT*.yml
+  sed_inplace() { sed -i "$@"; }
 fi
+
+echo "Fixing language root key in pt-BR and pt-PT crowdin files to match the filename"
+sed_inplace 's/^pt:/pt-BR:/' config/locales/crowdin/*pt-BR*.yml modules/*/config/locales/crowdin/*pt-BR*.yml
+sed_inplace 's/^pt:/pt-PT:/' config/locales/crowdin/*pt-PT*.yml modules/*/config/locales/crowdin/*pt-PT*.yml


### PR DESCRIPTION
Improvements to crowdin workflow:
* ~~Use fork of crowdin action to create files with runner owner instead of changing owner afterwards (crowdin/github-action#309)~~ => #22554
* Rewrite downloaded yamls using `script/i18n/rewrite_crowdin_yml_files` (#22533 should be merged first, as script should be both in dev and latest release branches). This should simplify the logic in #22249
* Cleanup `script/i18n/fix_crowdin_pt_language_root_key` a bit