### PR TITLE
[#73390] Workflow edit page subheader scrolls horizontally when tables are too wide  

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -9,7 +9,7 @@
   turbo-frame#workflow-table
     width: 100%
 
-  sub-header.SubHeader
+  #workflows-edit-sub-header-component
     position: sticky
     left: 0
     background: var(--body-background)


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->
https://community.openproject.org/work_packages/73390
<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->
