### PR TITLE
Bug/73477 work package details view squashes the main content

### DIFF
--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -141,5 +141,5 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   .op-backlogs-story
     grid-template-columns: var(--control-xsmall-size) 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
 
-  .op-backlogs-container
+  .op-backlogs-container, .op-sprint-planning-container
     flex-direction: column

--- a/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/sprint_planning.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% content_for :content_body do %>
-  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: sprint_planning_backlogs_project_backlogs_path(@project) %>
+  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: sprint_planning_backlogs_project_backlogs_path(@project), class: "op-backlogs-page" %>
 <% end %>
 
 <% content_for :content_body_right do %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73477

# What are you trying to accomplish?
Fix the details pane behaviour on the sprint planning page.

# What approach did you choose and why?
- Transfer the missing `.op-backlogs-page` class on the sprint planning list
- Complete the css definition of `.op-sprint-planning-container` to make it identical with the `.op-backlogs-container`.

## Screenshots

<img width="1230" height="779" alt="image" src="https://github.com/user-attachments/assets/62d352ac-45e5-473e-85d0-bda5e13d69c2" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
