### PR TITLE
[#73605] Permit identifier suggestion in sub-project creation

### DIFF
--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -249,7 +249,8 @@ Rails.application.reloader.to_prepare do
                      require: :member
 
       map.permission :add_subprojects,
-                     { projects: %i[new create] },
+                     { projects: %i[new create],
+                       "projects/identifier_suggestion": %i[show] },
                      permissible_on: :project,
                      require: :member
 

--- a/spec/requests/projects/identifier_suggestion_spec.rb
+++ b/spec/requests/projects/identifier_suggestion_spec.rb
@@ -71,6 +71,26 @@ RSpec.describe "GET /projects/identifier_suggestion", type: :rails_request do
         expect(response).to have_http_status(:unauthorized).or have_http_status(:redirect)
       end
     end
+
+    context "when user has no permissions" do
+      current_user { create(:user) }
+
+      it "returns forbidden" do
+        get "/projects/identifier_suggestion", params: { name: "Test" }, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when user has add_subprojects permission on a project" do
+      let(:project) { create(:project, identifier: "PRNT") }
+
+      current_user { create(:user, member_with_permissions: { project => %i[add_subprojects] }) }
+
+      it "returns a suggestion" do
+        get "/projects/identifier_suggestion", params: { name: "Test" }, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   context "with numeric (legacy) identifiers", with_settings: { work_packages_identifier: "numeric" } do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/73605

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the identifier suggestion endpoint returning a 403 on sub-project creation page.

## Screenshots
<img width="815" height="535" alt="Screenshot 2026-04-01 at 12 35 02" src="https://github.com/user-attachments/assets/ba92e7f1-9c53-49f0-814a-dac82ca5ed5e" />


# What approach did you choose and why?
Extend the endpoint permission set to `add_subprojects`.

This is not targeted enough to check permission on per-parent-project basis, but for this kind of endpoint this will suffice.



# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
