### PR TITLE
Rename work_packages_identifier setting values to "classic" and "semantic"

### DIFF
--- a/app/components/work_packages/admin/settings/change_identifiers_dialog_component.html.erb
+++ b/app/components/work_packages/admin/settings/change_identifiers_dialog_component.html.erb
@@ -58,7 +58,7 @@
     )
 
     dialog.with_additional_details(display: :none) do
-      hidden_field_tag("settings[work_packages_identifier]", Setting::WorkPackageIdentifier::ALPHANUMERIC)
+      hidden_field_tag("settings[work_packages_identifier]", Setting::WorkPackageIdentifier::SEMANTIC)
     end
   end
 %>

--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
@@ -64,7 +64,7 @@ module WorkPackages
         def form_id = "wp-identifier-settings-form"
 
         def show_autofix_section?
-          state == :edit && Setting::WorkPackageIdentifier.alphanumeric? && has_problematic_projects?
+          state == :edit && Setting::WorkPackageIdentifier.semantic? && has_problematic_projects?
         end
 
         def change_in_progress? = state == :change_in_progress

--- a/app/forms/projects/settings/editable_identifier_form.rb
+++ b/app/forms/projects/settings/editable_identifier_form.rb
@@ -31,7 +31,7 @@ module Projects
   module Settings
     class EditableIdentifierForm < ApplicationForm
       form do |f|
-        if Setting::WorkPackageIdentifier.alphanumeric?
+        if Setting::WorkPackageIdentifier.semantic?
           f.text_field(
             name: :identifier,
             label: attribute_name(:identifier),

--- a/app/forms/projects/settings/identifier_form.rb
+++ b/app/forms/projects/settings/identifier_form.rb
@@ -31,7 +31,7 @@ module Projects
   module Settings
     class IdentifierForm < ApplicationForm
       form do |f|
-        caption_key = if Setting::WorkPackageIdentifier.alphanumeric?
+        caption_key = if Setting::WorkPackageIdentifier.semantic?
                         :text_project_identifier_description
                       else
                         :text_project_identifier_url_description

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -53,12 +53,12 @@ module Projects::Identifier
                 limit: IDENTIFIER_MAX_LENGTH,
                 blacklist: RESERVED_IDENTIFIERS,
                 adapter: OpenProject::ActsAsUrl::Adapter::OpActiveRecord, # use a custom adapter able to handle edge cases
-                skip_if: -> { Setting::WorkPackageIdentifier.alphanumeric? }
+                skip_if: -> { Setting::WorkPackageIdentifier.semantic? }
 
     # Generate semantic identifier (when in the semantic mode)
     before_validation :generate_semantic_identifier,
                       on: :create,
-                      if: -> { Setting::WorkPackageIdentifier.alphanumeric? && identifier.blank? }
+                      if: -> { Setting::WorkPackageIdentifier.semantic? && identifier.blank? }
 
     ### ID validators
     # Shared validators for all identifier formats
@@ -70,11 +70,11 @@ module Projects::Identifier
 
     # Validators for the numeric (legacy) identifier format (e.g. "my-project", "project_one")
     validate :identifier_numeric_format,
-             if: ->(p) { p.identifier_changed? && p.identifier.present? && Setting::WorkPackageIdentifier.numeric? }
+             if: ->(p) { p.identifier_changed? && p.identifier.present? && Setting::WorkPackageIdentifier.classic? }
 
     # Validators for the semantic (alphanumeric) identifier format (e.g. "PROJ1")
     validate :identifier_alphanumeric_format,
-             if: ->(p) { p.identifier_changed? && p.identifier.present? && Setting::WorkPackageIdentifier.alphanumeric? }
+             if: ->(p) { p.identifier_changed? && p.identifier.present? && Setting::WorkPackageIdentifier.semantic? }
 
     validate :identifier_not_reserved, if: -> { identifier.present? }
 
@@ -96,7 +96,7 @@ module Projects::Identifier
 
   class_methods do
     def suggest_identifier(name)
-      if Setting::WorkPackageIdentifier.alphanumeric?
+      if Setting::WorkPackageIdentifier.semantic?
         WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator.suggest_identifier(name)
       else # This should closely enough emulate Project models' usage of acts_as_url
         name.to_url.first(IDENTIFIER_MAX_LENGTH).presence || "project"

--- a/app/models/setting/work_package_identifier.rb
+++ b/app/models/setting/work_package_identifier.rb
@@ -30,11 +30,11 @@
 
 class Setting
   module WorkPackageIdentifier
-    NUMERIC      = "numeric"
-    ALPHANUMERIC = "alphanumeric"
-    ALLOWED_VALUES = [NUMERIC, ALPHANUMERIC].freeze
+    CLASSIC  = "classic"
+    SEMANTIC = "semantic"
+    ALLOWED_VALUES = [CLASSIC, SEMANTIC].freeze
 
-    def self.alphanumeric? = Setting[:work_packages_identifier] == ALPHANUMERIC
-    def self.numeric?      = Setting[:work_packages_identifier] == NUMERIC
+    def self.semantic? = Setting[:work_packages_identifier] == SEMANTIC
+    def self.classic?  = Setting[:work_packages_identifier] == CLASSIC
   end
 end

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1323,12 +1323,12 @@ module Settings
       },
       work_packages_identifier: {
         description: "Defines how work packages are identified in the UI (e.g. in links and titles). " \
-                     "The 'numeric' option uses the work package numerical ID, " \
-                     "while 'alphanumeric' uses the project identifier and the work package ID separated by a dash " \
+                     "The 'classic' option uses the work package numerical ID, " \
+                     "while 'semantic' uses the project identifier and the work package ID separated by a dash " \
                      "(e.g. 'PROJA-123').",
         format: :string,
         allowed: -> { Setting::WorkPackageIdentifier::ALLOWED_VALUES },
-        default: "numeric"
+        default: "classic"
       },
       work_package_list_default_highlighted_attributes: {
         default: ["status", "priority", "due_date"],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,12 +398,12 @@ en:
           <p>Thank you</p>
       work_packages_identifier:
         page_header:
-          description: Choose between basic numerical work packages IDs or project-specific ones that prepend the project identifier to the work package ID.
+          description: Choose between classic numerical work package IDs or semantic project-specific ones that prepend the project identifier to the work package ID.
         banner:
           existing_identifiers_notice: >
-            Existing identifiers for %{project_count} projects don't meet requirements for project-based alphanumerical identifiers.
+            Existing identifiers for %{project_count} projects don't meet requirements for project-based semantic identifiers.
             OpenProject can automatically update these so that they are valid as in the examples below.
-            Click on 'Autofix and save' to update identifiers for all projects in this manner and enable project-based alphanumerical identifiers.
+            Click on 'Autofix and save' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
         box_header:
           label_project: Project
           label_previous_identifier: Previous identifier
@@ -433,7 +433,7 @@ en:
           checkbox_label: I understand that this will permanently change all work package IDs
         success_banner: Successfully updated work package identifier format.
         in_progress:
-          banner_message: Project identifiers are currently being updated to project-based alphanumerical identifiers. This may take some time.
+          banner_message: Project identifiers are currently being updated to project-based semantic identifiers. This may take some time.
     workflows:
       tabs:
         default_transitions: "Default transitions"
@@ -5205,11 +5205,11 @@ en:
   setting_welcome_text: "Welcome block text"
   setting_welcome_title: "Welcome block title"
   setting_welcome_on_homescreen: "Display welcome block on homescreen"
-  setting_work_packages_identifier_numeric: Instance-wide numerical sequence (default)
-  setting_work_packages_identifier_numeric_caption: >
+  setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)
+  setting_work_packages_identifier_classic_caption: >
     Every work package gets a sequential number starting with 1 and incremented with every new one. The numbers are unique within this instance so they remain the same even if work packages are moved between projects.
-  setting_work_packages_identifier_alphanumeric: Project-based alphanumerical identifiers
-  setting_work_packages_identifier_alphanumeric_caption: >
+  setting_work_packages_identifier_semantic: Project-based semantic identifiers
+  setting_work_packages_identifier_semantic_caption: >
     Every project has a unique identifier that is prefixed to the work package ID. If a work package moved to another project, a new identifier is generated but the old one continues to function.
   setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
   setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"

--- a/db/migrate/20260328120000_rename_work_packages_identifier_setting_values.rb
+++ b/db/migrate/20260328120000_rename_work_packages_identifier_setting_values.rb
@@ -23,24 +23,32 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-# ++
+#++
 
-module Projects
-  module Concerns
-    module IdentifierSuggestion
-      def identifier_suggestion_data
-        suggestion_mode = Setting::WorkPackageIdentifier.semantic? ? "semantic" : "classic"
+require Rails.root.join("db/migrate/migration_utils/utils")
 
-        {
-          controller: "projects--identifier-suggestion",
-          "projects--identifier-suggestion-mode-value": suggestion_mode,
-          "projects--identifier-suggestion-url-value": projects_identifier_suggestion_path,
-          "projects--identifier-suggestion-set-name-first-value": I18n.t("js.projects.identifier_suggestion.set_name_first")
-        }
-      end
-    end
+class RenameWorkPackagesIdentifierSettingValues < ActiveRecord::Migration[8.1]
+  include Migration::Utils
+
+  def up
+    rename_setting_value("numeric", "classic")
+    rename_setting_value("alphanumeric", "semantic")
+  end
+
+  def down
+    rename_setting_value("classic", "numeric")
+    rename_setting_value("semantic", "alphanumeric")
+  end
+
+  private
+
+  def rename_setting_value(from, to)
+    execute_sql(
+      "UPDATE settings SET value = :to WHERE name = 'work_packages_identifier' AND value = :from",
+      from:, to:
+    )
   end
 end

--- a/db/migrate/20260328120000_rename_work_packages_identifier_setting_values.rb
+++ b/db/migrate/20260328120000_rename_work_packages_identifier_setting_values.rb
@@ -28,27 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require Rails.root.join("db/migrate/migration_utils/utils")
+require Rails.root.join("db/migrate/migration_utils/setting_renamer")
 
-class RenameWorkPackagesIdentifierSettingValues < ActiveRecord::Migration[8.1]
-  include Migration::Utils
+class RenameWorkPackagesIdentifierSettingValues < ActiveRecord::Migration[8.0]
+  SETTING_NAME = "work_packages_identifier"
 
   def up
-    rename_setting_value("numeric", "classic")
-    rename_setting_value("alphanumeric", "semantic")
+    Migration::MigrationUtils::SettingRenamer.rename_value(SETTING_NAME, "numeric", "classic")
+    Migration::MigrationUtils::SettingRenamer.rename_value(SETTING_NAME, "alphanumeric", "semantic")
   end
 
   def down
-    rename_setting_value("classic", "numeric")
-    rename_setting_value("semantic", "alphanumeric")
-  end
-
-  private
-
-  def rename_setting_value(from, to)
-    execute_sql(
-      "UPDATE settings SET value = :to WHERE name = 'work_packages_identifier' AND value = :from",
-      from:, to:
-    )
+    Migration::MigrationUtils::SettingRenamer.rename_value(SETTING_NAME, "classic", "numeric")
+    Migration::MigrationUtils::SettingRenamer.rename_value(SETTING_NAME, "semantic", "alphanumeric")
   end
 end

--- a/db/migrate/migration_utils/setting_renamer.rb
+++ b/db/migrate/migration_utils/setting_renamer.rb
@@ -34,7 +34,7 @@ module Migration
       # define all the following methods as class methods
       class << self
         def rename(source_name, target_name)
-          ActiveRecord::Base.connection.execute <<-SQL.squish
+          ActiveRecord::Base.connection.execute <<~SQL.squish
             UPDATE #{settings_table}
             SET name = #{quote_value(target_name)}
             WHERE name = #{quote_value(source_name)}

--- a/db/migrate/migration_utils/setting_renamer.rb
+++ b/db/migrate/migration_utils/setting_renamer.rb
@@ -41,6 +41,14 @@ module Migration
           SQL
         end
 
+        def rename_value(setting_name, from, to)
+          ActiveRecord::Base.connection.execute <<~SQL.squish
+            UPDATE #{settings_table}
+            SET value = #{quote_value(to)}
+            WHERE name = #{quote_value(setting_name)} AND value = #{quote_value(from)}
+          SQL
+        end
+
         private
 
         def settings_table

--- a/frontend/src/stimulus/controllers/dynamic/admin/work-packages-identifier.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/work-packages-identifier.controller.ts
@@ -52,17 +52,17 @@ export default class WorkPackagesIdentifierController extends Controller {
   }
 
   private updateVisibility() {
-    const showAutofix = this.isAlphanumericSelected() && this.hasProblematicProjectsValue;
+    const showAutofix = this.isSemanticSelected() && this.hasProblematicProjectsValue;
 
     this.autofixSectionTarget.hidden = !showAutofix;
     this.saveButtonTarget.hidden     =  showAutofix;
     this.autofixButtonTarget.hidden  = !showAutofix;
   }
 
-  private isAlphanumericSelected():boolean {
+  private isSemanticSelected():boolean {
     const checked = this.element.querySelector<HTMLInputElement>(
       'input[name="settings[work_packages_identifier]"]:checked',
     );
-    return checked?.value === 'alphanumeric';
+    return checked?.value === 'semantic';
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/projects/identifier-suggestion.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/projects/identifier-suggestion.controller.ts
@@ -32,7 +32,7 @@ import {ApplicationController, useDebounce} from 'stimulus-use';
 
 const ALLOWED_CHARS:Record<string, RegExp> = {
   semantic: /[^A-Z0-9_]/g,
-  legacy: /[^a-z0-9\-_]/g,
+  classic: /[^a-z0-9\-_]/g,
 };
 
 export default class extends ApplicationController {
@@ -42,7 +42,7 @@ export default class extends ApplicationController {
   static values = {
     url: String,
     debounce: {type: Number, default: 300},
-    mode: {type: String, default: 'legacy'},
+    mode: {type: String, default: 'classic'},
     setNameFirst: {type: String, default: ''},
   };
 
@@ -88,7 +88,7 @@ export default class extends ApplicationController {
   private filterInput():void {
     if (!this.hasIdentifierTarget) return;
 
-    const pattern = ALLOWED_CHARS[this.modeValue] ?? ALLOWED_CHARS.legacy;
+    const pattern = ALLOWED_CHARS[this.modeValue] ?? ALLOWED_CHARS.classic;
     const current = this.identifierTarget.value;
     const filtered = current.replace(pattern, '');
 

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "renders the in-progress spinner message" do
       render_component(component)
-      expect(page).to have_text("Project identifiers are currently being updated to project-based alphanumerical identifiers.")
+      expect(page).to have_text("Project identifiers are currently being updated to project-based semantic identifiers.")
     end
 
     it "does not render the success banner" do
@@ -66,7 +66,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
     it "renders the radio buttons as disabled" do
       render_component(component)
       expect(page).to have_field("Instance-wide numerical sequence (default)", disabled: true)
-      expect(page).to have_field("Project-based alphanumerical identifiers", disabled: true)
+      expect(page).to have_field("Project-based semantic identifiers", disabled: true)
     end
 
     it "does not render the save or autofix buttons" do
@@ -91,13 +91,13 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not render the in-progress spinner message" do
       render_component(component)
-      expect(page).to have_no_text("Project identifiers are currently being updated to project-based alphanumerical identifiers.")
+      expect(page).to have_no_text("Project identifiers are currently being updated to project-based semantic identifiers.")
     end
 
     it "renders the radio buttons as enabled" do
       render_component(component)
       expect(page).to have_field("Instance-wide numerical sequence (default)", disabled: false)
-      expect(page).to have_field("Project-based alphanumerical identifiers", disabled: false)
+      expect(page).to have_field("Project-based semantic identifiers", disabled: false)
     end
 
     it "does not call PreviewQuery" do
@@ -121,12 +121,12 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not render in-progress or success content" do
       render_component(component)
-      expect(page).to have_no_text("Project identifiers are currently being updated to project-based alphanumerical identifiers.")
+      expect(page).to have_no_text("Project identifiers are currently being updated to project-based semantic identifiers.")
       expect(page).to have_no_text("Successfully updated work package identifier format.")
     end
 
-    context "with problematic projects and alphanumeric setting",
-            with_settings: { work_packages_identifier: "alphanumeric" } do
+    context "with problematic projects and semantic setting",
+            with_settings: { work_packages_identifier: "semantic" } do
       let(:project) { instance_double(Project, name: "Bad Project", id: 1, to_param: "bad-proj") }
       let(:problematic_result) do
         WorkPackages::IdentifierAutofix::PreviewQuery::Result.new(

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe "Work packages identifier admin settings", :js do
   context "when a project has a problematic identifier" do
     shared_let(:project) { create(:project, identifier: "bad-id", name: "Bad Project") }
 
-    context "when saving with the current numeric setting" do
+    context "when saving with the current classic setting" do
       it "saves without showing the confirmation dialog" do
         visit_settings
 
-        # The autofix section is hidden when numeric is selected
+        # The autofix section is hidden when classic is selected
         expect(page).to have_css(
           "[data-admin--work-packages-identifier-target=autofixSection][hidden]",
           visible: :all
@@ -76,13 +76,13 @@ RSpec.describe "Work packages identifier admin settings", :js do
       end
     end
 
-    context "when switching to alphanumeric" do
+    context "when switching to semantic" do
       before do
         visit_settings
-        choose "Project-based alphanumerical identifiers"
+        choose "Project-based semantic identifiers"
       end
 
-      it "shows the autofix section after selecting alphanumeric" do
+      it "shows the autofix section after selecting semantic" do
         expect(page).to have_css(
           "[data-admin--work-packages-identifier-target=autofixSection]:not([hidden])",
           visible: :visible

--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -562,7 +562,7 @@ RSpec.describe "Projects", "creation",
     end
   end
 
-  context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+  context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
     it "auto-suggests an identifier when the name field is blurred" do
       projects_page.create_new_workspace
       click_on "Continue"

--- a/spec/features/projects/edit_settings_spec.rb
+++ b/spec/features/projects/edit_settings_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Projects", "editing settings", :js do
   end
 
   describe "identifier edit" do
-    context "with numerical IDs", with_settings: { work_packages_identifier: "numeric" } do
+    context "with classic IDs", with_settings: { work_packages_identifier: "classic" } do
       it "updates the project identifier via dialog" do
         visit project_settings_general_path(project)
 
@@ -71,7 +71,7 @@ RSpec.describe "Projects", "editing settings", :js do
       end
     end
 
-    context "with alphanumeric IDs", with_settings: { work_packages_identifier: "alphanumeric" } do
+    context "with semantic IDs", with_settings: { work_packages_identifier: "semantic" } do
       it "updates the project identifier via dialog" do
         visit project_settings_general_path(project)
 

--- a/spec/forms/projects/settings/editable_identifier_form_spec.rb
+++ b/spec/forms/projects/settings/editable_identifier_form_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Projects::Settings::EditableIdentifierForm, type: :forms do
     end
   end
 
-  context "when the feature flag is on and the alphanumeric setting is active" do
+  context "when the feature flag is on and the semantic setting is active" do
     before do
       with_flags(semantic_work_package_ids: true)
-      allow(Setting::WorkPackageIdentifier).to receive(:alphanumeric?).and_return(true)
+      allow(Setting::WorkPackageIdentifier).to receive(:semantic?).and_return(true)
       vc_render_form
     end
 
@@ -61,10 +61,10 @@ RSpec.describe Projects::Settings::EditableIdentifierForm, type: :forms do
     end
   end
 
-  context "when the feature flag is on but the setting is numeric" do
+  context "when the feature flag is on but the setting is classic" do
     before do
       with_flags(semantic_work_package_ids: true)
-      allow(Setting::WorkPackageIdentifier).to receive(:alphanumeric?).and_return(false)
+      allow(Setting::WorkPackageIdentifier).to receive(:semantic?).and_return(false)
       vc_render_form
     end
 

--- a/spec/migrations/migration_utils/setting_renamer_spec.rb
+++ b/spec/migrations/migration_utils/setting_renamer_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("db/migrate/migration_utils/setting_renamer.rb")
+
+RSpec.describe Migration::MigrationUtils::SettingRenamer, type: :model do # rubocop:disable RSpec/SpecFilePathFormat
+  def insert_setting(name, value)
+    ActiveRecord::Base.connection.execute(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["INSERT INTO settings (name, value) VALUES (?, ?)", name, value]
+      )
+    )
+  end
+
+  def setting_value(name)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["SELECT value FROM settings WHERE name = ?", name]
+      )
+    )
+  end
+
+  def setting_exists?(name)
+    ActiveRecord::Base.connection.select_value(
+      ActiveRecord::Base.sanitize_sql_array(
+        ["SELECT EXISTS(SELECT 1 FROM settings WHERE name = ?)", name]
+      )
+    )
+  end
+
+  describe ".rename" do
+    before { insert_setting("old_setting", "some_value") }
+
+    it "renames the setting" do
+      described_class.rename("old_setting", "new_setting")
+
+      expect(setting_exists?("old_setting")).to be false
+      expect(setting_exists?("new_setting")).to be true
+      expect(setting_value("new_setting")).to eq("some_value")
+    end
+
+    it "does not affect other settings" do
+      insert_setting("unrelated_setting", "other_value")
+
+      described_class.rename("old_setting", "new_setting")
+
+      expect(setting_value("unrelated_setting")).to eq("other_value")
+    end
+
+    it "is a no-op when the source setting does not exist" do
+      expect { described_class.rename("nonexistent", "new_name") }.not_to raise_error
+    end
+  end
+
+  describe ".rename_value" do
+    before { insert_setting("my_setting", "old_value") }
+
+    it "updates the value when both name and value match" do
+      described_class.rename_value("my_setting", "old_value", "new_value")
+
+      expect(setting_value("my_setting")).to eq("new_value")
+    end
+
+    it "does not update when the name matches but value does not" do
+      described_class.rename_value("my_setting", "wrong_value", "new_value")
+
+      expect(setting_value("my_setting")).to eq("old_value")
+    end
+
+    it "does not update when the value matches but name does not" do
+      described_class.rename_value("other_setting", "old_value", "new_value")
+
+      expect(setting_value("my_setting")).to eq("old_value")
+    end
+
+    it "is a no-op when neither name nor value match" do
+      expect { described_class.rename_value("nonexistent", "nope", "new") }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Projects::Identifier do
     it { is_expected.to normalize(:identifier).from("my\n\x00project\t").to("myproject") }
   end
 
-  describe "url identifier", with_settings: { work_packages_identifier: "numeric" } do
+  describe "url identifier", with_settings: { work_packages_identifier: "classic" } do
     let(:reserved) do
       Rails.application.routes.routes
         .map { |route| route.path.spec.to_s }
@@ -193,7 +193,7 @@ RSpec.describe Projects::Identifier do
   end
 
   describe ".suggest_identifier" do
-    context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+    context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
       it "delegates to ProjectIdentifierSuggestionGenerator" do
         allow(WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
           .to receive(:suggest_identifier).with("My Project").and_return("MP")
@@ -203,7 +203,7 @@ RSpec.describe Projects::Identifier do
       end
     end
 
-    context "with numeric (legacy) identifiers", with_settings: { work_packages_identifier: "numeric" } do
+    context "with classic identifiers", with_settings: { work_packages_identifier: "classic" } do
       it "returns a slugified lowercase identifier" do
         expect(Project.suggest_identifier("My Cool Project")).to eq("my-cool-project")
       end

--- a/spec/models/setting/work_package_identifier_spec.rb
+++ b/spec/models/setting/work_package_identifier_spec.rb
@@ -31,13 +31,13 @@
 require "spec_helper"
 
 RSpec.describe Setting::WorkPackageIdentifier do
-  context "when the setting is 'alphanumeric'", with_settings: { work_packages_identifier: "alphanumeric" } do
-    it { expect(described_class.alphanumeric?).to be true }
-    it { expect(described_class.numeric?).to be false }
+  context "when the setting is 'semantic'", with_settings: { work_packages_identifier: "semantic" } do
+    it { expect(described_class.semantic?).to be true }
+    it { expect(described_class.classic?).to be false }
   end
 
-  context "when the setting is 'numeric'", with_settings: { work_packages_identifier: "numeric" } do
-    it { expect(described_class.alphanumeric?).to be false }
-    it { expect(described_class.numeric?).to be true }
+  context "when the setting is 'classic'", with_settings: { work_packages_identifier: "classic" } do
+    it { expect(described_class.semantic?).to be false }
+    it { expect(described_class.classic?).to be true }
   end
 end

--- a/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_form_resource_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe API::V3::Projects::Copy::CreateFormAPI, content_type: :json do
     end
   end
 
-  context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+  context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
     context "when name is provided but identifier is not" do
       let(:params) do
         { name: "My copied project" }

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
       end
     end
 
-    context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+    context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
       context "when identifier is not provided" do
         let(:params) do
           { name: "My copied project" }

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
     end
   end
 
-  context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+  context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
     context "when identifier is not provided" do
       let(:body) do
         { name: "Flight Planning Algorithm" }.to_json

--- a/spec/requests/projects/identifier_suggestion_spec.rb
+++ b/spec/requests/projects/identifier_suggestion_spec.rb
@@ -33,7 +33,7 @@ require "rails_helper"
 RSpec.describe "GET /projects/identifier_suggestion", type: :rails_request do
   current_user { create(:user, global_permissions: %i[add_project]) }
 
-  context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+  context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
     it "returns a suggested identifier derived from the name" do
       get "/projects/identifier_suggestion", params: { name: "Flight Planning Algorithm" }, as: :json
       expect(response).to have_http_status(:ok)
@@ -73,7 +73,7 @@ RSpec.describe "GET /projects/identifier_suggestion", type: :rails_request do
     end
   end
 
-  context "with numeric (legacy) identifiers", with_settings: { work_packages_identifier: "numeric" } do
+  context "with classic identifiers", with_settings: { work_packages_identifier: "classic" } do
     it "returns a slugified lowercase identifier" do
       get "/projects/identifier_suggestion", params: { name: "My Cool Project" }, as: :json
       expect(response).to have_http_status(:ok)

--- a/spec/support/shared/components/identifier_suggestion_data.rb
+++ b/spec/support/shared/components/identifier_suggestion_data.rb
@@ -18,15 +18,15 @@ RSpec.shared_examples "renders identifier_suggestion_data" do
     )
   end
 
-  context "with alphanumeric identifiers", with_settings: { work_packages_identifier: "alphanumeric" } do
+  context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
     it "sets mode to semantic" do
       expect(rendered_component).to have_css("[data-projects--identifier-suggestion-mode-value='semantic']")
     end
   end
 
-  context "with numeric identifiers", with_settings: { work_packages_identifier: "numeric" } do
-    it "sets mode to legacy" do
-      expect(rendered_component).to have_css("[data-projects--identifier-suggestion-mode-value='legacy']")
+  context "with classic identifiers", with_settings: { work_packages_identifier: "classic" } do
+    it "sets mode to classic" do
+      expect(rendered_component).to have_css("[data-projects--identifier-suggestion-mode-value='classic']")
     end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/73519

The setting previously used "numeric" and "alphanumeric" as its allowed values. Rename them to "classic" and "semantic" to better align with the product terminology for the work package identifier modes.

Includes a migration to update any stored setting values in the database, updated constants and helper methods on `Setting::WorkPackageIdentifier`, and all corresponding references across models, components, forms, frontend controllers, locales, and specs.

https://github.com/opf/openproject/pull/22406#discussion_r2975625545