### PR TITLE
[73434] Pagination component in mobile with one page looks weird

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -38,7 +38,10 @@ module PaginationHelper
   def pagination_links_full(paginator, params: {}, allowed_params: nil, per_page_links: true, **)
     return unless paginator.total_entries > 0
 
-    content_tag(:div, class: "op-pagination") do
+    classes = ["op-pagination"]
+    classes << "op-pagination--single-page" if paginator.total_pages <= 1
+
+    content_tag(:div, class: classes) do
       concat pagination_pages_section(paginator, params:, allowed_params:, **)
       concat pagination_options_section(paginator, params:, allowed_params:) if per_page_links
     end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -38,10 +38,7 @@ module PaginationHelper
   def pagination_links_full(paginator, params: {}, allowed_params: nil, per_page_links: true, **)
     return unless paginator.total_entries > 0
 
-    classes = ["op-pagination"]
-    classes << "op-pagination--single-page" if paginator.total_pages <= 1
-
-    content_tag(:div, class: classes) do
+    content_tag(:div, class: ["op-pagination", { "op-pagination--single-page": paginator.total_pages <= 1 }]) do
       concat pagination_pages_section(paginator, params:, allowed_params:, **)
       concat pagination_options_section(paginator, params:, allowed_params:) if per_page_links
     end

--- a/frontend/src/global_styles/content/_pagination.sass
+++ b/frontend/src/global_styles/content/_pagination.sass
@@ -34,6 +34,10 @@ $pagination--font-size: 0.8125rem
   width: 100%
   min-height: 45px
 
+  &--single-page
+    @media screen and (max-width: $breakpoint-sm)
+      display: none
+
   &--pages
     display: flex
     flex-grow: 2


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73434

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add a modifier class for single-page pagination in the helper and hide the pagination container on small screens.

## Screenshots
Before:
<img width="410" height="802" alt="Screenshot 2026-03-26 at 14 03 09" src="https://github.com/user-attachments/assets/ddb9f6c6-c206-47d1-89a7-8ca878ac935a" />

After:
<img width="393" height="838" alt="Screenshot 2026-03-26 at 14 09 10" src="https://github.com/user-attachments/assets/edc0725b-73c2-4e86-9081-093614088493" />