### PR TITLE
[#73741] Moving an agenda item to the next meeting does not work if the meeting has been rescheduled

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -233,7 +233,7 @@ module MeetingAgendaItems
     def next_meeting_action_item(menu, label:, action:, icon:)
       return unless has_next_occurrence?
 
-      from_time = @meeting.start_time.past? ? Time.current : @meeting.start_time
+      from_time = @meeting.start_time.past? ? Time.current : @meeting.scheduled_meeting.start_time
       result = @series.first_non_cancelled_occurrence(from_time:)
       return if result.nil?
 

--- a/modules/meeting/spec/components/meeting_agenda_items/item_component/show_component_spec.rb
+++ b/modules/meeting/spec/components/meeting_agenda_items/item_component/show_component_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe MeetingAgendaItems::ItemComponent::ShowComponent, type: :componen
 
     context "when the meeting is in the future" do
       let(:meeting_start_time) { 1.week.from_now }
+      let!(:scheduled_meeting) { create(:scheduled_meeting, recurring_meeting: series, start_time: meeting_start_time, meeting:) }
 
       it "calculates next occurrence from meeting start time" do
         next_occurrence = series.next_occurrence(from_time: meeting.start_time)
@@ -138,6 +139,7 @@ RSpec.describe MeetingAgendaItems::ItemComponent::ShowComponent, type: :componen
                start_time: 1.week.from_now,
                author: user)
       end
+      let!(:scheduled_meeting) { create(:scheduled_meeting, recurring_meeting: series, start_time: meeting.start_time, meeting:) }
 
       it "shows the duplicate submenu" do
         expect(series.next_occurrence(from_time: meeting.start_time)).to be_present

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
@@ -163,6 +163,47 @@ RSpec.describe "Recurring meetings move to next meeting", :js do
       end
     end
 
+    context "when the occurrence has been rescheduled to an earlier time (Bug #73741)" do
+      let(:current_user) { user_with_manage_permissions }
+      let(:first_occurrence_time) { series.next_occurrence(from_time: Time.current) }
+
+      let!(:rescheduled_occurrence) do
+        call = RecurringMeetings::InitOccurrenceService
+          .new(user: User.system, recurring_meeting: series)
+          .call(start_time: first_occurrence_time)
+        occurrence_meeting = call.result
+
+        # Reschedule to an earlier time
+        # This updates meeting.start_time, but not meeting.scheduled_meeting.start_time
+        occurrence_meeting.update!(start_time: first_occurrence_time - 1.day)
+        occurrence_meeting
+      end
+
+      let(:meeting) { rescheduled_occurrence }
+
+      it "moves the item to the occurrence after the original scheduled time" do
+        meeting_page.expect_agenda_item(title: "Test notes")
+
+        meeting_page.select_action(agenda_item, "Move to next meeting")
+        expect(page).to have_text("Move to next meeting?")
+
+        page.within_modal "Move to next meeting?" do
+          click_on "Move"
+        end
+
+        expect_and_dismiss_flash(message: "Agenda item moved to the next meeting")
+
+        meeting_page.expect_no_agenda_item(title: "Test notes")
+
+        next_meeting = Meeting.find(agenda_item.reload.meeting_id)
+        expect(next_meeting.id).not_to eq(rescheduled_occurrence.id)
+
+        next_meeting_page = Pages::Meetings::Show.new(next_meeting)
+        next_meeting_page.visit!
+        next_meeting_page.expect_agenda_item(title: "Test notes")
+      end
+    end
+
     context "with view permission only" do
       let(:current_user) { user_with_view_permissions }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/73741

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
