### PR TITLE
Introduce SubclassResponsibility error

### DIFF
--- a/app/components/individual_principal_base_filter_component.rb
+++ b/app/components/individual_principal_base_filter_component.rb
@@ -75,7 +75,7 @@ class IndividualPrincipalBaseFilterComponent < ApplicationComponent
     end
 
     def base_query
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     protected
@@ -93,7 +93,7 @@ class IndividualPrincipalBaseFilterComponent < ApplicationComponent
   # INSTANCE METHODS:
 
   def filter_path
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def initially_visible?

--- a/app/components/op_primer/email_updates_mode_selector_component.rb
+++ b/app/components/op_primer/email_updates_mode_selector_component.rb
@@ -38,7 +38,7 @@ module OpPrimer
       super()
 
       if !show_button && alt_text.blank?
-        raise NotImplementedError, "alt_text must be provided when the button is shown conditionally"
+        raise ArgumentError, "alt_text must be provided when the button is shown conditionally"
 
       end
 

--- a/app/components/op_primer/status_button_component.rb
+++ b/app/components/op_primer/status_button_component.rb
@@ -50,7 +50,7 @@ module OpPrimer
     end
 
     def default_button_title
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def disabled?

--- a/app/components/work_packages/exports/base_export_settings_component.rb
+++ b/app/components/work_packages/exports/base_export_settings_component.rb
@@ -40,7 +40,7 @@ module WorkPackages
       end
 
       def format
-        raise NotImplementedError, "Must be overridden in subclass"
+        raise SubclassResponsibilityError
       end
 
       def export_settings

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -122,7 +122,7 @@ module Projects
     end
 
     def manage_permission
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def with_unchanged_id

--- a/app/contracts/shares/base_contract.rb
+++ b/app/contracts/shares/base_contract.rb
@@ -48,7 +48,7 @@ module Shares
     end
 
     def user_allowed_to_manage?
-      raise NotImplementedError, "Must be overridden by subclass"
+      raise SubclassResponsibilityError
     end
 
     def single_non_inherited_role
@@ -76,7 +76,7 @@ module Shares
     end
 
     def assignable_role_class
-      raise NotImplementedError, "Must be overridden by subclass"
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
+++ b/app/controllers/admin/custom_fields/hierarchy/items_base_controller.rb
@@ -227,7 +227,7 @@ module Admin
         end
 
         def find_custom_field
-          raise NotImplementedError, "SubclassResponsibility"
+          raise SubclassResponsibilityError
         end
 
         def find_active_item

--- a/app/controllers/admin/settings/enumerations_controller_base.rb
+++ b/app/controllers/admin/settings/enumerations_controller_base.rb
@@ -136,7 +136,7 @@ module Admin
       end
 
       def enumeration_class
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def enumeration_permitted_params

--- a/app/controllers/concerns/custom_fields/attribute_help_text_actions.rb
+++ b/app/controllers/concerns/custom_fields/attribute_help_text_actions.rb
@@ -51,11 +51,11 @@ module CustomFields
     end
 
     def show_path
-      raise NotImplementedError, "#{self.class} must implement #show_path"
+      raise SubclassResponsibilityError, "#{self.class} must implement #show_path"
     end
 
     def render_attribute_help_text_form(status: :ok)
-      raise NotImplementedError, "#{self.class} must implement #render_attribute_help_text_form"
+      raise SubclassResponsibilityError, "#{self.class} must implement #render_attribute_help_text_form"
     end
 
     def find_or_initialize_attribute_help_text

--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -69,7 +69,7 @@ module CustomFields::CustomFieldRendering
   end
 
   def custom_fields
-    raise NotImplementedError, "#custom_fields method needs to be overwritten and provide all custom fields we want to show"
+    raise SubclassResponsibilityError, "#custom_fields needs to be overwritten and provide all custom fields we want to show"
   end
 
   private

--- a/app/forms/custom_fields/inputs/base/autocomplete/multi_value_input.rb
+++ b/app/forms/custom_fields/inputs/base/autocomplete/multi_value_input.rb
@@ -49,7 +49,7 @@ class CustomFields::Inputs::Base::Autocomplete::MultiValueInput < CustomFields::
   end
 
   def decorated?
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def custom_values

--- a/app/forms/custom_fields/inputs/base/autocomplete/single_value_input.rb
+++ b/app/forms/custom_fields/inputs/base/autocomplete/single_value_input.rb
@@ -49,6 +49,6 @@ class CustomFields::Inputs::Base::Autocomplete::SingleValueInput < CustomFields:
   end
 
   def decorated?
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/app/menus/submenu.rb
+++ b/app/menus/submenu.rb
@@ -72,7 +72,7 @@ class Submenu
   end
 
   def default_queries
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def global_queries
@@ -150,7 +150,7 @@ class Submenu
   end
 
   def query_path(query_params)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def url_helpers

--- a/app/models/activities/event_mapper.rb
+++ b/app/models/activities/event_mapper.rb
@@ -77,11 +77,11 @@ module Activities
     end
 
     def event_data(journal)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def event_title(journal, data)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/app/models/attribute_help_text.rb
+++ b/app/models/attribute_help_text.rb
@@ -80,15 +80,15 @@ class AttributeHelpText < ApplicationRecord
   end
 
   def type_caption
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def self.visible_condition(_user = nil)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def self.available_attributes
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end
 

--- a/app/models/auth_provider.rb
+++ b/app/models/auth_provider.rb
@@ -49,7 +49,7 @@ class AuthProvider < ApplicationRecord
   end
 
   def human_type
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def auth_url

--- a/app/models/custom_actions/actions/base.rb
+++ b/app/models/custom_actions/actions/base.rb
@@ -42,7 +42,7 @@ class CustomActions::Actions::Base
   end
 
   def allowed_values
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def value_objects
@@ -52,11 +52,11 @@ class CustomActions::Actions::Base
   end
 
   def type
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def apply(_work_package)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def human_name
@@ -64,7 +64,7 @@ class CustomActions::Actions::Base
   end
 
   def self.key
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def self.all

--- a/app/models/custom_actions/actions/custom_field.rb
+++ b/app/models/custom_actions/actions/custom_field.rb
@@ -35,7 +35,7 @@ class CustomActions::Actions::CustomField < CustomActions::Actions::Base
     end
 
     def custom_field
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def all

--- a/app/models/custom_actions/conditions/base.rb
+++ b/app/models/custom_actions/conditions/base.rb
@@ -67,7 +67,7 @@ class CustomActions::Conditions::Base
   end
 
   def self.key
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def validate(errors)

--- a/app/models/custom_value/ar_object_strategy.rb
+++ b/app/models/custom_value/ar_object_strategy.rb
@@ -69,7 +69,7 @@ class CustomValue::ARObjectStrategy < CustomValue::FormatStrategy
   end
 
   def ar_class
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def ar_object(value)

--- a/app/models/custom_value/format_strategy.rb
+++ b/app/models/custom_value/format_strategy.rb
@@ -42,7 +42,7 @@ class CustomValue::FormatStrategy
   # Returns the value of the CustomValue in a typed fashion (i.e. not as the string
   # that is used for representation in the database)
   def typed_value
-    raise "SubclassResponsibility"
+    raise SubclassResponsibilityError
   end
 
   # Returns the value of the CustomValue formatted to a string
@@ -59,6 +59,6 @@ class CustomValue::FormatStrategy
   # Validates the type of the custom field and returns a symbol indicating the validation error
   # if an error occurred; returns nil if no error occurred
   def validate_type_of_value
-    raise "SubclassResponsibility"
+    raise SubclassResponsibilityError
   end
 end

--- a/app/models/exports/exporter.rb
+++ b/app/models/exports/exporter.rb
@@ -63,7 +63,7 @@ module Exports
 
     # Run the export, yielding the result of the render output
     def export!
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     protected

--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -137,7 +137,7 @@ class Principal < ApplicationRecord
 
   # Columns required for formatting the principal's name.
   def self.columns_for_name(formatter = nil)
-    raise NotImplementedError, "Redefine in subclass" unless self == Principal
+    raise SubclassResponsibilityError, "Redefine in subclass" unless self == Principal
 
     [User, Group, PlaceholderUser].map { it.columns_for_name(formatter) }.inject(:|)
   end

--- a/app/models/queries/filters/base.rb
+++ b/app/models/queries/filters/base.rb
@@ -79,11 +79,11 @@ class Queries::Filters::Base
   end
 
   def human_name
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def type
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def allowed_values

--- a/app/models/queries/filters/shared/parsed_filter.rb
+++ b/app/models/queries/filters/shared/parsed_filter.rb
@@ -50,11 +50,11 @@ module Queries::Filters::Shared::ParsedFilter
   private
 
   def split_values
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def value_conditions
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def validate_values

--- a/app/models/queries/filters/strategies/numeric.rb
+++ b/app/models/queries/filters/strategies/numeric.rb
@@ -42,11 +42,11 @@ module Queries::Filters::Strategies
     private
 
     def numeric_class
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def error_message
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def validate_values_all_numeric

--- a/app/models/queries/group_bys/base.rb
+++ b/app/models/queries/group_bys/base.rb
@@ -45,7 +45,7 @@ module Queries
       end
 
       def self.key
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def association_class

--- a/app/models/queries/operators/base.rb
+++ b/app/models/queries/operators/base.rb
@@ -53,7 +53,7 @@ module Queries::Operators
     end
 
     def self.sql_for_field(_values, _db_table, _db_field)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def self.connection

--- a/app/models/queries/orders/base.rb
+++ b/app/models/queries/orders/base.rb
@@ -50,7 +50,7 @@ module Queries
       end
 
       def self.key
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def apply_to(query_scope)

--- a/app/models/queries/projects/filters/dynamically_from_project_phase.rb
+++ b/app/models/queries/projects/filters/dynamically_from_project_phase.rb
@@ -56,7 +56,7 @@ module Queries::Projects::Filters::DynamicallyFromProjectPhase
     end
 
     def key
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     private
@@ -77,7 +77,7 @@ module Queries::Projects::Filters::DynamicallyFromProjectPhase
     end
 
     def create_from_phase(_phase, _context)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def accessor_matches?(definition, match)

--- a/app/models/queries/projects/filters/filter_on_project_phase.rb
+++ b/app/models/queries/projects/filters/filter_on_project_phase.rb
@@ -74,23 +74,23 @@ module Queries::Projects::Filters::FilterOnProjectPhase
   private
 
   def on_date
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def on_today
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def between_date
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def this_week
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def none
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def project_phase_scope_limit(scope)

--- a/app/models/queries/relations/filters/visibility_checking.rb
+++ b/app/models/queries/relations/filters/visibility_checking.rb
@@ -54,7 +54,7 @@ module Queries
         private
 
         def visibility_checked_sql(_operator, _values, _visible_sql)
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
       end
     end

--- a/app/models/queries/selects/base.rb
+++ b/app/models/queries/selects/base.rb
@@ -32,7 +32,7 @@ class Queries::Selects::Base
   include ActiveModel::Validations
 
   def self.key
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def self.available?

--- a/app/models/queries/work_packages/filter/attachment_base_filter.rb
+++ b/app/models/queries/work_packages/filter/attachment_base_filter.rb
@@ -68,7 +68,7 @@ class Queries::WorkPackages::Filter::AttachmentBaseFilter < Queries::WorkPackage
   end
 
   def search_column
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def normalization_type

--- a/app/models/queries/work_packages/filter/filter_on_directed_relations_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_on_directed_relations_mixin.rb
@@ -47,7 +47,7 @@ module Queries::WorkPackages::Filter::FilterOnDirectedRelationsMixin
   end
 
   def relation_type
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def normalized_relation_type
@@ -57,10 +57,10 @@ module Queries::WorkPackages::Filter::FilterOnDirectedRelationsMixin
   private
 
   def relation_filter
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def relation_select
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/app/models/queries/work_packages/filter/filter_on_undirected_relations_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_on_undirected_relations_mixin.rb
@@ -42,7 +42,7 @@ module Queries::WorkPackages::Filter::FilterOnUndirectedRelationsMixin
   end
 
   def relation_type
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   private

--- a/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/or_filter_for_wp_mixin.rb
@@ -50,7 +50,7 @@ module Queries::WorkPackages::Filter::OrFilterForWpMixin
   end
 
   def filter_configurations
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def create_instances

--- a/app/models/sharing_strategies/base_strategy.rb
+++ b/app/models/sharing_strategies/base_strategy.rb
@@ -40,36 +40,36 @@ module SharingStrategies
 
     def available_roles
       # format: [{ label: "Role name", value: 42, description: "Role description", default: true }]
-      raise NotImplementedError, "Override in a subclass and return an array of roles that should be displayed"
+      raise SubclassResponsibilityError, "Override in a subclass and return an array of roles that should be displayed"
     end
 
     def viewable?
-      raise NotImplementedError,
+      raise SubclassResponsibilityError,
             "Override in a subclass and return true if the current user can view who the entity is shared with"
     end
 
     def manageable?
-      raise NotImplementedError, "Override in a subclass and return true if the current user can manage sharing"
+      raise SubclassResponsibilityError, "Override in a subclass and return true if the current user can manage sharing"
     end
 
     def create_contract_class
-      raise NotImplementedError, "Override in a subclass and return the contract class for creating a share"
+      raise SubclassResponsibilityError, "Override in a subclass and return the contract class for creating a share"
     end
 
     def update_contract_class
-      raise NotImplementedError, "Override in a subclass and return the contract class for updating a share"
+      raise SubclassResponsibilityError, "Override in a subclass and return the contract class for updating a share"
     end
 
     def delete_contract_class
-      raise NotImplementedError, "Override in a subclass and return the contract class for deleting a share"
+      raise SubclassResponsibilityError, "Override in a subclass and return the contract class for deleting a share"
     end
 
     def share_description(share)
-      raise NotImplementedError, "Override in a subclass and return a description for the shared user"
+      raise SubclassResponsibilityError, "Override in a subclass and return a description for the shared user"
     end
 
     def title
-      raise NotImplementedError, "Override in a subclass and return a title for the sharing dialog"
+      raise SubclassResponsibilityError, "Override in a subclass and return a title for the sharing dialog"
     end
 
     def enterprise_feature

--- a/app/models/type/form_group.rb
+++ b/app/models/type/form_group.rb
@@ -57,10 +57,10 @@ class Type::FormGroup
   end
 
   def members
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def active_members(_project)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -103,10 +103,10 @@ class UserPassword < ApplicationRecord
 
   # Require the implementation to provide a secure comparison
   def hash_matches?(_plain)
-    raise NotImplementedError, "Must be overridden by subclass"
+    raise SubclassResponsibilityError
   end
 
   def derive_password!(_input)
-    raise NotImplementedError, "Must be overridden by subclass"
+    raise SubclassResponsibilityError
   end
 end

--- a/app/models/users/function_user.rb
+++ b/app/models/users/function_user.rb
@@ -45,7 +45,7 @@ module Users::FunctionUser
 
     def builtin? = true
 
-    def name(*_args); raise NotImplementedError end
+    def name(*_args) = raise SubclassResponsibilityError
 
     def mail = nil
 

--- a/app/policies/scm/authorization_policy.rb
+++ b/app/policies/scm/authorization_policy.rb
@@ -51,7 +51,7 @@ class SCM::AuthorizationPolicy
   # Determines whether the given request is a read access
   # Must be implemented by descendents of this policy.
   def readonly_request?(_params)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   ##

--- a/app/seeders/basic_data/model_seeder.rb
+++ b/app/seeders/basic_data/model_seeder.rb
@@ -68,7 +68,7 @@ module BasicData
     end
 
     def model_attributes(model_data)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def applicable?

--- a/app/seeders/basic_data_seeder.rb
+++ b/app/seeders/basic_data_seeder.rb
@@ -29,7 +29,7 @@
 #++
 class BasicDataSeeder < CompositeSeeder
   def data_seeder_classes
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def namespace

--- a/app/seeders/composite_seeder.rb
+++ b/app/seeders/composite_seeder.rb
@@ -50,7 +50,7 @@ class CompositeSeeder < Seeder
   end
 
   def data_seeder_classes
-    raise NotImplementedError, "has to be implemented by subclasses"
+    raise SubclassResponsibilityError
   end
 
   def discovered_seeders
@@ -71,7 +71,7 @@ class CompositeSeeder < Seeder
   end
 
   def namespace
-    raise NotImplementedError, "has to be implemented by subclasses"
+    raise SubclassResponsibilityError
   end
 
   ##

--- a/app/seeders/seeder.rb
+++ b/app/seeders/seeder.rb
@@ -68,7 +68,7 @@ class Seeder
   end
 
   def seed_data!
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def applicable?

--- a/app/services/api/parse_resource_params_service.rb
+++ b/app/services/api/parse_resource_params_service.rb
@@ -60,7 +60,7 @@ module API
     private
 
     def deduce_representer(_model)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def parsing_representer

--- a/app/services/base_services/base_callable.rb
+++ b/app/services/base_services/base_callable.rb
@@ -59,7 +59,7 @@ module BaseServices
     attr_accessor :params
 
     def perform(*)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     private

--- a/app/services/base_services/base_contracted.rb
+++ b/app/services/base_services/base_contracted.rb
@@ -117,7 +117,7 @@ module BaseServices
     end
 
     def default_contract_class
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def namespace

--- a/app/services/base_services/write.rb
+++ b/app/services/base_services/write.rb
@@ -67,11 +67,11 @@ module BaseServices
     end
 
     def instance(_params)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def default_contract_class
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def instance_class

--- a/app/services/bulk_services/project_mappings/base_create_service.rb
+++ b/app/services/bulk_services/project_mappings/base_create_service.rb
@@ -107,12 +107,12 @@ module BulkServices
 
       # @return [Symbol] the permission required to create the mapping
       def permission
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       # @return [Symbol] the column name of the mapping
       def model_foreign_key_id
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def attributes_service_class

--- a/app/services/bulk_services/project_mappings/mapping_context_base.rb
+++ b/app/services/bulk_services/project_mappings/mapping_context_base.rb
@@ -39,11 +39,11 @@ module BulkServices
       end
 
       def mapping_attributes_for_all_projects(params)
-        raise NotImplementedError, "This method must be implemented in a subclass"
+        raise SubclassResponsibilityError
       end
 
       def incoming_projects
-        raise NotImplementedError, "This method must be implemented in a subclass"
+        raise SubclassResponsibilityError
       end
     end
   end

--- a/app/services/copy/dependency.rb
+++ b/app/services/copy/dependency.rb
@@ -96,7 +96,7 @@ module Copy
     end
 
     def copy_dependency(params:)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
+++ b/app/services/custom_fields/hierarchy/hierarchical_item_service.rb
@@ -159,9 +159,9 @@ module CustomFields
         Success()
       end
 
+      # Soft delete the item and children
       def soft_delete_item(item:)
-        # Soft delete the item and children
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       # Returns a hash of Item => { Item => [Item] }

--- a/app/services/groups/concerns/membership_manipulation.rb
+++ b/app/services/groups/concerns/membership_manipulation.rb
@@ -65,7 +65,7 @@ module Groups::Concerns
     end
 
     def modify_members_and_roles(_params)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def execute_query(query)

--- a/app/services/incoming_emails/handlers/base.rb
+++ b/app/services/incoming_emails/handlers/base.rb
@@ -41,12 +41,12 @@ module IncomingEmails::Handlers
 
     # Override in subclasses to determine if this handler can process the email
     def self.handles?(email, reference:, automated_email:)
-      raise NotImplementedError, "Subclasses must implement can_handle? method"
+      raise SubclassResponsibilityError, "Subclasses must implement handles? method"
     end
 
     # Override in subclasses to process the email
     def process
-      raise NotImplementedError, "Subclasses must implement handle method"
+      raise SubclassResponsibilityError, "Subclasses must implement process method"
     end
 
     def cleaned_up_text_body

--- a/app/services/ldap/base_service.rb
+++ b/app/services/ldap/base_service.rb
@@ -45,7 +45,7 @@ module Ldap
     end
 
     def perform
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     protected

--- a/app/services/members/concerns/notification_sender.rb
+++ b/app/services/members/concerns/notification_sender.rb
@@ -55,7 +55,7 @@ module Members::Concerns::NotificationSender
     end
 
     def event_type
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/app/services/reports/report.rb
+++ b/app/services/reports/report.rb
@@ -47,18 +47,18 @@ class Reports::Report
 
   # ---- every report needs to implement these methods to supply all needed data for a report -----
   def field
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def rows
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def data
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def title
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/app/services/work_packages/bulk/bulked_service.rb
+++ b/app/services/work_packages/bulk/bulked_service.rb
@@ -73,11 +73,11 @@ module WorkPackages
       end
 
       def alter_work_package(_work_package, _params)
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def call_move_hook(_work_package, _params)
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
     end
   end

--- a/app/workers/exports/export_job.rb
+++ b/app/workers/exports/export_job.rb
@@ -66,7 +66,7 @@ module Exports
     attr_accessor :export, :current_user, :mime_type, :query, :options
 
     def prepare!
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def list_export?

--- a/app/workers/mails/deliver_job.rb
+++ b/app/workers/mails/deliver_job.rb
@@ -57,12 +57,12 @@ class Mails::DeliverJob < ApplicationJob
   # To be implemented by subclasses.
   # Returns a Mail::Message, or nil if no message should be sent.
   def render_mail
-    raise NotImplementedError, "SubclassResponsibility"
+    raise SubclassResponsibilityError
   end
 
   def build_mail
     render_mail
-  rescue NotImplementedError
+  rescue SubclassResponsibilityError
     # Notify subclass of the need to implement
     raise
   rescue StandardError => e

--- a/app/workers/mails/member_job.rb
+++ b/app/workers/mails/member_job.rb
@@ -69,11 +69,11 @@ class Mails::MemberJob < ApplicationJob
   end
 
   def send_for_group_user(_current_user, _member, _group, _message)
-    raise NotImplementedError, "subclass responsibility"
+    raise SubclassResponsibilityError
   end
 
   def send_for_project_user(_current_user, _member, _message)
-    raise NotImplementedError, "subclass responsibility"
+    raise SubclassResponsibilityError
   end
 
   def send_updated_global(current_user, member, member_message)

--- a/app/workers/mails/watcher_job.rb
+++ b/app/workers/mails/watcher_job.rb
@@ -73,6 +73,6 @@ class Mails::WatcherJob < Mails::DeliverJob
   end
 
   def action
-    raise NotImplementedError, "subclass responsibility"
+    raise SubclassResponsibilityError
   end
 end

--- a/app/workers/work_packages/bulk_job.rb
+++ b/app/workers/work_packages/bulk_job.rb
@@ -72,7 +72,7 @@ module WorkPackages
     end
 
     def service_class
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def successful_status_update(call)

--- a/db/migrate/tables/base.rb
+++ b/db/migrate/tables/base.rb
@@ -56,6 +56,6 @@ class Tables::Base
   end
 
   def self.table(_migration)
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/lib/api/decorators/simple_form.rb
+++ b/lib/api/decorators/simple_form.rb
@@ -53,15 +53,15 @@ module API
       end
 
       def commit_method
-        raise NotImplementedError, "subclass responsibility"
+        raise SubclassResponsibilityError
       end
 
       def form_url
-        raise NotImplementedError, "subclass responsibility"
+        raise SubclassResponsibilityError
       end
 
       def resource_url
-        raise NotImplementedError, "subclass responsibility"
+        raise SubclassResponsibilityError
       end
 
       def payload_representer
@@ -79,11 +79,11 @@ module API
       end
 
       def contract_class
-        raise NotImplementedError, "subclass responsibility"
+        raise SubclassResponsibilityError
       end
 
       def model
-        raise NotImplementedError, "subclass responsibility"
+        raise SubclassResponsibilityError
       end
 
       private

--- a/lib/api/root_api.rb
+++ b/lib/api/root_api.rb
@@ -303,6 +303,8 @@ module API
 
     error_response ActiveRecord::RecordNotFound, ::API::Errors::NotFound, log: false
     error_response ActiveRecord::StaleObjectError, ::API::Errors::Conflict, log: false
+
+    # TODO: Where do we expect this to be raised and **not** be a programming error?
     error_response NotImplementedError, ::API::Errors::NotImplemented, log: false
 
     error_response MultiJson::ParseError, ::API::Errors::ParseError

--- a/lib/api/utilities/endpoints/bodied.rb
+++ b/lib/api/utilities/endpoints/bodied.rb
@@ -33,7 +33,7 @@ module API
         include NamespacedLookup
 
         def default_instance_generator(_model)
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def default_params_modifier
@@ -146,11 +146,11 @@ module API
         private
 
         def present_success(_request, _call)
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def present_error(_call)
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def success?(call)
@@ -166,15 +166,15 @@ module API
         end
 
         def deduce_parse_representer
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def deduce_parse_service
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def deduce_render_representer
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def deduce_api_namespace
@@ -182,7 +182,7 @@ module API
         end
 
         def update_or_create
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
       end
     end

--- a/lib/api/utilities/endpoints/index.rb
+++ b/lib/api/utilities/endpoints/index.rb
@@ -44,7 +44,7 @@ module API
         end
 
         def mount
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         attr_accessor :model,
@@ -55,7 +55,7 @@ module API
         private
 
         def deduce_render_representer
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def deduce_api_namespace

--- a/lib/api/utilities/endpoints/modify.rb
+++ b/lib/api/utilities/endpoints/modify.rb
@@ -39,7 +39,7 @@ module API
         private
 
         def present_success(_request, _call)
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def present_error(call)

--- a/lib/api/utilities/endpoints/show.rb
+++ b/lib/api/utilities/endpoints/show.rb
@@ -74,7 +74,7 @@ module API
         private
 
         def deduce_render_representer
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         def deduce_api_namespace

--- a/lib/api/utilities/meta_property.rb
+++ b/lib/api/utilities/meta_property.rb
@@ -60,7 +60,7 @@ module API
       end
 
       def meta_representer_class
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
     end
   end

--- a/lib/api/v3/queries/form_representer.rb
+++ b/lib/api/v3/queries/form_representer.rb
@@ -63,19 +63,19 @@ module API
         end
 
         def commit_action
-          raise NotImplementedError, "subclass responsibility"
+          raise SubclassResponsibilityError
         end
 
         def commit_method
-          raise NotImplementedError, "subclass responsibility"
+          raise SubclassResponsibilityError
         end
 
         def form_url
-          raise NotImplementedError, "subclass responsibility"
+          raise SubclassResponsibilityError
         end
 
         def resource_url
-          raise NotImplementedError, "subclass responsibility"
+          raise SubclassResponsibilityError
         end
 
         def payload_representer

--- a/lib/api/v3/queries/schemas/filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/filter_dependency_representer.rb
@@ -82,11 +82,11 @@ module API
           end
 
           def type
-            raise NotImplementedError, "Subclass has to implement #type"
+            raise SubclassResponsibilityError, "Subclass has to implement #type"
           end
 
           def href_callback
-            raise NotImplementedError, "Subclass has to implement #href_callback"
+            raise SubclassResponsibilityError, "Subclass has to implement #href_callback"
           end
 
           attr_accessor :operator

--- a/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/principal_filter_dependency_representer.rb
@@ -47,7 +47,7 @@ module API
           private
 
           def filter_query
-            raise NotImplementedError, "Subclasses need to implement #filter_query"
+            raise SubclassResponsibilityError, "Subclasses need to implement #filter_query"
           end
         end
       end

--- a/lib/api/v3/schemas/schema_collection_representer.rb
+++ b/lib/api/v3/schemas/schema_collection_representer.rb
@@ -56,7 +56,7 @@ module API
         attr_accessor :form_embedded
 
         def model_self_link(_model)
-          raise NotImplementedError, "Subclass has to implement this"
+          raise SubclassResponsibilityError
         end
       end
     end

--- a/lib/api/v3/work_packages/eager_loading/base.rb
+++ b/lib/api/v3/work_packages/eager_loading/base.rb
@@ -39,7 +39,7 @@ module API
           end
 
           def apply(_work_package)
-            raise NotImplementedError
+            raise SubclassResponsibilityError
           end
 
           def self.module

--- a/lib/api/v3/work_packages/schema/base_work_package_schema.rb
+++ b/lib/api/v3/work_packages/schema/base_work_package_schema.rb
@@ -80,7 +80,7 @@ module API
           private
 
           def contract
-            raise NotImplementedError
+            raise SubclassResponsibilityError
           end
         end
       end

--- a/lib/open_project/rate_limiting/base.rb
+++ b/lib/open_project/rate_limiting/base.rb
@@ -92,15 +92,15 @@ module OpenProject
       end
 
       def discriminator(request)
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def default_limit
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def default_period
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
     end
   end

--- a/lib/open_project/scm/adapters/checkout_instructions.rb
+++ b/lib/open_project/scm/adapters/checkout_instructions.rb
@@ -59,7 +59,7 @@ module OpenProject
         ##
         # Returns the checkout command for this vendor
         def checkout_command
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
 
         private

--- a/lib/open_project/text_formatting/formats/base_format.rb
+++ b/lib/open_project/text_formatting/formats/base_format.rb
@@ -32,11 +32,11 @@ module OpenProject::TextFormatting::Formats
   class BaseFormat
     class << self
       def format
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def priority
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def helper

--- a/lib/open_project/text_formatting/formats/base_formatter.rb
+++ b/lib/open_project/text_formatting/formats/base_formatter.rb
@@ -39,7 +39,7 @@ module OpenProject::TextFormatting::Formats
     end
 
     def to_html(text)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     protected

--- a/lib/open_project/text_formatting/matchers/link_handlers/base.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/base.rb
@@ -62,7 +62,7 @@ module OpenProject::TextFormatting::Matchers
       ##
       # Test whether we should try to resolve the given link
       def applicable?
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       ##
@@ -70,7 +70,7 @@ module OpenProject::TextFormatting::Matchers
       # and matchers.
       # If nil is returned, the link remains as-is.
       def call
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def oid

--- a/lib/open_project/text_formatting/matchers/regex_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/regex_matcher.rb
@@ -63,13 +63,13 @@ module OpenProject::TextFormatting
       ##
       # Get the regexp that matches the content
       def self.regexp
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       ##
       # Called with a match from the regexp on the node's content
       def self.process_match(matchdata, matched_string, context)
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       ##

--- a/lib/subclass_responsibility_error.rb
+++ b/lib/subclass_responsibility_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -21,37 +23,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
+class SubclassResponsibilityError < StandardError
+  def initialize(message = nil)
+    message ||= "The subclass needs to implement this method."
 
-module API
-  module Utilities
-    module RepresenterToJsonCache
-      def to_json(*)
-        if json_cacheable?
-          OpenProject::Cache.fetch(*json_representer_name_cache_key, *json_cache_key) do
-            super
-          end
-        else
-          super
-        end
-      end
-
-      def json_cacheable?
-        true
-      end
-
-      def json_cache_key
-        raise SubclassResponsibilityError
-      end
-
-      private
-
-      def json_representer_name_cache_key
-        self.class.name.to_s.split("::") + ["json", I18n.locale]
-      end
-    end
+    super
   end
 end

--- a/modules/avatars/app/controllers/avatars/base_controller.rb
+++ b/modules/avatars/app/controllers/avatars/base_controller.rb
@@ -32,7 +32,7 @@ module ::Avatars
     private
 
     def redirect_path
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def ensure_enabled

--- a/modules/bim/app/representers/bim/bcf/api/v2_1/viewpoints/base_representer.rb
+++ b/modules/bim/app/representers/bim/bcf/api/v2_1/viewpoints/base_representer.rb
@@ -39,7 +39,7 @@ module Bim::Bcf::API::V2_1
     protected
 
     def scope
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/modules/bim/lib/open_project/bim/bcf_xml/base_writer.rb
+++ b/modules/bim/lib/open_project/bim/bcf_xml/base_writer.rb
@@ -11,7 +11,7 @@ module OpenProject::Bim::BcfXml
     protected
 
     def root_node
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def root_node_attributes

--- a/modules/costs/app/models/cost_scopes.rb
+++ b/modules/costs/app/models/cost_scopes.rb
@@ -18,15 +18,15 @@ module CostScopes
   end
 
   def view_allowed_entries_permission
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def view_allowed_own_entries_permission
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def view_rates_permissions
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def with_visible_costs_on(scope, user: User.current, project: nil)

--- a/modules/costs/app/models/entry/costs.rb
+++ b/modules/costs/app/models/entry/costs.rb
@@ -61,7 +61,7 @@ module Entry::Costs
     end
 
     def cost_attribute
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
   end
 end

--- a/modules/costs/app/models/work_package/abstract_costs.rb
+++ b/modules/costs/app/models/work_package/abstract_costs.rb
@@ -50,15 +50,15 @@ class WorkPackage
     #
     # @return [Class] Class of the model the costs are based on, e.g. CostEntry or TimeEntry.
     def costs_model
-      raise NotImplementedError, "subclass responsibility"
+      raise SubclassResponsibilityError
     end
 
     def costs_sum_alias
-      raise NotImplementedError, "subclass responsibility"
+      raise SubclassResponsibilityError
     end
 
     def subselect_alias
-      raise NotImplementedError, "subclass responsibility"
+      raise SubclassResponsibilityError
     end
 
     private

--- a/modules/grids/app/components/grids/widget_component.rb
+++ b/modules/grids/app/components/grids/widget_component.rb
@@ -49,7 +49,7 @@ module Grids
     # @abstract Subclasses must implement this method.
     # @return [String] a title suitable for display to users.
     def title
-      raise NotImplementedError, "#{self.class} must implement #{__method__}"
+      raise SubclassResponsibilityError, "#{self.class} must implement #{__method__}"
     end
 
     def widget_wrapper(**, &)

--- a/modules/grids/app/controllers/grids/widget_controller.rb
+++ b/modules/grids/app/controllers/grids/widget_controller.rb
@@ -33,7 +33,7 @@ class Grids::WidgetController < Grids::BaseInOptionalProjectController
   include OpTurbo::FlashStreamHelper
 
   def show
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   private

--- a/modules/grids/lib/grids/configuration/registration.rb
+++ b/modules/grids/lib/grids/configuration/registration.rb
@@ -93,7 +93,7 @@ module Grids::Configuration
       end
 
       def from_scope(_scope)
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def all_scopes

--- a/modules/reporting/lib/report/filter.rb
+++ b/modules/reporting/lib/report/filter.rb
@@ -40,6 +40,6 @@ class Report::Filter
   end
 
   def self.from_hash
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/modules/reporting/lib/report/filter/base.rb
+++ b/modules/reporting/lib/report/filter/base.rb
@@ -175,7 +175,7 @@ class Report::Filter
     end
 
     def to_hash
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def transformed_values

--- a/modules/reporting/lib/report/filter/no_filter.rb
+++ b/modules/reporting/lib/report/filter/no_filter.rb
@@ -32,6 +32,6 @@ class Report::Filter::NoFilter < Report::Filter::Base
   singleton
 
   def sql_statement
-    raise NotImplementedError, "My subclass should have overwritten 'sql_statement'"
+    raise SubclassResponsibilityError, "Subclass should have overwritten 'sql_statement'"
   end
 end

--- a/modules/reporting/lib/report/group_by.rb
+++ b/modules/reporting/lib/report/group_by.rb
@@ -42,6 +42,6 @@ class Report::GroupBy
   end
 
   def self.from_hash
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/modules/reporting/lib/widget/base.rb
+++ b/modules/reporting/lib/widget/base.rb
@@ -65,7 +65,7 @@ module ::Widget
     ##
     # Render this widget. Abstract method. Needs to call #write at least once
     def render
-      raise NotImplementedError, "#render is missing in my subclass #{self.class}"
+      raise SubclassResponsibilityError, "#render is missing in subclass #{self.class}"
     end
 
     ##

--- a/modules/storages/app/common/storages/adapters/authentication_strategies/authentication_strategy.rb
+++ b/modules/storages/app/common/storages/adapters/authentication_strategies/authentication_strategy.rb
@@ -36,7 +36,7 @@ module Storages
         include Dry::Monads[:result]
 
         def call(**)
-          raise Errors::SubclassResponsibility
+          raise SubclassResponsibilityError
         end
       end
     end

--- a/modules/storages/app/common/storages/adapters/connection_validators/base_validator_group.rb
+++ b/modules/storages/app/common/storages/adapters/connection_validators/base_validator_group.rb
@@ -38,7 +38,7 @@ module Storages
           new(storage).call
         end
 
-        def self.key = raise ::Storages::Errors::SubclassResponsibility
+        def self.key = raise SubclassResponsibilityError
 
         def initialize(storage)
           @storage = storage
@@ -55,7 +55,7 @@ module Storages
 
         private
 
-        def validate = raise ::Storages::Errors::SubclassResponsibility
+        def validate = raise SubclassResponsibilityError
 
         def register_checks(*keys)
           keys.each { @results.register_check(it) }

--- a/modules/storages/app/common/storages/adapters/oauth_configuration_base.rb
+++ b/modules/storages/app/common/storages/adapters/oauth_configuration_base.rb
@@ -31,11 +31,11 @@
 module Storages
   module Adapters
     class OAuthConfigurationBase
-      def scope = raise ::Storages::Errors::SubclassResponsibility
+      def scope = raise SubclassResponsibilityError
 
-      def basic_rack_oauth_client = raise ::Storages::Errors::SubclassResponsibility
+      def basic_rack_oauth_client = raise SubclassResponsibilityError
 
-      def to_httpx_oauth_config = raise ::Storages::Errors::SubclassResponsibility
+      def to_httpx_oauth_config = raise SubclassResponsibilityError
 
       def authorization_uri(state: nil)
         basic_rack_oauth_client.authorization_uri(scope:, state:)

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/base.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/base.rb
@@ -70,7 +70,7 @@ module Storages
             { drive_id:, location: Peripherals::ParentFolder.new(item_id || "/") }
           end
 
-          def request_uri = raise Errors::SubclassResponsibility
+          def request_uri = raise SubclassResponsibilityError
 
           # @param error [Results::Error]
           # @return [void]

--- a/modules/storages/app/common/storages/errors.rb
+++ b/modules/storages/app/common/storages/errors.rb
@@ -36,12 +36,6 @@ module Storages
 
     class ConfigurationError < BaseError; end
 
-    class SubclassResponsibility < BaseError
-      def message
-        "A subclass needs to implement its own version of this method."
-      end
-    end
-
     class IntegrationJobError < BaseError; end
   end
 end

--- a/modules/storages/app/models/queries/storages/projects/filter/storage_filter_mixin.rb
+++ b/modules/storages/app/models/queries/storages/projects/filter/storage_filter_mixin.rb
@@ -54,6 +54,6 @@ module Queries::Storages::Projects::Filter::StorageFilterMixin
   end
 
   def filter_column
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 end

--- a/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
+++ b/modules/storages/app/models/queries/storages/work_packages/filter/storages_filter_mixin.rb
@@ -41,14 +41,14 @@ module Queries::Storages::WorkPackages::Filter::StoragesFilterMixin
   #
   # Used in the where and joins clauses.
   def filter_model
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   # Returns the column name for which the filter will apply.
   #
   # Used in the where clause.
   def filter_column
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def allowed_values

--- a/modules/storages/app/models/storages/storage.rb
+++ b/modules/storages/app/models/storages/storage.rb
@@ -87,7 +87,7 @@ module Storages
                   .to_h.with_indifferent_access
       end
 
-      def short_provider_name = raise Errors::SubclassResponsibility
+      def short_provider_name = raise SubclassResponsibilityError
 
       def allowed_by_enterprise_token? = true
 
@@ -144,20 +144,20 @@ module Storages
 
     alias automatic_management_enabled automatically_managed
 
-    def available_project_folder_modes = raise Errors::SubclassResponsibility
+    def available_project_folder_modes = raise SubclassResponsibilityError
 
     # Returns a value of an audience, if configured for this storage.
     # The presence of an audience signals that this storage prioritizes
     # remote authentication via Single-Sign-On if possible.
-    def audience = raise Errors::SubclassResponsibility
+    def audience = raise SubclassResponsibilityError
 
-    def authenticate_via_idp? = raise Errors::SubclassResponsibility
+    def authenticate_via_idp? = raise SubclassResponsibilityError
 
-    def authenticate_via_storage? = raise Errors::SubclassResponsibility
+    def authenticate_via_storage? = raise SubclassResponsibilityError
 
     def configured? = configuration_checks.values.all?
 
-    def configuration_checks = raise Errors::SubclassResponsibility
+    def configuration_checks = raise SubclassResponsibilityError
 
     def uri
       return unless host
@@ -174,11 +174,11 @@ module Storages
       ["#{uri.scheme}://#{uri.host}#{port_part}"]
     end
 
-    def oauth_configuration = raise Errors::SubclassResponsibility
+    def oauth_configuration = raise SubclassResponsibilityError
 
-    def automatic_management_new_record? = raise Errors::SubclassResponsibility
+    def automatic_management_new_record? = raise SubclassResponsibilityError
 
-    def provider_fields_defaults = raise Errors::SubclassResponsibility
+    def provider_fields_defaults = raise SubclassResponsibilityError
 
     def non_confidential_configuration
       provider_fields.symbolize_keys

--- a/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
+++ b/modules/two_factor_authentication/app/controllers/two_factor_authentication/base_controller.rb
@@ -147,7 +147,7 @@ module ::TwoFactorAuthentication
     end
 
     def index_path
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     helper_method :index_path

--- a/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
+++ b/modules/two_factor_authentication/app/models/two_factor_authentication/device.rb
@@ -92,7 +92,7 @@ module TwoFactorAuthentication
     end
 
     def self.device_type
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def self.available_channels_in_strategy

--- a/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/base.rb
+++ b/modules/two_factor_authentication/lib/open_project/two_factor_authentication/token_strategy/base.rb
@@ -63,7 +63,7 @@ module OpenProject::TwoFactorAuthentication
       end
 
       def self.identifier
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def self.device_type

--- a/modules/webhooks/app/workers/represented_webhook_job.rb
+++ b/modules/webhooks/app/workers/represented_webhook_job.rb
@@ -73,11 +73,11 @@ class RepresentedWebhookJob < WebhookJob
   end
 
   def payload_key
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def payload_representer_class
-    raise NotImplementedError
+    raise SubclassResponsibilityError
   end
 
   def project_id # rubocop:disable Rails/Delegate

--- a/modules/webhooks/lib/open_project/webhooks/event_resources/base.rb
+++ b/modules/webhooks/lib/open_project/webhooks/event_resources/base.rb
@@ -34,7 +34,7 @@ module OpenProject::Webhooks::EventResources
       end
 
       def available_actions
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       ##
@@ -46,13 +46,13 @@ module OpenProject::Webhooks::EventResources
       ##
       # Get the name of this resource
       def resource_name
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       ##
       # Get the subscriptions for OP::Notifications
       def notification_names
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       protected

--- a/modules/wikis/app/models/wikis/provider.rb
+++ b/modules/wikis/app/models/wikis/provider.rb
@@ -37,7 +37,7 @@ module Wikis
     scope :enabled, -> { where(enabled: true) }
 
     class << self
-      def registry_prefix = raise NotImplementedError, "SubclassResponsibility"
+      def registry_prefix = raise SubclassResponsibilityError
     end
 
     def resolve(registry_path)

--- a/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
+++ b/modules/xls_export/app/models/xls_export/concerns/spreadsheet_builder.rb
@@ -2,11 +2,11 @@ module XlsExport
   module Concerns
     module SpreadsheetBuilder
       def records
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def spreadsheet_title
-        raise NotImplementedError
+        raise SubclassResponsibilityError
       end
 
       def export!

--- a/spec/components/op_primer/email_updates_mode_selector_component_spec.rb
+++ b/spec/components/op_primer/email_updates_mode_selector_component_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe OpPrimer::EmailUpdatesModeSelectorComponent, type: :component do
     let(:alt_text) { nil }
 
     it "throws an error" do
-      expect { render_inline(component) }.to raise_error(NotImplementedError)
+      expect { render_inline(component) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/components/op_primer/status_button_component_spec.rb
+++ b/spec/components/op_primer/status_button_component_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe OpPrimer::StatusButtonComponent, type: :component do
     let(:title) { nil }
 
     it "raises an exception" do
-      expect { render_inline(component) }.to raise_error(NotImplementedError)
+      expect { render_inline(component) }.to raise_error(SubclassResponsibilityError)
     end
   end
 end

--- a/spec/models/project/phase_spec.rb
+++ b/spec/models/project/phase_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Project::Phase do
   end
 
   it "can be instantiated" do
-    expect { described_class.new }.not_to raise_error(NotImplementedError)
+    expect { described_class.new }.not_to raise_error
   end
 
   it { is_expected.to have_readonly_attribute(:definition_id) }

--- a/spec/support/pages/work_packages/abstract_work_package.rb
+++ b/spec/support/pages/work_packages/abstract_work_package.rb
@@ -93,7 +93,7 @@ module Pages
     end
 
     def container
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def wait_for_activity_tab
@@ -364,7 +364,7 @@ module Pages
     private
 
     def create_page(_args)
-      raise NotImplementedError
+      raise SubclassResponsibilityError
     end
 
     def ensure_no_conflicting_modifications

--- a/spec/support/pages/work_packages/concerns/work_package_by_button_creator.rb
+++ b/spec/support/pages/work_packages/concerns/work_package_by_button_creator.rb
@@ -75,7 +75,7 @@ module Pages
         end
 
         def create_page_class
-          raise NotImplementedError
+          raise SubclassResponsibilityError
         end
       end
     end


### PR DESCRIPTION
This error is intended for cases when a method is
intentionally not implemented, because the module/class defining it expects a subclass (or class including the module) to implement the method.

This is intended to distinguish it from other cases, such as:
* feature not implemented yet
* edge case of a method call not yet supported

Notably it avoids the misuse of the Ruby-defined NotImplementedError, which is only intended for much more specific scenarios:

> Raised when a feature is not implemented on the current platform. For example, methods depending on the fsync or fork system calls may raise this exception [...]

Also see https://docs.ruby-lang.org/en/master/NotImplementedError.html