### PR TITLE
[#73170] User sees error when adding a WP to a meeting series backlog from the WP 'Meetings' tab  

### DIFF
--- a/modules/meeting/app/contracts/meeting_agenda_items/create_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/create_contract.rb
@@ -67,7 +67,7 @@ module MeetingAgendaItems
     def validate_meeting_existence
       # when creating a meeting agenda item from the work package tab and not selecting a meeting
       # the meeting and therefore the project is not set
-      # in this case we only want to show the "Meeting can't be blank" error instead of a misleading not existance error
+      # in this case we only want to show the "Meeting can't be blank" error instead of a misleading not existence error
       # the error is added by the models presence validation
       return if model.meeting.nil?
 
@@ -76,10 +76,18 @@ module MeetingAgendaItems
 
     def section_belongs_to_meeting
       return if model.meeting_section.nil? || model.meeting.nil?
+      return if section_is_meetings_backlog?
 
-      unless model.meeting_id == model.meeting_section.meeting_id
-        errors.add :base, :section_not_belong_to_meeting
-      end
+      errors.add :base, :section_not_belong_to_meeting unless section_meeting_matches?
+    end
+
+    def section_meeting_matches?
+      model.meeting_id == model.meeting_section.meeting_id
+    end
+
+    # For recurring meetings, the backlog belongs to the template, and so this exception is needed
+    def section_is_meetings_backlog?
+      model.meeting.recurring? && model.meeting.backlog.id == model.meeting_section.id
     end
 
     private

--- a/modules/meeting/spec/contracts/meeting_agenda_items/create_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_agenda_items/create_contract_spec.rb
@@ -117,4 +117,21 @@ RSpec.describe MeetingAgendaItems::CreateContract do
       expect(contract.errors[:base]).to include("Section does not belong to the same meeting.")
     end
   end
+
+  context "when creating an agenda item for a recurring meeting occurrence using the template's backlog (Regression #73170)" do
+    let(:recurring_meeting) { create(:recurring_meeting, project:) }
+    let(:occurrence) do
+      create(:meeting, recurring_meeting:, project:, template: false)
+    end
+    let(:backlog_section) { recurring_meeting.template.backlog }
+    let(:user) do
+      create(:user, member_with_permissions: { project => %i[view_meetings manage_agendas] })
+    end
+
+    let(:item) { build(:meeting_agenda_item, meeting: occurrence, meeting_section: backlog_section) }
+
+    it "is valid" do
+      expect(contract).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/73170

This is a side effect of the changes introduced in https://github.com/opf/openproject/pull/22075/changes/70512d15d3082a6b4936057274754e3193dc1331

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
