### PR TITLE
[#73203]  iCal RSVP response not processed due to case-sensitive email comparison in HandleICalResponseService

### DIFF
--- a/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
+++ b/modules/meeting/app/services/all_meetings/handle_ical_response_service.rb
@@ -130,7 +130,7 @@ module AllMeetings
     end
 
     def attendee(event)
-      event.attendee.find { it.value_ical == "mailto:#{user.mail}" }
+      event.attendee.find { it.value_ical.downcase == "mailto:#{user.mail}" }
     end
 
     def partstat(attendee)

--- a/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/handle_ical_response_service_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe AllMeetings::HandleICalResponseService, type: :model do
 
         expect(subject).to be_success
       end
+
+      context "when the attendee email has different casing" do
+        let(:participant_email) { user.mail.upcase }
+
+        it "still updates the participant's status" do
+          expect { subject }.to change {
+            meeting.participants.find_by(user: user).participation_status
+          }.from("needs_action").to("accepted")
+
+          expect(subject).to be_success
+        end
+      end
     end
 
     context "when declining the invitation" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/work_packages/73203

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
