### PR TITLE
[73594] Flash banner elements are misaligned

### DIFF
--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -180,5 +180,5 @@ ul.SegmentedControl,
       grid-template-columns: min-content 1fr min-content
       grid-template-rows: min-content min-content
 
-    & .Banner-actions
-      margin: var(--base-size-8) 0 0 var(--base-size-8)
+      & .Banner-actions
+        margin: var(--base-size-8) 0 0 var(--base-size-8)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73594

# What are you trying to accomplish?
Apply button styles only when container query is met

## Screenshots
<img width="1040" height="182" alt="Bildschirmfoto 2026-04-01 um 08 55 22" src="https://github.com/user-attachments/assets/5cdddd2b-716f-49ac-85da-bb28cd2b48c2" />

<img width="632" height="270" alt="Bildschirmfoto 2026-04-01 um 08 55 12" src="https://github.com/user-attachments/assets/0eb865f4-60a1-4806-a6a8-96fd2250e999" />
