### PR TITLE
[#73556] Add Start/Stop sprint permission to users with Create sprint

### DIFF
--- a/db/migrate/20260212145213_migrate_backlogs_permissions.rb
+++ b/db/migrate/20260212145213_migrate_backlogs_permissions.rb
@@ -1,5 +1,33 @@
 # frozen_string_literal: true
 
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
 require Rails.root.join("db/migrate/migration_utils/permission_renamer")
 require Rails.root.join("db/migrate/migration_utils/permission_adder")
 

--- a/db/migrate/migration_utils/permission_adder.rb
+++ b/db/migrate/migration_utils/permission_adder.rb
@@ -33,11 +33,12 @@ module Migration
     module PermissionAdder
       module_function
 
-      # Adds a permission to all roles that have the filter permission.
+      # Adds a permission to all roles that have the filter permission(s).
       # E.g. this can be used to add a new permission to all roles having the :view_work_packages permission.
+      # When an array is passed for `having`, only roles that have ALL of those permissions are selected.
       # It is possible to force adding the permission. This might be necessary for older migrations
       # where the permission has been removed/renamed in the meantime.
-      # @param [Symbol] having The permission to filter the roles by
+      # @param [Symbol, Array<Symbol>] having The permission(s) to filter the roles by
       # @param [Symbol] add The permission to add
       # @param [FalseClass, TrueClass] force Whether to force adding the permission even if it is not a valid permission.
       def add(having, add, force: false) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -48,10 +49,16 @@ module Migration
           return
         end
 
+        having_permissions = Array(having)
+        # Select all the roles that have all the permissions enumerated
+        # in the `having_permissions` variable.
+
         role_scope = Role
+          .unscoped
           .joins(:role_permissions)
-          .where(role_permissions: { permission: having.to_s })
-          .references(:role_permissions)
+          .where(role_permissions: { permission: having_permissions })
+          .group("roles.id")
+          .having("COUNT(DISTINCT role_permissions.permission) = ?", having_permissions.length)
 
         role_scope.find_each do |role|
           # Check if the add-permission already exists before adding

--- a/modules/backlogs/db/migrate/20260330134729_add_sprint_start_permission_to_users.rb
+++ b/modules/backlogs/db/migrate/20260330134729_add_sprint_start_permission_to_users.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require Rails.root.join("db/migrate/migration_utils/permission_adder")
+
+class AddSprintStartPermissionToUsers < ActiveRecord::Migration[8.1]
+  def change
+    having_permissions = %i[create_sprints manage_board_views manage_sprint_items]
+    ::Migration::MigrationUtils::PermissionAdder.add(having_permissions, :start_complete_sprint)
+  end
+end

--- a/modules/backlogs/spec/migrations/add_sprint_start_permission_to_users_spec.rb
+++ b/modules/backlogs/spec/migrations/add_sprint_start_permission_to_users_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require Rails.root.join("modules/backlogs/db/migrate/20260330134729_add_sprint_start_permission_to_users")
+
+RSpec.describe AddSprintStartPermissionToUsers, type: :model do
+  subject(:migrate) { ActiveRecord::Migration.suppress_messages { described_class.migrate(:up) } }
+
+  let!(:role_with_all) do
+    create(:project_role, permissions: %i[create_sprints manage_board_views manage_sprint_items])
+  end
+  let!(:role_with_partial) do
+    create(:project_role, permissions: %i[create_sprints manage_board_views])
+  end
+  let!(:role_without_any) { create(:project_role) }
+
+  it "grants start_complete_sprint only to roles fulfilling all required permissions" do
+    migrate
+
+    expect(role_with_all.reload.permissions).to include(:start_complete_sprint)
+    expect(role_with_partial.reload.permissions).not_to include(:start_complete_sprint)
+    expect(role_without_any.reload.permissions).not_to include(:start_complete_sprint)
+  end
+end

--- a/spec/migrations/permission_adder_spec.rb
+++ b/spec/migrations/permission_adder_spec.rb
@@ -86,6 +86,20 @@ RSpec.describe Migration::MigrationUtils::PermissionAdder, type: :model do # rub
     end
   end
 
+  context "when having is an array of permissions" do
+    let!(:role_with_all) { create(:project_role, permissions: %i[view_project view_work_packages]) }
+    let!(:role_with_partial) { create(:project_role, permissions: %i[view_project]) }
+    let!(:role_with_none) { create(:project_role) }
+
+    it "only adds the permission to roles that have ALL of the having permissions" do
+      described_class.add(%i[view_project view_work_packages], :view_project_attributes)
+
+      expect(role_with_all.reload.permissions).to include(:view_project_attributes)
+      expect(role_with_partial.reload.permissions).not_to include(:view_project_attributes)
+      expect(role_with_none.reload.permissions).not_to include(:view_project_attributes)
+    end
+  end
+
   context "with a permission that does not exist" do
     it "results in a no-op" do
       result = nil


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/73556

# What are you trying to accomplish?
- Add the `start_complete_sprint` permission for roles having the `create_sprints` permission.

# What approach did you choose and why?
Add the `start_complete_sprint` permission to roles where `create_sprints` is present only if the given role fulfils the dependencies of the `start_complete_sprint` permission.
- The dependencies are: `view_sprints manage_board_views manage_sprint_items`.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
