### PR TITLE
Fix turbo-stream error handling for project custom field sections

### DIFF
--- a/app/controllers/admin/settings/project_custom_field_sections_controller.rb
+++ b/app/controllers/admin/settings/project_custom_field_sections_controller.rb
@@ -30,6 +30,7 @@
 
 module Admin::Settings
   class ProjectCustomFieldSectionsController < ::Admin::SettingsController
+    include FlashMessagesOutputSafetyHelper
     include OpTurbo::ComponentStream
     include Admin::Settings::ProjectCustomFields::ComponentStreams
 
@@ -72,7 +73,7 @@ module Admin::Settings
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
-        # TODO: show error message
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors.full_messages))
       end
 
       respond_with_turbo_streams
@@ -86,7 +87,7 @@ module Admin::Settings
       if call.success?
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
-        # TODO: show error message
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors.full_messages))
       end
 
       respond_with_turbo_streams
@@ -101,7 +102,7 @@ module Admin::Settings
         update_header_via_turbo_stream(allow_custom_field_creation: allow_custom_field_creation?)
         update_sections_via_turbo_stream(project_custom_field_sections: ProjectCustomFieldSection.all)
       else
-        # TODO: show error message
+        render_error_flash_message_via_turbo_stream(message: join_flash_messages(call.errors.full_messages))
       end
       respond_with_turbo_streams
     end

--- a/modules/backlogs/spec/models/story_spec.rb
+++ b/modules/backlogs/spec/models/story_spec.rb
@@ -197,4 +197,30 @@ RSpec.describe Story do
       end
     end
   end
+
+  describe "#task_status" do
+    it "returns zero counts when the story has no tasks" do
+      expect(story1.task_status).to eq(open: 0, closed: 0)
+    end
+
+    it "counts open and closed tasks" do
+      create(:story,
+             version:,
+             project:,
+             parent: story1,
+             status: status1,
+             type: task_type,
+             priority: issue_priority)
+
+      create(:story,
+             version:,
+             project:,
+             parent: story1,
+             status: create(:closed_status),
+             type: task_type,
+             priority: issue_priority)
+
+      expect(story1.task_status).to eq(open: 1, closed: 1)
+    end
+  end
 end

--- a/spec/controllers/admin/settings/project_custom_field_sections_controller_spec.rb
+++ b/spec/controllers/admin/settings/project_custom_field_sections_controller_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Admin::Settings::ProjectCustomFieldSectionsController do
+  shared_let(:user) { create(:admin) }
+  shared_let(:section) { create(:project_custom_field_section) }
+
+  current_user { user }
+  render_views
+
+  let(:error_message) { "Something went wrong." }
+  let(:service_result) do
+    ServiceResult.failure(result: section).tap do |result|
+      result.errors.add(:base, error_message)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it "renders an error flash turbo stream" do
+      delete_service = instance_double(ProjectCustomFieldSections::DeleteService, call: service_result)
+
+      allow(ProjectCustomFieldSections::DeleteService)
+        .to receive(:new)
+        .with(user:, model: section)
+        .and_return(delete_service)
+
+      delete :destroy, params: { id: section.id }, format: :turbo_stream
+
+      expect(response).to be_successful
+      expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      expect(response.body).to include(error_message)
+    end
+  end
+
+  describe "PUT #move" do
+    before do
+      update_service = instance_double(ProjectCustomFieldSections::UpdateService, call: service_result)
+
+      allow(ProjectCustomFieldSections::UpdateService)
+        .to receive(:new)
+        .with(user:, model: section)
+        .and_return(update_service)
+    end
+
+    it "renders an error flash turbo stream" do
+      put :move, params: { id: section.id, move_to: "higher" }, format: :turbo_stream
+
+      expect(response).to be_successful
+      expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      expect(response.body).to include(error_message)
+    end
+  end
+
+  describe "PUT #drop" do
+    before do
+      update_service = instance_double(ProjectCustomFieldSections::UpdateService, call: service_result)
+
+      allow(ProjectCustomFieldSections::UpdateService)
+        .to receive(:new)
+        .with(user:, model: section)
+        .and_return(update_service)
+    end
+
+    it "renders an error flash turbo stream" do
+      put :drop, params: { id: section.id, position: "2" }, format: :turbo_stream
+
+      expect(response).to be_successful
+      expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      expect(response.body).to include(error_message)
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

No ticket linked.

# What are you trying to accomplish?

This PR adds turbo-stream error feedback for failed admin project custom field section actions.

Previously, failed `destroy`, `move`, and `drop` actions in `Admin::Settings::ProjectCustomFieldSectionsController` did not surface a user-visible error in the UI.

## Screenshots

No visual screenshots attached. This change affects turbo-stream flash behavior for failure cases.

# What approach did you choose and why?

I followed the existing turbo-stream error handling pattern already used in neighboring admin controllers.

Instead of leaving the failure branches empty, the controller now renders an error flash via `render_error_flash_message_via_turbo_stream(...)` using joined validation/service error messages.

This approach keeps the change small, consistent with the surrounding code, and improves admin feedback without changing the successful flow.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)