### PR TITLE
Fix move to sprint dialog

### DIFF
--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
         buttons.with_component(
           Primer::Beta::Button.new(scheme: :primary, form: FORM_ID, data: { turbo: true }, type: :submit)
         ) do
-          t(:button_save)
+          t(:button_move)
         end
       end
     end

--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    d.with_footer(show_divider: true) do
+    d.with_footer do
       component_collection do |buttons|
         buttons.with_component(Primer::Beta::Button.new(data: { close_dialog_id: DIALOG_ID })) do
           t(:button_cancel)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73508

# What are you trying to accomplish?
- As a result of feedback from the UX team, the move to sprint dialog divider is removed.

## Screenshots
<img width="501" height="180" alt="image" src="https://github.com/user-attachments/assets/9b75a0e7-2ad7-4606-9a7f-ad52877bff31" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
