### PR TITLE
[#73415] Align Backlog Inbox and Sprint headers

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
-<%= component_wrapper(tag: "turbo-frame", refresh: :morph) do %>
+<%= component_wrapper(tag: "turbo-frame", refresh: :morph, style: "display:contents") do %>
   <%=
     render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
       head.with_heading(

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 <%= component_wrapper(tag: "turbo-frame", refresh: :morph, style: "display:contents") do %>
   <%=
-    render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+    render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
       head.with_heading(
         tag: :h3,
         size: :medium,

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -38,7 +38,7 @@ See COPYRIGHT and LICENSE files for more details.
     </div>
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
       <%=
-        render(Primer::Beta::Subhead.new(hide_border: true)) do |head|
+        render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
           head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Agile::Sprint.human_model_name.pluralize }
 
           if allow_sprint_creation?(@project)


### PR DESCRIPTION
> [!NOTE]
> This PR is based off #22524. Please review/merge first.

# Ticket

https://community.openproject.org/wp/73415

# What are you trying to accomplish?

Align the Inbox and Sprints section headers on the sprint planning page. The turbo-frame wrapper around the Inbox component was creating extra layout space, and both Subhead components had excessive bottom padding.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1631" height="290" alt="Screenshot 2026-03-26 at 17 36 05" src="https://github.com/user-attachments/assets/c525a1d2-00c2-4889-bdcc-0cfdee5ee55c" /> | <img width="1629" height="290" alt="Screenshot 2026-03-26 at 17 36 55" src="https://github.com/user-attachments/assets/607ece80-fede-404c-98b5-bfbe9606a306" /> | 

# What approach did you choose and why?

- Added `display:contents` to the Inbox `turbo-frame` wrapper so it becomes transparent to the parent layout. This pattern is already used in `grids/widget_box_component.rb`. Primer's `display:` system argument doesn't support `:contents`, so inline `style:` is necessary.
- Set `pb: 0` on both Subhead components to remove bottom padding and achieve consistent spacing.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)