### PR TITLE
[#73474] Make Inbox - Sprints divider full height

### DIFF
--- a/frontend/src/assets/sass/backlogs/_index.sass
+++ b/frontend/src/assets/sass/backlogs/_index.sass
@@ -37,6 +37,7 @@
 @import "../../../global_styles/openproject/_variable_defaults.scss"
 
 @import "../../../global_styles/openproject/_variables.sass"
+@import "../../../global_styles/openproject/_mixins.sass"
 
 @import global
 @import global_print

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -29,6 +29,9 @@
 $op-backlogs-header--points-min-width: 5rem
 $op-backlogs-header--points-min-width-narrow: 2rem
 
+.action-sprint_planning
+  @include extended-content--bottom
+
 .op-backlogs-header
   display: grid
   grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
@@ -71,6 +74,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
 .op-backlogs-page
   display: block
+  height: 100%
   container-name: backlogsListsContainer
   container-type: inline-size
 
@@ -78,21 +82,23 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   display: flex
   flex-direction: row
   gap: var(--stack-gap-normal)
+  height: 100%
+  align-items: stretch
+  overflow: hidden
 
-  // Line that separates left side of sprint planning from right side of sprint planning
-  .op-sprint-planning-lists:first-child
-    border-right: 1px solid var(--borderColor-default)
-    padding-right: var(--stack-gap-normal)
 
 .op-backlogs-lists, .op-sprint-planning-lists
   display: flex
   flex-direction: column
   gap: var(--stack-gap-normal)
   flex: 1 1 100%
-  overflow: hidden
+  min-height: 0
+  overflow-y: auto
+  overflow-x: hidden
 
 .op-sprint-planning-lists
-  padding-top: var(--base-size-16)
+  padding-top: var(--stack-padding-normal)
+  padding-bottom: var(--stack-padding-normal)
 
 //------------------ Header form responsive styling -----------------------
 // Note: Using hardcoded values because Sass doesn't interpolate variables in
@@ -130,6 +136,12 @@ $op-backlogs-header--points-min-width-narrow: 2rem
       margin-top: -6px
 
 
+//------------------ Sprint planning divider (side-by-side only) ----
+@container backlogsListsContainer (min-width: 655px)
+  .op-sprint-planning-lists:not(:last-child)
+    border-right: 1px solid var(--borderColor-default)
+    padding-right: var(--stack-gap-normal)
+
 //------------------ Mobile responsive styling -----------------------
 @container backlogsListsContainer (max-width: 654px)
   .op-backlogs-header
@@ -143,3 +155,4 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
   .op-backlogs-container, .op-sprint-planning-container
     flex-direction: column
+

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -154,5 +154,9 @@ $op-backlogs-header--points-min-width-narrow: 2rem
     grid-template-columns: var(--control-xsmall-size) 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
 
   .op-backlogs-container, .op-sprint-planning-container
+    height: unset
+    overflow: auto
     flex-direction: column
 
+  .op-sprint-planning-lists
+    padding-top: 0

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -41,9 +41,10 @@ interface TargetConfig {
 }
 
 export default class GenericDragAndDropController extends Controller {
-  static targets = ['container'];
+  static targets = ['container', 'scrollContainer'];
 
   containerTargets:HTMLElement[];
+  scrollContainerTargets:HTMLElement[];
 
   static values = { handleSelector: { type: String, default: '.DragHandle' } };
   declare readonly handleSelectorValue:string;
@@ -128,10 +129,12 @@ export default class GenericDragAndDropController extends Controller {
 
     // Setup autoscroll
     void window.OpenProject.getPluginContext().then((pluginContext) => {
+      const scrollTargets:Element[] = this.scrollContainerTargets.length > 0
+        ? this.scrollContainerTargets
+        : [document.getElementById('content-body')!];
+
       new pluginContext.classes.DomAutoscrollService(
-        [
-          document.getElementById('content-body')!,
-        ],
+        scrollTargets,
         {
           margin: 25,
           maxSpeed: 10,

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -31,6 +31,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { FetchRequest } from '@rails/request.js';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
+import type { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
 import dragula, { Drake } from 'dragula';
 import invariant from 'tiny-invariant';
 
@@ -50,17 +51,21 @@ export default class GenericDragAndDropController extends Controller {
   declare readonly handleSelectorValue:string;
 
   private drake:Drake|null = null;
+  private autoscroll:DomAutoscrollService|null = null;
   private containers:HTMLElement[] = [];
   private targetConfigs:TargetConfig[] = [];
   private dragOriginSource:Element|null = null;
   private dragOriginNextSibling:Element|null = null;
 
   connect() {
+    this.autoscroll?.destroy();
     this.drake?.destroy();
     this.initDrake();
   }
 
   disconnect() {
+    this.autoscroll?.destroy();
+    this.autoscroll = null;
     this.drake?.destroy();
     this.drake = null;
   }
@@ -129,11 +134,13 @@ export default class GenericDragAndDropController extends Controller {
 
     // Setup autoscroll
     void window.OpenProject.getPluginContext().then((pluginContext) => {
+      if (!this.element.isConnected) return;
+
       const scrollTargets:Element[] = this.scrollContainerTargets.length > 0
         ? this.scrollContainerTargets
         : [document.getElementById('content-body')!];
 
-      new pluginContext.classes.DomAutoscrollService(
+      this.autoscroll = new pluginContext.classes.DomAutoscrollService(
         scrollTargets,
         {
           margin: 25,

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -29,14 +29,16 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= turbo_frame_tag "backlogs_container", refresh: :morph, class: "op-backlogs-page" do %>
   <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
-    <div id="owner_backlogs_container" class="op-sprint-planning-lists">
+    <div id="owner_backlogs_container" class="op-sprint-planning-lists"
+         data-generic-drag-and-drop-target="scrollContainer">
       <%= render Backlogs::InboxComponent.new(
             work_packages: @inbox_work_packages,
             project: @project,
             show_all: params[:all].present?
           ) %>
     </div>
-    <div id="sprint_backlogs_container" class="op-sprint-planning-lists">
+    <div id="sprint_backlogs_container" class="op-sprint-planning-lists"
+         data-generic-drag-and-drop-target="scrollContainer">
       <%=
         render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
           head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Agile::Sprint.human_model_name.pluralize }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73474
https://community.openproject.org/wp/73475

# What are you trying to accomplish?

Make the vertical divider between the Inbox and Sprints columns extend to full height on the sprint planning page. Also adds configurable drag-and-drop autoscroll targets ([OP #73475](https://community.openproject.org/wp/73475)) so that each column scrolls independently during drag operations.

## Screenshots

<img width="1629" height="769" alt="image" src="https://github.com/user-attachments/assets/b24f98e9-b30a-42e5-adf1-c84b1496cc4e" />

# What approach did you choose and why?

## Full-height divider ([#73474](https://community.openproject.org/wp/73474))

- `height: 100%` on `.op-backlogs-page` and `.op-sprint-planning-container` to establish the full height chain from `#content-wrapper` down to the flex columns
- `align-items: stretch` on the flex container so the border divider stretches to full height
- `min-height: 0` + `overflow-y: auto` on children to allow independent column scrolling (standard flexbox shrink pattern)
- Moved `overflow: hidden` from children to the container
- Use `extended-content--bottom` mixin (scoped to `.action-sprint_planning`) to remove `#content-body`'s bottom padding so the layout fills the viewport edge; inner padding restored via `--stack-padding-normal` on `.op-sprint-planning-lists`
- Moved the column divider border into a `@container (min-width: 655px)` query so it only appears when columns are side-by-side, avoiding a specificity conflict with the `max-width: 654px` stacking rule
- Changed divider selector from `:first-child` to `:not(:last-child)` for robustness

## Configurable autoscroll targets ([#73475](https://community.openproject.org/wp/73475))

- Added a `scrollContainer` Stimulus target to `GenericDragAndDropController`
- When scroll container targets are present, they are used as autoscroll targets for `DomAutoscrollService` during drag operations; falls back to `#content-body` when none are declared
- Each `.op-sprint-planning-lists` column is marked as a scroll container target on the sprint planning page, enabling per-column autoscroll
- On mobile (stacked layout), the columns don't overflow so autoscroll is a no-op on them; `#content-body` would need to be added as a target if mobile autoscroll is needed (deferred)

# Merge checklist

- [ ] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
- [x] Verified drag-and-drop autoscroll works within scrollable columns
- [x] Verified `height: 100%` resolves correctly through the parent chain (divider reaches full height)
- [x] Verified works responsively (needs [OP #73477](https://community.openproject.org/wp/73477))