### PR TITLE
switch user in crowdin action instead of changing owner after run

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -76,12 +76,10 @@ jobs:
           crowdin_branch_name: ${{ steps.vars.outputs.crowdin_branch }}
           # Dont create a PR for the updated translations
           push_translations: false
+          user: auto
         env:
           OPENPROJECT_CROWDIN_PROJECT: ${{ secrets.OPENPROJECT_CROWDINV2_PROJECT }}
           OPENPROJECT_CROWDIN_API_KEY: ${{ secrets.OPENPROJECT_CROWDINV2_API_KEY }}
-      - name: "Fix ownership of downloaded translation files"
-        run: |
-          sudo chown -R $(id -u):$(id -g) config/locales/crowdin/ modules/*/config/locales/crowdin/
       - name: "Fix root key in Portuguese crowdin translation files"
         run: |
           script/i18n/fix_crowdin_pt_language_root_key


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

# What are you trying to accomplish?

The Crowdin GitHub Action runs as root inside a Docker container, causing downloaded translation files to be owned by root. This breaks subsequent workflow steps that need to edit or `git add` those files.

# What approach did you choose and why?

Use the `user: auto` input added in [crowdin/github-action#309](https://github.com/crowdin/github-action/pull/309) (shipped in v2.16.0) to run the action as the workspace owner instead of root. This avoids the file ownership problem at the source, removing the need for the follow-up `sudo chown` step.

- Added `user: auto` to the `crowdin/github-action` step so the Docker container runs as the workspace owner (detected from `.git` directory ownership).
- Removed the `"Fix ownership of downloaded translation files"` step that previously ran `sudo chown` to correct ownership after the fact.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.