### PR TITLE
[#73711] refactor: Rename the project identifier namespace

### DIFF
--- a/app/components/work_packages/admin/settings/identifier_autofix_section_component.rb
+++ b/app/components/work_packages/admin/settings/identifier_autofix_section_component.rb
@@ -34,7 +34,7 @@ module WorkPackages
       class IdentifierAutofixSectionComponent < ApplicationComponent
         include OpPrimer::ComponentHelpers
 
-        DISPLAY_COUNT = WorkPackages::IdentifierAutofix::PreviewQuery::DISPLAY_COUNT
+        DISPLAY_COUNT = ProjectIdentifiers::IdentifierAutofix::PreviewQuery::DISPLAY_COUNT
 
         def initialize(projects_data:, total_count: projects_data.size)
           super()

--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
@@ -46,7 +46,7 @@ module WorkPackages
           super()
           @state = state
           if state == :edit
-            result         = WorkPackages::IdentifierAutofix::PreviewQuery.new.call
+            result         = ProjectIdentifiers::IdentifierAutofix::PreviewQuery.new.call
             @projects_data = result.projects_data
             @total_count   = result.total_count
           else

--- a/app/controllers/admin/settings/work_packages_identifier_controller.rb
+++ b/app/controllers/admin/settings/work_packages_identifier_controller.rb
@@ -39,7 +39,7 @@ module Admin::Settings
     end
 
     def show
-      @form_state = WorkPackages::IdentifierAutofix.job_in_progress? ? :change_in_progress : :edit
+      @form_state = ProjectIdentifiers::IdentifierAutofix.job_in_progress? ? :change_in_progress : :edit
     end
 
     def update
@@ -55,7 +55,7 @@ module Admin::Settings
     end
 
     def status
-      if WorkPackages::IdentifierAutofix.job_in_progress?
+      if ProjectIdentifiers::IdentifierAutofix.job_in_progress?
         head :no_content
       else
         replace_via_turbo_stream(
@@ -68,7 +68,7 @@ module Admin::Settings
     private
 
     def switch_to_semantic
-      unless WorkPackages::IdentifierAutofix.job_in_progress?
+      unless ProjectIdentifiers::IdentifierAutofix.job_in_progress?
         ProjectIdentifiers::ConvertInstanceToSemanticIdsJob.perform_later
       end
       redirect_to action: "show"
@@ -78,7 +78,7 @@ module Admin::Settings
       call = update_service.new(user: current_user)
                                     .call(work_packages_identifier: Setting::WorkPackageIdentifier::CLASSIC)
       call.on_success do
-        unless WorkPackages::IdentifierAutofix.job_in_progress?
+        unless ProjectIdentifiers::IdentifierAutofix.job_in_progress?
           ProjectIdentifiers::RevertInstanceToClassicIdsJob.perform_later
         end
         redirect_to action: "show"

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -97,8 +97,8 @@ module Projects::Identifier
   class_methods do
     def suggest_identifier(name)
       if Setting::WorkPackageIdentifier.semantic?
-        exclude = WorkPackages::IdentifierAutofix::ProblematicIdentifiers.reserved_identifiers
-        WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator
+        exclude = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.reserved_identifiers
+        ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator
           .suggest_identifier(name, exclude:)
       else # This should closely enough emulate Project models' usage of acts_as_url
         name.to_url.first(IDENTIFIER_MAX_LENGTH).presence || "project"

--- a/app/services/project_identifiers/identifier_autofix.rb
+++ b/app/services/project_identifiers/identifier_autofix.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
+module ProjectIdentifiers
   module IdentifierAutofix
     def self.job_in_progress?
       GoodJob::Job

--- a/app/services/project_identifiers/identifier_autofix/preview_query.rb
+++ b/app/services/project_identifiers/identifier_autofix/preview_query.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
+module ProjectIdentifiers
   module IdentifierAutofix
     class PreviewQuery
       Result = Data.define(:projects_data, :total_count)

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
+module ProjectIdentifiers
   module IdentifierAutofix
     # Identifies projects whose identifiers violate the semantic identifier format
     # and provides classification and exclusion sets for suggestion generation.

--- a/app/services/project_identifiers/identifier_autofix/project_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/identifier_autofix/project_identifier_suggestion_generator.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
+module ProjectIdentifiers
   module IdentifierAutofix
     # Generates a short uppercase semantic identifier for each project.
     #

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
   subject(:component) { described_class.new(state:) }
 
   let(:empty_result) do
-    WorkPackages::IdentifierAutofix::PreviewQuery::Result.new(projects_data: [], total_count: 0)
+    ProjectIdentifiers::IdentifierAutofix::PreviewQuery::Result.new(projects_data: [], total_count: 0)
   end
 
   def render_component(component)
@@ -46,8 +46,8 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
   end
 
   before do
-    preview_stub = instance_double(WorkPackages::IdentifierAutofix::PreviewQuery, call: empty_result)
-    allow(WorkPackages::IdentifierAutofix::PreviewQuery).to receive(:new).and_return(preview_stub)
+    preview_stub = instance_double(ProjectIdentifiers::IdentifierAutofix::PreviewQuery, call: empty_result)
+    allow(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).to receive(:new).and_return(preview_stub)
   end
 
   context "when state is :change_in_progress" do
@@ -77,7 +77,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not call PreviewQuery" do
       render_component(component)
-      expect(WorkPackages::IdentifierAutofix::PreviewQuery).not_to have_received(:new)
+      expect(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).not_to have_received(:new)
     end
   end
 
@@ -102,7 +102,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not call PreviewQuery" do
       render_component(component)
-      expect(WorkPackages::IdentifierAutofix::PreviewQuery).not_to have_received(:new)
+      expect(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).not_to have_received(:new)
     end
   end
 
@@ -111,7 +111,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "calls PreviewQuery" do
       render_component(component)
-      expect(WorkPackages::IdentifierAutofix::PreviewQuery).to have_received(:new).once
+      expect(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).to have_received(:new).once
     end
 
     it "renders the save button" do
@@ -129,7 +129,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
             with_settings: { work_packages_identifier: "semantic" } do
       let(:project) { instance_double(Project, name: "Bad Project", id: 1, to_param: "bad-proj") }
       let(:problematic_result) do
-        WorkPackages::IdentifierAutofix::PreviewQuery::Result.new(
+        ProjectIdentifiers::IdentifierAutofix::PreviewQuery::Result.new(
           projects_data: [
             { project:, current_identifier: "bad-proj", suggested_identifier: "BP", error_reason: :special_characters }
           ],
@@ -138,8 +138,8 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
       end
 
       before do
-        stub = instance_double(WorkPackages::IdentifierAutofix::PreviewQuery, call: problematic_result)
-        allow(WorkPackages::IdentifierAutofix::PreviewQuery).to receive(:new).and_return(stub)
+        stub = instance_double(ProjectIdentifiers::IdentifierAutofix::PreviewQuery, call: problematic_result)
+        allow(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).to receive(:new).and_return(stub)
       end
 
       it "hides the plain save button" do

--- a/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
+++ b/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
 
       context "when a migration job is already in progress" do
         before do
-          allow(WorkPackages::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
+          allow(ProjectIdentifiers::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
         end
 
         it "does not enqueue another job but still redirects" do
@@ -73,7 +73,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
 
       context "when a migration job is already in progress" do
         before do
-          allow(WorkPackages::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
+          allow(ProjectIdentifiers::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
         end
 
         it "does not enqueue another job but still updates the setting and redirects" do

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -195,10 +195,10 @@ RSpec.describe Projects::Identifier do
   describe ".suggest_identifier" do
     context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
       it "delegates to ProjectIdentifierSuggestionGenerator with an exclusion set" do
-        allow(WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+        allow(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
           .to receive(:suggest_identifier).and_return("MP")
         expect(Project.suggest_identifier("My Project")).to eq("MP")
-        expect(WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+        expect(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
           .to have_received(:suggest_identifier).with("My Project", exclude: a_kind_of(Set))
       end
     end

--- a/spec/services/project_identifiers/identifier_autofix/preview_query_spec.rb
+++ b/spec/services/project_identifiers/identifier_autofix/preview_query_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe WorkPackages::IdentifierAutofix::PreviewQuery do
+RSpec.describe ProjectIdentifiers::IdentifierAutofix::PreviewQuery do
   subject(:result) { described_class.new.call }
 
   let(:display_count) { described_class::DISPLAY_COUNT }
@@ -166,10 +166,10 @@ RSpec.describe WorkPackages::IdentifierAutofix::PreviewQuery do
 
       # Simulate a new scope condition that catches a project
       # not covered by any error_reason branch (drift scenario).
-      analysis = WorkPackages::IdentifierAutofix::ProblematicIdentifiers.new
+      analysis = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.new
       forced_scope = Project.where(id: project.id)
       allow(analysis).to receive(:scope).and_return(forced_scope)
-      allow(WorkPackages::IdentifierAutofix::ProblematicIdentifiers).to receive(:new).and_return(analysis)
+      allow(ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers).to receive(:new).and_return(analysis)
 
       expect(result.projects_data.first[:error_reason]).to eq(:unknown)
     end

--- a/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
+++ b/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe WorkPackages::IdentifierAutofix::ProblematicIdentifiers do
+RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
   subject(:analysis) { described_class.new }
 
   # Bypasses model validations to set an exact identifier in the database,

--- a/spec/services/project_identifiers/identifier_autofix/project_identifier_suggestion_generator_spec.rb
+++ b/spec/services/project_identifiers/identifier_autofix/project_identifier_suggestion_generator_spec.rb
@@ -30,7 +30,7 @@
 
 require "rails_helper"
 
-RSpec.describe WorkPackages::IdentifierAutofix::ProjectIdentifierSuggestionGenerator do
+RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator do
   describe ".call" do
     context "when given an empty array" do
       it "returns an empty array" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/73711/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Move the identifier conversion-related code into its own module.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
