### PR TITLE
Add RTL support for Arabic/Hebrew/Farsi browser rendering

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -30,6 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <html xmlns="http://www.w3.org/1999/xhtml"
       lang="<%= I18n.locale.to_s %>"
       xml:lang="<%= I18n.locale.to_s %>"
+      dir="<%= %i[ar fa he].include?(I18n.locale) ? 'rtl' : 'ltr' %>"
       class="<%= "in_modal" unless show_decoration %>">
 <head>
   <%= render partial: "layouts/common_head" %>

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -64,6 +64,22 @@
   h3
     font-size: 1.17em
 
+  // -------------------- RTL / Arabic print support --------------------
+  .-rtl,
+  [dir="rtl"]
+    direction: rtl
+    text-align: right
+    font-feature-settings: "liga" 1, "calt" 1
+    letter-spacing: normal
+    word-spacing: normal
+    text-rendering: optimizeLegibility
+
+    table.list
+      direction: rtl
+
+      th, td
+        text-align: right
+
   .-browser-firefox
     #content-wrapper
       // Needed to prevent an empty first page when printing in Firefox

--- a/frontend/src/global_styles/openproject/_generic.sass
+++ b/frontend/src/global_styles/openproject/_generic.sass
@@ -96,6 +96,9 @@ a
 
 .-rtl
   direction: rtl
+  text-align: right
+  font-feature-settings: "liga" 1, "calt" 1
+  letter-spacing: normal
 
   ul, ol
     margin-left: 0
@@ -106,6 +109,7 @@ a
 
   .-placeholder &
     direction: ltr
+    text-align: left
 
 .-draggable
   cursor: grab

--- a/frontend/src/global_styles/openproject/_index.sass
+++ b/frontend/src/global_styles/openproject/_index.sass
@@ -13,5 +13,6 @@
 @import working-days-admin-settings
 
 @import ndc-dynamic
+@import rtl
 
 @import backlogs

--- a/frontend/src/global_styles/openproject/_rtl.sass
+++ b/frontend/src/global_styles/openproject/_rtl.sass
@@ -46,13 +46,10 @@
         left: auto
         right: 0
 
-  // -------------------- Content area --------------------
-  #content-wrapper
-    margin-left: 0
-    margin-right: var(--main-menu-width)
-
-    &.content-wrapper--with-hidden-sidebar
-      margin-right: var(--main-menu-folded-width)
+  // -------------------- Main menu resizer --------------------
+  .main-menu--resizer
+    left: auto
+    right: calc(var(--main-menu-width) - 0.25rem)
 
   // -------------------- Breadcrumbs --------------------
   .op-breadcrumb

--- a/frontend/src/global_styles/openproject/_rtl.sass
+++ b/frontend/src/global_styles/openproject/_rtl.sass
@@ -1,0 +1,151 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+// -------------------- RTL (Right-to-Left) Support --------------------
+// Provides global RTL overrides for Arabic, Hebrew, and Farsi locales.
+// The dir="rtl" attribute is set on the <html> element by the server
+// when the user's locale is RTL.
+
+[dir="rtl"]
+  // -------------------- Text alignment --------------------
+  body,
+  p,
+  td,
+  th,
+  li,
+  dd,
+  dl,
+  label,
+  .form--label,
+  .generic-table--header,
+  .op-tab-row--link
+    text-align: right
+
+  // -------------------- Main layout --------------------
+  #wrapper
+    direction: rtl
+
+  // -------------------- Main menu --------------------
+  #main-menu
+    left: auto
+    right: 0
+
+    .main-menu--children
+      padding-left: 0
+      padding-right: 10px
+
+    .main-item-wrapper
+      .main-menu--arrow-left-to-project
+        left: auto
+        right: 0
+
+  // -------------------- Content area --------------------
+  #content-wrapper
+    margin-left: 0
+    margin-right: var(--main-menu-width)
+
+    &.content-wrapper--with-hidden-sidebar
+      margin-right: var(--main-menu-folded-width)
+
+  // -------------------- Breadcrumbs --------------------
+  .op-breadcrumb
+    direction: rtl
+    text-align: right
+
+  // -------------------- Toolbar --------------------
+  .toolbar-container
+    .toolbar-items
+      margin-left: 0
+      margin-right: auto
+
+  // -------------------- Forms --------------------
+  .form--field
+    .form--label
+      text-align: right
+
+    .form--field-container
+      direction: rtl
+
+  // -------------------- Tables --------------------
+  .generic-table
+    direction: rtl
+
+    td, th
+      text-align: right
+
+      &:first-child
+        padding-left: 0
+        padding-right: 6px
+
+      &:last-child
+        padding-right: 0
+        padding-left: 6px
+
+  // -------------------- Work package table --------------------
+  .work-package-table
+    direction: rtl
+
+  // -------------------- Sidebar --------------------
+  #sidebar
+    left: auto
+    right: 0
+
+  // -------------------- Modals/Overlays --------------------
+  .op-modal--modal-container
+    direction: rtl
+    text-align: right
+
+  // -------------------- Buttons --------------------
+  .button--icon + .button--text,
+  .op-icon + span
+    margin-left: 0
+    margin-right: 0.35rem
+
+  // -------------------- Flash messages --------------------
+  .op-toast
+    direction: rtl
+    text-align: right
+
+  // -------------------- Lists --------------------
+  ul, ol
+    padding-left: 0
+    padding-right: 40px
+
+  // -------------------- Input fields --------------------
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="search"],
+  input[type="number"],
+  input[type="url"],
+  textarea,
+  select
+    direction: rtl
+    text-align: right
+
+  // -------------------- Checkboxes & radios --------------------
+  input[type="checkbox"],
+  input[type="radio"]
+    margin-left: 0.5rem
+    margin-right: 0
+
+  // -------------------- Gantt chart --------------------
+  // The timeline uses absolute left positioning for bars and grid.
+  // Force LTR on the scroll container and inner elements so JS
+  // positioning and scrollLeft calculations stay valid.
+  .work-packages-tabletimeline--timeline-side,
+  .wp-table-timeline--outer,
+  .wp-table-timeline--container,
+  .wp-table-timeline--body
+    direction: ltr
+
+  // -------------------- Font features for Arabic ligatures --------------------
+  font-feature-settings: "liga" 1, "calt" 1
+  letter-spacing: normal

--- a/frontend/src/global_styles/openproject/_variable_defaults.scss
+++ b/frontend/src/global_styles/openproject/_variable_defaults.scss
@@ -49,7 +49,7 @@
    */
 
   --app-height: 100vh;
-  --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", "Noto Sans Arabic", Tahoma, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   --body-font-size: var(--text-body-size-medium);
 
   --gray: #EAEAEA;

--- a/spec/features/rtl_support_spec.rb
+++ b/spec/features/rtl_support_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'features/support/components/ng_select_autocomplete_helpers'
+
+RSpec.describe 'RTL language support', :js do
+  let(:user) { create(:admin, language: 'ar') }
+
+  before do
+    login_as(user)
+  end
+
+  it 'sets dir=rtl on html element for Arabic locale' do
+    visit root_path
+    expect(page).to have_css('html[dir="rtl"]')
+  end
+
+  it 'sets dir=ltr for English locale' do
+    user.update!(language: 'en')
+    visit root_path
+    expect(page).to have_css('html[dir="ltr"]')
+  end
+end

--- a/spec/features/rtl_support_spec.rb
+++ b/spec/features/rtl_support_spec.rb
@@ -1,20 +1,21 @@
-require 'spec_helper'
-require 'features/support/components/ng_select_autocomplete_helpers'
+# frozen_string_literal: true
 
-RSpec.describe 'RTL language support', :js do
-  let(:user) { create(:admin, language: 'ar') }
+require "spec_helper"
+
+RSpec.describe "RTL language support", :js do
+  let(:user) { create(:admin, language: "ar") }
 
   before do
     login_as(user)
   end
 
-  it 'sets dir=rtl on html element for Arabic locale' do
+  it "sets dir=rtl on html element for Arabic locale" do
     visit root_path
     expect(page).to have_css('html[dir="rtl"]')
   end
 
-  it 'sets dir=ltr for English locale' do
-    user.update!(language: 'en')
+  it "sets dir=ltr for English locale" do
+    user.update!(language: "en")
     visit root_path
     expect(page).to have_css('html[dir="ltr"]')
   end


### PR DESCRIPTION
## Summary

- Set `dir="rtl"` on `<html>` tag for Arabic, Farsi, and Hebrew locales
- Add global RTL stylesheet (`_rtl.sass`) with `[dir="rtl"]` overrides for main menu, content area, forms, tables, modals, inputs, breadcrumbs, and buttons
- Add Noto Sans Arabic and Tahoma to CSS font stack for browser-side Arabic rendering
- Enhance `.-rtl` class with `font-feature-settings` for Arabic ligature preservation
- Add RTL-aware `@media print` styles
- Fix Gantt chart timeline scroll position in RTL mode

## Test plan

- [ ] Switch user language to Arabic — UI should be right-to-left
- [ ] Main menu appears on the right side
- [ ] Forms, tables, and modals are RTL
- [ ] Arabic text has connected characters (ligatures)
- [ ] Gantt chart displays and scrolls correctly
- [ ] Browser print (Ctrl+P) renders correctly in RTL
- [ ] English locale remains LTR and unaffected