### PR TITLE
[#71445] Adding user to meeting series template does not add them to already open meeting  

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/meetings/participants/update-occurrence-participants.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/participants/update-occurrence-participants.controller.ts
@@ -1,0 +1,57 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class UpdateOccurrenceParticipantsController extends Controller {
+  static targets = ['removeButton', 'controlCheckbox'];
+
+  declare readonly controlCheckboxTarget:HTMLInputElement;
+  declare readonly hasControlCheckboxTarget:boolean;
+
+  removeButtonTargetConnected(element:HTMLAnchorElement):void {
+    element.addEventListener('click', this.handleRemoveClick);
+  }
+
+  removeButtonTargetDisconnected(element:HTMLAnchorElement):void {
+    element.removeEventListener('click', this.handleRemoveClick);
+  }
+
+  private handleRemoveClick = (event:MouseEvent):void => {
+    const button = event.currentTarget as HTMLAnchorElement;
+    const url = new URL(button.href);
+    if (this.hasControlCheckboxTarget && this.controlCheckboxTarget.checked) {
+      url.searchParams.set('apply_to_upcoming', '1');
+    } else {
+      url.searchParams.delete('apply_to_upcoming');
+    }
+    button.href = url.toString();
+  };
+}

--- a/frontend/src/stimulus/controllers/dynamic/meetings/participants/update-occurrence-participants.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/meetings/participants/update-occurrence-participants.controller.ts
@@ -33,8 +33,18 @@ import { Controller } from '@hotwired/stimulus';
 export default class UpdateOccurrenceParticipantsController extends Controller {
   static targets = ['removeButton', 'controlCheckbox'];
 
-  declare readonly controlCheckboxTarget:HTMLInputElement;
-  declare readonly hasControlCheckboxTarget:boolean;
+  // Tracks checkbox state so it isn't reset after every action
+  // Initially true to match the rendered default
+  private applyToUpcoming = true;
+
+  controlCheckboxTargetConnected(element:HTMLInputElement):void {
+    element.checked = this.applyToUpcoming;
+    element.addEventListener('change', this.handleCheckboxChange);
+  }
+
+  controlCheckboxTargetDisconnected(element:HTMLInputElement):void {
+    element.removeEventListener('change', this.handleCheckboxChange);
+  }
 
   removeButtonTargetConnected(element:HTMLAnchorElement):void {
     element.addEventListener('click', this.handleRemoveClick);
@@ -44,10 +54,14 @@ export default class UpdateOccurrenceParticipantsController extends Controller {
     element.removeEventListener('click', this.handleRemoveClick);
   }
 
+  private handleCheckboxChange = (event:Event):void => {
+    this.applyToUpcoming = (event.target as HTMLInputElement).checked;
+  };
+
   private handleRemoveClick = (event:MouseEvent):void => {
     const button = event.currentTarget as HTMLAnchorElement;
     const url = new URL(button.href);
-    if (this.hasControlCheckboxTarget && this.controlCheckboxTarget.checked) {
+    if (this.applyToUpcoming) {
       url.searchParams.set('apply_to_upcoming', '1');
     } else {
       url.searchParams.delete('apply_to_upcoming');

--- a/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.html.erb
@@ -58,10 +58,7 @@
                 href: project_meeting_participant_path(@meeting.project, @meeting, @participant),
                 icon: :x,
                 aria: { label: I18n.t("meeting.participants.label.remove_participant") },
-                data: {
-                  turbo_method: :delete,
-                  test_selector: "remove_button_#{@participant.user_id}"
-                }
+                data: remove_button_data_attributes
               )
             )
           end

--- a/modules/meeting/app/components/meetings/participants/box_row_component.rb
+++ b/modules/meeting/app/components/meetings/participants/box_row_component.rb
@@ -45,5 +45,15 @@ module Meetings
     def wrapper_uniq_by
       @participant.id
     end
+
+    private
+
+    def remove_button_data_attributes
+      {
+        turbo_method: :delete,
+        test_selector: "remove_button_#{@participant.user_id}",
+        "meetings--participants--update-occurrence-participants-target": (@meeting.series_template? ? "removeButton" : nil)
+      }
+    end
   end
 end

--- a/modules/meeting/app/components/meetings/participants/manage_participants_dialog.html.erb
+++ b/modules/meeting/app/components/meetings/participants/manage_participants_dialog.html.erb
@@ -5,7 +5,7 @@
         id: DIALOG_ID,
         size: :xlarge,
         title: I18n.t("meeting.participants.label.manage_participants"),
-        data: { "keep-open-on-submit": true }
+        data: { "keep-open-on-submit": true, controller: "meetings--participants--update-occurrence-participants" }
       )
     ) do |d|
       d.with_header(variant: :large)

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -73,11 +73,16 @@ class MeetingParticipantsController < ApplicationController
   end
 
   def destroy
+    user_id = @participant.user_id
     call = MeetingParticipants::DeleteService
       .new(user: User.current, model: @participant)
       .call
 
     if call.success?
+      if @meeting.series_template? && params[:apply_to_upcoming] == "1"
+        remove_from_upcoming_occurrences(user_id)
+      end
+
       update_add_user_form_component_via_turbo_stream
       update_list_component_via_turbo_stream
       update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
@@ -106,7 +111,7 @@ class MeetingParticipantsController < ApplicationController
     user_ids.each { |user_id| create_new_participant(user_id) }
 
     if @meeting.series_template? && params.dig(:meeting_participant, :apply_to_upcoming) == "1"
-      update_upcoming_occurrences(user_ids)
+      add_to_upcoming_occurrences(user_ids)
     end
 
     update_list_component_via_turbo_stream
@@ -114,10 +119,19 @@ class MeetingParticipantsController < ApplicationController
     update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
   end
 
-  def update_upcoming_occurrences(user_ids)
-    upcoming_meetings = @meeting.recurring_meeting.instantiated_meetings
+  def remove_from_upcoming_occurrences(user_id)
+    @meeting.recurring_meeting.instantiated_meetings.each do |meeting|
+      participant = meeting.participants.find_by(user_id:)
+      next unless participant
 
-    upcoming_meetings.each do |meeting|
+      MeetingParticipants::DeleteService
+        .new(user: User.current, model: participant)
+        .call
+    end
+  end
+
+  def add_to_upcoming_occurrences(user_ids)
+    @meeting.recurring_meeting.instantiated_meetings.each do |meeting|
       user_ids.each do |user_id|
         next if meeting.participants.exists?(user_id:)
 

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -105,9 +105,27 @@ class MeetingParticipantsController < ApplicationController
   def create_new_participants(user_ids)
     user_ids.each { |user_id| create_new_participant(user_id) }
 
+    if @meeting.series_template? && params.dig(:meeting_participant, :apply_to_upcoming) == "1"
+      update_upcoming_occurrences(user_ids)
+    end
+
     update_list_component_via_turbo_stream
     update_add_user_form_component_via_turbo_stream
     update_sidebar_participants_component_via_turbo_stream(meeting: @meeting)
+  end
+
+  def update_upcoming_occurrences(user_ids)
+    upcoming_meetings = @meeting.recurring_meeting.instantiated_meetings
+
+    upcoming_meetings.each do |meeting|
+      user_ids.each do |user_id|
+        next if meeting.participants.exists?(user_id:)
+
+        MeetingParticipants::CreateService
+          .new(user: User.current)
+          .call(meeting:, user_id:, invited: true, attended: false)
+      end
+    end
   end
 
   def create_new_participant(user_id)

--- a/modules/meeting/app/controllers/meeting_participants_controller.rb
+++ b/modules/meeting/app/controllers/meeting_participants_controller.rb
@@ -120,7 +120,7 @@ class MeetingParticipantsController < ApplicationController
   end
 
   def remove_from_upcoming_occurrences(user_id)
-    @meeting.recurring_meeting.instantiated_meetings.each do |meeting|
+    @meeting.recurring_meeting.instantiated_meetings.upcoming.each do |meeting|
       participant = meeting.participants.find_by(user_id:)
       next unless participant
 
@@ -131,7 +131,7 @@ class MeetingParticipantsController < ApplicationController
   end
 
   def add_to_upcoming_occurrences(user_ids)
-    @meeting.recurring_meeting.instantiated_meetings.each do |meeting|
+    @meeting.recurring_meeting.instantiated_meetings.upcoming.each do |meeting|
       user_ids.each do |user_id|
         next if meeting.participants.exists?(user_id:)
 

--- a/modules/meeting/app/forms/meeting/participant.rb
+++ b/modules/meeting/app/forms/meeting/participant.rb
@@ -54,6 +54,14 @@ class Meeting::Participant < ApplicationForm
         }
       }
     )
+
+    if meeting.series_template?
+      participant_form.check_box(
+        name: :apply_to_upcoming,
+        label: I18n.t("meeting.participants.label.apply_to_upcoming_meetings"),
+        checked: true
+      )
+    end
   end
 
   private

--- a/modules/meeting/app/forms/meeting/participant.rb
+++ b/modules/meeting/app/forms/meeting/participant.rb
@@ -59,7 +59,8 @@ class Meeting::Participant < ApplicationForm
       participant_form.check_box(
         name: :apply_to_upcoming,
         label: I18n.t("meeting.participants.label.apply_to_upcoming_meetings"),
-        checked: true
+        checked: true,
+        data: { "meetings--participants--update-occurrence-participants-target": "controlCheckbox" }
       )
     end
   end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -306,6 +306,7 @@ class Meeting < ApplicationRecord
   def send_emails?
     return false if onetime_template?
     return false if template? && recurring_meeting.scheduled_meetings.none?
+    return false if closed?
 
     persisted? && notify?
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -229,6 +229,7 @@ en:
         manage_participants: "Manage participants"
         no_participants: "No participants"
         show_all: "Show all"
+        apply_to_upcoming_meetings: "Apply these changes to all upcoming meetings in this series"
       text:
         template: "These participants will be invited automatically to all future meetings as they are created."
         manage_participants: "Search for and add project members as participants to this meeting."

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb
@@ -171,6 +171,7 @@ RSpec.describe "Recurring meetings creation",
         template_page.expect_participant(other_user, editable: false)
         template_page.expect_available_participants(count: 2)
 
+        template_page.uncheck_apply_to_upcoming
         template_page.select_participant(third_user)
         template_page.expect_participant(third_user, editable: false)
         template_page.expect_available_participants(count: 3)

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_participants_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_participants_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/meetings/show"
+
+RSpec.describe "Series template participant management",
+               :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:user) do
+    create(:user, member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings] })
+  end
+  shared_let(:participant_a) do
+    create(:user, member_with_permissions: { project => %i[view_meetings] })
+  end
+  shared_let(:participant_b) do
+    create(:user, member_with_permissions: { project => %i[view_meetings] })
+  end
+
+  let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+  let(:template) { recurring_meeting.template }
+  let(:template_page) { Pages::Meetings::Show.new(template) }
+
+  before do
+    login_as user
+    template_page.visit!
+  end
+
+  describe "'apply to upcoming' checkbox state" do
+    context "when adding multiple participants with checkbox unchecked" do
+      it "keeps the checkbox unchecked after each addition" do
+        template_page.open_participant_form
+        template_page.in_participant_form do
+          template_page.uncheck_apply_to_upcoming
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.select_participant(participant_a)
+          end
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.select_participant(participant_b)
+          end
+          template_page.expect_apply_to_upcoming_unchecked
+        end
+      end
+
+      it "does not add participants to occurrences" do
+        open_scheduled = create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 1.day.from_now)
+
+        template_page.open_participant_form
+        template_page.in_participant_form do
+          template_page.uncheck_apply_to_upcoming
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.select_participant(participant_a)
+          end
+          wait_for_turbo_stream do
+            template_page.select_participant(participant_b)
+          end
+        end
+
+        expect(open_scheduled.meeting.participants.pluck(:user_id))
+          .not_to include(participant_a.id, participant_b.id)
+      end
+    end
+
+    context "when removing multiple participants with checkbox unchecked" do
+      let!(:meeting_participant_a) do
+        create(:meeting_participant, meeting: template, user: participant_a, invited: true)
+      end
+      let!(:meeting_participant_b) do
+        create(:meeting_participant, meeting: template, user: participant_b, invited: true)
+      end
+
+      it "keeps the checkbox unchecked after each removal" do
+        template_page.open_participant_form
+        template_page.in_participant_form do
+          template_page.uncheck_apply_to_upcoming
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.remove_participant(participant_a)
+          end
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.remove_participant(participant_b)
+          end
+          template_page.expect_apply_to_upcoming_unchecked
+        end
+      end
+
+      it "does not remove participants from occurrences" do
+        open_scheduled = create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 1.day.from_now)
+        create(:meeting_participant, meeting: open_scheduled.meeting, user: participant_a, invited: true)
+        create(:meeting_participant, meeting: open_scheduled.meeting, user: participant_b, invited: true)
+
+        template_page.open_participant_form
+        template_page.in_participant_form do
+          template_page.uncheck_apply_to_upcoming
+          template_page.expect_apply_to_upcoming_unchecked
+
+          wait_for_turbo_stream do
+            template_page.remove_participant(participant_a)
+          end
+          wait_for_turbo_stream do
+            template_page.remove_participant(participant_b)
+          end
+        end
+
+        expect(open_scheduled.meeting.participants.reload.pluck(:user_id))
+          .to include(participant_a.id, participant_b.id)
+      end
+    end
+
+    it "defaults to checked when the dialog is reopened" do
+      template_page.open_participant_form
+      template_page.in_participant_form do
+        template_page.uncheck_apply_to_upcoming
+        template_page.expect_apply_to_upcoming_unchecked
+        page.find(".close-button").click
+      end
+
+      template_page.open_participant_form
+      template_page.in_participant_form do
+        template_page.expect_apply_to_upcoming_checked
+      end
+    end
+  end
+end

--- a/modules/meeting/spec/requests/meeting_participants_spec.rb
+++ b/modules/meeting/spec/requests/meeting_participants_spec.rb
@@ -254,4 +254,160 @@ RSpec.describe "MeetingParticipants requests",
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "series template participant management" do
+    let!(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+    let!(:template) { recurring_meeting.template }
+
+    let!(:open_scheduled) { create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 1.day.from_now) }
+    let!(:open_occurrence) { open_scheduled.meeting }
+
+    let!(:closed_scheduled) { create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 2.days.from_now) }
+    let!(:closed_occurrence) { closed_scheduled.meeting.tap { |m| m.update!(state: :closed) } }
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    describe "POST - adding participants" do
+      let(:add_params) do
+        {
+          meeting_id: template.id,
+          project_id: project.id,
+          meeting_participant: { user_id: [user_with_meeting_permissions.id] }
+        }
+      end
+
+      context "without apply_to_upcoming" do
+        it "only adds participant to the series template" do
+          post project_meeting_participants_path(project, template), params: add_params, as: :turbo_stream
+
+          expect(template.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+          expect(open_occurrence.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+          expect(closed_occurrence.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+        end
+
+        it "only sends series invitation emails" do
+          post project_meeting_participants_path(project, template), params: add_params, as: :turbo_stream
+          perform_enqueued_jobs
+
+          # 1 series invite to new participant + 1 participant added email to existing participant
+          expect(ActionMailer::Base.deliveries.size).to eq(2)
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(user_with_meeting_permissions.mail)
+        end
+      end
+
+      context "with apply_to_upcoming" do
+        let(:params) { add_params.deep_merge(meeting_participant: { apply_to_upcoming: "1" }) }
+
+        it "adds participant to template and all instantiated occurrences" do
+          post project_meeting_participants_path(project, template), params:, as: :turbo_stream
+
+          expect(template.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+          expect(open_occurrence.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+          expect(closed_occurrence.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+        end
+
+        it "does not add participant to past instantiated occurrences" do
+          past_scheduled = create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 1.week.ago)
+
+          post project_meeting_participants_path(project, template), params:, as: :turbo_stream
+
+          expect(past_scheduled.meeting.participants.reload.pluck(:user_id))
+            .not_to include(user_with_meeting_permissions.id)
+        end
+
+        it "does not automatically instantiate future unscheduled occurrences" do
+          future_uninstantiated = create(:scheduled_meeting, recurring_meeting:, start_time: 2.weeks.from_now)
+
+          post project_meeting_participants_path(project, template), params:, as: :turbo_stream
+
+          expect(future_uninstantiated.reload.meeting).to be_nil
+        end
+
+        it "sends emails for series and open occurrences, but not closed" do
+          post project_meeting_participants_path(project, template), params:, as: :turbo_stream
+          perform_enqueued_jobs
+
+          # 1 series invite to new participant + 1 participant added email to existing participant + 1 occurrence invite
+          expect(ActionMailer::Base.deliveries.size).to eq(3)
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+            .to include(user_with_meeting_permissions.mail, user.mail)
+        end
+      end
+    end
+
+    describe "DELETE - removing participants" do
+      let!(:template_participant) do
+        create(:meeting_participant, meeting: template, user: user_with_meeting_permissions, invited: true)
+      end
+      let!(:open_occurrence_participant) do
+        create(:meeting_participant, meeting: open_occurrence, user: user_with_meeting_permissions, invited: true)
+      end
+      let!(:closed_occurrence_participant) do
+        create(:meeting_participant, meeting: closed_occurrence, user: user_with_meeting_permissions, invited: true)
+      end
+
+      context "without apply_to_upcoming" do
+        it "only removes participant from the series template" do
+          delete project_meeting_participant_path(project, template, template_participant), as: :turbo_stream
+
+          expect(template.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+          expect(open_occurrence.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+          expect(closed_occurrence.participants.reload.pluck(:user_id)).to include(user_with_meeting_permissions.id)
+        end
+
+        it "only sends template cancellation emails" do
+          delete project_meeting_participant_path(project, template, template_participant), as: :turbo_stream
+          perform_enqueued_jobs
+
+          # 1 cancelled series to removed participant + 1 participant removed to remaining template participant
+          expect(ActionMailer::Base.deliveries.size).to eq(2)
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(user_with_meeting_permissions.mail)
+        end
+      end
+
+      context "with apply_to_upcoming" do
+        let(:delete_params) { { apply_to_upcoming: "1" } }
+
+        it "removes participant from template and upcoming instantiated occurrences" do
+          delete project_meeting_participant_path(project, template, template_participant),
+                 params: delete_params, as: :turbo_stream
+
+          expect(template.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+          expect(open_occurrence.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+          expect(closed_occurrence.participants.reload.pluck(:user_id)).not_to include(user_with_meeting_permissions.id)
+        end
+
+        it "does not remove participant from past instantiated occurrences" do
+          past_scheduled = create(:scheduled_meeting, :persisted, recurring_meeting:, start_time: 1.week.ago)
+          create(:meeting_participant, meeting: past_scheduled.meeting, user: user_with_meeting_permissions, invited: true)
+
+          delete project_meeting_participant_path(project, template, template_participant),
+                 params: delete_params, as: :turbo_stream
+
+          expect(past_scheduled.meeting.participants.reload.pluck(:user_id))
+            .to include(user_with_meeting_permissions.id)
+        end
+
+        it "does not automatically instantiate future unscheduled occurrences" do
+          future_uninstantiated = create(:scheduled_meeting, recurring_meeting:, start_time: 2.weeks.from_now)
+
+          delete project_meeting_participant_path(project, template, template_participant),
+                 params: delete_params, as: :turbo_stream
+
+          expect(future_uninstantiated.reload.meeting).to be_nil
+        end
+
+        it "sends cancellation emails for template and open occurrences, but not closed" do
+          delete project_meeting_participant_path(project, template, template_participant),
+                 params: delete_params, as: :turbo_stream
+          perform_enqueued_jobs
+
+          # 1 cancelled series to removed participant + 1 participant removed to remaining participant +
+          # 1 occurrence cancelled
+          expect(ActionMailer::Base.deliveries.size).to eq(3)
+          expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(user_with_meeting_permissions.mail)
+        end
+      end
+    end
+  end
 end

--- a/modules/meeting/spec/requests/meeting_participants_spec.rb
+++ b/modules/meeting/spec/requests/meeting_participants_spec.rb
@@ -248,10 +248,51 @@ RSpec.describe "MeetingParticipants requests",
   end
 
   describe "GET /meetings/:meeting_id/participants/manage_participants_dialog" do
+    let(:apply_to_upcoming_checkbox) { "meeting_participant[apply_to_upcoming]" }
+
     it "responds with the manage participants dialog" do
       get manage_participants_dialog_project_meeting_participants_path(project, meeting), as: :turbo_stream
 
       expect(response).to have_http_status(:ok)
+    end
+
+    context "for a one-time meeting" do
+      it "does not show the apply to upcoming checkbox" do
+        get manage_participants_dialog_project_meeting_participants_path(project, meeting), as: :turbo_stream
+
+        expect(response.body).not_to include(apply_to_upcoming_checkbox)
+      end
+    end
+
+    context "for a one-time template" do
+      let(:onetime_template) { create(:onetime_template, project:, author: user) }
+
+      it "does not show the apply to upcoming checkbox" do
+        get manage_participants_dialog_project_meeting_participants_path(project, onetime_template), as: :turbo_stream
+
+        expect(response.body).not_to include(apply_to_upcoming_checkbox)
+      end
+    end
+
+    context "for a series template" do
+      let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+
+      it "shows the apply to upcoming checkbox" do
+        get manage_participants_dialog_project_meeting_participants_path(project, recurring_meeting.template), as: :turbo_stream
+
+        expect(response.body).to include(apply_to_upcoming_checkbox)
+      end
+    end
+
+    context "for a series occurrence" do
+      let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+      let(:occurrence) { create(:meeting, project:, author: user, recurring_meeting:) }
+
+      it "does not show the apply to upcoming checkbox" do
+        get manage_participants_dialog_project_meeting_participants_path(project, occurrence), as: :turbo_stream
+
+        expect(response.body).not_to include(apply_to_upcoming_checkbox)
+      end
     end
   end
 

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -579,6 +579,14 @@ module Pages::Meetings
       page.find('input[type="checkbox"][name="meeting_participant[apply_to_upcoming]"]').set(false)
     end
 
+    def expect_apply_to_upcoming_checked
+      expect(page).to have_checked_field("meeting_participant[apply_to_upcoming]")
+    end
+
+    def expect_apply_to_upcoming_unchecked
+      expect(page).to have_unchecked_field("meeting_participant[apply_to_upcoming]")
+    end
+
     def expect_no_participant(participant)
       autocomplete = page.find('[data-test-selector="participants-dialog-autocomplete"]')
       search_autocomplete(autocomplete, query: participant.lastname, results_selector: "body")

--- a/modules/meeting/spec/support/pages/meetings/show.rb
+++ b/modules/meeting/spec/support/pages/meetings/show.rb
@@ -575,6 +575,10 @@ module Pages::Meetings
       click_on "Add"
     end
 
+    def uncheck_apply_to_upcoming
+      page.find('input[type="checkbox"][name="meeting_participant[apply_to_upcoming]"]').set(false)
+    end
+
     def expect_no_participant(participant)
       autocomplete = page.find('[data-test-selector="participants-dialog-autocomplete"]')
       search_autocomplete(autocomplete, query: participant.lastname, results_selector: "body")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/71445

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Add a checkbox to allow adding/removing participants from upcoming occurrences when they are updated in the series template to avoid repeated actions

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add a checkbox in the form that controls this setting
   - This is enabled by default, but can be unchecked and keeps state as long as the dialog is open (survives multiple additions/removals)
- For additions, since the checkbox is a part of the form, its value is read in the rails controller that decides what to do
- For removals, a stimulus controller is necessary to add/remove a param from all removal buttons depending on the value of the checkbox
- Email notification behaviour wise, nothing changes, so additions/removals send emails for the series as well as how many ever occurrences have been affected
   - Closed upcoming occurrences will get their participants updated, but no emails are sent out in this case

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
