### PR TITLE
[#73678] User facing work package link from Github tab is not the shortened version

### DIFF
--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -69,11 +69,11 @@ describe('GitActionsService', function() {
     expect(service.branchName(wp)).toEqual('user-story/42-find-the-question');
     expect(service.commitMessage(wp)).toEqual(`[#42] Find the question
 
-http://localhost:9876/work_packages/42
+http://localhost:9876/wp/42
 `);
     expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question' && git commit --allow-empty -m '[#42] Find the question
 
-http://localhost:9876/work_packages/42
+http://localhost:9876/wp/42
 '`);
   });
 
@@ -81,7 +81,7 @@ http://localhost:9876/work_packages/42
     const wp = createWorkPackage({ subject: "' && rm -rf / #" });
     expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] \\' && rm -rf / #
 
-http://localhost:9876/work_packages/42
+http://localhost:9876/wp/42
 '`);
   });
 });

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -47,7 +47,7 @@ export class GitActionsService {
     const type = workPackage.type.name || '';
     const id = workPackage.id || '';
     const title = workPackage.subject;
-    const url = window.location.origin + workPackage.pathHelper.workPackagePath(id);
+    const url = window.location.origin + workPackage.pathHelper.workPackageShortPath(id);
     const description = '';
 
     return({


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
 https://community.openproject.org/work_packages/73678

This bugged me for a while

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
