### PR TITLE
move to a previous based positioning on drag&drop

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -47,8 +47,13 @@ export default class GenericDragAndDropController extends Controller {
   containerTargets:HTMLElement[];
   scrollContainerTargets:HTMLElement[];
 
-  static values = { handleSelector: { type: String, default: '.DragHandle' } };
+  static values = {
+    handleSelector: { type: String, default: '.DragHandle' },
+    positionMode: { type: String, default: 'index' },
+  };
+
   declare readonly handleSelectorValue:string;
+  declare readonly positionModeValue:string;
 
   private drake:Drake|null = null;
   private autoscroll:DomAutoscrollService|null = null;
@@ -192,17 +197,13 @@ export default class GenericDragAndDropController extends Controller {
   }
 
   protected buildData(el:Element, target:Element):FormData {
-    let targetPosition = Array.from(target.children).indexOf(el);
-    if (target.children.length > 0 && target.children[0].getAttribute('data-empty-list-item') === 'true') {
-      // if the target container is empty, a list item showing an empty message might be shown
-      // this should not be counted as a list item
-      // thus we need to subtract 1 from the target position
-      targetPosition -= 1;
-    }
-
     const data = new FormData();
 
-    data.append('position', (targetPosition + 1).toString());
+    if (this.positionModeValue === 'prev_id') {
+      data.append('prev_id', this.resolveTargetPrevious(el) ?? '');
+    } else {
+      data.append('position', this.resolveTargetPosition(el, target).toString());
+    }
 
     const targetConfig = this.targetConfigs.find((config) => config.container === target);
     const targetId = targetConfig?.targetId as string|undefined;
@@ -224,5 +225,24 @@ export default class GenericDragAndDropController extends Controller {
     const container = target.querySelector<HTMLElement>(accessor);
     invariant(container, `Expected container element matching "${accessor}"`);
     return container;
+  }
+
+  // Returns the data-draggable-id of the element preceding el in its container,
+  // or null if el is the first item (signals "move to top").
+  private resolveTargetPrevious(el:Element):string|null {
+    return el.previousElementSibling?.getAttribute('data-draggable-id') ?? null;
+  }
+
+  private resolveTargetPosition(el:Element, container:Element):number {
+    let targetPosition = Array.from(container.children).indexOf(el);
+
+    if (container.children.length > 0 && container.children[0].getAttribute('data-empty-list-item') === 'true') {
+      // if the target container is empty, a list item showing an empty message might be shown
+      // this should not be counted as a list item
+      // thus we need to subtract 1 from the target position
+      targetPosition -= 1;
+    }
+
+    return targetPosition + 1;
   }
 }

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -83,7 +83,13 @@ See COPYRIGHT and LICENSE files for more details.
     <% if paginate? %>
       <% border_box.with_row(
            id: "inbox-more-row-#{project.id}", scheme: :neutral,
-           classes: "backlogs-inbox-component--show-more-row"
+           classes: "backlogs-inbox-component--show-more-row",
+           # This exists for the edge case of a user dragging a work package just below the fold.
+           # The dragged work package is then placed just after the last work package omitted
+           # by the placeholder.
+           data: {
+             draggable_id: id_of_last_omitted_in_middle
+           }
          ) do %>
         <%=
           render(

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -83,6 +83,10 @@ module Backlogs
       work_packages.last(LAST_PAGE_SIZE)
     end
 
+    def id_of_last_omitted_in_middle
+      work_packages.reverse_order.offset(LAST_PAGE_SIZE).limit(1).pick(:id)
+    end
+
     def middle_count
       total - FIRST_PAGE_SIZE - LAST_PAGE_SIZE
     end

--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -102,11 +102,17 @@ class InboxController < RbApplicationController
 
   def move_params
     params.require(%i[target_id])
-    params.permit(:position, :target_id)
+    params.permit(:position, :prev_id, :target_id)
   end
 
   def position_attributes
-    { position: move_params[:position]&.to_i }.compact
+    if move_params.has_key?(:prev_id)
+      { prev_id: move_params[:prev_id].to_i }
+    elsif move_params.has_key?(:position)
+      { position: move_params[:position].to_i }
+    else
+      {}
+    end
   end
 
   def reorder_param

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -112,10 +112,7 @@ class RbStoriesController < RbApplicationController
   def update_story_with_target_and_position(attributes:)
     Stories::UpdateService
       .new(user: current_user, story: @story)
-      .call(
-        attributes:,
-        position: move_params[:position].to_i
-      )
+      .call(attributes:, **position_attributes)
   end
 
   def replace_typed_component_via_turbo_stream(sprint:)
@@ -212,8 +209,18 @@ class RbStoriesController < RbApplicationController
   end
 
   def move_params
-    params.require(%i[position target_id])
-    params.permit(:position, :target_id)
+    params.require(%i[target_id])
+    params.permit(:position, :prev_id, :target_id)
+  end
+
+  def position_attributes
+    if move_params.has_key?(:prev_id)
+      { prev_id: move_params[:prev_id].to_i }
+    elsif move_params.has_key?(:position)
+      { position: move_params[:position].to_i }
+    else
+      {}
+    end
   end
 
   def reorder_param

--- a/modules/backlogs/app/services/stories/update_service.rb
+++ b/modules/backlogs/app/services/stories/update_service.rb
@@ -34,14 +34,18 @@ class Stories::UpdateService
     self.story = story
   end
 
-  def call(attributes: {}, position: nil)
+  def call(attributes: {}, position: nil, prev_id: nil)
     create_call = WorkPackages::UpdateService
                   .new(user:,
                        model: story)
                   .call(**attributes.to_h.symbolize_keys)
 
-    if create_call.success? && position
-      create_call.result.move_after(position:)
+    if create_call.success?
+      if prev_id
+        create_call.result.move_after(prev_id: prev_id.to_i)
+      elsif position
+        create_call.result.move_after(position:)
+      end
     end
 
     create_call

--- a/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_sprint_planning_list.html.erb
@@ -28,7 +28,8 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= turbo_frame_tag "backlogs_container", refresh: :morph, class: "op-backlogs-page" do %>
-  <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop">
+  <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop"
+       data-generic-drag-and-drop-position-mode-value="prev_id">
     <div id="owner_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
       <%= render Backlogs::InboxComponent.new(

--- a/modules/backlogs/spec/controllers/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/inbox_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
   describe "PUT #move" do
     let(:agile_sprint) { create(:agile_sprint, name: "Sprint 1", project:) }
     let(:target_id) { "sprint:#{agile_sprint.id}" }
-    let(:position) { 1 }
+    let(:prev_id) { 1 }
 
     subject do
       put :move,
@@ -130,7 +130,7 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
             project_id: project.id,
             id: work_package.id,
             target_id:,
-            position:
+            prev_id:
           },
           format: :turbo_stream
     end
@@ -148,7 +148,7 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
 
     context "when reordering within the Inbox" do
       let(:target_id) { "inbox" }
-      let(:position) { 2 }
+      let(:prev_id) { work_packages.first.id }
 
       it "replaces only the inbox component without a flash", :aggregate_failures do
         expect(response).to be_successful
@@ -167,15 +167,17 @@ RSpec.describe InboxController, with_flag: { scrum_projects_active: true } do
       end
     end
 
-    context "when no position is provided" do
+    context "when no prev_id is provided" do
       let!(:work_packages) { create_list(:work_package, 5, project:, sprint: agile_sprint) }
-      let(:position) { nil }
+      let(:prev_id) { nil }
 
-      it "places the work package at the last position in the sprint" do
+      it "places the work package at the top of the sprint" do
         expect { work_package.reload }
-          .to change(work_package, :position).from(1).to(6)
+          .to not_change(work_package, :position)
         expect { work_packages.each(&:reload) }
-          .not_to change { work_packages.map(&:position) }
+          .to change { work_packages.map(&:position) }
+                .from([1, 2, 3, 4, 5])
+                .to([2, 3, 4, 5, 6])
       end
     end
 

--- a/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_stories_controller_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe RbStoriesController do
                      sprint_id: agile_sprint.id,
                      id: story_in_agile_sprint.id,
                      target_id: "sprint:#{other_agile_sprint.id}",
-                     position: 1
+                     prev_id: nil
                    },
                    format: :turbo_stream
 
@@ -232,7 +232,7 @@ RSpec.describe RbStoriesController do
                        sprint_id: agile_sprint.id,
                        id: story_in_agile_sprint.id,
                        target_id: "sprint:#{other_agile_sprint.id}",
-                       position: 1
+                       prev_id: nil
                      },
                      format: :turbo_stream
 
@@ -260,7 +260,7 @@ RSpec.describe RbStoriesController do
                      sprint_id: agile_sprint.id,
                      id: story_in_agile_sprint.id,
                      target_id: "version:#{version_sprint.id}",
-                     position: 1
+                     prev_id: nil
                    },
                    format: :turbo_stream
 
@@ -287,7 +287,7 @@ RSpec.describe RbStoriesController do
                      sprint_id: agile_sprint.id,
                      id: story_in_agile_sprint.id,
                      target_id: "inbox",
-                     position: 2
+                     prev_id: existing_inbox_item.id
                    },
                    format: :turbo_stream
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_inbox_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+require_relative "../../support/pages/sprint_planning"
+
+RSpec.describe "Dragging work packages in the inbox",
+               :js, with_flag: { scrum_projects: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) { create(:project) }
+  shared_let(:manage_sprint_items_role) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           manage_sprint_items
+                           view_work_packages
+                           edit_work_packages))
+  end
+  shared_let(:edit_role_without_manage_sprint_items) do
+    create(:project_role,
+           permissions: %i(view_sprints
+                           view_work_packages
+                           edit_work_packages))
+  end
+  # The explicit positioning can be removed once the scrum_projects flag is removed
+  shared_let(:inbox_wp1) { create(:work_package, sprint: nil, project:, position: 1) }
+  shared_let(:inbox_wp2) { create(:work_package, sprint: nil, project:, position: 2) }
+  shared_let(:inbox_wp3) { create(:work_package, sprint: nil, project:, position: 3) }
+  shared_let(:inbox_wp4) { create(:work_package, sprint: nil, project:, position: 4) }
+  shared_let(:inbox_wp5) { create(:work_package, sprint: nil, project:, position: 5) }
+
+  let(:backlogs_page) { Pages::SprintPlanning.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_roles: {
+             project => manage_sprint_items_role
+           })
+  end
+
+  it "displays work packages in correct order and allows dragging them around" do
+    backlogs_page.visit!
+
+    backlogs_page
+      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+                                                              inbox_wp2,
+                                                              inbox_wp3,
+                                                              inbox_wp4,
+                                                              inbox_wp5])
+    backlogs_page
+      .drag_work_package(inbox_wp1, before: inbox_wp4)
+
+    backlogs_page
+      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2,
+                                                              inbox_wp3,
+                                                              inbox_wp1,
+                                                              inbox_wp4,
+                                                              inbox_wp5])
+    backlogs_page
+      .drag_work_package(inbox_wp1, before: inbox_wp3)
+
+    backlogs_page
+      .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp2,
+                                                              inbox_wp1,
+                                                              inbox_wp3,
+                                                              inbox_wp4,
+                                                              inbox_wp5])
+  end
+
+  context "when having closed work packages at the top" do
+    let(:closed_status) { create(:closed_status) }
+
+    before do
+      inbox_wp2.update!(status: closed_status)
+      inbox_wp3.update!(status: closed_status)
+    end
+
+    it "displays work packages in correct order and allows dragging them" do
+      backlogs_page.visit!
+
+      backlogs_page
+        .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp1,
+                                                                inbox_wp4,
+                                                                inbox_wp5])
+      backlogs_page
+        .drag_work_package(inbox_wp1, before: inbox_wp5)
+
+      backlogs_page
+        .expect_work_packages_in_inbox_in_order(work_packages: [inbox_wp4,
+                                                                inbox_wp1,
+                                                                inbox_wp5])
+    end
+  end
+
+  context "when lacking the permission to manage sprint items" do
+    current_user do
+      create(:user,
+             member_with_roles: {
+               project => edit_role_without_manage_sprint_items
+             })
+    end
+
+    it "displays work packages in correct order but does not allow dragging them around" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_work_package_not_draggable(inbox_wp1)
+      backlogs_page.expect_work_package_not_draggable(inbox_wp2)
+      backlogs_page.expect_work_package_not_draggable(inbox_wp3)
+      backlogs_page.expect_work_package_not_draggable(inbox_wp4)
+      backlogs_page.expect_work_package_not_draggable(inbox_wp5)
+    end
+  end
+end

--- a/modules/backlogs/spec/models/work_packages/position_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/position_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe WorkPackage, "positions", with_flag: { scrum_projects: true } do 
     end
 
     context "when moving inside a sprint with a previous that is the first element" do
-      it "moves the work_package to the top of the sprint" do
+      it "moves the work_package to the second position" do
         sprint1_wp4.move_after(prev_id: sprint1_wp1.id)
 
         expect(wp_of_sprint_by_id_and_position(sprint1))
@@ -285,6 +285,19 @@ RSpec.describe WorkPackage, "positions", with_flag: { scrum_projects: true } do 
     context "when inside a sprint with a previous that does not exist in that sprint" do
       it "moves the work_package to the top of the sprint" do
         sprint1_wp4.move_after(prev_id: sprint2_wp2.id)
+
+        expect(wp_of_sprint_by_id_and_position(sprint1))
+          .to eq(sprint1_wp4.id => 1,
+                 sprint1_wp1.id => 2,
+                 sprint1_wp2.id => 3,
+                 sprint1_wp3.id => 4,
+                 sprint1_wp5.id => 5)
+      end
+    end
+
+    context "when inside a sprint with a previous that is nil" do
+      it "moves the work_package to the top of the sprint" do
+        sprint1_wp4.move_after(prev_id: nil)
 
         expect(wp_of_sprint_by_id_and_position(sprint1))
           .to eq(sprint1_wp4.id => 1,
@@ -350,8 +363,19 @@ RSpec.describe WorkPackage, "positions", with_flag: { scrum_projects: true } do 
       end
     end
 
-    context "when moving outside a sprint with a previous that is the first element" do
+    context "when moving outside a sprint with a previous that is nil" do
       it "moves the work_package to the top of the sprint" do
+        no_sprint_wp3.move_after(prev_id: nil)
+
+        expect(wp_of_sprint_by_id_and_position(nil))
+          .to eq(no_sprint_wp3.id => 1,
+                 no_sprint_wp1.id => 2,
+                 no_sprint_wp2.id => 3)
+      end
+    end
+
+    context "when moving outside a sprint with a previous that is the first element" do
+      it "moves the work_package to the second position" do
         no_sprint_wp3.move_after(prev_id: no_sprint_wp1.id)
 
         expect(wp_of_sprint_by_id_and_position(nil))

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -124,7 +124,9 @@ module Pages
                          find(sprint_selector(into))
                        end
 
-      moved_element.native.drag_to(target_element.native, delay: 0.1)
+      wait_for_turbo_stream do
+        moved_element.native.drag_to(target_element.native, delay: 0.1)
+      end
     rescue Capybara::Cuprite::ObsoleteNode
       retry
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73533

# What are you trying to accomplish?

Stabilize ordering in the inbox in case:
* there are closed work packages
* sorting happens below the "Show x more items"
* probably also for when multiple users order at the same time
 
Before, the new position was communicated based on DOM elements before in the drop target. E.g. if there where 3 siblings before (representing work packages), the new position was determined to be 4 and that was communicated to the backend.

This does not work in case not all work packages part of the same positioning schema are displayed in the DOM. This can happen if there are closed work packages which the inbox does not show. It also doesn't work if work packages are omitted for brevity as the inbox does.

The new mechanism is based on the id of the previous work package. That information has been present before, used to know the id of the dragged element. Now it is additionally used to set the `prev_id` parameter sent to the backend. If that field is set, the work package's position will be set to be one higher than the one of the `prev`. If `prev_id` is sent without a value, the work package is placed at the very top of the list.

This behaviour is used for both the inbox as well as for the sprints.

There is an edge case with the "See x more items" fold in the inbox. That one would not have an id. It artificially gets one set (the last work package omitted by the fold) without becoming draggable itself.

Cleaning up the code has been deliberately skipped in this PR since it is a bug fix on a release branch. Ideally:
* `position` would no longer be accepted as a parameter by the controllers
* Only one controller would be used for moving work packages. 

# Merge checklist

- [x] Added/updated tests