### PR TITLE
[72850] Right side bar from Overview page is read out before main page content

### DIFF
--- a/modules/overviews/app/components/overviews/show_component.html.erb
+++ b/modules/overviews/app/components/overviews/show_component.html.erb
@@ -31,7 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(
     OpPrimer::ConditionalLayoutComponent.new(
       condition: sidebar_enabled?,
-      classes: "op-grid-page"
+      classes: "op-grid-page",
+      first_in_source: :main
     )
   ) do |component|
     component.with_sidebar(width: :narrow, col_placement: :end) do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72850

# What are you trying to accomplish?
Move main section as first in source so that the tabbing order matches the visual order
