### PR TITLE
Add aria-describedby screen reader hint for external links in BlockNote

### DIFF
--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -29,6 +29,7 @@
  */
 
 import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
 import { User } from '@blocknote/core/comments';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
@@ -104,13 +105,12 @@ export function OpBlockNoteEditor({
       },
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
-      // When external link capture is enabled, intercept clicks on external
-      // links via a ProseMirror plugin and route through /external_redirect.
-      ...(captureExternalLinks && {
-        _tiptapOptions: {
-          extensions: [ExternalLinkCaptureExtension],
-        },
-      }),
+      _tiptapOptions: {
+        extensions: [
+          ExternalLinkA11yExtension,
+          ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
+        ],
+      },
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -1,0 +1,97 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import type { Node as PmNode } from '@tiptap/pm/model';
+import { isHrefExternal } from 'core-stimulus/helpers/external-link-helpers';
+
+const pluginKey = new PluginKey('externalLinkA11y');
+
+function buildDecorations(doc:PmNode):DecorationSet {
+  const decorations:Decoration[] = [];
+  doc.descendants((node, pos) => {
+    for (const mark of node.marks) {
+      if (mark.type.name === 'link' && isHrefExternal(String(mark.attrs.href ?? ''))) {
+        decorations.push(
+          Decoration.inline(pos, pos + node.nodeSize, {
+            'aria-describedby': 'open-blank-target-link-description',
+          }),
+        );
+        break;
+      }
+    }
+  });
+  return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * TipTap extension that adds `aria-describedby` to external links inside the
+ * editor via ProseMirror Decorations.
+ *
+ * Decorations add DOM attributes without modifying the document model, so
+ * ProseMirror does not re-render and there is no risk of infinite loops (the
+ * reason direct DOM mutation was previously avoided for this attribute).
+ *
+ * Uses the `state.init/apply` pattern: decorations are rebuilt only when the
+ * document changes, and cheaply remapped via `DecorationSet.map()` otherwise
+ * (e.g. on selection changes or non-doc transactions).
+ *
+ * The referenced description element (`open-blank-target-link-description`) is
+ * a screen-reader-only `<span>` that tells assistive-technology users the link
+ * opens in a new tab. It lives in the main layout (`base.html.erb`) and is
+ * cloned into the BlockNote shadow DOM by `block-note-element.ts`.
+ */
+export const ExternalLinkA11yExtension = Extension.create({
+  name: 'externalLinkA11y',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: pluginKey,
+        state: {
+          init(_, { doc }) {
+            return buildDecorations(doc);
+          },
+          apply(tr, oldDecos) {
+            if (tr.docChanged) {
+              return buildDecorations(tr.doc);
+            }
+            return oldDecos.map(tr.mapping, tr.doc);
+          },
+        },
+        props: {
+          decorations(state) {
+            return pluginKey.getState(state) as DecorationSet;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/frontend/src/stimulus/helpers/external-link-helpers.ts
+++ b/frontend/src/stimulus/helpers/external-link-helpers.ts
@@ -42,18 +42,27 @@ export function isLinkBlank(link:HTMLAnchorElement) {
 }
 
 /**
+ * Returns true when the given href string points to a different origin than
+ * the current page. Works with plain URL strings (e.g. from ProseMirror mark
+ * attrs) where no HTMLAnchorElement is available.
+ */
+export function isHrefExternal(href:string):boolean {
+  try {
+    const linkUrl = new URL(href, window.location.origin);
+    return linkUrl.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Returns true when the link points to a different origin than the current page.
  * External links receive special treatment for security (noopener/noreferrer)
  * and, when capture is enabled, are routed through `/external_redirect` for
  * phishing prevention.
  */
 export function isLinkExternal(link:HTMLAnchorElement) {
-  try {
-    const linkUrl = new URL(link.href, window.location.origin);
-    return linkUrl.origin !== window.location.origin;
-  } catch {
-    return false;
-  }
+  return isHrefExternal(link.href);
 }
 
 /**

--- a/frontend/src/stimulus/helpers/external-link-helpers.ts
+++ b/frontend/src/stimulus/helpers/external-link-helpers.ts
@@ -45,10 +45,15 @@ export function isLinkBlank(link:HTMLAnchorElement) {
  * Returns true when the given href string points to a different origin than
  * the current page. Works with plain URL strings (e.g. from ProseMirror mark
  * attrs) where no HTMLAnchorElement is available.
+ *
+ * Only considers http/https URLs — non-web protocols (mailto:, tel:,
+ * javascript:, etc.) return false because they don't navigate to an
+ * external origin.
  */
 export function isHrefExternal(href:string):boolean {
   try {
     const linkUrl = new URL(href, window.location.origin);
+    if (!linkUrl.protocol.startsWith('http')) return false;
     return linkUrl.origin !== window.location.origin;
   } catch {
     return false;

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -78,11 +78,17 @@ RSpec.describe "External links in BlockNote editor",
     expect(link[:rel]).to include("noreferrer")
   end
 
-  it "does not set aria-describedby inside contenteditable to avoid ProseMirror re-render loop" do
+  it "sets aria-describedby on external links for screen reader accessibility" do
     editor.paste_links(text: "Accessible Link", url: "https://example.com")
 
-    link = editor.shadow_root.find("a[target='_blank']", text: "Accessible Link", wait: 5)
-    expect(link[:"aria-describedby"]).to be_nil.or eq("")
+    # ProseMirror inline decorations wrap the text node in a <span> with the
+    # attribute, rather than adding it to the <a> element (which is rendered
+    # by the link mark). The screen reader hint is on the link's text content.
+    editor.shadow_root.find(
+      "a[target='_blank'] [aria-describedby='open-blank-target-link-description']",
+      text: "Accessible Link",
+      wait: 5
+    )
   end
 
   it_behaves_like "does not freeze when pasting multiple external links"


### PR DESCRIPTION
### Ticket

https://community.openproject.org/wp/73721

### What are you trying to accomplish?

The parent PR (#22689) had to skip `aria-describedby` inside BlockNote's contenteditable because mutating link attributes from outside ProseMirror triggers an infinite re-render loop. This means screen reader users don't hear "opens in new tab" when focused on an external link inside the editor.

This PR adds the hint back using ProseMirror Decorations — the correct mechanism for adding DOM attributes without touching the document model. No mutation loop, no document corruption, just a well-behaved `<span aria-describedby="...">` wrapping the link text.

<img width="1726" height="1132" alt="Screenshot 2026-04-08 at 9 16 20 PM" src="https://github.com/user-attachments/assets/24d88252-f765-4d23-8767-765011108ee3" />


### What approach did you choose and why?

📖 https://prosemirror.net/docs/ref/#view.Decorations

> _Decorations make it possible to influence the way the document is drawn, without actually changing the document._

ProseMirror inline decorations create a wrapper <span> inside the mark's element, they do not modify the mark-rendered <a> tag itself.

<img width="1392" height="678" alt="Screenshot 2026-04-08 at 9 29 26 PM" src="https://github.com/user-attachments/assets/481a2f19-a3c5-4fed-950d-17f59bb1e150" />

A new `ExternalLinkA11yExtension` (TipTap extension) that lives alongside the existing `ExternalLinkCaptureExtension`. It's separate because the a11y hint should always be present, while capture is feature-gated.

The plugin uses the `state.init/apply` pattern so decorations are only rebuilt when the document changes — on selection changes and other non-doc transactions, positions are cheaply remapped via `DecorationSet.map()`.

Also extracted `isHrefExternal(string)` from `isLinkExternal(HTMLAnchorElement)` so the decoration plugin can check externality from ProseMirror mark attrs (plain href strings) without needing a DOM element.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
