### PR TITLE
Bug/73448 closing the work package split view reloads whole page

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -85,7 +85,7 @@
           icon: :x,
           tag: :a,
           href: base_route,
-          data: { turbo: true, target: "_top", turbo_action: "advance" },
+          data: { turbo: true, turbo_action: "advance" },
           scheme: :invisible,
           test_selector: "wp-details-tab-component--close",
           aria: { label: I18n.t(:button_close) }

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
@@ -53,7 +53,9 @@ export class WorkPackageSplitViewEntryComponent {
   @Input() activeTab:string;
   @Input() resizerClass:string;
 
-  constructor(readonly elementRef:ElementRef) {
+  readonly elementRef = inject(ElementRef);
+
+  constructor() {
     populateInputsFromDataset(this);
 
     document.body.classList.add('router--work-packages-partitioned-split-view-details');

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view-entry.component.ts
@@ -26,11 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnDestroy, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
+
+const splitViewBodyClass = 'router--work-packages-partitioned-split-view-details';
 
 /**
  * An entry component to be rendered by Rails which opens an isolated query space
@@ -48,7 +50,7 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: false,
 })
-export class WorkPackageSplitViewEntryComponent {
+export class WorkPackageSplitViewEntryComponent implements OnDestroy {
   @Input() workPackageId:string;
   @Input() activeTab:string;
   @Input() resizerClass:string;
@@ -58,6 +60,10 @@ export class WorkPackageSplitViewEntryComponent {
   constructor() {
     populateInputsFromDataset(this);
 
-    document.body.classList.add('router--work-packages-partitioned-split-view-details');
+    document.body.classList.add(splitViewBodyClass);
+  }
+
+  ngOnDestroy():void {
+    document.body.classList.remove(splitViewBodyClass);
   }
 }

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -74,6 +74,8 @@ class RbMasterBacklogsController < RbApplicationController
     end
   end
 
+  private
+
   def split_view_base_route
     if OpenProject::FeatureDecisions.scrum_projects_active?
       backlog_backlogs_project_backlogs_path(request.query_parameters)
@@ -81,8 +83,6 @@ class RbMasterBacklogsController < RbApplicationController
       backlogs_project_backlogs_path(request.query_parameters)
     end
   end
-
-  private
 
   def load_backlogs
     @owner_backlogs = Backlog.owner_backlogs(@project)

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -41,7 +41,8 @@ class RbMasterBacklogsController < RbApplicationController
   before_action :load_backlogs, only: %i[index backlog]
 
   def backlog
-    if turbo_frame_request?
+    case turbo_frame_request_id
+    when "backlogs_container"
       render partial: "backlog_list", layout: false
     else
       render :backlog

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -32,12 +32,10 @@ class RbMasterBacklogsController < RbApplicationController
   include WorkPackages::WithSplitView
 
   # Without the feature flag, there is only the top level menu item, select it
-  menu_item :backlogs_legacy
+  menu_item :backlogs_legacy, only: :index
 
   # With the feature flag, we have a proper menu, select the correct sub entry
-  current_menu_item do
-    :backlog
-  end
+  menu_item :backlog, only: %i[backlog details]
 
   before_action :not_authorized_on_feature_flag_inactive, only: :backlog
   before_action :load_backlogs, only: %i[index backlog]

--- a/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/rb_master_backlogs_controller.rb
@@ -35,7 +35,7 @@ class RbMasterBacklogsController < RbApplicationController
   menu_item :backlogs_legacy
 
   # With the feature flag, we have a proper menu, select the correct sub entry
-  current_menu_item [:backlog] do
+  current_menu_item do
     :backlog
   end
 

--- a/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
@@ -54,5 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% end %>
 
 <% content_for :content_body_right do %>
+  <%# copy of the hack from app/views/notifications/index.html.erb %>
+  <%= turbo_stream.set_title(title: page_title(*html_title_parts)) if turbo_frame_request? %>
   <%= render(split_view_instance) if render_work_package_split_view? %>
 <% end %>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73448

# What are you trying to accomplish?

Don't reload whole page when closing work package split pane in backlogs.
Also fix padding disappearing when closing split pane in notifications.

## Screenshots
https://github.com/user-attachments/assets/7259e987-dbd2-40c8-a666-65cab0783325

# What approach did you choose and why?
There were problems on multiple levels:
* `data: {target: "_top"}` was confusing, as `data-target` is not a turbo frame attribute, so the link still loads only to the frame
* backlog was rendering `backlog_list` for any turbo frame request, so turbo was receiving a response without the expected frame
* by default turbo shows `Content messing`, but handle `turbo:frame-missing` in `frontend/src/turbo/setup.ts` and load the whole page again instead, which contains empty right pane and leads to third request to backlog action to load `backlog_list`
* `router--work-packages-partitioned-split-view-details` class was not removed from body when split pane was closed

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
