### PR TITLE
fix(documents): add grace period to disconnect handler to suppress transient blips

### DIFF
--- a/frontend/src/react/hooks/useCollaboration.ts
+++ b/frontend/src/react/hooks/useCollaboration.ts
@@ -138,17 +138,33 @@ function useProviderAuthError(onAuthError:() => void) {
 function useCollaboration(provider:HocuspocusProvider) {
   const [isLoading, setIsLoading] = useState(true);
   const [offlineMode, setOfflineMode] = useState(false);
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearDisconnectTimer = useCallback(() => {
+    if (disconnectTimerRef.current !== null) {
+      clearTimeout(disconnectTimerRef.current);
+      disconnectTimerRef.current = null;
+    }
+  }, []);
 
   const handleSynced = useCallback(() => {
     debugLog('(BlockNote Editor) synced with collaboration server');
+    clearDisconnectTimer();
     setIsLoading(false);
     setOfflineMode(false);
-  }, []);
+  }, [clearDisconnectTimer]);
 
   const handleDisconnect = useCallback(() => {
-    debugLog('(BlockNote Editor) Disconnected - offline mode');
+    debugLog('(BlockNote Editor) Disconnected — starting grace period');
     setIsLoading(false);
-    setOfflineMode(true);
+    // Don't go offline immediately. Start a grace timer so that transient
+    // reconnections (idle heartbeat, token-expiry reconnect) never surface
+    // to the user. If synced fires within the window the timer is cancelled.
+    disconnectTimerRef.current ??= setTimeout(() => {
+      disconnectTimerRef.current = null;
+      debugLog('(BlockNote Editor) Grace period expired — offline mode');
+      setOfflineMode(true);
+    }, 5_000);
   }, []);
 
   const handleTimeout = useCallback(() => {
@@ -158,9 +174,14 @@ function useCollaboration(provider:HocuspocusProvider) {
   }, []);
 
   const handleAuthError = useCallback(() => {
+    // Auth errors are permanent — bypass the grace period.
+    clearDisconnectTimer();
     setOfflineMode(true);
     setIsLoading(false);
-  }, []);
+  }, [clearDisconnectTimer]);
+
+  // Clean up the grace timer on unmount.
+  useEffect(() => clearDisconnectTimer, [clearDisconnectTimer]);
 
   useConnectionTimeout(provider, handleTimeout);
   useCollaborationProvider(provider, handleSynced, handleDisconnect);


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/73571

## What are you trying to accomplish?

The document editor flashes a connection error banner (and briefly unmounts the editor) during normal operation — typically after ~30 seconds of idle time or when the browser throttles token-refresh timers in a backgrounded tab. The underlying HocusPocus connection recovers within ~1 second, but the UI reacts as if the connection is permanently lost.

## What approach did you choose and why?

The root cause is that `useCollaboration` treats every WebSocket `disconnect` event as a sustained outage, immediately setting `offlineMode = true` — which unmounts the entire editor. But the HocusPocus provider fires `disconnect` on *any* WebSocket close, including routine reconnection cycles (idle heartbeat, token-expiry race).

The fix adds a 5-second grace period before transitioning to offline mode. If the provider re-syncs within that window (which it does for transient disconnects), the timer is cancelled and no UI disruption occurs. Auth errors bypass the grace period since they're permanent.

This is safe because the Y.Doc already has synced content at this point — the empty-doc data loss scenario from #21415 only applies to the initial connection, which is separately guarded by `isLoading`.

## Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)