### PR TITLE
Prevent loading the default value of all custom options when loaded a…

### DIFF
--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -96,9 +96,15 @@ class CustomField < ApplicationRecord
     true
   end
 
-  def default_value
+  def default_value # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
     if list?
-      ids = custom_options.where(default_value: true).pluck(:id).map(&:to_s)
+      # Use loaded association data when available to avoid N+1 queries.
+      # .where().pluck() always hits the database, bypassing eager-loaded data.
+      ids = if custom_options.loaded?
+              custom_options.select(&:default_value).map { |o| o.id.to_s }
+            else
+              custom_options.where(default_value: true).pluck(:id).map(&:to_s)
+            end
 
       if multi_value?
         ids


### PR DESCRIPTION
When building schemas of work packages, we iterate a lot of custom fields repeatedely, and this results in accessing custom options.

Here's the call stack from the API: 

  1. add_custom_fields_to_form_attributes (type/attributes.rb:151) iterates ALL 789 WorkPackageCustomField records
  2. For each, it calls custom_field.default_value.present? (line 154)
  3. CustomField#default_value (custom_field.rb:101) for list fields runs: custom_options.where(default_value: true).pluck(:id) even though custom_options have been preloaded
  eager-loaded data)
  4. This is called ~22 times during schema serialization (once per attribute group per schema, × 4 schemas), resulting in 22 × 299 list CFs = 6578 queries