### PR TITLE
Try to fix flaky ./modules/my_page/spec/features/my/my_page_spec.rb:103

### DIFF
--- a/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
+++ b/modules/boards/spec/features/action_boards/custom_field_filters_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe "Custom field filter in boards",
 
     board_page.add_list option: "Closed", query: "closed"
     board_page.expect_list "Closed"
+    board_page.wait_for_lists_reload
 
     # Expect card to be present
     board_page.expect_card("Open", "Foo", present: true)

--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -135,8 +135,11 @@ RSpec.describe "Arbitrary WorkPackage query table widget on my page",
       end
 
       # Wait for the column save PATCH to complete after the DOM has confirmed the
-      # Angular state update. Without this ordering, wait_for_network_idle can fire
-      # during the gap before the async PATCH request is initiated.
+      # Angular state update. The sleep allows Angular's debounced save to queue the
+      # PATCH before wait_for_network_idle checks for network activity; without it,
+      # wait_for_network_idle can fire in the gap before the PATCH is initiated, causing
+      # the column change to race with the subsequent title-rename PATCH.
+      sleep(0.5)
       wait_for_network_idle
 
       scroll_to_element(filter_area.area)

--- a/spec/features/members/invitation_spec.rb
+++ b/spec/features/members/invitation_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "invite user via email", :js do
         end
 
         members_page.search_and_select_principal! "hugo@openproject.com",
-                                                  "Hugo Hurriedhugo@openproject.com"
+                                                  "Hugo Hurried"
         members_page.select_role! "Developer"
 
         click_on "Add"

--- a/spec/support/components/grids/grid_area.rb
+++ b/spec/support/components/grids/grid_area.rb
@@ -92,7 +92,8 @@ module Components
 
         sleep(1)
 
-        move_to(drop_area, &:release)
+        # Re-find drop_area to get a fresh native reference after CDK drag has modified the DOM
+        move_to(self.class.of(row * 2, column * 2).area, &:release)
       end
 
       def expect_to_exist


### PR DESCRIPTION
Stale element reference during drag-and-drop. CDK drag restructures the DOM between the click_and_hold and release phases, invalidating the drop_area.native Selenium reference held from before the drag started.
