### PR TITLE
fix: Correctly auto-generate semantic identifiers on project copy

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -163,6 +163,8 @@ module Projects::Identifier
   end
 
   def generate_semantic_identifier
-    self.identifier = self.class.suggest_identifier(name) if name.present?
+    return unless name.present?
+
+    self.identifier = WorkPackages::IdentifierAutofix::SemanticIdentifierGenerator.generate(name)
   end
 end

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -163,7 +163,7 @@ module Projects::Identifier
   end
 
   def generate_semantic_identifier
-    return unless name.present?
+    return if name.blank?
 
     self.identifier = WorkPackages::IdentifierAutofix::SemanticIdentifierGenerator.generate(name)
   end

--- a/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
@@ -81,8 +81,12 @@ module WorkPackages
       # Returns a Set of identifiers historically reserved via FriendlyId slug history
       # that are no longer the active identifier of any project.
       # Useful for callers that manage their own current-identifier exclusions.
-      def self.reserved_identifiers
-        new.reserved_identifiers
+      def reserved_identifiers
+        @reserved_identifiers ||= FriendlyId::Slug
+                                    .where(sluggable_type: Project.name)
+                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
+                                    .pluck(:slug)
+                                    .to_set
       end
 
       private
@@ -113,13 +117,6 @@ module WorkPackages
         @in_use_identifiers ||= Project.where.not(id: scope.select(:id)).pluck(:identifier).to_set
       end
 
-      def reserved_identifiers
-        @reserved_identifiers ||= FriendlyId::Slug
-                                    .where(sluggable_type: Project.name)
-                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                    .pluck(:slug)
-                                    .to_set
-      end
     end
   end
 end

--- a/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
@@ -81,12 +81,8 @@ module WorkPackages
       # Returns a Set of identifiers historically reserved via FriendlyId slug history
       # that are no longer the active identifier of any project.
       # Useful for callers that manage their own current-identifier exclusions.
-      def reserved_identifiers
-        @reserved_identifiers ||= FriendlyId::Slug
-                                    .where(sluggable_type: Project.name)
-                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                    .pluck(:slug)
-                                    .to_set
+      def self.reserved_identifiers
+        new.reserved_identifiers
       end
 
       private
@@ -117,6 +113,13 @@ module WorkPackages
         @in_use_identifiers ||= Project.where.not(id: scope.select(:id)).pluck(:identifier).to_set
       end
 
+      def reserved_identifiers
+        @reserved_identifiers ||= FriendlyId::Slug
+                                    .where(sluggable_type: Project.name)
+                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
+                                    .pluck(:slug)
+                                    .to_set
+      end
     end
   end
 end

--- a/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
@@ -78,6 +78,17 @@ module WorkPackages
         reserved_identifiers | in_use_identifiers
       end
 
+      # Returns a Set of identifiers historically reserved via FriendlyId slug history
+      # that are no longer the active identifier of any project.
+      # Useful for callers that manage their own current-identifier exclusions.
+      def reserved_identifiers
+        @reserved_identifiers ||= FriendlyId::Slug
+                                    .where(sluggable_type: Project.name)
+                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
+                                    .pluck(:slug)
+                                    .to_set
+      end
+
       private
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", max_identifier_length)
@@ -106,13 +117,6 @@ module WorkPackages
         @in_use_identifiers ||= Project.where.not(id: scope.select(:id)).pluck(:identifier).to_set
       end
 
-      def reserved_identifiers
-        @reserved_identifiers ||= FriendlyId::Slug
-                                    .where(sluggable_type: Project.name)
-                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                    .pluck(:slug)
-                                    .to_set
-      end
     end
   end
 end

--- a/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
+++ b/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
@@ -49,7 +49,7 @@ module WorkPackages
       private
 
       def exclusion_set
-        Project.pluck(:identifier).to_set | ProblematicIdentifiers.new.reserved_identifiers
+        Project.pluck(:identifier).to_set | ProblematicIdentifiers.reserved_identifiers
       end
     end
   end

--- a/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
+++ b/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
@@ -49,7 +49,7 @@ module WorkPackages
       private
 
       def exclusion_set
-        Project.pluck(:identifier).to_set | ProblematicIdentifiers.reserved_identifiers
+        Project.pluck(:identifier).to_set | ProblematicIdentifiers.new.reserved_identifiers
       end
     end
   end

--- a/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
+++ b/app/services/work_packages/identifier_autofix/semantic_identifier_generator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module WorkPackages
+  module IdentifierAutofix
+    # Generates a unique semantic identifier for a new project by combining
+    # the suggestion algorithm with a DB-backed exclusion set.
+    #
+    # The exclusion set covers:
+    # * all current project identifiers (to satisfy the uniqueness constraint)
+    # * historically reserved identifiers from FriendlyId slug history
+    #   (to satisfy the identifier_not_historically_reserved validation)
+    class SemanticIdentifierGenerator
+      def self.generate(name)
+        new.generate(name)
+      end
+
+      def generate(name)
+        ProjectIdentifierSuggestionGenerator.suggest_identifier(name, exclude: exclusion_set)
+      end
+
+      private
+
+      def exclusion_set
+        Project.pluck(:identifier).to_set | ProblematicIdentifiers.new.reserved_identifiers
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
+++ b/spec/requests/api/v3/projects/copy/copy_resource_spec.rb
@@ -211,6 +211,19 @@ RSpec.describe "API::V3::Projects::Copy::CopyAPI", content_type: :json, with_goo
           expect(project).to be_present
           expect(project.identifier).to eq("MCP")
         end
+
+        context "when the generated identifier is already taken" do
+          let!(:existing_project) { create(:project, identifier: "MCP") }
+
+          it "auto-generates a unique identifier instead" do
+            GoodJob.perform_inline
+
+            project = Project.find_by(name: "My copied project")
+            expect(project).to be_present
+            expect(project.identifier).not_to eq("MCP")
+            expect(project.identifier).to match(/\A[A-Z][A-Z0-9_]*\z/)
+          end
+        end
       end
 
       context "when an invalid identifier is provided" do

--- a/spec/requests/api/v3/projects/create_resource_spec.rb
+++ b/spec/requests/api/v3/projects/create_resource_spec.rb
@@ -464,14 +464,17 @@ RSpec.describe "API v3 Project resource create", content_type: :json do
 
     context "when auto-generated identifier already exists" do
       # The outer before already created a project with identifier "FPA".
-      # A second request with the same name must fail with a conflict.
+      # A second request with the same name must resolve the collision automatically.
       let(:body) do
         { name: "Flight Planning Algorithm" }.to_json
       end
 
-      it "responds with 422" do
+      it "responds with 201 and generates the next unique identifier" do
         post path, body
-        expect(last_response).to have_http_status(:unprocessable_entity)
+        expect(last_response).to have_http_status(:created)
+        expect(last_response.body)
+          .to be_json_eql("FLPA".to_json)
+          .at_path("identifier")
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/73789/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When copying a project via the API in semantic identifier mode without supplying an identifier, the model auto-generates an identifier from name. The generation is missing conflict detection, so copying a project via API will generate the _same identifier_ as for the old one, and the process will fail due to unique constraint.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Introduce `SemanticIdentifierGenerator` in the IdentifierAutofix namespace, which builds an exclusion set from all current project identifiers plus historically reserved `FriendlyId` slugs before calling `ProjectIdentifierSuggestionGenerator`.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
