### PR TITLE
[#73761] Global search: Find work packages by their identifier

### DIFF
--- a/app/models/queries/operators.rb
+++ b/app/models/queries/operators.rb
@@ -37,6 +37,7 @@ module Queries::Operators
     Queries::Operators::None,
     Queries::Operators::All,
     Queries::Operators::Contains,
+    Queries::Operators::StartsWith,
     Queries::Operators::NotContains,
     Queries::Operators::InLessThan,
     Queries::Operators::InMoreThan,

--- a/app/models/queries/operators/concerns/starts_with_all_values.rb
+++ b/app/models/queries/operators/concerns/starts_with_all_values.rb
@@ -37,7 +37,7 @@ module Queries::Operators::Concerns
         values
           .first
           .split(/\s+/)
-          .map { |token| "#{db_table}.#{db_field} ILIKE '#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(token)}%'" }
+          .map { |token| "lower(#{db_table}.#{db_field}) LIKE lower('#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(token)}%')" }
           .join(" AND ")
       end
     end

--- a/app/models/queries/operators/concerns/starts_with_all_values.rb
+++ b/app/models/queries/operators/concerns/starts_with_all_values.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries::Operators::Concerns
+  module StartsWithAllValues
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def sql_for_field(values, db_table, db_field)
+        values
+          .first
+          .split(/\s+/)
+          .map { |token| "#{db_table}.#{db_field} ILIKE '#{OpenProject::SqlSanitization.quoted_sanitized_sql_like(token)}%'" }
+          .join(" AND ")
+      end
+    end
+  end
+end

--- a/app/models/queries/operators/starts_with.rb
+++ b/app/models/queries/operators/starts_with.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries::Operators
+  class StartsWith < Base
+    include Concerns::StartsWithAllValues
+
+    label "starts_with"
+    set_symbol "^"
+  end
+end

--- a/app/models/queries/work_packages/filter/typeahead_filter.rb
+++ b/app/models/queries/work_packages/filter/typeahead_filter.rb
@@ -44,6 +44,7 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
     parts.map do |part|
       conditions = [subject_condition(part),
                     project_name_condition(part),
+                    work_package_identifier_condition(part),
                     type_name_condition(part),
                     status_condition(part)]
 
@@ -61,6 +62,14 @@ class Queries::WorkPackages::Filter::TypeaheadFilter <
 
   def project_name_condition(string)
     Queries::Operators::Contains.sql_for_field([string], Project.table_name, "name")
+  end
+
+  def work_package_identifier_condition(string)
+    alias_condition = Queries::Operators::StartsWith.sql_for_field(
+      [string], WorkPackageSemanticAlias.table_name, "identifier"
+    )
+    "#{WorkPackage.table_name}.id IN " \
+      "(SELECT work_package_id FROM #{WorkPackageSemanticAlias.table_name} WHERE #{alias_condition})"
   end
 
   def type_name_condition(string)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3824,6 +3824,7 @@ en:
   label_commits_per_month: "Commits per month"
   label_confirmation: "Confirmation"
   label_contains: "contains"
+  label_starts_with: "starts with"
   label_content: "Content"
   label_color_plural: "Colors"
   label_copied: "copied"

--- a/spec/factories/work_package_semantic_alias_factory.rb
+++ b/spec/factories/work_package_semantic_alias_factory.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+FactoryBot.define do
+  factory :work_package_semantic_alias do
+    work_package
+    sequence(:identifier) { |n| "PROJ-#{n}" }
+  end
+end

--- a/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
@@ -236,6 +236,42 @@ RSpec.describe Queries::WorkPackages::Filter::TypeaheadFilter do
       end
     end
 
+    describe "when the setting for work package identifiers is set to classic but was semantic before",
+             with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::CLASSIC } do
+      let!(:identifier_work_package1) do
+        create(:work_package,
+               project:,
+               subject: "First semantic work package")
+      end
+
+      let!(:identifier_work_package1_semantic_alias) do
+        create(:work_package_semantic_alias,
+               work_package: identifier_work_package1,
+               identifier: "PHO-1")
+      end
+
+      let!(:identifier_work_package2) do
+        create(:work_package,
+               project:,
+               subject: "Second semantic work package")
+      end
+
+      let!(:identifier_work_package2_semantic_alias) do
+        create(:work_package_semantic_alias,
+               work_package: identifier_work_package2,
+               identifier: "PHO-2")
+      end
+
+      context "and there are still entries in the semantic alias registry" do
+        let(:values) { [identifier_work_package1_semantic_alias.identifier] }
+
+        it "still finds by existing identifiers" do
+          expect(subject).to include(identifier_work_package1)
+          expect(subject).not_to include(identifier_work_package2)
+        end
+      end
+    end
+
     context "when searching by status" do
       shared_let(:open_work_package)   { create(:work_package, project:, status: open_status,   subject: "wide work package") }
       shared_let(:closed_work_package) { create(:work_package, project:, status: closed_status, subject: "narrow work package") }

--- a/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/typeahead_filter_spec.rb
@@ -172,6 +172,70 @@ RSpec.describe Queries::WorkPackages::Filter::TypeaheadFilter do
       end
     end
 
+    describe "when the setting for work package identifiers is set to semantic",
+             with_settings: { work_packages_identifier: Setting::WorkPackageIdentifier::SEMANTIC } do
+      before do
+        previous_identifier = project.identifier
+        project.update!(identifier: "PHX")
+        project.handle_semantic_rename(previous_identifier)
+      end
+
+      let!(:identifier_work_package1) do
+        create(:work_package,
+               project:,
+               subject: "First semantic work package")
+      end
+
+      let!(:identifier_work_package2) do
+        create(:work_package,
+               project:,
+               subject: "Second semantic work package")
+      end
+
+      context "when searching by work package identifier" do
+        let(:values) { [identifier_work_package1.identifier] }
+
+        it "returns work packages with matching identifier" do
+          expect(subject).to include(identifier_work_package1)
+          expect(subject).not_to include(identifier_work_package2)
+        end
+      end
+
+      context "when searching by lower case work package identifier" do
+        let(:values) { [identifier_work_package1.identifier.downcase] }
+
+        it "returns work packages with matching identifier" do
+          expect(subject).to include(identifier_work_package1)
+          expect(subject).not_to include(identifier_work_package2)
+        end
+      end
+
+      context "when searching for partial identifier" do
+        let(:values) { [project.identifier] }
+
+        it "returns work packages with matching identifier" do
+          expect(subject).to include(identifier_work_package1, identifier_work_package2)
+        end
+      end
+
+      context "and the project identifier changed" do
+        before do
+          project.update!(identifier: "PHO")
+          project.reload.handle_semantic_rename("PHX")
+        end
+
+        context "when searching for the previous identifier of the work package" do
+          let(:values) { ["PHX-#{identifier_work_package1.sequence_number}"] }
+
+          it "still finds the work package" do
+            expect(identifier_work_package1.reload.identifier).to start_with("PHO")
+            expect(subject).to include(identifier_work_package1)
+            expect(subject).not_to include(identifier_work_package2)
+          end
+        end
+      end
+    end
+
     context "when searching by status" do
       shared_let(:open_work_package)   { create(:work_package, project:, status: open_status,   subject: "wide work package") }
       shared_let(:closed_work_package) { create(:work_package, project:, status: closed_status, subject: "narrow work package") }


### PR DESCRIPTION
https://community.openproject.org/wp/73761

# What are you trying to accomplish?
Allow to find work packages by their semantic identifier in the global search

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
