### PR TITLE
[#73462] Vertically center Backlogs Inbox counter

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -29,9 +29,16 @@ See COPYRIGHT and LICENSE files for more details.
 <%= component_wrapper(tag: "turbo-frame", refresh: :morph) do %>
   <%=
     render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-      head.with_heading(tag: :h3, font_weight: :bold, size: :medium) do
+      head.with_heading(
+        tag: :h3,
+        size: :medium,
+        font_weight: :bold,
+        display: :inline_flex,
+        align_items: :center,
+        classes: "gap-2"
+      ) do
         concat t(:label_backlog)
-        concat render(Primer::Beta::Counter.new(count: total, scheme: :default, ml: 1))
+        concat render(Primer::Beta::Counter.new(count: total, scheme: :default))
       end
 
       if allow_sprint_creation?(project)

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
       <%=
         render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
-          head.with_heading(tag: :h3, font_weight: :bold, size: :medium) { Agile::Sprint.human_model_name.pluralize }
+          head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Agile::Sprint.human_model_name.pluralize }
 
           if allow_sprint_creation?(@project)
             head.with_actions do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73462

# What are you trying to accomplish?

Vertically centers Backlogs Inbox counter. Also increases space between "Backlog" text and counter to 8px.

## Screenshots

| Before | After |
|--------|--------|
| <img width="697" height="63" alt="Screenshot 2026-03-26 at 14 01 20" src="https://github.com/user-attachments/assets/7fa31629-5202-430e-ae21-46fe680530d8" />| <img width="696" height="74" alt="Screenshot 2026-03-26 at 13 59 12" src="https://github.com/user-attachments/assets/dce85065-24d5-46e5-b500-291502cdd610" />|

# What approach did you choose and why?

n/a

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
