### PR TITLE
[#73458] Missing feature specs on drag & drop

### DIFF
--- a/modules/backlogs/spec/controllers/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/inbox_controller_spec.rb
@@ -48,6 +48,30 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
     subject
   end
 
+  shared_examples_for "checks permissions for private projects" do
+    context "with a private project" do
+      let(:project) { create(:private_project) }
+
+      context "when the user is not a member" do
+        let(:user) { create(:user) }
+
+        it "responds with 404" do
+          expect(response).to have_http_status :not_found
+        end
+      end
+
+      context "when the user is a member with required permissions" do
+        let(:user) do
+          create(:user, member_with_permissions: { project => %i[manage_sprint_items view_sprints view_work_packages] })
+        end
+
+        it "responds successfully" do
+          expect(response).to be_successful
+        end
+      end
+    end
+  end
+
   describe "POST #reorder" do
     subject do
       post :reorder,
@@ -91,6 +115,8 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
         expect(response).to have_http_status :not_found
       end
     end
+
+    it_behaves_like "checks permissions for private projects"
   end
 
   describe "PUT #move" do
@@ -171,6 +197,8 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
         expect(response).to have_http_status :not_found
       end
     end
+
+    it_behaves_like "checks permissions for private projects"
   end
 
   describe "GET #move_to_sprint_dialog" do
@@ -204,5 +232,7 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
         expect(response).to have_http_status :not_found
       end
     end
+
+    it_behaves_like "checks permissions for private projects"
   end
 end

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -55,7 +55,13 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
   let!(:role) do
     create(:project_role, permissions:)
   end
-  let!(:current_user) { create(:user, member_with_roles: { project => role }) }
+  let(:user_password) { "bob" * 4 }
+  let!(:current_user) do
+    create(:user,
+           member_with_roles: { project => role },
+           password: user_password,
+           password_confirmation: user_password)
+  end
 
   let(:planning_page) { Pages::SprintPlanning.new(project) }
 
@@ -294,6 +300,27 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
         planning_page.expect_story_in_sprint(inbox_wp1, sprint)
         planning_page.expect_story_in_sprint(inbox_wp2, sprint)
         planning_page.expect_story_in_sprint(inbox_wp3, sprint)
+      end
+
+      context "with real authentication and a private project" do
+        let!(:project) do
+          create(:private_project,
+                 types: [type],
+                 enabled_module_names: %w[work_package_tracking backlogs],
+                 sprint_sharing:)
+        end
+
+        before do
+          logout
+          login_with(current_user.login, user_password)
+          planning_page.visit!
+        end
+
+        it "moves a backlog item to the sprint without an error (Regression#73416)" do
+          planning_page.drag_inbox_item_to_sprint(inbox_wp1, sprint)
+          planning_page.expect_no_inbox_item(inbox_wp1)
+          expect_and_dismiss_flash(message: "Successful move from Inbox to Sprint 1.")
+        end
       end
     end
 

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
       public { true } # Remark: public defaults to true
     end
 
+    factory :private_project do
+      public { false }
+    end
+
     factory :template_project do
       sequence(:name) { |n| "Template project No. #{n}" }
       sequence(:identifier) { |n| "template_no_#{n}" }

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -80,6 +80,8 @@ module AuthenticationHelpers
     else
       page.driver.clear_cookies
     end
+
+    allow(RequestStore).to receive(:[]).with(:current_user).and_call_original
   end
 
   private

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -81,7 +81,9 @@ module AuthenticationHelpers
       page.driver.clear_cookies
     end
 
-    allow(RequestStore).to receive(:[]).with(:current_user).and_call_original
+    # The login_as method call short circuits the login by mocking the current user.
+    # Thus logging out should also reset the login mock in order to make the logout complete.
+    allow(RequestStore).to receive(:[]).and_call_original
   end
 
   private


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/73458

# What are you trying to accomplish?
- Add missing specs for https://community.openproject.org/wp/73416

# What approach did you choose and why?
- Check that project permissions are verified on the `InboxController`
- Use a real sign in workflow to reproduce the bug caused by the previous buggy `prepend_before_action` impementation.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
