### PR TITLE
[#73535] Update "finish" sprint to "complete" sprint

### DIFF
--- a/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.html.erb
@@ -63,7 +63,7 @@ See COPYRIGHT and LICENSE files for more details.
             type: :submit
           )
         ) do
-          t(".button_close_sprint")
+          t(".button_complete_sprint")
         end
       end
     end

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.html.erb
@@ -53,9 +53,9 @@ See COPYRIGHT and LICENSE files for more details.
         end
       end
 
-      if show_finish_sprint_action?
+      if show_complete_sprint_action?
         menu.with_item(
-          label: t(".action_menu.finish_sprint"),
+          label: t(".action_menu.complete_sprint"),
           tag: :button,
           href: finish_project_sprint_path(project, sprint),
           form_arguments: { method: :post }

--- a/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_menu_component.rb
@@ -66,8 +66,8 @@ module Backlogs
       sprint.in_planning? && ::Sprints::StartContract.can_start?(user: current_user, sprint:, project:)
     end
 
-    def show_finish_sprint_action?
-      sprint.active? && ::Sprints::StartContract.can_start_or_finish?(user: current_user, sprint:)
+    def show_complete_sprint_action?
+      sprint.active? && ::Sprints::StartContract.can_start_or_complete?(user: current_user, sprint:)
     end
 
     def disable_start_sprint_action?

--- a/modules/backlogs/app/contracts/sprints/start_contract.rb
+++ b/modules/backlogs/app/contracts/sprints/start_contract.rb
@@ -35,19 +35,19 @@ module Sprints
     validate :validate_dates_present
     validate :validate_no_other_active_sprint
 
-    def self.can_start_or_finish?(user:, sprint:)
+    def self.can_start_or_complete?(user:, sprint:)
       user.allowed_in_project?(:start_complete_sprint, sprint.project)
     end
 
     def self.can_start?(user:, sprint:, project:)
-      can_start_or_finish?(user:, sprint:) &&
+      can_start_or_complete?(user:, sprint:) &&
         user.allowed_in_project?(:show_board_views, project)
     end
 
     private
 
     def validate_permission
-      return if self.class.can_start_or_finish?(user:, sprint: model)
+      return if self.class.can_start_or_complete?(user:, sprint: model)
 
       errors.add :base, :error_unauthorized
     end

--- a/modules/backlogs/app/controllers/rb_sprints_controller.rb
+++ b/modules/backlogs/app/controllers/rb_sprints_controller.rb
@@ -281,6 +281,6 @@ class RbSprintsController < RbApplicationController
 
   def authorize_finish!
     deny_access unless current_user.allowed_in_project?(:view_sprints, @project) &&
-      Sprints::StartContract.can_start_or_finish?(user: current_user, sprint: @sprint)
+      Sprints::StartContract.can_start_or_complete?(user: current_user, sprint: @sprint)
   end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -209,13 +209,13 @@ en:
         move_to_bottom_of_backlog: "Move them to the bottom of the backlog"
         move_to_sprint: "Move them to another sprint"
       select_sprint_label: "Select sprint"
-      button_close_sprint: "Close sprint"
+      button_complete_sprint: "Complete sprint"
 
     sprint_menu_component:
       label_actions: "Sprint actions"
       action_menu:
         start_sprint: "Start sprint"
-        finish_sprint: "Finish sprint"
+        complete_sprint: "Complete sprint"
         start_sprint_disabled_description: "Another sprint is already active."
         start_sprint_missing_dates_description: "Start and finish dates are required in order to start the sprint."
         edit_sprint: "Edit sprint"

--- a/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_menu_component_spec.rb
@@ -121,10 +121,10 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
       let(:permissions) { %i[view_sprints view_work_packages start_complete_sprint create_sprints manage_sprint_items] }
       let!(:task_board) { create(:board_grid_with_query, project:, linked: sprint) }
 
-      it "shows Finish sprint and Sprint board" do
+      it "shows Complete sprint and Sprint board" do
         render_component
 
-        expect(menu_items.first).to eq("Finish sprint")
+        expect(menu_items.first).to eq("Complete sprint")
         expect(page).to have_octicon(:check)
         expect(page).to have_element(:form, action: finish_sprint_path, method: "post")
         expect(menu_items).to include("Sprint board")
@@ -133,7 +133,7 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
       it "renders dividers between each menu section" do
         render_component
 
-        expect(menu_items).to eq(["Finish sprint", "Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
+        expect(menu_items).to eq(["Complete sprint", "Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
         expect(page).to have_list_item position: 3, role: "presentation"
         expect(page).to have_list_item position: 5, role: "presentation"
       end
@@ -270,10 +270,10 @@ RSpec.describe Backlogs::SprintMenuComponent, type: :component do
                roles: [create(:project_role, permissions: %i[view_sprints start_complete_sprint])])
       end
 
-      it "shows Finish sprint" do
+      it "shows Complete sprint" do
         render_component
 
-        expect(page).to have_selector(:menuitem, text: "Finish sprint")
+        expect(page).to have_selector(:menuitem, text: "Complete sprint")
       end
 
       it "does not show Sprint board for a board in the source project" do

--- a/modules/backlogs/spec/features/sprints/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/sprints/start_finish_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe "Start and finish sprints",
 
     it "finishes the sprint and returns to the backlog" do
       planning_page.within_sprint_menu(first_sprint) do |menu|
-        expect(menu).to have_selector :menuitem, "Finish sprint"
-        menu.find(:button, "Finish sprint").click
+        expect(menu).to have_selector :menuitem, "Complete sprint"
+        menu.find(:button, "Complete sprint").click
       end
 
       planning_page.expect_current_path

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -392,7 +392,7 @@ module Pages
 
     def click_to_finish_sprint(sprint)
       within_sprint_menu(sprint) do |menu|
-        menu.find(:button, "Finish sprint").click
+        menu.find(:button, "Complete sprint").click
       end
     end
 
@@ -401,7 +401,7 @@ module Pages
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_sprint")
         select sprint_name, from: "Select sprint"
 
-        click_button "Close sprint"
+        click_button "Complete sprint"
       end
     end
 
@@ -409,7 +409,7 @@ module Pages
       within sprint_finish_modal_selector do
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_top_of_backlog")
 
-        click_button "Close sprint"
+        click_button "Complete sprint"
       end
     end
 
@@ -417,7 +417,7 @@ module Pages
       within sprint_finish_modal_selector do
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_bottom_of_backlog")
 
-        click_button "Close sprint"
+        click_button "Complete sprint"
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/73535

# What are you trying to accomplish?
Rename "finish" to "complete" sprint

# What approach did you choose and why?
- Rename the menu item and the complete sprint button.
- Dialog names, routes etc are left unaffected.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
