### PR TITLE
Add OpenProject::Cache.fetch_request_cached for hot-path caching

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -223,10 +223,12 @@ class Query < ApplicationRecord
   end
 
   def self.available_columns(project = nil)
-    Queries::Register
-      .selects[self]
-      .map { |col| col.instances(project) }
-      .flatten
+    RequestStore.fetch(:"available_columns_#{project&.id}") do
+      Queries::Register
+        .selects[self]
+        .map { |col| col.instances(project) }
+        .flatten
+    end
   end
 
   def self.displayable_columns

--- a/app/models/type/attributes.rb
+++ b/app/models/type/attributes.rb
@@ -82,10 +82,10 @@ module Type::Attributes
         WorkPackageCustomField.pluck(Arel.sql("max(updated_at), count(id)")).flatten
       end
 
-      OpenProject::Cache.fetch("all_work_package_form_attributes",
-                               *wp_cf_cache_parts,
-                               EXCLUDED.length,
-                               merge_date) do
+      OpenProject::Cache.fetch_request_cached("all_work_package_form_attributes",
+                                              *wp_cf_cache_parts,
+                                              EXCLUDED.length,
+                                              merge_date) do
         calculate_all_work_package_form_attributes(merge_date)
       end
     end

--- a/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
+++ b/lib/api/v3/work_packages/schema/work_package_schema_representer.rb
@@ -385,7 +385,7 @@ module API
           end
 
           def form_config_attribute_representation(group)
-            OpenProject::Cache.fetch(*form_config_attribute_cache_key(group)) do
+            OpenProject::Cache.fetch_request_cached(*form_config_attribute_cache_key(group)) do
               ::JSON::parse(::API::V3::WorkPackages::Schema::FormConfigurations::AttributeRepresenter
                               .new(group, current_user:, project: represented.project, embed_links: true)
                               .to_json)

--- a/lib/open_project/cache.rb
+++ b/lib/open_project/cache.rb
@@ -34,6 +34,18 @@ module OpenProject
       Rails.cache.fetch(CacheKey.key(*), **, &)
     end
 
+    # Like .fetch, but caches the result in RequestStore for the
+    # lifetime of the current request.
+    # Useful when accessing many times during a request to avoid
+    # multiple cache round-trips.
+    def self.fetch_request_cached(*, **, &)
+      key = CacheKey.key(*)
+
+      RequestStore.fetch(key) do
+        Rails.cache.fetch(key, **, &)
+      end
+    end
+
     def self.read(name, **, &)
       Rails.cache.read(CacheKey.key(name), **, &)
     end


### PR DESCRIPTION
Add fetch_request_cached method that layers RequestStore in front of Rails.cache.fetch

Used in the following places, as they are repeatedly accessed during schema initialization.

all_work_package_form_attributes, form_config_attribute_representation, Query.available_columns

In my tests, this improves cold cache access by reducing initial number of queries to access cache