### PR TITLE
[#73239] WP templates are not visible in the modal when creating new work package meeting outcome  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/create_work_package_form_component.html.erb
@@ -10,7 +10,15 @@
       ),
       method: :post,
       html: {
-        id: "create-work-package-outcome-form"
+        id: "create-work-package-outcome-form",
+        data: {
+          controller: "work-packages--create-dialog",
+          "work-packages--create-dialog-refresh-url-value": refresh_work_package_dialog_project_meeting_agenda_item_outcomes_path(
+            meeting.project,
+            meeting,
+            meeting_agenda_item
+          )
+        }
       }
     ) do |f|
       flex_layout(mb: 3) do |modal_body|

--- a/modules/meeting/app/controllers/meeting_outcomes_controller.rb
+++ b/modules/meeting/app/controllers/meeting_outcomes_controller.rb
@@ -33,11 +33,13 @@ class MeetingOutcomesController < ApplicationController
   include Meetings::AgendaComponentStreams
 
   load_and_authorize_with_permission_in_project :manage_outcomes
-  authorize_with_permission :add_work_packages, only: %i[create_work_package_dialog create_work_package]
+  authorize_with_permission :add_work_packages,
+                            only: %i[create_work_package_dialog create_work_package refresh_work_package_dialog]
 
   before_action :set_meeting
   before_action :set_meeting_agenda_item
-  before_action :set_meeting_outcome, except: %i[new cancel_new create create_work_package_dialog create_work_package]
+  before_action :set_meeting_outcome,
+                except: %i[new cancel_new create create_work_package_dialog create_work_package refresh_work_package_dialog]
 
   def new
     update_meeting_metadata_via_turbo_stream
@@ -149,6 +151,20 @@ class MeetingOutcomesController < ApplicationController
       meeting: @meeting,
       meeting_agenda_item: @meeting_agenda_item
     )
+  end
+
+  def refresh_work_package_dialog
+    work_package = create_work_package_service.build_work_package(permitted_params.update_work_package)
+
+    form_component = MeetingAgendaItems::Outcomes::CreateWorkPackageFormComponent.new(
+      work_package:,
+      project: @project,
+      meeting: @meeting,
+      meeting_agenda_item: @meeting_agenda_item
+    )
+
+    update_via_turbo_stream(component: form_component)
+    respond_with_turbo_streams
   end
 
   def create_work_package # rubocop:disable Metrics/AbcSize

--- a/modules/meeting/config/routes.rb
+++ b/modules/meeting/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
             get :cancel_new
             get :create_work_package_dialog
             post :create_work_package
+            post :refresh_work_package_dialog
           end
 
           member do

--- a/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
+++ b/modules/meeting/spec/features/meeting_work_package_outcomes_spec.rb
@@ -219,6 +219,44 @@ RSpec.describe "Work package meeting outcomes", :js do
           expect(page).to have_no_selector(:dialog, I18n.t(:label_work_package_new), wait: 10)
           expect(WorkPackage.count).to eq(initial_wp_count)
         end
+
+        context "when changing the WP type" do
+          let!(:type_without_template) { create(:type, name: "No template type") }
+          let!(:type_with_template) do
+            create(:type, name: "Templated type",
+                          description: "Some default template text here...")
+          end
+
+          before do
+            project.types = [type_without_template, type_with_template]
+          end
+
+          it "refreshes the form when the type is changed" do
+            show_page.visit!
+            wait_for_network_idle
+
+            show_page.open_menu(meeting_agenda_item) do
+              click_on "Add outcome"
+              click_on "New work package"
+            end
+
+            expect(page).to have_dialog(I18n.t(:label_work_package_new))
+            expect(page).to have_no_css(".ck-content", text: "Some default template text here...")
+
+            page.within_dialog(I18n.t(:label_work_package_new)) do
+              wait_for_turbo_stream do
+                select_autocomplete(find_test_selector("work_package_create_dialog_type"),
+                                    query: type_with_template.name,
+                                    select_text: type_with_template.name.upcase,
+                                    results_selector: "body")
+              end
+            end
+
+            page.within_dialog(I18n.t(:label_work_package_new)) do
+              expect(page).to have_css(".ck-content", text: "Some default template text here...")
+            end
+          end
+        end
       end
 
       context "when user lacks add_work_packages permission" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/73239

Looks like the form wasn't being refreshed at all before on switching types 

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
