### PR TITLE
[#73522] Workflow table shows two empty cells with border shadows in Firefox  

### DIFF
--- a/frontend/src/global_styles/content/work_packages/_workflows.sass
+++ b/frontend/src/global_styles/content/work_packages/_workflows.sass
@@ -44,6 +44,9 @@
     th:first-child
       z-index: 3
 
+    thead th:first-child
+      box-shadow: none
+
     tbody
       span.workflow-table--turned-header
         white-space: nowrap


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/73522

# Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Before
<img width="478" height="247" alt="image" src="https://github.com/user-attachments/assets/1d29b1cd-a0ab-4ab4-b1ba-67c413da1a3e" />

### After
<img width="480" height="240" alt="image" src="https://github.com/user-attachments/assets/82db5c83-44dc-4d8a-8d7d-c566b56cac5a" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
