### PR TITLE
[#73521] Sprint#to_s -> name

### DIFF
--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -100,5 +100,7 @@ module Agile
     def visible_to?(project)
       self.class.for_project(project).exists?(id:)
     end
+
+    def to_s = name
   end
 end

--- a/modules/backlogs/spec/models/agile/sprint_spec.rb
+++ b/modules/backlogs/spec/models/agile/sprint_spec.rb
@@ -343,4 +343,10 @@ RSpec.describe Agile::Sprint do
       end
     end
   end
+
+  describe "#to_s" do
+    it "returns the name" do
+      expect(sprint.to_s).to eq("Sprint 1")
+    end
+  end
 end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
            name: "Rich text project custom field",
            default_value: "rich text field value with a table <table></table>")
   end
+  let(:enabled_module_names) { nil }
   let(:project) do
     create(:project,
            name: "Foo Bla. Report No. 4/2021 with/for Case 42",
            types: [type],
+           **(enabled_module_names ? { enabled_module_names: } : {}),
            public: true,
            status_code: "on_track",
            description: "A **rich** text description",
@@ -623,6 +625,66 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           expect(pdf[:logos].first.hash[:Height]).to eq(30)
           expect(pdf[:logos].first.hash[:Width]).to eq(149)
         end
+      end
+    end
+
+    context "with the backlogs module enabled and the feature flag active", with_flag: { scrum_projects: true } do
+      let(:enabled_module_names) { %i[backlogs] }
+      let(:sprint) { create(:agile_sprint, name: "Sprint name for export", project:) }
+
+      let(:expected_details) do
+        result = [
+          "#{type.name} ##{work_package.id} - #{work_package.subject}",
+          " ", exporter.prawn_badge_text_stuffing(work_package.status.name.downcase), # badge & padding
+          "People",
+          "Assignee", user.name,
+          "Accountable", user.name,
+          "Estimates and progress",
+          "Work", "10h",
+          "Remaining work", "9h",
+          "% Complete", "25%",
+          "Spent time", "0h",
+          # Story points added by the backlogs module:
+          "Story Points", "1",
+          "Details",
+          "Priority", "Normal",
+          # Sprint added by the backlogs module and feature flag:
+          "Sprint", work_package.sprint,
+          "Version", work_package.version,
+          "Category", work_package.category,
+          "Project phase",
+          "Date", "05/30/2024 - 03/13/2025",
+          "Other",
+          # Position added by the backlogs module:
+          "Position", "1",
+          "Work Package Custom Field Long Text", "foo   faa",
+          "Empty Work Package Custom Field Long Text",
+          "Work Package Custom Field Boolean", "Yes",
+          "My Link", "https://example.com",
+          "Costs",
+          "Spent units", "Labor costs", "Unit costs", "Overall costs", "Budget"
+        ]
+        result
+      end
+
+      before do
+        work_package.sprint = sprint
+        work_package.save!
+      end
+
+      it "contains correct data" do
+        result = remove_pdf_page_footers(pdf[:strings].join(" "), 2)
+        expected_result = [
+          *expected_details,
+          label_title(:description),
+          "Lorem", " ", "ipsum", " ", "dolor", " ", "sit", " ",
+          "amet", ", consetetur sadipscing elitr.", " ", "@OpenProject Admin",
+          "Image Caption",
+          "Image Redirect",
+          "Foo"
+        ].flatten.join(" ")
+        expect(result).to eq(expected_result)
+        expect(result).not_to include("DisabledCustomField")
       end
     end
   end

--- a/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
+++ b/spec/models/work_packages/pdf_export/work_package_to_pdf_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
     end
   end
   let(:expected_details) do
-    result = [
+    [
       "#{type.name} ##{work_package.id} - #{work_package.subject}",
       " ", exporter.prawn_badge_text_stuffing(work_package.status.name.downcase), # badge & padding
       "People",
@@ -259,7 +259,6 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       "Costs",
       "Spent units", "Labor costs", "Unit costs", "Overall costs", "Budget"
     ]
-    result
   end
 
   def get_column_value(column_name)
@@ -633,7 +632,7 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
       let(:sprint) { create(:agile_sprint, name: "Sprint name for export", project:) }
 
       let(:expected_details) do
-        result = [
+        [
           "#{type.name} ##{work_package.id} - #{work_package.subject}",
           " ", exporter.prawn_badge_text_stuffing(work_package.status.name.downcase), # badge & padding
           "People",
@@ -664,7 +663,6 @@ RSpec.describe WorkPackage::PDFExport::WorkPackageToPdf do
           "Costs",
           "Spent units", "Labor costs", "Unit costs", "Overall costs", "Budget"
         ]
-        result
       end
 
       before do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73521

# What are you trying to accomplish?
Fix the representation of Sprints within PDF exports by overriding the `to_s` method of sprints.

I provided a basic spec to verify the new behavior to work in PDF exports. It would have been cleaner to add the spec to the backlogs modules spec folder - but that would have required copying the entire setup, so I kept it simple.

## Screenshots

https://github.com/user-attachments/assets/1ddd7c3e-0a2e-4610-bde5-289aa0d2fd45

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
