### PR TITLE
Bug/56847 problems with gitlab and GitHub integration snippets descriptions

### DIFF
--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -40,7 +40,7 @@ describe('GitActionsService', function () {
       formattedId: '#42',
       subject: "Find the question, or don't",
       description: {
-        raw: "I recently found the answer is 42. We'd need to compute the correct question."
+        raw: "I recently found\nthe answer is 42.\n\nWe'd need to compute\nthe correct question."
       },
       type: { name: 'User Story' },
       pathHelper: new PathHelperService()
@@ -61,16 +61,22 @@ describe('GitActionsService', function () {
     expect(service.branchName(wp)).toEqual('user-story/42-find-the-question-or-don-t');
     expect(service.commitMessage(wp)).toEqual(`[#42] Find the question, or don't
 
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
 ${origin}/wp/42`);
 
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m '${origin}/wp/42'`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/42'`);
   });
 
   it('shell-escapes output for the git-command', () => {
     const wp = createWorkPackage({ subject: "' && rm -rf / #" });
     const origin = window.location.origin;
 
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] '\\'' && rm -rf / #' -m '${origin}/wp/42'`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] '\\'' && rm -rf / #' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/42'`);
   });
 
   it('uses semantic identifiers when in semantic mode', () => {
@@ -78,7 +84,22 @@ ${origin}/wp/42`);
     const origin = window.location.origin;
 
     expect(service.branchName(wp)).toEqual('user-story/proj-42-find-the-question-or-don-t');
-    expect(service.commitMessage(wp)).toEqual(`[PROJ-42] Find the question, or don't\n\n${origin}/wp/PROJ-42`);
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m '[PROJ-42] Find the question, or don'\\''t' -m '${origin}/wp/PROJ-42'`);
+    expect(service.commitMessage(wp)).toEqual(`[PROJ-42] Find the question, or don't
+
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
+${origin}/wp/PROJ-42`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m '[PROJ-42] Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/PROJ-42'`);
+  });
+
+  it('skips empty description', () => {
+    const wp = createWorkPackage({ description: {raw: ''} });
+    const origin = window.location.origin;
+
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m '${origin}/wp/42'`);
   });
 });

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -38,7 +38,7 @@ describe('GitActionsService', function() {
       id: '42',
       subject: "Find the question, or don't",
       description: {
-        raw: "I recently found the answer is 42. We'd need to compute the correct question."
+        raw: "I recently found\nthe answer is 42.\n\nWe'd need to compute\nthe correct question."
       },
       type: { name: 'User Story' },
       pathHelper: new PathHelperService()
@@ -58,17 +58,30 @@ describe('GitActionsService', function() {
     expect(service.commitMessage(wp)).toEqual(
       `[#42] Find the question, or don't
 
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
 http://localhost:9876/wp/42`
     );
     expect(service.gitCommand(wp)).toEqual(
-      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m 'http://localhost:9876/wp/42'`
+      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m 'http://localhost:9876/wp/42'`
     );
   });
 
   it('shell-escapes output for the git-command', () => {
     const wp = createWorkPackage({ subject: "' && rm -rf / #" });
     expect(service.gitCommand(wp)).toEqual(
-      `git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] '\\'' && rm -rf / #' -m 'http://localhost:9876/wp/42'`
+      `git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] '\\'' && rm -rf / #' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m 'http://localhost:9876/wp/42'`
+    );
+  });
+
+  it('skips empty description', () => {
+    const wp = createWorkPackage({ description: {raw: ''} });
+    expect(service.gitCommand(wp)).toEqual(
+      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m '[#42] Find the question, or don'\\''t' -m 'http://localhost:9876/wp/42'`
     );
   });
 });

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -49,7 +49,7 @@ export class GitActionsService {
     const formattedId = workPackage.formattedId;
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackageShortPath(id);
-    const description = '';
+    const description = workPackage.description?.raw || '';
 
     return { id, formattedId, type, title, url, description };
   }
@@ -65,7 +65,7 @@ export class GitActionsService {
 
   private commitMessageParts(workPackage:WorkPackageResource):string[] {
     const { title, formattedId, description, url } = this.formattingInput(workPackage);
-    return [`[${formattedId}] ${title}`, description, url].filter(Boolean);
+    return [`[${formattedId}] ${title}`, ...(description ? description.split("\n\n") : []), url];
   }
 
   public commitMessage(workPackage:WorkPackageResource):string {

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -48,7 +48,7 @@ export class GitActionsService {
     const id = workPackage.id || '';
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackageShortPath(id);
-    const description = '';
+    const description = workPackage.description?.raw || '';
 
     return({
       id, type, title, url, description
@@ -66,7 +66,7 @@ export class GitActionsService {
 
   private commitMessageParts(workPackage:WorkPackageResource):string[] {
     const { title, id, description, url } = this.formattingInput(workPackage);
-    return [`[#${id}] ${title}`, description, url].filter(Boolean);
+    return [`[#${id}] ${title}`, ...(description ? description.split("\n\n") : []), url];
   }
 
   public commitMessage(workPackage:WorkPackageResource):string {

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -39,7 +39,7 @@ describe('GitActionsService', function () {
       displayId: '42',
       subject: "Find the question, or don't",
       description: {
-        raw: "I recently found the answer is 42. We'd need to compute the correct question."
+        raw: "I recently found\nthe answer is 42.\n\nWe'd need to compute\nthe correct question."
       },
       type: { name: 'User Story' },
       pathHelper: new PathHelperService()
@@ -60,16 +60,22 @@ describe('GitActionsService', function () {
     expect(service.branchName(wp)).toEqual('user-story/42-find-the-question-or-don-t');
     expect(service.commitMessage(wp)).toEqual(`OP#42 Find the question, or don't
 
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
 ${origin}/wp/42`);
 
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m '${origin}/wp/42'`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/42'`);
   });
 
   it('shell-escapes output for the git-command', () => {
     const wp = createWorkPackage({ subject: "' && rm -rf / #" });
     const origin = window.location.origin;
 
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m 'OP#42 '\\'' && rm -rf / #' -m '${origin}/wp/42'`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m 'OP#42 '\\'' && rm -rf / #' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/42'`);
   });
 
   it('uses semantic identifiers when in semantic mode', () => {
@@ -77,7 +83,22 @@ ${origin}/wp/42`);
     const origin = window.location.origin;
 
     expect(service.branchName(wp)).toEqual('user-story/proj-42-find-the-question-or-don-t');
-    expect(service.commitMessage(wp)).toEqual(`OP#PROJ-42 Find the question, or don't\n\n${origin}/wp/PROJ-42`);
-    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#PROJ-42 Find the question, or don'\\''t' -m '${origin}/wp/PROJ-42'`);
+    expect(service.commitMessage(wp)).toEqual(`OP#PROJ-42 Find the question, or don't
+
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
+${origin}/wp/PROJ-42`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#PROJ-42 Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m '${origin}/wp/PROJ-42'`);
+  });
+
+  it('skips empty description', () => {
+    const wp = createWorkPackage({ description: {raw: ''} });
+    const origin = window.location.origin;
+
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m '${origin}/wp/42'`);
   });
 });

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -38,7 +38,7 @@ describe('GitActionsService', function() {
       id: '42',
       subject: "Find the question, or don't",
       description: {
-        raw: "I recently found the answer is 42. We'd need to compute the correct question."
+        raw: "I recently found\nthe answer is 42.\n\nWe'd need to compute\nthe correct question."
       },
       type: { name: 'User Story' },
       pathHelper: new PathHelperService()
@@ -58,17 +58,30 @@ describe('GitActionsService', function() {
     expect(service.commitMessage(wp)).toEqual(
       `OP#42 Find the question, or don't
 
+I recently found
+the answer is 42.
+
+We'd need to compute
+the correct question.
+
 http://localhost:9876/work_packages/42`
     );
     expect(service.gitCommand(wp)).toEqual(
-      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m 'http://localhost:9876/work_packages/42'`
+      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m 'http://localhost:9876/work_packages/42'`
     );
   });
 
   it('shell-escapes output for the git-command', () => {
     const wp = createWorkPackage({ subject: "' && rm -rf / #" });
     expect(service.gitCommand(wp)).toEqual(
-      `git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m 'OP#42 '\\'' && rm -rf / #' -m 'http://localhost:9876/work_packages/42'`
+      `git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m 'OP#42 '\\'' && rm -rf / #' -m 'I recently found\nthe answer is 42.' -m 'We'\\''d need to compute\nthe correct question.' -m 'http://localhost:9876/work_packages/42'`
+    );
+  });
+
+  it('skips empty description', () => {
+    const wp = createWorkPackage({ description: {raw: ''} });
+    expect(service.gitCommand(wp)).toEqual(
+      `git checkout -b 'user-story/42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#42 Find the question, or don'\\''t' -m 'http://localhost:9876/work_packages/42'`
     );
   });
 });

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -51,7 +51,7 @@ export class GitActionsService {
     const id = workPackage.displayId;
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackageShortPath(id);
-    const description = '';
+    const description = workPackage.description?.raw || '';
 
     return { id, type, title, url, description };
   }
@@ -67,7 +67,7 @@ export class GitActionsService {
 
   private commitMessageParts(workPackage:WorkPackageResource):string[] {
     const { title, id, description, url } = this.formattingInput(workPackage);
-    return [`OP#${id} ${title}`, description, url].filter(Boolean);
+    return [`OP#${id} ${title}`, ...(description ? description.split("\n\n") : []), url];
   }
 
   public commitMessage(workPackage:WorkPackageResource):string {

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -51,7 +51,7 @@ export class GitActionsService {
     const id = workPackage.id || '';
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackagePath(id);
-    const description = '';
+    const description = workPackage.description?.raw || '';
 
     return({
       id, type, title, url, description
@@ -69,7 +69,7 @@ export class GitActionsService {
 
   private commitMessageParts(workPackage:WorkPackageResource):string[] {
     const { title, id, description, url } = this.formattingInput(workPackage);
-    return [`OP#${id} ${title}`, description, url].filter(Boolean);
+    return [`OP#${id} ${title}`, ...(description ? description.split("\n\n") : []), url];
   }
 
   public commitMessage(workPackage:WorkPackageResource):string {


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/56847

# What are you trying to accomplish?
Add description to commit message and command

I'm not sure it is a good idea to just add it, as descriptions can be pretty lengthy. Created the PR to make it possible to look at how it works, feels like a checkbox to include/not include description would be nice
Adding description was removed in #9329 (https://community.openproject.org/wp/37108)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
