### PR TITLE
[#73723] Fix meeting section lookup

### DIFF
--- a/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
+++ b/modules/meeting/app/contracts/meeting_agenda_items/update_contract.rb
@@ -30,6 +30,7 @@
 module MeetingAgendaItems
   class UpdateContract < BaseContract
     validate :user_allowed_to_edit
+    validate :section_belongs_to_meeting
 
     attribute :lock_version do
       if model.lock_version.nil? || model.lock_version_changed?
@@ -46,6 +47,23 @@ module MeetingAgendaItems
       unless user.allowed_in_project?(:manage_agendas, model.project)
         errors.add :base, :error_unauthorized
       end
+    end
+
+    def section_belongs_to_meeting
+      return unless model.meeting_section_id_changed?
+
+      item_meeting = model.meeting
+      section_meeting = model.meeting_section.meeting
+
+      return if item_meeting == section_meeting
+
+      # For recurring meetings, allow moves across meetings in the same series
+      if item_meeting.recurring? &&
+        item_meeting.recurring_meeting_id == section_meeting.recurring_meeting_id
+        return
+      end
+
+      errors.add :meeting_section, :invalid
     end
   end
 end

--- a/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
+++ b/modules/meeting/app/controllers/meeting_agenda_items_controller.rb
@@ -281,7 +281,12 @@ class MeetingAgendaItemsController < ApplicationController
   end
 
   def move_to_section
-    meeting_section = MeetingSection.find_by(id: params[:meeting_agenda_item][:meeting_section_id])
+    section_scope = if @meeting.recurring_meeting_id.present?
+                      MeetingSection.joins(:meeting).where(meetings: { recurring_meeting_id: @meeting.recurring_meeting_id })
+                    else
+                      @meeting.sections
+                    end
+    meeting_section = section_scope.find_by(id: params[:meeting_agenda_item][:meeting_section_id])
     @meeting = meeting_section.meeting unless meeting_section.backlog?
 
     call = update_agenda_item(meeting_section:)

--- a/modules/meeting/spec/contracts/meeting_agenda_items/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meeting_agenda_items/update_contract_spec.rb
@@ -62,6 +62,43 @@ RSpec.describe MeetingAgendaItems::UpdateContract do
       it_behaves_like "contract is invalid", item_type: :error_readonly
     end
 
+    context "when moving to a different meeting_section" do
+      let(:new_section) { create(:meeting_section, meeting:) }
+
+      before { item.meeting_section = new_section }
+
+      context "when the section belongs to the same meeting" do
+        it_behaves_like "contract is valid"
+      end
+
+      context "when the section belongs to an unrelated meeting" do
+        let(:other_meeting) { create(:meeting, project:) }
+        let(:new_section) { create(:meeting_section, meeting: other_meeting) }
+
+        it_behaves_like "contract is invalid", meeting_section: :invalid
+      end
+
+      context "when the section belongs to a different meeting in the same series" do
+        let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+        let(:occurrence) do
+          create(:meeting, project:, recurring_meeting:, template: false)
+        end
+        let(:item) { create(:meeting_agenda_item, meeting: recurring_meeting.template) }
+        let(:new_section) { create(:meeting_section, meeting: occurrence) }
+
+        it_behaves_like "contract is valid"
+      end
+
+      context "when the section belongs to a meeting in a different series" do
+        let(:other_recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+        let(:new_section) { create(:meeting_section, meeting: other_recurring_meeting.template) }
+        let(:recurring_meeting) { create(:recurring_meeting, project:, author: user) }
+        let(:item) { create(:meeting_agenda_item, meeting: recurring_meeting.template) }
+
+        it_behaves_like "contract is invalid", meeting_section: :invalid
+      end
+    end
+
     context "with presenter" do
       before do
         item.presenter = presenter


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/73723

I couldn't do the suggested fix in the WP as that would break moving sections to other occurrences/the template for a series. This is now handled conditionally, but still prevents random sections from being allowed

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
