### PR TITLE
fix(documents): add grace period to disconnect handler to suppress transient blips

### DIFF
--- a/frontend/src/react/hooks/useCollaboration.ts
+++ b/frontend/src/react/hooks/useCollaboration.ts
@@ -112,21 +112,41 @@ export function useCollaboration(
 ) {
   const [isLoading, setIsLoading] = useState(true);
   const [connectionError, setConnectionError] = useState(false);
+  const disconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearDisconnectTimer = useCallback(() => {
+    if (disconnectTimerRef.current !== null) {
+      clearTimeout(disconnectTimerRef.current);
+      disconnectTimerRef.current = null;
+    }
+  }, []);
 
   const handleSynced = useCallback(() => {
     debugLog('(BlockNote Editor) synced with collaboration server');
+    clearDisconnectTimer();
     setIsLoading(false);
     setConnectionError(false);
-  }, []);
+  }, [clearDisconnectTimer]);
 
   const handleDisconnect = useCallback(() => {
-    debugLog('(BlockNote Editor) Disconnected from collaboration server');
-    setConnectionError(true);
+    debugLog('(BlockNote Editor) Disconnected — starting grace period');
+    // Don't flag a connection error immediately. Start a grace timer so that
+    // transient reconnections (idle heartbeat, token-expiry reconnect) never
+    // surface to the user. If synced fires within the window the timer is
+    // cancelled.
+    disconnectTimerRef.current ??= setTimeout(() => {
+      disconnectTimerRef.current = null;
+      debugLog('(BlockNote Editor) Grace period expired — connection error');
+      setConnectionError(true);
+    }, 5_000);
   }, []);
 
   const hasTimedOut = useConnectionTimeout(provider);
   useCollaborationProvider(provider, handleSynced, handleDisconnect);
   useLocalDocumentSync(doc, inputField, !provider);
+
+  // Clean up the grace timer on unmount and when the provider changes.
+  useEffect(() => clearDisconnectTimer, [provider, clearDisconnectTimer]);
 
   useEffect(() => {
     if (!provider) {
@@ -146,12 +166,14 @@ export function useCollaboration(
     const handleProviderAuthError = (event:Event) => {
       const customEvent = event as CustomEvent<{ kind:ProviderAuthErrorKind; message:string }>;
       debugLog(`(BlockNote Editor) Provider auth error: ${customEvent.detail.kind} - ${customEvent.detail.message}`);
+      // Auth errors are permanent — bypass the grace period.
+      clearDisconnectTimer();
       setConnectionError(true);
     };
 
     document.addEventListener(PROVIDER_AUTH_ERROR_EVENT, handleProviderAuthError);
     return () => document.removeEventListener(PROVIDER_AUTH_ERROR_EVENT, handleProviderAuthError);
-  }, []);
+  }, [clearDisconnectTimer]);
 
   return { isLoading, connectionError } as const;
 }


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/73571

## What are you trying to accomplish?

The document editor flashes a connection error banner (and briefly unmounts the editor) during normal operation — typically after ~30 seconds of idle time or when the browser throttles token-refresh timers in a backgrounded tab. The underlying HocusPocus connection recovers within ~1 second, but the UI reacts as if the connection is permanently lost.

## What approach did you choose and why?

The root cause is that `useCollaboration` treats every WebSocket `disconnect` event as a sustained outage, immediately setting `offlineMode = true` — which unmounts the entire editor. But the HocusPocus provider fires `disconnect` on *any* WebSocket close, including routine reconnection cycles (idle heartbeat, token-expiry race).

The fix adds a 5-second grace period before transitioning to offline mode. If the provider re-syncs within that window (which it does for transient disconnects), the timer is cancelled and no UI disruption occurs. Auth errors bypass the grace period since they're permanent.

This is safe because the Y.Doc already has synced content at this point — the empty-doc data loss scenario from #21415 only applies to the initial connection, which is separately guarded by `isLoading`.

Additionally, the grace timer cleanup effect now also depends on `provider`, so any pending disconnect timer is cleared whenever the provider instance is replaced (e.g., during navigation or session refresh). This prevents a stale timer from an old provider incorrectly setting `connectionError` on the new provider instance.

## Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)