### PR TITLE
[#72208] User without edit meetings permissions get a 403 when clicking on 'Duplicate meeting' menu item

### DIFF
--- a/modules/meeting/app/components/meetings/header_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_component.html.erb
@@ -80,14 +80,16 @@
         end
 
         unless @meeting.template?
-          menu.with_item(
-            label: copy_label,
-            href: copy_project_meeting_path(@project, @meeting),
-            content_arguments: {
-              data: { turbo_stream: true }
-            }
-          ) do |item|
-            item.with_leading_visual_icon(icon: :duplicate)
+          if copy_enabled?
+            menu.with_item(
+              label: copy_label,
+              href: copy_project_meeting_path(@project, @meeting),
+              content_arguments: {
+                data: { turbo_stream: true }
+              }
+            ) do |item|
+              item.with_leading_visual_icon(icon: :duplicate)
+            end
           end
 
           menu.with_item(

--- a/modules/meeting/app/components/meetings/header_component.rb
+++ b/modules/meeting/app/components/meetings/header_component.rb
@@ -83,6 +83,10 @@ module Meetings
       !@meeting.series_template? && User.current.allowed_in_project?(:delete_meetings, @meeting.project)
     end
 
+    def copy_enabled?
+      User.current.allowed_in_project?(:create_meetings, @meeting.project)
+    end
+
     def finish_setup_enabled?
       @meeting.draft? &&
         !@meeting.onetime_template? &&

--- a/modules/meeting/spec/components/meetings/header_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/header_component_spec.rb
@@ -77,4 +77,80 @@ RSpec.describe Meetings::HeaderComponent, type: :component do
       end
     end
   end
+
+  describe "duplicate meeting" do
+    context "when user has create_meetings permission" do
+      before do
+        mock_permissions_for(user) do |mock|
+          mock.allow_in_project(:create_meetings, project:)
+        end
+      end
+
+      it "renders the duplicate menu item" do
+        expect(subject).to have_text I18n.t("button_duplicate")
+      end
+    end
+
+    context "when user does not have create_meetings permission" do
+      it "does not render the duplicate menu item" do
+        expect(subject).to have_no_text I18n.t("button_duplicate")
+      end
+    end
+
+    context "when meeting is a template" do
+      let(:meeting) { build_stubbed(:meeting, project:, template: true) }
+
+      before do
+        mock_permissions_for(user) do |mock|
+          mock.allow_in_project(:create_meetings, project:)
+        end
+      end
+
+      it "does not render the duplicate menu item" do
+        expect(subject).to have_no_text I18n.t("button_duplicate")
+      end
+    end
+
+    context "when meeting is a series occurrence" do
+      let(:recurring_meeting) { build_stubbed(:recurring_meeting, project:) }
+      let(:meeting) { build_stubbed(:meeting, project:, recurring_meeting:) }
+
+      before do
+        allow(meeting).to receive(:notify?).and_return(false)
+      end
+
+      context "when user has create_meetings permission" do
+        before do
+          mock_permissions_for(user) do |mock|
+            mock.allow_in_project(:create_meetings, project:)
+          end
+        end
+
+        it "renders the duplicate as one-time meeting menu item" do
+          expect(subject).to have_text I18n.t("label_recurring_meeting_duplicate")
+        end
+      end
+
+      context "when user does not have create_meetings permission" do
+        it "does not render the duplicate as one-time meeting menu item" do
+          expect(subject).to have_no_text I18n.t("label_recurring_meeting_duplicate")
+        end
+      end
+    end
+
+    context "when meeting is a series template" do
+      let(:recurring_meeting) { build_stubbed(:recurring_meeting, project:) }
+      let(:meeting) { build_stubbed(:meeting, project:, template: true, recurring_meeting:) }
+
+      before do
+        mock_permissions_for(user) do |mock|
+          mock.allow_in_project(:create_meetings, project:)
+        end
+      end
+
+      it "does not render the duplicate menu item" do
+        expect(subject).to have_no_text I18n.t("label_recurring_meeting_duplicate")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/72208

I'm surprised we didn't have this already or run into this before. Maybe a regression? 🤷🏽 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
