### PR TITLE
Fix flickering spec for meeting dialog

### DIFF
--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -500,7 +500,7 @@ RSpec.describe "Open the Meetings tab",
           )
         end
 
-        it "allows the user to select ongoing meetings", skip: "flickering spec (#68952)" do
+        it "allows the user to select ongoing meetings" do
           work_package_page.visit!
           switch_to_meetings_tab
 
@@ -512,13 +512,12 @@ RSpec.describe "Open the Meetings tab",
             1
           )
 
-          wait_for_network_idle
-
           meetings_tab.expect_upcoming_counter_to_be(1)
 
-          page.within_test_selector("op-meeting-container-#{ongoing_meeting.id}") do
-            expect(page).to have_content("Some notes to be added")
-          end
+          expect(page).to have_test_selector(
+            "op-meeting-container-#{ongoing_meeting.id}",
+            text: "Some notes to be added"
+          )
         end
 
         it "allows the user to select in progress meetings (Bug #65502)" do

--- a/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
+++ b/modules/meeting/spec/support/pages/work_package_meetings_tab.rb
@@ -104,8 +104,9 @@ module Pages
     def fill_and_submit_meeting_dialog(meeting, notes, counter)
       retry_block do
         fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
-        page.find(".ng-option-marked", text: meeting.title) # wait for selection
-        page.find(".ng-option-marked").click
+        wait_for_turbo_stream do
+          page.find(".ng-option-marked", text: meeting.title).click
+        end
         page.find(".ck-editor__editable").set(notes)
 
         wait_for_turbo_stream { click_on("Save") }

--- a/modules/overviews/spec/features/project_description_widget_spec.rb
+++ b/modules/overviews/spec/features/project_description_widget_spec.rb
@@ -78,13 +78,11 @@ RSpec.describe "Project description widget", :js do
       description_field = Components::Common::InplaceEditField.new(portfolio, :description)
 
       # Activate the field for editing
-      description_field.open_field
-
-      wait_for_network_idle
+      wait_for_turbo_stream { description_field.open_field }
 
       # Set a new description
       new_description = "This is a **test** project description with markdown formatting."
-      description_field.fill_and_submit_value(name: "project[description]", val: new_description, ckeditor: true)
+      wait_for_turbo_stream { description_field.fill_and_submit_value(name: "project[description]", val: new_description, ckeditor: true) }
 
       tested_page.expect_and_dismiss_flash message: I18n.t("js.notice_successful_update")
 


### PR DESCRIPTION
Selecting the meeting dialog triggers a reload, which will kill the CKEditor notes when timing is just right.

https://community.openproject.org/projects/team-sirius/work_packages/68952/activity?query_id=6707