### PR TITLE
fix German translation for required workpackages

### DIFF
--- a/config/locales/crowdin/de.yml
+++ b/config/locales/crowdin/de.yml
@@ -1457,7 +1457,7 @@ de:
       part_of_description: "Dieses Arbeitspaket enthält das verknüpfte Arbeitspaket, ohne dass dies zusätzliche Auswirkungen hat"
       label_requires_singular: "benötigt"
       label_requires_plural: "benötigt"
-      requires_description: "Markiert dieses Arbeitspaket als Voraussetzung für das verknüpfte Arbeitspaket"
+      requires_description: "Markiert das verknüpfte Arbeitspaket als Voraussetzung für dieses Arbeitspaket"
       label_required_singular: "die benötigt werden von"
       label_required_plural: "die benötigt werden von"
       required_description: "Markiert dieses Arbeitspaket als Voraussetzung für das verknüpfte Arbeitspaket"


### PR DESCRIPTION
The translated string for `requires_description` and `required_description` were identical

# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

before:
<img width="228" height="187" alt="grafik" src="https://github.com/user-attachments/assets/3eb874ac-a422-49ee-88ea-7fd669326e4d" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

A fast PR because this fix was <5min for me. Creating a Ticket (and an account, ....) would take me more than it already has. No real tests or anything as this is just a updated translation string. Is this the correct place or are translations maintained somewhere else?

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
