### PR TITLE
script to rewrite yaml files using psych

### DIFF
--- a/script/i18n/rewrite_crowdin_yml_files
+++ b/script/i18n/rewrite_crowdin_yml_files
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "stringio"
+require "tempfile"
+require "yaml"
+
+crowdin_yml_files = Dir.glob("{,modules/*/}config/locales/crowdin/*.yml")
+
+rewritten_count = crowdin_yml_files.count do |path|
+  content = File.read(path)
+  comments = content.lines.take_while { it.start_with?("#") }
+  data = YAML.safe_load(content, permitted_classes: [Symbol])
+
+  rewritten_content = StringIO.open do |io|
+    io.puts comments
+    YAML.dump(data, io)
+
+    io.string
+  end
+
+  next if rewritten_content == content
+
+  Tempfile.create(File.basename(path), File.dirname(path)) do |tmp|
+    tmp.write(rewritten_content)
+    tmp.close
+    File.rename(tmp.path, path)
+  end
+end
+
+puts "Rewrote #{rewritten_count} crowdin YAML files"

--- a/script/i18n/rewrite_crowdin_yml_files
+++ b/script/i18n/rewrite_crowdin_yml_files
@@ -42,7 +42,7 @@ rewritten_count = crowdin_yml_files.count do |path|
 
   rewritten_content = StringIO.open do |io|
     io.puts comments
-    YAML.dump(data, io)
+    YAML.dump(data, io, line_width: -1)
 
     io.string
   end

--- a/script/i18n/rewrite_crowdin_yml_files
+++ b/script/i18n/rewrite_crowdin_yml_files
@@ -56,4 +56,4 @@ rewritten_count = crowdin_yml_files.count do |path|
   end
 end
 
-puts "Rewrote #{rewritten_count} crowdin YAML files"
+puts "Rewrote #{rewritten_count}/#{crowdin_yml_files.count} Crowdin YAML files"


### PR DESCRIPTION
Script to rewrite YAMLs downloaded using crowdin/github-action using ruby library, so that the auto merging script #22249 will not cause irrelevant style changes when auto resolving conflicts.

The script needs to first be present in dev and latest release branches to be able to use it from crowdin workflow changed in #22519.