### PR TITLE
[#73535] Update "finish" sprint to "complete" sprint [FOLLOW UP]

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_header_component.html.erb
@@ -89,7 +89,7 @@ See COPYRIGHT and LICENSE files for more details.
           render(Primer::Beta::Button.new(**finish_sprint_button_arguments)) do |button|
             button.with_leading_visual_icon(icon: :check)
 
-            t(".label_finish_sprint")
+            t(".label_complete_sprint")
           end
         end
       %>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -185,7 +185,7 @@ en:
 
     sprint_header_component:
       label_start_sprint: "Start"
-      label_finish_sprint: "Finish"
+      label_complete_sprint: "Complete"
       start_sprint_disabled_reason_active_sprint: "Another sprint is already active."
       start_sprint_disabled_reason_missing_dates: "Start and finish dates are required in order to start the sprint."
       label_story_count:

--- a/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_header_component_spec.rb
@@ -168,10 +168,10 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
         expect(page).to have_octicon(:play)
       end
 
-      it "does not show Finish" do
+      it "does not show Complete" do
         render_component
 
-        expect(page).to have_no_selector(:link_or_button, "Finish")
+        expect(page).to have_no_selector(:link_or_button, "Complete")
       end
 
       context "when another sprint is already active" do
@@ -217,10 +217,10 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
                               start_date:, finish_date:)
       end
 
-      it "shows a Finish button" do
+      it "shows a Complete button" do
         render_component
 
-        expect(page).to have_selector(:link_or_button, "Finish")
+        expect(page).to have_selector(:link_or_button, "Complete")
         expect(page).to have_octicon(:check)
       end
 
@@ -237,11 +237,11 @@ RSpec.describe Backlogs::SprintHeaderComponent, type: :component do
                               start_date:, finish_date:)
       end
 
-      it "shows neither Start nor Finish" do
+      it "shows neither Start nor Complete" do
         render_component
 
         expect(page).to have_no_selector(:link_or_button, "Start")
-        expect(page).to have_no_selector(:link_or_button, "Finish")
+        expect(page).to have_no_selector(:link_or_button, "Complete")
       end
     end
 

--- a/modules/backlogs/spec/features/sprints/start_finish_spec.rb
+++ b/modules/backlogs/spec/features/sprints/start_finish_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe "Start and finish sprints",
     end
     let!(:task_board) { create(:board_grid_with_query, project:, linked: first_sprint) }
 
-    it "finishes the sprint and returns to the backlog" do
-      planning_page.click_finish_sprint_button(first_sprint)
+    it "completes the sprint and returns to the backlog" do
+      planning_page.click_complete_sprint_button(first_sprint)
 
       planning_page.expect_current_path
       expect_and_dismiss_flash type: :success, message: "The sprint was completed."
@@ -200,9 +200,9 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the next sprint" do
-        planning_page.click_to_finish_sprint(first_sprint)
+        planning_page.click_to_complete_sprint(first_sprint)
 
-        planning_page.expect_sprint_finishing_modal
+        planning_page.expect_sprint_completing_modal
 
         planning_page.expect_sprints_to_choose_for_moving_unfinished_work_packages_to second_sprint
         planning_page.choose_to_move_unfinished_work_packages_to_sprint second_sprint.name
@@ -220,9 +220,9 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the top of the backlog" do
-        planning_page.click_to_finish_sprint(first_sprint)
+        planning_page.click_to_complete_sprint(first_sprint)
 
-        planning_page.expect_sprint_finishing_modal
+        planning_page.expect_sprint_completing_modal
         planning_page.choose_to_move_unfinished_work_packages_to_top_of_backlog
 
         planning_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."
@@ -235,9 +235,9 @@ RSpec.describe "Start and finish sprints",
       end
 
       it "allows moving unfinished work packages to the bottom of the backlog" do
-        planning_page.click_to_finish_sprint(first_sprint)
+        planning_page.click_to_complete_sprint(first_sprint)
 
-        planning_page.expect_sprint_finishing_modal
+        planning_page.expect_sprint_completing_modal
         planning_page.choose_to_move_unfinished_work_packages_to_bottom_of_backlog
 
         planning_page.expect_and_dismiss_flash type: :success, message: "The sprint was completed."

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -398,7 +398,7 @@ module Pages
 
     def click_finish_sprint_button(sprint)
       within_sprint(sprint) do
-        click_on("Finish")
+        click_on("Complete")
       end
     end
 

--- a/modules/backlogs/spec/support/pages/sprint_planning.rb
+++ b/modules/backlogs/spec/support/pages/sprint_planning.rb
@@ -369,12 +369,12 @@ module Pages
       expect(page).to have_css("#create-work-package-dialog")
     end
 
-    def expect_sprint_finishing_modal
-      expect(page).to have_css sprint_finish_modal_selector
+    def expect_sprint_completing_modal
+      expect(page).to have_css sprint_complete_modal_selector
     end
 
     def expect_sprints_to_choose_for_moving_unfinished_work_packages_to(*sprints)
-      within sprint_finish_modal_selector do
+      within sprint_complete_modal_selector do
         expect(page).to have_select("Select sprint", options: sprints.map(&:name))
       end
     end
@@ -396,18 +396,18 @@ module Pages
       end
     end
 
-    def click_finish_sprint_button(sprint)
+    def click_complete_sprint_button(sprint)
       within_sprint(sprint) do
         click_on("Complete")
       end
     end
 
-    def click_to_finish_sprint(sprint)
-      click_finish_sprint_button(sprint)
+    def click_to_complete_sprint(sprint)
+      click_complete_sprint_button(sprint)
     end
 
     def choose_to_move_unfinished_work_packages_to_sprint(sprint_name)
-      within sprint_finish_modal_selector do
+      within sprint_complete_modal_selector do
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_sprint")
         select sprint_name, from: "Select sprint"
 
@@ -416,7 +416,7 @@ module Pages
     end
 
     def choose_to_move_unfinished_work_packages_to_top_of_backlog
-      within sprint_finish_modal_selector do
+      within sprint_complete_modal_selector do
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_top_of_backlog")
 
         click_button "Complete sprint"
@@ -424,7 +424,7 @@ module Pages
     end
 
     def choose_to_move_unfinished_work_packages_to_bottom_of_backlog
-      within sprint_finish_modal_selector do
+      within sprint_complete_modal_selector do
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_bottom_of_backlog")
 
         click_button "Complete sprint"
@@ -469,7 +469,7 @@ module Pages
       test_selector("work-package-#{work_package.id}")
     end
 
-    def sprint_finish_modal_selector
+    def sprint_complete_modal_selector
       "##{::Backlogs::FinishSprintDialogComponent::DIALOG_ID}"
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73535

# What are you trying to accomplish?

Follow-up to opf/openproject#22643 and opf/openproject#22649.

The "Finish" to "Complete" sprint rename from commit 5140086 needs to be reapplied now that the "Start" and "Finish" actions have been moved out of the sprint menu into the sprint header component.

- Renames the sprint header action from "Finish" to "Complete"
- Renames the backing English translation key to `label_complete_sprint`
- Updates Backlogs specs and page objects to match the visible "Complete" wording

> [!NOTE]
>  implementation-level names (routes, controller actions, component class names) still use "finish" and are not renamed in this PR.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1218" height="288" alt="before" src="https://github.com/user-attachments/assets/7dfe42f6-4892-4183-abb1-0f8a55f5a4de" /> | <img width="1218" height="288" alt="after" src="https://github.com/user-attachments/assets/9c385a18-4d9f-4dba-8806-3978bb8b47b3" /> |

# What approach did you choose and why?

Straightforward rename of the button label, translation key, and corresponding page object methods / specs.

# Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)