### PR TITLE
[#73482] Fix Inbox, Sprint Blankslate icons and alignment

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -65,6 +65,7 @@ See COPYRIGHT and LICENSE files for more details.
       <% border_box.with_row(data: { empty_list_item: true }) do %>
         <%=
           render Primer::Beta::Blankslate.new(spacious: true, role: "status", aria: { live: "polite" }) do |blankslate|
+            blankslate.with_visual_icon(icon: :"op-backlogs")
             blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
             blankslate.with_description_content(t(".blankslate_description"))
           end

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -108,7 +108,7 @@ See COPYRIGHT and LICENSE files for more details.
 
         <%=
           render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
-            blankslate.with_visual_icon(icon: :versions)
+            blankslate.with_visual_icon(icon: :zap)
             blankslate.with_heading(tag: :h4).with_content(t("backlogs.sprint_planning.blankslate.title"))
             blankslate.with_description_content(description_content)
           end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73482

# What are you trying to accomplish?

Fix missing/incorrect blankslate icons and vertical misalignment between the Inbox and Sprint blankslates on the sprint planning page.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1223" height="669" alt="Screenshot 2026-03-27 at 22 27 46" src="https://github.com/user-attachments/assets/1c1451f7-095e-4b2f-b016-9ce943d556d6" /> | <img width="1226" height="671" alt="Screenshot 2026-03-27 at 22 25 46" src="https://github.com/user-attachments/assets/c4a6697e-185d-4b05-a117-83744c020ade" /> | 


# What approach did you choose and why?

**Commit 1:** Update blankslate icons — `:op-backlogs` for Inbox (matches sidebar nav), `:zap` for Sprints (matches inbox menu entries). Adds the previously missing icon to the Inbox blankslate.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
- [ ] Discuss a more robust approach for the blankslate alignment fix (commit 2)