### PR TITLE
[chore] add tsconfig to wikis module

### DIFF
--- a/modules/wikis/frontend/module/main.ts
+++ b/modules/wikis/frontend/module/main.ts
@@ -25,14 +25,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 
 import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+
+import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpSharedModule } from 'core-app/shared/shared.module';
-import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
+import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import {
   WorkPackageTabsService,
 } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
+
 import { WikisTabComponent } from './wikis-tab/wikis-tab.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 export function initializeWikiPlugin(injector:Injector) {
   const wpTabService = injector.get(WorkPackageTabsService);

--- a/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
+++ b/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
@@ -27,6 +27,7 @@
 //++
 
 import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab';
 import { I18nService } from 'core-app/core/i18n/i18n.service';

--- a/modules/wikis/frontend/tsconfig.json
+++ b/modules/wikis/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../frontend/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../../../frontend",
+    "typeRoots": [
+      "../../../frontend/node_modules/@types",
+      "../../../frontend/node_modules"
+    ]
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}


### PR DESCRIPTION
# What are you trying to accomplish?
- use my IDE without red lines everywhere

# What approach did you choose and why?
- needed to tell IDEs to lookup the lookup paths
- doesn't affect build, as the `tsconfig.json` in the module directory should be ignored by esbuild of the core app.

