### PR TITLE
Bug/56847 problems with gitlab and GitHub integration snippets textareas

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   get "/wp(/)" => redirect("#{rails_relative_url_root}/work_packages")
   get "/wp/*rest" => redirect { |params, _req|
     "#{rails_relative_url_root}/work_packages/#{URI::RFC2396_Parser.new.escape(params[:rest])}"
-  }
+  }, as: :work_package_short
 
   # Add catch method for Rack OmniAuth to allow route helpers
   # Note: This renders a 404 in rails but is caught by omniauth in Rack before

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
@@ -38,16 +38,16 @@ describe('GitActionsMenuComponent', () => {
 
     await TestBed
       .configureTestingModule({
-      declarations: [
-        GitActionsMenuComponent,
-        OpIconComponent,
-      ],
-      providers: [
-        { provide: I18nService, useValue: I18nServiceStub },
-        { provide: OpContextMenuLocalsToken, useValue: localsStub },
-        { provide: GitActionsService, useValue: gitActionsServiceSpy },
-      ],
-    })
+        declarations: [
+          GitActionsMenuComponent,
+          OpIconComponent,
+        ],
+        providers: [
+          { provide: I18nService, useValue: I18nServiceStub },
+          { provide: OpContextMenuLocalsToken, useValue: localsStub },
+          { provide: GitActionsService, useValue: gitActionsServiceSpy },
+        ],
+      })
       .compileComponents();
   });
 

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -68,20 +68,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.branch_name'),
-      textToDisplay: () => this.gitActions.branchName(this.workPackage),
-      textToCopy: () => this.gitActions.branchName(this.workPackage),
+      text: () => this.gitActions.branchName(this.workPackage),
     },
     {
       id: 'message',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.commit_message'),
-      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
-      textToCopy: () => this.gitActions.commitMessage(this.workPackage),
+      multiline: true,
+      text: () => this.gitActions.commitMessage(this.workPackage),
     },
     {
       id: 'command',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.cmd'),
-      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
-      textToCopy: () => this.gitActions.gitCommand(this.workPackage),
+      multiline: true,
+      text: () => this.gitActions.gitCommand(this.workPackage),
     },
   ];
 
@@ -91,7 +90,7 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
   }
 
   public onCopyButtonClick(snippet:ISnippet):void {
-    const success = copy(snippet.textToCopy());
+    const success = copy(snippet.text());
 
     if (success) {
       this.lastCopyResult = this.text.copyResult.success;

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -99,6 +99,10 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     this.workPackage = this.locals.workPackage as WorkPackageResource;
   }
 
+  public onInputClick(e: Event):void {
+    (e.target as HTMLInputElement | HTMLTextAreaElement).select();
+  }
+
   public onCopyButtonClick(snippet:ISnippet):void {
     const success = copy(snippet.text());
 

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -73,20 +73,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.branch_name'),
-      textToDisplay: () => this.gitActions.branchName(this.workPackage),
-      textToCopy: () => this.gitActions.branchName(this.workPackage),
+      text: () => this.gitActions.branchName(this.workPackage),
     },
     {
       id: 'message',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.commit_message'),
-      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
-      textToCopy: () => this.gitActions.commitMessage(this.workPackage),
+      multiline: true,
+      text: () => this.gitActions.commitMessage(this.workPackage),
     },
     {
       id: 'command',
       name: this.I18n.t('js.github_integration.tab_header.git_actions.cmd'),
-      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
-      textToCopy: () => this.gitActions.gitCommand(this.workPackage),
+      multiline: true,
+      text: () => this.gitActions.gitCommand(this.workPackage),
     },
   ];
 
@@ -101,7 +100,7 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
   }
 
   public onCopyButtonClick(snippet:ISnippet):void {
-    const success = copy(snippet.textToCopy());
+    const success = copy(snippet.text());
 
     if (success) {
       this.lastCopyResult = this.text.copyResult.success;

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -5,7 +5,7 @@
     <div class="copy-wrapper spot-form-field">
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
-        <div class="spot-form-field--input">
+        <div class="spot-form-field--input copy-input">
           @if (snippet.multiline) {
             <textarea class="copy-content op-input" rows="3" readonly>{{ snippet.text() }}</textarea>
           } @else {

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -6,7 +6,11 @@
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
-          <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
+          @if (snippet.multiline) {
+            <textarea class="copy-content op-input" rows="3" readonly>{{ snippet.text() }}</textarea>
+          } @else {
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+          }
           <button
             class="button copy-button"
             type="button"

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -7,9 +7,9 @@
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
           @if (snippet.multiline) {
-            <textarea class="copy-content op-input" readonly>{{ snippet.text() }}</textarea>
+            <textarea class="copy-content op-input" readonly (click)="onInputClick($event)">{{ snippet.text() }}</textarea>
           } @else {
-            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" (click)="onInputClick($event)" />
           }
           <button
             class="button copy-button"

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -6,7 +6,11 @@
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
-          <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
+          @if (snippet.multiline) {
+            <textarea class="copy-content op-input" readonly>{{ snippet.text() }}</textarea>
+          } @else {
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+          }
           <button
             class="button copy-button"
             type="button"

--- a/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -14,9 +14,9 @@
     width: calc(100% - 3em)
     // the min-height should be the size of the copy-icon, which is the sum of:
     // 2 * button padding (0.65em)
-    // font-size of the icon (0.9em)
+    // size of the icon (1rem, size="small" = 16px)
     // 1px where I don't know where it comes from
-    min-height: calc(2 * 0.65em + 0.9em + 1px)
+    min-height: calc(2 * 0.65em + 1rem + 1px)
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
@@ -45,7 +45,7 @@
     color: var(--main-menu-font-color)
     position: absolute
     right: 0
-    top: calc(2 * 0.65em + 0.9em + 1px + 9px)
+    top: calc(2 * 0.65em + 1rem + 1px + 9px)
     box-shadow: 1px 1px 4px var(--fgColor-muted)
     z-index: 1
 

--- a/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -10,13 +10,16 @@
     position: relative
     margin-bottom: 1rem
 
-  .copy-content
-    width: calc(100% - 3em)
+  .copy-content,
+  .copy-button
     // the min-height should be the size of the copy-icon, which is the sum of:
     // 2 * button padding (0.65em)
     // size of the icon (1rem, size="small" = 16px)
     // 1px where I don't know where it comes from
     min-height: calc(2 * 0.65em + 1rem + 1px)
+
+  .copy-content
+    width: calc(100% - 3em)
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
@@ -32,6 +35,7 @@
     left: -1px
     position: relative
     font-size: 0.9rem
+    align-self: flex-start
 
     &:hover
       background: var(--button--background-hover-color)

--- a/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -20,7 +20,6 @@
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
-    white-space: pre
     resize: none
     font-size: 0.9rem
     display: inline-block

--- a/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/github_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -7,8 +7,10 @@
 
   .copy-wrapper
     width: 100%
-    position: relative
     margin-bottom: 1rem
+
+  .copy-input
+    position: relative
 
   .copy-content,
   .copy-button
@@ -49,7 +51,7 @@
     color: var(--main-menu-font-color)
     position: absolute
     right: 0
-    top: calc(2 * 0.65em + 1rem + 1px + 9px)
+    top: calc(2 * 0.65em + 1rem + 1px)
     box-shadow: 1px 1px 4px var(--fgColor-muted)
     z-index: 1
 

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -73,10 +73,6 @@ export class GitActionsService {
     return this.commitMessageParts(workPackage).join("\n\n");
   }
 
-  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
-    return this.commitMessageParts(workPackage).join(' ');
-  }
-
   public gitCommand(workPackage:WorkPackageResource):string {
     const branch = this.branchName(workPackage);
     const messageParts = this.commitMessageParts(workPackage);

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -72,10 +72,6 @@ export class GitActionsService {
     return this.commitMessageParts(workPackage).join("\n\n");
   }
 
-  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
-    return this.commitMessageParts(workPackage).join(' ');
-  }
-
   public gitCommand(workPackage:WorkPackageResource):string {
     const branch = this.branchName(workPackage);
     const messageParts = this.commitMessageParts(workPackage);

--- a/modules/github_integration/frontend/module/state/github-pull-request.model.ts
+++ b/modules/github_integration/frontend/module/state/github-pull-request.model.ts
@@ -7,8 +7,8 @@ import { ID } from '@datorama/akita';
 export interface ISnippet {
   id:string;
   name:string;
-  textToDisplay:() => string;
-  textToCopy:() => string
+  multiline?:boolean;
+  text:() => string;
 }
 
 export interface IGithubUserResource {

--- a/modules/github_integration/spec/features/work_package_github_tab_spec.rb
+++ b/modules/github_integration/spec/features/work_package_github_tab_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe "Open the GitHub tab", :js do
       expect(page).to have_text("a check run name")
     end
 
+    it "shows a commit message with newlines between title and link" do
+      work_package_page.visit!
+      work_package_page.switch_to_tab(tab: "github")
+      github_tab.git_actions_menu_button.click
+
+      commit_message_input_text = page.find_field("Commit message").value
+      expect(commit_message_input_text)
+        .to eq("[##{work_package.id}] A test work_package\n\n#{work_package_short_url(work_package)}")
+    end
+
     context "when there are no pull requests" do
       let(:check_run) {}
       let(:pull_request) {}

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
@@ -1,3 +1,31 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { GitActionsMenuComponent } from './git-actions-menu.component';
@@ -38,16 +66,16 @@ describe('GitActionsMenuComponent', () => {
 
     await TestBed
       .configureTestingModule({
-      declarations: [
-        GitActionsMenuComponent,
-        OpIconComponent,
-      ],
-      providers: [
-        { provide: I18nService, useValue: I18nServiceStub },
-        { provide: OpContextMenuLocalsToken, useValue: localsStub },
-        { provide: GitActionsService, useValue: gitActionsServiceSpy },
-      ],
-    })
+        declarations: [
+          GitActionsMenuComponent,
+          OpIconComponent,
+        ],
+        providers: [
+          { provide: I18nService, useValue: I18nServiceStub },
+          { provide: OpContextMenuLocalsToken, useValue: localsStub },
+          { provide: GitActionsService, useValue: gitActionsServiceSpy },
+        ],
+      })
       .compileComponents();
   });
 

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.spec.ts
@@ -1,3 +1,31 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { GitActionsMenuComponent } from "./git-actions-menu.component";

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -92,6 +92,10 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     this.workPackage = this.locals.workPackage;
   }
 
+  public onInputClick(e: Event):void {
+    (e.target as HTMLInputElement | HTMLTextAreaElement).select();
+  }
+
   public onCopyButtonClick(snippet:ISnippet):void {
     const success = copy(snippet.text());
 

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -68,20 +68,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.branch_name'),
-      textToDisplay: () => this.gitActions.branchName(this.workPackage),
-      textToCopy: () => this.gitActions.branchName(this.workPackage)
+      text: () => this.gitActions.branchName(this.workPackage),
     },
     {
       id: 'message',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.commit_message'),
-      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
-      textToCopy: () => this.gitActions.commitMessage(this.workPackage)
+      multiline: true,
+      text: () => this.gitActions.commitMessage(this.workPackage),
     },
     {
       id: 'command',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.cmd'),
-      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
-      textToCopy: () => this.gitActions.gitCommand(this.workPackage)
+      multiline: true,
+      text: () => this.gitActions.gitCommand(this.workPackage),
     },
   ];
 
@@ -94,7 +93,7 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
   }
 
   public onCopyButtonClick(snippet:ISnippet):void {
-    const success = copy(snippet.textToCopy());
+    const success = copy(snippet.text());
 
     if (success) {
       this.lastCopyResult = this.text.copyResult.success;

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -67,20 +67,19 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     {
       id: 'branch',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.branch_name'),
-      textToDisplay: () => this.gitActions.branchName(this.workPackage),
-      textToCopy: () => this.gitActions.branchName(this.workPackage)
+      text: () => this.gitActions.branchName(this.workPackage),
     },
     {
       id: 'message',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.commit_message'),
-      textToDisplay: () => this.gitActions.commitMessageDisplayText(this.workPackage),
-      textToCopy: () => this.gitActions.commitMessage(this.workPackage)
+      multiline: true,
+      text: () => this.gitActions.commitMessage(this.workPackage),
     },
     {
       id: 'command',
       name: this.I18n.t('js.gitlab_integration.tab_header_mr.git_actions.cmd'),
-      textToDisplay: () => this.gitActions.gitCommand(this.workPackage),
-      textToCopy: () => this.gitActions.gitCommand(this.workPackage)
+      multiline: true,
+      text: () => this.gitActions.gitCommand(this.workPackage),
     },
   ];
 
@@ -90,7 +89,7 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
   }
 
   public onCopyButtonClick(snippet:ISnippet):void {
-    const success = copy(snippet.textToCopy());
+    const success = copy(snippet.text());
 
     if (success) {
       this.lastCopyResult = this.text.copyResult.success;

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -5,7 +5,7 @@
     <div class="copy-wrapper spot-form-field">
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
-        <div class="spot-form-field--input">
+        <div class="spot-form-field--input copy-input">
           @if (snippet.multiline) {
             <textarea class="copy-content op-input" rows="3" readonly>{{ snippet.text() }}</textarea>
           } @else {

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -6,7 +6,11 @@
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
-          <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
+          @if (snippet.multiline) {
+            <textarea class="copy-content op-input" rows="3" readonly>{{ snippet.text() }}</textarea>
+          } @else {
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+          }
           <button
             class="button copy-button"
             type="button"

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -7,9 +7,9 @@
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
           @if (snippet.multiline) {
-            <textarea class="copy-content op-input" readonly>{{ snippet.text() }}</textarea>
+            <textarea class="copy-content op-input" readonly (click)="onInputClick($event)">{{ snippet.text() }}</textarea>
           } @else {
-            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" (click)="onInputClick($event)" />
           }
           <button
             class="button copy-button"

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -6,7 +6,11 @@
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>
         <div class="spot-form-field--input">
-          <input type="text" class="copy-content op-input" readonly="true" [value]="snippet.textToDisplay()">
+          @if (snippet.multiline) {
+            <textarea class="copy-content op-input" readonly>{{ snippet.text() }}</textarea>
+          } @else {
+            <input type="text" class="copy-content op-input" readonly [value]="snippet.text()" />
+          }
           <button
             class="button copy-button"
             type="button"

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -38,13 +38,16 @@
     position: relative
     margin-bottom: 1rem
 
-  .copy-content
-    width: calc(100% - 3em)
+  .copy-content,
+  .copy-button
     // the min-height should be the size of the copy-icon, which is the sum of:
     // 2 * button padding (0.65em)
     // size of the icon (1rem, size="small" = 16px)
     // 1px where I don't know where it comes from
     min-height: calc(2 * 0.65em + 1rem + 1px)
+
+  .copy-content
+    width: calc(100% - 3em)
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
@@ -60,6 +63,7 @@
     left: -1px
     position: relative
     font-size: 0.9rem
+    align-self: flex-start
 
     &:hover
       background: var(--button--background-hover-color)

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -48,7 +48,6 @@
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
-    white-space: pre
     resize: none
     font-size: 0.9rem
     display: inline-block

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -42,9 +42,9 @@
     width: calc(100% - 3em)
     // the min-height should be the size of the copy-icon, which is the sum of:
     // 2 * button padding (0.65em)
-    // font-size of the icon (0.9em)
+    // size of the icon (1rem, size="small" = 16px)
     // 1px where I don't know where it comes from
-    min-height: calc(2 * 0.65em + 0.9em + 1px)
+    min-height: calc(2 * 0.65em + 1rem + 1px)
     border-radius: 2px 0 0 2px
     padding: 0.65em
     color: var(--fgColor-muted)
@@ -73,7 +73,7 @@
     color: var(--main-menu-font-color)
     position: absolute
     right: 0
-    top: calc(2 * 0.65em + 0.9em + 1px + 9px)
+    top: calc(2 * 0.65em + 1rem + 1px + 9px)
     box-shadow: 1px 1px 4px var(--fgColor-muted)
     z-index: 1
 

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/styles/git-actions-menu.sass
@@ -35,8 +35,10 @@
 
   .copy-wrapper
     width: 100%
-    position: relative
     margin-bottom: 1rem
+
+  .copy-input
+    position: relative
 
   .copy-content,
   .copy-button
@@ -77,7 +79,7 @@
     color: var(--main-menu-font-color)
     position: absolute
     right: 0
-    top: calc(2 * 0.65em + 1rem + 1px + 9px)
+    top: calc(2 * 0.65em + 1rem + 1px)
     box-shadow: 1px 1px 4px var(--fgColor-muted)
     z-index: 1
 

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -28,7 +28,7 @@
 //++
 
 import { Injectable } from '@angular/core';
-import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 
 // probably not providable in root when we want to cache the formatter and set custom templates
 @Injectable({
@@ -72,10 +72,6 @@ export class GitActionsService {
 
   public commitMessage(workPackage:WorkPackageResource):string {
     return this.commitMessageParts(workPackage).join("\n\n");
-  }
-
-  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
-    return this.commitMessageParts(workPackage).join(' ');
   }
 
   public gitCommand(workPackage:WorkPackageResource):string {

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -76,10 +76,6 @@ export class GitActionsService {
     return this.commitMessageParts(workPackage).join("\n\n");
   }
 
-  public commitMessageDisplayText(workPackage:WorkPackageResource):string {
-    return this.commitMessageParts(workPackage).join(' ');
-  }
-
   public gitCommand(workPackage:WorkPackageResource):string {
     const branch = this.branchName(workPackage);
     const messageParts = this.commitMessageParts(workPackage);

--- a/modules/gitlab_integration/frontend/module/typings.d.ts
+++ b/modules/gitlab_integration/frontend/module/typings.d.ts
@@ -33,8 +33,8 @@ import { HalResourceClass } from 'core-app/modules/hal/resources/hal-resource';
 export interface ISnippet {
   id:string;
   name:string;
-  textToDisplay:()=>string;
-  textToCopy:()=>string
+  multiline?:boolean;
+  text:()=>string;
 }
 
 export interface IGitlabIssueResource extends HalResourceClass {

--- a/modules/gitlab_integration/spec/features/work_package_gitlab_tab_spec.rb
+++ b/modules/gitlab_integration/spec/features/work_package_gitlab_tab_spec.rb
@@ -107,11 +107,12 @@ RSpec.describe "Open the Gitlab tab", :js do
         expect_clipboard_content("#{work_package.type.name.downcase}/#{work_package.id}-a-test-work_package")
       end
 
-      it "shows a commit message with space between title and link" do
+      it "shows a commit message with newlines between title and link" do
         gitlab_tab.git_actions_menu_button.click
 
         commit_message_input_text = page.find_field("Commit message").value
-        expect(commit_message_input_text).to include("A test work_package http://")
+        expect(commit_message_input_text)
+          .to eq("OP##{work_package.id} A test work_package\n\n#{work_package_url(work_package)}")
       end
 
       it "allows the user to copy a commit message with newlines between title and link to the clipboard" do

--- a/spec/routing/short_uri_wp_spec.rb
+++ b/spec/routing/short_uri_wp_spec.rb
@@ -56,5 +56,10 @@ RSpec.describe "routes for old issue uris", type: :request do
       expect(last_response).to be_redirect
       expect(last_response.location).to end_with "/work_packages/1234"
     end
+
+    it "has a path helper" do
+      expect(work_package_short_path("123")).to eq("/wp/123")
+      expect(work_package_short_path(%w[123 a_tab foo])).to eq("/wp/123/a_tab/foo")
+    end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/56847

# What are you trying to accomplish?
Also use textareas for commit message and command, as they contain newlines which get lost when using input tags
Kept copy button for textareas to be same as for input following suggestion from @psatyal 
Also fixing position of result message

# Before
https://github.com/user-attachments/assets/f0a69c23-3376-4623-affd-329d87c7edba

# After
https://github.com/user-attachments/assets/0755276f-b24e-4493-b5c6-4a0de698c3f1

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
