### PR TITLE
[68582] Represent Meetings duration as ISO8601

### DIFF
--- a/docs/api/apiv3/components/schemas/meeting_model.yml
+++ b/docs/api/apiv3/components/schemas/meeting_model.yml
@@ -38,7 +38,8 @@ properties:
     format: date-time
     description: The scheduled meeting start time.
   duration:
-    type: number
+    type: string
+    format: duration
     description: The meeting duration in hours.
   createdAt:
     type: string

--- a/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
+++ b/modules/meeting/lib/api/v3/meetings/meeting_representer.rb
@@ -55,7 +55,11 @@ module API
         date_time_property :start_time
         date_time_property :end_time
 
-        property :duration
+        property :duration,
+                 exec_context: :decorator,
+                 getter: ->(*) do
+                   datetime_formatter.format_duration_from_hours(represented.duration)
+                 end
 
         associated_resource :author,
                             v3_path: :user,

--- a/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
+++ b/modules/meeting/spec/lib/api/v3/meetings/meeting_representer_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe API::V3::Meetings::MeetingRepresenter do
       expect(subject).to be_json_eql(meeting.lock_version.to_json).at_path("lockVersion")
       expect(subject).to be_json_eql(meeting.start_time.utc.iso8601(3).to_json).at_path("startTime")
       expect(subject).to be_json_eql(meeting.end_time.utc.iso8601(3).to_json).at_path("endTime")
-      expect(subject).to be_json_eql(meeting.duration.to_json).at_path("duration")
+      expect(subject).to be_json_eql("PT1H".to_json).at_path("duration")
       expect(subject).to be_json_eql(meeting.location.to_json).at_path("location")
 
       expect(subject).to be_json_eql(meeting.created_at.utc.iso8601(3).to_json).at_path("createdAt")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/68582

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

> Like most other durations indicated in the API, e.g. `spentTime` or `duration` on `work_packages`, the duration on meetings should be indicated as an ISO 8601 duration. For example `PT2H`.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Mimics the `WorkPackageRepresenter`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
