### PR TITLE
Reinstate "external links capture within blocknote shadow dom"

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -30,6 +30,8 @@
 
 import { User } from '@blocknote/core/comments';
 import { HocuspocusProvider } from '@hocuspocus/provider';
+import { Application } from '@hotwired/stimulus';
+import ExternalLinksController from 'core-stimulus/controllers/external-links.controller';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { ShadowDomWrapper } from 'op-blocknote-extensions';
 import React from 'react';
@@ -38,9 +40,10 @@ import { createRoot } from 'react-dom/client';
 import OpBlockNoteContainer from '../react/OpBlockNoteContainer';
 
 class BlockNoteElement extends HTMLElement {
-  private editorRoot:HTMLDivElement;
+  private stimulusRoot:HTMLDivElement;
   private editorMount:HTMLDivElement;
-  private reactRoot:Root|null = null;
+  private reactRoot:Root | null = null;
+  private stimulusApp:Application | null = null;
   private renderCallback:((provider:HocuspocusProvider) => void) | null = null;
 
   constructor() {
@@ -48,22 +51,26 @@ class BlockNoteElement extends HTMLElement {
 
     const shadowRoot = this.attachShadow({ mode: 'open' });
 
-    this.editorRoot = document.createElement('div');
+    this.stimulusRoot = document.createElement('div');
     const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
     if (browserSpecificClasses.length > 0) {
-      this.editorRoot.classList.add(...browserSpecificClasses);
+      this.stimulusRoot.classList.add(...browserSpecificClasses);
     }
     // Clone the blank-target link description into the shadow DOM
     // so aria-describedby references resolve for links inside the editor
     const blankLinkDesc = document.getElementById('open-blank-target-link-description');
     if (blankLinkDesc) {
-      this.editorRoot.appendChild(blankLinkDesc.cloneNode(true));
+      this.stimulusRoot.appendChild(blankLinkDesc.cloneNode(true));
     }
 
     this.editorMount = document.createElement('div');
 
-    this.editorRoot.appendChild(this.editorMount);
-    shadowRoot.appendChild(this.editorRoot);
+    // Copy over definition for external-links handling
+    this.editorMount.dataset.controller = 'external-links';
+    this.editorMount.dataset.externalLinksEnabledValue = document.body.dataset.externalLinksEnabledValue;
+
+    this.stimulusRoot.appendChild(this.editorMount);
+    shadowRoot.appendChild(this.stimulusRoot);
 
     const blockNoteStylesheetUrl = this.getAttribute('blocknote-stylesheet-url');
     if (blockNoteStylesheetUrl) {
@@ -86,6 +93,10 @@ class BlockNoteElement extends HTMLElement {
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
     if (!collaborationEnabled) return;
 
+    // Initialize Stimulus application within shadow DOM
+    this.stimulusApp = Application.start(this.stimulusRoot);
+    this.stimulusApp.register('external-links', ExternalLinksController);
+
     this.reactRoot = createRoot(this.editorMount);
 
     this.renderCallback = (provider:HocuspocusProvider) => {
@@ -107,6 +118,11 @@ class BlockNoteElement extends HTMLElement {
     if (this.reactRoot) {
       this.reactRoot.unmount();
       this.reactRoot = null;
+    }
+
+    if (this.stimulusApp) {
+      this.stimulusApp.stop();
+      this.stimulusApp = null;
     }
   }
 

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -31,7 +31,7 @@
 import { User } from '@blocknote/core/comments';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Application } from '@hotwired/stimulus';
-import ExternalLinksController from 'core-stimulus/controllers/external-links.controller';
+import ProseMirrorExternalLinksController from 'core-stimulus/controllers/prosemirror-external-links.controller';
 import { LiveCollaborationManager } from 'core-stimulus/helpers/live-collaboration-helpers';
 import { ShadowDomWrapper } from 'op-blocknote-extensions';
 import React from 'react';
@@ -95,7 +95,7 @@ class BlockNoteElement extends HTMLElement {
 
     // Initialize Stimulus application within shadow DOM
     this.stimulusApp = Application.start(this.stimulusRoot);
-    this.stimulusApp.register('external-links', ExternalLinksController);
+    this.stimulusApp.register('external-links', ProseMirrorExternalLinksController);
 
     this.reactRoot = createRoot(this.editorMount);
 

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -122,12 +122,11 @@ export default class ExternalLinksController extends ApplicationController {
     });
   }
 
-  private updateBlankLink(link:HTMLAnchorElement) {
-    // Ensure accessibility description
+  protected updateBlankLink(link:HTMLAnchorElement) {
     attributeTokenList(link, 'aria-describedby').add(BLANK_LINK_DESCRIPTION_ID);
   }
 
-  private updateExternalLink(link:HTMLAnchorElement) {
+  protected updateExternalLink(link:HTMLAnchorElement) {
     // Ensure external link behavior
     link.target = '_blank';
     attributeTokenList(link, 'rel').add('noopener', 'noreferrer');

--- a/frontend/src/stimulus/controllers/prosemirror-external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/prosemirror-external-links.controller.ts
@@ -1,0 +1,90 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { attributeTokenList } from 'core-app/shared/helpers/dom-helpers';
+import ExternalLinksController from './external-links.controller';
+
+/**
+ * Specialised ExternalLinksController for ProseMirror-based editors (BlockNote/TipTap).
+ *
+ * ProseMirror maintains an internal document model and a MutationObserver
+ * (DOMObserver) that watches every attribute change inside its contenteditable
+ * region. When an attribute is changed on a DOM node, ProseMirror re-parses
+ * the node against its schema and re-renders it — which creates a *new* DOM
+ * node, triggering our own MutationObserver all over again.
+ *
+ * Two categories of attribute writes cause problems:
+ *
+ * 1. **Attributes not in the Link mark schema** (e.g. `aria-describedby`):
+ *    ProseMirror strips them on re-render because they aren't in the schema,
+ *    producing a new node without the attribute → our observer re-adds it →
+ *    infinite loop.
+ *
+ * 2. **Redundant writes to schema-recognised attributes** (e.g. `target`,
+ *    `rel`): even though ProseMirror keeps these, the write itself triggers
+ *    the DOMObserver → re-parse → re-render (new node) → our observer fires
+ *    again → unconditional write → loop.  With many links (e.g. pasting rich
+ *    text) this cascade freezes the browser.
+ *
+ * This subclass overrides two methods to address both:
+ *
+ * - `updateBlankLink`: skips `aria-describedby` entirely inside
+ *   `contenteditable` (category 1).
+ * - `updateExternalLink`: guards every DOM write with an idempotency check
+ *   so no attribute is touched when it already holds the correct value
+ *   (category 2).
+ */
+export default class ProseMirrorExternalLinksController extends ExternalLinksController {
+  protected updateBlankLink(link:HTMLAnchorElement) {
+    // aria-describedby is not in ProseMirror's Link mark schema, so adding
+    // it triggers a re-parse → strip → re-add loop. Skip it inside the
+    // contenteditable region; the body-level controller still handles it
+    // for links outside the editor.
+    if (link.closest('[contenteditable="true"]')) return;
+
+    super.updateBlankLink(link);
+  }
+
+  protected updateExternalLink(link:HTMLAnchorElement) {
+    // Only write when the value actually changes, to avoid triggering
+    // ProseMirror's DOMObserver unnecessarily.
+    if (link.target !== '_blank') link.target = '_blank';
+
+    const rel = attributeTokenList(link, 'rel');
+    if (!rel.contains('noopener') || !rel.contains('noreferrer')) {
+      rel.add('noopener', 'noreferrer');
+    }
+
+    // Capture external links through redirect page
+    if (this.enabledValue && !link.dataset.allowExternalLink && !link.href.includes('/external_redirect?url=')) {
+      const originalHref = link.href;
+      const basePath = window.appBasePath ?? '';
+      link.href = `${basePath}/external_redirect?url=${encodeURIComponent(originalHref)}`;
+    }
+  }
+}

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "External links in BlockNote editor",
+               :js,
+               :selenium,
+               with_settings: { real_time_text_collaboration_enabled: true } do
+  include_context "with hocuspocus"
+
+  let(:admin) { create(:admin) }
+  let(:document) { create(:document, :collaborative) }
+  let(:editor) { FormFields::Primerized::BlockNoteEditorInput.new }
+
+  before do
+    login_as(admin)
+    visit document_path(document)
+  end
+
+  it "editor remains interactive after ExternalLinksController connects" do
+    expect(page).to have_test_selector("blocknote-document-description")
+    editor.fill_in("Hello from the editor")
+    expect(editor.content).to include("Hello from the editor")
+
+    editor.element.send_keys(:enter)
+    editor.fill_in("Still typing just fine")
+    expect(editor.content).to include("Still typing just fine")
+  end
+
+  it "sets target and rel attributes on external links in the shadow DOM" do
+    paste_link_into_editor(text: "Example Site", url: "https://example.com")
+
+    link = editor.shadow_root.find("a[target='_blank']", text: "Example Site", wait: 5)
+    expect(link[:rel]).to include("noopener")
+    expect(link[:rel]).to include("noreferrer")
+  end
+
+  it "sets aria-describedby on external links for accessibility" do
+    paste_link_into_editor(text: "Accessible Link", url: "https://example.com")
+
+    link = editor.shadow_root.find("a[target='_blank']", text: "Accessible Link", wait: 5)
+    expect(link[:"aria-describedby"]).to include("open-blank-target-link-description")
+  end
+
+  it "does not rewrite internal links" do
+    paste_link_into_editor(text: "Internal Link", url: root_url)
+
+    link = editor.shadow_root.find("a", text: "Internal Link", wait: 5)
+    expect(link.native.property("href")).not_to include("/external_redirect")
+  end
+
+  context "with capture enabled",
+          with_ee: %i[capture_external_links],
+          with_settings: {
+            real_time_text_collaboration_enabled: true,
+            capture_external_links: true
+          } do
+    it "rewrites external link href to /external_redirect" do
+      paste_link_into_editor(text: "Captured Link", url: "https://example.com/page")
+
+      link = editor.shadow_root.find("a[target='_blank']", text: "Captured Link", wait: 5)
+      expect(link.native.property("href")).to include("/external_redirect?url=")
+      expect(link.native.property("href")).to include("example.com")
+    end
+  end
+
+  private
+
+  # Simulates pasting a link into the BlockNote editor — a common user interaction
+  # (e.g. copying a link from an email or browser and pasting it into a document).
+  #
+  # We use a synthetic ClipboardEvent because the alternative (Ctrl+K) requires the
+  # formatting toolbar to be visible, which only happens when text is selected.
+  # There is no reliable way to programmatically select text inside ProseMirror's
+  # contenteditable in Capybara/Selenium tests. The synthetic event exercises the
+  # same ProseMirror paste handler code path as a real Ctrl+V.
+  def paste_link_into_editor(text:, url:)
+    expect(page).to have_test_selector("blocknote-document-description")
+    editor.element.click
+
+    page.execute_script(<<~JS, url, text)
+      const el = document.querySelector('op-block-note').shadowRoot.querySelector('div[role="textbox"]');
+      const dt = new DataTransfer();
+      dt.setData('text/html', `<a href="${arguments[0]}">${arguments[1]}</a>`);
+      dt.setData('text/plain', arguments[1]);
+      el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+    JS
+  end
+end

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -56,22 +56,36 @@ RSpec.describe "External links in BlockNote editor",
   end
 
   it "sets target and rel attributes on external links in the shadow DOM" do
-    paste_link_into_editor(text: "Example Site", url: "https://example.com")
+    editor.paste_links(text: "Example Site", url: "https://example.com")
 
     link = editor.shadow_root.find("a[target='_blank']", text: "Example Site", wait: 5)
     expect(link[:rel]).to include("noopener")
     expect(link[:rel]).to include("noreferrer")
   end
 
-  it "sets aria-describedby on external links for accessibility" do
-    paste_link_into_editor(text: "Accessible Link", url: "https://example.com")
+  it "does not set aria-describedby inside contenteditable to avoid ProseMirror re-render loop" do
+    editor.paste_links(text: "Accessible Link", url: "https://example.com")
 
     link = editor.shadow_root.find("a[target='_blank']", text: "Accessible Link", wait: 5)
-    expect(link[:"aria-describedby"]).to include("open-blank-target-link-description")
+    expect(link[:"aria-describedby"]).to be_nil.or eq("")
+  end
+
+  it "does not freeze when pasting content with multiple external links" do
+    editor.paste_links(
+      { text: "Link One", url: "https://example.com/one" },
+      { text: "Link Two", url: "https://example.org/two" },
+      { text: "Link Three", url: "https://other-site.com/three" },
+      { text: "Link Four", url: "https://fourth-domain.net/four" },
+      { text: "Link Five", url: "https://fifth-place.io/five" }
+    )
+
+    # Verify the editor remains interactive after pasting multiple links
+    editor.fill_in(" Still typing after paste")
+    expect(editor.content).to include("Still typing after paste")
   end
 
   it "does not rewrite internal links" do
-    paste_link_into_editor(text: "Internal Link", url: root_url)
+    editor.paste_links(text: "Internal Link", url: root_url)
 
     link = editor.shadow_root.find("a", text: "Internal Link", wait: 5)
     expect(link.native.property("href")).not_to include("/external_redirect")
@@ -84,34 +98,11 @@ RSpec.describe "External links in BlockNote editor",
             capture_external_links: true
           } do
     it "rewrites external link href to /external_redirect" do
-      paste_link_into_editor(text: "Captured Link", url: "https://example.com/page")
+      editor.paste_links(text: "Captured Link", url: "https://example.com/page")
 
       link = editor.shadow_root.find("a[target='_blank']", text: "Captured Link", wait: 5)
       expect(link.native.property("href")).to include("/external_redirect?url=")
       expect(link.native.property("href")).to include("example.com")
     end
-  end
-
-  private
-
-  # Simulates pasting a link into the BlockNote editor — a common user interaction
-  # (e.g. copying a link from an email or browser and pasting it into a document).
-  #
-  # We use a synthetic ClipboardEvent because the alternative (Ctrl+K) requires the
-  # formatting toolbar to be visible, which only happens when text is selected.
-  # There is no reliable way to programmatically select text inside ProseMirror's
-  # contenteditable in Capybara/Selenium tests. The synthetic event exercises the
-  # same ProseMirror paste handler code path as a real Ctrl+V.
-  def paste_link_into_editor(text:, url:)
-    expect(page).to have_test_selector("blocknote-document-description")
-    editor.element.click
-
-    page.execute_script(<<~JS, url, text)
-      const el = document.querySelector('op-block-note').shadowRoot.querySelector('div[role="textbox"]');
-      const dt = new DataTransfer();
-      dt.setData('text/html', `<a href="${arguments[0]}">${arguments[1]}</a>`);
-      dt.setData('text/plain', arguments[1]);
-      el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
-    JS
   end
 end

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -42,6 +42,37 @@ module FormFields
         page.find("op-block-note").shadow_root
       end
 
+      # Simulates pasting one or more links into the editor — a common user
+      # interaction (e.g. copying a link from an email or browser and pasting it).
+      #
+      # Uses a synthetic ClipboardEvent because the Ctrl+K link insertion requires
+      # the formatting toolbar to be visible (text must be selected first), which
+      # has no reliable programmatic equivalent in Capybara/Selenium. The synthetic
+      # event exercises the same ProseMirror paste handler code path as a real Ctrl+V.
+      #
+      # @example Single link
+      #   editor.paste_links(text: "Example", url: "https://example.com")
+      #
+      # @example Multiple links
+      #   editor.paste_links(
+      #     { text: "One", url: "https://one.com" },
+      #     { text: "Two", url: "https://two.com" }
+      #   )
+      def paste_links(*links)
+        element.click
+
+        html = links.map { |l| %(<a href="#{l[:url]}">#{l[:text]}</a>) }.join(" ")
+        plain = links.pluck(:text).join(" ")
+
+        page.execute_script(<<~JS, html, plain)
+          const el = document.querySelector('op-block-note').shadowRoot.querySelector('div[role="textbox"]');
+          const dt = new DataTransfer();
+          dt.setData('text/html', arguments[0]);
+          dt.setData('text/plain', arguments[1]);
+          el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+        JS
+      end
+
       def element
         shadow_root.find("div[role='textbox']")
       end


### PR DESCRIPTION
## Ticket

https://community.openproject.org/work_packages/71111

## What are you trying to accomplish?

This PR reinstates external link capture within the BlockNote shadow DOM and fixes a browser freeze that was the reason the original PR got reverted.

When pasting text containing external links into a collaborative document, the browser would lock up completely. The root cause is a MutationObserver feedback loop between our `ExternalLinksController` and ProseMirror's internal `DOMObserver`. Two things were happening:

1. `ExternalLinksController` adds `aria-describedby` to blank-target links, but that attribute isn't in ProseMirror's Link mark schema — so ProseMirror strips it on re-render, producing a new DOM node, which our observer picks up and re-adds the attribute, ad infinitum.

2. Even for schema-recognised attributes like `target` and `rel`, the base controller writes them unconditionally. Each write triggers ProseMirror's DOMObserver → re-parse → re-render (new node) → our observer fires again. With multiple links this cascade freezes the tab.

This PR also adds comprehensive feature tests for external links inside BlockNote — something we didn't have before, which is partly why the freeze wasn't caught earlier.

## What approach did you choose and why?

Rather than patching the base `ExternalLinksController` with ProseMirror-specific guards (which felt like overreaching), we introduced a `ProseMirrorExternalLinksController` subclass that's registered only inside the BlockNote shadow DOM. It overrides two methods:

- **`updateBlankLink`** — skips `aria-describedby` inside `contenteditable` regions entirely. The body-level controller still handles it for links outside the editor, so accessibility isn't lost.
- **`updateExternalLink`** — adds idempotency checks so `target`, `rel`, and `href` are only written when their value actually needs to change. This prevents redundant DOM writes from re-triggering ProseMirror.

The base controller only needed `private` → `protected` on those two methods to allow the override — no behavioral change.

CKEditor is unaffected by the original bug because it doesn't use a schema-based DOM parser that strips unknown attributes, so the subclass approach keeps the fix scoped to where it's needed.

We also extracted a `paste_links` helper into `BlockNoteEditorInput` so it's reusable across specs. We use synthetic `ClipboardEvent`s for this because the Ctrl+K link toolbar requires text to be selected first, and there's no reliable way to programmatically select text inside ProseMirror's contenteditable in Capybara/Selenium.

Follows:

* #22006
* #22174

### Known trade-off: `aria-describedby` skipped inside the editor

The subclass skips adding `aria-describedby` (the "opens in new tab" screen reader hint) to links inside the contenteditable region. Here's what's preserved and what's not:

| Behavior | Body-level controller | ProseMirror subclass | Gap? |
|---|---|---|---|
| `target="_blank"` on external links | Yes | Yes (idempotency guard) | No |
| `rel="noopener noreferrer"` | Yes | Yes (idempotency guard) | No |
| `href` rewrite to `/external_redirect` | Yes | Yes (idempotency guard) | No |
| `aria-describedby` on `target="_blank"` links | Yes | **Skipped** inside `contenteditable` | **Yes** |

This means screen reader users won't hear "opens in new tab" for links while editing a collaborative document. Once the document is rendered in the read-only view (no contenteditable), the body-level controller adds `aria-describedby` normally.

The proper fix would be a ProseMirror plugin that sets `aria-describedby` through the transaction/decoration pipeline — so ProseMirror owns the attribute instead of an external observer fighting with it. That's a bigger lift and should be tracked as a follow-up.

## Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
