### PR TITLE
Bug/73483 move to sprint dialog save button should read move

### DIFF
--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.html.erb
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
     end
 
-    d.with_footer(show_divider: true) do
+    d.with_footer(mt: 2) do
       component_collection do |buttons|
         buttons.with_component(Primer::Beta::Button.new(data: { close_dialog_id: DIALOG_ID })) do
           t(:button_cancel)
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
         buttons.with_component(
           Primer::Beta::Button.new(scheme: :primary, form: FORM_ID, data: { turbo: true }, type: :submit)
         ) do
-          t(:button_save)
+          t(:button_move)
         end
       end
     end

--- a/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Backlogs::MoveToSprintDialogComponent, type: :component do
     render_component
 
     expect(page).to have_button(I18n.t(:button_cancel))
-    expect(page).to have_button(I18n.t(:button_save))
+    expect(page).to have_button(I18n.t(:button_move))
   end
 
   context "when in_planning and active sprints exist" do

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "Inbox column in sprint planning view", :js, with_flag: { scrum_p
           expect(page).to have_select("target_id", with_options: ["Sprint 1", "Sprint 2"])
 
           select sprint.name, from: "target_id"
-          click_button "Save"
+          click_button "Move"
         end
 
         planning_page.expect_no_inbox_item(inbox_wp1)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73483

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots

Before:
<img width="1207" height="946" alt="image" src="https://github.com/user-attachments/assets/8192d3bf-5695-4437-9500-0742d3972884" />


After:
<img width="1207" height="946" alt="image" src="https://github.com/user-attachments/assets/0223f3c4-5b88-477c-8e4e-679e362324db" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
