### PR TITLE
Feature/73531 existing burndown charts working on sprints

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_menu_component.html.erb
@@ -87,7 +87,7 @@ See COPYRIGHT and LICENSE files for more details.
 
       menu.with_item(
         id: dom_target(sprint, :menu, :burndown_chart),
-        label: t(".action_menu.burndown_chart"),
+        label: t("backlogs.label_burndown_chart"),
         tag: :a,
         href: backlogs_project_sprint_burndown_chart_path(project, sprint),
         disabled: !sprint.has_burndown?

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -96,7 +96,7 @@ See COPYRIGHT and LICENSE files for more details.
     with_item_group(menu) do
       if show_task_board_link?
         menu.with_item(
-          label: t(".action_menu.task_board"),
+          label: t("backlogs.label_sprint_board"),
           tag: :a,
           href: backlogs_project_sprint_taskboard_path(project, sprint)
         ) do |item|
@@ -104,13 +104,15 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
 
-      menu.with_item(
-        label: t(".action_menu.burndown"),
-        tag: :a,
-        href: backlogs_project_sprint_burndown_chart_path(project, sprint),
-        disabled: !sprint.date_range_set?
-      ) do |item|
-        item.with_leading_visual_icon(icon: :graph)
+      if show_burndown_link?
+        menu.with_item(
+          label: t("backlogs.label_burndown_chart"),
+          tag: :a,
+          href: backlogs_project_sprint_burndown_chart_path(project, sprint),
+          disabled: !sprint.date_range_set?
+        ) do |item|
+          item.with_leading_visual_icon(icon: :graph)
+        end
       end
     end
   end

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -103,6 +103,15 @@ See COPYRIGHT and LICENSE files for more details.
           item.with_leading_visual_icon(icon: :"op-view-cards")
         end
       end
+
+      menu.with_item(
+        label: t(".action_menu.burndown"),
+        tag: :a,
+        href: backlogs_project_sprint_burndown_chart_path(project, sprint),
+        disabled: !sprint.date_range_set?
+      ) do |item|
+        item.with_leading_visual_icon(icon: :graph)
+      end
     end
   end
 %>

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -74,6 +74,10 @@ module Backlogs
       sprint.in_planning? && (!sprint.date_range_set? || project_has_another_active_sprint?)
     end
 
+    def show_burndown_link?
+      sprint.active?
+    end
+
     def start_sprint_action_description
       return unless disable_start_sprint_action?
 

--- a/modules/backlogs/app/controllers/rb_burndown_charts_controller.rb
+++ b/modules/backlogs/app/controllers/rb_burndown_charts_controller.rb
@@ -32,7 +32,11 @@ class RbBurndownChartsController < RbApplicationController
   helper :burndown_charts
 
   def show
-    @burndown = @sprint.burndown(@project)
+    @burndown = if OpenProject::FeatureDecisions.scrum_projects_active?
+                  Burndown.new(@sprint, @project)
+                else
+                  @sprint.burndown(@project)
+                end
 
     respond_to do |format|
       format.html { render layout: true }

--- a/modules/backlogs/app/helpers/rb_common_helper.rb
+++ b/modules/backlogs/app/helpers/rb_common_helper.rb
@@ -181,4 +181,8 @@ module RbCommonHelper
   def get_backlogs_preference(assignee, attr)
     assignee.is_a?(User) ? assignee.backlogs_preference(attr) : "#24B3E7"
   end
+
+  def sprint_board_label
+    OpenProject::FeatureDecisions.scrum_projects_active? ? t("backlogs.label_sprint_board") : t(:label_task_board)
+  end
 end

--- a/modules/backlogs/app/models/burndown.rb
+++ b/modules/backlogs/app/models/burndown.rb
@@ -52,7 +52,11 @@ class Burndown
   private
 
   def make_date_series(sprint)
-    @days = sprint.days
+    @days = if sprint.is_a?(Agile::Sprint)
+              Day.working.from_range(from: sprint.start_date, to: sprint.finish_date).map(&:date)
+            else
+              sprint.days
+            end
   end
 
   def calculate_series(series_data)
@@ -100,6 +104,7 @@ class Burndown
     Hash[*keys.zip(values).flatten]
   end
 
+  # TODO: Check if this can be removed
   def workday_before(date = Date.today)
     d = date - 1
     # TODO: make weekday configurable

--- a/modules/backlogs/app/models/burndown.rb
+++ b/modules/backlogs/app/models/burndown.rb
@@ -52,8 +52,10 @@ class Burndown
   private
 
   def make_date_series(sprint)
-    @days = if sprint.is_a?(Agile::Sprint)
+    @days = if sprint.is_a?(Agile::Sprint) && sprint.start_date && sprint.finish_date
               Day.working.from_range(from: sprint.start_date, to: sprint.finish_date).map(&:date)
+            elsif sprint.is_a?(Agile::Sprint)
+              []
             else
               sprint.days
             end
@@ -102,13 +104,5 @@ class Burndown
 
   def to_h(keys, values)
     Hash[*keys.zip(values).flatten]
-  end
-
-  # TODO: Check if this can be removed
-  def workday_before(date = Date.today)
-    d = date - 1
-    # TODO: make weekday configurable
-    d = workday_before(d) unless d.wday > 0 and d.wday < 6
-    d
   end
 end

--- a/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
       aria: { label: t(:label_task_board) }
     ) do |button|
       button.with_leading_visual_icon(icon: :"op-view-cards")
-      t(:label_task_board)
+      OpenProject::FeatureDecisions.scrum_projects_active? ? t("backlogs.label_sprint_board") : t(:label_task_board)
     end
   end
 %>

--- a/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
+++ b/modules/backlogs/app/views/rb_burndown_charts/show.html.erb
@@ -39,11 +39,11 @@ See COPYRIGHT and LICENSE files for more details.
       tag: :a,
       href: backlogs_project_sprint_taskboard_path(@project, @sprint),
       mobile_icon: :"op-view-cards",
-      mobile_label: t(:label_task_board),
-      aria: { label: t(:label_task_board) }
+      mobile_label: sprint_board_label,
+      aria: { label: sprint_board_label }
     ) do |button|
       button.with_leading_visual_icon(icon: :"op-view-cards")
-      OpenProject::FeatureDecisions.scrum_projects_active? ? t("backlogs.label_sprint_board") : t(:label_task_board)
+      sprint_board_label
     end
   end
 %>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -104,6 +104,8 @@ en:
     sharing: "Sharing"
     impediment: "Impediment"
     label_versions_default_fold_state: "Show versions folded"
+    label_burndown_chart: "Burndown chart"
+    label_sprint_board: "Sprint board"
     caption_versions_default_fold_state: "Versions will not be expanded by default when viewing backlogs. Each one has to be manually expanded."
     work_package_is_closed: "Work package is done, when"
     label_is_done_status: "Status %{status_name} means done"
@@ -115,7 +117,7 @@ en:
     rebuild: "Rebuild"
     rebuild_positions: "Rebuild positions"
     remaining_hours: "Remaining work"
-    show_burndown_chart: "Burndown Chart"
+    show_burndown_chart: "Burndown chart"
     story: "Story"
     story_points:
       one: "%{count} story point"
@@ -195,7 +197,6 @@ en:
         new_story: "New story"
         stories_tasks: "Stories/Tasks"
         task_board: "Task board"
-        burndown_chart: "Burndown chart"
         wiki: "Wiki"
         properties: "Properties"
 
@@ -219,8 +220,6 @@ en:
         start_sprint_missing_dates_description: "Start and finish dates are required in order to start the sprint."
         edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
-        task_board: "Sprint board"
-        burndown: "Burndown"
 
     story_component:
       label_drag_story: "Move %{name}"
@@ -260,8 +259,10 @@ en:
   label_backlogs: "Backlogs"
   label_backlogs_unconfigured: "You have not configured Backlogs yet. Please go to %{administration} > %{plugins}, then click on the %{configure} link for this plugin. Once you have set the fields, come back to this page to start using the tool."
   label_blocks_ids: "IDs of blocked work packages"
+  label_burndown_chart: "Burndown chart"
   label_column_in_backlog: "Column in backlog"
   label_used_as_backlog: "Used as backlog"
+  label_sprint_board: "Sprint board"
   label_points_burn_down: "Down"
   label_points_burn_up: "Up"
   label_sprint_edit: "Edit sprint"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -220,6 +220,7 @@ en:
         edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
         task_board: "Sprint board"
+        burndown: "Burndown"
 
     story_component:
       label_drag_story: "Move %{name}"

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -48,7 +48,7 @@ module OpenProject::Backlogs::Burndown
     def collect_data
       initialize_self_for_collection
 
-      data_for_dates(collected_days).each do |day_data|
+      data_for_dates.each do |day_data|
         date = day_data["date"]
         date = Date.parse(date) unless date.is_a?(Date)
 
@@ -75,151 +75,83 @@ module OpenProject::Backlogs::Burndown
     end
 
     def collected_days
-      @collected_days ||= begin
-        days = if sprint.is_a?(Agile::Sprint)
-                 Day.working.from_range(from: sprint.start_date, to: sprint.finish_date).map(&:date)
-               else
-                 sprint.days(nil)
-               end
-
-        days.sort.select { |d| d <= Date.today }
-      end
+      @collected_days ||= Day
+          .working
+          .from_range(from: sprint.start_date, to: sprint.is_a?(Agile::Sprint) ? sprint.finish_date : sprint.effective_date)
+          .where(date: ..Time.zone.today)
+          .order(:date)
+          .map(&:date)
     end
 
-    def data_for_dates(dates)
-      return [] if dates.empty?
-
+    def data_for_dates
       query_string = <<-SQL
-      SELECT
-        date_journals.date,
-        SUM(work_package_journals.story_points) as story_points
-      FROM
-        work_package_journals
-      JOIN journals AS id_journals
-      ON work_package_journals.id = id_journals.data_id
-        AND id_journals.data_type = '#{Journal::WorkPackageJournal.name}'
-        AND #{container_query}
-        AND #{project_id_query}
-        AND #{type_id_query}
-        #{and_status_query}
-      JOIN
-        (
-          #{authoritative_journal_for_date(dates)}
-        ) AS date_journals
-      ON date_journals.journable_id = id_journals.journable_id
-        AND date_journals.version = id_journals.version
-        AND id_journals.journable_type = 'WorkPackage'
-      GROUP BY date_journals.date
-      ORDER BY date_journals.date
+        SELECT
+          days.date,
+          COALESCE(SUM(work_package_journals.story_points), 0.0) as story_points
+        FROM
+          work_package_journals
+        LEFT JOIN
+          journals
+        ON work_package_journals.id = journals.data_id
+          AND journals.data_type = '#{Journal::WorkPackageJournal.name}'
+          AND #{container_query}
+          AND #{project_id_query}
+          AND #{type_id_query}
+          #{and_status_query}
+        JOIN
+          (#{day_query}) days
+        ON (days.date::timestamp + interval '23:59:59') AT TIME ZONE '#{User.current.time_zone.tzinfo.name}' <@ journals.validity_period
+        GROUP BY days.date
+        ORDER BY days.date
       SQL
 
       Journal::WorkPackageJournal.connection.select_all query_string
     end
 
-    def authoritative_journal_for_date(dates)
-      raise "dates must not be empty!" if dates.empty?
-
-      <<-SQL
-      SELECT
-        d.date,
-        j.journable_id,
-        MAX(j.version) as version
-      FROM
-        (
-          #{dates_of_interest_join_table(dates)}
-        ) as d
-      JOIN
-        (
-          SELECT
-            CAST(j.updated_at AS DATE) AS updated_at,
-            j.journable_id,
-            MAX(j.version) as version
-          FROM
-            journals AS j
-          WHERE
-            j.journable_id IN (
-              SELECT journable_id
-              FROM
-                journals
-              JOIN
-                work_package_journals
-              ON work_package_journals.id = journals.data_id
-                AND journals.data_type = '#{Journal::WorkPackageJournal.name}'
-                AND #{container_query}
-                AND #{project_id_query}
-                AND #{type_id_query}
-                #{and_status_query})
-          GROUP BY
-            CAST(j.updated_at AS DATE),
-            j.journable_type,
-            j.journable_id
-          HAVING j.journable_type = 'WorkPackage'
-          ORDER BY j.journable_id, version
-        ) as j
-      ON d.date >= j.updated_at
-      GROUP BY d.date, j.journable_id
-      ORDER BY j.journable_id, d.date, version
-      SQL
-    end
-
-    def dates_of_interest_join_table(dates)
-      raise "dates must not be empty!" if dates.empty?
-
-      @date_join ||= dates.map do |date|
-        "SELECT CAST('#{date}' AS DATE) AS date"
-      end.join(" UNION ")
-    end
-
     def and_status_query
-      @status_query ||= begin
-        non_closed_statuses = Status.where(is_closed: false).select(:id).map(&:id)
+      non_closed_statuses = Status.where(is_closed: false).pluck(:id)
 
-        done_statuses_for_project = project.done_statuses.select(:id).map(&:id)
+      done_statuses_for_project = project.done_statuses.pluck(:id)
 
-        open_status_ids = non_closed_statuses - done_statuses_for_project
+      open_status_ids = non_closed_statuses - done_statuses_for_project
 
-        if open_status_ids.empty?
-          ""
-        else
-          "AND (#{Journal::WorkPackageJournal.table_name}.status_id IN (#{open_status_ids.join(',')}))"
-        end
+      if open_status_ids.empty?
+        ""
+      else
+        "AND (#{Journal::WorkPackageJournal.table_name}.status_id IN (#{open_status_ids.join(',')}))"
       end
     end
 
     def container_query
-      @container_query ||= if sprint.is_a?(Agile::Sprint)
-                             "(#{Journal::WorkPackageJournal.table_name}.sprint_id = #{sprint.id})"
-                           else
-                             "(#{Journal::WorkPackageJournal.table_name}.version_id = #{sprint.id})"
-                           end
+      if sprint.is_a?(Agile::Sprint)
+        "(#{Journal::WorkPackageJournal.table_name}.sprint_id = #{sprint.id})"
+      else
+        "(#{Journal::WorkPackageJournal.table_name}.version_id = #{sprint.id})"
+      end
     end
 
     def project_id_query
-      @project_id_query ||= "(#{Journal::WorkPackageJournal.table_name}.project_id = #{project.id})"
+      "(#{Journal::WorkPackageJournal.table_name}.project_id = #{project.id})"
     end
 
     def type_id_query
-      @type_id_query ||= if sprint.is_a?(Agile::Sprint)
-                           "1 = 1"
-                         else
-                           "(#{Journal::WorkPackageJournal.table_name}.type_id in (#{collected_types.join(',')}))"
-                         end
+      if sprint.is_a?(Agile::Sprint)
+        "1 = 1"
+      else
+        "(#{Journal::WorkPackageJournal.table_name}.type_id in (#{collected_types.join(',')}))"
+      end
     end
 
-    # TODO: can this be removed?
-    # does not seem to be called
-    def ignore_if_has_parent
-      @ignore_if_has_parent ||= "(#{Journal::WorkPackageJournal.table_name}.parent_id IS NOT NULL)"
-    end
+    def day_query
+      lower_bound = sprint.start_date
+      upper_date = sprint.is_a?(Agile::Sprint) ? sprint.finish_date : sprint.effective_date
+      upper_bound = Time.zone.today.clamp(lower_bound, upper_date)
 
-    # TODO: can this be removed?
-    # does not seem to be called
-    def collected_from_children?(key, story)
-      key == "remaining_hours" && story_has_children?(story)
+      Day.working.from_range(from: lower_bound, to: upper_bound).to_sql
     end
 
     def collected_types
-      @collected_types ||= Story.types << Task.type
+      Story.types << Task.type
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -75,12 +75,7 @@ module OpenProject::Backlogs::Burndown
     end
 
     def collected_days
-      @collected_days ||= Day
-          .working
-          .from_range(from: sprint.start_date, to: sprint.is_a?(Agile::Sprint) ? sprint.finish_date : sprint.effective_date)
-          .where(date: ..Time.zone.today)
-          .order(:date)
-          .map(&:date)
+      @collected_days ||= day_query.where(date: ..Time.zone.today).order(:date).map(&:date)
     end
 
     def data_for_dates
@@ -99,7 +94,7 @@ module OpenProject::Backlogs::Burndown
           AND #{type_id_query}
           #{and_status_query}
         JOIN
-          (#{day_query}) days
+          (#{day_query.to_sql}) days
         ON (days.date::timestamp + interval '23:59:59') AT TIME ZONE '#{User.current.time_zone.tzinfo.name}' <@ journals.validity_period
         GROUP BY days.date
         ORDER BY days.date
@@ -147,7 +142,7 @@ module OpenProject::Backlogs::Burndown
       upper_date = sprint.is_a?(Agile::Sprint) ? sprint.finish_date : sprint.effective_date
       upper_bound = Time.zone.today.clamp(lower_bound, upper_date)
 
-      Day.working.from_range(from: lower_bound, to: upper_bound).to_sql
+      Day.working.from_range(from: lower_bound, to: upper_bound)
     end
 
     def collected_types

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -142,6 +142,8 @@ module OpenProject::Backlogs::Burndown
       upper_date = sprint.is_a?(Agile::Sprint) ? sprint.finish_date : sprint.effective_date
       upper_bound = Time.zone.today.clamp(lower_bound, upper_date)
 
+      return Day.none unless upper_bound && lower_bound
+
       Day.working.from_range(from: lower_bound, to: upper_bound)
     end
 

--- a/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
+++ b/modules/backlogs/lib/open_project/backlogs/burndown/series_raw_data.rb
@@ -76,7 +76,12 @@ module OpenProject::Backlogs::Burndown
 
     def collected_days
       @collected_days ||= begin
-        days = sprint.days(nil)
+        days = if sprint.is_a?(Agile::Sprint)
+                 Day.working.from_range(from: sprint.start_date, to: sprint.finish_date).map(&:date)
+               else
+                 sprint.days(nil)
+               end
+
         days.sort.select { |d| d <= Date.today }
       end
     end
@@ -93,7 +98,7 @@ module OpenProject::Backlogs::Burndown
       JOIN journals AS id_journals
       ON work_package_journals.id = id_journals.data_id
         AND id_journals.data_type = '#{Journal::WorkPackageJournal.name}'
-        AND #{version_query}
+        AND #{container_query}
         AND #{project_id_query}
         AND #{type_id_query}
         #{and_status_query}
@@ -126,7 +131,7 @@ module OpenProject::Backlogs::Burndown
       JOIN
         (
           SELECT
-            CAST(j.created_at AS DATE) AS created_at,
+            CAST(j.updated_at AS DATE) AS updated_at,
             j.journable_id,
             MAX(j.version) as version
           FROM
@@ -140,18 +145,18 @@ module OpenProject::Backlogs::Burndown
                 work_package_journals
               ON work_package_journals.id = journals.data_id
                 AND journals.data_type = '#{Journal::WorkPackageJournal.name}'
-                AND #{version_query}
+                AND #{container_query}
                 AND #{project_id_query}
                 AND #{type_id_query}
                 #{and_status_query})
           GROUP BY
-            CAST(j.created_at AS DATE),
+            CAST(j.updated_at AS DATE),
             j.journable_type,
             j.journable_id
           HAVING j.journable_type = 'WorkPackage'
           ORDER BY j.journable_id, version
         ) as j
-      ON d.date >= j.created_at
+      ON d.date >= j.updated_at
       GROUP BY d.date, j.journable_id
       ORDER BY j.journable_id, d.date, version
       SQL
@@ -181,8 +186,12 @@ module OpenProject::Backlogs::Burndown
       end
     end
 
-    def version_query
-      @version_query ||= "(#{Journal::WorkPackageJournal.table_name}.version_id = #{sprint.id})"
+    def container_query
+      @container_query ||= if sprint.is_a?(Agile::Sprint)
+                             "(#{Journal::WorkPackageJournal.table_name}.sprint_id = #{sprint.id})"
+                           else
+                             "(#{Journal::WorkPackageJournal.table_name}.version_id = #{sprint.id})"
+                           end
     end
 
     def project_id_query
@@ -190,13 +199,21 @@ module OpenProject::Backlogs::Burndown
     end
 
     def type_id_query
-      @type_id_query ||= "(#{Journal::WorkPackageJournal.table_name}.type_id in (#{collected_types.join(',')}))"
+      @type_id_query ||= if sprint.is_a?(Agile::Sprint)
+                           "1 = 1"
+                         else
+                           "(#{Journal::WorkPackageJournal.table_name}.type_id in (#{collected_types.join(',')}))"
+                         end
     end
 
+    # TODO: can this be removed?
+    # does not seem to be called
     def ignore_if_has_parent
       @ignore_if_has_parent ||= "(#{Journal::WorkPackageJournal.table_name}.parent_id IS NOT NULL)"
     end
 
+    # TODO: can this be removed?
+    # does not seem to be called
     def collected_from_children?(key, story)
       key == "remaining_hours" && story_has_children?(story)
     end

--- a/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_menu_component_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       it "shows no Burndown chart link" do
         render_component
 
-        expect(page).to have_no_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.burndown_chart"))
+        expect(page).to have_no_text(I18n.t(:"backlogs.label_burndown_chart"))
       end
     end
 
@@ -288,7 +288,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
       it "shows Burndown chart link" do
         render_component
 
-        expect(page).to have_text(I18n.t(:"backlogs.backlog_menu_component.action_menu.burndown_chart"))
+        expect(page).to have_css("li", text: I18n.t(:"backlogs.label_burndown_chart"))
       end
 
       context "when sprint has no burndown (no dates)" do
@@ -297,7 +297,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
         it "shows Burndown chart link as disabled" do
           render_component
 
-          burndown_item = page.find("li", text: I18n.t(:"backlogs.backlog_menu_component.action_menu.burndown_chart"))
+          burndown_item = page.find("li", text: I18n.t(:"backlogs.label_burndown_chart"))
           expect(burndown_item[:class]).to include("ActionListItem--disabled")
         end
       end
@@ -306,7 +306,7 @@ RSpec.describe Backlogs::BacklogMenuComponent, type: :component do
         it "shows Burndown chart link as enabled" do
           render_component
 
-          burndown_item = page.find("li", text: I18n.t(:"backlogs.backlog_menu_component.action_menu.burndown_chart"))
+          burndown_item = page.find("li", text: I18n.t(:"backlogs.label_burndown_chart"))
           expect(burndown_item[:class]).not_to include("ActionListItem--disabled")
         end
       end

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
       it "renders dividers between each menu section" do
         render_component
 
-        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Sprint board"])
+        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
         expect(page).to have_list_item position: 3, role: "presentation"
         expect(page).to have_list_item position: 5, role: "presentation"
       end

--- a/modules/backlogs/spec/features/burndown/show_spec.rb
+++ b/modules/backlogs/spec/features/burndown/show_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Show burndown chart", :js, with_flag: { scrum_projects: true } d
   include Redmine::I18n
 
   shared_let(:project) { create(:project, enabled_module_names: %w(backlogs)) }
-  shared_let(:sprint) { create(:agile_sprint, project:, start_date: 1.week.ago, finish_date: 1.week.from_now) }
+  shared_let(:sprint) { create(:agile_sprint, status: "active", project:, start_date: 1.week.ago, finish_date: 1.week.from_now) }
 
   let(:planning_page) { Pages::SprintPlanning.new(project) }
   let(:role) do
@@ -43,15 +43,12 @@ RSpec.describe "Show burndown chart", :js, with_flag: { scrum_projects: true } d
            permissions: %i[view_work_packages view_sprints])
   end
 
-  current_user do
-    create(:user,
-           member_with_roles: { project => role })
-  end
+  current_user { create(:user, member_with_roles: { project => role }) }
 
   it "lists burndown in the menu by which the user can navigate to the burndown chart" do
     planning_page.visit!
 
-    planning_page.click_in_sprint_menu(sprint, "Burndown")
+    planning_page.click_in_sprint_menu(sprint, "Burndown chart")
 
     expect(page)
       .to have_content(sprint.name)

--- a/modules/backlogs/spec/features/burndown/show_spec.rb
+++ b/modules/backlogs/spec/features/burndown/show_spec.rb
@@ -28,36 +28,34 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Backlogs
-  class SprintPageHeaderComponent < ApplicationComponent
-    include ApplicationHelper
-    include RbCommonHelper
+require "spec_helper"
+require_relative "../../support/pages/sprint_planning"
 
-    delegate :with_action_button, to: :@page_header
+RSpec.describe "Show burndown chart", :js, with_flag: { scrum_projects: true } do
+  include Redmine::I18n
 
-    def initialize(sprint:, project:)
-      super
+  shared_let(:project) { create(:project, enabled_module_names: %w(backlogs)) }
+  shared_let(:sprint) { create(:agile_sprint, project:, start_date: 1.week.ago, finish_date: 1.week.from_now) }
 
-      @sprint  = sprint
-      @project = project
+  let(:planning_page) { Pages::SprintPlanning.new(project) }
+  let(:role) do
+    create(:project_role,
+           permissions: %i[view_work_packages view_sprints])
+  end
 
-      @page_header = Primer::OpenProject::PageHeader.new
-    end
+  current_user do
+    create(:user,
+           member_with_roles: { project => role })
+  end
 
-    def breadcrumb_items
-      [{ href: project_overview_path(@project), text: @project.name },
-       { href: backlogs_project_backlogs_path(@project), text: t(:label_backlogs) },
-       @sprint.name]
-    end
+  it "lists burndown in the menu by which the user can navigate to the burndown chart" do
+    planning_page.visit!
 
-    private
+    planning_page.click_in_sprint_menu(sprint, "Burndown")
 
-    def date_range
-      if @sprint.is_a?(Agile::Sprint)
-        [@sprint.start_date, @sprint.finish_date]
-      else
-        [@sprint.start_date, @sprint.effective_date]
-      end
-    end
+    expect(page)
+      .to have_content(sprint.name)
+    expect(page)
+      .to have_content "#{format_date(sprint.start_date)} – #{format_date(sprint.finish_date)}"
   end
 end

--- a/modules/backlogs/spec/features/burndown/show_spec.rb
+++ b/modules/backlogs/spec/features/burndown/show_spec.rb
@@ -54,5 +54,7 @@ RSpec.describe "Show burndown chart", :js, with_flag: { scrum_projects: true } d
       .to have_content(sprint.name)
     expect(page)
       .to have_content "#{format_date(sprint.start_date)} – #{format_date(sprint.finish_date)}"
+    expect(page)
+      .to have_css "opce-burndown-chart"
   end
 end

--- a/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
+++ b/modules/backlogs/spec/features/tasks_on_taskboard_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "Tasks on taskboard", :js,
     # There is a button to the burndown chart
     expect(page)
       .to have_css("a[href='#{backlogs_project_sprint_burndown_chart_path(project, sprint)}']",
-                   text: "Burndown Chart")
+                   text: "Burndown chart")
 
     # Tasks can get a color per assigned user
     visit my_interface_path

--- a/modules/backlogs/spec/models/burndown_spec.rb
+++ b/modules/backlogs/spec/models/burndown_spec.rb
@@ -37,32 +37,26 @@ RSpec.describe Burndown do
     story.journals[-1].update_columns(created_at: day, updated_at: day, validity_period: day..Float::INFINITY)
   end
 
-  let(:user) { create(:user) }
+  let(:project) { create(:project) }
   let(:role) { create(:project_role) }
   let(:type_feature) { create(:type_feature) }
   let(:type_task) { create(:type_task) }
   let(:issue_priority) { create(:priority, is_default: true) }
 
-  let(:project) do
-    project = build(:project)
-    project.members = [build(:member,
-                             principal: user,
-                             project:,
-                             roles: [role])]
-    project
+  let!(:non_working_days) do
+    [
+      create(:non_working_day, date: Date.new(2011, 4, 2)),
+      create(:non_working_day, date: Date.new(2011, 4, 3)),
+      create(:non_working_day, date: Date.new(2011, 4, 9)),
+      create(:non_working_day, date: Date.new(2011, 4, 10))
+    ]
   end
 
   let(:issue_open) { create(:status, name: "status 1", is_default: true) }
   let(:issue_closed) { create(:status, name: "status 2", is_closed: true) }
   let(:issue_resolved) { create(:status, name: "status 3", is_closed: false) }
 
-  before do
-    Rails.cache.clear
-
-    login_as(user)
-
-    project.save!
-  end
+  current_user { create(:user, member_with_roles: { project => role }) }
 
   subject(:burndown) { described_class.new(sprint, project) }
 
@@ -199,14 +193,6 @@ RSpec.describe Burndown do
   end
 
   describe "for an agile sprint" do
-    let!(:non_working_days) do
-      [
-        create(:non_working_day, date: Date.new(2011, 4, 2)),
-        create(:non_working_day, date: Date.new(2011, 4, 3)),
-        create(:non_working_day, date: Date.new(2011, 4, 9)),
-        create(:non_working_day, date: Date.new(2011, 4, 10))
-      ]
-    end
     let(:sprint) { create(:agile_sprint, project:) }
 
     describe "WITH the today date fixed to April 4th, 2011 and having a 10 (working days) sprint" do

--- a/modules/backlogs/spec/models/burndown_spec.rb
+++ b/modules/backlogs/spec/models/burndown_spec.rb
@@ -42,8 +42,6 @@ RSpec.describe Burndown do
   let(:type_feature) { create(:type_feature) }
   let(:type_task) { create(:type_task) }
   let(:issue_priority) { create(:priority, is_default: true) }
-  let(:version) { create(:version, project:) }
-  let(:sprint) { Sprint.find(version.id) }
 
   let(:project) do
     project = build(:project)
@@ -63,23 +61,22 @@ RSpec.describe Burndown do
 
     login_as(user)
 
-    allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ "points_burn_direction" => "down",
-                                                                         "wiki_template" => "",
-                                                                         "story_types" => [type_feature.id.to_s],
-                                                                         "task_type" => type_task.id.to_s })
-
     project.save!
-
-    [issue_open, issue_closed, issue_resolved].permutation(2).each do |transition|
-      create(:workflow,
-             old_status: transition[0],
-             new_status: transition[1],
-             role:,
-             type_id: type_feature.id)
-    end
   end
 
-  describe "Sprint Burndown" do
+  subject(:burndown) { described_class.new(sprint, project) }
+
+  describe "for a version sprint" do
+    let(:version) { create(:version, project:) }
+    let(:sprint) { Sprint.find(version.id) }
+
+    before do
+      allow(Setting).to receive(:plugin_openproject_backlogs).and_return({ "points_burn_direction" => "down",
+                                                                           "wiki_template" => "",
+                                                                           "story_types" => [type_feature.id.to_s],
+                                                                           "task_type" => type_task.id.to_s })
+    end
+
     describe "WITH the today date fixed to April 4th, 2011 and having a 10 (working days) sprint" do
       before do
         allow(Time).to receive(:now).and_return(Time.utc(2011, "apr", 4, 20, 15, 1))
@@ -93,8 +90,8 @@ RSpec.describe Burndown do
           version.save!
         end
 
-        it "generates a burndown" do
-          expect(sprint.burndown(project).series[:story_points]).to be_empty
+        it "generates an empty burndown" do
+          expect(burndown.series[:story_points]).to be_empty
         end
       end
 
@@ -123,8 +120,6 @@ RSpec.describe Burndown do
               story.save!
               story.last_journal.update_columns(created_at: story.created_at, updated_at: story.created_at)
             end
-
-            subject(:burndown) { described_class.new(sprint, project) }
 
             describe "WITH the story being closed and opened again within the sprint duration" do
               before do
@@ -189,12 +184,150 @@ RSpec.describe Burndown do
               end
 
               describe "THEN" do
-                subject(:burndown) { described_class.new(sprint, project) }
-
                 it { expect(burndown.story_points).to eql [90.0, 80.0, 70.0, 60.0, 50.0, 50.0] }
                 it { expect(burndown.story_points.unit).to be :points }
                 it { expect(burndown.days).to eql(sprint.days) }
                 it { expect(burndown.max[:hours]).to be 0.0 }
+                it { expect(burndown.max[:points]).to be 90.0 }
+                it { expect(burndown.story_points_ideal).to eql [90.0, 80.0, 70.0, 60.0, 50.0, 40.0, 30.0, 20.0, 10.0, 0.0] }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "for an agile sprint" do
+    let!(:non_working_days) do
+      [
+        create(:non_working_day, date: Date.new(2011, 4, 2)),
+        create(:non_working_day, date: Date.new(2011, 4, 3)),
+        create(:non_working_day, date: Date.new(2011, 4, 9)),
+        create(:non_working_day, date: Date.new(2011, 4, 10))
+      ]
+    end
+    let(:sprint) { create(:agile_sprint, project:) }
+
+    describe "WITH the today date fixed to April 4th, 2011 and having a 10 (working days) sprint" do
+      before do
+        allow(Time).to receive(:now).and_return(Time.utc(2011, "apr", 4, 20, 15, 1))
+        allow(Date).to receive(:today).and_return(Date.civil(2011, 4, 4))
+      end
+
+      describe "WITH having a sprint in the future" do
+        before do
+          sprint.start_date = Time.zone.today + 1.day
+          sprint.finish_date = Time.zone.today + 6.days
+          sprint.save!
+        end
+
+        it "generates an empty burndown" do
+          expect(burndown.series[:story_points]).to be_empty
+        end
+      end
+
+      describe "WITH having a 10 (working days) sprint and being 5 (working) days into it" do
+        before do
+          sprint.start_date = Time.zone.today - 7.days
+          sprint.finish_date = Time.zone.today + 6.days
+          sprint.save!
+        end
+
+        describe "WITH 1 story assigned to the sprint" do
+          let(:story) do
+            build(:story, subject: "Story 1",
+                          project:,
+                          sprint:,
+                          type: type_feature,
+                          status: issue_open,
+                          priority: issue_priority,
+                          created_at: Time.zone.today - 20.days,
+                          updated_at: Time.zone.today - 20.days)
+          end
+
+          describe "WITH the story having story_point defined on creation" do
+            before do
+              story.story_points = 9
+              story.save!
+              story.last_journal.update_columns(created_at: story.created_at, updated_at: story.created_at)
+            end
+
+            describe "WITH the story being closed and opened again within the sprint duration" do
+              before do
+                set_attribute_journalized story, :status_id=, issue_closed.id, 6.days.ago
+                set_attribute_journalized story, :status_id=, issue_open.id, 3.days.ago
+              end
+
+              it { expect(burndown.story_points).to eql [9.0, 0.0, 0.0, 0.0, 9.0, 9.0] }
+              it { expect(burndown.story_points.unit).to be :points }
+
+              it {
+                expect(burndown.days).to eql(Day.working.from_range(from: sprint.start_date,
+                                                                    to: sprint.finish_date).map(&:date))
+              }
+
+              it { expect(burndown.max[:points]).to be 9.0 }
+              it { expect(burndown.story_points_ideal).to eql [9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0] }
+            end
+
+            describe "WITH the story marked as resolved and consequently 'done'" do
+              before do
+                set_attribute_journalized story, :status_id=, issue_resolved.id, 6.days.ago
+                set_attribute_journalized story, :status_id=, issue_open.id, 3.days.ago
+                project.done_statuses << issue_resolved
+              end
+
+              it { expect(story.done?).to be false }
+              it { expect(burndown.story_points).to eql [9.0, 0.0, 0.0, 0.0, 9.0, 9.0] }
+            end
+          end
+        end
+
+        describe "WITH 10 stories assigned to the sprint" do
+          let!(:stories) do
+            stories = []
+
+            10.times do |i|
+              stories[i] = create(:story, subject: "Story #{i}",
+                                          project:,
+                                          sprint:,
+                                          type: type_feature,
+                                          status: issue_open,
+                                          priority: issue_priority,
+                                          created_at: Time.zone.today - (20 - i).days,
+                                          updated_at: Time.zone.today - (20 - i).days)
+              stories[i].last_journal.update_columns(created_at: stories[i].created_at,
+                                                     updated_at: stories[i].created_at,
+                                                     validity_period: stories[i].created_at..Float::INFINITY)
+            end
+
+            stories
+          end
+
+          describe "WITH each story having story points defined at start" do
+            before do
+              stories.each do |s|
+                set_attribute_journalized s, :story_points=, 10, sprint.start_date - 3.days
+              end
+            end
+
+            describe "WITH 5 stories having been reduced to 0 story points, one story per day" do
+              before do
+                5.times do |i|
+                  set_attribute_journalized stories[i], :story_points=, nil, sprint.start_date + i.days + 1.hour
+                end
+              end
+
+              describe "THEN" do
+                it { expect(burndown.story_points).to eql [90.0, 80.0, 70.0, 60.0, 50.0, 50.0] }
+                it { expect(burndown.story_points.unit).to be :points }
+
+                it {
+                  expect(burndown.days).to eql(Day.working.from_range(from: sprint.start_date,
+                                                                      to: sprint.finish_date).map(&:date))
+                }
+
                 it { expect(burndown.max[:points]).to be 90.0 }
                 it { expect(burndown.story_points_ideal).to eql [90.0, 80.0, 70.0, 60.0, 50.0, 40.0, 30.0, 20.0, 10.0, 0.0] }
               end

--- a/modules/backlogs/spec/models/burndown_spec.rb
+++ b/modules/backlogs/spec/models/burndown_spec.rb
@@ -322,5 +322,25 @@ RSpec.describe Burndown do
         end
       end
     end
+
+    context "without dates on the sprint" do
+      let(:sprint) { create(:agile_sprint, project:, start_date: nil, finish_date: nil) }
+      let(:story) do
+        build(:story,
+              :created_in_past,
+              subject: "Story 1",
+              project:,
+              sprint:,
+              type: type_feature,
+              status: issue_open,
+              priority: issue_priority,
+              created_at: Time.zone.today - 20.days,
+              updated_at: Time.zone.today - 20.days)
+      end
+
+      it "generates an empty burndown" do
+        expect(burndown.series[:story_points]).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73531

# What are you trying to accomplish?

For active sprints:
* show a "Burndown chart" menu item
* the menu item takes the user to the burndown chart
* that chart works for the `Agile::Sprint` model

There should not be functional changes in the way the burndown data is collected. It does so by fetching data from the journals and sums them up. Because `Agile::Sprint` was introduced and the type restriction removed, there are now different filters active if an `Agile::Sprint` is used compared to the former `Sprint` object.

The sql has been simplified. This was made possible because journals by now have the `validity_period` column and there is always only one journal active for a work package at a given time. By using that column, finding the last journal active on the day, the one that has the relevant data, is quite simple and no longer requires ordering all journals (in the version/sprint). The check for the last journal has become time zone dependent which is probably what the user expects. But it can mean that users in Nepal will get a different burndown compared to their team members in Canada.   

The one change that would also affect users not having the feature flag active is that non working days are now taken from the configuration, where before, it was statically set to be Sa and Su. 

## Screenshots

<img width="1176" height="694" alt="image" src="https://github.com/user-attachments/assets/38b50527-13e5-46a8-8140-814d2555a5d6" />

# Merge checklist

- [x] Added/updated tests