### PR TITLE
short-circuit more permission checks if you're an active admin

### DIFF
--- a/app/models/capabilities/scopes/visible.rb
+++ b/app/models/capabilities/scopes/visible.rb
@@ -34,7 +34,7 @@ module Capabilities::Scopes
 
     class_methods do
       def visible(user = User.current)
-        scope = if user.admin?
+        scope = if user.active_admin?
                   all
                 else
                   where(context_id: nil)

--- a/app/models/custom_fields/scopes/visible.rb
+++ b/app/models/custom_fields/scopes/visible.rb
@@ -34,9 +34,13 @@ module CustomFields::Scopes
 
     class_methods do
       def visible(user = User.current)
-        known_subclasses
-          .inject(none) do |scope, klass|
-          scope.or(where(type: klass.name).and(klass.visible(user)))
+        if user.active_admin?
+          all
+        else
+          known_subclasses
+            .inject(none) do |scope, klass|
+            scope.or(where(type: klass.name).and(klass.visible(user)))
+          end
         end
       end
 

--- a/app/models/group_custom_fields/scopes/visible.rb
+++ b/app/models/group_custom_fields/scopes/visible.rb
@@ -34,7 +34,7 @@ module GroupCustomFields::Scopes
 
     class_methods do
       def visible(user = User.current)
-        if user.admin?
+        if user.active_admin?
           all
         else
           where(admin_only: false)

--- a/app/models/members/scopes/visible.rb
+++ b/app/models/members/scopes/visible.rb
@@ -35,7 +35,7 @@ module Members::Scopes
     class_methods do
       # Find all members visible to the inquiring user
       def visible(user = User.current)
-        if user.admin?
+        if user.active_admin?
           visible_for_admins
         else
           visible_for_non_admins(user)

--- a/app/models/principals/scopes/visible.rb
+++ b/app/models/principals/scopes/visible.rb
@@ -42,7 +42,7 @@ module Principals::Scopes
 
     class_methods do
       def visible(user = ::User.current)
-        if user.allowed_globally?(:view_all_principals) || user.admin?
+        if user.allowed_globally?(:view_all_principals)
           all
         else
           in_visible_project_or_me_or_same_groups(user)

--- a/app/models/project_custom_field.rb
+++ b/app/models/project_custom_field.rb
@@ -56,7 +56,7 @@ class ProjectCustomField < CustomField
 
   class << self
     def visible(user = User.current, project: nil)
-      if user.admin?
+      if user.active_admin?
         all
       elsif user.allowed_in_any_project?(:select_project_custom_fields) || user.allowed_globally?(:add_project)
         where(admin_only: false)

--- a/app/models/project_custom_fields/scopes/visible.rb
+++ b/app/models/project_custom_fields/scopes/visible.rb
@@ -34,7 +34,7 @@ module ProjectCustomFields::Scopes
 
     class_methods do
       def visible(user = User.current, project: nil)
-        if user.admin?
+        if user.active_admin?
           all
         elsif user.allowed_in_any_project?(:select_project_custom_fields) || user.allowed_globally?(:add_project)
           where(admin_only: false)

--- a/app/models/projects/scopes/visible.rb
+++ b/app/models/projects/scopes/visible.rb
@@ -40,7 +40,7 @@ module Projects::Scopes
       def visible(user = User.current)
         # Use a shortcut for admins and anonymous where
         # we don't need to calculate for work package roles which is more expensive
-        if user.admin? || user.anonymous?
+        if user.active_admin? || user.anonymous?
           allowed_to(user, :view_project)
         else
           active.public_projects.or(active.where(id: user.members.select(:project_id)))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -514,6 +514,10 @@ class User < Principal
     !logged?
   end
 
+  def active_admin?
+    admin? && active?
+  end
+
   def consent_expired?
     # Always if the user has not consented
     return true if consented_at.blank?

--- a/app/models/user_custom_fields/scopes/visible.rb
+++ b/app/models/user_custom_fields/scopes/visible.rb
@@ -34,7 +34,7 @@ module UserCustomFields::Scopes
 
     class_methods do
       def visible(user = User.current)
-        if user.admin?
+        if user.active_admin?
           all
         else
           where(admin_only: false)

--- a/app/services/authorization/user_permissible_service.rb
+++ b/app/services/authorization/user_permissible_service.rb
@@ -39,37 +39,38 @@ module Authorization
     def allowed_globally?(permission)
       perms = contextual_permissions(permission, :global)
       return false unless authorizable_user?
+      return true if admin_and_all_granted_to_admin?(perms)
 
       cached_permissions(nil).intersect?(perms.map(&:name))
     end
 
     def allowed_in_project?(permission, projects_to_check)
-      perms = contextual_permissions(permission, :project)
+      permissions = contextual_permissions(permission, :project)
       return false if projects_to_check.blank?
       return false unless authorizable_user?
 
       Array(projects_to_check).all? do |project|
-        allowed_in_single_project?(perms, project)
+        allowed_in_single_project?(permissions, project)
       end
     end
 
     def allowed_in_any_project?(permission)
-      perms = contextual_permissions(permission, :project)
+      permissions = contextual_permissions(permission, :project)
       return false unless authorizable_user?
 
-      cached_in_any_project?(perms)
+      cached_in_any_project?(permissions)
     end
 
     def allowed_in_entity?(permission, entities_to_check, entity_class)
       return false if entities_to_check.blank?
       return false unless authorizable_user?
 
-      perms = contextual_permissions(permission, context_name(entity_class))
+      permissions = contextual_permissions(permission, context_name(entity_class))
 
       entities = Array(entities_to_check)
 
       entities.all? do |entity|
-        allowed_in_single_entity?(perms, entity, entity_class)
+        allowed_in_single_entity?(permissions, entity, entity_class)
       end
     end
 
@@ -110,6 +111,7 @@ module Authorization
       permissions_filtered_for_project = permissions_by_enabled_project_modules(project, permissions)
 
       return false if permissions_filtered_for_project.empty?
+      return true if admin_and_all_granted_to_admin?(permissions)
 
       cached_permissions(project).intersect?(permissions_filtered_for_project)
     end
@@ -164,7 +166,7 @@ module Authorization
     end
 
     def admin_and_all_granted_to_admin?(permissions)
-      user.admin? && permissions.all?(&:grant_to_admin?)
+      user.active_admin? && permissions.all?(&:grant_to_admin?)
     end
 
     def authorizable_user?

--- a/modules/budgets/app/models/budget.rb
+++ b/modules/budgets/app/models/budget.rb
@@ -61,9 +61,13 @@ class Budget < ApplicationRecord
 
   class << self
     def visible(user = User.current)
-      includes(:project)
-        .references(:projects)
-        .merge(Project.allowed_to(user, :view_budgets))
+      if user.active_admin?
+        all
+      else
+        includes(:project)
+          .references(:projects)
+          .merge(Project.allowed_to(user, :view_budgets))
+      end
     end
 
     # TODO: Extract into copy service

--- a/spec/requests/api/v3/user/user_resource_spec.rb
+++ b/spec/requests/api/v3/user/user_resource_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe "API v3 User resource", content_type: :json do
     context "as locked admin" do
       let(:current_user) { locked_admin }
 
-      it_behaves_like "unauthorized access"
+      it_behaves_like "not found"
     end
 
     context "as non-admin" do

--- a/spec/services/authorization/user_permissible_service_spec.rb
+++ b/spec/services/authorization/user_permissible_service_spec.rb
@@ -107,12 +107,12 @@ RSpec.describe Authorization::UserPermissibleService do
       end
 
       context "and the user is an admin" do
-        let(:user) { create(:admin) }
+        let(:queried_user) { admin }
 
         it { is_expected.to be_allowed_globally(permission) }
 
         context "and the account is locked" do
-          before { user.locked! }
+          before { admin.locked! }
 
           it { is_expected.not_to be_allowed_globally(permission) }
         end
@@ -186,6 +186,17 @@ RSpec.describe Authorization::UserPermissibleService do
             it { is_expected.not_to be_allowed_in_project(permission, project) }
           end
         end
+      end
+
+      context "and the user is an admin but the permission is not granted to admins" do
+        # :work_package_assigned has grant_to_admin: false, so the admin short-circuit
+        # does not apply. Additionally, all_permissions_for for admins only returns
+        # grant_to_admin? permissions (ignoring memberships), so the admin cannot
+        # gain this permission at all.
+        let(:queried_user) { admin }
+        let(:permission) { :work_package_assigned }
+
+        it { is_expected.not_to be_allowed_in_project(permission, project) }
       end
 
       context "and the user is a member of a project" do
@@ -272,6 +283,17 @@ RSpec.describe Authorization::UserPermissibleService do
             it { is_expected.not_to be_allowed_in_any_project(permission) }
           end
         end
+      end
+
+      context "and the user is an admin but the permission is not granted to admins" do
+        # :work_package_assigned has grant_to_admin: false, so the admin short-circuit
+        # does not apply. Additionally, all_permissions_for for admins only returns
+        # grant_to_admin? permissions (ignoring memberships), so the admin cannot
+        # gain this permission at all.
+        let(:queried_user) { admin }
+        let(:permission) { :work_package_assigned }
+
+        it { is_expected.not_to be_allowed_in_any_project(permission) }
       end
 
       context "and the user is a member of a project" do
@@ -376,6 +398,16 @@ RSpec.describe Authorization::UserPermissibleService do
               project.enabled_module_names = project.enabled_module_names - ["work_package_tracking"]
               project.reload
             end
+
+            it { is_expected.not_to be_allowed_in_entity(permission, work_package, WorkPackage) }
+          end
+
+          context "when the permission is not granted to admins" do
+            # :work_package_assigned has grant_to_admin: false, so the admin short-circuit
+            # does not apply. Additionally, all_permissions_for for admins only returns
+            # grant_to_admin? permissions (ignoring memberships), so the admin cannot
+            # gain this permission at all.
+            let(:permission) { :work_package_assigned }
 
             it { is_expected.not_to be_allowed_in_entity(permission, work_package, WorkPackage) }
           end
@@ -484,6 +516,16 @@ RSpec.describe Authorization::UserPermissibleService do
 
           it { is_expected.not_to be_allowed_in_any_entity(permission, WorkPackage) }
           it { is_expected.not_to be_allowed_in_any_entity(permission, WorkPackage, in_project: project) }
+        end
+
+        context "when the permission is not granted to admins" do
+          # :work_package_assigned has grant_to_admin: false, so the admin short-circuit
+          # does not apply. Additionally, all_permissions_for for admins only returns
+          # grant_to_admin? permissions (ignoring memberships), so the admin cannot
+          # gain this permission at all.
+          let(:permission) { :work_package_assigned }
+
+          it { is_expected.not_to be_allowed_in_any_entity(permission, WorkPackage) }
         end
       end
 

--- a/spec/services/authorization/user_permissible_service_spec.rb
+++ b/spec/services/authorization/user_permissible_service_spec.rb
@@ -118,6 +118,25 @@ RSpec.describe Authorization::UserPermissibleService do
         end
       end
 
+      context "and the user is an admin but the permission is not granted to admins" do
+        include_context "with blank access control state"
+
+        before do
+          OpenProject::AccessControl.map do |map|
+            map.permission :not_granted_to_admin_global,
+                           {},
+                           permissible_on: :global,
+                           require: :loggedin,
+                           grant_to_admin: false
+          end
+        end
+
+        let(:queried_user) { admin }
+        let(:permission) { :not_granted_to_admin_global }
+
+        it { is_expected.not_to be_allowed_globally(permission) }
+      end
+
       it_behaves_like "the Authorization.roles scope used" do
         let(:context) { nil }
         subject { service.allowed_globally?(permission) }


### PR DESCRIPTION
Permission checks should short-circuit IF the permission is admin grantable and the user is an active admin. With this change, we can get rid of some of the checks in visible scopes.

https://community.openproject.org/projects/openproject/work_packages/73538/activity
