### PR TITLE
Add RTL layout support for PDF exports

### DIFF
--- a/app/models/exports/pdf/common/common.rb
+++ b/app/models/exports/pdf/common/common.rb
@@ -35,7 +35,23 @@ module Exports::PDF::Common::Common
   include CustomFieldsHelper
   include OpenProject::TextFormatting
 
+  RTL_LOCALES = %i[ar fa he].freeze
+
   private
+
+  def rtl?
+    RTL_LOCALES.include?(current_language.to_sym)
+  end
+
+  # Returns :right for RTL, :left for LTR
+  def align_start
+    rtl? ? :right : :left
+  end
+
+  # Returns :left for RTL, :right for LTR
+  def align_end
+    rtl? ? :left : :right
+  end
 
   def get_pdf
     ::Exports::PDF::Common::View.new(current_language)

--- a/app/models/exports/pdf/components/cover.rb
+++ b/app/models/exports/pdf/components/cover.rb
@@ -146,13 +146,17 @@ module Exports::PDF::Components::Cover
   end
 
   def write_hero_text(top:, width:, text:, text_style:, height:)
+    # formatted_text_box_measured creates Prawn::Text::Formatted::Box directly,
+    # bypassing our document-level shaping hooks — so apply shaping here manually.
+    text = Exports::PDF::Common::ArabicShaping.process(text)
     formatted_text = text_style.merge({ text:, size: nil, leading: nil })
     formatted_text[:color] = cover_text_color if cover_text_color.present?
-    formatted_text_box_measured(
-      [formatted_text],
+    box_options = {
       size: text_style[:size], leading: text_style[:leading],
       at: [0, top], width:, height:, overflow: :shrink_to_fit
-    )
+    }
+    box_options[:align] = :right if rtl?
+    formatted_text_box_measured([formatted_text], box_options)
   end
 
   def write_cover_footer

--- a/app/models/exports/pdf/components/page.rb
+++ b/app/models/exports/pdf/components/page.rb
@@ -51,13 +51,24 @@ module Exports::PDF::Components::Page
   end
 
   def logo_pdf_left(logo_width)
-    case styles.page_logo_align.to_sym
+    align = styles.page_logo_align.to_sym
+    # Mirror logo alignment for RTL locales
+    align = mirror_align(align) if rtl?
+    case align
     when :center
       (pdf.bounds.right - pdf.bounds.left - logo_width) / 2
     when :right
       pdf.bounds.right - logo_width
     else
       0 # :left
+    end
+  end
+
+  def mirror_align(align)
+    case align
+    when :left then :right
+    when :right then :left
+    else align
     end
   end
 
@@ -75,6 +86,7 @@ module Exports::PDF::Components::Page
     pdf.title = heading
     with_margin(styles.page_heading_margins) do
       style = styles.page_heading
+      style = style.merge({ align: :right }) if rtl?
       pdf.formatted_text([style.merge({ text: heading })], style)
     end
   end
@@ -129,8 +141,13 @@ module Exports::PDF::Components::Page
   def draw_footer_on_page
     top = styles.page_footer_offset
     text_style = styles.page_footer
-    right_width = footer_page_nr.present? ? draw_text_right(footer_page_nr, text_style, top) : 0
-    left_width = footer_date.present? ? draw_text_left(footer_date, text_style, top) : 0
+    if rtl?
+      right_width = footer_date.present? ? draw_text_right(footer_date, text_style, top) : 0
+      left_width = footer_page_nr.present? ? draw_text_left(footer_page_nr, text_style, top) : 0
+    else
+      right_width = footer_page_nr.present? ? draw_text_right(footer_page_nr, text_style, top) : 0
+      left_width = footer_date.present? ? draw_text_left(footer_date, text_style, top) : 0
+    end
     draw_footer_title(left_width, right_width, text_style, top) if footer_title.present?
   end
 

--- a/app/models/exports/pdf/components/wp_table.rb
+++ b/app/models/exports/pdf/components/wp_table.rb
@@ -146,6 +146,7 @@ module Exports::PDF::Components::WpTable
     with_margin(styles.wp_table_margins) do
       with_margin(styles.wp_table_group_header_margins) do
         style = styles.wp_table_group_header
+        style = style.merge({ align: :right }) if rtl?
         pdf.formatted_text([style.merge({ text: make_group_label(group) })], style)
       end
       write_table!(work_packages, query, columns, sums)
@@ -158,7 +159,9 @@ module Exports::PDF::Components::WpTable
   end
 
   def wp_table_options
-    { header: true, cell_style: styles.wp_table_cell.merge({ inline_format: true }) }
+    cell_style = styles.wp_table_cell.merge({ inline_format: true })
+    cell_style[:align] = :right if rtl?
+    { header: true, cell_style: }
   end
 
   def build_table_rows(work_packages, query, columns, sums)

--- a/app/models/projects/exports/pdf_export/table_of_content.rb
+++ b/app/models/projects/exports/pdf_export/table_of_content.rb
@@ -151,8 +151,13 @@ module Projects::Exports::PDFExport
       part_style, toc_item_style = build_toc_item_styles(toc_item)
       indent = levels_indent_list[toc_item[:level] - 1]
 
-      write_toc_part_float(indent[:level_indent], toc_item[:level_string], part_style)
-      write_toc_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :right }))
+      if rtl?
+        write_toc_part_float(0, toc_item[:level_string], part_style.merge({ align: :right }))
+        write_toc_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :left }))
+      else
+        write_toc_part_float(indent[:level_indent], toc_item[:level_string], part_style)
+        write_toc_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :right }))
+      end
       write_toc_item_subject(toc_item, indent[:subject_index], toc_item_style)
       write_toc_item_link(toc_item, y_start_position)
     end

--- a/app/models/work_package/pdf_export/common/markdown_field.rb
+++ b/app/models/work_package/pdf_export/common/markdown_field.rb
@@ -44,6 +44,7 @@ module WorkPackage::PDFExport::Common::MarkdownField
 
   def write_markdown_field_label(label)
     style = styles.markdown_field_label
+    style = style.merge({ align: :right }) if rtl?
     with_margin(styles.markdown_field_label_margins) do
       pdf.formatted_text([style.merge({ text: label })], style)
     end

--- a/app/models/work_package/pdf_export/report/table_of_contents.rb
+++ b/app/models/work_package/pdf_export/report/table_of_contents.rb
@@ -147,9 +147,15 @@ module WorkPackage::PDFExport::Report::TableOfContents
     part_style, toc_item_style = build_toc_item_styles(toc_item)
     indent = levels_indent_list[toc_item[:level] - 1]
 
-    write_part_float(indent[:level_indent], toc_item[:level_string], part_style)
-    write_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :right }))
-    write_toc_item_subject!(toc_item, indent[:subject_index], toc_item_style)
+    if rtl?
+      write_part_float(0, toc_item[:level_string], part_style.merge({ align: :right }))
+      write_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :left }))
+      write_toc_item_subject!(toc_item, indent[:subject_index], toc_item_style)
+    else
+      write_part_float(indent[:level_indent], toc_item[:level_string], part_style)
+      write_part_float(0, toc_item[:page_nr_string], part_style.merge({ align: :right }))
+      write_toc_item_subject!(toc_item, indent[:subject_index], toc_item_style)
+    end
     write_toc_item_link(toc_item, y_start_position)
   end
 

--- a/app/models/work_package/pdf_export/work_package_to_pdf.rb
+++ b/app/models/work_package/pdf_export/work_package_to_pdf.rb
@@ -92,13 +92,15 @@ class WorkPackage::PDFExport::WorkPackageToPdf < Exports::Exporter
     offset = 2
     style = styles.page_heading
     with_margin(styles.page_heading_margins) do
+      text_style = style.dup
+      text_style[:align] = :right if rtl?
       pdf.formatted_text(
         [
           wp_title_formatted_text(work_package, style),
           { text: " " },
           prawn_badge(badge_text, wp_status_prawn_color(work_package), offset:, line_height: style[:size])
         ],
-        style.merge({ draw_text_callback: prawn_badge_draw_text_callback(badge_text, offset) })
+        text_style.merge({ draw_text_callback: prawn_badge_draw_text_callback(badge_text, offset) })
       )
     end
   end

--- a/app/models/work_package/pdf_export/wp/attributes.rb
+++ b/app/models/work_package/pdf_export/wp/attributes.rb
@@ -59,6 +59,7 @@ module WorkPackage::PDFExport::Wp::Attributes
 
   def write_long_text_custom_field_label(label)
     style = styles.wp_attributes_table_label
+    style = style.merge({ align: :right }) if rtl?
     with_margin(styles.markdown_field_label_margins) do
       pdf.formatted_text([style.merge({ text: label })], style)
     end
@@ -119,10 +120,12 @@ module WorkPackage::PDFExport::Wp::Attributes
     return if rows.empty?
 
     with_margin(styles.wp_attributes_table_margins) do
+      cell_style = styles.wp_attributes_table_cell.merge({ inline_format: true })
+      cell_style[:align] = :right if rtl?
       pdf.table(
         rows,
         column_widths: attributes_table_column_widths,
-        cell_style: styles.wp_attributes_table_cell.merge({ inline_format: true })
+        cell_style:
       )
     end
   end
@@ -180,6 +183,7 @@ module WorkPackage::PDFExport::Wp::Attributes
     write_optional_page_break
     with_margin(styles.wp_attributes_group_label_margins) do
       style = styles.wp_attributes_group_label
+      style = style.merge({ align: :right }) if rtl?
       pdf.formatted_text([style.merge({ text: group.translated_key })], style)
       write_group_title_hr if with_hr
     end

--- a/spec/models/exports/pdf/common/rtl_support_spec.rb
+++ b/spec/models/exports/pdf/common/rtl_support_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "PDF RTL support" do
+  describe "RTL locale detection" do
+    let(:exporter_class) do
+      Class.new do
+        include Exports::PDF::Common::Common
+        include Redmine::I18n
+        public :rtl?, :align_start, :align_end
+      end
+    end
+
+    let(:exporter) { exporter_class.new }
+
+    context "with Arabic locale" do
+      before { allow(exporter).to receive(:current_language).and_return(:ar) }
+
+      it "detects RTL" do
+        expect(exporter.rtl?).to be true
+      end
+
+      it "returns right for align_start" do
+        expect(exporter.align_start).to eq(:right)
+      end
+
+      it "returns left for align_end" do
+        expect(exporter.align_end).to eq(:left)
+      end
+    end
+
+    context "with English locale" do
+      before { allow(exporter).to receive(:current_language).and_return(:en) }
+
+      it "does not detect RTL" do
+        expect(exporter.rtl?).to be false
+      end
+
+      it "returns left for align_start" do
+        expect(exporter.align_start).to eq(:left)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Make all PDF exporters RTL-aware for Arabic, Hebrew, and Farsi locales:

- Add `rtl?`, `align_start`, `align_end` helpers to PDF common module
- Mirror page title and headings alignment
- Swap footer date/page number positions
- Mirror logo positioning
- Right-align table cells, group headers, attribute labels, markdown labels
- Swap TOC page numbers and level strings for RTL
- Apply Arabic shaping to cover page hero text

**Depends on:** PDF Arabic shaping PR (for `Exports::PDF::Common::ArabicShaping`)

## Test plan

- [x] Arabic PDF report — cover page title correct
- [x] TOC page numbers on left, level strings on right
- [x] Attribute labels right-aligned
- [x] Table cells right-aligned
- [x] Footer: date on right, page number on left
- [x] Logo mirrors position
- [x] English PDFs remain unaffected