### PR TITLE
Log an error when rescuing turbo frame missing

### DIFF
--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -60,5 +60,10 @@ TurboPower.initialize(Turbo.StreamActions);
 document.addEventListener('turbo:frame-missing', (event) => {
   const { detail: { response, visit } } = event;
   event.preventDefault();
+  whenDebugging(() => {
+    const frameId = event.target instanceof Element ? event.target.id : undefined;
+    const message = frameId ? `no turbo-frame#${frameId} in` : 'destination frame id missing for';
+    console.error(`${message} response from ${response.url}`);
+  });
   void visit(response.url, {});
 });

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -24,10 +24,10 @@ whenDebugging(() => {
   TURBO_EVENTS
     .filter((name) => name !== 'turbo:before-stream-render')
     .forEach((name:string) => {
-    document.addEventListener(name, (event) => {
-      debugLog(`[TURBO EVENT ${name}] %O`, event);
+      document.addEventListener(name, (event) => {
+        debugLog(`[TURBO EVENT ${name}] %O`, event);
+      });
     });
-  });
 
   document.addEventListener('turbo:before-stream-render', (event) => {
     const { detail: { newStream:stream } } = event;

--- a/frontend/src/turbo/setup.ts
+++ b/frontend/src/turbo/setup.ts
@@ -60,5 +60,9 @@ TurboPower.initialize(Turbo.StreamActions);
 document.addEventListener('turbo:frame-missing', (event) => {
   const { detail: { response, visit } } = event;
   event.preventDefault();
+  whenDebugging(() => {
+    const frameId = event.target instanceof Element ? event.target.id : undefined;
+    console.error(`no turbo-frame#${frameId} in response from ${response.url}`);
+  });
   void visit(response.url, {});
 });


### PR DESCRIPTION
# Ticket
Follow up for https://community.openproject.org/wp/73448

# What are you trying to accomplish?
I would like to get rid of rescuing `turbo:frame-missing` as it is very implicit way to resolve sending wrong response.
As a first step we can log the error showing the reason for following a turbo frame update with a turbo page visit.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
