### PR TITLE
Update overview of existing APIs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -6,15 +6,18 @@ sidebar_navigation:
 
 # OpenProject API
 
-OpenProject offers two APIs. The general purpose HATEOAS API v3 and the BCF API v2.1 api targeted towards BIM use cases.
+OpenProject offers different APIs:
 
-Please note that we intend to keep this specification as accurate and stable as possible, however work on the API is still ongoing
-and not all resources and actions in OpenProject are yet accessible through the API.
+* API v3 (OpenProject's general purpose HATEOAS API)
+* SCIM (System for Cross-domain Identity Management)
+* MCP (Model Context Protocol)
+* BCF API v2.1 api targeted towards BIM use cases
 
-This document will be subject to changes as we add more endpoints and functionality to the API. The development version of this document
+Please note that we intend to keep this specification as accurate and stable as possible, however work on APIs is still ongoing
+and not all resources and actions in OpenProject are yet accessible through the APIs.
+
+This document will be subject to changes as we add more endpoints and functionality. The development version of this document
 may have breaking changes while we work on new endpoints for the application.
-
-We try to keep stable releases of OpenProject with changes to this API backwards compatible whenever possible.
 
 ## API v3
 
@@ -23,16 +26,30 @@ The API v3 is a general purpose API supporting multiple use cases.
 While by no means complete, a whole lot of different scenarios can be automatized which otherwise would have to be carried out by hand via the UI.
 Examples for this include managing work packages, projects and users.
 
+We try to keep stable releases of OpenProject with changes to this API backwards compatible whenever possible.
+
 ➔ [Go to OpenProject API](./introduction/)
 
 ### OpenAPI specification
 
 Download the API specification in OpenAPI format as [json](https://www.openproject.org/docs/api/v3/spec.json) or [yml](https://www.openproject.org/docs/api/v3/spec.yml).
 
+## SCIM
+
+OpenProject allows to manage users and groups using System for Cross-domain Identity Management. This is a standardized API (see [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644)) that might thus be supported by existing identity providers.
+
+➔ [Configuration instructions](../system-admin-guide/authentication/scim/)
+
+## MCP
+
+A growing number of tools and resources is offered through the Model Context Protocol API of OpenProject. This API is primarily targeted at AI agents and similar tools, as it supports auto-discovery of supported operations.
+
+➔ [Configuration instructions](../system-admin-guide/integrations/mcp-server/)
+
 ## BCF v2.1
 
 This API supports BCF management in the context of BIM projects.
 
-While this API supports way less use cases than the more generic *API v3* it is compatible with the generic specification of a BCF API as [defined by the standard](https://github.com/buildingSMART/BCF-API/blob/release_2_1/README.md). This, clients implementing the specification can manage topics and viewpoints.
+While this API supports way less use cases than the more generic *API v3* it is compatible with the generic specification of a BCF API as [defined by the standard](https://github.com/buildingSMART/BCF-API/blob/release_2_1/README.md). Clients implementing the specification can manage topics and viewpoints.
 
 ➔ [Go to BCF API](./bcf-rest-api/)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -26,7 +26,7 @@ The API v3 is a general purpose API supporting multiple use cases.
 While by no means complete, a whole lot of different scenarios can be automatized which otherwise would have to be carried out by hand via the UI.
 Examples for this include managing work packages, projects and users.
 
-We try to keep stable releases of OpenProject with changes to this API backwards compatible whenever possible.
+We strive to maintain backward compatibility with this API in our stable OpenProject releases whenever possible.
 
 ➔ [Go to OpenProject API](./introduction/)
 
@@ -38,13 +38,13 @@ Download the API specification in OpenAPI format as [json](https://www.openproje
 
 OpenProject allows to manage users and groups using System for Cross-domain Identity Management. This is a standardized API (see [RFC 7643](https://datatracker.ietf.org/doc/html/rfc7643) and [RFC 7644](https://datatracker.ietf.org/doc/html/rfc7644)) that might thus be supported by existing identity providers.
 
-➔ [Configuration instructions](../system-admin-guide/authentication/scim/)
+➔ [Read more on configuration instructions](../system-admin-guide/authentication/scim/)
 
 ## MCP
 
 A growing number of tools and resources is offered through the Model Context Protocol API of OpenProject. This API is primarily targeted at AI agents and similar tools, as it supports auto-discovery of supported operations.
 
-➔ [Configuration instructions](../system-admin-guide/integrations/mcp-server/)
+➔ [Read more on configuration instructions](../system-admin-guide/integrations/mcp-server/)
 
 ## BCF v2.1
 


### PR DESCRIPTION
We only used to mention the APIv3 and the BCF API and even then some parts of the text were clearly written as if only APIv3 existed.

This has been updated to mention the other kinds of APIs currently offered by OpenProject.

# Ticket
https://community.openproject.org/wp/73305