### PR TITLE
[#73557] Fix bug when all the backlog items are loaded all the time

### DIFF
--- a/modules/backlogs/app/helpers/rb_common_helper.rb
+++ b/modules/backlogs/app/helpers/rb_common_helper.rb
@@ -142,6 +142,10 @@ module RbCommonHelper
       !project.receive_shared_sprints?
   end
 
+  def show_all_backlog
+    ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
+  end
+
   private
 
   def work_package_status_for_id(id)

--- a/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/_backlog_list.html.erb
@@ -35,7 +35,7 @@ See COPYRIGHT and LICENSE files for more details.
       <%= render Backlogs::InboxComponent.new(
             work_packages: @inbox_work_packages,
             project: @project,
-            show_all: params[:all].present?,
+            show_all: show_all_backlog,
             open_sprints_exist: @sprints.any?
           ) %>
     </div>

--- a/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
@@ -49,7 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% content_for :content_body do %>
   <%= turbo_frame_tag :backlogs_container,
                       refresh: :morph,
-                      src: backlog_backlogs_project_backlogs_path(@project, all: params[:all].present?),
+                      src: backlog_backlogs_project_backlogs_path(@project, all: show_all_backlog),
                       class: "op-backlogs-page" %>
 <% end %>
 

--- a/modules/backlogs/spec/helpers/rb_common_helper_spec.rb
+++ b/modules/backlogs/spec/helpers/rb_common_helper_spec.rb
@@ -72,4 +72,42 @@ RSpec.describe RbCommonHelper do
       end
     end
   end
+
+  describe "#show_all_backlog" do
+    before do
+      allow(helper).to receive(:params).and_return(params)
+    end
+
+    context "when the all param is absent" do
+      let(:params) { {} }
+
+      it "is false" do
+        expect(helper.show_all_backlog).to be false
+      end
+    end
+
+    context "when the all param is a Rails boolean truthy string" do
+      let(:params) { { all: "1" } }
+
+      it "is true" do
+        expect(helper.show_all_backlog).to be true
+      end
+    end
+
+    context "when the all param is the string false" do
+      let(:params) { { all: "false" } }
+
+      it "is false" do
+        expect(helper.show_all_backlog).to be false
+      end
+    end
+
+    context "when the all param is the string zero" do
+      let(:params) { { all: "0" } }
+
+      it "is false" do
+        expect(helper.show_all_backlog).to be false
+      end
+    end
+  end
 end

--- a/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
+++ b/modules/backlogs/spec/requests/rb_master_backlogs_spec.rb
@@ -101,6 +101,14 @@ RSpec.describe "RbMasterBacklogs", :skip_csrf, type: :rails_request do
         expect(response).to have_turbo_frame "content-bodyRight"
       end
 
+      it "passes all=true on the backlog turbo frame when requested" do
+        get "/projects/#{project.identifier}/backlogs/backlog", params: { all: "1" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to have_turbo_frame "backlogs_container",
+                                             src: "/projects/#{project.identifier}/backlogs/backlog?all=true"
+      end
+
       context "with a Turbo Frame request" do
         it "renders the sprint planning list partial" do
           get "/projects/#{project.identifier}/backlogs/backlog", headers: { "Turbo-Frame" => "backlogs_container" }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73557

# What are you trying to accomplish?
Fix the bug where all the inbox items are loaded all the time and no "Show X items" link is shown.

# What approach did you choose and why?
Parse the `params[:all]` via the `ActiveRecord::Types::Boolean`, to ensure various forms are all parsed to false.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
