### PR TITLE
Add rel=nofollow to user-generated links to deter SEO spam

### DIFF
--- a/lib/open_project/text_formatting/filters/autolink_custom_protocols_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_custom_protocols_filter.rb
@@ -81,7 +81,7 @@ module OpenProject::TextFormatting
                       href,
                       href:,
                       class: autolink_context[:classes],
-                      rel: "noopener noreferrer")
+                      rel: "noopener noreferrer nofollow")
         end
 
         node.replace(content) if matched

--- a/lib/open_project/text_formatting/filters/autolink_filter.rb
+++ b/lib/open_project/text_formatting/filters/autolink_filter.rb
@@ -44,7 +44,7 @@ module OpenProject::TextFormatting
         autolink_context = default_autolink_options.merge context.fetch(:autolink, {})
         return doc if autolink_context[:enabled] == false
 
-        ::Rinku.auto_link(html, :all, "class=\"#{autolink_context[:classes]}\" rel=\"noopener noreferrer\"", nil,
+        ::Rinku.auto_link(html, :all, "class=\"#{autolink_context[:classes]}\" rel=\"noopener noreferrer nofollow\"", nil,
                           Rinku::AUTOLINK_SHORT_DOMAINS)
       end
 

--- a/lib/open_project/text_formatting/filters/sanitization_filter.rb
+++ b/lib/open_project/text_formatting/filters/sanitization_filter.rb
@@ -63,9 +63,9 @@ module OpenProject::TextFormatting
             "td" => ["style"]
           ),
 
-          # Add rel attribute to prevent tabnabbing
+          # Add rel attribute to prevent tabnabbing and SEO spam
           add_attributes: {
-            "a" => { "rel" => "noopener noreferrer" }
+            "a" => { "rel" => "noopener noreferrer nofollow" }
           },
 
           # Add custom transformer logic for more complex modifications

--- a/spec/lib/open_project/text_formatting/allowed_link_protocols_spec.rb
+++ b/spec/lib/open_project/text_formatting/allowed_link_protocols_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">OpenProject</a></p>
+          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">OpenProject</a></p>
         EXPECTED
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">Contact us via <a href="mailto:info@openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">email</a></p>
+          <p class="op-uc-p">Contact us via <a href="mailto:info@openproject.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">email</a></p>
         EXPECTED
       end
     end
@@ -86,7 +86,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link with <a rel="noopener noreferrer" target="_top" class="op-uc-link">custom protocol</a></p>
+          <p class="op-uc-p">A link with <a rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">custom protocol</a></p>
         EXPECTED
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer" target="_top" class="op-uc-link">OpenProject</a></p>
+          <p class="op-uc-p">A link to <a href="https://www.openproject.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">OpenProject</a></p>
         EXPECTED
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link with <a href="ftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">FTP protocol</a></p>
+          <p class="op-uc-p">A link with <a href="ftp://example.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">FTP protocol</a></p>
         EXPECTED
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">An autolinked <a href="ftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">ftp://example.org</a></p>
+          <p class="op-uc-p">An autolinked <a href="ftp://example.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">ftp://example.org</a></p>
         EXPECTED
       end
     end
@@ -144,7 +144,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">An autolinked <a href="ftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">ftp://example.org</a>.</p>
+          <p class="op-uc-p">An autolinked <a href="ftp://example.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">ftp://example.org</a>.</p>
         EXPECTED
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link with <a href="sftp://example.org" rel="noopener noreferrer" target="_top" class="op-uc-link">SFTP protocol</a></p>
+          <p class="op-uc-p">A link with <a href="sftp://example.org" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">SFTP protocol</a></p>
         EXPECTED
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link with <a rel="noopener noreferrer" target="_top" class="op-uc-link">data protocol</a></p>
+          <p class="op-uc-p">A link with <a rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">data protocol</a></p>
         EXPECTED
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">A link with <a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==" rel="noopener noreferrer" target="_top" class="op-uc-link">data protocol</a></p>
+          <p class="op-uc-p">A link with <a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">data protocol</a></p>
         EXPECTED
       end
     end
@@ -202,7 +202,7 @@ RSpec.describe OpenProject::TextFormatting, "OpenProject allowed link protocols"
 
       let(:expected) do
         <<~EXPECTED
-          <p class="op-uc-p">An autolinked <a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==" rel="noopener noreferrer" target="_top" class="op-uc-link">data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==</a>.</p>
+          <p class="op-uc-p">An autolinked <a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==</a>.</p>
         EXPECTED
       end
     end

--- a/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/attribute_macros_spec.rb
@@ -58,7 +58,7 @@ RSpec.shared_examples_for "resolving macros" do
         <<~EXPECTED
           <h1 class="op-uc-h1" id="op-frag-my-headline">
             My headline
-            <a class="op-uc-link_permalink icon-link op-uc-link" aria-hidden="true" href="#op-frag-my-headline" rel="noopener noreferrer"></a>
+            <a class="op-uc-link_permalink icon-link op-uc-link" aria-hidden="true" href="#op-frag-my-headline" rel="noopener noreferrer nofollow"></a>
           </h1>
           <p class="op-uc-p">
             Inline reference to WP: <opce-macro-attribute-label data-model="workPackage" data-id="1234" data-attribute="subject"></opce-macro-attribute-label>
@@ -110,7 +110,7 @@ RSpec.shared_examples_for "resolving macros" do
         <<~EXPECTED
           <h1 class="op-uc-h1" id="op-frag-my-headline">
             My headline
-            <a class="op-uc-link_permalink icon-link op-uc-link" aria-hidden="true" href="#op-frag-my-headline" rel="noopener noreferrer"></a>
+            <a class="op-uc-link_permalink icon-link op-uc-link" aria-hidden="true" href="#op-frag-my-headline" rel="noopener noreferrer nofollow"></a>
           </h1>
           <p class="op-uc-p">
             Inline reference to WP: <opce-macro-attribute-value data-model="workPackage" data-id="1234" data-attribute="subject"></opce-macro-attribute-value>

--- a/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/headings_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe OpenProject::TextFormatting,
               <a class="op-uc-link_permalink icon-link op-uc-link"
                  aria-hidden="true"
                  href="#op-frag-the-heading"
-                 rel="noopener noreferrer"></a>
+                 rel="noopener noreferrer nofollow"></a>
             </h#{level}>
             <p class="op-uc-p">more text</p>
           EXPECTED
@@ -123,7 +123,7 @@ RSpec.describe OpenProject::TextFormatting,
               <a class="op-uc-link_permalink icon-link op-uc-link"
                  href="#op-frag-20090209"
                  aria-hidden="true"
-                 rel="noopener noreferrer"></a>
+                 rel="noopener noreferrer nofollow"></a>
             </h1>
           EXPECTED
         end

--- a/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/lists_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe OpenProject::TextFormatting,
                         <ul class="op-uc-list_task-list op-uc-list">
                           <li class="op-uc-list--item">
                             <input type="checkbox" class="op-uc-list--task-checkbox" disabled>
-                            <a class="op-uc-link" target="_top" href="https://example.com/" rel="noopener noreferrer">
+                            <a class="op-uc-link" target="_top" href="https://example.com/" rel="noopener noreferrer nofollow">
                               <span>asdfasd</span>
                               <span> asdf</span>
                             </a>
@@ -318,7 +318,7 @@ RSpec.describe OpenProject::TextFormatting,
                           <li class="op-uc-list--item">
                             <input type="checkbox" class="op-uc-list--task-checkbox" disabled>
                             <span>asdfasdfasdf </span>
-                            <a class="op-uc-link" href="https://example.com/" target="_top" rel="noopener noreferrer">
+                            <a class="op-uc-link" href="https://example.com/" target="_top" rel="noopener noreferrer nofollow">
                               <span>foobar</span>
                             </a>
                           </li>

--- a/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
             let(:expected) do
               <<~EXPECTED
                 <p class="op-uc-p">
-                  Link to user:"<a class="op-uc-link" rel="noopener noreferrer" target="_top" href="mailto:foo@bar.com">foo@bar.com</a>"
+                  Link to user:"<a class="op-uc-link" rel="noopener noreferrer nofollow" target="_top" href="mailto:foo@bar.com">foo@bar.com</a>"
                 </p>
               EXPECTED
             end

--- a/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/setting_variable_spec.rb
@@ -59,15 +59,15 @@ RSpec.describe OpenProject::TextFormatting,
             Inline reference to variable setting: #{OpenProject::StaticRouting::UrlHelpers.host}
           </p>
           <p class="op-uc-p">
-            Inline reference to base_url variable: <a href="#{Rails.application.root_url}" target="_top" rel="noopener noreferrer"
+            Inline reference to base_url variable: <a href="#{Rails.application.root_url}" target="_top" rel="noopener noreferrer nofollow"
                class="op-uc-link">#{Rails.application.root_url}</a>
           </p>
           <p class="op-uc-p">
-            <a href="#{Rails.application.root_url}/foo/bar" target="_top" rel="noopener noreferrer"
+            <a href="#{Rails.application.root_url}/foo/bar" target="_top" rel="noopener noreferrer nofollow"
                class="op-uc-link">Link with setting</a>
           </p>
           <p class="op-uc-p">
-            <a href="#{Rails.application.root_url}/foo/bar" target="_top" rel="noopener noreferrer"
+            <a href="#{Rails.application.root_url}/foo/bar" target="_top" rel="noopener noreferrer nofollow"
                class="op-uc-link">Saved and transformed link with setting</a>
           </p>
           <p class="op-uc-p">

--- a/spec/lib/open_project/text_formatting/markdown/toc_macro_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/toc_macro_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-first-h1-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h1>
         <p class="op-uc-p">Some text after the first h1 heading</p>
         <h2 class="op-uc-h2" id="op-frag-the-first-h2-heading">
@@ -131,7 +131,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-first-h2-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h2>
         <p class="op-uc-p">Some text after the first h2 heading</p>
         <h3 class="op-uc-h3" id="op-frag-the-first-h3-heading">
@@ -139,7 +139,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-first-h3-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h3>
         <p class="op-uc-p">Some text after the first h3 heading</p>
         <h1 class="op-uc-h1" id="op-frag-the-second-h1-heading">
@@ -147,7 +147,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-second-h1-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h1>
         <p class="op-uc-p">Some text after the second h1 heading</p>
         <h2 class="op-uc-h2" id="op-frag-the-second-h2-heading">
@@ -155,7 +155,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-second-h2-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h2>
         <p class="op-uc-p">Some text after the second h2 heading</p>
         <h3 class="op-uc-h3" id="op-frag-the-second-h3-heading">
@@ -163,7 +163,7 @@ RSpec.describe OpenProject::TextFormatting,
           <a class="op-uc-link_permalink icon-link op-uc-link"
              href="#op-frag-the-second-h3-heading"
              aria-hidden="true"
-             rel="noopener noreferrer"></a>
+             rel="noopener noreferrer nofollow"></a>
         </h3>
         <p class="op-uc-p">Some text after the second h3 heading</p>
       EXPECTED
@@ -259,7 +259,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-1-the-first-h1-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h1>
           <p class="op-uc-p">Some text after the first h1 heading</p>
           <h2 class="op-uc-h2" id="op-frag-11-the-first-h2-heading">
@@ -267,7 +267,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-11-the-first-h2-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h2>
           <p class="op-uc-p">Some text after the first h2 heading</p>
           <h3 class="op-uc-h3" id="op-frag-111-the-first-h3-heading">
@@ -275,7 +275,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-111-the-first-h3-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h3>
           <p class="op-uc-p">Some text after the first h3 heading</p>
           <h1 class="op-uc-h1" id="op-frag-2-the-second-h1-heading">
@@ -283,7 +283,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-2-the-second-h1-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h1>
           <p class="op-uc-p">Some text after the second h1 heading</p>
           <h2 class="op-uc-h2" id="op-frag-21-the-second-h2-heading">
@@ -291,7 +291,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-21-the-second-h2-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h2>
           <p class="op-uc-p">Some text after the second h2 heading</p>
           <h3 class="op-uc-h3" id="op-frag-211---the-second-h3-heading">
@@ -299,7 +299,7 @@ RSpec.describe OpenProject::TextFormatting,
             <a class="op-uc-link_permalink icon-link op-uc-link"
                href="#op-frag-211---the-second-h3-heading"
                aria-hidden="true"
-               rel="noopener noreferrer"></a>
+               rel="noopener noreferrer nofollow"></a>
           </h3>
           <p class="op-uc-p">Some text after the second h3 heading</p>
         EXPECTED

--- a/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/user_provided_links_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            this is a <a href="http://malicious" target="_top" rel="noopener noreferrer" class="op-uc-link">
+            this is a <a href="http://malicious" target="_top" rel="noopener noreferrer nofollow" class="op-uc-link">
           </p>
         EXPECTED
       end
@@ -63,7 +63,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
       let(:expected) do
         <<~EXPECTED
           <p class="op-uc-p">
-            this is a <a href="http://external.com" rel="noopener noreferrer" target="_top" class="op-uc-link">external link</a>
+            this is a <a href="http://external.com" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">external link</a>
           </p>
         EXPECTED
       end
@@ -82,7 +82,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Autolink to <a href="http://www.google.com" rel="noopener noreferrer" target="_top" class="op-uc-link">http://www.google.com</a>
+              Autolink to <a href="http://www.google.com" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">http://www.google.com</a>
             </p>
           EXPECTED
         end
@@ -100,7 +100,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Mailto link to <a href="mailto:foo@bar.com" rel="noopener noreferrer" target="_top" class="op-uc-link">foo@bar.com</a>
+              Mailto link to <a href="mailto:foo@bar.com" rel="noopener noreferrer nofollow" target="_top" class="op-uc-link">foo@bar.com</a>
             </p>
           EXPECTED
         end
@@ -120,7 +120,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Link to <a href="/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer">relative path</a>
+              Link to <a href="/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer nofollow">relative path</a>
             </p>
           EXPECTED
         end
@@ -140,7 +140,7 @@ RSpec.describe OpenProject::TextFormatting, "user provided links" do # rubocop:d
         let(:expected) do
           <<~EXPECTED
             <p class="op-uc-p">
-              Link to <a href="http://openproject.org/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer">relative path</a>
+              Link to <a href="http://openproject.org/foo/bar" target="_top" class="op-uc-link" rel="noopener noreferrer nofollow">relative path</a>
             </p>
           EXPECTED
         end

--- a/spec/requests/api/v3/render_resource_spec.rb
+++ b/spec/requests/api/v3/render_resource_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "API v3 Render resource" do
                     Hello World! This <em>is</em> markdown with a
                     <a href="http://community.openproject.org"
                        target="_top"
-                       rel="noopener noreferrer"
+                       rel="noopener noreferrer nofollow"
                        class="op-uc-link">link</a>
                     and ümläutß.</p>
                 HTML


### PR DESCRIPTION
## Work package

https://community.openproject.org/projects/openproject/work_packages/73503/github

## Summary

- Links in user-generated content (work package descriptions, comments, wiki pages, forum posts) carried `rel="noopener noreferrer"` but not `nofollow`
- Search engines therefore passed PageRank through user-posted links, making community instances attractive targets for SEO spammers
- This adds `nofollow` to all user-generated links in both the `SanitizationFilter` and `AutolinkFilter`, so all links render with `rel="noopener noreferrer nofollow"`

## Test plan

- [x] Verify rendered work package descriptions contain `rel="noopener noreferrer nofollow"` on external links, 
  - [x] work package description
  - [x] forum entry and comment
  - [x] Wiki page
  - [x] Instance homepage welcome text    