### PR TITLE
[#73463] Inbox and Sprint counter display improvements

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -38,7 +38,14 @@ See COPYRIGHT and LICENSE files for more details.
         classes: "gap-2"
       ) do
         concat t(:label_backlog)
-        concat render(Primer::Beta::Counter.new(count: total, scheme: :default))
+        concat render(
+          Primer::Beta::Counter.new(
+            scheme: :default,
+            count: total,
+            round: true,
+            limit: 1_000
+          )
+        )
       end
 
       if allow_sprint_creation?(project)

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -43,7 +43,8 @@ See COPYRIGHT and LICENSE files for more details.
             scheme: :default,
             count: total,
             round: true,
-            limit: 1_000
+            limit: 1_000,
+            hide_if_zero: true
           )
         )
       end

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -43,6 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
             scheme: :default,
             count: story_count,
             round: true,
+            limit: 1_000,
             aria: {
               label: t(".label_story_count", count: story_count),
               live: "polite"

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -44,6 +44,7 @@ See COPYRIGHT and LICENSE files for more details.
             count: story_count,
             round: true,
             limit: 1_000,
+            hide_if_zero: true,
             aria: {
               label: t(".label_story_count", count: story_count),
               live: "polite"

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       expect(page).to have_css("h4", text: "Backlog inbox is empty")
       expect(page).to have_text("All open work packages in this project will automatically appear here.")
     end
+
+    it "hides the counter" do
+      expect(page).to have_css(".Counter", text: "0", visible: :hidden)
+    end
   end
 
   describe "with work packages" do

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -83,6 +83,10 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       # does not show the blankslate
       expect(page).to have_no_css("h4", text: "Backlog inbox is empty")
     end
+
+    it "shows the counter with the work package count" do
+      expect(page).to have_css(".Counter", text: "2")
+    end
   end
 
   describe "pagination" do

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -134,10 +134,10 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
     context "with no stories" do
       let(:stories) { [] }
 
-      it "shows 0 story count" do
+      it "hides the story count counter" do
         render_component
 
-        expect(page).to have_css(".Counter", text: "0")
+        expect(page).to have_css(".Counter", text: "0", visible: :hidden)
       end
 
       it "shows 0 points" do


### PR DESCRIPTION
> [!NOTE]
> This PR is based off #22524. Please review/merge first.

## Ticket

https://community.openproject.org/wp/73463

## Summary

- Round large counter values using Primer's `round: true` (e.g. 1,234 → "1.2k")
- Cap displayed value at 1,000 via `limit: 1_000` (aligned across Inbox and Sprint Header)
- Hide counters when count is zero via `hide_if_zero: true`

## Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)