### PR TITLE
Make sprint planning page items draggable accross the whole item area.

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.rb
@@ -61,7 +61,7 @@ module Backlogs
     def row_options
       {
         id: dom_id(work_package),
-        classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
+        classes: row_classes,
         data: {
           draggable_id: work_package.id,
           draggable_type: "story",
@@ -76,6 +76,11 @@ module Backlogs
         },
         tabindex: 0
       }
+    end
+
+    def row_classes
+      "Box-row--hover-blue Box-row--focus-gray \
+       Box-row--clickable Box-row--draggable #{'DragHandle' if draggable?}"
     end
 
     def card_test_selector

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -86,7 +86,7 @@ module Backlogs
       classes = "Box-row--hover-blue Box-row--focus-gray Box-row--clickable"
 
       if work_package_draggable?
-        classes += " Box-row--draggable"
+        classes += " Box-row--draggable DragHandle"
       end
 
       classes


### PR DESCRIPTION
# Ticket
- https://community.openproject.org/wp/73473

# What are you trying to accomplish?
- Make the whole sprint card draggable.
## Screenshots
![Mar-30-2026 11-28-24](https://github.com/user-attachments/assets/64f7100e-17f8-4110-ba8d-5e5fbbe9946b)

# What approach did you choose and why?
- Move the `.DragHandle` class to the card element, to make it draggable.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
