### PR TITLE
hide backlog's task colour setting

### DIFF
--- a/modules/backlogs/app/forms/my/backlogs_form.rb
+++ b/modules/backlogs/app/forms/my/backlogs_form.rb
@@ -30,10 +30,12 @@
 
 class My::BacklogsForm < ApplicationForm
   form do |f|
-    f.text_field name: :task_color,
-                 label: I18n.t("backlogs.task_color"),
-                 value: @color,
-                 input_width: :xsmall
+    unless OpenProject::FeatureDecisions.scrum_projects_active?
+      f.text_field name: :task_color,
+                   label: I18n.t("backlogs.task_color"),
+                   value: @color,
+                   input_width: :xsmall
+    end
 
     f.check_box name: :versions_default_fold_state,
                 value: DEFAULT_FOLD_STATE,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73466

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Screenshots

No longer display the "Task color" field in the user settings

<img width="713" height="219" alt="image" src="https://github.com/user-attachments/assets/4b13d64f-2d4a-40f4-8950-00c473ff6911" />
