### PR TITLE
[#73847] Improve backlogs "Show x more items" frontend performance

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs.controller.ts
@@ -27,26 +27,16 @@
 //++
 
 import { Controller } from '@hotwired/stimulus';
-import { FrameElement, TurboVisitEvent } from '@hotwired/turbo';
+import { FrameElement } from '@hotwired/turbo';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { filter, Subscription } from 'rxjs';
-import StoryController from './backlogs/story.controller';
 
 export default class BacklogsController extends Controller<HTMLElement> {
-  static outlets = ['backlogs--story'];
-  declare backlogsStoryOutlets:StoryController[];
-
-  private abortController:AbortController|null = null;
   private service:HalEventsService|null = null;
   private subscription:Subscription|null = null;
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   async connect() {
-    this.abortController = new AbortController();
-    const { signal } = this.abortController;
-
-    document.addEventListener('turbo:visit', this.updateSelection, { signal });
-
     const { services: { halEvents } } = await window.OpenProject.getPluginContext();
 
     this.service = halEvents;
@@ -59,34 +49,6 @@ export default class BacklogsController extends Controller<HTMLElement> {
     this.subscription?.unsubscribe();
     this.subscription = null;
     this.service = null;
-
-    this.abortController?.abort();
-    this.abortController = null;
-  }
-
-  backlogsStoryOutletConnected(outlet:StoryController) {
-    const selectedId = this.getSelectedIdFromPathname(window.location.pathname);
-    if (selectedId !== null && outlet.idValue === selectedId) {
-      outlet.markAsSelected();
-    }
-  }
-
-  private updateSelection = (event:TurboVisitEvent) => {
-    const url = new URL(event.detail.url, window.location.origin);
-    const selectedId = this.getSelectedIdFromPathname(url.pathname);
-
-    this.backlogsStoryOutlets.forEach((story) => {
-      if (selectedId !== null && story.idValue === selectedId) {
-        story.markAsSelected(event);
-      } else {
-        story.unmarkAsSelected(event);
-      }
-    });
-  };
-
-  private getSelectedIdFromPathname(pathname:string):number|null {
-    const match = /\/details\/(\d+)/.exec(pathname);
-    return match ? Number(match[1]) : null;
   }
 
   private refreshList() {

--- a/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/backlogs/story.controller.ts
@@ -28,6 +28,8 @@
 
 import { Controller } from '@hotwired/stimulus';
 import * as Turbo from '@hotwired/turbo';
+import type { TurboVisitEvent } from '@hotwired/turbo';
+
 
 export default class StoryController extends Controller<HTMLElement> implements EventListenerObject {
   static values = {
@@ -53,6 +55,11 @@ export default class StoryController extends Controller<HTMLElement> implements 
     this.element.addEventListener('click', this, { signal });
     this.element.addEventListener('dblclick', this, { signal });
     this.element.addEventListener('keydown', this, { signal });
+    document.addEventListener('turbo:visit', (event:TurboVisitEvent) => {
+      this.syncSelectionFromUrl(event.detail.url);
+    }, { signal });
+
+    this.syncSelectionFromUrl(window.location.href);
   }
 
   disconnect():void {
@@ -65,12 +72,22 @@ export default class StoryController extends Controller<HTMLElement> implements 
     }
   }
 
-  markAsSelected(_event?:Event) {
+  private syncSelectionFromUrl(locationUrl:string):void {
+    const { pathname } = new URL(locationUrl, window.location.origin);
+    const [, id] = /\/details\/(\d+)/.exec(pathname) ?? [];
+    if (id !== undefined && Number(id) === this.idValue) {
+      this.markAsSelected();
+    } else {
+      this.unmarkAsSelected();
+    }
+  }
+
+  markAsSelected():void {
     this.element.classList.add(this.selectedClass);
     this.element.setAttribute('aria-current', 'true');
   }
 
-  unmarkAsSelected(_event?:Event) {
+  unmarkAsSelected():void {
     this.element.classList.remove(this.selectedClass);
     this.element.removeAttribute('aria-current');
   }

--- a/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/backlog.html.erb
@@ -30,8 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% html_title t(:label_backlogs) %>
 
 <% content_controller "backlogs",
-                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project),
-                      "backlogs-backlogs--story-outlet": "li[data-story]" %>
+                      "backlogs-list-url-value": backlogs_project_backlogs_path(@project) %>
 
 <% content_for :content_header do %>
   <%=

--- a/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
+++ b/modules/backlogs/app/views/rb_master_backlogs/index.html.erb
@@ -29,8 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% html_title t(:label_backlogs) %>
 
-<% content_controller "backlogs",
-                      "backlogs-backlogs--story-outlet": "li[data-story]" %>
+<% content_controller "backlogs" %>
 
 <% content_for :content_header do %>
   <%=


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73847

# What are you trying to accomplish?
Improve the performance of the "Show X more items" link.

# What approach did you choose and why?
- Remove the use of `StoryController` as outlets in the `BacklogsController`. Having a large number of stories used as outlet gives a high performance hit to the rendering. It takes up more than 2/3rd of the loading time.
- Implement the same functionality only inside the `StoryController`.

In my local environment using 1000 work packages, the processing time is **reduced from 24 seconds to 1.7 seconds**..
# Screenshots

**Before:**
<img width="1232" height="737" alt="image" src="https://github.com/user-attachments/assets/14dc1a07-3837-457d-8e74-085ab54ed7d9" />


**After**
<img width="1233" height="736" alt="image" src="https://github.com/user-attachments/assets/a03642ee-5b49-48b4-895e-fe49e44fb5e2" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
