### PR TITLE
[#72873] Template drop-down is not showing if user starts meeting creation from global meeting index pt. 2

### DIFF
--- a/modules/meeting/app/forms/meeting/template_autocompleter.rb
+++ b/modules/meeting/app/forms/meeting/template_autocompleter.rb
@@ -34,17 +34,7 @@ class Meeting::TemplateAutocompleter < ApplicationForm
       name: :template_id,
       label: I18n.t(:label_meeting_template),
       caption: I18n.t(:caption_meeting_template_select),
-      autocomplete_options: {
-        decorated: true,
-        defaultData: false,
-        multiple: false,
-        disabled: @disabled,
-        placeholder: @placeholder,
-        appendTo: "#new-meeting-dialog",
-        data: {
-          "test-selector": "template_id"
-        }
-      }
+      autocomplete_options:
     ) do |select|
       templates.each do |template|
         select.option(
@@ -65,6 +55,21 @@ class Meeting::TemplateAutocompleter < ApplicationForm
   end
 
   private
+
+  def autocomplete_options
+    opts = {
+      decorated: true,
+      defaultData: false,
+      multiple: false,
+      disabled: @disabled,
+      appendTo: "#new-meeting-dialog",
+      data: {
+        "test-selector": "template_id"
+      }
+    }
+    opts[:placeholder] = @placeholder if @placeholder
+    opts
+  end
 
   def templates
     return [] if @disabled


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72873

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
When there is no `placeholder` option, the default "Type to search" is used. Adding this as an autocomplete option only when it's defined ensures the correct behaviour