### PR TITLE
[73528] Add menu separator before "Log out" in user menu

### DIFF
--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -167,6 +167,7 @@ Redmine::MenuManager.map :account_menu do |menu|
   menu.push :logout,
             :signout_path,
             icon: :"sign-out",
+            show_divider_before: true,
             scheme: :danger,
             if: ->(_) { User.current.logged? },
             html: {

--- a/lib/redmine/menu_manager/menu_item.rb
+++ b/lib/redmine/menu_manager/menu_item.rb
@@ -39,7 +39,8 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
               :partial,
               :scheme,
               :engine,
-              :enterprise_feature
+              :enterprise_feature,
+              :show_divider_before
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/PerceivedComplexity
@@ -60,6 +61,7 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
     @icon = options[:icon]
     @icon_after = options[:icon_after]
     @enterprise_feature = options[:enterprise_feature]
+    @show_divider_before = options[:show_divider_before]
     @caption = options[:caption]
     @context = options[:context]
     @html_options = options[:html].nil? ? {} : options[:html].dup
@@ -177,5 +179,9 @@ class Redmine::MenuManager::MenuItem < Redmine::MenuManager::TreeNode
 
   def enterprise_feature_missing?
     @enterprise_feature.present? && !EnterpriseToken.allows_to?(@enterprise_feature)
+  end
+
+  def show_divider_before?
+    @show_divider_before || false
   end
 end

--- a/lib/redmine/menu_manager/top_menu/user_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/user_menu.rb
@@ -141,6 +141,8 @@ module Redmine::MenuManager::TopMenu::UserMenu
 
   def add_lateral_user_menu_items(list, link_items)
     link_items.each do |item|
+      list.with_divider if item.show_divider_before?
+
       list.with_item(
         href: allowed_node_url(item, nil),
         label: item.caption,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73528

# What are you trying to accomplish?
Add a divider before the "log out" menu entry to avoid accidental misclicks

## Screenshots

<img width="338" height="326" alt="Bildschirmfoto 2026-04-02 um 08 24 22" src="https://github.com/user-attachments/assets/d0b2d16f-203a-4771-8154-30cc9c9a9ea3" />
