### PR TITLE
Use displayId in stateful navigation and fix semantic ID state management

### DIFF
--- a/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@angular/core';
 import { UIRouterGlobals } from '@uirouter/core';
 import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/resolve-routing-id';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { DragAndDropService } from 'core-app/shared/helpers/drag-and-drop/drag-and-drop.service';
@@ -136,7 +137,6 @@ export class BcfListComponent extends WorkPackageListViewComponent implements Un
   }
 
   private resolveRoutingId(workPackageId:string):string {
-    const wp = this.states.workPackages.get(workPackageId)?.value;
-    return wp?.displayId ?? workPackageId;
+    return resolveRoutingId(this.states, workPackageId);
   }
 }

--- a/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/bcf/list/bcf-list.component.ts
@@ -129,8 +129,14 @@ export class BcfListComponent extends WorkPackageListViewComponent implements Un
       : 'bim.partitioned.show';
     // Passing the card param to the new state because the router doesn't keep
     // it when going to 'bim.partitioned.show'
-    const params = { workPackageId, cards, focus };
+    const routingId = this.resolveRoutingId(workPackageId);
+    const params = { workPackageId: routingId, cards, focus };
 
     void this.$state.go(stateToGo, params);
+  }
+
+  private resolveRoutingId(workPackageId:string):string {
+    const wp = this.states.workPackages.get(workPackageId)?.value;
+    return wp?.displayId ?? workPackageId;
   }
 }

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -27,6 +27,7 @@ import { Highlighting } from 'core-app/features/work-packages/components/wp-fast
 import { WorkPackageCardViewComponent } from 'core-app/features/work-packages/components/wp-card-view/wp-card-view.component';
 import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
 import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/resolve-routing-id';
 import { BoardService } from 'core-app/features/boards/board/board.service';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
@@ -514,8 +515,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   }
 
   private resolveRoutingId(workPackageId:string):string {
-    const wp = this.states.workPackages.get(workPackageId)?.value;
-    return wp?.displayId ?? workPackageId;
+    return resolveRoutingId(this.states, workPackageId);
   }
 
   private schema(workPackage:WorkPackageResource) {

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -26,6 +26,7 @@ import { AuthorisationService } from 'core-app/core/model-auth/model-auth.servic
 import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
 import { WorkPackageCardViewComponent } from 'core-app/features/work-packages/components/wp-card-view/wp-card-view.component';
 import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
+import { States } from 'core-app/core/states/states.service';
 import { BoardService } from 'core-app/features/boards/board/board.service';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
@@ -175,6 +176,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     readonly keepTab:KeepTabService,
     readonly currentProject:CurrentProjectService,
     readonly pathHelper:PathHelperService,
+    readonly states:States,
   ) {
     super(I18n, injector);
   }
@@ -488,17 +490,19 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   openFullViewOnDoubleClick(event:{ workPackageId:string, double:boolean }) {
     if (event.double) {
+      const routingId = this.resolveRoutingId(event.workPackageId);
       const projectIdentifier = this.currentProject.identifier;
-      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, event.workPackageId) + window.location.search;
+      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, routingId) + window.location.search;
       Turbo.visit(link, { action: 'advance' });
     }
   }
 
   openStateLink(event:{ workPackageId:string; requestedState:string }) {
+    const routingId = this.resolveRoutingId(event.workPackageId);
     if (event.requestedState === 'split') {
-      this.goToSplitView(event.workPackageId);
+      this.goToSplitView(routingId);
     } else {
-      this.keepTab.goCurrentShowState(event.workPackageId);
+      this.keepTab.goCurrentShowState(routingId);
     }
   }
 
@@ -507,6 +511,11 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
     const search = window.location.search;
     const link = search ? `${base}${search}` : base;
     Turbo.visit(link, { frame: 'content-bodyRight', action: 'advance' });
+  }
+
+  private resolveRoutingId(workPackageId:string):string {
+    const wp = this.states.workPackages.get(workPackageId)?.value;
+    return wp?.displayId ?? workPackageId;
   }
 
   private schema(workPackage:WorkPackageResource) {

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -54,6 +54,7 @@ import {
 } from 'core-app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/resolve-routing-id';
 import {
   WorkPackageViewContextMenu,
 } from 'core-app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive';
@@ -307,8 +308,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
   }
 
   private resolveRoutingId(workPackageId:string):string {
-    const wp = this.states.workPackages.get(workPackageId)?.value;
-    return wp?.displayId ?? workPackageId;
+    return resolveRoutingId(this.states, workPackageId);
   }
 
   public onCardClicked({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -53,6 +53,7 @@ import {
   uiStateLinkClass,
 } from 'core-app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
+import { States } from 'core-app/core/states/states.service';
 import {
   WorkPackageViewContextMenu,
 } from 'core-app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive';
@@ -112,6 +113,7 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     readonly calendarService:OpCalendarService,
     readonly weekdayService:WeekdayService,
     readonly dayService:DayResourceService,
+    readonly states:States,
   ) {
     super();
   }
@@ -287,19 +289,26 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
       return;
     }
 
+    const routingId = this.resolveRoutingId(id);
     void this.$state.go(
       `${splitViewRoute(this.$state)}.tabs`,
-      { workPackageId: id, tabIdentifier: 'overview' },
+      { workPackageId: routingId, tabIdentifier: 'overview' },
     );
   }
 
   public openFullView(id:string):void {
     this.wpTableSelection.setSelection(id, -1);
 
+    const routingId = this.resolveRoutingId(id);
     void this.$state.go(
       'work-packages.show',
-      { workPackageId: id },
+      { workPackageId: routingId },
     );
+  }
+
+  private resolveRoutingId(workPackageId:string):string {
+    const wp = this.states.workPackages.get(workPackageId)?.value;
+    return wp?.displayId ?? workPackageId;
   }
 
   public onCardClicked({ workPackageId, event }:{ workPackageId:string, event:MouseEvent }):void {

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -342,15 +342,16 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
         }
 
         if (evt.event.extendedProps.workPackage) {
-          const workPackageId = (evt.event.extendedProps.workPackage as WorkPackageResource).id!;
+          const wp = evt.event.extendedProps.workPackage as WorkPackageResource;
           // Currently the calendar widget is shown on multiple pages,
           // but only the calendar module itself is a partitioned query space which can deal with a split screen request
           if (this.$state.includes('calendar')) {
-            this.workPackagesCalendar.openSplitView(workPackageId);
+            this.workPackagesCalendar.openSplitView(wp.id!);
           } else {
+            const routingId = wp.displayId ?? wp.id!;
             void this.$state.go(
               'work-packages.show',
-              { workPackageId },
+              { workPackageId: routingId },
             );
           }
         }

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -142,7 +142,8 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
         this.untilDestroyed(),
         map(() => {
           if (this.selectedWhenOpen) {
-            return this.uiRouterGlobals.params.workPackageId === this.workPackage.id;
+            const routeWpId = this.uiRouterGlobals.params.workPackageId;
+            return routeWpId === this.workPackage.id || routeWpId === this.workPackage.displayId;
           }
 
           return this.wpTableSelection.isSelected(this.workPackage.id!);

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -142,6 +142,8 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
         this.untilDestroyed(),
         map(() => {
           if (this.selectedWhenOpen) {
+            // Route param may be semantic ("PROJ-7") or numeric ("42").
+            // Compare against both id and displayId to handle both modes.
             const routeWpId = this.uiRouterGlobals.params.workPackageId;
             return routeWpId === this.workPackage.id || routeWpId === this.workPackage.displayId;
           }

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
@@ -130,15 +130,16 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
 
     this.editForm?.cancel(false);
 
+    const routingId = savedResource.displayId ?? savedResource.id!;
     if(this.routedFromAngular && this.successState) {
-      this.$state.go(this.successState, { workPackageId: savedResource.id })
+      this.$state.go(this.successState, { workPackageId: routingId })
         .then(() => {
           this.wpViewFocus.updateFocus(savedResource.id!);
           this.notificationService.showSave(savedResource, isInitial);
         });
     } else {
       window.OpenProject.pageState = 'submitted';
-      Turbo.visit(this.pathHelper.projectWorkPackagePath(savedResource.project.identifier, savedResource.id!) + window.location.search);
+      Turbo.visit(this.pathHelper.projectWorkPackagePath(savedResource.project.identifier, routingId) + window.location.search);
     }
 
   }

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -24,6 +24,7 @@ import {
   KeepTabService,
 } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/resolve-routing-id';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { firstValueFrom } from 'rxjs';
 import { QueryRequestParams } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
@@ -215,7 +216,6 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
   }
 
   private resolveRoutingId(workPackageId:string):string {
-    const wp = this.states.workPackages.get(workPackageId)?.value;
-    return wp?.displayId ?? workPackageId;
+    return resolveRoutingId(this.states, workPackageId);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -23,6 +23,7 @@ import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decora
 import {
   KeepTabService,
 } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
+import { States } from 'core-app/core/states/states.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { firstValueFrom } from 'rxjs';
 import { QueryRequestParams } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
@@ -62,6 +63,8 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
   @InjectField() wpTablePagination:WorkPackageViewPaginationService;
 
   @InjectField() keepTab:KeepTabService;
+
+  @InjectField() states:States;
 
   // Cache the form promise
   private formPromise:Promise<QueryFormResource|undefined>|undefined;
@@ -190,15 +193,17 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
 
   handleWorkPackageClicked(event:{ workPackageId:string; double:boolean }) {
     if (event.double) {
+      const routingId = this.resolveRoutingId(event.workPackageId);
       const projectIdentifier = this.currentProject.identifier;
-      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, event.workPackageId) + window.location.search;
+      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, routingId) + window.location.search;
       Turbo.visit(link, { action: 'advance' });
     }
   }
 
   openStateLink(event:{ workPackageId:string; requestedState:'show'|'split' }) {
+    const routingId = this.resolveRoutingId(event.workPackageId);
     const params = {
-      workPackageId: event.workPackageId,
+      workPackageId: routingId,
       focus: true,
     };
 
@@ -207,5 +212,10 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
     } else {
       this.keepTab.goCurrentShowState(params.workPackageId);
     }
+  }
+
+  private resolveRoutingId(workPackageId:string):string {
+    const wp = this.states.workPackages.get(workPackageId)?.value;
+    return wp?.displayId ?? workPackageId;
   }
 }

--- a/frontend/src/app/features/work-packages/helpers/resolve-routing-id.ts
+++ b/frontend/src/app/features/work-packages/helpers/resolve-routing-id.ts
@@ -2,7 +2,9 @@ import { States } from 'core-app/core/states/states.service';
 
 /**
  * Resolve a numeric work package ID to its semantic routing ID (e.g. "PROJ-42").
- * Falls back to the input ID if the WP is not in cache or has no displayId.
+ * Falls back to the input ID if the WP is not in cache or has no displayId —
+ * this is a best-effort lookup, not a guarantee. The URL just shows the
+ * numeric ID temporarily until the WP is cached.
  *
  * Used in navigation handlers where only the numeric PK is available from
  * data-work-package-id attributes, but the URL should show the semantic form.

--- a/frontend/src/app/features/work-packages/helpers/resolve-routing-id.ts
+++ b/frontend/src/app/features/work-packages/helpers/resolve-routing-id.ts
@@ -1,0 +1,13 @@
+import { States } from 'core-app/core/states/states.service';
+
+/**
+ * Resolve a numeric work package ID to its semantic routing ID (e.g. "PROJ-42").
+ * Falls back to the input ID if the WP is not in cache or has no displayId.
+ *
+ * Used in navigation handlers where only the numeric PK is available from
+ * data-work-package-id attributes, but the URL should show the semantic form.
+ */
+export function resolveRoutingId(states:States, workPackageId:string):string {
+  const wp = states.workPackages.get(workPackageId)?.value;
+  return wp?.displayId ?? workPackageId;
+}

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
@@ -58,6 +58,7 @@ import { WorkPackageViewBaselineService } from '../wp-view-base/view-services/wp
 import { combineLatest } from 'rxjs';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/resolve-routing-id';
 
 @Component({
   selector: 'wp-list-view',
@@ -212,7 +213,6 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
   }
 
   private resolveRoutingId(workPackageId:string):string {
-    const wp = this.states.workPackages.get(workPackageId)?.value;
-    return wp?.displayId ?? workPackageId;
+    return resolveRoutingId(this.states, workPackageId);
   }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-list-view/wp-list-view.component.ts
@@ -57,6 +57,7 @@ import { KeepTabService } from 'core-app/features/work-packages/components/wp-si
 import { WorkPackageViewBaselineService } from '../wp-view-base/view-services/wp-view-baseline.service';
 import { combineLatest } from 'rxjs';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { States } from 'core-app/core/states/states.service';
 
 @Component({
   selector: 'wp-list-view',
@@ -85,6 +86,7 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
   readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
   readonly pathHelper = inject(PathHelperService);
+  readonly states = inject(States);
 
   text = {
     jump_to_pagination: this.I18n.t('js.work_packages.jump_marks.pagination'),
@@ -178,8 +180,9 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
   }
 
   openStateLink(event:{ workPackageId:string; requestedState:'show'|'split' }) {
+    const routingId = this.resolveRoutingId(event.workPackageId);
     const params = {
-      workPackageId: event.workPackageId,
+      workPackageId: routingId,
       focus: true,
     };
 
@@ -203,7 +206,13 @@ export class WorkPackageListViewComponent extends UntilDestroyedMixin implements
   }
 
   private openInFullView(workPackageId:string) {
+    const routingId = this.resolveRoutingId(workPackageId);
     const projectIdentifier = this.CurrentProject.identifier;
-    window.location.href = this.pathHelper.genericWorkPackagePath(projectIdentifier, workPackageId) + window.location.search;
+    window.location.href = this.pathHelper.genericWorkPackagePath(projectIdentifier, routingId) + window.location.search;
+  }
+
+  private resolveRoutingId(workPackageId:string):string {
+    const wp = this.states.workPackages.get(workPackageId)?.value;
+    return wp?.displayId ?? workPackageId;
   }
 }

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -117,6 +117,14 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
       });
   }
 
+  /**
+   * Set focus, selection, and recent-items after the WP has loaded.
+   *
+   * Intentionally deferred from ngOnInit because the route param
+   * (this.workPackageId) may be a semantic identifier like "PROJ-7",
+   * but focus/selection services are keyed by numeric PK. By the time
+   * init() runs, this.workPackage.id is guaranteed to be the numeric PK.
+   */
   protected override init():void {
     super.init();
     const numericId = this.workPackage.id!;

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -101,19 +101,13 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
   ngOnInit():void {
     this.observeWorkPackage();
 
-    const wpId = (this.$state.params.workPackageId || this.workPackageId) as string;
-    this.wpTableFocus.updateFocus(wpId, false);
-
-    if (this.wpTableSelection.isEmpty) {
-      this.wpTableSelection.setRowState(wpId, true);
-    }
-
     this.wpTableFocus.whenChanged()
       .pipe(
         this.untilDestroyed(),
       )
       .subscribe((newId) => {
-        const idSame = wpId.toString() === newId.toString();
+        const currentId = this.workPackage?.id ?? this.workPackageId;
+        const idSame = currentId.toString() === newId.toString();
         if (!idSame && this.$state.includes(`${this.baseRoute}.details`)) {
           this.$state.go(
             (this.$state.current.name!),
@@ -121,7 +115,18 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
           );
         }
       });
-    this.recentItemsService.add(wpId);
+  }
+
+  protected override init():void {
+    super.init();
+    const numericId = this.workPackage.id!;
+    this.wpTableFocus.updateFocus(numericId, false);
+
+    if (this.wpTableSelection.isEmpty) {
+      this.wpTableSelection.setRowState(numericId, true);
+    }
+
+    this.recentItemsService.add(numericId);
   }
 
   get activeTabComponent():Type<TabComponent>|undefined {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -141,6 +141,12 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
   /**
    * Observe changes of work package and re-run initialization.
    * Needs to be run explicitly by descendants.
+   *
+   * Note: this.workPackageId may be a semantic identifier (e.g. "PROJ-7")
+   * from the route param. The API resolves it correctly, but the cache key
+   * would be "PROJ-7" while list queries cache the same WP under "42".
+   * After the first load we normalize to the numeric PK to prevent
+   * dual cache entries.
    */
   protected observeWorkPackage():void {
     this

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -150,6 +150,13 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
       .requireAndStream()
       .pipe(this.untilDestroyed())
       .subscribe((wp:WorkPackageResource) => {
+        // Normalize semantic route param (e.g. "PROJ-7") to numeric PK
+        // for cache coherence — downstream code uses this.workPackageId
+        // as a cache key, and the canonical key is always numeric.
+        if (this.workPackageId !== wp.id && wp.id) {
+          this.workPackageId = wp.id;
+        }
+
         if (!this.workPackage) {
           this.workPackage = wp;
           this.init();

--- a/frontend/src/app/features/work-packages/services/work-package.service.ts
+++ b/frontend/src/app/features/work-packages/services/work-package.service.ts
@@ -34,6 +34,7 @@ import { UrlParamsHelperService } from 'core-app/features/work-packages/componen
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalDeletedEvent, HalEventsService } from 'core-app/features/hal/services/hal-events.service';
+import { States } from 'core-app/core/states/states.service';
 
 @Injectable()
 export class WorkPackageService {
@@ -47,7 +48,8 @@ export class WorkPackageService {
     private readonly UrlParamsHelper:UrlParamsHelperService,
     private readonly toastService:ToastService,
     private readonly I18n:I18nService,
-    private readonly halEvents:HalEventsService) {
+    private readonly halEvents:HalEventsService,
+    private readonly states:States) {
   }
 
   public performBulkDelete(ids:string[], defaultHandling:boolean) {
@@ -68,8 +70,11 @@ export class WorkPackageService {
 
           ids.forEach((id) => this.halEvents.push({ _type: 'WorkPackage', id }, { eventType: 'deleted' } as HalDeletedEvent));
 
+          const routeWpId = this.$state.params.workPackageId as string;
+          const wp = this.states.workPackages.get(routeWpId)?.value;
+          const numericId = wp?.id ?? routeWpId;
           if (this.$state.includes('**.list.details.**')
-            && ids.includes(this.$state.params.workPackageId)) {
+            && ids.includes(numericId)) {
             this.$state.go('work-packages.partitioned.list', this.$state.params);
           }
         })

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
@@ -137,12 +137,14 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
         void this.turboRequests.requestStream(String(link));
         break;
 
-      case 'relations':
+      case 'relations': {
+        const routingId = this.workPackage.displayId ?? this.workPackageId;
         void this.$state.go(
           `${splitViewRoute(this.$state)}.tabs`,
-          { workPackageId: this.workPackageId, tabIdentifier: 'relations' },
+          { workPackageId: routingId, tabIdentifier: 'relations' },
         );
         break;
+      }
 
       default:
         window.location.href = link!;


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73834

Builds on #22733

# What are you trying to accomplish?

Wire displayId into all `$state.go()` callers and Turbo navigation handlers so that the browser URL bar shows semantic identifiers (e.g. `PROJ-7`) during stateful navigations — split view opening, board card clicks, calendar event clicks, post-creation redirects, and context menu actions.

Also fixes four bugs where passing semantic identifiers through Angular state params broke internal systems that assume numeric PKs.

# What approach did you choose and why?

PR #22733 was split into two: href-only changes (safe, landed first) and stateful navigation changes (this PR). The split isolates the riskier `$state.go()` changes so they get focused review alongside the bug fixes they require.

The key insight is that `$state.params.workPackageId` is consumed by many downstream systems (focus/selection, card highlighting, bulk delete detection, API cache) that assume numeric PKs. Semantic IDs should flow into URLs only — internal plumbing must always use numeric IDs.

Changes:

**Shared utility** — Extracted `resolveRoutingId()` to replace 5 identical private methods across components. Pure function that takes `States` and returns `displayId ?? workPackageId`.

**Navigation handlers** — List view, embedded tables, boards, BCF, calendar, create flow, and context menu now use `resolveRoutingId()` for URL generation while keeping numeric IDs for state management.

**Bug fixes:**

- **Split view focus/selection** — `updateFocus()` and `setRowState()` received the raw route param (e.g. `"PROJ-7"`) but the selection system is keyed by numeric PK (`"42"`). Deferred these calls to `init()` (after WP loads) so they use the resolved numeric ID.
- **Card view highlight** — The card's selected state compared the route param against `workPackage.id` only. When the route param is semantic, this never matches. Now compares against both `id` and `displayId`.
- **Bulk delete split view close** — After bulk deletion, the split view checks whether the displayed WP was among those deleted. The check compared numeric deletion IDs against the (potentially semantic) route param. Now resolves the route param to its numeric PK first.
- **Cache dual-entry** — Opening a WP via semantic URL (e.g. `/work_packages/PROJ-7`) created a cache entry under `"PROJ-7"`, while list queries cached the same WP under `"42"`. Updates to one wouldn't propagate to the other. Now normalizes `this.workPackageId` to the numeric PK after first load.

# Merge checklist

- [x] Added/updated tests
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)