### PR TITLE
Bug/72951 wrong message when wp created in backlogs

### DIFF
--- a/app/controllers/work_packages/dialogs_controller.rb
+++ b/app/controllers/work_packages/dialogs_controller.rb
@@ -45,7 +45,7 @@ class WorkPackages::DialogsController < ApplicationController
     call = WorkPackages::CreateService.new(user: current_user).call(create_params)
 
     if call.success?
-      flash[:notice] = I18n.t("work_package_relations_tab.relations.label_new_child_created")
+      flash[:notice] = create_success_message(call.result)
       redirect_back fallback_location: project_work_package_path(@project, call.result), status: :see_other
     else
       form_component = WorkPackages::Dialogs::CreateFormComponent.new(work_package: call.result, project: @project)
@@ -98,5 +98,13 @@ class WorkPackages::DialogsController < ApplicationController
       type: contract.assignable_types.first,
       project: @project
     }
+  end
+
+  def create_success_message(work_package)
+    if work_package.child?
+      I18n.t("work_package_relations_tab.relations.label_new_child_created")
+    else
+      I18n.t(:notice_successful_create)
+    end
   end
 end

--- a/modules/backlogs/spec/features/backlogs/create_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Create", :js do
           click_on "Create"
         end
 
-        expect_and_dismiss_flash(message: "Successful creation.")
+        expect_and_dismiss_flash(exact_message: "Successful creation.")
         planning_page.expect_sprint_names_in_order(initial_sprint.name, "Created sprint")
 
         sprint = project.reload.sprints.last

--- a/modules/backlogs/spec/features/backlogs/create_story_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/create_story_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "Backlogs", :js do
       click_on "Create"
     end
 
-    expect_and_dismiss_flash type: :success, message: "New work package created"
+    expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
     # velocity should be summed up immediately
     # TODO: removed in OP #57688, to be reimplemented

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Edit", :js do
 
       wait_for_reload
 
-      expect_and_dismiss_flash type: :success, message: "New work package created and added as a child"
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
       created_wp = first_sprint.reload.work_packages.last
       expect(created_wp.subject).to eq("Story created in sprint")
       planning_page.expect_story_in_sprint(created_wp, first_sprint)

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Create work package in sprint", :js, with_flag: { scrum_projects
         click_on "Create"
       end
 
-      expect_and_dismiss_flash type: :success, message: "New work package created"
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
       created_work_package = WorkPackage.last
 
@@ -144,7 +144,7 @@ RSpec.describe "Create work package in sprint", :js, with_flag: { scrum_projects
         click_on "Create"
       end
 
-      expect_and_dismiss_flash type: :success, message: "New work package created"
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
       created_work_package = WorkPackage.last
 
@@ -166,7 +166,7 @@ RSpec.describe "Create work package in sprint", :js, with_flag: { scrum_projects
         click_on "Create"
       end
 
-      expect_and_dismiss_flash type: :success, message: "New work package created"
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
 
       created_work_package = WorkPackage.last
 

--- a/spec/features/work_packages/tabs/relations_children_spec.rb
+++ b/spec/features/work_packages/tabs/relations_children_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
 
       wait_for_network_idle
 
+      expect_and_dismiss_flash type: :success, exact_message: "New work package created and added as a child"
+
       page.within("#work-package-relations-tab-content") do
         expect(page).to have_content("Hello there")
         expect(page).to have_content("RISK")
@@ -82,6 +84,8 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
         create_dialog.submit
 
         wait_for_network_idle
+
+        expect_and_dismiss_flash type: :success, exact_message: "New work package created and added as a child"
 
         page.within("#work-package-relations-tab-content") do
           expect(page).to have_content("Hello there")
@@ -135,6 +139,8 @@ RSpec.describe "Relations children tab", :js, :with_cuprite do
         create_dialog.submit
 
         wait_for_network_idle
+
+        expect_and_dismiss_flash type: :success, exact_message: "New work package created and added as a child"
 
         page.within("#work-package-relations-tab-content") do
           expect(page).to have_content("Hello there")

--- a/spec/support/components/work_packages/create_dialog.rb
+++ b/spec/support/components/work_packages/create_dialog.rb
@@ -47,6 +47,8 @@ module Components
         in_dialog do
           select_combo_box_option value, from: "Type"
         end
+
+        wait_for_network_idle # form is updated
       end
 
       def set_subject(value)

--- a/spec/support/components/work_packages/relations.rb
+++ b/spec/support/components/work_packages/relations.rb
@@ -62,13 +62,13 @@ module Components
         # Search the current window in order to avoid within scope restrictions
         within_window(page.current_window) do
           within("wp-relations-tab") do
-            expect(page).to have_no_css("op-content-loader")
+            expect(page).to have_no_css("op-content-loader", wait: 10)
           end
         end
       end
 
       def expect_add_relation_button
-        expect(page).to have_test_selector("add-relation-action-menu")
+        expect(page).to have_test_selector("add-relation-action-menu", wait: 10)
       end
 
       def expect_no_add_relation_button
@@ -145,7 +145,7 @@ module Components
       end
 
       def new_relation_button
-        page.find(id: "add-relation-action-menu-button")
+        page.find(id: "add-relation-action-menu-button", wait: 10)
       end
 
       def new_relation_sub_menu_button

--- a/spec/support/flash/expectations.rb
+++ b/spec/support/flash/expectations.rb
@@ -2,9 +2,11 @@
 
 module Flash
   module Expectations
-    def expect_flash(message:, type: :success, wait: 20)
+    def expect_flash(message: nil, exact_message: nil, type: :success, wait: 20)
+      fail ArgumentError, "provide at least one of message and exact_message" if !message && !exact_message
+
       expected_css = expected_flash_css(type)
-      expect(page).to have_css(expected_css, text: message, wait:)
+      expect(page).to have_css(expected_css, wait:, **{ text: message, exact_text: exact_message }.compact)
     end
 
     def find_flash_element(type:)
@@ -12,22 +14,22 @@ module Flash
       page.find(expected_css)
     end
 
-    def expect_and_dismiss_flash(message: nil, type: :success, wait: 20)
-      expect_flash(type:, message:, wait:)
+    def expect_and_dismiss_flash(message: nil, exact_message: nil, type: :success, wait: 20)
+      expect_flash(type:, message:, exact_message:, wait:)
       dismiss_flash!
-      expect_no_flash(type:, message:, wait: 0.1)
+      expect_no_flash(type:, message:, exact_message:, wait: 0.1)
     end
 
     def dismiss_flash!
       page.find(".Banner-close button").click # rubocop:disable Capybara/SpecificActions
     end
 
-    def expect_no_flash(type: :success, message: nil, wait: 10)
+    def expect_no_flash(type: :success, message: nil, exact_message: nil, wait: 10)
       if type.nil?
         expect(page).not_to have_test_selector("op-primer-flash-message")
       else
         expected_css = expected_flash_css(type)
-        expect(page).to have_no_css(expected_css, text: message, wait:)
+        expect(page).to have_no_css(expected_css, wait:, **{ text: message, exact_text: exact_message }.compact)
       end
     end
 

--- a/spec/support/flash/expectations.rb
+++ b/spec/support/flash/expectations.rb
@@ -33,8 +33,8 @@ module Flash
 
     def expected_flash_css(type)
       scheme = mapped_flash_type(type)
-      case scheme
-      when :default
+
+      if scheme == :default
         %{[data-test-selector="op-primer-flash-message"].Banner}
       else
         %{[data-test-selector="op-primer-flash-message"].Banner--#{scheme}}
@@ -43,11 +43,9 @@ module Flash
 
     def mapped_flash_type(type)
       case type
-      when :error
-        :error # The class is error, but the scheme is danger
-      when :warning
-        :warning
-      when :success, :notice
+      when :error, :warning, :success
+        type
+      when :notice
         :success
       else
         :default


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72951

# What are you trying to accomplish?
`WorkPackages::DialogsController` is originally created for creating child work packages. As we are reusing it to create work packages directly from sprint, success message should be different if work package is not a child.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
