### PR TITLE
[68309] Too much space between widget title and content on News overview widget

### DIFF
--- a/frontend/src/global_styles/content/_widget_box.sass
+++ b/frontend/src/global_styles/content/_widget_box.sass
@@ -211,6 +211,7 @@ $widget-box--enumeration-width: 20px
 
   &:first-of-type
     border-top: none
+    padding-top: 0
 
   &:last-of-type
     border-bottom-right-radius: var(--borderRadius-medium)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68309

# What are you trying to accomplish?
The first row inside `.op-widget-box--rows` like all rows currently has top padding, which creates unnecessary spacing between the widget header and its first content row, so we should remove the padding for the first row.

## Screenshots
Before:
<img width="408" height="158" alt="Screenshot 2026-03-26 at 14 04 56" src="https://github.com/user-attachments/assets/00d25dd6-397e-4a3d-a882-d2f8167bd2b3" />

After:
<img width="384" height="162" alt="Screenshot 2026-03-26 at 14 02 56" src="https://github.com/user-attachments/assets/5081ba33-c3f2-4cd1-b1c0-95b93fd141ff" />
