### PR TITLE
Try to fix time_entry_dialog_spec

### DIFF
--- a/modules/costs/spec/features/time_entry_dialog_spec.rb
+++ b/modules/costs/spec/features/time_entry_dialog_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "time entry dialog", :js do
         find("opce-time-entry-trigger-actions .icon-edit").click
 
         time_logging_modal.is_visible(true)
-        time_logging_modal.update_field("entity_id", work_package_c.id)
+        time_logging_modal.update_field("entity_id", work_package_c.subject)
         wait_for_network_idle # form refresh is happening here
         time_logging_modal.submit
         wait_for_network_idle
@@ -307,7 +307,7 @@ RSpec.describe "time entry dialog", :js do
 
       expect do
         time_logging_modal.is_visible(true)
-        time_logging_modal.update_field("entity_id", work_package_b.id)
+        time_logging_modal.update_field("entity_id", work_package_b.subject)
         wait_for_network_idle # form refresh is happening here
         time_logging_modal.submit
         wait_for_network_idle
@@ -341,7 +341,7 @@ RSpec.describe "time entry dialog", :js do
         time_logging_modal.is_visible(true)
 
         # ensure the work package autocompleter is filled
-        time_logging_modal.update_field("entity_id", work_package_a.id)
+        time_logging_modal.update_field("entity_id", work_package_a.subject)
 
         # validates the required custom field and prevents update when missing
         time_logging_modal.submit


### PR DESCRIPTION
TypeaheadFilter#id_condition uses LIKE '%N%' to match the ID. When work_package_a.id is e.g. 2, work packages with IDs like 12, 22 also match. The spec fails if these IDs exist due to the order of execution. Both appear as .ng-option elements and this causes an Ambiguous match

```
  1) time entry dialog when the user can edit time entries with custom field validation I can update a time entry with a custom field value including validation
     Failure/Error: target_dropdown.find(".ng-option", text:)

     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching visible css ".ng-option" with text 2 within #<Capybara::Node::Element tag="dialog" path="//HTML[1]/BODY[1]/DIALOG-HELPER[1]/DIALOG[1]">
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:310:in 'block in Capybara::Node::Finders#synced_resolve'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in 'Capybara::Node::Base#synchronize'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:301:in 'Capybara::Node::Finders#synced_resolve'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/node/finders.rb:60:in 'Capybara::Node::Finders#find'
     # ./spec/support/components/autocompleter/autocomplete_helpers.rb:68:in 'Components::Autocompleter::AutocompleteHelpers#select_autocomplete'
     # ./spec/features/support/components/time_logging_modal.rb:137:in 'Components::TimeLoggingModal#update_field'
     # ./modules/costs/spec/features/time_entry_dialog_spec.rb:344:in 'block (4 levels) in <top (required)>'
     # ./spec/support/capybara.rb:22:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/without_env.rb:52:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:60:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:197:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # ./spec/support/rspec_retry.rb:26:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:165:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in 'block (2 levels) in RSpec::Retry.setup'
```
