### PR TITLE
[#73557] Performance Issues with Backlog on v17.2.2 (Part 1)

### DIFF
--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -77,7 +77,8 @@ See COPYRIGHT and LICENSE files for more details.
           paginate? ? first_page : work_packages,
           container: border_box,
           project:,
-          max_position:
+          max_position:,
+          open_sprints_exist:
         ) %>
 
     <% if paginate? %>
@@ -110,7 +111,8 @@ See COPYRIGHT and LICENSE files for more details.
             last_page,
             container: border_box,
             project:,
-            max_position:
+            max_position:,
+            open_sprints_exist:
           ) %>
     <% end %>
   <% end %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -38,15 +38,16 @@ module Backlogs
     FIRST_PAGE_SIZE = 50
     LAST_PAGE_SIZE = 10
 
-    attr_reader :work_packages, :project, :current_user, :show_all
+    attr_reader :work_packages, :project, :current_user, :show_all, :open_sprints_exist
 
-    def initialize(work_packages:, project:, show_all: false, current_user: User.current, **system_arguments)
+    def initialize(work_packages:, project:, open_sprints_exist:, show_all: false, current_user: User.current, **system_arguments)
       super()
 
       @work_packages = work_packages
       @project = project
       @show_all = show_all
       @current_user = current_user
+      @open_sprints_exist = open_sprints_exist
 
       @system_arguments = system_arguments
       @system_arguments[:id] = inbox_dom_id

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
@@ -49,7 +49,12 @@ See COPYRIGHT and LICENSE files for more details.
       <% end %>
     <% end %>
     <% grid.with_area(:menu) do %>
-      <%= render(Backlogs::InboxMenuComponent.new(work_package:, project:, max_position:)) %>
+      <%= render Backlogs::InboxMenuComponent.new(
+            work_package:,
+            project:,
+            max_position:,
+            open_sprints_exist:
+          ) %>
     <% end %>
     <% grid.with_area(:subject) do %>
       <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { work_package.subject } %>

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.rb
@@ -32,15 +32,17 @@ module Backlogs
   class InboxItemComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package, :project, :container, :max_position, :current_user
+    attr_reader :work_package, :project, :container, :max_position, :current_user, :open_sprints_exist
 
-    def initialize(inbox_item:, project:, container:, max_position:, current_user: User.current)
+    def initialize(inbox_item:, project:, container:, max_position:, open_sprints_exist:,
+                   current_user: User.current)
       super()
 
       @work_package = inbox_item
       @project = project
       @container = container
       @max_position = max_position
+      @open_sprints_exist = open_sprints_exist
       @current_user = current_user
     end
 

--- a/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_menu_component.rb
@@ -32,15 +32,16 @@ module Backlogs
   class InboxMenuComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    attr_reader :work_package, :project, :max_position, :current_user
+    attr_reader :work_package, :project, :max_position, :current_user, :open_sprints_exist
 
-    def initialize(work_package:, project:, max_position:, current_user: User.current, **system_arguments)
+    def initialize(work_package:, project:, max_position:, open_sprints_exist:, current_user: User.current, **system_arguments)
       super()
 
       @work_package = work_package
       @project = project
       @max_position = max_position
       @current_user = current_user
+      @open_sprints_exist = open_sprints_exist
 
       @system_arguments = system_arguments
       @system_arguments[:menu_id] = dom_target(work_package, :menu)
@@ -63,8 +64,7 @@ module Backlogs
     end
 
     def show_move_to_sprint?
-      allowed_to_manage_sprint_items? &&
-        Agile::Sprint.for_project(project).not_completed.exists?
+      allowed_to_manage_sprint_items? && open_sprints_exist
     end
 
     def allowed_to_manage_sprint_items?

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -44,7 +44,7 @@ module Backlogs
       @project = project
       @current_user = current_user
       @active_sprint_ids = active_sprint_ids
-      @stories = stories || sprint.work_packages_for(project)
+      @stories = stories || sprint.work_packages_for(project).includes(:status, :type)
 
       @system_arguments = system_arguments
       @system_arguments[:id] = dom_id(sprint)

--- a/modules/backlogs/app/controllers/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/inbox_controller.rb
@@ -75,9 +75,13 @@ class InboxController < RbApplicationController
   end
 
   def replace_inbox_component_via_turbo_stream
-    inbox_work_packages = Backlog.inbox_for(project: @project)
+    work_packages = Backlog.inbox_for(project: @project)
     replace_via_turbo_stream(
-      component: Backlogs::InboxComponent.new(work_packages: inbox_work_packages, project: @project),
+      component: Backlogs::InboxComponent.new(
+        work_packages:,
+        project: @project,
+        open_sprints_exist: true
+      ),
       method: :morph
     )
   end

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -91,6 +91,7 @@ class RbMasterBacklogsController < RbApplicationController
       @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
       @stories_by_sprint_id = WorkPackage
         .where(sprint: @sprints, project: @project)
+        .includes(:type, :status)
         .order_by_position
         .group_by(&:sprint_id)
       @active_sprint_ids = @sprints.select(&:active?).map(&:id)

--- a/modules/backlogs/app/controllers/rb_stories_controller.rb
+++ b/modules/backlogs/app/controllers/rb_stories_controller.rb
@@ -127,9 +127,10 @@ class RbStoriesController < RbApplicationController
     render_success_flash_message_via_turbo_stream(
       message: I18n.t(:notice_successful_move, from: @sprint.name, to: I18n.t(:label_inbox))
     )
-    inbox_work_packages = Backlog.inbox_for(project: @project)
+    work_packages = Backlog.inbox_for(project: @project)
+    open_sprints_exist = Agile::Sprint.for_project(@project).not_completed.exists?
     replace_via_turbo_stream(
-      component: Backlogs::InboxComponent.new(work_packages: inbox_work_packages, project: @project),
+      component: Backlogs::InboxComponent.new(work_packages:, project: @project, open_sprints_exist:),
       method: :morph
     )
   end

--- a/modules/backlogs/app/models/backlog.rb
+++ b/modules/backlogs/app/models/backlog.rb
@@ -43,6 +43,7 @@ class Backlog
       .visible
       .with_status_open
       .where(project:, sprint_id: nil)
+      .includes(:type)
       .order(Arel.sql(Story::ORDER))
   end
 

--- a/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
@@ -35,7 +35,8 @@ See COPYRIGHT and LICENSE files for more details.
       <%= render Backlogs::InboxComponent.new(
             work_packages: @inbox_work_packages,
             project: @project,
-            show_all: params[:all].present?
+            show_all: params[:all].present?,
+            open_sprints_exist: @sprints.any?
           ) %>
     </div>
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists"

--- a/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
@@ -47,7 +47,10 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% content_for :content_body do %>
-  <%= turbo_frame_tag :backlogs_container, refresh: :morph, src: backlog_backlogs_project_backlogs_path(@project), class: "op-backlogs-page" %>
+  <%= turbo_frame_tag :backlogs_container,
+                      refresh: :morph,
+                      src: backlog_backlogs_project_backlogs_path(@project, all: params[:all].present?),
+                      class: "op-backlogs-page" %>
 <% end %>
 
 <% content_for :content_body_right do %>

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -40,9 +40,18 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
 
   let(:work_packages) { WorkPackage.none }
   let(:show_all) { false }
+  let(:open_sprints_exist) { true }
 
-  def render_component(**)
-    render_inline(described_class.new(work_packages:, project:, current_user: user, **))
+  def render_component(**extra)
+    render_inline(
+      described_class.new(
+        work_packages:,
+        project:,
+        open_sprints_exist:,
+        current_user: user,
+        **extra
+      )
+    )
   end
 
   def create_inbox_work_package(subject: "WP", position: nil)

--- a/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
@@ -52,7 +52,14 @@ RSpec.describe Backlogs::InboxItemComponent, type: :component do
   let(:work_packages) { WorkPackage.where(id: work_package.id).order(Arel.sql(Story::ORDER)) }
 
   before do
-    render_inline(Backlogs::InboxComponent.new(work_packages:, project:, current_user: user))
+    render_inline(
+      Backlogs::InboxComponent.new(
+        work_packages:,
+        project:,
+        open_sprints_exist: true,
+        current_user: user
+      )
+    )
   end
 
   it "rendering renders the Inbox Component", :aggregate_failures do

--- a/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
@@ -56,9 +56,17 @@ RSpec.describe Backlogs::InboxMenuComponent, type: :component do
            roles: [create(:project_role, permissions:)])
   end
 
-  def render_component(position: 2, max_position: 3)
+  def render_component(position: 2, max_position: 3, open_sprints_exist: true)
     work_package.update!(position:)
-    render_inline(described_class.new(work_package:, project:, max_position:, current_user: user))
+    render_inline(
+      described_class.new(
+        work_package:,
+        project:,
+        max_position:,
+        open_sprints_exist:,
+        current_user: user
+      )
+    )
   end
 
   describe "standard items" do
@@ -164,13 +172,31 @@ RSpec.describe Backlogs::InboxMenuComponent, type: :component do
         expect(page).to have_no_text(I18n.t(:label_sort_lowest))
       end
 
-      it "hides the Move submenu when there is only one item" do
-        render_component(position: 1, max_position: 1)
+      it "hides the Move submenu when there is only one item and no open sprints" do
+        render_component(position: 1, max_position: 1, open_sprints_exist: false)
 
         expect(page).to have_no_selector(
           :menuitem,
           text: I18n.t("backlogs.inbox_menu_component.action_menu.move_menu")
         )
+      end
+
+      context "when open_sprints_exist is true" do
+        it "shows Move to sprint in the Move submenu" do
+          render_component(open_sprints_exist: true)
+
+          expect(page).to have_link(I18n.t("backlogs.inbox_menu_component.label_move_to_sprint"))
+        end
+      end
+
+      context "when open_sprints_exist is false" do
+        it "hides Move to sprint but keeps reorder actions in the Move submenu" do
+          render_component(open_sprints_exist: false)
+
+          expect(page).to have_no_link(I18n.t("backlogs.inbox_menu_component.label_move_to_sprint"))
+          expect(page).to have_text(I18n.t(:label_sort_higher))
+          expect(page).to have_text(I18n.t(:label_sort_lower))
+        end
       end
     end
 

--- a/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
+++ b/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
@@ -96,9 +96,8 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
 
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:backlog)
-
         expect(response).to have_turbo_frame "backlogs_container",
-                                             src: "/projects/#{project.identifier}/backlogs/backlog"
+                                             src: "/projects/#{project.identifier}/backlogs/backlog?all=false"
         expect(response).to have_turbo_frame "content-bodyRight"
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/73557

# What are you trying to accomplish?
- Improve the performance of the `/projects/<project name>/backlogs/backlog?all=true` query, when all the backlog items are fetched.

# What approach did you choose and why?
This improvement will consist of 3 separate steps, rolled out gradually.
1. In this first PR, the N+1 queries are eliminated.
2. The second PR will aim to reduce the turbo frame content size, by lazy loading the dropdown menu for each backlog item.
3. The third PR will introduce turbo frame/stream based pagination with infinite scroll.

Eliminating the N+1 queries is speeding up the response time by **~22%** ⬆️ for 1000 work packages, reducing the loading time from 10.81s to 8.41. This is a humble improvement, however it is not negligible.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
