### PR TITLE
[chore] remove lefthook from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -334,9 +334,6 @@ group :development do
   gem "spring-commands-rubocop"
 
   gem "colored2"
-
-  # git hooks manager
-  gem "lefthook", require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -784,7 +784,6 @@ GEM
       addressable (~> 2.8)
       childprocess (~> 5.0)
       logger (~> 1.6)
-    lefthook (2.1.5)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
     letter_opener_web (3.0.0)
@@ -1653,7 +1652,6 @@ DEPENDENCIES
   json_spec (~> 1.1.4)
   ladle
   launchy (~> 3.1.0)
-  lefthook
   letter_opener_web
   listen (~> 3.10.0)
   lograge (~> 0.14.0)
@@ -2006,7 +2004,6 @@ CHECKSUMS
   ladle (1.0.1) sha256=e8586964108c798d48bf57d2a65bd5602e8e5223a176b6602a0fb36c0bda90dc
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
-  lefthook (2.1.5) sha256=24bd602992e1ec36057bcc667bb74f23918ed05c715050a44e5a156f0b7a4312
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
   letter_opener_web (3.0.0) sha256=3f391efe0e8b9b24becfab5537dfb17a5cf5eb532038f947daab58cb4b749860
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -41,5 +41,10 @@ echo 'prefer using Overmind over Foreman if available.'
 
 echo ""
 echo 'Setting up git hooks'
-echo 'If you want to have commit hooks for rubocop and eslint errors, you can install lefthook like so:'
-echo '`bundle exec lefthook install`'
+echo 'If you want to have commit hooks for rubocop and eslint errors, you can use lefthook.'
+echo 'We provide a `lefthook.yml`. To install lefthook, use an installation method of your choice, e.g.:'
+echo '`gem install lefthook`'
+echo '(Do not forget to make the executable available on the $PATH.)'
+echo ""
+echo 'To configure the git hooks:'
+echo '`lefthook install`'

--- a/docs/development/code-review-guidelines/README.md
+++ b/docs/development/code-review-guidelines/README.md
@@ -16,7 +16,10 @@ The same is true for eslint. Your editor will likely have support for eslint che
 
 **Lefthook**
 
-For automatically linting your files on committing them, please have a look at [Lefthook](https://github.com/evilmartians/lefthook). You can install these rules by using `bundle exec lefthook install`.
+For automatically linting your files on committing them, please have a look
+at [Lefthook](https://github.com/evilmartians/lefthook). You can install these rules by using `lefthook install`. There
+are several options on how to install `lefthook` on your system, including using `brew`, `apt`, `bundle`, or `npm`. For
+example, one can add a `Gemfile.local` and thus the `lefthook` to the bundle.
 
 ### Structure of commit messages
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,8 +1,14 @@
 # Lefthook configuration
 #
-# Add commit hooks with `bundle exec lefthook install`
+# Install lefthook with any preferred method (see https://github.com/evilmartians/lefthook?tab=readme-ov-file#install).
+#   example: `gem install lefthook`
 #
-# Refer for explanation to following link:
+# Add commit hooks with `lefthook install`.
+#
+# To override any config, create a `lefthook-local.yml` file - e.g., for changing the run command
+# to be executed in a docker container context.
+#
+# Refer for explanation to the following link:
 # https://github.com/evilmartians/lefthook/blob/master/docs/usage.md
 
 pre-commit:


### PR DESCRIPTION
- installation of lefthook is now in the responsibility of the developer
- reasoning: the different development settings require different setups nevertheless
