### PR TITLE
Consider Sec-Fetch-Site header for session auth

### DIFF
--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -70,7 +70,8 @@ info:
     This means you have to login to OpenProject via the Web-Interface to be authenticated in the API.
     This method is well-suited for clients acting within the browser, like the Angular-Client built into OpenProject.
 
-    In this case, you always need to pass the HTTP header `X-Requested-With "XMLHttpRequest"` for authentication.
+    Keep in mind that session-based authentication is only possible when accessing the API from the same origin. This
+    is assured by checking the `Sec-Fetch-Site` HTTP header.
 
     ### API token as bearer token
 

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -70,7 +70,8 @@ info:
     This means you have to login to OpenProject via the Web-Interface to be authenticated in the API.
     This method is well-suited for clients acting within the browser, like the Angular-Client built into OpenProject.
 
-    In this case, you always need to pass the HTTP header `X-Requested-With "XMLHttpRequest"` for authentication.
+    Keep in mind that session-based authentication is only possible when accessing the API from the same origin. This
+    is assured by checking the `sec-fetch-site` header.
 
     ### API token as bearer token
 

--- a/docs/release-notes/17-5-0/README.md
+++ b/docs/release-notes/17-5-0/README.md
@@ -1,0 +1,48 @@
+---
+title: OpenProject 17.5.0
+sidebar_navigation:
+    title: 17.5.0
+release_version: 17.5.0
+release_date: 2026-06-10
+---
+
+ # OpenProject 17.5.0
+
+ Release date: 2026-06-10
+
+ TODO
+
+<!-- BEGIN CVE AUTOMATED SECTION -->
+
+<!-- END CVE AUTOMATED SECTION -->
+
+## Important feature changes
+
+TODO
+
+## Important technical updates
+
+### Session authentication relies on new header for non-GET requests
+
+Previously when making session-authenticated requests to APIv3 endpoints, non-GET requests were only allowed when the
+HTTP Header `X-Requested-With: XMLHttpRequest` was present. This header is usually associated with frameworks such as jQuery,
+but is also added for all requests originating from the OpenProject frontend still. For session authentication it served the
+purpose of preventing cross-site request forgery, e.g. through simple HTTP forms.
+
+The usage of this header has now been replaced with a check for `Sec-Fetch-Site: same-origin`, which is added by a browser automatically
+to requests and also can't be added or altered through JavaScript. It's unlikely that this causes any disruptions, because session authentication
+should only be used for browser-contexts, where the new header will still be present. Non-browser API-access should use different authentication
+methods (e.g. OAuth or API tokens), which are not affected by this change.
+
+## Bug fixes and changes
+
+<!-- Warning: Anything within the below lines will be automatically removed by the release script -->
+<!-- BEGIN AUTOMATED SECTION -->
+
+<!-- END AUTOMATED SECTION -->
+<!-- Warning: Anything above this line will be automatically removed by the release script -->
+
+## Contributions
+
+TODO
+

--- a/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
@@ -1,5 +1,5 @@
 import {
-  HttpEvent, HttpHandler, HttpHeaders, HttpInterceptor, HttpRequest,
+  HttpEvent, HttpHandler, HttpInterceptor, HttpRequest,
 } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
@@ -30,19 +30,18 @@ export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   }
 
   private handleAuthenticatedRequest(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
-    let headers:HttpHeaders;
     const csrfToken = getMetaContent('csrf-token');
 
+    let newHeaders = req.headers.set('X-Requested-With', 'XMLHttpRequest');
+
     if (csrfToken) {
-      headers = req.headers.set('X-CSRF-TOKEN', csrfToken);
-    } else {
-      headers = req.headers;
+      newHeaders = newHeaders.set('X-CSRF-TOKEN', csrfToken);
     }
 
     // Clone the request to add the new header
     const clonedRequest = req.clone({
       withCredentials: true,
-      headers: headers,
+      headers: newHeaders,
     });
 
     // Pass the cloned request instead of the original request to the next handle

--- a/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
+++ b/frontend/src/app/features/hal/http/openproject-header-interceptor.ts
@@ -1,5 +1,5 @@
 import {
-  HttpEvent, HttpHandler, HttpInterceptor, HttpRequest,
+  HttpEvent, HttpHandler, HttpHeaders, HttpInterceptor, HttpRequest,
 } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
@@ -30,18 +30,19 @@ export class OpenProjectHeaderInterceptor implements HttpInterceptor {
   }
 
   private handleAuthenticatedRequest(req:HttpRequest<any>, next:HttpHandler):Observable<HttpEvent<any>> {
+    let headers:HttpHeaders;
     const csrfToken = getMetaContent('csrf-token');
 
-    let newHeaders = req.headers.set('X-Requested-With', 'XMLHttpRequest');
-
     if (csrfToken) {
-      newHeaders = newHeaders.set('X-CSRF-TOKEN', csrfToken);
+      headers = req.headers.set('X-CSRF-TOKEN', csrfToken);
+    } else {
+      headers = req.headers;
     }
 
     // Clone the request to add the new header
     const clonedRequest = req.clone({
       withCredentials: true,
-      headers: newHeaders,
+      headers: headers,
     });
 
     // Pass the cloned request instead of the original request to the next handle

--- a/lib_static/open_project/authentication/strategies/warden/session.rb
+++ b/lib_static/open_project/authentication/strategies/warden/session.rb
@@ -50,19 +50,14 @@ module OpenProject
             return true if request.get?
 
             # For all other requests, to mitigate CSRF vectors,
-            # require frontend headers to be present or browser indication
-            # that this was a same-origin request
-            xml_request_header_set? || same_origin?
+            # require browser indication that this was a same-origin request
+            same_origin?
           end
 
           def authenticate!
             user = user_id ? User.find(user_id) : User.anonymous
 
             success! user
-          end
-
-          def xml_request_header_set?
-            request.env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest"
           end
 
           def same_origin?

--- a/lib_static/open_project/authentication/strategies/warden/session.rb
+++ b/lib_static/open_project/authentication/strategies/warden/session.rb
@@ -50,8 +50,9 @@ module OpenProject
             return true if request.get?
 
             # For all other requests, to mitigate CSRF vectors,
-            # require the frontend header to be present.
-            xml_request_header_set?
+            # require frontend headers to be present or browser indication
+            # that this was a same-origin request
+            xml_request_header_set? || same_origin?
           end
 
           def authenticate!
@@ -62,6 +63,10 @@ module OpenProject
 
           def xml_request_header_set?
             request.env["HTTP_X_REQUESTED_WITH"] == "XMLHttpRequest"
+          end
+
+          def same_origin?
+            request.env["HTTP_SEC_FETCH_SITE"] == "same-origin"
           end
 
           def user_id

--- a/modules/bim/lib/open_project/bim/engine.rb
+++ b/modules/bim/lib/open_project/bim/engine.rb
@@ -238,7 +238,7 @@ module OpenProject::Bim
 
       OpenProject::Authentication.update_strategies(OpenProject::Authentication::Scope::BCF_V2_1,
                                                     store: false) do |_strategies|
-        %i[oauth session]
+        %i[oauth session anonymous_fallback]
       end
     end
     config.to_prepare do

--- a/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
+++ b/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "POST /projects/:project_id/ifc_models/set_direct_upload_file_nam
   context "when user is not logged in" do
     it "requires login" do
       post set_direct_upload_file_name_bcf_project_ifc_models_path(project_id: project.id)
-      expect(last_response).to have_http_status(:not_acceptable)
+      expect(last_response).to have_http_status(:found)
     end
   end
 

--- a/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
+++ b/modules/bim/spec/requests/ifc_models/set_direct_upload_filename_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "POST /projects/:project_id/ifc_models/set_direct_upload_file_nam
   context "when user is not logged in" do
     it "requires login" do
       post set_direct_upload_file_name_bcf_project_ifc_models_path(project_id: project.id)
-      expect(last_response).to have_http_status(:not_acceptable)
+      expect(last_response).to have_http_status(:found)
     end
   end
 

--- a/modules/reporting/spec/requests/custom_field_cache_spec.rb
+++ b/modules/reporting/spec/requests/custom_field_cache_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe "Custom field filter and group by caching" do
 
   def visit_cost_reports_index
     header "Content-Type", "text/html"
-    header "X-Requested-With", "XMLHttpRequest"
     get "/projects/#{project.id}/cost_reports"
   end
 

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_ac
         project_id: project_storage.project.id,
         id: project_storage
       )
-      expect(last_response).to have_http_status(:unauthorized)
+      expect(last_response).to have_http_status(:found)
     end
   end
 

--- a/spec/features/security/session_ttl_spec.rb
+++ b/spec/features/security/session_ttl_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe "Session TTL",
 
   describe "outdated TTL on API request" do
     it "expires on the next APIv3 request" do
-      page.driver.header("X-Requested-With", "XMLHttpRequest")
       visit "/api/v3/work_packages/#{work_package.id}"
 
       body = JSON.parse(page.body)

--- a/spec/requests/api/v3/authentication_spec.rb
+++ b/spec/requests/api/v3/authentication_spec.rb
@@ -42,6 +42,67 @@ RSpec.describe "API V3 Authentication" do
   end
   let(:resource_metadata) { 'resource_metadata="http://test.host/.well-known/oauth-protected-resource"' }
 
+  describe "session auth" do
+    let(:user) { create(:admin) }
+    let(:session_data) { ActiveSupport::HashWithIndifferentAccess.new(user_id: user.id, updated_at: Time.current) }
+
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(OpenProject::Authentication::Strategies::Warden::Session)
+        .to receive(:session)
+        .and_return(session_data)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context "when making a GET request" do
+      before do
+        get resource
+      end
+
+      it "authenticates successfully" do
+        expect(last_response).to have_http_status :ok
+      end
+    end
+
+    context "when making a POST request" do
+      let(:add_additional_headers) { nil }
+
+      before do
+        header "Content-Type", "application/json"
+        add_additional_headers
+        post resource, { name: "Test" }.to_json
+      end
+
+      it "is not authenticated" do
+        expect(last_response).to have_http_status :unauthorized
+      end
+
+      context "and when the Sec-Fetch-Site header indicates a same-origin request" do
+        let(:add_additional_headers) { header "Sec-Fetch-Site", "same-origin" }
+
+        it "authenticates successfully" do
+          expect(last_response).to have_http_status :created
+        end
+      end
+
+      context "and when the Sec-Fetch-Site header indicates a cross-site request" do
+        let(:add_additional_headers) { header "Sec-Fetch-Site", "cross-site" }
+
+        it "is not authenticated" do
+          expect(last_response).to have_http_status :unauthorized
+        end
+      end
+
+      context "and when the Sec-Fetch-Site header indicates a same-site request" do
+        let(:add_additional_headers) { header "Sec-Fetch-Site", "same-site" }
+
+        it "is not authenticated" do
+          expect(last_response).to have_http_status :unauthorized
+        end
+      end
+    end
+  end
+
   describe "oauth" do
     let(:oauth_access_token) { "" }
     let(:expected_message) { "You did not provide the correct credentials." }

--- a/spec/requests/api/v3/root_resource_spec.rb
+++ b/spec/requests/api/v3/root_resource_spec.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++

--- a/spec/requests/api/v3/root_resource_spec.rb
+++ b/spec/requests/api/v3/root_resource_spec.rb
@@ -82,13 +82,6 @@ RSpec.describe "API v3 Root resource" do
         expect(subject).to have_json_path("instanceName")
       end
 
-      context "without the X-requested-with header", :skip_xhr_header do
-        it "returns OK because GET requests are allowed" do
-          expect(response).to have_http_status(:ok)
-          expect(subject).to have_json_path("instanceName")
-        end
-      end
-
       context "with content-type application/hal+json" do
         before do
           header("Content-Type", "application/hal+json")

--- a/spec/requests/oauth_clients/callback_flow_spec.rb
+++ b/spec/requests/oauth_clients/callback_flow_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "OAuthClient callback endpoint" do
   context "when user is not logged in" do
     it "requires login" do
       get uri.to_s
-      expect(last_response).to have_http_status(:unauthorized)
+      expect(last_response).to have_http_status(:found)
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe "OAuthClient callback endpoint" do
 
       allow(Rack::OAuth2::Client).to receive(:new).and_return(rack_oauth2_client)
       allow(rack_oauth2_client)
-        .to receive(:access_token!)
+        .to(receive(:access_token!))
         .with(:body)
         .and_return(Rack::OAuth2::AccessToken::Bearer.new(access_token: "xyzaccesstoken",
                                                           refresh_token: "xyzrefreshtoken",

--- a/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
+++ b/spec/requests/oauth_clients/ensure_connection_flow_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "/oauth_clients/:oauth_client_id/ensure_connection endpoint", :we
     context "when user is not logged in" do
       it "requires login" do
         get oauth_clients_ensure_connection_url(oauth_client_id: oauth_client.client_id)
-        expect(last_response).to have_http_status(:unauthorized)
+        expect(last_response).to have_http_status(:found)
       end
     end
 

--- a/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting/api_v3_rate_limiting_spec.rb
@@ -49,14 +49,20 @@ RSpec.describe "Rate limiting APIv3",
       6.times do
         post "/api/v3/work_packages/form",
              nil,
-             "CONTENT_TYPE" => "application/json"
+             "CONTENT_TYPE" => "application/json",
+             # we need to emulate a valid session authentication,
+             # as the anonymous fallback does not work with rate limiting in the test setup
+             "HTTP_SEC_FETCH_SITE" => "same-origin"
 
         expect(last_response).to have_http_status :ok
       end
 
       post "/api/v3/work_packages/form",
            nil,
-           "CONTENT_TYPE" => "application/json"
+           "CONTENT_TYPE" => "application/json",
+           # we need to emulate a valid session authentication,
+           # as the anonymous fallback does not work with rate limiting in the test setup
+           "HTTP_SEC_FETCH_SITE" => "same-origin"
       expect(last_response).to have_http_status :too_many_requests
     end
   end

--- a/spec/support/request_with_header.rb
+++ b/spec/support/request_with_header.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.configure do |c|
-  ##
-  # Session-based API authentication requires the X-requested-with header to be present.
-  c.before(:each, type: :request) do |ex|
-    unless ex.metadata[:skip_xhr_header]
-      header("X-Requested-With", "XMLHttpRequest")
-    end
-  end
-
   c.before(:each, content_type: :json, type: :request) do |_ex|
     header("Content-Type", "application/json")
   end

--- a/spec/support/request_with_header.rb
+++ b/spec/support/request_with_header.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 RSpec.configure do |c|
   c.before(:each, content_type: :json, type: :request) do |_ex|
     header("Content-Type", "application/json")


### PR DESCRIPTION
This warden strategy is primarily used to allow APIv3 requests from the browser, which only authenticates using its session cookie.

Since this is susceptible to cross-site-request-forgery, prevention of CSRF must take place. This was so far only ensured through the usage of the X-Requested-With header. When a client sent along this header, the server could know that a CORS-preflight request must have been made (because it's none of the [CORS-safelisted](https://developer.mozilla.org/docs/Glossary/CORS-safelisted_request_header) headers) and thus the browser most certainly has validated that the request is valid according to CORS rules.

However, the header itself is a non-standard header and while some JavaScript frameworks add it to requests, not all of them do. For us this was practically visible on the API docs hosted under `/api/docs`.

The solution is to expect the browser to send the Sec-Fetch-Site header with a value of same-origin. This header can't be set through JavaScript, but only by the browser and the value "same-origin" ensures that scheme, host and port are the same for requester and requested endpoint, thus eliminating CSRF concerns. This feature is widely supported by all major browsers, the last of which was Safari which added support 3 years ago.

We might want to consider dropping the check for X-Requested-With entirely, since it should be superfluous. For now it was left in place for greater compatibility.

# References
* https://community.openproject.org/wp/73499
* https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site

CC opf/security. Extra eyes would be nice.