### PR TITLE
Bug/73316 page loads twice after sprint creation

### DIFF
--- a/frontend/src/app/shared/components/time_entries/services/time-entry-timer.service.ts
+++ b/frontend/src/app/shared/components/time_entries/services/time-entry-timer.service.ts
@@ -176,6 +176,8 @@ export class TimeEntryTimerService {
 
   private handleTimeEntryDialogClose(event:CustomEvent):void {
     const { detail: { dialog, submitted } } = event as { detail:{ dialog:HTMLDialogElement, submitted:boolean } };
+    if (!dialog) { return; }
+
     const isOngoing = dialog.dataset.ongoing === 'true';
 
     if (dialog.id === 'time-entry-dialog' && submitted && isOngoing) {

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -96,6 +96,9 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   overflow-y: auto
   overflow-x: hidden
 
+  .op-sprint-planning-lists--content
+    display: contents
+
 .op-sprint-planning-lists
   padding-top: var(--stack-padding-normal)
   padding-bottom: var(--stack-padding-normal)

--- a/frontend/src/turbo/dialog-stream-action.ts
+++ b/frontend/src/turbo/dialog-stream-action.ts
@@ -4,6 +4,7 @@ import { Idiomorph } from 'idiomorph';
 export function registerDialogStreamAction() {
   StreamActions.closeDialog = function closeDialogStreamAction(this:StreamElement) {
     const dialog = document.querySelector(this.target)!;
+    if (!dialog) { return; }
     const additionalData = JSON.parse(this.getAttribute('additional') || '{}') as unknown;
 
     // dispatching with submitted: true to indicate that the behavior of a successful submission should

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -88,7 +88,7 @@ class RbMasterBacklogsController < RbApplicationController
     @owner_backlogs = Backlog.owner_backlogs(@project)
 
     if OpenProject::FeatureDecisions.scrum_projects_active?
-      @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+      @sprints = Agile::Sprint.displayable_in_project(@project)
       @stories_by_sprint_id = WorkPackage
         .where(sprint: @sprints, project: @project)
         .order_by_position

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -122,14 +122,20 @@ class RbSprintsController < RbApplicationController
     end
   end
 
-  def finish
+  def finish # rubocop:disable Metrics/AbcSize
     result = finish_sprint
 
     if result.success?
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_finish))
       close_dialog_via_turbo_stream("##{Backlogs::FinishSprintDialogComponent::DIALOG_ID}")
       remove_finished_sprint_from_list_via_turbo_stream
-      update_target_sprint_component_via_turbo_stream
+
+      if moved_to_backlog?
+        update_inbox_component_via_turbo_stream
+      elsif params[:move_to_sprint_id].present?
+        update_target_sprint_component_via_turbo_stream
+      end
+
       respond_with_turbo_streams
     elsif result.includes_error?(:base, :unfinished_work_packages)
       show_finish_sprint_dialog
@@ -231,13 +237,23 @@ class RbSprintsController < RbApplicationController
   end
 
   def update_target_sprint_component_via_turbo_stream
-    return if params[:move_to_sprint_id].blank?
-
     target_sprint = Agile::Sprint.for_project(@project).visible.find(params[:move_to_sprint_id])
     replace_via_turbo_stream(
       component: Backlogs::SprintComponent.new(sprint: target_sprint, project: @project),
       method: :morph
     )
+  end
+
+  def update_inbox_component_via_turbo_stream
+    inbox_work_packages = Backlog.inbox_for(project: @project)
+    replace_via_turbo_stream(
+      component: Backlogs::InboxComponent.new(work_packages: inbox_work_packages, project: @project),
+      method: :morph
+    )
+  end
+
+  def moved_to_backlog?
+    params[:unfinished_action].in?(%w[move_to_top_of_backlog move_to_bottom_of_backlog])
   end
 
   def show_finish_sprint_dialog

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -129,6 +129,7 @@ class RbSprintsController < RbApplicationController
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_finish))
       close_dialog_via_turbo_stream("##{Backlogs::FinishSprintDialogComponent::DIALOG_ID}")
       remove_finished_sprint_from_list_via_turbo_stream
+      update_target_sprint_component_via_turbo_stream
       respond_with_turbo_streams
     elsif result.includes_error?(:base, :unfinished_work_packages)
       show_finish_sprint_dialog
@@ -226,6 +227,16 @@ class RbSprintsController < RbApplicationController
   def remove_finished_sprint_from_list_via_turbo_stream
     remove_via_turbo_stream(
       component: Backlogs::SprintComponent.new(sprint: @sprint, project: @project)
+    )
+  end
+
+  def update_target_sprint_component_via_turbo_stream
+    return if params[:move_to_sprint_id].blank?
+
+    target_sprint = Agile::Sprint.for_project(@project).visible.find(params[:move_to_sprint_id])
+    replace_via_turbo_stream(
+      component: Backlogs::SprintComponent.new(sprint: target_sprint, project: @project),
+      method: :morph
     )
   end
 

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -84,7 +84,7 @@ class RbSprintsController < RbApplicationController
     if call.success?
       render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_create))
       close_dialog_via_turbo_stream("##{Backlogs::NewSprintDialogComponent::DIALOG_ID}")
-      append_sprint_to_list_via_turbo_stream(sprint: call.result)
+      insert_sprint_into_list_via_turbo_stream(sprint: call.result)
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
     end
@@ -201,12 +201,26 @@ class RbSprintsController < RbApplicationController
     )
   end
 
-  def append_sprint_to_list_via_turbo_stream(sprint:)
+  def insert_sprint_into_list_via_turbo_stream(sprint:) # rubocop:disable Metrics/AbcSize
     component = Backlogs::SprintComponent.new(sprint:, project: @project)
-    turbo_streams << turbo_stream.append(
-      "sprint_planning_sprint_content",
-      component.render_in(view_context)
-    )
+
+    # Find the correct position by comparing dates with existing sprints
+    sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+    sprint_index = sprints.index { |s| s.id == sprint.id }
+
+    action, target = if sprint_index.nil? || sprint_index == sprints.length - 1
+                       # Sprint is last or not found in ordered list, append to end
+                       [:append, "sprint_planning_sprint_content"]
+                     elsif sprint_index.zero?
+                       # Sprint is first, prepend to beginning
+                       [:prepend, "sprint_planning_sprint_content"]
+                     else
+                       # Sprint is in the middle, insert before the next sprint
+                       next_sprint = sprints[sprint_index + 1]
+                       [:before, "backlogs-sprint-component-#{next_sprint.id}"]
+                     end
+
+    turbo_streams << turbo_stream.public_send(action, target, component.render_in(view_context))
   end
 
   def remove_finished_sprint_from_list_via_turbo_stream

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -205,7 +205,7 @@ class RbSprintsController < RbApplicationController
     component = Backlogs::SprintComponent.new(sprint:, project: @project)
 
     # Find the correct position by comparing dates with existing sprints
-    sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+    sprints = Agile::Sprint.displayable_in_project(@project)
     sprint_index = sprints.index { |s| s.id == sprint.id }
 
     action, target = if sprint_index.nil? || sprint_index == sprints.length - 1

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -213,7 +213,7 @@ class RbSprintsController < RbApplicationController
 
     # Find the correct position by comparing dates with existing sprints
     sprints = Agile::Sprint.displayable_in_project(@project)
-    sprint_index = sprints.index { |s| s.id == sprint.id }
+    sprint_index = sprints.index(sprint)
 
     action, target = if sprint_index.nil? || sprint_index == sprints.length - 1
                        # Sprint is last or not found in ordered list, append to end

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -76,18 +76,20 @@ class RbSprintsController < RbApplicationController
     respond_with_turbo_streams
   end
 
-  def create # rubocop:disable Metrics/AbcSize
+  def create
     call = Sprints::CreateService
              .new(user: current_user)
              .call(attributes: converted_agile_sprint_params)
 
     if call.success?
-      flash[:notice] = I18n.t(:notice_successful_create)
-      render turbo_stream: turbo_stream.redirect_to(backlog_backlogs_project_backlogs_path(@project))
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_create))
+      close_dialog_via_turbo_stream("##{Backlogs::NewSprintDialogComponent::DIALOG_ID}")
+      append_sprint_to_list_via_turbo_stream(sprint: call.result)
     else
       update_new_sprint_form_component_via_turbo_stream(sprint: call.result, base_errors: call.errors[:base])
-      respond_with_turbo_streams
     end
+
+    respond_with_turbo_streams
   end
 
   # Called like this due to `update` being taken by legacy sprints.
@@ -124,8 +126,10 @@ class RbSprintsController < RbApplicationController
     result = finish_sprint
 
     if result.success?
-      flash[:notice] = I18n.t(:notice_successful_finish)
-      render turbo_stream: turbo_stream.redirect_to(backlog_backlogs_project_backlogs_path(@project))
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_finish))
+      close_dialog_via_turbo_stream("##{Backlogs::FinishSprintDialogComponent::DIALOG_ID}")
+      remove_finished_sprint_from_list_via_turbo_stream
+      respond_with_turbo_streams
     elsif result.includes_error?(:base, :unfinished_work_packages)
       show_finish_sprint_dialog
     else
@@ -194,6 +198,20 @@ class RbSprintsController < RbApplicationController
         base_errors:
       ),
       status: :bad_request
+    )
+  end
+
+  def append_sprint_to_list_via_turbo_stream(sprint:)
+    component = Backlogs::SprintComponent.new(sprint:, project: @project)
+    turbo_streams << turbo_stream.append(
+      "sprint_planning_sprint_content",
+      component.render_in(view_context)
+    )
+  end
+
+  def remove_finished_sprint_from_list_via_turbo_stream
+    remove_via_turbo_stream(
+      component: Backlogs::SprintComponent.new(sprint: @sprint, project: @project)
     )
   end
 

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -50,7 +50,8 @@ module Agile
            :order_by_date,
            :receiving_projects,
            :visible,
-           :native_to_sprint_source
+           :native_to_sprint_source,
+           :displayable_in_project
 
     enum :status,
          {

--- a/modules/backlogs/app/models/agile/sprints/scopes/displayable_in_project.rb
+++ b/modules/backlogs/app/models/agile/sprints/scopes/displayable_in_project.rb
@@ -28,22 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Backlogs
-  class MoveToSprintDialogComponent < ApplicationComponent
-    include OpTurbo::Streamable
-    include OpPrimer::ComponentHelpers
+module Agile::Sprints::Scopes
+  module DisplayableInProject
+    extend ActiveSupport::Concern
 
-    DIALOG_ID = "move-to-sprint-dialog"
-    FORM_ID = "move-to-sprint-dialog-form"
-
-    attr_reader :work_package, :project, :sprints
-
-    def initialize(work_package:, project:)
-      super()
-
-      @work_package = work_package
-      @project = project
-      @sprints = Agile::Sprint.displayable_in_project(@project)
+    class_methods do
+      # Returns all non-completed sprints for a project, ordered by date.
+      # Used in most views to display relevant sprints.
+      def displayable_in_project(project)
+        for_project(project)
+          .not_completed
+          .order_by_date
+      end
     end
   end
 end

--- a/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
@@ -117,14 +117,16 @@ See COPYRIGHT and LICENSE files for more details.
           end
         %>
       <% else %>
-        <% @sprints.each do |sprint| %>
-          <%= render Backlogs::SprintComponent.new(
-                sprint:,
-                project: @project,
-                stories: @stories_by_sprint_id[sprint.id],
-                active_sprint_ids: @active_sprint_ids
-              ) %>
-        <% end %>
+        <div id="sprint_planning_sprint_content" class="op-sprint-planning-lists--content">
+          <% @sprints.each do |sprint| %>
+            <%= render Backlogs::SprintComponent.new(
+              sprint:,
+              project: @project,
+              stories: @stories_by_sprint_id[sprint.id],
+              active_sprint_ids: @active_sprint_ids
+            ) %>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe RbSprintsController do
         expect(response).to be_successful
         expect(response).to have_http_status :ok
         expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
-        assert_select %(turbo-stream[action="update"][target="backlogs-backlog-header-component-#{sprint.id}"][method="morph"])
         expect(assigns(:project)).to eq(project)
         expect(assigns(:sprint)).to eq(sprint)
         expect(assigns(:backlog)).to be_a(Backlog)
@@ -91,7 +90,6 @@ RSpec.describe RbSprintsController do
         expect(response).to be_successful
         expect(response).to have_http_status :ok
         expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
-        assert_select %(turbo-stream[action="update"][target="backlogs-backlog-header-component-#{sprint.id}"][method="morph"])
         expect(assigns(:project)).to eq(project)
         expect(assigns(:sprint)).to eq(sprint)
         expect(assigns(:backlog)).to be_a(Backlog)
@@ -121,7 +119,6 @@ RSpec.describe RbSprintsController do
           expect(response).to be_successful
           expect(response).to have_http_status :ok
           expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
-          assert_select %(turbo-stream[action="update"][target="backlogs-backlog-header-component-#{sprint.id}"][method="morph"])
           expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
           expect(assigns(:project)).to eq(project)
           expect(assigns(:sprint)).to eq(sprint)
@@ -143,7 +140,6 @@ RSpec.describe RbSprintsController do
           expect(response).not_to be_successful
           expect(response).to have_http_status :unprocessable_entity
           expect(response).to have_turbo_stream action: "update", target: "backlogs-backlog-header-component-#{sprint.id}"
-          assert_select %(turbo-stream[action="update"][target="backlogs-backlog-header-component-#{sprint.id}"][method="morph"])
           expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
           expect(assigns(:project)).to eq(project)
           expect(assigns(:sprint)).to eq(sprint)
@@ -233,16 +229,17 @@ RSpec.describe RbSprintsController do
           }
         end
 
-        it "responds with success, creates a sprint, and redirects to backlogs", :aggregate_failures do
+        it "responds with success, creates a sprint, and adds it to the view", :aggregate_failures do
           post :create, format: :turbo_stream, params: params
 
           expect(response).to be_successful
           expect(response).to have_http_status :ok
-          expect(response.body).to include("turbo-stream")
-          expect(response.body).to include("action=\"redirect_to\"")
-          expect(response.body).to include(backlogs_project_backlogs_path(project))
+
+          expect(response.body).to have_turbo_stream action: "flash"
+          expect(response.body).to have_turbo_stream action: "closeDialog", target: "#new-sprint-dialog"
+          expect(response.body).to have_turbo_stream action: "append", target: "sprint_planning_sprint_content"
+          expect(response.body).to include(I18n.t(:notice_successful_create))
           expect(project.reload.sprints.last.name).to eq("My Sprint")
-          expect(flash[:notice]).to eq(I18n.t(:notice_successful_create))
         end
 
         context "without the 'create_sprints' permission" do
@@ -277,7 +274,6 @@ RSpec.describe RbSprintsController do
           expect(response).to have_http_status :ok
           expect(response.body).to have_turbo_stream action: "flash"
           expect(response.body).to have_turbo_stream action: "update", target: "backlogs-sprint-header-component-#{sprint.id}"
-          assert_select %(turbo-stream[action="update"][target="backlogs-sprint-header-component-#{sprint.id}"][method="morph"])
           expect(response.body).to include("Successful update.")
           expect(sprint.reload.name).to eq("Changed sprint name")
         end
@@ -490,16 +486,6 @@ RSpec.describe RbSprintsController do
                    roles: [create(:project_role, permissions: source_permissions)])
           end
 
-          it "finishes the sprint and redirects to the backlog", :aggregate_failures do
-            post :finish, params: request_params
-
-            expect(response).to be_successful
-            expect(response.body).to include("action=\"redirect_to\"")
-            expect(response.body).to include(backlogs_project_backlogs_path(project))
-            expect(flash[:notice]).to eq(I18n.t(:notice_successful_finish))
-            expect(service).to have_received(:call)
-          end
-
           context "without source-project start permission" do
             let(:source_permissions) { %i[view_sprints] }
 
@@ -513,13 +499,13 @@ RSpec.describe RbSprintsController do
           end
         end
 
-        it "finishes the sprint and redirects to the backlog via turbo stream", :aggregate_failures do
+        it "finishes the sprint and removes it from the view", :aggregate_failures do
           post :finish, format: :turbo_stream, params: request_params
 
           expect(response).to be_successful
-          expect(response.body).to include("action=\"redirect_to\"")
-          expect(response.body).to include(backlogs_project_backlogs_path(project))
-          expect(flash[:notice]).to eq(I18n.t(:notice_successful_finish))
+          expect(response).to have_turbo_stream action: "flash"
+          expect(response).to have_turbo_stream action: "closeDialog"
+          expect(response).to have_turbo_stream action: "remove", target: "backlogs-sprint-component-#{sprint.id}"
           expect(service).to have_received(:call)
         end
 
@@ -580,7 +566,9 @@ RSpec.describe RbSprintsController do
             post :finish, format: :turbo_stream, params: request_params
 
             expect(response).to be_successful
-            expect(response.body).to include("action=\"redirect_to\"")
+            expect(response).to have_turbo_stream action: "flash"
+            expect(response).to have_turbo_stream action: "closeDialog"
+            expect(response).to have_turbo_stream action: "remove", target: "backlogs-sprint-component-#{sprint.id}"
             expect(service).to have_received(:call)
               .with(hash_including(unfinished_action: "move_to_top_of_backlog"))
           end
@@ -589,11 +577,13 @@ RSpec.describe RbSprintsController do
         context "when moving to the bottom of the backlog" do
           let(:request_params) { { project_id: project.id, id: sprint.id, unfinished_action: "move_to_bottom_of_backlog" } }
 
-          it "passes unfinished_action to the service and redirects via turbo stream", :aggregate_failures do
+          it "passes unfinished_action to the service and removes the sprint component via turbo", :aggregate_failures do
             post :finish, format: :turbo_stream, params: request_params
 
             expect(response).to be_successful
-            expect(response.body).to include("action=\"redirect_to\"")
+            expect(response).to have_turbo_stream action: "flash"
+            expect(response).to have_turbo_stream action: "closeDialog"
+            expect(response).to have_turbo_stream action: "remove", target: "backlogs-sprint-component-#{sprint.id}"
             expect(service).to have_received(:call)
               .with(hash_including(unfinished_action: "move_to_bottom_of_backlog"))
           end

--- a/modules/backlogs/spec/features/backlogs/create_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_spec.rb
@@ -97,6 +97,92 @@ RSpec.describe "Create", :js do
         expect(sprint.finish_date).to eq finish_date
       end
 
+      context "when inserting sprints at different positions" do
+        shared_let(:early_sprint) do
+          create(:agile_sprint,
+                 project:,
+                 name: "Sprint 1 (Early)",
+                 start_date: Date.new(2025, 1, 1),
+                 finish_date: Date.new(2025, 1, 15))
+        end
+
+        it "inserts a sprint at the beginning when it has the earliest dates" do
+          planning_page.visit!
+
+          planning_page.expect_sprint_names_in_order(early_sprint.name, initial_sprint.name)
+
+          planning_page.open_create_sprint_dialog
+
+          within_dialog "New sprint" do
+            page.fill_in "Sprint name", with: "Sprint 0 (Earliest)"
+            page.fill_in "Start date", with: "2024-12-01"
+            page.fill_in "Finish date", with: "2024-12-15"
+
+            click_on "Create"
+          end
+
+          expect_and_dismiss_flash(message: "Successful creation.")
+          planning_page.expect_sprint_names_in_order("Sprint 0 (Earliest)", early_sprint.name, initial_sprint.name)
+        end
+
+        it "inserts a sprint in the middle when it has intermediate dates" do
+          planning_page.visit!
+
+          planning_page.expect_sprint_names_in_order(early_sprint.name, initial_sprint.name)
+
+          planning_page.open_create_sprint_dialog
+
+          within_dialog "New sprint" do
+            page.fill_in "Sprint name", with: "Sprint 2 (Middle)"
+            page.fill_in "Start date", with: "2025-02-01"
+            page.fill_in "Finish date", with: "2025-02-15"
+
+            click_on "Create"
+          end
+
+          expect_and_dismiss_flash(message: "Successful creation.")
+          planning_page.expect_sprint_names_in_order(early_sprint.name, "Sprint 2 (Middle)", initial_sprint.name)
+        end
+
+        it "inserts a sprint at the end when it has the latest dates" do
+          planning_page.visit!
+
+          planning_page.expect_sprint_names_in_order(early_sprint.name, initial_sprint.name)
+
+          planning_page.open_create_sprint_dialog
+
+          within_dialog "New sprint" do
+            page.fill_in "Sprint name", with: "Sprint 4 (Latest)"
+            page.fill_in "Start date", with: "2025-10-01"
+            page.fill_in "Finish date", with: "2025-10-15"
+
+            click_on "Create"
+          end
+
+          expect_and_dismiss_flash(message: "Successful creation.")
+          planning_page.expect_sprint_names_in_order(early_sprint.name, initial_sprint.name, "Sprint 4 (Latest)")
+        end
+
+        it "orders by finish date when start dates are the same" do
+          planning_page.visit!
+
+          # Create a sprint with the same start date as early_sprint but earlier finish date
+          planning_page.open_create_sprint_dialog
+
+          within_dialog "New sprint" do
+            page.fill_in "Sprint name", with: "Sprint 1.5 (Earlier finish)"
+            page.fill_in "Start date", with: "2025-01-01"
+            page.fill_in "Finish date", with: "2025-01-10"
+
+            click_on "Create"
+          end
+
+          expect_and_dismiss_flash(message: "Successful creation.")
+          # Should appear before early_sprint due to earlier finish date
+          planning_page.expect_sprint_names_in_order("Sprint 1.5 (Earlier finish)", early_sprint.name, initial_sprint.name)
+        end
+      end
+
       it "previews the sprint duration when changing the dates" do
         planning_page.visit!
 

--- a/modules/backlogs/spec/features/backlogs/create_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe "Create", :js do
         planning_page.open_create_sprint_dialog
 
         within_dialog "New sprint" do
-          page.fill_in "Sprint name", with: "Created sprint"
-          page.fill_in "Start date", with: start_date_fmt
-          page.fill_in "Finish date", with: finish_date_fmt
+          fill_in "Sprint name", with: "Created sprint"
+          fill_in "Start date", with: start_date_fmt
+          fill_in "Finish date", with: finish_date_fmt
 
           click_on "Create"
         end
@@ -114,9 +114,9 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Sprint name", with: "Sprint 0 (Earliest)"
-            page.fill_in "Start date", with: "2024-12-01"
-            page.fill_in "Finish date", with: "2024-12-15"
+            fill_in "Sprint name", with: "Sprint 0 (Earliest)"
+            fill_in "Start date", with: "2024-12-01"
+            fill_in "Finish date", with: "2024-12-15"
 
             click_on "Create"
           end
@@ -133,9 +133,9 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Sprint name", with: "Sprint 2 (Middle)"
-            page.fill_in "Start date", with: "2025-02-01"
-            page.fill_in "Finish date", with: "2025-02-15"
+            fill_in "Sprint name", with: "Sprint 2 (Middle)"
+            fill_in "Start date", with: "2025-02-01"
+            fill_in "Finish date", with: "2025-02-15"
 
             click_on "Create"
           end
@@ -152,9 +152,9 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Sprint name", with: "Sprint 4 (Latest)"
-            page.fill_in "Start date", with: "2025-10-01"
-            page.fill_in "Finish date", with: "2025-10-15"
+            fill_in "Sprint name", with: "Sprint 4 (Latest)"
+            fill_in "Start date", with: "2025-10-01"
+            fill_in "Finish date", with: "2025-10-15"
 
             click_on "Create"
           end
@@ -170,9 +170,9 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Sprint name", with: "Sprint 1.5 (Earlier finish)"
-            page.fill_in "Start date", with: "2025-01-01"
-            page.fill_in "Finish date", with: "2025-01-10"
+            fill_in "Sprint name", with: "Sprint 1.5 (Earlier finish)"
+            fill_in "Start date", with: "2025-01-01"
+            fill_in "Finish date", with: "2025-01-10"
 
             click_on "Create"
           end
@@ -191,8 +191,8 @@ RSpec.describe "Create", :js do
         within_dialog "New sprint" do
           expect(page).to have_field "Duration", with: "", readonly: true
 
-          page.fill_in "Start date", with: start_date_fmt
-          page.fill_in "Finish date", with: finish_date_fmt
+          fill_in "Start date", with: start_date_fmt
+          fill_in "Finish date", with: finish_date_fmt
 
           expect(page).to have_field "Duration", with: "16 days", readonly: true
         end
@@ -207,7 +207,7 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Sprint name", with: ""
+            fill_in "Sprint name", with: ""
 
             click_on "Create"
 
@@ -223,8 +223,8 @@ RSpec.describe "Create", :js do
           planning_page.open_create_sprint_dialog
 
           within_dialog "New sprint" do
-            page.fill_in "Start date", with: start_date_fmt
-            page.fill_in "Finish date", with: too_early_finish_date.strftime("%Y-%m-%d")
+            fill_in "Start date", with: start_date_fmt
+            fill_in "Finish date", with: too_early_finish_date.strftime("%Y-%m-%d")
 
             # Shows duration as zero if finish date is before start date:
             expect(page).to have_field "Duration", with: "0 days", readonly: true

--- a/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/start_finish_spec.rb
@@ -60,12 +60,14 @@ RSpec.describe "Start and finish sprints",
   end
   let!(:first_sprint) do
     create(:agile_sprint,
+           name: "First sprint",
            project:,
            start_date: Date.new(2025, 9, 5),
            finish_date: Date.new(2025, 9, 15))
   end
   let!(:second_sprint) do
     create(:agile_sprint,
+           name: "Second sprint",
            project:,
            start_date: Date.new(2025, 9, 16),
            finish_date: Date.new(2025, 9, 26))
@@ -86,11 +88,10 @@ RSpec.describe "Start and finish sprints",
       .and_return("story_types" => [story_type.id.to_s], "task_type" => task_type.id.to_s)
 
     create(:workflow, type: task_type, old_status: default_status, new_status: default_status, role: create(:project_role))
-
-    planning_page.visit!
   end
 
   it "starts the sprint and redirects to the board" do
+    planning_page.visit!
     planning_page.click_in_sprint_menu(first_sprint, "Start sprint")
 
     expect_and_dismiss_flash type: :success, message: "The sprint was started."
@@ -134,6 +135,7 @@ RSpec.describe "Start and finish sprints",
   context "when the sprint is active" do
     let!(:first_sprint) do
       create(:agile_sprint,
+             name: "First sprint",
              project:,
              status: "active",
              start_date: Date.new(2025, 9, 5),
@@ -142,6 +144,7 @@ RSpec.describe "Start and finish sprints",
     let!(:task_board) { create(:board_grid_with_query, project:, linked: first_sprint) }
 
     it "finishes the sprint and returns to the backlog" do
+      planning_page.visit!
       planning_page.within_sprint_menu(first_sprint) do |menu|
         expect(menu).to have_selector :menuitem, "Complete sprint"
         menu.find(:button, "Complete sprint").click
@@ -192,6 +195,7 @@ RSpec.describe "Start and finish sprints",
       # work packages to.
       let!(:sprint_from_other_project) do
         create(:agile_sprint,
+               name: "Sprint from other project",
                project: create(:project),
                start_date: Date.new(2025, 9, 5),
                finish_date: Date.new(2025, 9, 15)) do |sprint|
@@ -203,12 +207,18 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the next sprint" do
+        planning_page.visit!
+
+        planning_page.expect_sprint_names_in_order(first_sprint.name, sprint_from_other_project.name, second_sprint.name)
         planning_page.click_to_finish_sprint(first_sprint)
 
         planning_page.expect_sprint_finishing_modal
 
         planning_page.expect_sprints_to_choose_for_moving_unfinished_work_packages_to second_sprint
-        planning_page.choose_to_move_unfinished_work_packages_to_sprint second_sprint.name
+
+        wait_for_turbo_stream do
+          planning_page.choose_to_move_unfinished_work_packages_to_sprint second_sprint.name
+        end
 
         planning_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."
 
@@ -223,10 +233,15 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the top of the backlog" do
+        planning_page.visit!
+
+        planning_page.expect_sprint_names_in_order(first_sprint.name, sprint_from_other_project.name, second_sprint.name)
         planning_page.click_to_finish_sprint(first_sprint)
 
         planning_page.expect_sprint_finishing_modal
-        planning_page.choose_to_move_unfinished_work_packages_to_top_of_backlog
+        wait_for_turbo_stream do
+          planning_page.choose_to_move_unfinished_work_packages_to_top_of_backlog
+        end
 
         planning_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."
 
@@ -238,10 +253,15 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the bottom of the backlog" do
+        planning_page.visit!
+
+        planning_page.expect_sprint_names_in_order(first_sprint.name, sprint_from_other_project.name, second_sprint.name)
         planning_page.click_to_finish_sprint(first_sprint)
 
         planning_page.expect_sprint_finishing_modal
-        planning_page.choose_to_move_unfinished_work_packages_to_bottom_of_backlog
+        wait_for_turbo_stream do
+          planning_page.choose_to_move_unfinished_work_packages_to_bottom_of_backlog
+        end
 
         planning_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -77,7 +77,7 @@ module Pages
     end
 
     def sprint_names_in_order
-      page.find_all("#sprint_backlogs_container > section .CollapsibleHeader-title").map(&:text)
+      page.find_all("#sprint_planning_sprint_content > section .CollapsibleHeader-title").map(&:text)
     end
 
     def expect_work_packages_in_sprint_in_order(sprint,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73316

# What are you trying to accomplish?
Do not perform an unnecessary request after sprint creation (submitting the creation dialog).

While looking into this, I thought: why not update the view in place using turbo instead of performing an unnecessary redirect? The tricky part about this is finding out where to insert the created sprint. So we have to compare some dates to find the correct index.

I noticed that multiple places in the project collect sprints for a project in chronological order, so I introduced a new scope for this use case: `Sprint.displayable_in_project`. This way, if we change our display-logic in the future, we only have to adjust the scope instead of having to remember all these places.

While working on this, I discovered we had the same reload-issue when finishing a sprint -> updated this to use turbo, too. This was a bit more elaborate as we have to remove the finished sprint **and** update the target (another sprint, or the backlog inbox) in case there are any unfinished work packages.

Also added a simple cache to the SprintComponents `stories` method, as it is called multiple times during view rendering.

## Caveats

The RbSprintsController now has an even stronger coupling to the views of other controllers than before. Changing the view and components of the RbMasterBacklogsController has consequences for the RbSprintsController and vice versa. Apart from specs, there is currently no mechanism to prevent that. I am not happy with this - but I couldn't come up with a better solution in the current state of very active development. I have the hope that we can properly™ solve this once everything has calmed down.

This PR tries to get rid of the double page load and offer some turbo snappiness, without doing the heavy-lifting of re-organizing our entire turbo handling. In other words: it tries to be subtle while still adding some perceived value.

## Screenshots

Using an earlier date for the created sprint, notice how it is inserted at the top. If we chose a later date, it would have been inserted further below (or at the end).

https://github.com/user-attachments/assets/9e340cd4-0879-4e03-bcd4-449971521e62

Finishing a sprint works, too. Didn't add a video for this.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
