### PR TITLE
Render new wiki macros

### DIFF
--- a/modules/wikis/app/components/wikis/page_link_component.html.erb
+++ b/modules/wikis/app/components/wikis/page_link_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
 
   <%=
     render(Primer::Alpha::StackItem.new(grow: true, classes: "ellipsis")) do
-      render(Primer::Beta::Link.new(href: link.href, scheme: :primary)) { page_title_service.read(link) }
+      render(Primer::Beta::Link.new(href: page_href, scheme: :primary)) { page_title }
     end
   %>
 

--- a/modules/wikis/app/components/wikis/page_link_component.rb
+++ b/modules/wikis/app/components/wikis/page_link_component.rb
@@ -52,7 +52,9 @@ module Wikis
     private
 
     def page_info_result
-      @page_info_result ||= link.provider.resolve("queries.page_info").call(identifier: link.identifier)
+      @page_info_result ||= Wikis::Adapters::Input::PageInfo.build(identifier: link.identifier).bind do |input|
+        link.provider.resolve("queries.page_info").call(input)
+      end
     end
   end
 end

--- a/modules/wikis/app/components/wikis/page_link_component.rb
+++ b/modules/wikis/app/components/wikis/page_link_component.rb
@@ -35,12 +35,24 @@ module Wikis
 
     alias_method :link, :model
 
-    def page_title_service
-      @page_title_service ||= PageTitleService.new
+    def page_title
+      # TODO: Define behaviour for errors
+      page_info_result.either(->(pi) { pi.title }, ->(_) { "Nothing to see here" })
+    end
+
+    def page_href
+      # TODO: Define behaviour for errors
+      page_info_result.either(->(pi) { pi.href }, ->(_) { "#" })
     end
 
     def show_action_menu?
       link.relation?
+    end
+
+    private
+
+    def page_info_result
+      @page_info_result ||= link.provider.resolve("queries.page_info").call(identifier: link.identifier)
     end
   end
 end

--- a/modules/wikis/app/contracts/wikis/adapters/input/page_info_call_contract.rb
+++ b/modules/wikis/app/contracts/wikis/adapters/input/page_info_call_contract.rb
@@ -28,15 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# This query is only intended for demo purposes and can be deleted once we have real queries
-module Wikis::Adapters::Providers::XWiki::Queries
-  class Test
-    def initialize(provider)
-      @provider = provider
-    end
-
-    def call(*args, **opts)
-      puts "#{args} and #{opts} passed to internal test query for #{@provider}" # rubocop:disable Rails/Output
+module Wikis
+  module Adapters
+    module Input
+      class PageInfoCallContract < DryApplicationContract
+        params do
+          required(:identifier).filled(:string)
+        end
+      end
     end
   end
 end

--- a/modules/wikis/app/contracts/wikis/adapters/input/page_info_contract.rb
+++ b/modules/wikis/app/contracts/wikis/adapters/input/page_info_contract.rb
@@ -31,7 +31,7 @@
 module Wikis
   module Adapters
     module Input
-      class PageInfoCallContract < DryApplicationContract
+      class PageInfoContract < DryApplicationContract
         params do
           required(:identifier).filled(:string)
         end

--- a/modules/wikis/app/models/wikis/adapters/input/page_info.rb
+++ b/modules/wikis/app/models/wikis/adapters/input/page_info.rb
@@ -28,31 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis::Adapters::Providers::Internal::Queries
-  class PageInfo < Wikis::Adapters::BaseQuery
-    def call(input_data)
-      # TODO: should we accept implicit User.current or do we want to pass in a user explicitly?
-      wiki_page = WikiPage.visible.find_by(id: input_data.identifier)
-      return failure(code: :not_found) if wiki_page.nil?
+module Wikis::Adapters::Input
+  PageInfo = Data.define(:identifier) do
+    private_class_method :new
 
-      success(
-        Wikis::Adapters::Results::PageInfo.new(
-          title: wiki_page.title,
-          href: url_for(only_path: true,
-                        controller: "/wiki",
-                        action: "show",
-                        project_id: wiki_page.project.identifier,
-                        id: wiki_page.slug)
-        )
-      )
-    end
-
-    private
-
-    delegate :url_for, to: :url_helpers
-
-    def url_helpers
-      OpenProject::StaticRouting::StaticRouter.new.url_helpers
+    def self.build(identifier:, contract: PageInfoContract.new)
+      contract.call(identifier:).to_monad.fmap { new(**it.to_h) }
     end
   end
 end

--- a/modules/wikis/app/models/wikis/adapters/results/error.rb
+++ b/modules/wikis/app/models/wikis/adapters/results/error.rb
@@ -30,28 +30,10 @@
 
 module Wikis
   module Adapters
-    module Providers
-      module XWiki
-        Registry = Dry::Container::Namespace.new("xwiki") do
-          namespace("authentication") do
-            # ...
-          end
-
-          namespace("commands") do
-            # ...
-          end
-
-          namespace("components") do
-            # ...
-          end
-
-          namespace("contracts") do
-            # ...
-          end
-
-          namespace("queries") do
-            register(:page_info, Queries::PageInfo)
-          end
+    module Results
+      Error = Data.define(:code, :source) do
+        def initialize(source:, code: nil)
+          super
         end
       end
     end

--- a/modules/wikis/app/models/wikis/adapters/results/page_info.rb
+++ b/modules/wikis/app/models/wikis/adapters/results/page_info.rb
@@ -23,22 +23,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  class PageTitleService
-    def read(_page_link)
-      # Mock implementation until connection to Wikis API is done
-      # TODO: Replace with real implementation
-
-      [
-        "How to write wiki pages",
-        "Technical specifications",
-        "A brief introduction on how to write wiki page titles that are short enough to be memorable"
-      ].sample
-    end
-  end
+module Wikis::Adapters::Results
+  PageInfo = Data.define(:title, :href)
 end

--- a/modules/wikis/app/models/wikis/page_link.rb
+++ b/modules/wikis/app/models/wikis/page_link.rb
@@ -39,10 +39,6 @@ module Wikis
 
     def inline? = false
 
-    def href
-      "#"
-    end
-
     def render_author? = false
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/base_query.rb
+++ b/modules/wikis/app/services/wikis/adapters/base_query.rb
@@ -32,23 +32,13 @@ module Wikis::Adapters
   class BaseQuery
     include Dry::Monads[:result]
 
-    class << self
-      def call_contract
-        raise SubclassResponsibilityError
-      end
-    end
-
     attr_reader :provider
 
     def initialize(provider)
       @provider = provider
     end
 
-    def call(**)
-      self.class.call_contract.new.call(**).to_monad.bind { handle_query(**it.to_h) }
-    end
-
-    def handle_query(**)
+    def call(_input_data)
       raise SubclassResponsibilityError
     end
 

--- a/modules/wikis/app/services/wikis/adapters/base_query.rb
+++ b/modules/wikis/app/services/wikis/adapters/base_query.rb
@@ -28,32 +28,38 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  module Adapters
-    module Providers
-      module XWiki
-        Registry = Dry::Container::Namespace.new("xwiki") do
-          namespace("authentication") do
-            # ...
-          end
+module Wikis::Adapters
+  class BaseQuery
+    include Dry::Monads[:result]
 
-          namespace("commands") do
-            # ...
-          end
-
-          namespace("components") do
-            # ...
-          end
-
-          namespace("contracts") do
-            # ...
-          end
-
-          namespace("queries") do
-            register(:page_info, Queries::PageInfo)
-          end
-        end
+    class << self
+      def call_contract
+        raise SubclassResponsibilityError
       end
+    end
+
+    attr_reader :provider
+
+    def initialize(provider)
+      @provider = provider
+    end
+
+    def call(**)
+      self.class.call_contract.new.call(**).to_monad.bind { handle_query(**it.to_h) }
+    end
+
+    def handle_query(**)
+      raise SubclassResponsibilityError
+    end
+
+    private
+
+    def success(result)
+      Success(result)
+    end
+
+    def failure(code:)
+      Failure(Results::Error.new(source: self.class, code:))
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/queries/page_info.rb
@@ -37,18 +37,28 @@ module Wikis::Adapters::Providers::Internal::Queries
     end
 
     def handle_query(identifier:)
-      title = [
-        "How to write wiki pages",
-        "Technical specifications",
-        "A brief introduction on how to write wiki page titles that are short enough to be memorable"
-      ].sample
+      # TODO: should we accept implicit User.current or do we want to pass in a user explicitly?
+      wiki_page = WikiPage.visible.find_by(id: identifier)
+      return failure(code: :not_found) if wiki_page.nil?
 
       success(
         Wikis::Adapters::Results::PageInfo.new(
-          title:,
-          href: "#"
+          title: wiki_page.title,
+          href: url_for(only_path: true,
+                        controller: "/wiki",
+                        action: "show",
+                        project_id: wiki_page.project.identifier,
+                        id: wiki_page.slug)
         )
       )
+    end
+
+    private
+
+    delegate :url_for, to: :url_helpers
+
+    def url_helpers
+      OpenProject::StaticRouting::StaticRouter.new.url_helpers
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/queries/page_info.rb
@@ -28,15 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# This query is only intended for demo purposes and can be deleted once we have real queries
 module Wikis::Adapters::Providers::Internal::Queries
-  class Test
-    def initialize(provider)
-      @provider = provider
+  class PageInfo < Wikis::Adapters::BaseQuery
+    class << self
+      def call_contract
+        Wikis::Adapters::Input::PageInfoCallContract
+      end
     end
 
-    def call(*args, **opts)
-      puts "#{args} and #{opts} passed to internal test query for #{@provider}" # rubocop:disable Rails/Output
+    def handle_query(identifier:)
+      title = [
+        "How to write wiki pages",
+        "Technical specifications",
+        "A brief introduction on how to write wiki page titles that are short enough to be memorable"
+      ].sample
+
+      success(
+        Wikis::Adapters::Results::PageInfo.new(
+          title:,
+          href: "#"
+        )
+      )
     end
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
@@ -50,7 +50,7 @@ module Wikis
           end
 
           namespace("queries") do
-            register(:test, Queries::Test)
+            register(:page_info, Queries::PageInfo)
           end
         end
       end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
@@ -30,13 +30,7 @@
 
 module Wikis::Adapters::Providers::XWiki::Queries
   class PageInfo < Wikis::Adapters::BaseQuery
-    class << self
-      def call_contract
-        Wikis::Adapters::Input::PageInfoCallContract
-      end
-    end
-
-    def handle_query(identifier:) # rubocop:disable Lint/UnusedMethodArgument
+    def call(_input_data)
       title = [
         "What makes XWiki special?",
         "API documentation",

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
@@ -28,32 +28,27 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  module Adapters
-    module Providers
-      module XWiki
-        Registry = Dry::Container::Namespace.new("xwiki") do
-          namespace("authentication") do
-            # ...
-          end
-
-          namespace("commands") do
-            # ...
-          end
-
-          namespace("components") do
-            # ...
-          end
-
-          namespace("contracts") do
-            # ...
-          end
-
-          namespace("queries") do
-            register(:page_info, Queries::PageInfo)
-          end
-        end
+module Wikis::Adapters::Providers::XWiki::Queries
+  class PageInfo < Wikis::Adapters::BaseQuery
+    class << self
+      def call_contract
+        Wikis::Adapters::Input::PageInfoCallContract
       end
+    end
+
+    def handle_query(identifier:) # rubocop:disable Lint/UnusedMethodArgument
+      title = [
+        "What makes XWiki special?",
+        "API documentation",
+        "A brief introduction on configuring your own XWiki instance and connect it to OpenProject."
+      ].sample
+
+      success(
+        Wikis::Adapters::Results::PageInfo.new(
+          title:,
+          href: "#"
+        )
+      )
     end
   end
 end

--- a/modules/wikis/app/services/wikis/text_formatting/wiki_link_matcher.rb
+++ b/modules/wikis/app/services/wikis/text_formatting/wiki_link_matcher.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  module TextFormatting
+    class WikiLinkMatcher < OpenProject::TextFormatting::Matchers::RegexMatcher
+      class << self
+        def applicable?(*)
+          super && OpenProject::FeatureDecisions.wiki_enhancements_active?
+        end
+
+        def regexp
+          /\[\[\[([0-9]+):([^\]\n]+)\]\]\]/
+        end
+
+        def process_match(match, _matched_string, _context)
+          instance = new(
+            provider_id: match[1],
+            identifier: match[2]
+          )
+
+          instance.process
+        end
+      end
+
+      def initialize(provider_id:, identifier:)
+        super()
+
+        @provider_id = provider_id
+        @identifier = identifier
+      end
+
+      def process
+        provider = Wikis::Provider.find_by(id: @provider_id)
+        title, href = resolve_page(provider, @identifier)
+
+        view_context = ApplicationController.new.view_context
+        OpPrimer::InlineMacroComponent.new.render_in(view_context) do |component|
+          component.with_leading_visual_icon(icon: :"op-file-doc")
+
+          if title.nil? || href.nil?
+            Primer::Beta::Text.new(color: :muted).render_in(view_context) { I18n.t("wikis.macro.page_not_found") }
+          else
+            Primer::Beta::Link.new(href:).render_in(view_context) { title }
+          end
+        end
+      end
+
+      private
+
+      def resolve_page(provider, identifier)
+        return nil if provider.nil?
+
+        page_info = provider.resolve("queries.page_info").call(identifier:).value_or { return nil }
+
+        [page_info.title, page_info.href]
+      end
+    end
+  end
+end

--- a/modules/wikis/app/services/wikis/text_formatting/wiki_link_matcher.rb
+++ b/modules/wikis/app/services/wikis/text_formatting/wiki_link_matcher.rb
@@ -31,6 +31,8 @@
 module Wikis
   module TextFormatting
     class WikiLinkMatcher < OpenProject::TextFormatting::Matchers::RegexMatcher
+      include Dry::Monads[:result]
+
       class << self
         def applicable?(*)
           super && OpenProject::FeatureDecisions.wiki_enhancements_active?
@@ -59,28 +61,33 @@ module Wikis
 
       def process
         provider = Wikis::Provider.find_by(id: @provider_id)
-        title, href = resolve_page(provider, @identifier)
-
         view_context = ApplicationController.new.view_context
         OpPrimer::InlineMacroComponent.new.render_in(view_context) do |component|
           component.with_leading_visual_icon(icon: :"op-file-doc")
 
-          if title.nil? || href.nil?
-            Primer::Beta::Text.new(color: :muted).render_in(view_context) { I18n.t("wikis.macro.page_not_found") }
-          else
-            Primer::Beta::Link.new(href:).render_in(view_context) { title }
-          end
+          resolve_page(provider, @identifier).either(
+            ->(page_info) { render_page_info_macro(view_context, page_info) },
+            ->(error) { render_error_macro(view_context, error) }
+          )
         end
       end
 
       private
 
       def resolve_page(provider, identifier)
-        return nil if provider.nil?
+        return Failure() if provider.nil?
 
-        page_info = provider.resolve("queries.page_info").call(identifier:).value_or { return nil }
+        Wikis::Adapters::Input::PageInfo.build(identifier:).bind do |input|
+          provider.resolve("queries.page_info").call(input)
+        end
+      end
 
-        [page_info.title, page_info.href]
+      def render_page_info_macro(view_context, page_info)
+        Primer::Beta::Link.new(href: page_info.href).render_in(view_context) { page_info.title }
+      end
+
+      def render_error_macro(view_context, _error)
+        Primer::Beta::Text.new(color: :muted).render_in(view_context) { I18n.t("wikis.macro.page_not_found") }
       end
     end
   end

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -65,3 +65,5 @@ en:
         delete:
           title: Delete wiki provider
           warning_html: "You are about to delete %{wiki_provider}. This action is irreversible."
+    macro:
+      page_not_found: Linked wiki page no longer available

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -58,6 +58,8 @@ module OpenProject::Wikis
         :wikisAvailable,
         getter: ->(*) { ::Wikis::Provider.enabled.exists? }
       )
+
+      OpenProject::TextFormatting::Filters::PatternMatcherFilter.append_matcher ::Wikis::TextFormatting::WikiLinkMatcher
     end
 
     replace_principal_references "Wikis::PageLink" => %i[author_id]


### PR DESCRIPTION
Limitations on the page_info query aside (see first commit for details), this already works
the way that I'd expect this to work once we implemented real interactions
with wiki providers.

The macro markup is currently rather simple and builds on top of the existing
syntax for wiki links. The main downside is that during editing, it's not quite
clear to which page a macro related.

This macro format should be a good first iteration and if we have more time for
improvement available before release, we could replace it with an HTML-ized macro
similar to `<mention>` that is also properly rendered in CKEditor. However, this requires
a substantial amount of additional effort and is thus not quite feasible for a first iteration.

# Ticket
Part of https://community.openproject.org/wp/72986

# Depends on

* [x] https://github.com/opf/openproject/pull/22758
* [x] https://github.com/opf/openproject/pull/22759