### PR TITLE
[73250] Duplicate work package title in html meta title tag

### DIFF
--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -157,8 +157,10 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
           this.workPackage = wp;
         }
 
-        // Push the current title
-        this.titleService.setFirstPart(this.workPackage.subjectWithType(-1));
+        if (this.routedFromAngular) {
+          // Push the current title
+          this.titleService.setFirstPart(this.workPackage.subjectWithType(-1));
+        }
 
         this.cdRef.detectChanges();
       }, (error) => {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73250

# What are you trying to accomplish?
Only udpate the html title when routing from Angular. The Rails routed views already add the title themselves