### PR TITLE
Adapt colors for non-working days

### DIFF
--- a/app/components/users/non_working_times/calendar_component.sass
+++ b/app/components/users/non_working_times/calendar_component.sass
@@ -13,6 +13,7 @@
 
   .op-fc-wrapper
     flex-grow: 1
+
 .users-non-working-times-calendar-view
   .op-fc-wrapper
     // Rounded corners for the entire calendar
@@ -21,10 +22,10 @@
 
     // Global non-working days rendered as FullCalendar background events
     .fc-bg-event.non-working-day--global
-      background-color: var(--bgColor-done-muted) !important
-      color: var(--fgColor-sponsors) !important
+      background-color: var(--data-pink-color-muted) !important
+      color: var(--display-pink-scale-9) !important
       opacity: 0.8 !important
-      border: 1px solid var(--display-pink-scale-5) !important
+      border: 1px solid var(--data-pink-color-emphasis) !important
 
     // User non-working day ranges rendered as foreground all-day bars
     .fc-event.non-working-day--user
@@ -41,5 +42,3 @@
         &.fc-day-today
           background-color: var(--bgColor-accent-muted) !important
           color: var(--fgColor-accent) !important
-
-


### PR DESCRIPTION
# Ticket
None

# What are you trying to accomplish?
* Use semantically more fitting colors for the non working days. 
* Increase the contrast 

## Screenshots
**Before**

<img width="1008" height="537" alt="Bildschirmfoto 2026-03-31 um 07 57 08" src="https://github.com/user-attachments/assets/43e47b7f-8af4-4c0a-93d8-4fa0b53f7295" />

**After**
<img width="1049" height="561" alt="Bildschirmfoto 2026-03-31 um 08 12 13" src="https://github.com/user-attachments/assets/59bf05e3-e9da-4341-95fc-5aff22906d81" />
