### PR TITLE
feat: lifecycle stage + portfolio/project manager fields

### DIFF
--- a/app/components/projects/lifecycle_stage_badge_component.html.erb
+++ b/app/components/projects/lifecycle_stage_badge_component.html.erb
@@ -1,0 +1,3 @@
+<%=
+  render(Primer::Beta::Label.new(size: :medium, inline: true, scheme: scheme, **@system_arguments)) { name }
+%>

--- a/app/components/projects/lifecycle_stage_badge_component.rb
+++ b/app/components/projects/lifecycle_stage_badge_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Projects::LifecycleStageBadgeComponent < ApplicationComponent
+  include OpPrimer::ComponentHelpers
+  include Primer::ClassNameHelper
+
+  STAGE_COLORS = {
+    "discovery" => :accent,
+    "design" => :accent,
+    "build" => :attention,
+    "test" => :attention,
+    "pre_launch" => :severe,
+    "live" => :success,
+    "support" => :done,
+    "archived" => :default
+  }.freeze
+
+  def initialize(project:, **system_arguments)
+    super
+
+    @project = project
+    @system_arguments = system_arguments
+  end
+
+  def render?
+    @project.lifecycle_stage.present?
+  end
+
+  def name
+    I18n.t("activerecord.attributes.project.lifecycle_stages.#{@project.lifecycle_stage}",
+           default: @project.lifecycle_stage.to_s.humanize)
+  end
+
+  def scheme
+    STAGE_COLORS[@project.lifecycle_stage.to_s] || :default
+  end
+end

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -222,6 +222,15 @@ module Projects
       end
     end
 
+
+    def lifecycle_stage
+      return nil unless user_can_view_project_attributes?
+
+      if project.lifecycle_stage.present?
+        render Projects::LifecycleStageBadgeComponent.new(project:)
+      end
+    end
+
     def status_explanation
       return nil unless user_can_view_project_attributes?
 

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -223,6 +223,19 @@ module Projects
     end
 
 
+
+    def portfolio_manager
+      return nil unless user_can_view_project_attributes?
+
+      project.portfolio_manager&.name
+    end
+
+    def project_manager
+      return nil unless user_can_view_project_attributes?
+
+      project.project_manager&.name
+    end
+
     def lifecycle_stage
       return nil unless user_can_view_project_attributes?
 

--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -88,6 +88,24 @@ See COPYRIGHT and LICENSE files for more details.
   %>
 <% end %>
 
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
+  <%=
+    render(Primer::Beta::Subhead.new) do |component|
+      component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_lifecycle_stage") }
+    end
+  %>
+  <%=
+    settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
+      render(
+        Primer::Forms::FormList.new(
+          Projects::Settings::LifecycleStageForm.new(f),
+          Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_lifecycle_stage"))
+        )
+      )
+    end
+  %>
+<% end %>
+
 <% if parent_allowed? %>
   <%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
     <%=

--- a/app/components/projects/settings/general/show_component.html.erb
+++ b/app/components/projects/settings/general/show_component.html.erb
@@ -91,6 +91,24 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
   <%=
     render(Primer::Beta::Subhead.new) do |component|
+      component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_management") }
+    end
+  %>
+  <%=
+    settings_primer_form_with(model: project, url: project_settings_general_path(project)) do |f|
+      render(
+        Primer::Forms::FormList.new(
+          Projects::Settings::ManagementForm.new(f),
+          Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_management"))
+        )
+      )
+    end
+  %>
+<% end %>
+
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
+  <%=
+    render(Primer::Beta::Subhead.new) do |component|
       component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_lifecycle_stage") }
     end
   %>

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -52,6 +52,12 @@ module Projects
     attribute :lifecycle_stage do
       validate_lifecycle_stage_included
     end
+    attribute :portfolio_manager_id do
+      validate_manager_is_active_user(:portfolio_manager)
+    end
+    attribute :project_manager_id do
+      validate_manager_is_active_user(:project_manager)
+    end
     attribute :templated do
       validate_templated_set_by_admin
     end
@@ -120,6 +126,15 @@ module Projects
 
     def validate_status_code_included
       errors.add :status, :inclusion if model.status_code && Project.status_codes.keys.exclude?(model.status_code.to_s)
+    end
+
+    def validate_manager_is_active_user(attribute)
+      manager_id = model.send(:"#{attribute}_id")
+      return if manager_id.blank?
+
+      unless User.active.exists?(id: manager_id)
+        errors.add attribute, :invalid
+      end
     end
 
     def validate_lifecycle_stage_included

--- a/app/contracts/projects/base_contract.rb
+++ b/app/contracts/projects/base_contract.rb
@@ -49,6 +49,9 @@ module Projects
       validate_status_code_included
     end
     attribute :status_explanation
+    attribute :lifecycle_stage do
+      validate_lifecycle_stage_included
+    end
     attribute :templated do
       validate_templated_set_by_admin
     end
@@ -73,6 +76,10 @@ module Projects
 
     def assignable_status_codes
       Project.status_codes.keys
+    end
+
+    def assignable_lifecycle_stages
+      Project.lifecycle_stages.keys
     end
 
     protected
@@ -113,6 +120,12 @@ module Projects
 
     def validate_status_code_included
       errors.add :status, :inclusion if model.status_code && Project.status_codes.keys.exclude?(model.status_code.to_s)
+    end
+
+    def validate_lifecycle_stage_included
+      if model.lifecycle_stage && Project.lifecycle_stages.keys.exclude?(model.lifecycle_stage.to_s)
+        errors.add :lifecycle_stage, :inclusion
+      end
     end
 
     def validate_templated_set_by_admin

--- a/app/controllers/projects/settings/management_controller.rb
+++ b/app/controllers/projects/settings/management_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Projects::Settings::ManagementController < Projects::SettingsController
+  menu_item :settings_management
+
+  def update
+    call = Projects::UpdateService
+      .new(model: @project, user: current_user)
+      .call(permitted_params.project)
+
+    @project = call.result
+
+    if call.success?
+      flash[:notice] = I18n.t(:notice_successful_update)
+      redirect_to project_settings_management_path(@project)
+    else
+      flash.now[:error] = I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
+      render action: :show, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/forms/projects/settings/lifecycle_stage_form.rb
+++ b/app/forms/projects/settings/lifecycle_stage_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Projects
+  module Settings
+    class LifecycleStageForm < ApplicationForm
+      form do |f|
+        f.select_list(
+          name: :lifecycle_stage,
+          label: I18n.t("activerecord.attributes.project.lifecycle_stage"),
+          include_blank: I18n.t("label_not_set")
+        ) do |list|
+          Project.lifecycle_stages.each_key do |stage|
+            list.with_option(
+              value: stage,
+              label: I18n.t("activerecord.attributes.project.lifecycle_stages.#{stage}",
+                            default: stage.to_s.humanize)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/forms/projects/settings/management_form.rb
+++ b/app/forms/projects/settings/management_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Projects
+  module Settings
+    class ManagementForm < ApplicationForm
+      form do |f|
+        f.select_list(
+          name: :portfolio_manager_id,
+          label: I18n.t("activerecord.attributes.project.portfolio_manager"),
+          include_blank: I18n.t("label_not_set")
+        ) do |list|
+          User.active.order(:lastname, :firstname).each do |user|
+            list.with_option(value: user.id, label: user.name)
+          end
+        end
+
+        f.select_list(
+          name: :project_manager_id,
+          label: I18n.t("activerecord.attributes.project.project_manager"),
+          include_blank: I18n.t("label_not_set")
+        ) do |list|
+          User.active.order(:lastname, :firstname).each do |user|
+            list.with_option(value: user.id, label: user.name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/lifecycle_stage_transition.rb
+++ b/app/models/lifecycle_stage_transition.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class LifecycleStageTransition < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  validates :to_stage, presence: true
+
+  # Map integer values to human-readable stage names
+  STAGE_NAMES = Project.defined_enums["lifecycle_stage"].invert.freeze
+
+  def from_stage_name
+    STAGE_NAMES[from_stage]
+  end
+
+  def to_stage_name
+    STAGE_NAMES[to_stage]
+  end
+end

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -292,6 +292,7 @@ class PermittedParams
                                                 :templated,
                                                 :status_code,
                                                 :status_explanation,
+                                                :lifecycle_stage,
                                                 work_package_custom_field_ids: [],
                                                 type_ids: [],
                                                 enabled_module_names: [],
@@ -299,6 +300,7 @@ class PermittedParams
 
     whitelist
       .tap { nilify_params!(it, :status_code) }
+      .tap { nilify_params!(it, :lifecycle_stage) }
       .merge(custom_field_values(:project))
   end
 

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -293,6 +293,8 @@ class PermittedParams
                                                 :status_code,
                                                 :status_explanation,
                                                 :lifecycle_stage,
+                                                :portfolio_manager_id,
+                                                :project_manager_id,
                                                 work_package_custom_field_ids: [],
                                                 type_ids: [],
                                                 enabled_module_names: [],

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -101,6 +101,7 @@ class Project < ApplicationRecord
            class_name: "Project::Phase",
            inverse_of: :project
 
+  has_many :lifecycle_stage_transitions, dependent: :destroy
   has_many :recurring_meetings, dependent: :destroy
 
   belongs_to :template, class_name: "Project", optional: true
@@ -146,6 +147,7 @@ class Project < ApplicationRecord
   register_journal_formatted_fields "identifier", "name", formatter_key: :plaintext
   register_journal_formatted_fields "status_explanation", "description", formatter_key: :diff
   register_journal_formatted_fields "status_code", formatter_key: :project_status_code
+  register_journal_formatted_fields "lifecycle_stage", formatter_key: :plaintext
   register_journal_formatted_fields "public", formatter_key: :visibility
   register_journal_formatted_fields "parent_id", formatter_key: :subproject_named_association
   register_journal_formatted_fields /\Acustom_fields_\d+\z/, formatter_key: :custom_field
@@ -202,6 +204,17 @@ class Project < ApplicationRecord
     finished: 4,
     discontinued: 5
   }
+
+  enum :lifecycle_stage, {
+    discovery: 0,
+    design: 1,
+    build: 2,
+    test: 3,
+    pre_launch: 4,
+    live: 5,
+    support: 6,
+    archived: 7
+  }, prefix: true
 
   def visible?(user = User.current)
     active? && (public? || user.admin? || user.access_to?(self))

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -104,6 +104,9 @@ class Project < ApplicationRecord
   has_many :lifecycle_stage_transitions, dependent: :destroy
   has_many :recurring_meetings, dependent: :destroy
 
+  belongs_to :portfolio_manager, class_name: "User", optional: true
+  belongs_to :project_manager, class_name: "User", optional: true
+
   belongs_to :template, class_name: "Project", optional: true
 
   has_many :templated_projects,
@@ -148,6 +151,8 @@ class Project < ApplicationRecord
   register_journal_formatted_fields "status_explanation", "description", formatter_key: :diff
   register_journal_formatted_fields "status_code", formatter_key: :project_status_code
   register_journal_formatted_fields "lifecycle_stage", formatter_key: :plaintext
+  register_journal_formatted_fields "portfolio_manager_id", formatter_key: :named_association
+  register_journal_formatted_fields "project_manager_id", formatter_key: :named_association
   register_journal_formatted_fields "public", formatter_key: :visibility
   register_journal_formatted_fields "parent_id", formatter_key: :subproject_named_association
   register_journal_formatted_fields /\Acustom_fields_\d+\z/, formatter_key: :custom_field

--- a/app/models/queries/projects/filters/lifecycle_stage_filter.rb
+++ b/app/models/queries/projects/filters/lifecycle_stage_filter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Queries::Projects::Filters::LifecycleStageFilter < Queries::Projects::Filters::Base
+  def allowed_values
+    @allowed_values ||= Project.lifecycle_stages.map do |stage, id|
+      [I18n.t("activerecord.attributes.project.lifecycle_stages.#{stage}", default: stage.to_s.humanize), id.to_s]
+    end
+  end
+
+  def type
+    :list_optional
+  end
+
+  def where
+    operator_strategy.sql_for_field(values, model.table_name, :lifecycle_stage)
+  end
+
+  def self.key
+    :lifecycle_stage
+  end
+
+  def human_name
+    I18n.t("label_lifecycle_stage_filter")
+  end
+end

--- a/app/services/projects/set_attributes_service.rb
+++ b/app/services/projects/set_attributes_service.rb
@@ -35,12 +35,13 @@ module Projects
     def set_attributes(params)
       super(set_attributes_params(params)).tap do
         set_status_code(params[:status_code]) if status_code_provided?(params)
+        set_lifecycle_stage(params[:lifecycle_stage]) if lifecycle_stage_provided?(params)
       end
     end
 
     def set_attributes_params(params)
       # Remove fields that cannot be directly set
-      filtered = params.except(:status_code)
+      filtered = params.except(:status_code, :lifecycle_stage)
 
       custom_field_value_params = filtered[:custom_field_values]
       return filtered unless custom_field_value_params
@@ -114,6 +115,30 @@ module Projects
 
     def first_not_set_code
       (Project.status_codes.keys - [model.status_code]).first
+    end
+
+
+    def lifecycle_stage_provided?(params)
+      params.key?(:lifecycle_stage)
+    end
+
+    def set_lifecycle_stage(lifecycle_stage)
+      if faulty_lifecycle_stage?(lifecycle_stage)
+        model.lifecycle_stage = first_not_set_lifecycle_stage
+        stage_attributes = model.instance_variable_get(:@attributes)["lifecycle_stage"]
+        stage_attributes.instance_variable_set(:@value_before_type_cast, lifecycle_stage)
+        stage_attributes.instance_variable_set(:@value, lifecycle_stage)
+      else
+        model.lifecycle_stage = lifecycle_stage
+      end
+    end
+
+    def faulty_lifecycle_stage?(lifecycle_stage)
+      lifecycle_stage && Project.lifecycle_stages.keys.exclude?(lifecycle_stage.to_s)
+    end
+
+    def first_not_set_lifecycle_stage
+      (Project.lifecycle_stages.keys - [model.lifecycle_stage]).first
     end
 
     def set_custom_values_to_validate(params)

--- a/app/services/projects/update_service.rb
+++ b/app/services/projects/update_service.rb
@@ -61,6 +61,7 @@ module Projects
       send_update_notification
       update_wp_versions_on_parent_change
       handle_archiving
+      record_lifecycle_stage_transition
 
       ret
     end
@@ -123,6 +124,18 @@ module Projects
       # already been checked in Projects::UpdateContract
       service = service_class.new(user:, model:, contract_class: EmptyContract)
       service.call
+    end
+
+    def record_lifecycle_stage_transition
+      return unless memoized_changes["lifecycle_stage"]
+
+      from_stage, to_stage = memoized_changes["lifecycle_stage"]
+      LifecycleStageTransition.create!(
+        project: model,
+        user:,
+        from_stage: from_stage.nil? ? nil : Project.lifecycle_stages[from_stage],
+        to_stage: Project.lifecycle_stages[to_stage]
+      )
     end
   end
 end

--- a/app/views/projects/settings/management/show.html.erb
+++ b/app/views/projects/settings/management/show.html.erb
@@ -1,0 +1,47 @@
+<%= render Projects::Settings::IndexPageHeaderComponent.new(project: @project) %>
+
+<%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
+  <%=
+    render(Primer::Beta::Subhead.new) do |component|
+      component.with_heading(tag: :h3, size: :medium) { I18n.t("projects.settings.header_management") }
+    end
+  %>
+  <%=
+    settings_primer_form_with(model: @project, url: project_settings_management_path(@project)) do |f|
+      render(
+        Primer::Forms::FormList.new(
+          Projects::Settings::ManagementForm.new(f),
+          Projects::Settings::Submit.new(f, label: I18n.t("projects.settings.button_update_management"))
+        )
+      )
+    end
+  %>
+<% end %>
+
+<% if @project.portfolio_manager || @project.project_manager %>
+  <%= render(Primer::BaseComponent.new(tag: :section, mb: 4)) do %>
+    <%=
+      render(Primer::Beta::Subhead.new) do |component|
+        component.with_heading(tag: :h3, size: :medium) { I18n.t("label_management") + " Details" }
+      end
+    %>
+    <% if @project.portfolio_manager %>
+      <div class="Box p-3 mb-3">
+        <h4><%= I18n.t("label_portfolio_manager") %></h4>
+        <p><strong><%= @project.portfolio_manager.name %></strong></p>
+        <% if @project.portfolio_manager.mail.present? %>
+          <p><%= mail_to @project.portfolio_manager.mail %></p>
+        <% end %>
+      </div>
+    <% end %>
+    <% if @project.project_manager %>
+      <div class="Box p-3 mb-3">
+        <h4><%= I18n.t("label_project_manager") %></h4>
+        <p><strong><%= @project.project_manager.name %></strong></p>
+        <% if @project.project_manager.mail.present? %>
+          <p><%= mail_to @project.project_manager.mail %></p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -765,6 +765,7 @@ Redmine::MenuManager.map :project_menu do |menu|
 
   project_menu_items = {
     general: { caption: :label_information_plural },
+    management: { caption: :label_management },
     life_cycle_steps: {
       caption: :label_project_life_cycle,
       action: :index

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -214,6 +214,19 @@ Rails.application.reloader.to_prepare do
                      dependencies: :view_lifecycle_stage,
                      contract_actions: { projects: %i[update] }
 
+      map.permission :view_project_management,
+                     {},
+                     permissible_on: :project,
+                     dependencies: :view_project
+
+      map.permission :edit_project_management,
+                     {},
+                     permissible_on: :project,
+                     require: :member,
+                     dependencies: :view_project_management,
+                     contract_actions: { projects: %i[update] }
+
+
       map.permission :manage_members,
                      {
                        members: %i[index new create update destroy destroy_by_principal autocomplete_for_member menu],

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -202,6 +202,18 @@ Rails.application.reloader.to_prepare do
                      require: :member,
                      dependencies: :edit_project_phases
 
+      map.permission :view_lifecycle_stage,
+                     {},
+                     permissible_on: :project,
+                     dependencies: :view_project
+
+      map.permission :edit_lifecycle_stage,
+                     {},
+                     permissible_on: :project,
+                     require: :member,
+                     dependencies: :view_lifecycle_stage,
+                     contract_actions: { projects: %i[update] }
+
       map.permission :manage_members,
                      {
                        members: %i[index new create update destroy destroy_by_principal autocomplete_for_member menu],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -880,10 +880,12 @@ en:
       header_details: Basic details
       header_status: Status
       header_lifecycle_stage: Project Stage
+      header_management: Management
       header_relations: Project relations
       button_update_details: Update details
       button_update_status_description: Update status description
       button_update_lifecycle_stage: Update project stage
+      button_update_management: Update management
       button_update_parent_project: Update parent project
       public_warning: >
         This project is public.
@@ -1763,6 +1765,8 @@ en:
           off_track: "Off track"
           finished: "Finished"
           discontinued: "Discontinued"
+        portfolio_manager: "Portfolio Manager"
+        project_manager: "Project Manager"
         lifecycle_stage: "Project Stage"
         lifecycle_stages:
           discovery: "Discovery"
@@ -4114,6 +4118,9 @@ en:
   label_project_plural: "Projects"
   label_project_list_plural: "Project lists"
   label_project_life_cycle: "Project life cycle"
+  label_management: "Management"
+  label_portfolio_manager: "Portfolio Manager"
+  label_project_manager: "Project Manager"
   label_lifecycle_pipeline: "Project Pipeline"
   label_lifecycle_stage: "Project Stage"
   label_lifecycle_stage_filter: "Project Stage"
@@ -4785,6 +4792,8 @@ en:
   permission_view_project_phases: "View project phases"
   permission_view_lifecycle_stage: "View project lifecycle stage"
   permission_edit_lifecycle_stage: "Edit project lifecycle stage"
+  permission_view_project_management: "View project management"
+  permission_edit_project_management: "Edit project management"
   permission_save_bcf_queries: "Save BCF queries"
   permission_manage_public_bcf_queries: "Manage public BCF queries"
   permission_edit_attribute_help_texts: "Edit attribute help texts"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,9 +879,11 @@ en:
     settings:
       header_details: Basic details
       header_status: Status
+      header_lifecycle_stage: Project Stage
       header_relations: Project relations
       button_update_details: Update details
       button_update_status_description: Update status description
+      button_update_lifecycle_stage: Update project stage
       button_update_parent_project: Update parent project
       public_warning: >
         This project is public.
@@ -1761,6 +1763,16 @@ en:
           off_track: "Off track"
           finished: "Finished"
           discontinued: "Discontinued"
+        lifecycle_stage: "Project Stage"
+        lifecycle_stages:
+          discovery: "Discovery"
+          design: "Design"
+          build: "Build"
+          test: "Test"
+          pre_launch: "Pre-Launch"
+          live: "Live"
+          support: "Support"
+          archived: "Archived"
         project_creation_wizard_assignee_custom_field: "Assignee when submitted"
         project_creation_wizard_notification_text: "Notification text"
         project_creation_wizard_send_confirmation_email: "Confirmation email"
@@ -4102,6 +4114,9 @@ en:
   label_project_plural: "Projects"
   label_project_list_plural: "Project lists"
   label_project_life_cycle: "Project life cycle"
+  label_lifecycle_pipeline: "Project Pipeline"
+  label_lifecycle_stage: "Project Stage"
+  label_lifecycle_stage_filter: "Project Stage"
   label_project_attributes_plural: "Project attributes"
   label_project_custom_field_plural: "Project attributes"
   label_project_settings: "Project settings"
@@ -4768,6 +4783,8 @@ en:
   permission_view_project_activity: "View project activity"
   permission_view_project_attributes: "View project attributes"
   permission_view_project_phases: "View project phases"
+  permission_view_lifecycle_stage: "View project lifecycle stage"
+  permission_edit_lifecycle_stage: "Edit project lifecycle stage"
   permission_save_bcf_queries: "Save BCF queries"
   permission_manage_public_bcf_queries: "Manage public BCF queries"
   permission_edit_attribute_help_texts: "Edit attribute help texts"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,6 +296,7 @@ Rails.application.routes.draw do
   resources :projects, except: %i[new create show edit update] do
     scope module: "projects" do
       namespace "settings" do
+        resource :management, only: %i[show update], controller: "management"
         resource :general, only: %i[show update], controller: "general" do
           get :toggle_public_dialog
           post :toggle_public

--- a/db/migrate/20260403120000_add_lifecycle_stage_to_projects.rb
+++ b/db/migrate/20260403120000_add_lifecycle_stage_to_projects.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddLifecycleStageToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_column :projects, :lifecycle_stage, :integer, default: nil
+    add_index :projects, :lifecycle_stage
+
+    create_table :lifecycle_stage_transitions do |t|
+      t.references :project, null: false, foreign_key: true
+      t.integer :from_stage
+      t.integer :to_stage, null: false
+      t.references :user, null: false, foreign_key: true
+      t.datetime :created_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    add_index :lifecycle_stage_transitions, %i[project_id created_at]
+  end
+end

--- a/db/migrate/20260403120001_add_manager_fields_to_projects.rb
+++ b/db/migrate/20260403120001_add_manager_fields_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddManagerFieldsToProjects < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :projects, :portfolio_manager, foreign_key: { to_table: :users }, null: true
+    add_reference :projects, :project_manager, foreign_key: { to_table: :users }, null: true
+  end
+end

--- a/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transition_representer.rb
+++ b/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transition_representer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    module LifecycleStageTransitions
+      class LifecycleStageTransitionRepresenter < ::API::Decorators::Single
+        include API::Decorators::DateProperty
+
+        property :id
+
+        property :from_stage_name,
+                 as: :fromStage
+
+        property :to_stage_name,
+                 as: :toStage
+
+        date_time_property :created_at
+
+        resource :project,
+                 getter: ->(*) {
+                   ::API::V3::Projects::ProjectRepresenter.create(represented.project, current_user:, embed_links: false)
+                 },
+                 link: ->(*) {
+                   {
+                     href: api_v3_paths.project(represented.project_id),
+                     title: represented.project.name
+                   }
+                 }
+
+        resource :user,
+                 getter: ->(*) {
+                   ::API::V3::Users::UserRepresenter.create(represented.user, current_user:)
+                 },
+                 link: ->(*) {
+                   {
+                     href: api_v3_paths.user(represented.user_id),
+                     title: represented.user.name
+                   }
+                 }
+
+        def _type
+          "LifecycleStageTransition"
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transitions_by_project_api.rb
+++ b/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transitions_by_project_api.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    module LifecycleStageTransitions
+      class LifecycleStageTransitionsByProjectAPI < ::API::OpenProjectAPI
+        resources :lifecycle_stage_transitions do
+          get do
+            transitions = @project.lifecycle_stage_transitions
+                                  .includes(:user, :project)
+                                  .order(created_at: :desc)
+
+            ::API::V3::LifecycleStageTransitions::LifecycleStageTransitionsCollectionRepresenter
+              .new(transitions,
+                   self_link: api_v3_paths.project(@project.id) + "/lifecycle_stage_transitions",
+                   current_user:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transitions_collection_representer.rb
+++ b/lib/api/v3/lifecycle_stage_transitions/lifecycle_stage_transitions_collection_representer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    module LifecycleStageTransitions
+      class LifecycleStageTransitionsCollectionRepresenter < ::API::Decorators::UnpaginatedCollection
+        element_decorator ::API::V3::LifecycleStageTransitions::LifecycleStageTransitionRepresenter
+      end
+    end
+  end
+end

--- a/lib/api/v3/projects/lifecycle_stages/lifecycle_stage_representer.rb
+++ b/lib/api/v3/projects/lifecycle_stages/lifecycle_stage_representer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    module Projects
+      module LifecycleStages
+        class LifecycleStageRepresenter < ::API::Decorators::Single
+          link :self do
+            {
+              href: api_v3_paths.project_lifecycle_stage(represented),
+              title: I18n.t(:"activerecord.attributes.project.lifecycle_stages.#{represented}",
+                            default: represented.to_s.humanize)
+            }
+          end
+
+          property :id,
+                   getter: ->(*) { self }
+
+          property :name,
+                   getter: ->(*) {
+                     I18n.t(:"activerecord.attributes.project.lifecycle_stages.#{self}",
+                            default: to_s.humanize)
+                   }
+
+          def _type
+            "ProjectLifecycleStage"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/projects/lifecycle_stages/lifecycle_stages_api.rb
+++ b/lib/api/v3/projects/lifecycle_stages/lifecycle_stages_api.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module API
+  module V3
+    module Projects
+      module LifecycleStages
+        class LifecycleStagesAPI < ::API::OpenProjectAPI
+          resources :project_lifecycle_stages do
+            params do
+              requires :id, desc: "Project lifecycle stage identifier"
+            end
+            route_param :id do
+              helpers do
+                def lifecycle_stage_exists?
+                  ::Project.lifecycle_stages.keys.include?(params[:id])
+                end
+              end
+
+              after_validation do
+                raise API::Errors::NotFound unless lifecycle_stage_exists?
+              end
+
+              get do
+                API::V3::Projects::LifecycleStages::LifecycleStageRepresenter
+                  .new(params[:id], current_user:, embed_links: true)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/projects/project_payload_representer.rb
+++ b/lib/api/v3/projects/project_payload_representer.rb
@@ -35,7 +35,7 @@ module API
         cached_representer disabled: true
 
         def writable_attributes
-          super + %w[status]
+          super + %w[status lifecycle_stage]
         end
       end
     end

--- a/lib/api/v3/projects/project_payload_representer.rb
+++ b/lib/api/v3/projects/project_payload_representer.rb
@@ -35,7 +35,7 @@ module API
         cached_representer disabled: true
 
         def writable_attributes
-          super + %w[status lifecycle_stage]
+          super + %w[status lifecycle_stage portfolioManager projectManager]
         end
       end
     end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -237,6 +237,39 @@ module API
         formattable_property :status_explanation,
                              cache_if: current_user_view_allowed_lambda
 
+        resource :lifecycle_stage,
+                 skip_render: ->(*) {
+                   !current_user.allowed_in_project?(:view_project, represented) &&
+                     !current_user.allowed_globally?(:add_project)
+                 },
+                 link_cache_if: current_user_view_allowed_lambda,
+                 getter: ->(*) {
+                           next unless represented.lifecycle_stage
+
+                           ::API::V3::Projects::LifecycleStages::LifecycleStageRepresenter
+                             .create(represented.lifecycle_stage, current_user:, embed_links:)
+                         },
+                 link: ->(*) {
+                         if represented.lifecycle_stage
+                           {
+                             href: api_v3_paths.project_lifecycle_stage(represented.lifecycle_stage),
+                             title: I18n.t(:"activerecord.attributes.project.lifecycle_stages.#{represented.lifecycle_stage}",
+                                           default: represented.lifecycle_stage.to_s.humanize)
+                           }.compact
+                         else
+                           {
+                             href: nil
+                           }
+                         end
+                       },
+                 setter: ->(fragment:, represented:, **) {
+                           link = ::API::Decorators::LinkObject.new(represented,
+                                                                    path: :project_lifecycle_stage,
+                                                                    property_name: :lifecycle_stage,
+                                                                    setter: :"lifecycle_stage=")
+                           link.from_hash(fragment)
+                         }
+
         def _type
           strategy.type
         end

--- a/lib/api/v3/projects/project_representer.rb
+++ b/lib/api/v3/projects/project_representer.rb
@@ -270,6 +270,67 @@ module API
                            link.from_hash(fragment)
                          }
 
+
+        resource :portfolioManager,
+                 skip_render: ->(*) {
+                   !current_user.allowed_in_project?(:view_project, represented) &&
+                     !current_user.allowed_globally?(:add_project)
+                 },
+                 link_cache_if: current_user_view_allowed_lambda,
+                 getter: ->(*) {
+                           next unless represented.portfolio_manager
+
+                           ::API::V3::Users::UserRepresenter.create(represented.portfolio_manager, current_user:)
+                         },
+                 link: ->(*) {
+                         if represented.portfolio_manager
+                           {
+                             href: api_v3_paths.user(represented.portfolio_manager_id),
+                             title: represented.portfolio_manager.name
+                           }
+                         else
+                           { href: nil }
+                         end
+                       },
+                 setter: ->(fragment:, represented:, **) {
+                           link = ::API::Decorators::LinkObject.new(represented,
+                                                                    path: :user,
+                                                                    property_name: :portfolio_manager,
+                                                                    setter: :"portfolio_manager_id=",
+                                                                    getter: :portfolio_manager_id)
+                           link.from_hash(fragment)
+                         }
+
+        resource :projectManager,
+                 skip_render: ->(*) {
+                   !current_user.allowed_in_project?(:view_project, represented) &&
+                     !current_user.allowed_globally?(:add_project)
+                 },
+                 link_cache_if: current_user_view_allowed_lambda,
+                 getter: ->(*) {
+                           next unless represented.project_manager
+
+                           ::API::V3::Users::UserRepresenter.create(represented.project_manager, current_user:)
+                         },
+                 link: ->(*) {
+                         if represented.project_manager
+                           {
+                             href: api_v3_paths.user(represented.project_manager_id),
+                             title: represented.project_manager.name
+                           }
+                         else
+                           { href: nil }
+                         end
+                       },
+                 setter: ->(fragment:, represented:, **) {
+                           link = ::API::Decorators::LinkObject.new(represented,
+                                                                    path: :user,
+                                                                    property_name: :project_manager,
+                                                                    setter: :"project_manager_id=",
+                                                                    getter: :project_manager_id)
+                           link.from_hash(fragment)
+                         }
+
         def _type
           strategy.type
         end

--- a/lib/api/v3/root.rb
+++ b/lib/api/v3/root.rb
@@ -71,6 +71,7 @@ module API
       mount ::API::V3::ProjectPhaseDefinitions::ProjectPhaseDefinitionsAPI
       mount ::API::V3::ProjectPhases::ProjectPhasesAPI
       mount ::API::V3::Projects::Statuses::StatusesAPI
+      mount ::API::V3::Projects::LifecycleStages::LifecycleStagesAPI
       mount ::API::V3::Queries::QueriesAPI
       mount ::API::V3::Render::RenderAPI
       mount ::API::V3::Relations::RelationsAPI

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -388,6 +388,7 @@ module API
           end
 
           show :project_status
+          show :project_lifecycle_stage
 
           def self.projects_available_parents(of: nil, workspace_type: nil)
             query = { of:, workspace_type: }.compact_blank.to_query

--- a/lib/api/v3/workspaces/nested_apis.rb
+++ b/lib/api/v3/workspaces/nested_apis.rb
@@ -39,6 +39,7 @@ module API
         mount API::V3::Versions::VersionsByProjectAPI
         mount API::V3::Queries::QueriesByWorkspaceAPI
         mount API::V3::Favorites::FavoriteActionsAPI, with: { favorite_object_getter: ->(*) { @project } }
+        mount API::V3::LifecycleStageTransitions::LifecycleStageTransitionsByProjectAPI
       end
     end
   end


### PR DESCRIPTION
## Summary
- **Feature #1 - Project Lifecycle Stage**: Adds `lifecycle_stage` enum column to projects (discovery, design, build, test, pre_launch, live, support, archived) with transition tracking, API support, UI dropdown on General settings, badge component for project list, filter, and permissions.
- **Feature #2 - Portfolio Manager + Project Manager**: Adds `portfolio_manager_id` and `project_manager_id` FK columns to projects with user validation, API linked resources, Management settings tab with user select dropdowns, project list columns, and permissions.

## Changes

### Feature #1: Project Lifecycle Stage
- Migration: `lifecycle_stage` integer column + `lifecycle_stage_transitions` table
- Model: enum on Project, LifecycleStageTransition model with belongs_to project/user
- Contract: validates lifecycle_stage inclusion in base_contract
- Service: SetAttributesService handles lifecycle_stage, UpdateService records transitions
- API: lifecycle_stage as linked resource on ProjectRepresenter, transitions endpoint nested under projects
- UI: Dropdown on General settings, LifecycleStageBadgeComponent for project list
- Permissions: view_lifecycle_stage, edit_lifecycle_stage
- Filter: LifecycleStageFilter for project queries

### Feature #2: Portfolio Manager + Project Manager
- Migration: `portfolio_manager_id` and `project_manager_id` FKs to users table
- Model: belongs_to associations on Project
- Contract: validates both managers are active users
- API: portfolioManager and projectManager as linked resources
- UI: Management tab in project settings with user dropdowns + contact details
- Permissions: view_project_management, edit_project_management

## Test plan
- [ ] Run migrations on test1, verify columns and tables exist
- [ ] API: PATCH project with lifecycleStage link, verify it persists
- [ ] API: GET project, verify lifecycleStage and managers appear in response
- [ ] API: GET transitions endpoint after stage change
- [ ] UI: Open project settings > General, verify stage dropdown
- [ ] UI: Open project settings > Management tab, verify manager dropdowns
- [ ] UI: Change stage and managers, verify persistence
- [ ] UI: Verify lifecycle stage badge on project list
- [ ] UI: Verify manager columns on project list

🤖 Generated with [Claude Code](https://claude.com/claude-code)