### PR TITLE
[#73402] Move Start, Finish buttons to sprint header

### DIFF
--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -32,21 +32,38 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 .action-sprint_planning
   @include extended-content--bottom
 
-.op-backlogs-header
+.op-backlogs-header,
+.op-sprint-header
   display: grid
   grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
-  grid-template-areas: "collapsible points menu"
   align-items: center
 
-.op-backlogs-header--collapsible
-  margin-left: calc(var(--stack-padding-normal) / 2)
+  &--collapsible
+    margin-left: calc(var(--stack-padding-normal) / 2)
 
-.op-backlogs-header--points
-  margin-left: var(--stack-gap-normal)
-  font-variant-numeric: tabular-nums
+  &--actions
+    margin-left: var(--stack-gap-normal)
 
-.op-backlogs-header--menu
-  margin-left: var(--stack-gap-normal)
+  &--menu
+    margin-left: var(--stack-gap-normal)
+
+.op-backlogs-header
+  grid-template-areas: "collapsible points menu"
+
+  &--points
+    margin-left: var(--stack-gap-normal)
+    font-variant-numeric: tabular-nums
+
+.op-sprint-header
+  grid-template-areas: "collapsible actions menu"
+
+  &--actions,
+  &--menu
+    margin-left: var(--stack-gap-normal)
+    align-self: flex-start
+    // Unfortunately, the invisible button style bites us here again.
+    margin-top: -6px
+
 
 .op-backlogs-story
   display: grid

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -41,7 +41,7 @@ See COPYRIGHT and LICENSE files for more details.
       %>
          <% collapsible.with_title { sprint.name } %>
          <% collapsible.with_count(
-              scheme: :default,
+              scheme: :primary,
               count: story_count,
               round: true,
               limit: 1_000,

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -77,16 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
     <% grid.with_area(:actions) do %>
       <%=
         if show_start_sprint_action?
-          render(
-            Primer::Beta::Button.new(
-              id: dom_target(sprint, :start_button),
-              scheme: :invisible,
-              tag: :a,
-              href: start_project_sprint_path(project, sprint),
-              disabled: disable_start_sprint_action?,
-              data: { turbo_method: :post }
-            )
-          ) do |button|
+          render(Primer::Beta::Button.new(**start_sprint_button_arguments)) do |button|
             button.with_leading_visual_icon(icon: :play)
             if start_sprint_disabled_reason.present?
               button.with_tooltip(text: start_sprint_disabled_reason, type: :description, direction: :sw)
@@ -95,15 +86,7 @@ See COPYRIGHT and LICENSE files for more details.
             t(".label_start_sprint")
           end
         elsif show_finish_sprint_action?
-          render(
-            Primer::Beta::Button.new(
-              id: dom_target(sprint, :finish_button),
-              scheme: :invisible,
-              tag: :a,
-              href: finish_project_sprint_path(project, sprint),
-              data: { turbo_method: :post }
-            )
-          ) do |button|
+          render(Primer::Beta::Button.new(**finish_sprint_button_arguments)) do |button|
             button.with_leading_visual_icon(icon: :check)
 
             t(".label_finish_sprint")

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -28,52 +28,92 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= component_wrapper(tag: :header) do %>
-  <%= grid_layout("op-backlogs-header", tag: :div) do |grid| %>
+  <%= grid_layout("op-sprint-header", tag: :div) do |grid| %>
     <% grid.with_area(:collapsible) do %>
       <%=
         render(
           Primer::OpenProject::BorderBox::CollapsibleHeader.new(
             collapsible_id: "#{dom_id(sprint)}-list",
             collapsed:,
-            multi_line: false
+            multi_line: true
           )
         ) do |collapsible|
-          collapsible.with_title { sprint.name }
-          collapsible.with_count(
-            scheme: :default,
-            count: story_count,
-            round: true,
-            limit: 1_000,
-            hide_if_zero: true,
-            aria: {
-              label: t(".label_story_count", count: story_count),
-              live: "polite"
-            }
-          )
-          collapsible.with_description(role: "group") do
-            format_date_range(date_range)
+      %>
+         <% collapsible.with_title { sprint.name } %>
+         <% collapsible.with_count(
+              scheme: :default,
+              count: story_count,
+              round: true,
+              limit: 1_000,
+              hide_if_zero: true,
+              aria: {
+                label: t(".label_story_count", count: story_count),
+                live: "polite"
+              }
+            ) %>
+          <% collapsible.with_description do %>
+            <%=
+              render(
+                Primer::Beta::Text.new(
+                  color: :subtle,
+                  mr: 3,
+                  classes: "velocity",
+                  aria: { live: "polite" }
+                )
+              ) do
+            %>
+              <%= story_points %>&nbsp;<%= t(:"backlogs.points_label", count: story_points) %>
+            <% end %>
+            <% if sprint.date_range_set? %>
+              <%= render(Primer::Beta::Text.new(color: :subtle, role: :group)) do %>
+                <%= render(Primer::Beta::Octicon.new(:calendar, size: :small, mr: 1)) %>
+                <%= format_date_range([sprint.start_date, sprint.finish_date]) %>
+              <% end %>
+            <% end %>
+          <% end %>
+       <% end %>
+    <% end %>
+
+    <% grid.with_area(:actions) do %>
+      <%=
+        if show_start_sprint_action?
+          render(
+            Primer::Beta::Button.new(
+              id: dom_target(sprint, :start_button),
+              scheme: :invisible,
+              tag: :a,
+              href: start_project_sprint_path(project, sprint),
+              disabled: disable_start_sprint_action?,
+              data: { turbo_method: :post }
+            )
+          ) do |button|
+            button.with_leading_visual_icon(icon: :play)
+            if start_sprint_disabled_reason.present?
+              button.with_tooltip(text: start_sprint_disabled_reason, type: :description, direction: :sw)
+            end
+
+            t(".label_start_sprint")
+          end
+        elsif show_finish_sprint_action?
+          render(
+            Primer::Beta::Button.new(
+              id: dom_target(sprint, :finish_button),
+              scheme: :invisible,
+              tag: :a,
+              href: finish_project_sprint_path(project, sprint),
+              data: { turbo_method: :post }
+            )
+          ) do |button|
+            button.with_leading_visual_icon(icon: :check)
+
+            t(".label_finish_sprint")
           end
         end
       %>
     <% end %>
 
-    <% grid.with_area(:points) do %>
-      <%=
-        render(
-          Primer::Beta::Text.new(
-            color: :subtle,
-            classes: "velocity",
-            aria: { live: "polite" }
-          )
-        ) do
-      %>
-        <%= story_points %>
-        <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
-      <% end %>
-    <% end %>
-
     <% grid.with_area(:menu) do %>
-      <%= render(Backlogs::SprintMenuComponent.new(sprint:, project:, active_sprint_ids:)) %>
+      <%= render(Backlogs::SprintMenuComponent.new(sprint:, project:)) %>
     <% end %>
   <% end %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.rb
@@ -78,6 +78,29 @@ module Backlogs
       sprint.in_planning? && (!sprint.date_range_set? || project_has_another_active_sprint?)
     end
 
+    def start_sprint_button_arguments
+      args = {
+        id: dom_target(sprint, :start_button),
+        scheme: :invisible
+      }
+
+      if disable_start_sprint_action?
+        args.merge(tag: :button, inactive: true, aria: { disabled: true })
+      else
+        args.merge(tag: :a, href: start_project_sprint_path(project, sprint), data: { turbo_method: :post })
+      end
+    end
+
+    def finish_sprint_button_arguments
+      {
+        id: dom_target(sprint, :finish_button),
+        scheme: :invisible,
+        tag: :a,
+        href: finish_project_sprint_path(project, sprint),
+        data: { turbo_method: :post }
+      }
+    end
+
     def story_points
       @story_points ||= stories.sum { |story| story.story_points || 0 }
     end

--- a/modules/backlogs/app/components/backlogs/sprint_header_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.rb
@@ -66,6 +66,18 @@ module Backlogs
 
     private
 
+    def show_start_sprint_action?
+      sprint.in_planning? && ::Sprints::StartContract.can_start?(user: current_user, sprint:, project:)
+    end
+
+    def show_finish_sprint_action?
+      sprint.active? && ::Sprints::StartContract.can_start_or_finish?(user: current_user, sprint:)
+    end
+
+    def disable_start_sprint_action?
+      sprint.in_planning? && (!sprint.date_range_set? || project_has_another_active_sprint?)
+    end
+
     def story_points
       @story_points ||= stories.sum { |story| story.story_points || 0 }
     end
@@ -74,8 +86,22 @@ module Backlogs
       @story_count ||= stories.size
     end
 
-    def date_range
-      [sprint.start_date, sprint.finish_date]
+    def project_has_another_active_sprint?
+      (resolved_active_sprint_ids - [sprint.id]).any?
+    end
+
+    def start_sprint_disabled_reason
+      return unless disable_start_sprint_action?
+
+      if sprint.date_range_set?
+        t(".start_sprint_disabled_reason_active_sprint")
+      else
+        t(".start_sprint_disabled_reason_missing_dates")
+      end
+    end
+
+    def resolved_active_sprint_ids
+      active_sprint_ids || Agile::Sprint.for_project(sprint.project).active.pluck(:id)
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -37,33 +37,6 @@ See COPYRIGHT and LICENSE files for more details.
     )
 
     with_item_group(menu) do
-      if show_start_sprint_action?
-        menu.with_item(
-          label: t(".action_menu.start_sprint"),
-          tag: :button,
-          href: start_project_sprint_path(project, sprint),
-          disabled: disable_start_sprint_action?,
-          form_arguments: {
-            method: :post,
-            data: { turbo: false }
-          }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :play)
-          item.with_description(start_sprint_action_description) if start_sprint_action_description.present?
-        end
-      end
-
-      if show_finish_sprint_action?
-        menu.with_item(
-          label: t(".action_menu.finish_sprint"),
-          tag: :button,
-          href: finish_project_sprint_path(project, sprint),
-          form_arguments: { method: :post }
-        ) do |item|
-          item.with_leading_visual_icon(icon: :check)
-        end
-      end
-
       if user_allowed?(:create_sprints)
         menu.with_item(
           id: dom_target(sprint, :menu, :edit_sprint),

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -33,15 +33,14 @@ module Backlogs
     include OpPrimer::ComponentHelpers
     include RbCommonHelper
 
-    attr_reader :sprint, :project, :current_user, :active_sprint_ids
+    attr_reader :sprint, :project, :current_user
 
-    def initialize(sprint:, project:, current_user: User.current, active_sprint_ids: nil, **system_arguments)
+    def initialize(sprint:, project:, current_user: User.current, **system_arguments)
       super()
 
       @sprint = sprint
       @project = project
       @current_user = current_user
-      @active_sprint_ids = active_sprint_ids
 
       @system_arguments = system_arguments
       @system_arguments[:menu_id] = dom_target(sprint, :menu)
@@ -62,30 +61,8 @@ module Backlogs
       sprint.task_board_for(project).present?
     end
 
-    def show_start_sprint_action?
-      sprint.in_planning? && ::Sprints::StartContract.can_start?(user: current_user, sprint:, project:)
-    end
-
-    def show_finish_sprint_action?
-      sprint.active? && ::Sprints::StartContract.can_start_or_finish?(user: current_user, sprint:)
-    end
-
-    def disable_start_sprint_action?
-      sprint.in_planning? && (!sprint.date_range_set? || project_has_another_active_sprint?)
-    end
-
     def show_burndown_link?
       sprint.active?
-    end
-
-    def start_sprint_action_description
-      return unless disable_start_sprint_action?
-
-      if sprint.date_range_set?
-        t(".action_menu.start_sprint_disabled_description")
-      else
-        t(".action_menu.start_sprint_missing_dates_description")
-      end
     end
 
     def user_allowed?(permission)
@@ -94,14 +71,6 @@ module Backlogs
 
     def available_story_types
       @available_story_types ||= story_types & project.types
-    end
-
-    def project_has_another_active_sprint?
-      (resolved_active_sprint_ids - [sprint.id]).any?
-    end
-
-    def resolved_active_sprint_ids
-      active_sprint_ids || Agile::Sprint.for_project(sprint.project).active.pluck(:id)
     end
   end
 end

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -113,8 +113,10 @@ class RbSprintsController < RbApplicationController
 
     if result.success?
       @sprint = result.result
-      redirect_to project_work_package_board_path(@project, @sprint.task_board_for(@project)),
-                  notice: I18n.t(:notice_successful_start)
+      flash[:notice] = I18n.t(:notice_successful_start)
+      render turbo_stream: turbo_stream.redirect_to(
+        project_work_package_board_path(@project, @sprint.task_board_for(@project))
+      )
     else
       respond_with_start_finish_failure(message: start_finish_failure_message(:start, result.message))
     end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -184,7 +184,10 @@ en:
         settings_link_text: "project settings"
 
     sprint_header_component:
-      label_toggle_backlog: "Collapse/Expand %{name}"
+      label_start_sprint: "Start"
+      label_finish_sprint: "Finish"
+      start_sprint_disabled_reason_active_sprint: "Another sprint is already active."
+      start_sprint_disabled_reason_missing_dates: "Start and finish dates are required in order to start the sprint."
       label_story_count:
         zero: "No stories in sprint"
         one: "%{count} story in sprint"
@@ -214,10 +217,6 @@ en:
     sprint_menu_component:
       label_actions: "Sprint actions"
       action_menu:
-        start_sprint: "Start sprint"
-        finish_sprint: "Finish sprint"
-        start_sprint_disabled_description: "Another sprint is already active."
-        start_sprint_missing_dates_description: "Start and finish dates are required in order to start the sprint."
         edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
 

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
         it "shows Start disabled with a reason" do
           render_component(active_sprint_ids: [active_sprint.id])
 
-          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_selector(:link_or_button, "Start", aria: { disabled: true })
           expect(page).to have_text("Another sprint is already active.")
         end
       end
@@ -194,7 +194,7 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
         it "shows Start disabled with a missing dates reason" do
           render_component
 
-          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_selector(:link_or_button, "Start", aria: { disabled: true })
           expect(page).to have_text("Start and finish dates are required in order to start the sprint.")
         end
       end
@@ -205,7 +205,7 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
         it "shows Start disabled with a missing dates reason" do
           render_component
 
-          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_selector(:link_or_button, "Start", aria: { disabled: true })
           expect(page).to have_text("Start and finish dates are required in order to start the sprint.")
         end
       end

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
       .and_return("story_types" => [type_feature.id.to_s], "task_type" => type_task.id.to_s)
   end
 
-  def render_component(folded: false)
-    render_inline(described_class.new(sprint:, project:, folded:, current_user: user))
+  def render_component(folded: false, active_sprint_ids: nil)
+    render_inline(described_class.new(sprint:, project:, folded:, current_user: user, active_sprint_ids:))
   end
 
   describe "show state (default)" do
@@ -150,10 +150,110 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
     context "when sprint has no dates" do
       let(:sprint) { build_stubbed(:agile_sprint, project:, name: "Sprint 1", start_date: nil, finish_date: nil) }
 
-      it "renders without date range" do
+      it "renders without date range or calendar icon" do
         render_component
 
         expect(page).to have_no_css("time")
+        expect(page).to have_no_octicon(:calendar)
+      end
+    end
+  end
+
+  describe "start and finish actions" do
+    context "when the sprint is in planning and the user can start it" do
+      it "shows a Start button" do
+        render_component
+
+        expect(page).to have_selector(:link_or_button, "Start")
+        expect(page).to have_octicon(:play)
+      end
+
+      it "does not show Finish" do
+        render_component
+
+        expect(page).to have_no_selector(:link_or_button, "Finish")
+      end
+
+      context "when another sprint is already active" do
+        let!(:active_sprint) do
+          create(:agile_sprint, project:, name: "Active Sprint", status: "active",
+                                start_date: Date.yesterday, finish_date: Date.tomorrow)
+        end
+
+        it "shows Start disabled with a reason" do
+          render_component(active_sprint_ids: [active_sprint.id])
+
+          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_text("Another sprint is already active.")
+        end
+      end
+
+      context "when the sprint has no start date" do
+        let(:start_date) { nil }
+
+        it "shows Start disabled with a missing dates reason" do
+          render_component
+
+          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_text("Start and finish dates are required in order to start the sprint.")
+        end
+      end
+
+      context "when the sprint has no finish date" do
+        let(:finish_date) { nil }
+
+        it "shows Start disabled with a missing dates reason" do
+          render_component
+
+          expect(page).to have_selector(:link_or_button, "Start", disabled: true)
+          expect(page).to have_text("Start and finish dates are required in order to start the sprint.")
+        end
+      end
+    end
+
+    context "when the sprint is active and the user can finish it" do
+      let(:sprint) do
+        create(:agile_sprint, project:, name: "Sprint 1", status: "active",
+                              start_date:, finish_date:)
+      end
+
+      it "shows a Finish button" do
+        render_component
+
+        expect(page).to have_selector(:link_or_button, "Finish")
+        expect(page).to have_octicon(:check)
+      end
+
+      it "does not show Start" do
+        render_component
+
+        expect(page).to have_no_selector(:link_or_button, "Start")
+      end
+    end
+
+    context "when the sprint is completed" do
+      let(:sprint) do
+        create(:agile_sprint, project:, name: "Sprint 1", status: "completed",
+                              start_date:, finish_date:)
+      end
+
+      it "shows neither Start nor Finish" do
+        render_component
+
+        expect(page).to have_no_selector(:link_or_button, "Start")
+        expect(page).to have_no_selector(:link_or_button, "Finish")
+      end
+    end
+
+    context "when the user lacks the start_complete_sprint permission" do
+      let(:user) do
+        create(:user, member_with_permissions: { project => %i[view_sprints view_work_packages] })
+      end
+
+      it "does not show Start" do
+        render_component
+
+        expect(page).to have_no_selector(:link_or_button, "Start")
       end
     end
   end

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
   let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: Date.tomorrow) }
   let(:user) { create(:user) }
   let(:permissions) { [] }
-  let(:start_sprint_path) { Rails.application.routes.url_helpers.start_project_sprint_path(project, sprint) }
-  let(:finish_sprint_path) { Rails.application.routes.url_helpers.finish_project_sprint_path(project, sprint) }
 
   before do
     allow(Setting)
@@ -53,8 +51,8 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
     login_as(user)
   end
 
-  def render_component(active_sprint_ids: nil)
-    render_inline(described_class.new(sprint:, project:, current_user: user, active_sprint_ids:))
+  def render_component
+    render_inline(described_class.new(sprint:, project:, current_user: user))
   end
 
   def menu_items
@@ -106,10 +104,10 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
     end
   end
 
-  describe "task board actions" do
+  describe "task board link" do
     let(:permissions) { %i[view_sprints view_work_packages] }
 
-    context "when the sprint is active" do
+    context "when the sprint is active and has a task board" do
       let(:sprint) do
         create(:agile_sprint,
                project:,
@@ -118,133 +116,39 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
                finish_date: Date.tomorrow,
                status: "active")
       end
-      let(:permissions) { %i[view_sprints view_work_packages start_complete_sprint create_sprints manage_sprint_items] }
+      let(:permissions) { %i[view_sprints view_work_packages create_sprints manage_sprint_items] }
       let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-      it "shows Finish sprint and Sprint board" do
+      it "shows Sprint board" do
         render_component
 
-        expect(menu_items.first).to eq("Finish sprint")
-        expect(page).to have_octicon(:check)
-        expect(page).to have_element(:form, action: finish_sprint_path, method: "post")
         expect(menu_items).to include("Sprint board")
       end
 
       it "renders dividers between each menu section" do
         render_component
 
-        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
-        expect(page).to have_list_item position: 3, role: "presentation"
-        expect(page).to have_list_item position: 5, role: "presentation"
+        expect(menu_items).to eq(["Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
+        expect(page).to have_list_item position: 2, role: "presentation"
+        expect(page).to have_list_item position: 4, role: "presentation"
       end
     end
 
-    context "when the sprint is in planning and the user can start it" do
-      let(:permissions) { %i[view_sprints view_work_packages show_board_views start_complete_sprint] }
+    context "when the sprint is completed and has a task board" do
+      let(:sprint) do
+        create(:agile_sprint,
+               project:,
+               name: "Sprint 1",
+               start_date: Date.yesterday,
+               finish_date: Date.tomorrow,
+               status: "completed")
+      end
+      let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-      it "shows Start sprint as the first item" do
+      it "shows Sprint board" do
         render_component
 
-        expect(menu_items.first).to eq("Start sprint")
-        expect(page).to have_octicon(:play)
-        expect(page).to have_no_selector(:menuitem, text: "Sprint board")
-        expect(page).to have_element(:form, action: start_sprint_path, method: "post", "data-turbo": "false")
-      end
-
-      context "when another sprint is already active" do
-        let!(:active_sprint) do
-          create(:agile_sprint,
-                 project:,
-                 name: "Sprint 2",
-                 start_date: Date.yesterday,
-                 finish_date: Date.tomorrow,
-                 status: "active")
-        end
-
-        it "shows Start sprint disabled with a description" do
-          render_component
-
-          expect(menu_items.first).to include("Start sprint")
-          expect(page).to have_selector(
-            :menuitem,
-            text: "Start sprint",
-            disabled: true
-          )
-          expect(page).to have_text("Another sprint is already active.")
-        end
-
-        it "uses precomputed active sprint ids when provided" do
-          allow(Agile::Sprint).to receive(:for_project).and_call_original
-
-          render_component(active_sprint_ids: [active_sprint.id])
-
-          expect(Agile::Sprint).not_to have_received(:for_project)
-        end
-      end
-
-      context "when the sprint has no start date" do
-        let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: nil, finish_date: Date.tomorrow) }
-
-        it "shows Start sprint disabled with a missing dates description" do
-          render_component
-
-          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: true)
-          expect(page).to have_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.start_sprint_missing_dates_description"))
-        end
-      end
-
-      context "when the sprint has no finish date" do
-        let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: nil) }
-
-        it "shows Start sprint disabled with a missing dates description" do
-          render_component
-
-          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: true)
-          expect(page).to have_text(I18n.t(:"backlogs.sprint_menu_component.action_menu.start_sprint_missing_dates_description"))
-        end
-      end
-
-      context "when the sprint has both start and finish dates" do
-        it "shows Start sprint enabled" do
-          render_component
-
-          expect(page).to have_selector(:menuitem, text: "Start sprint", disabled: false)
-        end
-      end
-
-      context "when the sprint is in planning and the user cannot start it" do
-        let(:permissions) { %i[view_sprints view_work_packages] }
-
-        it "does not show task-board-related items" do
-          render_component
-
-          expect(page).to have_no_selector(:menuitem, text: "Start sprint")
-          expect(page).to have_no_selector(:menuitem, text: "Sprint board")
-        end
-      end
-
-      context "when the sprint is completed" do
-        let(:sprint) do
-          create(:agile_sprint,
-                 project:,
-                 name: "Sprint 1",
-                 start_date: Date.yesterday,
-                 finish_date: Date.tomorrow,
-                 status: "completed")
-        end
-        let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
-
-        it "shows Sprint board" do
-          render_component
-
-          expect(menu_items).to include("Sprint board")
-        end
-
-        it "does not render a divider when task board is the only visible item" do
-          render_component
-
-          expect(page).not_to have_list_item(role: "presentation")
-        end
+        expect(menu_items).to include("Sprint board")
       end
     end
 
@@ -270,12 +174,6 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
                roles: [create(:project_role, permissions: %i[view_sprints start_complete_sprint])])
       end
 
-      it "shows Finish sprint" do
-        render_component
-
-        expect(page).to have_selector(:menuitem, text: "Finish sprint")
-      end
-
       it "does not show Sprint board for a board in the source project" do
         create(:board_grid_with_query, project: source_project, linked: sprint)
 
@@ -290,33 +188,6 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
         render_component
 
         expect(page).to have_selector(:menuitem, text: "Sprint board")
-      end
-
-      context "when the sprint is in planning" do
-        let(:sprint) do
-          create(:agile_sprint,
-                 project: source_project,
-                 name: "Shared Sprint",
-                 start_date: Date.yesterday,
-                 finish_date: Date.tomorrow,
-                 status: "in_planning")
-        end
-
-        it "shows Start sprint" do
-          render_component
-
-          expect(page).to have_selector(:menuitem, text: "Start sprint")
-        end
-
-        context "without rendered-project board access" do
-          let(:permissions) { %i[view_sprints view_work_packages create_sprints manage_sprint_items] }
-
-          it "hides Start sprint" do
-            render_component
-
-            expect(page).to have_no_selector(:menuitem, text: "Start sprint")
-          end
-        end
       end
     end
   end

--- a/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/rb_sprints_controller_spec.rb
@@ -324,9 +324,10 @@ RSpec.describe RbSprintsController do
           end
 
           it "starts the sprint and redirects to the board", :aggregate_failures do
-            post :start, params: request_params
+            post :start, format: :turbo_stream, params: request_params
 
-            expect(response).to redirect_to(project_work_package_board_path(project, board))
+            expect(response).to be_successful
+            expect(response).to have_turbo_stream(action: "redirect_to")
             expect(service).to have_received(:call)
           end
 
@@ -363,9 +364,10 @@ RSpec.describe RbSprintsController do
           end
 
           it "starts the sprint and redirects to the board", :aggregate_failures do
-            post :start, params: request_params
+            post :start, format: :turbo_stream, params: request_params
 
-            expect(response).to redirect_to(project_work_package_board_path(project, existing_board))
+            expect(response).to be_successful
+            expect(response).to have_turbo_stream(action: "redirect_to")
             expect(service).to have_received(:call)
           end
         end
@@ -382,9 +384,11 @@ RSpec.describe RbSprintsController do
           end
 
           it "creates the board, starts the sprint, and redirects to the board", :aggregate_failures do
-            post :start, params: request_params
+            post :start, format: :turbo_stream, params: request_params
 
-            expect(response).to redirect_to(project_work_package_board_path(project, board))
+            expect(response).to be_successful
+            expect(response).to have_turbo_stream(action: "redirect_to")
+            expect(flash[:notice]).to eq(I18n.t(:notice_successful_start))
             expect(service).to have_received(:call)
           end
         end

--- a/modules/backlogs/spec/features/sprints/edit_spec.rb
+++ b/modules/backlogs/spec/features/sprints/edit_spec.rb
@@ -110,11 +110,9 @@ RSpec.describe "Edit", :js do
       context "when editing a sprint" do
         it "displays all menu entries" do
           planning_page.within_sprint_menu(first_sprint) do |menu|
-            expect(menu).to have_selector :menuitem, count: 3
-            expect(menu).to have_selector :menuitem, "Start sprint"
+            expect(menu).to have_selector :menuitem, count: 2
             expect(menu).to have_selector :menuitem, "Edit sprint"
             expect(menu).to have_selector :menuitem, "Add work package"
-            expect(menu).to have_css "form[action='#{start_project_sprint_path(project, first_sprint)}'][data-turbo='false']"
           end
         end
 
@@ -138,8 +136,7 @@ RSpec.describe "Edit", :js do
 
           it "has no menu entry for creating a new story" do
             planning_page.within_sprint_menu(first_sprint) do |menu|
-              expect(menu).to have_selector :menuitem, count: 2
-              expect(menu).to have_selector :menuitem, "Start sprint"
+              expect(menu).to have_selector :menuitem, count: 1
               expect(menu).to have_selector :menuitem, "Edit sprint"
 
               expect(menu).to have_no_selector :menuitem, "Add work package"
@@ -183,7 +180,6 @@ RSpec.describe "Edit", :js do
       it "has no menu entry for editing a sprint" do
         planning_page.within_sprint_menu(first_sprint) do |menu|
           expect(menu).to have_no_selector :menuitem, "Edit sprint"
-          expect(menu).to have_no_selector :menuitem, "Start sprint"
         end
       end
     end

--- a/modules/backlogs/spec/features/sprints/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/sprints/start_finish_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Start and finish sprints",
   end
 
   it "starts the sprint and redirects to the board" do
-    planning_page.click_in_sprint_menu(first_sprint, "Start sprint")
+    planning_page.click_start_sprint_button(first_sprint)
 
     expect_and_dismiss_flash type: :success, message: "The sprint was started."
 
@@ -142,10 +142,7 @@ RSpec.describe "Start and finish sprints",
     let!(:task_board) { create(:board_grid_with_query, project:, linked: first_sprint) }
 
     it "finishes the sprint and returns to the backlog" do
-      planning_page.within_sprint_menu(first_sprint) do |menu|
-        expect(menu).to have_selector :menuitem, "Finish sprint"
-        menu.find(:button, "Finish sprint").click
-      end
+      planning_page.click_finish_sprint_button(first_sprint)
 
       planning_page.expect_current_path
       expect_and_dismiss_flash type: :success, message: "The sprint was completed."

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -388,10 +388,20 @@ module Pages
       within(work_package_selector(work_package), &)
     end
 
-    def click_to_finish_sprint(sprint)
-      within_sprint_menu(sprint) do |menu|
-        menu.find(:button, "Finish sprint").click
+    def click_start_sprint_button(sprint)
+      within_sprint(sprint) do
+        click_on("Start")
       end
+    end
+
+    def click_finish_sprint_button(sprint)
+      within_sprint(sprint) do
+        click_on("Finish")
+      end
+    end
+
+    def click_to_finish_sprint(sprint)
+      click_finish_sprint_button(sprint)
     end
 
     def choose_to_move_unfinished_work_packages_to_sprint(sprint_name)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73402
https://community.openproject.org/wp/73615

# What are you trying to accomplish?

Promotes Start and Finish sprint actions from the kebab action menu to visible buttons in the sprint header bar. Relocates story points into the collapsible header description and removes the now-dead sprint lifecycle code from `SprintMenuComponent`.

Also updates the counter background colour to "primary".

## Screenshots

**Start action in sprint header** (note this screenshot shows hover)

<img width="611" height="88" alt="Screenshot 2026-04-01 at 20 10 20" src="https://github.com/user-attachments/assets/75336087-442a-4846-ae96-d81dd4b5f031" />

**Disabled start: missing dates**

<img width="605" height="114" alt="Screenshot 2026-04-01 at 20 09 55" src="https://github.com/user-attachments/assets/546df30f-3d6b-4aae-95fe-e25c0e861c3d" />

**Disabled start: another sprint active**

<img width="601" height="86" alt="Screenshot 2026-04-01 at 20 09 15" src="https://github.com/user-attachments/assets/259bf3b6-761d-4210-b999-1817c8b92fa4" />

**Finish action in sprint header**

<img width="600" height="79" alt="Screenshot 2026-04-01 at 20 09 25" src="https://github.com/user-attachments/assets/0ce883d7-8784-4fce-ae4a-3c0d3cfcb45e" />


# What approach did you choose and why?

> [!NOTE]
>  We use `inactive` + `aria-disabled` instead of `disabled` so the Start button remains focusable and its tooltip is reachable by keyboard and assistive technology users.

## What this PR doesn't do

This PR does not rename `Finish sprint` to `Close sprint`. That should happen as a separate, follow up PR.

# Merge checklist

- [X] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
