### PR TITLE
Add migration to backfill sharing values for old onetime templates

### DIFF
--- a/modules/meeting/db/migrate/20260327140627_backfill_sharing_for_existing_one_time_templates.rb
+++ b/modules/meeting/db/migrate/20260327140627_backfill_sharing_for_existing_one_time_templates.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class BackfillSharingForExistingOneTimeTemplates < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE meetings
+      SET sharing = 'none'
+      WHERE template = TRUE
+        AND recurring_meeting_id IS NULL
+        AND sharing IS NULL
+    SQL
+  end
+
+  def down
+    # no-op as user set vs. migration set "none" values cannot be distinguished
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/73493

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
Onetime templates created between 17.2 and 17.3 get their sharing set to nil instead of "none", which this migration handles

# To test

1. Checkout `release/17.2`
2. Create onetime template
3. Checkout `release/17.3`
4. View template to see missing translation/see sharing set to nil in the DB