### PR TITLE
[70388] Sidebar menu button unresponsive on mobile (after PIR)

### DIFF
--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -49,7 +49,9 @@ export class MainMenuToggleService {
 
   private htmlNode = document.getElementsByTagName('html')[0];
 
-  private mainMenu = document.querySelector<HTMLElement>('#main-menu')!; // main menu, containing sidebar and resizer
+  private get mainMenu():HTMLElement|null {
+    return document.querySelector<HTMLElement>('#main-menu');
+  }
 
   // Notes all changes of the menu size (currently needed in wp-resizer.component.ts)
   private changeData = new BehaviorSubject<number|undefined>(undefined);
@@ -69,7 +71,8 @@ export class MainMenuToggleService {
   }
 
   public initializeMenu():void {
-    if (!this.mainMenu) {
+    const mainMenu = this.mainMenu;
+    if (!mainMenu) {
       return;
     }
 
@@ -80,7 +83,7 @@ export class MainMenuToggleService {
     this.wasCollapsedByUser = menuCollapsed;
 
     if (!this.elementWidth) {
-      this.saveWidth(this.mainMenu.offsetWidth);
+      this.saveWidth(mainMenu.offsetWidth);
     } else if (menuCollapsed) {
       this.closeMenu();
     } else {
@@ -129,7 +132,9 @@ export class MainMenuToggleService {
     // This needs to be called after AngularJS has rendered the menu, which happens some when after(!) we leave this
     // method here. So we need to set the focus after a timeout.
     setTimeout(() => {
-      const firstVisibleMenuItem = queryVisible('[class*="-menu-item"]', this.mainMenu)[0];
+      const mainMenu = this.mainMenu;
+      if (!mainMenu) return;
+      const firstVisibleMenuItem = queryVisible('[class*="-menu-item"]', mainMenu)[0];
       firstVisibleMenuItem?.focus();
     }, 500);
   }
@@ -151,8 +156,11 @@ export class MainMenuToggleService {
       this.elementWidth = width;
     }
 
+    const mainMenu = this.mainMenu;
+    if (!mainMenu) return;
+
     // Apply the width directly to the main menu
-    this.mainMenu.style.width = `${this.elementWidth}px`;
+    mainMenu.style.width = `${this.elementWidth}px`;
 
     // Apply to root CSS variable for any related layout adjustments
     this.htmlNode.style.setProperty('--main-menu-width', `${this.elementWidth}px`);

--- a/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/menus/main-toggle.controller.ts
@@ -2,18 +2,24 @@ import { Controller } from '@hotwired/stimulus';
 import { MainMenuToggleService } from 'core-app/core/main-menu/main-menu-toggle.service';
 
 export default class MainToggleController extends Controller {
-  mainMenuService:MainMenuToggleService;
+  mainMenuService:MainMenuToggleService|undefined;
 
-  async connect() {
-    await window.OpenProject.getPluginContext()
+  connect() {
+    window.OpenProject.getPluginContext()
       .then((pluginContext) => pluginContext.injector.get(MainMenuToggleService))
       .then((service) => {
+        if (!this.element.isConnected) return;
         this.mainMenuService = service;
         this.mainMenuService.initializeMenu();
-      });
+      })
+      .catch(() => { /* Do nothing */ });
+  }
+
+  disconnect() {
+    this.mainMenuService = undefined;
   }
 
   toggleNavigation(e:Event) {
-    this.mainMenuService.toggleNavigation(e);
+    this.mainMenuService?.toggleNavigation(e);
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/70388

# What are you trying to accomplish?
Catch a case where the service is loaded before the turbo event has finished

