### PR TITLE
Add endpoints for meetings, sections, agenda items

### DIFF
--- a/docs/api/apiv3/components/examples/meeting_create_request.yml
+++ b/docs/api/apiv3/components/examples/meeting_create_request.yml
@@ -1,0 +1,12 @@
+# Example: Meeting create request
+---
+description: Request to create a basic meeting
+value:
+  title: "Weekly Standup"
+  location: "Conference Room A"
+  startTime: "2026-06-01T10:00:00Z"
+  duration: "PT1H"
+  _links:
+    project:
+      href: "/api/v3/projects/10"
+      title: "Death Star"

--- a/docs/api/apiv3/components/examples/meeting_update_request.yml
+++ b/docs/api/apiv3/components/examples/meeting_update_request.yml
@@ -1,0 +1,7 @@
+# Example: Meeting update request
+---
+description: Example request body to update the title and location of a meeting.
+value:
+  title: "Updated Standup"
+  location: "Room B"
+  lockVersion: 13

--- a/docs/api/apiv3/components/schemas/meeting_agenda_item_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_agenda_item_collection_model.yml
@@ -1,0 +1,39 @@
+# Schema: MeetingAgendaItemCollectionModel
+---
+type: object
+required:
+  - _type
+  - count
+  - total
+  - _embedded
+  - _links
+properties:
+  _type:
+    type: string
+    enum:
+      - Collection
+  count:
+    type: integer
+  total:
+    type: integer
+  _embedded:
+    type: object
+    required:
+      - elements
+    properties:
+      elements:
+        type: array
+        items:
+          $ref: './meeting_agenda_item_model.yml'
+  _links:
+    type: object
+    required:
+      - self
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The link to this agenda item collection resource
+
+              **Resource**: MeetingAgendaItemCollection

--- a/docs/api/apiv3/components/schemas/meeting_agenda_item_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_agenda_item_model.yml
@@ -1,0 +1,99 @@
+# Schema: MeetingAgendaItemModel
+---
+type: object
+required:
+  - _type
+  - id
+  - title
+  - itemType
+  - position
+  - createdAt
+  - updatedAt
+properties:
+  _type:
+    type: string
+    enum:
+      - MeetingAgendaItem
+  id:
+    type: integer
+    description: Identifier of this agenda item
+    minimum: 1
+  title:
+    type: string
+    description: The agenda item's title. Required for simple items.
+  notes:
+    $ref: "./formattable.yml"
+  position:
+    type: integer
+    description: The position of the agenda item within its section.
+  durationInMinutes:
+    type:
+      - integer
+      - "null"
+    description: The agenda item's duration in minutes.
+  itemType:
+    type: string
+    description: |-
+      The type of this agenda item. Possible values:
+
+      - *simple*: a simple text agenda item
+      - *work_package*: an agenda item linked to a work package
+    enum:
+      - simple
+      - work_package
+  lockVersion:
+    type: integer
+    description: The version of the item as used for optimistic locking.
+  createdAt:
+    type: string
+    format: date-time
+    description: Time of creation.
+  updatedAt:
+    type: string
+    format: date-time
+    description: Time of the most recent change.
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              This agenda item
+
+              **Resource**: MeetingAgendaItem
+      meeting:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The meeting this agenda item belongs to
+
+              **Resource**: Meeting
+      author:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The user who created this agenda item
+
+              **Resource**: User
+      presenter:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The user presenting this agenda item
+
+              **Resource**: User
+      workPackage:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The linked work package (for work_package type items)
+
+              **Resource**: WorkPackage
+      section:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The section this agenda item belongs to
+
+              **Resource**: MeetingSection

--- a/docs/api/apiv3/components/schemas/meeting_agenda_item_write_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_agenda_item_write_model.yml
@@ -1,0 +1,47 @@
+# Schema: MeetingAgendaItemWriteModel
+---
+type: object
+properties:
+  title:
+    type: string
+    description: The agenda item's title.
+  notes:
+    $ref: "./formattable.yml"
+  durationInMinutes:
+    type:
+      - integer
+      - "null"
+    description: The agenda item's duration in minutes.
+  itemType:
+    type: string
+    description: The type of this agenda item (simple or work_package).
+    enum:
+      - simple
+      - work_package
+  lockVersion:
+    type: integer
+    description: The version of the item as used for optimistic locking. Required for PATCH operations.
+  _links:
+    type: object
+    properties:
+      workPackage:
+        allOf:
+          - $ref: "./link.yml"
+          - description: |-
+              The linked work package (for work_package type items)
+
+              **Resource**: WorkPackage
+      presenter:
+        allOf:
+          - $ref: "./link.yml"
+          - description: |-
+              The user presenting this agenda item
+
+              **Resource**: User
+      section:
+        allOf:
+          - $ref: "./link.yml"
+          - description: |-
+              The section this agenda item belongs to
+
+              **Resource**: MeetingSection

--- a/docs/api/apiv3/components/schemas/meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_model.yml
@@ -36,10 +36,44 @@ properties:
   endTime:
     type: string
     format: date-time
-    description: The scheduled meeting start time.
+    description: The scheduled meeting end time.
   duration:
     type: number
     description: The meeting duration in hours.
+  state:
+    type: string
+    description: |-
+      The current state of the meeting. Possible values:
+
+      - *open*: the meeting is open
+      - *draft*: the meeting is in draft state
+      - *in_progress*: the meeting is currently in progress
+      - *cancelled*: the meeting has been cancelled
+      - *closed*: the meeting is closed
+    enum:
+      - open
+      - draft
+      - in_progress
+      - cancelled
+      - closed
+  sharing:
+    type: string
+    description: |-
+      How the meeting template is shared. Only applicable for one-time templates. Possible values:
+
+      - *none*: not shared
+      - *descendants*: shared with descendant projects
+      - *system*: shared globally
+    enum:
+      - none
+      - descendants
+      - system
+  template:
+    type: boolean
+    description: Whether this meeting is a template.
+  notify:
+    type: boolean
+    description: Whether to send email notifications to participants.
   createdAt:
     type: string
     format: date-time
@@ -70,6 +104,40 @@ properties:
               This meeting
 
               **Resource**: Meeting
+      schema:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The meeting schema
+
+              **Resource**: Schema
+      update:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              Form endpoint to update this meeting
+
+              # Conditions
+
+              **Permission**: edit meetings
+      updateImmediately:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              Directly update this meeting
+
+              # Conditions
+
+              **Permission**: edit meetings
+      delete:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              Delete this meeting
+
+              # Conditions
+
+              **Permission**: delete meetings
       author:
         allOf:
           - $ref: './link.yml'
@@ -88,7 +156,7 @@ properties:
         allOf:
           - $ref: './link.yml'
           - description: |-
-              The attachment collection of this grid.
+              The attachment collection of this meeting.
 
               **Resource**: AttachmentCollection
       addAttachment:
@@ -99,4 +167,4 @@ properties:
 
               # Conditions
 
-              **Permission**: edit meeting
+              **Permission**: edit meetings

--- a/docs/api/apiv3/components/schemas/meeting_section_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_section_collection_model.yml
@@ -1,0 +1,39 @@
+# Schema: MeetingSectionCollectionModel
+---
+type: object
+required:
+  - _type
+  - count
+  - total
+  - _embedded
+  - _links
+properties:
+  _type:
+    type: string
+    enum:
+      - Collection
+  count:
+    type: integer
+  total:
+    type: integer
+  _embedded:
+    type: object
+    required:
+      - elements
+    properties:
+      elements:
+        type: array
+        items:
+          $ref: './meeting_section_model.yml'
+  _links:
+    type: object
+    required:
+      - self
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The link to this section collection resource
+
+              **Resource**: MeetingSectionCollection

--- a/docs/api/apiv3/components/schemas/meeting_section_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_section_model.yml
@@ -1,0 +1,50 @@
+# Schema: MeetingSectionModel
+---
+type: object
+required:
+  - _type
+  - id
+  - title
+  - position
+  - createdAt
+  - updatedAt
+properties:
+  _type:
+    type: string
+    enum:
+      - MeetingSection
+  id:
+    type: integer
+    description: Identifier of this section
+    minimum: 1
+  title:
+    type: string
+    description: The section's title.
+  position:
+    type: integer
+    description: The position of the section within the meeting.
+  createdAt:
+    type: string
+    format: date-time
+    description: Time of creation.
+  updatedAt:
+    type: string
+    format: date-time
+    description: Time of the most recent change.
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              This section
+
+              **Resource**: MeetingSection
+      meeting:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The meeting this section belongs to
+
+              **Resource**: Meeting

--- a/docs/api/apiv3/components/schemas/meeting_section_write_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_section_write_model.yml
@@ -1,0 +1,7 @@
+# Schema: MeetingSectionWriteModel
+---
+type: object
+properties:
+  title:
+    type: string
+    description: The section's title.

--- a/docs/api/apiv3/components/schemas/meeting_write_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_write_model.yml
@@ -1,0 +1,64 @@
+# Schema: MeetingWriteModel
+---
+type: object
+properties:
+  title:
+    type: string
+    description: The meeting's title
+  location:
+    type: string
+    description: The meeting's location
+  startTime:
+    type: string
+    format: date-time
+    description: The scheduled meeting start time.
+  duration:
+    type: string
+    description: |-
+      The meeting duration as an ISO 8601 duration (e.g. `PT1H` for 1 hour, `PT1H30M` for 1.5 hours).
+  state:
+    type: string
+    description: |-
+      The current state of the meeting. Possible values:
+
+      - *open*
+      - *draft*
+      - *in_progress*
+      - *cancelled*
+      - *closed*
+    enum:
+      - open
+      - draft
+      - in_progress
+      - cancelled
+      - closed
+  sharing:
+    type: string
+    description: |-
+      How the meeting template is shared. Only applicable for one-time templates.
+    enum:
+      - none
+      - descendants
+      - system
+  template:
+    type: boolean
+    description: Whether this meeting is a template.
+  notify:
+    type: boolean
+    description: Whether to send email notifications to participants.
+  lockVersion:
+    type: integer
+    description: |-
+      The version of the item as used for optimistic locking.
+
+      Required for PATCH operations to detect concurrent modifications.
+  _links:
+    type: object
+    properties:
+      project:
+        allOf:
+          - $ref: "./link.yml"
+          - description: |-
+              The project the meeting belongs to. Required on creation.
+
+              **Resource**: Project

--- a/docs/api/apiv3/components/schemas/recurring_meeting_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_collection_model.yml
@@ -1,0 +1,30 @@
+# Schema: RecurringMeetingCollectionModel
+---
+allOf:
+  - $ref: './paginated_collection_model.yml'
+  - type: object
+    required:
+      - _embedded
+      - _links
+    properties:
+      _embedded:
+        type: object
+        required:
+          - elements
+        properties:
+          elements:
+            type: array
+            items:
+              $ref: './recurring_meeting_model.yml'
+      _links:
+        type: object
+        required:
+          - self
+        properties:
+          self:
+            allOf:
+              - $ref: './link.yml'
+              - description: |-
+                  The link to this recurring meeting collection resource
+
+                  **Resource**: RecurringMeetingCollection

--- a/docs/api/apiv3/components/schemas/recurring_meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_model.yml
@@ -1,0 +1,171 @@
+# Schema: RecurringMeetingModel
+---
+type: object
+required:
+  - _type
+  - id
+  - title
+  - frequency
+  - interval
+  - endAfter
+  - startTime
+  - createdAt
+  - updatedAt
+properties:
+  _type:
+    type: string
+    enum:
+      - RecurringMeeting
+  id:
+    type: integer
+    description: Identifier of this recurring meeting
+    minimum: 1
+  title:
+    type: string
+    description: The recurring meeting's title
+  frequency:
+    type: string
+    description: |-
+      The recurrence frequency. Possible values:
+
+      - *daily*: repeats every day (or every N days depending on interval)
+      - *working_days*: repeats on working days only
+      - *weekly*: repeats every week (or every N weeks depending on interval)
+    enum:
+      - daily
+      - working_days
+      - weekly
+  interval:
+    type: integer
+    description: |-
+      The interval between occurrences. For example, an interval of 2 with a weekly frequency
+      means the meeting occurs every 2 weeks. Not applicable for working_days frequency.
+    minimum: 1
+  endAfter:
+    type: string
+    description: |-
+      How the recurrence ends. Possible values:
+
+      - *specific_date*: ends on a specific date
+      - *iterations*: ends after a specific number of occurrences
+      - *never*: never ends
+    enum:
+      - specific_date
+      - iterations
+      - never
+  endDate:
+    type:
+      - 'string'
+      - 'null'
+    format: date
+    description: |-
+      The date on which the recurrence ends. Only present when endAfter is `specific_date`.
+  iterations:
+    type:
+      - 'integer'
+      - 'null'
+    description: |-
+      The number of occurrences after which the recurrence ends.
+      Only present when endAfter is `iterations`.
+    minimum: 1
+  timeZone:
+    type: string
+    description: The time zone in which the recurring meeting is scheduled (e.g. "Europe/Berlin").
+  startTime:
+    type: string
+    format: date-time
+    description: The scheduled start time of the recurring meeting.
+  location:
+    type: string
+    description: The meeting's location (inherited from the template meeting).
+  duration:
+    type: number
+    description: The meeting duration in hours (inherited from the template meeting).
+  notify:
+    type: boolean
+    description: Whether to send email notifications to participants (inherited from the template meeting).
+  createdAt:
+    type: string
+    format: date-time
+    description: Time of creation.
+  updatedAt:
+    type: string
+    format: date-time
+    description: Time of the most recent change to the recurring meeting.
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              This recurring meeting
+
+              **Resource**: RecurringMeeting
+      updateImmediately:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              Directly update this recurring meeting
+
+              # Conditions
+
+              **Permission**: edit meetings
+      delete:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              Delete this recurring meeting
+
+              # Conditions
+
+              **Permission**: delete meetings
+      template:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The template meeting associated with this recurring meeting
+
+              **Resource**: Meeting
+      project:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The project the recurring meeting belongs to
+
+              **Resource**: Project
+      author:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The user who created this recurring meeting
+
+              **Resource**: User
+      occurrencesUpcoming:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The upcoming occurrences of this recurring meeting
+
+              **Resource**: MeetingOccurrenceCollection
+      occurrencesPast:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The past occurrences of this recurring meeting
+
+              **Resource**: MeetingOccurrenceCollection
+      occurrencesCancelled:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The cancelled occurrences of this recurring meeting
+
+              **Resource**: MeetingOccurrenceCollection
+      occurrencesOpen:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The open (instantiated) occurrences of this recurring meeting
+
+              **Resource**: MeetingOccurrenceCollection

--- a/docs/api/apiv3/components/schemas/recurring_meeting_occurrence_collection_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_occurrence_collection_model.yml
@@ -1,0 +1,30 @@
+# Schema: RecurringMeetingOccurrenceCollectionModel
+---
+allOf:
+  - $ref: './collection_model.yml'
+  - type: object
+    required:
+      - _links
+      - _embedded
+    properties:
+      _links:
+        type: object
+        required:
+          - self
+        properties:
+          self:
+            allOf:
+              - $ref: './link.yml'
+              - description: |-
+                  This occurrence collection
+
+                  **Resource**: MeetingOccurrenceCollection
+      _embedded:
+        type: object
+        required:
+          - elements
+        properties:
+          elements:
+            type: array
+            items:
+              $ref: './recurring_meeting_occurrence_model.yml'

--- a/docs/api/apiv3/components/schemas/recurring_meeting_occurrence_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_occurrence_model.yml
@@ -1,0 +1,52 @@
+# Schema: RecurringMeetingOccurrenceModel
+---
+type: object
+required:
+  - _type
+  - startTime
+  - state
+properties:
+  _type:
+    type: string
+    enum:
+      - MeetingOccurrence
+  startTime:
+    type: string
+    format: date-time
+    description: The start time of this occurrence.
+  state:
+    type: string
+    description: |-
+      The current state of the occurrence. Possible values:
+
+      - *open*: the occurrence has been instantiated as a meeting
+      - *cancelled*: the occurrence has been cancelled
+      - *scheduled*: the occurrence is scheduled but not yet instantiated
+    enum:
+      - open
+      - cancelled
+      - scheduled
+  _links:
+    type: object
+    properties:
+      self:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              This occurrence
+
+              **Resource**: MeetingOccurrence
+      meeting:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The instantiated meeting for this occurrence, if it exists.
+
+              **Resource**: Meeting
+      recurringMeeting:
+        allOf:
+          - $ref: './link.yml'
+          - description: |-
+              The recurring meeting this occurrence belongs to
+
+              **Resource**: RecurringMeeting

--- a/docs/api/apiv3/components/schemas/recurring_meeting_write_model.yml
+++ b/docs/api/apiv3/components/schemas/recurring_meeting_write_model.yml
@@ -1,0 +1,74 @@
+# Schema: RecurringMeetingWriteModel
+---
+type: object
+properties:
+  title:
+    type: string
+    description: The recurring meeting's title
+  frequency:
+    type: string
+    description: |-
+      The recurrence frequency. Possible values:
+
+      - *daily*
+      - *working_days*
+      - *weekly*
+    enum:
+      - daily
+      - working_days
+      - weekly
+  interval:
+    type: integer
+    description: |-
+      The interval between occurrences. Not applicable for working_days frequency.
+    minimum: 1
+  endAfter:
+    type: string
+    description: |-
+      How the recurrence ends. Possible values:
+
+      - *specific_date*
+      - *iterations*
+      - *never*
+    enum:
+      - specific_date
+      - iterations
+      - never
+  endDate:
+    type:
+      - 'string'
+      - 'null'
+    format: date
+    description: |-
+      The date on which the recurrence ends. Required when endAfter is `specific_date`.
+  iterations:
+    type:
+      - 'integer'
+      - 'null'
+    description: |-
+      The number of occurrences after which the recurrence ends.
+      Required when endAfter is `iterations`.
+    minimum: 1
+  startTime:
+    type: string
+    format: date-time
+    description: The scheduled start time of the recurring meeting.
+  location:
+    type: string
+    description: The meeting's location.
+  duration:
+    type: number
+    description: The meeting duration in hours.
+  notify:
+    type: boolean
+    description: Whether to send email notifications to participants.
+  _links:
+    type: object
+    properties:
+      project:
+        allOf:
+          - $ref: "./link.yml"
+          - description: |-
+              The project the recurring meeting belongs to. Required on creation.
+
+              **Resource**: Project

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -272,6 +272,12 @@ paths:
     "$ref": "./paths/meeting.yml"
   "/api/v3/meetings/{id}/attachments":
     "$ref": "./paths/meeting_attachments.yml"
+  "/api/v3/meetings/{id}/form":
+    "$ref": "./paths/meeting_form.yml"
+  "/api/v3/meetings/form":
+    "$ref": "./paths/meetings_form.yml"
+  "/api/v3/meetings/schema":
+    "$ref": "./paths/meeting_schema.yml"
   "/api/v3/memberships":
     "$ref": "./paths/memberships.yml"
   "/api/v3/memberships/available_projects":
@@ -609,6 +615,10 @@ components:
       $ref: "./components/examples/meeting_collection_simple_response.yml"
     MeetingSimpleResponse:
       $ref: "./components/examples/meeting_simple_response.yml"
+    MeetingCreateRequest:
+      $ref: "./components/examples/meeting_create_request.yml"
+    MeetingUpdateRequest:
+      $ref: "./components/examples/meeting_update_request.yml"
     MembershipCreateRequestCustomMessage:
       $ref: "./components/examples/membership-create-request-custom-message.yml"
     MembershipCreateRequestGlobalRole:
@@ -855,6 +865,8 @@ components:
       "$ref": "./components/schemas/meeting_collection_model.yml"
     MeetingModel:
       "$ref": "./components/schemas/meeting_model.yml"
+    MeetingWriteModel:
+      "$ref": "./components/schemas/meeting_write_model.yml"
     MarkdownModel:
       "$ref": "./components/schemas/markdown_model.yml"
     MembershipCollectionModel:

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -434,6 +434,22 @@ paths:
     "$ref": "./paths/query_star.yml"
   "/api/v3/queries/{id}/unstar":
     "$ref": "./paths/query_unstar.yml"
+  "/api/v3/recurring_meetings":
+    "$ref": "./paths/recurring_meetings.yml"
+  "/api/v3/recurring_meetings/{id}":
+    "$ref": "./paths/recurring_meeting.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/upcoming":
+    "$ref": "./paths/recurring_meeting_occurrences_upcoming.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/past":
+    "$ref": "./paths/recurring_meeting_occurrences_past.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/cancelled":
+    "$ref": "./paths/recurring_meeting_occurrences_cancelled.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/open":
+    "$ref": "./paths/recurring_meeting_occurrences_open.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/{start_time}":
+    "$ref": "./paths/recurring_meeting_occurrence.yml"
+  "/api/v3/recurring_meetings/{id}/occurrences/{start_time}/init":
+    "$ref": "./paths/recurring_meeting_occurrence_init.yml"
   "/api/v3/relations":
     "$ref": "./paths/relations.yml"
   "/api/v3/relations/{id}":
@@ -987,6 +1003,16 @@ components:
       "$ref": "./components/schemas/query_sort_by_model.yml"
     Query_Update_Form:
       "$ref": "./components/schemas/query_update_form.yml"
+    RecurringMeetingCollectionModel:
+      "$ref": "./components/schemas/recurring_meeting_collection_model.yml"
+    RecurringMeetingModel:
+      "$ref": "./components/schemas/recurring_meeting_model.yml"
+    RecurringMeetingWriteModel:
+      "$ref": "./components/schemas/recurring_meeting_write_model.yml"
+    RecurringMeetingOccurrenceCollectionModel:
+      "$ref": "./components/schemas/recurring_meeting_occurrence_collection_model.yml"
+    RecurringMeetingOccurrenceModel:
+      "$ref": "./components/schemas/recurring_meeting_occurrence_model.yml"
     RelationCollectionModel:
       "$ref": "./components/schemas/relation_collection_model.yml"
     RelationReadModel:

--- a/docs/api/apiv3/openapi-spec.yml
+++ b/docs/api/apiv3/openapi-spec.yml
@@ -270,10 +270,18 @@ paths:
     "$ref": "./paths/meetings.yml"
   "/api/v3/meetings/{id}":
     "$ref": "./paths/meeting.yml"
+  "/api/v3/meetings/{id}/agenda_items":
+    "$ref": "./paths/meeting_agenda_items.yml"
+  "/api/v3/meetings/{meeting_id}/agenda_items/{id}":
+    "$ref": "./paths/meeting_agenda_item.yml"
   "/api/v3/meetings/{id}/attachments":
     "$ref": "./paths/meeting_attachments.yml"
   "/api/v3/meetings/{id}/form":
     "$ref": "./paths/meeting_form.yml"
+  "/api/v3/meetings/{id}/sections":
+    "$ref": "./paths/meeting_sections.yml"
+  "/api/v3/meetings/{meeting_id}/sections/{id}":
+    "$ref": "./paths/meeting_section.yml"
   "/api/v3/meetings/form":
     "$ref": "./paths/meetings_form.yml"
   "/api/v3/meetings/schema":
@@ -861,10 +869,22 @@ components:
       "$ref": "./components/schemas/list_of_news_model.yml"
     List_workspaces_by_versionModel:
       "$ref": "./components/schemas/list_workspaces_by_version_model.yml"
+    MeetingAgendaItemModel:
+      "$ref": "./components/schemas/meeting_agenda_item_model.yml"
+    MeetingAgendaItemWriteModel:
+      "$ref": "./components/schemas/meeting_agenda_item_write_model.yml"
+    MeetingAgendaItemCollectionModel:
+      "$ref": "./components/schemas/meeting_agenda_item_collection_model.yml"
     MeetingCollectionModel:
       "$ref": "./components/schemas/meeting_collection_model.yml"
     MeetingModel:
       "$ref": "./components/schemas/meeting_model.yml"
+    MeetingSectionModel:
+      "$ref": "./components/schemas/meeting_section_model.yml"
+    MeetingSectionWriteModel:
+      "$ref": "./components/schemas/meeting_section_write_model.yml"
+    MeetingSectionCollectionModel:
+      "$ref": "./components/schemas/meeting_section_collection_model.yml"
     MeetingWriteModel:
       "$ref": "./components/schemas/meeting_write_model.yml"
     MarkdownModel:

--- a/docs/api/apiv3/paths/meeting.yml
+++ b/docs/api/apiv3/paths/meeting.yml
@@ -38,4 +38,131 @@ get:
       description: |-
         Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
 
-        **Required permission:** view meetings in the page's project
+        **Required permission:** view meetings in the meeting's project
+
+patch:
+  summary: Update meeting
+  operationId: update_meeting
+  tags:
+    - Meetings
+  description: |-
+    Updates the given meeting by applying the attributes provided in the body.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_write_model.yml"
+        examples:
+          'update meeting':
+            $ref: "../components/examples/meeting_update_request.yml"
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_model.yml"
+          examples:
+            response:
+              $ref: "../components/examples/meeting_simple_response.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** edit meetings in the meeting's project
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the meeting's project
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+delete:
+  summary: Delete meeting
+  operationId: delete_meeting
+  tags:
+    - Meetings
+  description: Deletes the meeting. Participants will be notified of the cancellation.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '204':
+      description: Returned if the meeting was successfully deleted
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** delete meetings
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the meeting's project
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/meeting_agenda_item.yml
+++ b/docs/api/apiv3/paths/meeting_agenda_item.yml
@@ -1,0 +1,169 @@
+# /api/v3/meetings/{meeting_id}/agenda_items/{id}
+---
+get:
+  summary: Get a meeting agenda item
+  operationId: get_meeting_agenda_item
+  tags:
+    - Meetings
+  description: Retrieve an individual agenda item of a meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Agenda item identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_agenda_item_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the agenda item or meeting does not exist or the client does not have sufficient permissions.
+
+patch:
+  summary: Update a meeting agenda item
+  operationId: update_meeting_agenda_item
+  tags:
+    - Meetings
+  description: Updates the given agenda item.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Agenda item identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_agenda_item_write_model.yml"
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_agenda_item_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the agenda item or meeting does not exist.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+delete:
+  summary: Delete a meeting agenda item
+  operationId: delete_meeting_agenda_item
+  tags:
+    - Meetings
+  description: Deletes the agenda item.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Agenda item identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '204':
+      description: Returned if the agenda item was successfully deleted
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the agenda item or meeting does not exist.

--- a/docs/api/apiv3/paths/meeting_agenda_items.yml
+++ b/docs/api/apiv3/paths/meeting_agenda_items.yml
@@ -1,0 +1,104 @@
+# /api/v3/meetings/{id}/agenda_items
+---
+get:
+  summary: List meeting agenda items
+  operationId: list_meeting_agenda_items
+  tags:
+    - Meetings
+  description: Lists all agenda items for the given meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_agenda_item_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings
+
+post:
+  summary: Create meeting agenda item
+  operationId: create_meeting_agenda_item
+  tags:
+    - Meetings
+  description: Creates a new agenda item for the given meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_agenda_item_write_model.yml"
+  responses:
+    '201':
+      description: Created
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_agenda_item_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/docs/api/apiv3/paths/meeting_form.yml
+++ b/docs/api/apiv3/paths/meeting_form.yml
@@ -1,0 +1,42 @@
+# /api/v3/meetings/{id}/form
+---
+post:
+  summary: Meeting update form
+  operationId: meeting_update_form
+  tags:
+    - Meetings
+  description: ''
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      headers: {}
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** edit meetings in the meeting's project
+      headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/meeting_schema.yml
+++ b/docs/api/apiv3/paths/meeting_schema.yml
@@ -1,0 +1,29 @@
+# /api/v3/meetings/schema
+---
+get:
+  summary: Get meeting schema
+  operationId: get_meeting_schema
+  tags:
+    - Meetings
+  description: |-
+    Retrieves the schema for meetings, providing information about which properties are writable,
+    their types, and constraints.
+  responses:
+    '200':
+      description: OK
+      headers: {}
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** view meetings in any project

--- a/docs/api/apiv3/paths/meeting_section.yml
+++ b/docs/api/apiv3/paths/meeting_section.yml
@@ -1,0 +1,169 @@
+# /api/v3/meetings/{meeting_id}/sections/{id}
+---
+get:
+  summary: Get a meeting section
+  operationId: get_meeting_section
+  tags:
+    - Meetings
+  description: Retrieve an individual section of a meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Section identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_section_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the section or meeting does not exist or the client does not have sufficient permissions.
+
+patch:
+  summary: Update a meeting section
+  operationId: update_meeting_section
+  tags:
+    - Meetings
+  description: Updates the given section.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Section identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_section_write_model.yml"
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_section_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the section or meeting does not exist.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+delete:
+  summary: Delete a meeting section
+  operationId: delete_meeting_section
+  tags:
+    - Meetings
+  description: Deletes the section and all its agenda items.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: meeting_id
+      required: true
+      schema:
+        type: integer
+    - description: Section identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '204':
+      description: Returned if the section was successfully deleted
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the section or meeting does not exist.

--- a/docs/api/apiv3/paths/meeting_sections.yml
+++ b/docs/api/apiv3/paths/meeting_sections.yml
@@ -1,0 +1,104 @@
+# /api/v3/meetings/{id}/sections
+---
+get:
+  summary: List meeting sections
+  operationId: list_meeting_sections
+  tags:
+    - Meetings
+  description: Lists all sections for the given meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_section_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings
+
+post:
+  summary: Create meeting section
+  operationId: create_meeting_section
+  tags:
+    - Meetings
+  description: Creates a new section for the given meeting.
+  parameters:
+    - description: Meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_section_write_model.yml"
+  responses:
+    '201':
+      description: Created
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_section_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** manage agendas
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the meeting does not exist or the client does not have sufficient permissions to see it.
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/docs/api/apiv3/paths/meetings.yml
+++ b/docs/api/apiv3/paths/meetings.yml
@@ -5,7 +5,7 @@ get:
   operationId: list_meetings
   tags:
     - Meetings
-  description: |- 
+  description: |-
     Retrieve a paginated collection of meetings visible to the authenticated user.
   responses:
     '200':
@@ -17,3 +17,58 @@ get:
               $ref: "../components/examples/meeting_collection_simple_response.yml"
           schema:
             $ref: "../components/schemas/meeting_collection_model.yml"
+
+post:
+  summary: Create meeting
+  operationId: create_meeting
+  tags:
+    - Meetings
+  description: |-
+    Creates a new meeting applying the attributes provided in the body.
+
+    You can use the form and schema to retrieve the valid attribute values and by that be guided towards
+    successful creation.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/meeting_write_model.yml"
+        examples:
+          'create meeting':
+            $ref: '../components/examples/meeting_create_request.yml'
+  responses:
+    '201':
+      description: Created
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_model.yml"
+          examples:
+            response:
+              $ref: '../components/examples/meeting_simple_response.yml'
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** create meetings
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/docs/api/apiv3/paths/meetings_form.yml
+++ b/docs/api/apiv3/paths/meetings_form.yml
@@ -1,0 +1,34 @@
+# /api/v3/meetings/form
+---
+post:
+  summary: Meeting create form
+  operationId: meeting_create_form
+  tags:
+    - Meetings
+  description: ''
+  responses:
+    '200':
+      description: OK
+      headers: {}
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** create meetings in any project
+      headers: {}
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/recurring_meeting.yml
+++ b/docs/api/apiv3/paths/recurring_meeting.yml
@@ -1,0 +1,164 @@
+# /api/v3/recurring_meetings/{id}
+---
+get:
+  summary: Get a recurring meeting
+  operationId: get_recurring_meeting
+  tags:
+    - Recurring Meetings
+  description: Retrieve an individual recurring meeting series as identified by the id parameter.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+
+patch:
+  summary: Update recurring meeting
+  operationId: update_recurring_meeting
+  tags:
+    - Recurring Meetings
+  description: |-
+    Updates the given recurring meeting series by applying the attributes provided in the body.
+    If schedule-related attributes (frequency, interval, startTime, endAfter, etc.) are changed,
+    the meeting schedule is automatically recalculated.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/recurring_meeting_write_model.yml"
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** edit meetings in the recurring meeting's project
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)
+
+delete:
+  summary: Delete recurring meeting
+  operationId: delete_recurring_meeting
+  tags:
+    - Recurring Meetings
+  description: |-
+    Deletes the entire recurring meeting series, including the template meeting and all
+    scheduled occurrences that have not yet been instantiated. Already-created meeting
+    instances are not deleted.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '204':
+      description: Returned if the recurring meeting was successfully deleted.
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** delete meetings
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"

--- a/docs/api/apiv3/paths/recurring_meeting_occurrence.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrence.yml
@@ -1,0 +1,76 @@
+# /api/v3/recurring_meetings/{id}/occurrences/{start_time}
+---
+delete:
+  summary: Cancel an occurrence
+  operationId: cancel_recurring_meeting_occurrence
+  tags:
+    - Recurring Meetings
+  description: |-
+    Cancels the occurrence at the given `start_time` for this recurring meeting series.
+    A `ScheduledMeeting` record is created (or updated) with `cancelled: true`.
+
+    An occurrence that has already been instantiated as a meeting cannot be cancelled via this
+    endpoint — delete the meeting directly via `DELETE /api/v3/meetings/{id}` instead.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    - description: The ISO 8601 start time of the occurrence to cancel (e.g. `2025-06-02T10:00:00Z`)
+      example: "2025-06-02T10:00:00Z"
+      in: path
+      name: start_time
+      required: true
+      schema:
+        type: string
+        format: date-time
+  responses:
+    '204':
+      description: Returned if the occurrence was successfully cancelled.
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** edit meetings in the recurring meeting's project
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+    '409':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:Conflict
+                message: Cannot cancel an already instantiated occurrence. Delete the meeting instead.
+      description: |-
+        Returned if the occurrence has already been instantiated as a meeting.
+        Delete the meeting directly via `DELETE /api/v3/meetings/{id}` instead.

--- a/docs/api/apiv3/paths/recurring_meeting_occurrence_init.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrence_init.yml
@@ -1,0 +1,68 @@
+# /api/v3/recurring_meetings/{id}/occurrences/{start_time}/init
+---
+post:
+  summary: Instantiate an occurrence
+  operationId: init_recurring_meeting_occurrence
+  tags:
+    - Recurring Meetings
+  description: |-
+    Instantiates the occurrence at the given `start_time` by creating a real meeting from
+    the recurring meeting's template. Returns the newly created `Meeting` resource.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    - description: The ISO 8601 start time of the occurrence to instantiate (e.g. `2025-06-02T10:00:00Z`)
+      example: "2025-06-02T10:00:00Z"
+      in: path
+      name: start_time
+      required: true
+      schema:
+        type: string
+        format: date-time
+  responses:
+    '201':
+      description: Created — the occurrence was successfully instantiated as a meeting.
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/meeting_model.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** create meetings in the recurring meeting's project
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/docs/api/apiv3/paths/recurring_meeting_occurrences_cancelled.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrences_cancelled.yml
@@ -1,0 +1,40 @@
+# /api/v3/recurring_meetings/{id}/occurrences/cancelled
+---
+get:
+  summary: List cancelled occurrences of a recurring meeting
+  operationId: list_recurring_meeting_occurrences_cancelled
+  tags:
+    - Recurring Meetings
+  description: |-
+    Returns a collection of cancelled occurrences for the given recurring meeting.
+    Only persisted `ScheduledMeeting` records with `cancelled: true` are returned.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_occurrence_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project

--- a/docs/api/apiv3/paths/recurring_meeting_occurrences_open.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrences_open.yml
@@ -1,0 +1,40 @@
+# /api/v3/recurring_meetings/{id}/occurrences/open
+---
+get:
+  summary: List open occurrences of a recurring meeting
+  operationId: list_recurring_meeting_occurrences_open
+  tags:
+    - Recurring Meetings
+  description: |-
+    Returns a collection of open (instantiated, non-cancelled) occurrences for the given recurring meeting.
+    Only persisted `ScheduledMeeting` records that have an associated meeting and are not cancelled are returned.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_occurrence_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project

--- a/docs/api/apiv3/paths/recurring_meeting_occurrences_past.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrences_past.yml
@@ -1,0 +1,40 @@
+# /api/v3/recurring_meetings/{id}/occurrences/past
+---
+get:
+  summary: List past occurrences of a recurring meeting
+  operationId: list_recurring_meeting_occurrences_past
+  tags:
+    - Recurring Meetings
+  description: |-
+    Returns a collection of past, non-cancelled occurrences for the given recurring meeting.
+    Only persisted `ScheduledMeeting` records with a `start_time` in the past are returned.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_occurrence_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project

--- a/docs/api/apiv3/paths/recurring_meeting_occurrences_upcoming.yml
+++ b/docs/api/apiv3/paths/recurring_meeting_occurrences_upcoming.yml
@@ -1,0 +1,51 @@
+# /api/v3/recurring_meetings/{id}/occurrences/upcoming
+---
+get:
+  summary: List upcoming occurrences of a recurring meeting
+  operationId: list_recurring_meeting_occurrences_upcoming
+  tags:
+    - Recurring Meetings
+  description: |-
+    Returns a collection of upcoming occurrences for the given recurring meeting.
+    The list merges computed occurrences from the recurrence schedule (via IceCube) with
+    any persisted `ScheduledMeeting` records, including already-instantiated open meetings.
+
+    Occurrences are ordered chronologically and limited by the `limit` parameter.
+  parameters:
+    - description: Recurring meeting identifier
+      example: 1
+      in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+    - description: Maximum number of occurrences to return. Defaults to 20.
+      example: 20
+      in: query
+      name: limit
+      required: false
+      schema:
+        type: integer
+        default: 20
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_occurrence_collection_model.yml"
+    '404':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:NotFound
+                message: The requested resource could not be found.
+      description: |-
+        Returned if the recurring meeting does not exist or the client does not have sufficient permissions to see it.
+
+        **Required permission:** view meetings in the recurring meeting's project

--- a/docs/api/apiv3/paths/recurring_meetings.yml
+++ b/docs/api/apiv3/paths/recurring_meetings.yml
@@ -1,0 +1,63 @@
+# /api/v3/recurring_meetings
+---
+get:
+  summary: List all visible recurring meetings
+  operationId: list_recurring_meetings
+  tags:
+    - Recurring Meetings
+  description: |-
+    Retrieve a paginated collection of recurring meetings visible to the authenticated user.
+  responses:
+    '200':
+      description: OK
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_collection_model.yml"
+
+post:
+  summary: Create recurring meeting
+  operationId: create_recurring_meeting
+  tags:
+    - Recurring Meetings
+  description: |-
+    Creates a new recurring meeting series applying the attributes provided in the body.
+    A template meeting is automatically created alongside the recurring meeting.
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/recurring_meeting_write_model.yml"
+  responses:
+    '201':
+      description: Created
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/recurring_meeting_model.yml"
+    '400':
+      $ref: "../components/responses/invalid_request_body.yml"
+    '403':
+      content:
+        application/hal+json:
+          schema:
+            $ref: "../components/schemas/error_response.yml"
+          examples:
+            response:
+              value:
+                _type: Error
+                errorIdentifier: urn:openproject-org:api:v3:errors:MissingPermission
+                message: You are not authorized to access this resource.
+      description: |-
+        Returned if the client does not have sufficient permissions.
+
+        **Required permission:** create meetings in the given project
+    '406':
+      $ref: "../components/responses/missing_content_type.yml"
+    '415':
+      $ref: "../components/responses/unsupported_media_type.yml"
+    '422':
+      description: |-
+        Returned if:
+
+        * a constraint for a property was violated (`PropertyConstraintViolation`)

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -312,10 +312,11 @@ class MeetingAgendaItemsController < ApplicationController
 
     attributes[:meeting_id] = target_meeting.id
     attributes[:meeting_section_id] = MeetingSection.find_by(id: params.dig(:meeting_agenda_item, :meeting_section_id))&.id
+    attributes[:source_meeting_id] = @meeting_agenda_item.meeting_id
 
     ::MeetingAgendaItems::CreateService
       .new(user: current_user)
-      .call(attributes, source_meeting_id: @meeting_agenda_item.meeting_id)
+      .call(attributes)
   end
 
   def init_next_meeting_occurrence

--- a/modules/meeting/app/models/queries/recurring_meetings.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings.rb
@@ -28,32 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+module Queries::RecurringMeetings
+  ::Queries::Register.register(RecurringMeetingQuery) do
+    filter Filters::ProjectFilter
+    filter Filters::AuthorFilter
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
-
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
-      end
-    end
+    order Orders::DefaultOrder
   end
 end

--- a/modules/meeting/app/models/queries/recurring_meetings/filters/author_filter.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings/filters/author_filter.rb
@@ -28,32 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+class Queries::RecurringMeetings::Filters::AuthorFilter <
+  Queries::RecurringMeetings::Filters::RecurringMeetingFilter
+  def type
+    :list_optional
+  end
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
+  def type_strategy
+    @type_strategy ||= ::Queries::Filters::Strategies::IntegerListOptional.new(self)
+  end
 
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
+  def self.key
+    :author_id
+  end
 
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
-      end
-    end
+  def available_operators
+    [::Queries::Operators::Equals]
   end
 end

--- a/modules/meeting/app/models/queries/recurring_meetings/filters/project_filter.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings/filters/project_filter.rb
@@ -28,32 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
-
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
-
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
-      end
-    end
-  end
+class Queries::RecurringMeetings::Filters::ProjectFilter <
+  Queries::RecurringMeetings::Filters::RecurringMeetingFilter
+  include Queries::Filters::Shared::ProjectFilter::Optional
 end

--- a/modules/meeting/app/models/queries/recurring_meetings/filters/recurring_meeting_filter.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings/filters/recurring_meeting_filter.rb
@@ -28,31 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+module Queries::RecurringMeetings
+  module Filters
+    class RecurringMeetingFilter < Queries::Filters::Base
+      self.model = RecurringMeeting
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
-
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
+      def human_name
+        RecurringMeeting.human_attribute_name(name)
       end
     end
   end

--- a/modules/meeting/app/models/queries/recurring_meetings/orders/default_order.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings/orders/default_order.rb
@@ -28,32 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+class Queries::RecurringMeetings::Orders::DefaultOrder < Queries::Orders::Base
+  self.model = RecurringMeeting
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
-
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
-      end
-    end
+  def self.key
+    /\A(id|start_time|created_at)\z/
   end
 end

--- a/modules/meeting/app/models/queries/recurring_meetings/recurring_meeting_query.rb
+++ b/modules/meeting/app/models/queries/recurring_meetings/recurring_meeting_query.rb
@@ -28,32 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+module Queries::RecurringMeetings
+  class RecurringMeetingQuery
+    include ::Queries::BaseQuery
+    include ::Queries::UnpersistedQuery
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
+    def self.model
+      RecurringMeeting
+    end
 
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
+    def results
+      super
+        .includes(:author)
+    end
 
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
-
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
-      end
+    def default_scope
+      RecurringMeeting
+        .visible(user)
+        .unscope(:order)
     end
   end
 end

--- a/modules/meeting/app/services/meeting_agenda_items/create_service.rb
+++ b/modules/meeting/app/services/meeting_agenda_items/create_service.rb
@@ -34,9 +34,9 @@ module MeetingAgendaItems
 
     alias_method :original_after_perform, :after_perform
 
-    def call(params, source_meeting_id: nil)
-      @source_meeting_id = source_meeting_id
-      super(params)
+    def call(params)
+      @source_meeting_id = params.delete(:source_meeting_id)
+      super
     end
 
     def after_perform(call)

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -53,6 +53,9 @@ en:
         start_date: "Date"
         start_time: "Start time"
         start_time_hour: "Start time"
+        end_time: "End time"
+        template: "Template"
+        notify: "Send notifications"
         sharing: "Sharing"
       meeting_agenda_item:
         title: "Title"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
         title: "Title"
         position: "Position"
       recurring_meeting:
+        title: "Title"
         frequency: "Frequency"
         interval: "Interval"
         start_date: "Starts on"
@@ -79,6 +80,10 @@ en:
         end_after: "Meeting series ends"
         end_date: "End date"
         iterations: "Occurrences"
+        time_zone: "Time zone"
+        location: "Location"
+        duration: "Duration"
+        notify: "Send notifications"
       recurring_meeting_interim_response:
         start_time: "Start time"
       meeting_participant:

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -63,8 +63,13 @@ en:
         duration_in_minutes: "Duration"
         description: "Notes"
         presenter: "Presenter"
+        item_type: "Type"
+        position: "Position"
+        lock_version: "Lock version"
+        notes: "Notes"
       meeting_section:
         title: "Title"
+        position: "Position"
       recurring_meeting:
         frequency: "Frequency"
         interval: "Interval"

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/agenda_items_by_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/agenda_items_by_meeting_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,33 +30,33 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+    module MeetingAgendaItems
+      class AgendaItemsByMeetingAPI < ::API::OpenProjectAPI
+        resources :agenda_items do
+          get do
+            items = @meeting.agenda_items.includes(:author, :presenter, :work_package, :meeting_section)
+            MeetingAgendaItemCollectionRepresenter.new(items,
+                                                       self_link: api_v3_paths.meeting_agenda_items(@meeting.id),
+                                                       current_user:)
+          end
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
+          post(&::API::V3::Utilities::Endpoints::Create
+                 .new(model: MeetingAgendaItem,
+                      params_modifier: ->(params) {
+                        params.except(:meeting, :meeting_id).merge(meeting: @meeting)
+                      })
+                 .mount)
 
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
+          route_param :agenda_item_id, type: Integer, desc: "Agenda item ID" do
             after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
+              @meeting_agenda_item = @meeting.agenda_items.find(declared_params[:agenda_item_id])
             end
 
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
+            get &::API::V3::Utilities::Endpoints::Show.new(model: MeetingAgendaItem).mount
 
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
+            patch &::API::V3::Utilities::Endpoints::Update.new(model: MeetingAgendaItem).mount
 
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
+            delete &::API::V3::Utilities::Endpoints::Delete.new(model: MeetingAgendaItem).mount
           end
         end
       end

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_collection_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,35 +30,8 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
-          end
-        end
+    module MeetingAgendaItems
+      class MeetingAgendaItemCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_payload_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_payload_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,35 +30,11 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+    module MeetingAgendaItems
+      class MeetingAgendaItemPayloadRepresenter < MeetingAgendaItemRepresenter
+        include ::API::Utilities::PayloadRepresenter
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
-          end
-        end
+        cached_representer disabled: true
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_agenda_items/meeting_agenda_item_representer.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module MeetingAgendaItems
+      class MeetingAgendaItemRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::Decorators::DateProperty
+        include API::Decorators::FormattableProperty
+        include ::API::Caching::CachedRepresenter
+
+        self.to_eager_load = %i[author presenter work_package meeting_section meeting]
+
+        self_link id_attribute: ->(*) { [represented.meeting_id, represented.id] },
+                  title_getter: ->(*) { represented.title }
+
+        property :id
+
+        property :title
+
+        formattable_property :notes
+
+        property :position
+
+        property :duration_in_minutes
+
+        property :item_type
+
+        property :lock_version,
+                 render_nil: true,
+                 getter: ->(*) {
+                   lock_version.to_i
+                 }
+
+        associated_resource :meeting,
+                            link: ->(*) {
+                              {
+                                href: api_v3_paths.meeting(represented.meeting_id),
+                                title: represented.meeting.title
+                              }
+                            }
+
+        associated_resource :author,
+                            v3_path: :user,
+                            representer: ::API::V3::Users::UserRepresenter
+
+        associated_resource :presenter,
+                            v3_path: :user,
+                            representer: ::API::V3::Users::UserRepresenter,
+                            skip_render: ->(*) { represented.presenter_id.nil? }
+
+        associated_resource :work_package,
+                            skip_render: ->(*) { represented.work_package_id.nil? }
+
+        associated_resource :meeting_section,
+                            as: :section,
+                            link: ->(*) {
+                              next if represented.meeting_section_id.nil?
+
+                              {
+                                href: api_v3_paths.meeting_section(represented.meeting_id, represented.meeting_section_id),
+                                title: represented.meeting_section&.title
+                              }
+                            }
+
+        date_time_property :created_at
+        date_time_property :updated_at
+
+        def _type
+          "MeetingAgendaItem"
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/meeting_sections/meeting_section_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_sections/meeting_section_collection_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,35 +30,8 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
-          end
-        end
+    module MeetingSections
+      class MeetingSectionCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meeting_sections/meeting_section_payload_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_sections/meeting_section_payload_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,35 +30,11 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+    module MeetingSections
+      class MeetingSectionPayloadRepresenter < MeetingSectionRepresenter
+        include ::API::Utilities::PayloadRepresenter
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
-          end
-        end
+        cached_representer disabled: true
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meeting_sections/meeting_section_representer.rb
+++ b/modules/meeting/lib/api/v3/meeting_sections/meeting_section_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,34 +30,36 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+    module MeetingSections
+      class MeetingSectionRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::Decorators::DateProperty
+        include ::API::Caching::CachedRepresenter
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
+        self.to_eager_load = [:meeting]
 
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
+        self_link id_attribute: ->(*) { [represented.meeting_id, represented.id] },
+                  title_getter: ->(*) { represented.title }
 
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
+        property :id
 
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
+        property :title
 
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
+        property :position
 
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
+        associated_resource :meeting,
+                            link: ->(*) {
+                              {
+                                href: api_v3_paths.meeting(represented.meeting_id),
+                                title: represented.meeting.title
+                              }
+                            }
 
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
-          end
+        date_time_property :created_at
+        date_time_property :updated_at
+
+        def _type
+          "MeetingSection"
         end
       end
     end

--- a/modules/meeting/lib/api/v3/meeting_sections/sections_by_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/meeting_sections/sections_by_meeting_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -29,33 +30,33 @@
 
 module API
   module V3
-    module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+    module MeetingSections
+      class SectionsByMeetingAPI < ::API::OpenProjectAPI
+        resources :sections do
+          get do
+            sections = @meeting.sections
+            MeetingSectionCollectionRepresenter.new(sections,
+                                                    self_link: api_v3_paths.meeting_sections(@meeting.id),
+                                                    current_user:)
+          end
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
+          post(&::API::V3::Utilities::Endpoints::Create
+                 .new(model: MeetingSection,
+                      params_modifier: ->(params) {
+                        params.except(:meeting, :meeting_id).merge(meeting: @meeting)
+                      })
+                 .mount)
 
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
+          route_param :section_id, type: Integer, desc: "Section ID" do
             after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
+              @meeting_section = @meeting.sections.find(declared_params[:section_id])
             end
 
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
+            get &::API::V3::Utilities::Endpoints::Show.new(model: MeetingSection).mount
 
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
+            patch &::API::V3::Utilities::Endpoints::Update.new(model: MeetingSection).mount
 
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-            mount ::API::V3::MeetingAgendaItems::AgendaItemsByMeetingAPI
-            mount ::API::V3::MeetingSections::SectionsByMeetingAPI
+            delete &::API::V3::Utilities::Endpoints::Delete.new(model: MeetingSection).mount
           end
         end
       end

--- a/modules/meeting/lib/api/v3/meetings/create_form_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/create_form_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,31 +31,13 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
+      class CreateFormAPI < ::API::OpenProjectAPI
+        resource :form do
+          after_validation do
+            authorize_in_any_project(:create_meetings)
           end
+
+          post &::API::V3::Utilities::Endpoints::CreateForm.new(model: Meeting).mount
         end
       end
     end

--- a/modules/meeting/lib/api/v3/meetings/create_form_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/create_form_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,32 +31,8 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-          end
-        end
+      class CreateFormRepresenter < FormRepresenter
+        include API::Decorators::CreateForm
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meetings/form_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/form_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,31 +31,9 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-          end
+      class FormRepresenter < ::API::Decorators::SimpleForm
+        def model
+          Meeting
         end
       end
     end

--- a/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_collection_representer.rb
@@ -31,6 +31,23 @@ module API
   module V3
     module Meetings
       class MeetingCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+        link :createMeetingImmediately do
+          next unless current_user.allowed_in_any_project?(:create_meetings)
+
+          {
+            href: api_v3_paths.meetings,
+            method: :post
+          }
+        end
+
+        link :createMeeting do
+          next unless current_user.allowed_in_any_project?(:create_meetings)
+
+          {
+            href: api_v3_paths.create_meeting_form,
+            method: :post
+          }
+        end
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meetings/meeting_payload_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_payload_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,32 +31,10 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
+      class MeetingPayloadRepresenter < MeetingRepresenter
+        include ::API::Utilities::PayloadRepresenter
 
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-          end
-        end
+        cached_representer disabled: true
       end
     end
   end

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -38,9 +38,41 @@ module API
         include API::V3::Attachments::AttachableRepresenterMixin
         include API::Decorators::DateProperty
 
-        self.to_eager_load = [:author, { project: :enabled_modules }]
+        self.to_eager_load = [:author, { project: :enabled_modules }, { participants: :user }]
+
+        cached_representer key_parts: %i(project)
 
         self_link title_getter: ->(*) { represented.title }
+
+        link :schema do
+          {
+            href: api_v3_paths.meeting_schema
+          }
+        end
+
+        link :update,
+             cache_if: -> { current_user.allowed_in_project?(:edit_meetings, represented.project) } do
+          {
+            href: api_v3_paths.meeting_form(represented.id),
+            method: :post
+          }
+        end
+
+        link :updateImmediately,
+             cache_if: -> { current_user.allowed_in_project?(:edit_meetings, represented.project) } do
+          {
+            href: api_v3_paths.meeting(represented.id),
+            method: :patch
+          }
+        end
+
+        link :delete,
+             cache_if: -> { current_user.allowed_in_project?(:delete_meetings, represented.project) } do
+          {
+            href: api_v3_paths.meeting(represented.id),
+            method: :delete
+          }
+        end
 
         property :id
         property :title
@@ -57,9 +89,41 @@ module API
 
         property :duration
 
+        property :state
+
+        property :sharing
+
+        property :template
+
+        property :notify
+
         associated_resource :author,
                             v3_path: :user,
                             representer: ::API::V3::Users::UserRepresenter
+
+        associated_resources :users,
+                             as: :participants,
+                             getter: ->(*) {
+                               represented.participants.map do |participant|
+                                 ::API::V3::Users::UserRepresenter.create(participant.user, current_user:)
+                               end
+                             },
+                             setter: ->(fragment:, **) {
+                               ids = parse_link_ids_from_fragment(fragment, :user)
+                               represented[:participants_attributes] =
+                                 ids.map { |id| { user_id: id, invited: true } }
+                             },
+                             link: ->(*) {
+                               represented.participants.map do |participant|
+                                 ::API::Decorators::LinkObject
+                                   .new(participant.user,
+                                        property_name: :itself,
+                                        path: :user,
+                                        getter: :id,
+                                        title_attribute: :name)
+                                   .to_hash
+                               end
+                             }
 
         associated_project
 

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -74,6 +74,18 @@ module API
           }
         end
 
+        link :agendaItems do
+          {
+            href: api_v3_paths.meeting_agenda_items(represented.id)
+          }
+        end
+
+        link :sections do
+          {
+            href: api_v3_paths.meeting_sections(represented.id)
+          }
+        end
+
         property :id
         property :title
         property :location

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -86,6 +86,14 @@ module API
           }
         end
 
+        link :recurringMeeting do
+          next unless represented.recurring_meeting_id
+
+          {
+            href: api_v3_paths.recurring_meeting(represented.recurring_meeting_id)
+          }
+        end
+
         property :id
         property :title
         property :location

--- a/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,30 +31,14 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
+      module Schemas
+        class MeetingSchemaAPI < ::API::OpenProjectAPI
+          resources :schema do
+            before do
+              authorize_in_any_project(:view_meetings)
             end
 
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
+            get &::API::V3::Utilities::Endpoints::Schema.new(model: Meeting).mount
           end
         end
       end

--- a/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_representer.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module Meetings
+      module Schemas
+        class MeetingSchemaRepresenter < ::API::Decorators::SchemaRepresenter
+          def initialize(represented, self_link: nil, current_user: nil, form_embedded: false)
+            super
+          end
+
+          schema :id,
+                 type: "Integer"
+
+          schema :title,
+                 type: "String",
+                 min_length: 1
+
+          schema :location,
+                 type: "String",
+                 required: false
+
+          schema :duration,
+                 type: "Duration"
+
+          schema :start_time,
+                 type: "DateTime"
+
+          schema :end_time,
+                 type: "DateTime",
+                 writable: false
+
+          schema_with_allowed_string_collection :state,
+                                                type: "String",
+                                                values_callback: -> {
+                                                  Meeting.states.keys
+                                                }
+
+          schema_with_allowed_string_collection :sharing,
+                                                type: "String",
+                                                required: false,
+                                                values_callback: -> {
+                                                  Meeting.sharings.keys
+                                                }
+
+          schema :template,
+                 type: "Boolean"
+
+          schema :notify,
+                 type: "Boolean",
+                 required: false
+
+          schema_with_allowed_link :project,
+                                   has_default: false,
+                                   required: true,
+                                   href_callback: ->(*) { nil }
+
+          schema :lock_version,
+                 type: "Integer"
+
+          schema :created_at,
+                 type: "DateTime"
+
+          schema :updated_at,
+                 type: "DateTime"
+
+          def self.represented_class
+            Meeting
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/schemas/meeting_schema_representer.rb
@@ -81,7 +81,7 @@ module API
           schema_with_allowed_link :project,
                                    has_default: false,
                                    required: true,
-                                   href_callback: ->(*) { nil }
+                                   href_callback: ->(*) {}
 
           schema :lock_version,
                  type: "Integer"

--- a/modules/meeting/lib/api/v3/meetings/update_form_api.rb
+++ b/modules/meeting/lib/api/v3/meetings/update_form_api.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,31 +31,13 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
+      class UpdateFormAPI < ::API::OpenProjectAPI
+        resource :form do
+          after_validation do
+            authorize_in_any_project(:edit_meetings)
           end
+
+          post &::API::V3::Utilities::Endpoints::UpdateForm.new(model: Meeting).mount
         end
       end
     end

--- a/modules/meeting/lib/api/v3/meetings/update_form_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/update_form_representer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,32 +31,8 @@
 module API
   module V3
     module Meetings
-      class MeetingsAPI < ::API::OpenProjectAPI
-        resources :meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: Meeting).mount
-
-          post &::API::V3::Utilities::Endpoints::Create.new(model: Meeting).mount
-
-          mount ::API::V3::Meetings::Schemas::MeetingSchemaAPI
-          mount ::API::V3::Meetings::CreateFormAPI
-
-          route_param :id, type: Integer, desc: "Meeting ID" do
-            after_validation do
-              @meeting = Meeting.visible.find(declared_params[:id])
-            end
-
-            get &::API::V3::Utilities::Endpoints::Show
-              .new(model: ::Meeting)
-              .mount
-
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: Meeting).mount
-
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: Meeting).mount
-
-            mount ::API::V3::Meetings::UpdateFormAPI
-            mount ::API::V3::Attachments::AttachmentsByMeetingAPI
-          end
-        end
+      class UpdateFormRepresenter < FormRepresenter
+        include API::Decorators::UpdateForm
       end
     end
   end

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrence.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrence.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class Occurrence
+        attr_accessor :start_time, :recurring_meeting_id, :meeting_id, :cancelled
+
+        def initialize(start_time:, recurring_meeting_id:, meeting_id: nil, cancelled: false)
+          @start_time = start_time
+          @recurring_meeting_id = recurring_meeting_id
+          @meeting_id = meeting_id
+          @cancelled = cancelled
+        end
+
+        def state
+          if cancelled
+            "cancelled"
+          elsif meeting_id
+            "open"
+          else
+            "scheduled"
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrence_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrence_collection_representer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class OccurrenceCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        element_decorator OccurrenceRepresenter
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrence_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrence_representer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class OccurrenceRepresenter < ::API::Decorators::Single
+        link :self do
+          {
+            href: api_v3_paths.recurring_meeting_occurrence(
+              represented.recurring_meeting_id,
+              represented.start_time.utc.iso8601
+            )
+          }
+        end
+
+        link :meeting do
+          next unless represented.meeting_id
+
+          {
+            href: api_v3_paths.meeting(represented.meeting_id)
+          }
+        end
+
+        link :recurringMeeting do
+          {
+            href: api_v3_paths.recurring_meeting(represented.recurring_meeting_id)
+          }
+        end
+
+        property :start_time,
+                 getter: ->(*) { start_time&.utc&.iso8601 },
+                 as: :startTime
+
+        property :state
+
+        def _type
+          "MeetingOccurrence"
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/occurrences_by_recurring_meeting_api.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/occurrences_by_recurring_meeting_api.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class OccurrencesByRecurringMeetingAPI < ::API::OpenProjectAPI
+        helpers do
+          def build_occurrence(start_time:, scheduled_meeting: nil)
+            Occurrence.new(
+              start_time:,
+              recurring_meeting_id: @recurring_meeting.id,
+              meeting_id: scheduled_meeting&.meeting_id,
+              cancelled: scheduled_meeting&.cancelled || false
+            )
+          end
+
+          def occurrences_from_scheduled(scheduled_meetings)
+            scheduled_meetings.map { |sm| build_occurrence(start_time: sm.start_time, scheduled_meeting: sm) }
+          end
+
+          def occurrence_collection(occurrences, self_link:)
+            OccurrenceCollectionRepresenter.new(occurrences, self_link:, current_user:)
+          end
+
+          def persisted_upcoming
+            @recurring_meeting.scheduled_meetings.upcoming.index_by(&:start_time)
+          end
+
+          def opened_start_times(persisted)
+            persisted
+              .select { |_, sm| sm.meeting_id.present? && !sm.cancelled }
+              .keys
+              .to_set
+          end
+
+          def computed_start_times(opened_times, limit)
+            from_time = Time.current - (@recurring_meeting.template&.duration || 1).hours
+            @recurring_meeting
+              .scheduled_occurrences(limit: limit + opened_times.size, from_time:)
+              .reject { |t| opened_times.include?(t) }
+              .first(limit)
+          end
+
+          def build_upcoming_occurrences(limit: 20)
+            persisted = persisted_upcoming
+            opened_times = opened_start_times(persisted)
+            all_times = (opened_times.to_a + computed_start_times(opened_times, limit)).sort
+            all_times.map { |t| build_occurrence(start_time: t, scheduled_meeting: persisted[t]) }
+          end
+        end
+
+        namespace :occurrences do
+          namespace :upcoming do
+            params do
+              optional :limit, type: Integer, default: 20, desc: "Number of occurrences to return"
+            end
+
+            get do
+              occurrence_collection(
+                build_upcoming_occurrences(limit: declared_params[:limit]),
+                self_link: api_v3_paths.recurring_meeting_occurrences_upcoming(@recurring_meeting.id)
+              )
+            end
+          end
+
+          namespace :past do
+            get do
+              occurrence_collection(
+                occurrences_from_scheduled(@recurring_meeting.scheduled_meetings.past.not_cancelled),
+                self_link: api_v3_paths.recurring_meeting_occurrences_past(@recurring_meeting.id)
+              )
+            end
+          end
+
+          namespace :cancelled do
+            get do
+              occurrence_collection(
+                occurrences_from_scheduled(@recurring_meeting.scheduled_meetings.cancelled),
+                self_link: api_v3_paths.recurring_meeting_occurrences_cancelled(@recurring_meeting.id)
+              )
+            end
+          end
+
+          namespace :open do
+            get do
+              occurrence_collection(
+                occurrences_from_scheduled(@recurring_meeting.scheduled_meetings.instantiated.not_cancelled),
+                self_link: api_v3_paths.recurring_meeting_occurrences_open(@recurring_meeting.id)
+              )
+            end
+          end
+
+          route_param :start_time, type: DateTime, desc: "Occurrence start time (ISO 8601)" do
+            namespace :init do
+              post do
+                start_time = declared_params[:start_time]
+                call = ::RecurringMeetings::InitOccurrenceService
+                         .new(user: current_user, recurring_meeting: @recurring_meeting)
+                         .call(start_time:)
+
+                if call.success?
+                  status 201
+                  ::API::V3::Meetings::MeetingRepresenter.create(call.result, current_user:, embed_links: true)
+                else
+                  fail ::API::Errors::ErrorBase.create_and_merge_errors(call.errors)
+                end
+              end
+            end
+
+            delete do
+              start_time = declared_params[:start_time]
+              authorize_in_project(:edit_meetings, project: @recurring_meeting.project)
+
+              scheduled = @recurring_meeting.scheduled_meetings.find_or_initialize_by(start_time:)
+
+              if scheduled.meeting_id.present?
+                fail ::API::Errors::Conflict.new(
+                  message: "Cannot cancel an already instantiated occurrence. Delete the meeting instead."
+                )
+              end
+
+              scheduled.cancelled = true
+              if scheduled.save
+                status 204
+              else
+                fail ::API::Errors::ErrorBase.create_and_merge_errors(scheduled.errors)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_collection_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_collection_representer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class RecurringMeetingCollectionRepresenter < ::API::Decorators::OffsetPaginatedCollection
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_payload_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_payload_representer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class RecurringMeetingPayloadRepresenter < RecurringMeetingRepresenter
+        include ::API::Utilities::PayloadRepresenter
+
+        cached_representer disabled: true
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meeting_representer.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class RecurringMeetingRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+        include API::V3::Workspaces::LinkedResource
+        include API::Decorators::DateProperty
+        include ::API::Caching::CachedRepresenter
+
+        cached_representer key_parts: %i[project]
+
+        self.to_eager_load = [:author, :template, { project: :enabled_modules }]
+
+        self_link title_getter: ->(*) { represented.title }
+
+        link :updateImmediately,
+             cache_if: -> { current_user.allowed_in_project?(:edit_meetings, represented.project) } do
+          {
+            href: api_v3_paths.recurring_meeting(represented.id),
+            method: :patch
+          }
+        end
+
+        link :delete,
+             cache_if: -> { current_user.allowed_in_project?(:delete_meetings, represented.project) } do
+          {
+            href: api_v3_paths.recurring_meeting(represented.id),
+            method: :delete
+          }
+        end
+
+        link :template do
+          next unless represented.template
+
+          {
+            href: api_v3_paths.meeting(represented.template.id),
+            title: represented.template.title
+          }
+        end
+
+        link :occurrencesUpcoming do
+          {
+            href: api_v3_paths.recurring_meeting_occurrences_upcoming(represented.id)
+          }
+        end
+
+        link :occurrencesPast do
+          {
+            href: api_v3_paths.recurring_meeting_occurrences_past(represented.id)
+          }
+        end
+
+        link :occurrencesCancelled do
+          {
+            href: api_v3_paths.recurring_meeting_occurrences_cancelled(represented.id)
+          }
+        end
+
+        link :occurrencesOpen do
+          {
+            href: api_v3_paths.recurring_meeting_occurrences_open(represented.id)
+          }
+        end
+
+        property :id
+
+        property :title
+
+        property :frequency
+
+        property :interval
+
+        property :end_after
+
+        date_property :end_date
+
+        property :iterations
+
+        property :time_zone,
+                 getter: ->(*) { time_zone.name }
+
+        date_time_property :start_time
+
+        property :location,
+                 getter: ->(*) { template&.location }
+
+        property :duration,
+                 getter: ->(*) { template&.duration }
+
+        property :notify,
+                 getter: ->(*) { template&.notify }
+
+        associated_resource :author,
+                            v3_path: :user,
+                            representer: ::API::V3::Users::UserRepresenter
+
+        associated_project
+
+        date_time_property :created_at
+        date_time_property :updated_at
+
+        def _type
+          "RecurringMeeting"
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
+++ b/modules/meeting/lib/api/v3/recurring_meetings/recurring_meetings_api.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module RecurringMeetings
+      class RecurringMeetingsAPI < ::API::OpenProjectAPI
+        resources :recurring_meetings do
+          get do
+            recurring_meetings = RecurringMeeting.visible
+            RecurringMeetingCollectionRepresenter.new(
+              recurring_meetings,
+              self_link: api_v3_paths.recurring_meetings,
+              current_user:
+            )
+          end
+
+          post(&::API::V3::Utilities::Endpoints::Create
+                 .new(model: RecurringMeeting)
+                 .mount)
+
+          route_param :id, type: Integer, desc: "Recurring meeting ID" do
+            after_validation do
+              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
+            end
+
+            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
+
+            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
+
+            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
+
+            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -219,5 +219,17 @@ module OpenProject::Meeting
     add_api_path :attachments_by_meeting do |id|
       "#{meeting(id)}/attachments"
     end
+
+    add_api_path :meeting_schema do
+      "#{root}/meetings/schema"
+    end
+
+    add_api_path :create_meeting_form do
+      "#{root}/meetings/form"
+    end
+
+    add_api_path :meeting_form do |id|
+      "#{root}/meetings/#{id}/form"
+    end
   end
 end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -184,6 +184,7 @@ module OpenProject::Meeting
 
     add_api_endpoint "API::V3::Root" do
       mount ::API::V3::Meetings::MeetingsAPI
+      mount ::API::V3::RecurringMeetings::RecurringMeetingsAPI
     end
 
     config.to_prepare do
@@ -246,6 +247,34 @@ module OpenProject::Meeting
 
     add_api_path :meeting_section do |meeting_id, id|
       "#{meeting(meeting_id)}/sections/#{id}"
+    end
+
+    add_api_path :recurring_meetings do
+      "#{root}/recurring_meetings"
+    end
+
+    add_api_path :recurring_meeting do |id|
+      "#{root}/recurring_meetings/#{id}"
+    end
+
+    add_api_path :recurring_meeting_occurrences_upcoming do |id|
+      "#{recurring_meeting(id)}/occurrences/upcoming"
+    end
+
+    add_api_path :recurring_meeting_occurrences_past do |id|
+      "#{recurring_meeting(id)}/occurrences/past"
+    end
+
+    add_api_path :recurring_meeting_occurrences_cancelled do |id|
+      "#{recurring_meeting(id)}/occurrences/cancelled"
+    end
+
+    add_api_path :recurring_meeting_occurrences_open do |id|
+      "#{recurring_meeting(id)}/occurrences/open"
+    end
+
+    add_api_path :recurring_meeting_occurrence do |id, start_time|
+      "#{recurring_meeting(id)}/occurrences/#{start_time}"
     end
   end
 end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -231,5 +231,21 @@ module OpenProject::Meeting
     add_api_path :meeting_form do |id|
       "#{root}/meetings/#{id}/form"
     end
+
+    add_api_path :meeting_agenda_items do |meeting_id|
+      "#{meeting(meeting_id)}/agenda_items"
+    end
+
+    add_api_path :meeting_agenda_item do |meeting_id, id|
+      "#{meeting(meeting_id)}/agenda_items/#{id}"
+    end
+
+    add_api_path :meeting_sections do |meeting_id|
+      "#{meeting(meeting_id)}/sections"
+    end
+
+    add_api_path :meeting_section do |meeting_id, id|
+      "#{meeting(meeting_id)}/sections/#{id}"
+    end
   end
 end

--- a/modules/meeting/spec/models/queries/recurring_meetings/filters/author_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/recurring_meetings/filters/author_filter_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::RecurringMeetings::Filters::AuthorFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :list_optional }
+    let(:class_key) { :author_id }
+
+    describe "#available?" do
+      it "is true" do
+        expect(instance).to be_available
+      end
+    end
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
+  end
+
+  describe "#where clause" do
+    let(:project) { create(:project) }
+    let(:author1) { create(:user) }
+    let(:author2) { create(:user) }
+    let!(:series_by_author1) { create(:recurring_meeting, project:, author: author1) }
+    let!(:series_by_author2) { create(:recurring_meeting, project:, author: author2) }
+
+    let(:instance) do
+      described_class.create!(name: :author_id, operator:, values:)
+    end
+
+    context 'for "="' do
+      let(:operator) { "=" }
+      let(:values) { [author1.id.to_s] }
+
+      it "returns only recurring meetings by that author" do
+        result = RecurringMeeting.where(instance.where)
+
+        expect(result).to include(series_by_author1)
+        expect(result).not_to include(series_by_author2)
+      end
+    end
+
+    context 'for "!"' do
+      let(:operator) { "!" }
+      let(:values) { [author1.id.to_s] }
+
+      it "excludes recurring meetings by that author" do
+        result = RecurringMeeting.where(instance.where)
+
+        expect(result).not_to include(series_by_author1)
+        expect(result).to include(series_by_author2)
+      end
+    end
+
+    context 'for "*"' do
+      let(:operator) { "*" }
+      let(:values) { [] }
+
+      it "returns all recurring meetings with any author" do
+        result = RecurringMeeting.where(instance.where)
+
+        expect(result).to include(series_by_author1, series_by_author2)
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/models/queries/recurring_meetings/filters/project_filter_spec.rb
+++ b/modules/meeting/spec/models/queries/recurring_meetings/filters/project_filter_spec.rb
@@ -28,31 +28,31 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module API
-  module V3
-    module RecurringMeetings
-      class RecurringMeetingsAPI < ::API::OpenProjectAPI
-        resources :recurring_meetings do
-          get &::API::V3::Utilities::Endpoints::Index.new(model: RecurringMeeting).mount
+require "spec_helper"
 
-          post(&::API::V3::Utilities::Endpoints::Create
-                 .new(model: RecurringMeeting)
-                 .mount)
+RSpec.describe Queries::RecurringMeetings::Filters::ProjectFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :list_optional }
+    let(:class_key) { :project_id }
 
-          route_param :id, type: Integer, desc: "Recurring meeting ID" do
-            after_validation do
-              @recurring_meeting = RecurringMeeting.visible.find(declared_params[:id])
-            end
+    describe "#available?" do
+      it "is true" do
+        expect(instance).to be_available
+      end
+    end
 
-            get &::API::V3::Utilities::Endpoints::Show.new(model: RecurringMeeting).mount
+    describe "#allowed_values" do
+      let(:project) { build_stubbed(:project) }
 
-            patch &::API::V3::Utilities::Endpoints::Update.new(model: RecurringMeeting).mount
+      let(:visible_scope) { instance_double(ActiveRecord::Relation) }
 
-            delete &::API::V3::Utilities::Endpoints::Delete.new(model: RecurringMeeting).mount
+      before do
+        allow(Project).to receive(:visible).and_return(visible_scope)
+        allow(visible_scope).to receive(:pluck).with(:id).and_return([project.id])
+      end
 
-            mount ::API::V3::RecurringMeetings::OccurrencesByRecurringMeetingAPI
-          end
-        end
+      it "returns an array of [id, id_string] pairs for visible projects" do
+        expect(instance.allowed_values).to include([project.id, project.id.to_s])
       end
     end
   end

--- a/modules/meeting/spec/models/queries/recurring_meetings/recurring_meeting_query_spec.rb
+++ b/modules/meeting/spec/models/queries/recurring_meetings/recurring_meeting_query_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Queries::RecurringMeetings::RecurringMeetingQuery do
+  subject { described_class.new(user:) }
+
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:visible_project) do
+    create(:project, members: { user => create(:project_role, permissions: %i[view_meetings]) })
+  end
+  let!(:visible_series_a) do
+    create(:recurring_meeting, project: visible_project, author: user,
+                               start_time: 1.day.from_now, created_at: 2.days.ago)
+  end
+  let!(:visible_series_b) do
+    create(:recurring_meeting, project: visible_project, author: other_user,
+                               start_time: 2.days.from_now, created_at: 1.day.ago)
+  end
+
+  let(:invisible_project) { create(:project) }
+  let!(:invisible_series) { create(:recurring_meeting, project: invisible_project) }
+
+  context "without a filter" do
+    it "returns all visible recurring meetings" do
+      expect(subject.results).to contain_exactly(visible_series_a, visible_series_b)
+    end
+
+    it "does not return recurring meetings from projects without permission" do
+      expect(subject.results).not_to include(invisible_series)
+    end
+  end
+
+  context "when filtering by project" do
+    let(:other_visible_project) do
+      create(:project, members: { user => create(:project_role, permissions: %i[view_meetings]) })
+    end
+    let!(:other_visible_series) { create(:recurring_meeting, project: other_visible_project, author: user) }
+
+    before { subject.where("project_id", "=", [other_visible_project.id]) }
+
+    it "returns only visible recurring meetings for that project" do
+      expect(subject.results).to contain_exactly(other_visible_series)
+    end
+  end
+
+  context "when filtering by author" do
+    before { subject.where("author_id", "=", [other_user.id]) }
+
+    it "returns only recurring meetings created by that author" do
+      expect(subject.results).to contain_exactly(visible_series_b)
+    end
+  end
+
+  context "when sorting by start_time ascending" do
+    before { subject.order(start_time: :asc) }
+
+    it "returns results ordered by start_time asc" do
+      expect(subject.results.to_a).to eq([visible_series_a, visible_series_b])
+    end
+  end
+
+  context "when sorting by start_time descending" do
+    before { subject.order(start_time: :desc) }
+
+    it "returns results ordered by start_time desc" do
+      expect(subject.results.to_a).to eq([visible_series_b, visible_series_a])
+    end
+  end
+
+  context "when sorting by created_at ascending" do
+    before { subject.order(created_at: :asc) }
+
+    it "returns results ordered by created_at asc" do
+      expect(subject.results.to_a).to eq([visible_series_a, visible_series_b])
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_meeting_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meeting_agenda_items/agenda_items_by_meeting_resource_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Meeting Agenda Items sub-resource", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+
+  let(:permissions) { %i[view_meetings manage_agendas] }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:meeting) { create(:meeting, project:, author: current_user) }
+  let!(:section) { create(:meeting_section, meeting:) }
+  let!(:agenda_item) { create(:meeting_agenda_item, meeting:, meeting_section: section, author: current_user) }
+
+  before do
+    login_as current_user
+  end
+
+  describe "GET /api/v3/meetings/:meeting_id/agenda_items" do
+    let(:path) { api_v3_paths.meeting_agenda_items(meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and lists agenda items" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+
+      expect(last_response.body)
+        .to have_json_size(1)
+        .at_path("_embedded/elements")
+    end
+
+    context "without view_meetings permission" do
+      let(:permissions) { [] }
+
+      it "returns 404" do
+        expect(last_response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /api/v3/meetings/:meeting_id/agenda_items" do
+    let(:path) { api_v3_paths.meeting_agenda_items(meeting.id) }
+    let(:body) do
+      {
+        title: "New agenda item"
+      }.to_json
+    end
+
+    subject(:response) { post path, body }
+
+    it "responds with 201" do
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates the agenda item" do
+      response
+      expect(meeting.agenda_items.find_by(title: "New agenda item")).to be_present
+    end
+
+    it "returns the created item" do
+      expect(response.body)
+        .to be_json_eql("MeetingAgendaItem".to_json)
+        .at_path("_type")
+
+      expect(response.body)
+        .to be_json_eql("New agenda item".to_json)
+        .at_path("title")
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "GET /api/v3/meetings/:meeting_id/agenda_items/:id" do
+    let(:path) { api_v3_paths.meeting_agenda_item(meeting.id, agenda_item.id) }
+
+    before { get path }
+
+    it "returns 200 and the agenda item" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("MeetingAgendaItem".to_json)
+        .at_path("_type")
+
+      expect(last_response.body)
+        .to be_json_eql(agenda_item.id.to_json)
+        .at_path("id")
+    end
+
+    context "with an item from another meeting" do
+      let(:other_meeting) { create(:meeting, project:, author: current_user) }
+      let(:path) { api_v3_paths.meeting_agenda_item(other_meeting.id, agenda_item.id) }
+
+      it "returns 404" do
+        expect(last_response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "PATCH /api/v3/meetings/:meeting_id/agenda_items/:id" do
+    let(:path) { api_v3_paths.meeting_agenda_item(meeting.id, agenda_item.id) }
+    let(:body) do
+      {
+        title: "Updated title",
+        lockVersion: agenda_item.lock_version
+      }.to_json
+    end
+
+    subject(:response) { patch path, body }
+
+    it "responds with 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the agenda item" do
+      response
+      expect(agenda_item.reload.title).to eq("Updated title")
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/v3/meetings/:meeting_id/agenda_items/:id" do
+    let(:path) { api_v3_paths.meeting_agenda_item(meeting.id, agenda_item.id) }
+
+    before { delete path }
+
+    subject { last_response }
+
+    context "with required permissions" do
+      it "responds with 204" do
+        expect(subject.status).to eq 204
+      end
+
+      it "deletes the agenda item" do
+        expect(MeetingAgendaItem).not_to exist(agenda_item.id)
+      end
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meeting_sections/sections_by_meeting_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meeting_sections/sections_by_meeting_resource_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Meeting Sections sub-resource", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+
+  let(:permissions) { %i[view_meetings manage_agendas] }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:meeting) { create(:meeting, project:, author: current_user) }
+  let!(:section) { create(:meeting_section, meeting:, title: "First Section") }
+
+  before do
+    login_as current_user
+  end
+
+  describe "GET /api/v3/meetings/:meeting_id/sections" do
+    let(:path) { api_v3_paths.meeting_sections(meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and lists sections" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+    end
+
+    context "without view_meetings permission" do
+      let(:permissions) { [] }
+
+      it "returns 404" do
+        expect(last_response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /api/v3/meetings/:meeting_id/sections" do
+    let(:path) { api_v3_paths.meeting_sections(meeting.id) }
+    let(:body) do
+      {
+        title: "New Section"
+      }.to_json
+    end
+
+    subject(:response) { post path, body }
+
+    it "responds with 201" do
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates the section" do
+      response
+      expect(meeting.sections.find_by(title: "New Section")).to be_present
+    end
+
+    it "returns the created section" do
+      expect(response.body)
+        .to be_json_eql("MeetingSection".to_json)
+        .at_path("_type")
+
+      expect(response.body)
+        .to be_json_eql("New Section".to_json)
+        .at_path("title")
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "GET /api/v3/meetings/:meeting_id/sections/:id" do
+    let(:path) { api_v3_paths.meeting_section(meeting.id, section.id) }
+
+    before { get path }
+
+    it "returns 200 and the section" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("MeetingSection".to_json)
+        .at_path("_type")
+
+      expect(last_response.body)
+        .to be_json_eql(section.id.to_json)
+        .at_path("id")
+    end
+
+    context "with a section from another meeting" do
+      let(:other_meeting) { create(:meeting, project:, author: current_user) }
+      let(:path) { api_v3_paths.meeting_section(other_meeting.id, section.id) }
+
+      it "returns 404" do
+        expect(last_response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "PATCH /api/v3/meetings/:meeting_id/sections/:id" do
+    let(:path) { api_v3_paths.meeting_section(meeting.id, section.id) }
+    let(:body) do
+      {
+        title: "Updated Section Title"
+      }.to_json
+    end
+
+    subject(:response) { patch path, body }
+
+    it "responds with 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the section" do
+      response
+      expect(section.reload.title).to eq("Updated Section Title")
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/v3/meetings/:meeting_id/sections/:id" do
+    let(:path) { api_v3_paths.meeting_section(meeting.id, section.id) }
+
+    before { delete path }
+
+    subject { last_response }
+
+    context "with required permissions" do
+      it "responds with 204" do
+        expect(subject.status).to eq 204
+      end
+
+      it "deletes the section" do
+        expect(MeetingSection).not_to exist(section.id)
+      end
+    end
+
+    context "without manage_agendas permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meetings/create_form_api_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/create_form_api_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe API::V3::Meetings::CreateFormAPI, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:permissions) { %i[view_meetings create_meetings] }
+
+  let(:path) { api_v3_paths.create_meeting_form }
+  let(:parameters) { {} }
+
+  before do
+    login_as(user)
+    post path, parameters.to_json
+  end
+
+  subject(:response) { last_response }
+
+  describe "POST /api/v3/meetings/form" do
+    it "returns 200 OK" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns a form" do
+      expect(response.body)
+        .to be_json_eql("Form".to_json)
+        .at_path("_type")
+    end
+
+    it "does not create a meeting" do
+      expect(Meeting.count).to be 0
+    end
+
+    context "with empty parameters" do
+      it "has validation errors" do
+        expect(subject.body).to have_json_path("_embedded/validationErrors")
+      end
+
+      it "has a validation error on title" do
+        expect(subject.body).to have_json_path("_embedded/validationErrors/title")
+      end
+
+      it "has no commit link" do
+        expect(subject.body)
+          .not_to have_json_path("_links/commit")
+      end
+    end
+
+    context "with all minimum parameters" do
+      let(:parameters) do
+        {
+          title: "New Meeting",
+          startTime: "2026-06-01T10:00:00Z",
+          _links: {
+            project: {
+              href: api_v3_paths.project(project.id)
+            }
+          }
+        }
+      end
+
+      it "has 0 validation errors" do
+        expect(subject.body).to have_json_size(0).at_path("_embedded/validationErrors")
+      end
+
+      it "has a commit link" do
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.meetings.to_json)
+          .at_path("_links/commit/href")
+      end
+    end
+
+    context "with all parameters" do
+      let(:parameters) do
+        {
+          title: "Full Meeting",
+          location: "Room 42",
+          startTime: "2026-06-01T14:00:00Z",
+          duration: "PT2H",
+          _links: {
+            project: {
+              href: api_v3_paths.project(project.id)
+            }
+          }
+        }
+      end
+
+      it "has 0 validation errors" do
+        expect(subject.body).to have_json_size(0).at_path("_embedded/validationErrors")
+      end
+
+      it "has the values prefilled in the payload", :aggregate_failures do
+        expect(subject.body)
+          .to be_json_eql("Full Meeting".to_json)
+          .at_path("_embedded/payload/title")
+
+        expect(subject.body)
+          .to be_json_eql("Room 42".to_json)
+          .at_path("_embedded/payload/location")
+
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.project(project.id).to_json)
+          .at_path("_embedded/payload/_links/project/href")
+      end
+
+      it "has a commit link" do
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.meetings.to_json)
+          .at_path("_links/commit/href")
+      end
+    end
+
+    context "without the necessary permission" do
+      let(:permissions) { [:view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -30,56 +31,282 @@
 require "spec_helper"
 require "rack/test"
 
-RSpec.describe "API v3 Meeting resource" do
+RSpec.describe "API v3 Meeting resource", content_type: :json do
   include Rack::Test::Methods
   include API::V3::Utilities::PathHelper
 
-  shared_let(:project) { create(:project) }
-  shared_let(:meeting) { create(:meeting, project:) }
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:other_project) { create(:project, enabled_module_names: %w[meetings]) }
 
-  let(:permissions) { [:view_meetings] }
+  let(:permissions) { %i[view_meetings create_meetings edit_meetings delete_meetings] }
   let(:current_user) do
     create(:user,
            member_with_permissions: { project => permissions })
   end
 
-  describe "meetings/:id" do
+  before do
+    login_as current_user
+  end
+
+  describe "GET /api/v3/meetings/:id" do
+    let(:meeting) { create(:meeting, project:, author: current_user) }
     let(:get_path) { api_v3_paths.meeting meeting.id }
 
-    context "with logged in user" do
-      before do
-        allow(User).to receive(:current).and_return current_user
+    before do
+      get get_path
+    end
 
-        get get_path
+    context "with valid id" do
+      it "returns HTTP 200" do
+        expect(last_response).to have_http_status :ok
       end
 
-      context "when valid id" do
-        it "returns HTTP 200" do
-          expect(last_response).to have_http_status :ok
+      it "returns the meeting" do
+        expect(last_response.body)
+          .to be_json_eql("Meeting".to_json)
+          .at_path("_type")
+
+        expect(last_response.body)
+          .to be_json_eql(meeting.id.to_json)
+          .at_path("id")
+      end
+    end
+
+    context "without view_meetings permission" do
+      let(:permissions) { [] }
+
+      it "returns HTTP 404" do
+        expect(last_response).to have_http_status :not_found
+      end
+    end
+
+    context "with invalid id" do
+      let(:get_path) { api_v3_paths.meeting 0 }
+
+      it_behaves_like "not found"
+    end
+  end
+
+  describe "POST /api/v3/meetings" do
+    let(:path) { api_v3_paths.meetings }
+    let(:body) do
+      {
+        title: "New API Meeting",
+        location: "Conference Room A",
+        startTime: "2026-06-01T10:00:00Z",
+        duration: "PT1H",
+        _links: {
+          project: {
+            href: api_v3_paths.project(project.id)
+          }
+        }
+      }.to_json
+    end
+
+    subject(:response) { post path, body }
+
+    it "responds with 201" do
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates the meeting" do
+      response
+      expect(Meeting.find_by(title: "New API Meeting"))
+        .to be_present
+    end
+
+    it "returns the newly created meeting", :aggregate_failures do
+      expect(response.body)
+        .to be_json_eql("Meeting".to_json)
+        .at_path("_type")
+
+      expect(response.body)
+        .to be_json_eql("New API Meeting".to_json)
+        .at_path("title")
+
+      expect(response.body)
+        .to be_json_eql("Conference Room A".to_json)
+        .at_path("location")
+    end
+
+    context "without create_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "without title" do
+      let(:body) do
+        {
+          location: "Room B",
+          _links: {
+            project: {
+              href: api_v3_paths.project(project.id)
+            }
+          }
+        }.to_json
+      end
+
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "without project link" do
+      let(:body) do
+        {
+          title: "Meeting without project"
+        }.to_json
+      end
+
+      it "returns 422" do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "with participants" do
+      let(:other_user) do
+        create(:user, member_with_permissions: { project => [:view_meetings] })
+      end
+      let(:body) do
+        {
+          title: "Meeting with participants",
+          startTime: "2026-06-01T10:00:00Z",
+          duration: "PT1H",
+          _links: {
+            project: {
+              href: api_v3_paths.project(project.id)
+            },
+            participants: [
+              { href: api_v3_paths.user(current_user.id) },
+              { href: api_v3_paths.user(other_user.id) }
+            ]
+          }
+        }.to_json
+      end
+
+      it "responds with 201" do
+        expect(response).to have_http_status(:created)
+      end
+
+      it "creates the meeting with participants" do
+        response
+        meeting = Meeting.find_by(title: "Meeting with participants")
+        expect(meeting.participants.count).to eq(2)
+        expect(meeting.participants.map(&:user_id)).to contain_exactly(current_user.id, other_user.id)
+      end
+
+      it "returns the participants in the response" do
+        expect(response.body)
+          .to have_json_size(2)
+          .at_path("_links/participants")
+      end
+    end
+  end
+
+  describe "PATCH /api/v3/meetings/:id" do
+    let(:meeting) { create(:meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.meeting(meeting.id) }
+    let(:body) do
+      {
+        title: "Updated Title",
+        lockVersion: meeting.lock_version
+      }.to_json
+    end
+
+    subject(:response) { patch path, body }
+
+    it "responds with 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the meeting" do
+      response
+      expect(meeting.reload.title).to eq("Updated Title")
+    end
+
+    it "returns the updated meeting" do
+      expect(response.body)
+        .to be_json_eql("Updated Title".to_json)
+        .at_path("title")
+    end
+
+    context "without edit_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with stale lock version" do
+      let(:body) do
+        {
+          title: "Stale update",
+          lockVersion: meeting.lock_version - 1
+        }.to_json
+      end
+
+      it "returns 409 Conflict" do
+        expect(response).to have_http_status(:conflict)
+      end
+    end
+
+    context "when meeting is not visible" do
+      let(:meeting) { create(:meeting, project: other_project) }
+
+      it_behaves_like "not found" do
+        before do
+          response
         end
+
+        subject { last_response }
+      end
+    end
+  end
+
+  describe "DELETE /api/v3/meetings/:id" do
+    let(:meeting) { create(:meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.meeting(meeting.id) }
+
+    before do
+      delete path
+    end
+
+    subject { last_response }
+
+    context "with required permissions" do
+      it "responds with HTTP No Content" do
+        expect(subject.status).to eq 204
       end
 
-      context "when valid id, but not visible" do
-        let(:permissions) { [:view_work_packages] }
-
-        it "returns HTTP 404" do
-          expect(last_response).to have_http_status :not_found
-        end
+      it "deletes the meeting" do
+        expect(Meeting).not_to exist(meeting.id)
       end
 
-      context "when invalid id" do
-        let(:get_path) { api_v3_paths.budget "bogus" }
+      context "for a non-existent meeting" do
+        let(:path) { api_v3_paths.meeting 0 }
 
         it_behaves_like "not found"
       end
     end
 
-    context "with not logged in user" do
-      before do
-        get get_path
-      end
+    context "without permission to see meetings" do
+      let(:permissions) { [] }
 
-      it_behaves_like "not found response based on login_required"
+      it_behaves_like "not found"
+    end
+
+    context "without permission to delete meetings" do
+      let(:permissions) { %i[view_meetings] }
+
+      it_behaves_like "unauthorized access"
+
+      it "does not delete the meeting" do
+        expect(Meeting).to exist(meeting.id)
+      end
     end
   end
 end

--- a/modules/meeting/spec/requests/api/v3/meetings/schemas/meeting_schema_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/schemas/meeting_schema_resource_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Meeting schema resource", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:permissions) { [:view_meetings] }
+  let(:path) { api_v3_paths.meeting_schema }
+
+  before do
+    login_as(current_user)
+  end
+
+  subject(:response) { last_response }
+
+  describe "GET /api/v3/meetings/schema" do
+    before do
+      get path
+    end
+
+    it "responds with 200 OK" do
+      expect(subject.status).to eq(200)
+    end
+
+    it "returns a schema" do
+      expect(subject.body)
+        .to be_json_eql("Schema".to_json)
+        .at_path("_type")
+    end
+
+    it "has the expected schema properties", :aggregate_failures do
+      %w[id title location duration startTime endTime state project lockVersion createdAt updatedAt].each do |prop|
+        expect(subject.body).to have_json_path(prop)
+      end
+    end
+
+    it "marks title as required" do
+      expect(subject.body)
+        .to be_json_eql(true.to_json)
+        .at_path("title/required")
+    end
+
+    it "marks endTime as not writable" do
+      expect(subject.body)
+        .to be_json_eql(false.to_json)
+        .at_path("endTime/writable")
+    end
+
+    context "without permission" do
+      let(:permissions) { [] }
+
+      it "responds with 403" do
+        expect(subject.status).to eq(403)
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/meetings/update_form_api_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/update_form_api_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe API::V3::Meetings::UpdateFormAPI, content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  let(:meeting) { create(:meeting, project:, author: user) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:permissions) { %i[view_meetings edit_meetings] }
+
+  let(:path) { api_v3_paths.meeting_form(meeting.id) }
+  let(:parameters) do
+    {
+      title: "Updated Meeting Title"
+    }
+  end
+
+  before do
+    login_as(user)
+    post path, parameters.to_json
+  end
+
+  subject(:response) { last_response }
+
+  describe "POST /api/v3/meetings/:id/form" do
+    it "returns 200 OK" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns a form" do
+      expect(response.body)
+        .to be_json_eql("Form".to_json)
+        .at_path("_type")
+    end
+
+    it "does not update the meeting" do
+      expect(meeting.reload.title)
+        .not_to eql "Updated Meeting Title"
+    end
+
+    context "with valid parameters" do
+      it "has 0 validation errors" do
+        expect(subject.body).to have_json_size(0).at_path("_embedded/validationErrors")
+      end
+
+      it "has the values prefilled in the payload" do
+        expect(subject.body)
+          .to be_json_eql("Updated Meeting Title".to_json)
+          .at_path("_embedded/payload/title")
+      end
+
+      it "has a commit link" do
+        expect(subject.body)
+          .to be_json_eql(api_v3_paths.meeting(meeting.id).to_json)
+          .at_path("_links/commit/href")
+      end
+    end
+
+    context "with nulling title" do
+      let(:parameters) do
+        { title: nil }
+      end
+
+      it "has validation errors" do
+        expect(subject.body).to have_json_path("_embedded/validationErrors/title")
+      end
+
+      it "has no commit link" do
+        expect(subject.body)
+          .not_to have_json_path("_links/commit")
+      end
+    end
+
+    context "without the necessary edit permission" do
+      let(:permissions) { [:view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "without the necessary view permission" do
+      let(:permissions) { [] }
+
+      it "returns 404" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/occurrences_resource_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Recurring Meeting Occurrences", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+
+  let(:permissions) { %i[view_meetings edit_meetings create_meetings] }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+  let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+
+  before do
+    login_as current_user
+  end
+
+  describe "GET .../occurrences/upcoming" do
+    let(:path) { api_v3_paths.recurring_meeting_occurrences_upcoming(recurring_meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and a collection" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+    end
+
+    it "includes occurrences with state" do
+      elements = JSON.parse(last_response.body).dig("_embedded", "elements")
+      expect(elements).to be_present
+      expect(elements.first).to have_key("state")
+      expect(elements.first).to have_key("startTime")
+    end
+  end
+
+  describe "GET .../occurrences/past" do
+    let(:path) { api_v3_paths.recurring_meeting_occurrences_past(recurring_meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and a collection" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+    end
+  end
+
+  describe "GET .../occurrences/cancelled" do
+    let(:path) { api_v3_paths.recurring_meeting_occurrences_cancelled(recurring_meeting.id) }
+    let!(:cancelled_schedule) do
+      create(:scheduled_meeting,
+             recurring_meeting:,
+             start_time: recurring_meeting.first_occurrence,
+             cancelled: true)
+    end
+
+    before { get path }
+
+    it "returns 200 with cancelled occurrences" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to have_json_size(1)
+        .at_path("_embedded/elements")
+    end
+  end
+
+  describe "GET .../occurrences/open" do
+    let(:path) { api_v3_paths.recurring_meeting_occurrences_open(recurring_meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and a collection" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+    end
+  end
+
+  describe "POST .../occurrences/:start_time/init" do
+    let(:start_time) { recurring_meeting.first_occurrence }
+    let(:path) do
+      "#{api_v3_paths.recurring_meeting_occurrence(recurring_meeting.id, start_time.utc.iso8601)}/init"
+    end
+
+    subject(:response) { post path }
+
+    it "responds with 201 and creates a meeting" do
+      expect(response).to have_http_status(:created)
+
+      expect(response.body)
+        .to be_json_eql("Meeting".to_json)
+        .at_path("_type")
+    end
+
+    it "creates a scheduled meeting record" do
+      response
+      expect(recurring_meeting.scheduled_meetings.where(start_time:)).to exist
+    end
+  end
+
+  describe "DELETE .../occurrences/:start_time" do
+    let(:start_time) { recurring_meeting.first_occurrence }
+    let(:path) { api_v3_paths.recurring_meeting_occurrence(recurring_meeting.id, start_time.utc.iso8601) }
+
+    before { delete path }
+
+    subject { last_response }
+
+    it "responds with 204" do
+      expect(subject.status).to eq 204
+    end
+
+    it "creates a cancelled scheduled meeting" do
+      scheduled = recurring_meeting.scheduled_meetings.find_by(start_time:)
+      expect(scheduled).to be_present
+      expect(scheduled.cancelled).to be true
+    end
+
+    context "without edit_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
+end

--- a/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/recurring_meetings/recurring_meetings_resource_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require "rack/test"
+
+RSpec.describe "API v3 Recurring Meeting resource", content_type: :json do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+
+  let(:permissions) { %i[view_meetings create_meetings edit_meetings delete_meetings] }
+  let(:current_user) do
+    create(:user, member_with_permissions: { project => permissions })
+  end
+
+  before do
+    login_as current_user
+  end
+
+  describe "GET /api/v3/recurring_meetings" do
+    let!(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.recurring_meetings }
+
+    before { get path }
+
+    it "returns 200 and a collection" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("Collection".to_json)
+        .at_path("_type")
+    end
+
+    context "without view_meetings permission" do
+      let(:permissions) { [] }
+
+      it "returns an empty collection" do
+        expect(last_response).to have_http_status(:ok)
+        expect(last_response.body).to have_json_size(0).at_path("_embedded/elements")
+      end
+    end
+  end
+
+  describe "GET /api/v3/recurring_meetings/:id" do
+    let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.recurring_meeting(recurring_meeting.id) }
+
+    before { get path }
+
+    it "returns 200 and the recurring meeting" do
+      expect(last_response).to have_http_status(:ok)
+
+      expect(last_response.body)
+        .to be_json_eql("RecurringMeeting".to_json)
+        .at_path("_type")
+
+      expect(last_response.body)
+        .to be_json_eql(recurring_meeting.id.to_json)
+        .at_path("id")
+    end
+
+    it "includes occurrence links", :aggregate_failures do
+      expect(last_response.body).to have_json_path("_links/occurrencesUpcoming/href")
+      expect(last_response.body).to have_json_path("_links/occurrencesPast/href")
+      expect(last_response.body).to have_json_path("_links/occurrencesCancelled/href")
+      expect(last_response.body).to have_json_path("_links/occurrencesOpen/href")
+      expect(last_response.body).to have_json_path("_links/template/href")
+    end
+
+    context "without view_meetings permission" do
+      let(:permissions) { [] }
+
+      it "returns 404" do
+        expect(last_response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /api/v3/recurring_meetings" do
+    let(:path) { api_v3_paths.recurring_meetings }
+    let(:body) do
+      {
+        title: "Weekly Standup Series",
+        frequency: "weekly",
+        interval: 1,
+        endAfter: "specific_date",
+        endDate: 6.months.from_now.to_date.iso8601,
+        startTime: (Date.tomorrow + 10.hours).iso8601,
+        duration: "PT1H",
+        location: "Room A",
+        _links: {
+          project: {
+            href: api_v3_paths.project(project.id)
+          }
+        }
+      }.to_json
+    end
+
+    subject(:response) { post path, body }
+
+    it "responds with 201" do
+      expect(response).to have_http_status(:created)
+    end
+
+    it "creates the recurring meeting with a template" do
+      response
+      rm = RecurringMeeting.find_by(title: "Weekly Standup Series")
+      expect(rm).to be_present
+      expect(rm.template).to be_present
+      expect(rm.frequency).to eq("weekly")
+    end
+
+    it "returns the created recurring meeting" do
+      expect(response.body)
+        .to be_json_eql("RecurringMeeting".to_json)
+        .at_path("_type")
+
+      expect(response.body)
+        .to be_json_eql("Weekly Standup Series".to_json)
+        .at_path("title")
+    end
+
+    context "without create_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "PATCH /api/v3/recurring_meetings/:id" do
+    let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.recurring_meeting(recurring_meeting.id) }
+    let(:body) do
+      {
+        title: "Updated Series Title"
+      }.to_json
+    end
+
+    subject(:response) { patch path, body }
+
+    it "responds with 200" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "updates the recurring meeting" do
+      response
+      expect(recurring_meeting.reload.title).to eq("Updated Series Title")
+    end
+
+    context "without edit_meetings permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it "returns 403" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /api/v3/recurring_meetings/:id" do
+    let(:recurring_meeting) { create(:recurring_meeting, project:, author: current_user) }
+    let(:path) { api_v3_paths.recurring_meeting(recurring_meeting.id) }
+
+    before { delete path }
+
+    subject { last_response }
+
+    context "with required permissions" do
+      it "responds with 204" do
+        expect(subject.status).to eq 204
+      end
+
+      it "deletes the recurring meeting" do
+        expect(RecurringMeeting).not_to exist(recurring_meeting.id)
+      end
+    end
+
+    context "without permission" do
+      let(:permissions) { %i[view_meetings] }
+
+      it_behaves_like "unauthorized access"
+    end
+  end
+end

--- a/modules/meeting/spec/services/meeting_agenda_items/create_service_spec.rb
+++ b/modules/meeting/spec/services/meeting_agenda_items/create_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MeetingAgendaItems::CreateService do
   let(:meeting_b) { create(:meeting, project:) }
   let(:source_meeting_id) { meeting_a.id }
 
-  subject(:service_call) { described_class.new(user:).call(params, source_meeting_id: source_meeting_id) }
+  subject(:service_call) { described_class.new(user:).call(**params, source_meeting_id: source_meeting_id) }
 
   describe "duplicating agenda item to a different meeting" do
     context "when agenda item has attachments referenced in notes" do


### PR DESCRIPTION
Working towards https://community.openproject.org/projects/meetings-stream/work_packages/32280/activity

Adds endpoints:

Meetings
  - POST /api/v3/meetings
  - PATCH /api/v3/meetings/:id
  - DELETE /api/v3/meetings/:id
  - GET /api/v3/meetings/schema
  - POST /api/v3/meetings/form
  - POST /api/v3/meetings/:id/form
                                                                                                                                                                  
  Agenda Items
  - GET /api/v3/meetings/:meeting_id/agenda_items
  - POST /api/v3/meetings/:meeting_id/agenda_items
  - GET /api/v3/meetings/:meeting_id/agenda_items/:id
  - PATCH /api/v3/meetings/:meeting_id/agenda_items/:id
  - DELETE /api/v3/meetings/:meeting_id/agenda_items/:id
                                                                                                                                                                  
  Sections
  - GET /api/v3/meetings/:meeting_id/sections
  - POST /api/v3/meetings/:meeting_id/sections
  - GET /api/v3/meetings/:meeting_id/sections/:id
  - PATCH /api/v3/meetings/:meeting_id/sections/:id
  - DELETE /api/v3/meetings/:meeting_id/sections/:id

Recurring meetings
                                                                                                                                                   
  - GET /api/v3/recurring_meetings
  - POST /api/v3/recurring_meetings
  - GET /api/v3/recurring_meetings/:id
  - PATCH /api/v3/recurring_meetings/:id
  - DELETE /api/v3/recurring_meetings/:id

To be able to make use of standard index endpoint, introduce a RecurringMeetingQuery
                                                  
Occurrences of recurring meetings


  - GET /api/v3/recurring_meetings/:id/occurrences/upcoming — Computed IceCube schedule merged with persisted ScheduledMeetings                                                                     
  - GET /api/v3/recurring_meetings/:id/occurrences/past — Persisted past occurrences                                           
  - GET /api/v3/recurring_meetings/:id/occurrences/cancelled — Persisted cancelled occurrences
  - GET /api/v3/recurring_meetings/:id/occurrences/open — Persisted instantiated (open) occurrences        

To instantiate or cancel a meeting, we do not have a primary key yet (if the occurrence is not opened yet). The non working days API uses dates to identify them, so I think it's our best idea to use the same.
                                                                                           
  - POST /api/v3/recurring_meetings/:id/occurrences/:start_time/init — Instantiate a meeting from the template
  - DELETE /api/v3/recurring_meetings/:id/occurrences/:start_time — Cancel an occurrence 