### PR TITLE
[#73511] Fix robots meta tag rendered as text instead of HTML element

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -443,7 +443,7 @@ module ApplicationHelper
   # @param [optional, String] content the content of the ROBOTS tag.
   #   defaults to no index, follow, and no archive
   def robot_exclusion_tag(content = "NOINDEX,FOLLOW,NOARCHIVE")
-    content_tag(:meta, name: "ROBOTS", content:)
+    tag(:meta, name: "ROBOTS", content:)
   end
 
   def permitted_params

--- a/spec/views/wiki/new.html.erb_spec.rb
+++ b/spec/views/wiki/new.html.erb_spec.rb
@@ -72,4 +72,9 @@ RSpec.describe "wiki/new" do
     render
     assert_select "input", name: "page[parent_id]", value: "123", type: "hidden"
   end
+
+  it "renders a robots exclusion meta tag in the header tags" do
+    render
+    expect(view.content_for(:header_tags)).to include('name="ROBOTS"', 'content="NOINDEX,FOLLOW,NOARCHIVE"')
+  end
 end


### PR DESCRIPTION
## Summary

Fixes a bug where the ROBOTS meta tag was rendered as visible text on the wiki page when no wiki pages exist yet in a project.

- Replaces `content_tag(:meta, name:, content:)` with `tag(:meta, ...)` — `content_tag` treated the keyword arguments as text content rather than HTML attributes
- Adds a view spec assertion to cover the correct rendering

## Work package

https://community.openproject.org/projects/openproject/work_packages/73511/activity

## Test plan

- [x] Navigate to `/projects/<id>/wiki` on a project with no wiki pages — no JSON-like text should appear at the top of the page