### PR TITLE
[#73476] Restore sprint menu divider, fix board menu item label

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -36,81 +36,73 @@ See COPYRIGHT and LICENSE files for more details.
       tooltip_direction: :se
     )
 
-    if show_start_sprint_action?
-      menu.with_item(
-        label: t(".action_menu.start_sprint"),
-        tag: :button,
-        href: start_project_sprint_path(project, sprint),
-        disabled: disable_start_sprint_action?,
-        form_arguments: {
-          method: :post,
-          data: { turbo: false }
-        }
-      ) do |item|
-        item.with_leading_visual_icon(icon: :play)
-        item.with_description(start_sprint_action_description) if start_sprint_action_description.present?
+    with_item_group(menu) do
+      if show_start_sprint_action?
+        menu.with_item(
+          label: t(".action_menu.start_sprint"),
+          tag: :button,
+          href: start_project_sprint_path(project, sprint),
+          disabled: disable_start_sprint_action?,
+          form_arguments: {
+            method: :post,
+            data: { turbo: false }
+          }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :play)
+          item.with_description(start_sprint_action_description) if start_sprint_action_description.present?
+        end
+      end
+
+      if show_finish_sprint_action?
+        menu.with_item(
+          label: t(".action_menu.finish_sprint"),
+          tag: :button,
+          href: finish_project_sprint_path(project, sprint),
+          form_arguments: { method: :post }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :check)
+        end
+      end
+
+      if user_allowed?(:create_sprints)
+        menu.with_item(
+          id: dom_target(sprint, :menu, :edit_sprint),
+          label: t(".action_menu.edit_sprint"),
+          href: edit_dialog_project_sprint_path(project, sprint),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :pencil)
+        end
       end
     end
 
-    if show_finish_sprint_action?
-      menu.with_item(
-        label: t(".action_menu.finish_sprint"),
-        tag: :button,
-        href: finish_project_sprint_path(project, sprint),
-        form_arguments: { method: :post }
-      ) do |item|
-        item.with_leading_visual_icon(icon: :check)
+    with_item_group(menu) do
+      if user_allowed?(:manage_sprint_items)
+        menu.with_item(
+          id: dom_target(sprint, :menu, :new_story),
+          label: t(".action_menu.add_work_package"),
+          href: new_project_work_packages_dialog_path(
+            project,
+            sprint_id: sprint.id,
+            type_id: available_story_types.first
+          ),
+          content_arguments: { data: { turbo_stream: true } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :plus)
+        end
       end
     end
 
-    if user_allowed?(:create_sprints)
-      menu.with_item(
-        id: dom_target(sprint, :menu, :edit_sprint),
-        label: t(".action_menu.edit_sprint"),
-        href: edit_dialog_project_sprint_path(project, sprint),
-        content_arguments: { data: { controller: "async-dialog" } }
-      ) do |item|
-        item.with_leading_visual_icon(icon: :pencil)
+    with_item_group(menu) do
+      if show_task_board_link?
+        menu.with_item(
+          label: t(".action_menu.task_board"),
+          tag: :a,
+          href: backlogs_project_sprint_taskboard_path(project, sprint)
+        ) do |item|
+          item.with_leading_visual_icon(icon: :"op-view-cards")
+        end
       end
     end
-
-    if user_allowed?(:manage_sprint_items)
-      menu.with_item(
-        id: dom_target(sprint, :menu, :new_story),
-        label: t(".action_menu.add_work_package"),
-        href: new_project_work_packages_dialog_path(
-          project,
-          sprint_id: sprint.id,
-          type_id: available_story_types.first
-        ),
-        content_arguments: { data: { turbo_stream: true } }
-      ) do |item|
-        item.with_leading_visual_icon(icon: :plus)
-      end
-    end
-
-    # if user_allowed?(:create_sprints) || user_allowed?(:add_work_packages)
-    #   menu.with_divider
-    # end
-
-    if show_task_board_link?
-      menu.with_item(
-        label: t(".action_menu.task_board"),
-        tag: :a,
-        href: backlogs_project_sprint_taskboard_path(project, sprint)
-      ) do |item|
-        item.with_leading_visual_icon(icon: :"op-view-cards")
-      end
-    end
-
-    # menu.with_item(
-    #   # TODO: what to do with the burndown chart?
-    #   label: t(".action_menu.burndown_chart"),
-    #   tag: :a,
-    #   href: backlogs_project_sprint_burndown_chart_path(project, sprint),
-    #   disabled: !sprint.has_burndown?
-    # ) do |item|
-    #   item.with_leading_visual_icon(icon: :graph)
-    # end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -30,6 +30,7 @@
 
 module Backlogs
   class SprintMenuComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
     include RbCommonHelper
 
     attr_reader :sprint, :project, :current_user, :active_sprint_ids

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -219,7 +219,7 @@ en:
         start_sprint_missing_dates_description: "Start and finish dates are required in order to start the sprint."
         edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
-        task_board: "Task board"
+        task_board: "Sprint board"
 
     story_component:
       label_drag_story: "Move %{name}"

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
                finish_date: Date.tomorrow,
                status: "active")
       end
-      let(:permissions) { %i[view_sprints view_work_packages start_complete_sprint] }
+      let(:permissions) { %i[view_sprints view_work_packages start_complete_sprint create_sprints manage_sprint_items] }
       let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
       it "shows Finish sprint and Task board" do
@@ -128,6 +128,14 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         expect(page).to have_octicon(:check)
         expect(page).to have_element(:form, action: finish_sprint_path, method: "post")
         expect(menu_items).to include("Task board")
+      end
+
+      it "renders dividers between each menu section" do
+        render_component
+
+        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Task board"])
+        expect(page).to have_list_item position: 3, role: "presentation"
+        expect(page).to have_list_item position: 5, role: "presentation"
       end
     end
 
@@ -230,6 +238,12 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
           render_component
 
           expect(menu_items).to include("Task board")
+        end
+
+        it "does not render a divider when task board is the only visible item" do
+          render_component
+
+          expect(page).not_to have_list_item(role: "presentation")
         end
       end
     end

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -121,19 +121,19 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
       let(:permissions) { %i[view_sprints view_work_packages start_complete_sprint create_sprints manage_sprint_items] }
       let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-      it "shows Finish sprint and Task board" do
+      it "shows Finish sprint and Sprint board" do
         render_component
 
         expect(menu_items.first).to eq("Finish sprint")
         expect(page).to have_octicon(:check)
         expect(page).to have_element(:form, action: finish_sprint_path, method: "post")
-        expect(menu_items).to include("Task board")
+        expect(menu_items).to include("Sprint board")
       end
 
       it "renders dividers between each menu section" do
         render_component
 
-        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Task board"])
+        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Sprint board"])
         expect(page).to have_list_item position: 3, role: "presentation"
         expect(page).to have_list_item position: 5, role: "presentation"
       end
@@ -147,7 +147,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
 
         expect(menu_items.first).to eq("Start sprint")
         expect(page).to have_octicon(:play)
-        expect(page).to have_no_selector(:menuitem, text: "Task board")
+        expect(page).to have_no_selector(:menuitem, text: "Sprint board")
         expect(page).to have_element(:form, action: start_sprint_path, method: "post", "data-turbo": "false")
       end
 
@@ -219,7 +219,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
           render_component
 
           expect(page).to have_no_selector(:menuitem, text: "Start sprint")
-          expect(page).to have_no_selector(:menuitem, text: "Task board")
+          expect(page).to have_no_selector(:menuitem, text: "Sprint board")
         end
       end
 
@@ -234,10 +234,10 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         end
         let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-        it "shows Task board" do
+        it "shows Sprint board" do
           render_component
 
-          expect(menu_items).to include("Task board")
+          expect(menu_items).to include("Sprint board")
         end
 
         it "does not render a divider when task board is the only visible item" do
@@ -276,20 +276,20 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         expect(page).to have_selector(:menuitem, text: "Finish sprint")
       end
 
-      it "does not show Task board for a board in the source project" do
+      it "does not show Sprint board for a board in the source project" do
         create(:board_grid_with_query, project: source_project, linked: sprint)
 
         render_component
 
-        expect(page).to have_no_selector(:menuitem, text: "Task board")
+        expect(page).to have_no_selector(:menuitem, text: "Sprint board")
       end
 
-      it "shows Task board for a board in the rendered project" do
+      it "shows Sprint board for a board in the rendered project" do
         create(:board_grid_with_query, project:, linked: sprint)
 
         render_component
 
-        expect(page).to have_selector(:menuitem, text: "Task board")
+        expect(page).to have_selector(:menuitem, text: "Sprint board")
       end
 
       context "when the sprint is in planning" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73476

# What are you trying to accomplish?

- Restores the divider between sprint menu items
- Renames the menu item from "Task board" to "Sprint board"

## Screenshots

| Before | After |
|--------|--------|
| <img width="280" height="226" alt="Screenshot 2026-03-27 at 11 42 53" src="https://github.com/user-attachments/assets/c547be4b-48fd-47f7-b2a3-df88c2df159d" />| <img width="251" height="173" alt="Screenshot 2026-03-27 at 21 35 23" src="https://github.com/user-attachments/assets/c11d0f8a-7184-4ef9-8330-8e40d40a8ec7" />| 
| <img width="234" height="228" alt="Screenshot 2026-03-27 at 11 43 07" src="https://github.com/user-attachments/assets/8b28aa18-dd93-4f38-9a61-d654df30dd36" />| <img width="208" height="199" alt="Screenshot 2026-03-27 at 21 35 46" src="https://github.com/user-attachments/assets/6859e173-3e24-4e31-9364-ad3b088ab143" />|


# What approach did you choose and why?

n/a

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
