### PR TITLE
[64491] Children column on WP list cannot be expanded

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/relations/child-relations-render-pass.ts
@@ -1,13 +1,18 @@
-import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { RowRenderInfo } from '../primary-render-pass';
 import {
   RelationsRenderPass,
 } from 'core-app/features/work-packages/components/wp-fast-table/builders/relations/relations-render-pass';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 
 export class ChildRelationsRenderPass extends RelationsRenderPass {
   renderType = 'child_relations';
 
   label = this.I18n.t('js.relation_labels.child');
+
+  @InjectField() apiV3Service:ApiV3Service;
+
+  private loadingMissingTargets = false;
 
   public render() {
     // If no relation column active, skip this pass
@@ -17,6 +22,8 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
 
     // Render for each original row, clone it since we're modifying the tablepass
     const rendered = _.clone(this.tablePass.renderedOrder);
+    const missingChildIds:string[] = [];
+
     rendered.forEach((row:RowRenderInfo) => {
       // We only care for rows that are natural work packages
       if (!row.workPackage) {
@@ -25,7 +32,7 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
 
       // If the work package has no children, ignore
       const { workPackage } = row;
-      if (workPackage.children?.length === 0) {
+      if (!workPackage.children?.length) {
         return;
       }
 
@@ -36,9 +43,16 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
       }
 
       const column = this.wpTableColumns.findById(expanded)!;
+
       // Render the child relations
       workPackage.children.forEach((child) => {
-        const target = this.states.workPackages.get(child.id!).value!;
+        const target = this.states.workPackages.get(child.id!).value;
+
+        if (!target) {
+          missingChildIds.push(child.id!);
+          return;
+        }
+
         // Build each relation row (currently sorted by order defined in API)
         const [relationRow] = this.relationRowBuilder.buildEmptyRelationRow(
           workPackage,
@@ -49,9 +63,30 @@ export class ChildRelationsRenderPass extends RelationsRenderPass {
         this.renderRelationRow(relationRow, row, this.label, column, workPackage, target, 'children');
       });
     });
+
+    this.loadMissingTargets(missingChildIds);
   }
 
   public get isApplicable() {
     return this.wpTableColumns.hasChildRelationsColumn();
+  }
+
+  private loadMissingTargets(ids:string[]) {
+    const uniqueIds = _.uniq(ids);
+
+    if (uniqueIds.length === 0 || this.loadingMissingTargets) {
+      return;
+    }
+
+    this.loadingMissingTargets = true;
+
+    void this.apiV3Service.work_packages.requireAll(uniqueIds)
+      .then(() => {
+        this.loadingMissingTargets = false;
+        this.tablePass.workPackageTable.redrawTable();
+      })
+      .catch(() => {
+        this.loadingMissingTargets = false;
+      });
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/64491

# What are you trying to accomplish?
Child relation rows assumed that all child work packages are already available in the client cache. On edge/stage, this is not always the case, leading to undefined targets and broken expand behavior.

This change makes the render pass resilient by:
- Skipping rendering when a child target is not yet available
- Collecting missing child work package IDs during rendering
- Loading them in a single batch via ApiV3Service#requireAll
- Triggering a table redraw once the data is available

This avoids crashes, reduces API calls, and ensures consistent behavior between local and production environments.