### PR TITLE
[#73379] Flickering of dialog/content when switching tabs after ignoring confirmation dialog  

### DIFF
--- a/app/components/workflows/confirmation_dialog_component.html.erb
+++ b/app/components/workflows/confirmation_dialog_component.html.erb
@@ -31,7 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     Primer::OpenProject::FeedbackDialog.new(
       id: DIALOG_ID,
-      title: t("admin.workflows.leave_confirmation.title")
+      title: t("admin.workflows.leave_confirmation.title"),
+      data: { turbo_temporary: true }
     )
   ) do |dialog|
     dialog.with_feedback_message(icon_arguments: { icon: :none }) do |message|

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
             { action: :update },
             id: "workflow_form",
             method: :patch,
-            data: { turbo_frame: "_top", controller: "admin--workflow-checkbox-state", has_status_changes: ("true" if @has_status_changes) }
+            data: { turbo_frame: "_top", controller: "admin--workflow-checkbox-state", has_status_changes: ("true" if @has_status_changes), turbo_temporary: true }
           ) do %>
           <%= hidden_field_tag "type_id", @type.id %>
           <%= hidden_field_tag "role_id", @role.id %>


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/73379

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
