### PR TITLE
Draft: [68582] Blank page and error 404 when calendar, board, team planner, role is deleted

### DIFF
--- a/app/controllers/admin/import/jira/instances_controller.rb
+++ b/app/controllers/admin/import/jira/instances_controller.rb
@@ -70,7 +70,7 @@ module Admin::Import::Jira
         @jira.destroy!
         flash[:notice] = t(:notice_successful_delete)
       end
-      redirect_to action: :index
+      redirect_to action: :index, status: :see_other
     end
 
     def delete_token

--- a/app/controllers/admin/settings/enumerations_controller_base.rb
+++ b/app/controllers/admin/settings/enumerations_controller_base.rb
@@ -74,10 +74,10 @@ module Admin
           handle_reassignment_on_deletion
         elsif @enumeration.destroy
           flash[:notice] = I18n.t(:notice_successful_delete)
-          redirect_to(action: :index)
+          redirect_to(action: :index, status: :see_other)
         else
           flash.now[:error] = I18n.t(:error_can_not_delete_entry)
-          redirect_to(action: :index)
+          redirect_to(action: :index, status: :see_other)
         end
       end
 

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -120,7 +120,7 @@ class ForumsController < ApplicationController
     @forum.destroy!
 
     flash[:notice] = I18n.t(:notice_successful_delete)
-    redirect_to project_forums_path(@project)
+    redirect_to project_forums_path(@project), status: :see_other
   end
 
   private

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -94,7 +94,7 @@ class RolesController < ApplicationController
     else
       flash[:error] = I18n.t(:error_can_not_remove_role)
     end
-    redirect_to action: "index"
+    redirect_to action: "index", status: :see_other
   end
 
   def report

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -63,7 +63,7 @@ module ::Boards
           render json: { redirect_url: project_work_package_boards_path(@project) }
         end
         format.html do
-          redirect_to action: "index", project_id: @project
+          redirect_to action: "index", project_id: @project, status: :see_other
         end
       end
     end

--- a/modules/boards/spec/controllers/boards/boards_controller_spec.rb
+++ b/modules/boards/spec/controllers/boards/boards_controller_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Boards::BoardsController do
 
         expect(flash[:notice]).to eq(I18n.t(:notice_successful_delete))
         expect(response).to redirect_to(project_work_package_boards_path(project))
+        expect(response).to have_http_status(:see_other)
       end
     end
 

--- a/modules/calendar/app/controllers/calendar/calendars_controller.rb
+++ b/modules/calendar/app/controllers/calendar/calendars_controller.rb
@@ -72,7 +72,7 @@ module ::Calendar
         flash[:error] = t(:error_can_not_delete_entry)
       end
 
-      redirect_to action: :index
+      redirect_to action: :index, status: :see_other
     end
 
     private

--- a/modules/calendar/spec/controllers/calendar_controller_spec.rb
+++ b/modules/calendar/spec/controllers/calendar_controller_spec.rb
@@ -73,4 +73,30 @@ RSpec.describe Calendar::CalendarsController do
       it_behaves_like "calendar#index"
     end
   end
+
+  describe "#destroy" do
+    let(:permissions) { [:manage_calendars] }
+    let(:query) { create(:query, project:, user:) }
+
+    before do
+      create(:view_work_packages_calendar, query:)
+      allow(Query)
+        .to receive(:visible)
+        .and_return(Query.where(id: query.id))
+    end
+
+    context "within a project context" do
+      subject { delete :destroy, params: { project_id: project.id, id: query.id } }
+
+      it "redirects to index with 303 See Other" do
+        subject
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(project_calendars_path(project.id))
+      end
+
+      it "deletes the calendar" do
+        expect { subject }.to change { Query.exists?(query.id) }.from(true).to(false)
+      end
+    end
+  end
 end

--- a/modules/costs/app/controllers/costlog_controller.rb
+++ b/modules/costs/app/controllers/costlog_controller.rb
@@ -88,9 +88,9 @@ class CostlogController < ApplicationController
     flash[:notice] = t(:notice_successful_delete)
 
     if request.referer.include?("cost_reports")
-      redirect_to controller: "/cost_reports", action: :index
+      redirect_to controller: "/cost_reports", action: :index, status: :see_other
     else
-      redirect_back_or_to(polymorphic_path(@cost_entry.entity))
+      redirect_back_or_to(polymorphic_path(@cost_entry.entity), status: :see_other)
     end
   end
 

--- a/modules/costs/spec/controllers/costlog_controller_spec.rb
+++ b/modules/costs/spec/controllers/costlog_controller_spec.rb
@@ -528,6 +528,19 @@ RSpec.describe CostlogController do
     end
   end
 
+  describe "DELETE destroy" do
+    before do
+      cost_entry.save(validate: false)
+      grant_current_user_permissions user, %i[view_project view_work_packages view_cost_entries edit_cost_entries]
+      request.env["HTTP_REFERER"] = "http://example.com/work_packages"
+    end
+
+    it "redirects with see_other status" do
+      delete :destroy, params: { id: cost_entry.id }
+      expect(response).to have_http_status(:see_other)
+    end
+  end
+
   describe "PUT update" do
     let(:params) do
       { "id" => cost_entry.id.to_s,

--- a/modules/github_integration/spec/requests/deploy_targets_spec.rb
+++ b/modules/github_integration/spec/requests/deploy_targets_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DeployTargetsController < ApplicationController
-  layout "admin"
+require "spec_helper"
 
-  menu_item :admin_github_integration
+RSpec.describe "Deploy targets", :skip_csrf, type: :rails_request do
+  let(:admin) { create(:admin) }
+  let(:deploy_target) { create(:deploy_target) }
 
-  before_action :require_admin
-
-  def index
-    @deploy_targets = DeployTarget.all
+  before do
+    login_as(admin)
   end
 
-  def new
-    @deploy_target = DeployTarget.new type: "OpenProject"
-  end
-
-  def create
-    args = params
-      .permit("deploy_target" => ["host", "type", "api_key"])[:deploy_target]
-      .to_h
-      .merge(type: "OpenProject")
-
-    @deploy_target = DeployTarget.create **args
-
-    if @deploy_target.persisted?
-      flash[:success] = I18n.t(:notice_deploy_target_created)
-
-      redirect_to deploy_targets_path
-    else
-      render "new"
+  describe "DELETE /deploy_targets/:id" do
+    it "redirects with 303 See Other" do
+      delete deploy_target_path(deploy_target)
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(deploy_targets_path)
     end
-  end
-
-  def destroy
-    deploy_target = DeployTarget.find params[:id]
-
-    deploy_target.destroy!
-
-    flash[:success] = I18n.t(:notice_deploy_target_destroyed)
-
-    redirect_to deploy_targets_path, status: :see_other
   end
 end

--- a/modules/ldap_groups/app/controllers/ldap_groups/synchronized_filters_controller.rb
+++ b/modules/ldap_groups/app/controllers/ldap_groups/synchronized_filters_controller.rb
@@ -56,7 +56,7 @@ module LdapGroups
         flash[:error] = I18n.t(:error_can_not_delete_entry)
       end
 
-      redirect_to ldap_groups_synchronized_groups_path
+      redirect_to ldap_groups_synchronized_groups_path, status: :see_other
     end
 
     def synchronize

--- a/modules/ldap_groups/spec/requests/synchronized_filters_spec.rb
+++ b/modules/ldap_groups/spec/requests/synchronized_filters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,21 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DeployTargetsController < ApplicationController
-  layout "admin"
+require_relative "../spec_helper"
 
-  menu_item :admin_github_integration
+RSpec.describe "LDAP synchronized filters", :skip_csrf, type: :rails_request do
+  let(:admin) { create(:admin) }
+  let(:filter) { create(:ldap_synchronized_filter) }
 
-  before_action :require_admin
-
-  def index
-    @deploy_targets = DeployTarget.all
+  before do
+    login_as(admin)
   end
 
-  def new
-    @deploy_target = DeployTarget.new type: "OpenProject"
-  end
-
-  def create
-    args = params
-      .permit("deploy_target" => ["host", "type", "api_key"])[:deploy_target]
-      .to_h
-      .merge(type: "OpenProject")
-
-    @deploy_target = DeployTarget.create **args
-
-    if @deploy_target.persisted?
-      flash[:success] = I18n.t(:notice_deploy_target_created)
-
-      redirect_to deploy_targets_path
-    else
-      render "new"
+  describe "DELETE /ldap_groups/synchronized_filters/:ldap_filter_id" do
+    it "redirects with 303 See Other" do
+      delete ldap_groups_synchronized_filter_path(ldap_filter_id: filter.id)
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(ldap_groups_synchronized_groups_path)
     end
-  end
-
-  def destroy
-    deploy_target = DeployTarget.find params[:id]
-
-    deploy_target.destroy!
-
-    flash[:success] = I18n.t(:notice_deploy_target_destroyed)
-
-    redirect_to deploy_targets_path, status: :see_other
   end
 end

--- a/modules/storages/app/controllers/storages/admin/storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/storages_controller.rb
@@ -190,7 +190,7 @@ module Storages
         service_result.on_success do
           flash[:notice] = I18n.t(:notice_successful_delete)
         end
-        redirect_to admin_settings_storages_path
+        redirect_to admin_settings_storages_path, status: :see_other
       end
 
       def replace_oauth_application

--- a/modules/storages/spec/controllers/storages/admin/storages_controller_spec.rb
+++ b/modules/storages/spec/controllers/storages/admin/storages_controller_spec.rb
@@ -65,4 +65,21 @@ RSpec.describe Storages::Admin::StoragesController do
       end
     end
   end
+
+  describe "DELETE #destroy" do
+    let(:storage) { build_stubbed(:nextcloud_storage) }
+    let(:service_result) { ServiceResult.success }
+    let(:delete_service) { instance_double(Storages::Storages::DeleteService, call: service_result) }
+
+    before do
+      allow(Storages::Storage).to receive(:visible).and_return(instance_double(ActiveRecord::Relation, find: storage))
+      allow(Storages::Storages::DeleteService).to receive(:new).and_return(delete_service)
+    end
+
+    it "redirects to storages index with see_other" do
+      delete :destroy, params: { id: storage.id }
+      expect(response).to redirect_to(admin_settings_storages_path)
+      expect(response).to have_http_status(:see_other)
+    end
+  end
 end

--- a/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
+++ b/modules/team_planner/app/controllers/team_planner/team_planner_controller.rb
@@ -50,7 +50,7 @@ module ::TeamPlanner
         flash[:error] = t(:error_can_not_delete_entry)
       end
 
-      redirect_to action: :index
+      redirect_to action: :index, status: :see_other
     end
 
     current_menu_item :index do

--- a/modules/team_planner/spec/requests/team_planner_spec.rb
+++ b/modules/team_planner/spec/requests/team_planner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -26,45 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class DeployTargetsController < ApplicationController
-  layout "admin"
+require "spec_helper"
 
-  menu_item :admin_github_integration
+RSpec.describe "Team planners", :skip_csrf, type: :rails_request, with_ee: %i[team_planner_view] do
+  let(:project) { create(:project) }
+  let(:user) do
+    create(:user, member_with_permissions: { project => %i[view_work_packages view_team_planner manage_team_planner] })
+  end
+  let(:query) { create(:query, project:, user:) }
 
-  before_action :require_admin
-
-  def index
-    @deploy_targets = DeployTarget.all
+  before do
+    create(:view_team_planner, query:)
+    login_as(user)
   end
 
-  def new
-    @deploy_target = DeployTarget.new type: "OpenProject"
-  end
-
-  def create
-    args = params
-      .permit("deploy_target" => ["host", "type", "api_key"])[:deploy_target]
-      .to_h
-      .merge(type: "OpenProject")
-
-    @deploy_target = DeployTarget.create **args
-
-    if @deploy_target.persisted?
-      flash[:success] = I18n.t(:notice_deploy_target_created)
-
-      redirect_to deploy_targets_path
-    else
-      render "new"
+  describe "DELETE /projects/:project_id/team_planners/:id" do
+    it "redirects with 303 See Other" do
+      delete project_team_planner_path(project, query)
+      expect(response).to have_http_status(:see_other)
+      expect(response).to redirect_to(project_team_planners_path(project))
     end
-  end
-
-  def destroy
-    deploy_target = DeployTarget.find params[:id]
-
-    deploy_target.destroy!
-
-    flash[:success] = I18n.t(:notice_deploy_target_destroyed)
-
-    redirect_to deploy_targets_path, status: :see_other
   end
 end

--- a/spec/controllers/admin/import/jira/instances_controller_spec.rb
+++ b/spec/controllers/admin/import/jira/instances_controller_spec.rb
@@ -358,6 +358,7 @@ RSpec.describe Admin::Import::Jira::InstancesController do
         jira_to_delete = create(:jira)
         delete :destroy, params: { id: jira_to_delete.id }
         expect(response).to redirect_to(action: :index)
+        expect(response).to have_http_status(:see_other)
       end
     end
 
@@ -378,6 +379,7 @@ RSpec.describe Admin::Import::Jira::InstancesController do
       it "redirects to index" do
         delete :destroy, params: { id: jira.id }
         expect(response).to redirect_to(action: :index)
+        expect(response).to have_http_status(:see_other)
       end
     end
 

--- a/spec/controllers/forums_controller_spec.rb
+++ b/spec/controllers/forums_controller_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe ForumsController do
         end.to change(Forum, :count).by(-1)
 
         expect(response).to redirect_to project_forums_path(project)
+        expect(response).to have_http_status(:see_other)
         expect(flash[:notice]).to eq(I18n.t(:notice_successful_delete))
       end
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -352,6 +352,7 @@ RSpec.describe RolesController do
         expect(enqueued_jobs.count).to eq(1)
         expect(enqueued_jobs[0][:job]).to eq(Storages::ManageStorageIntegrationsJob)
         expect(response).to redirect_to roles_path
+        expect(response).to have_http_status(:see_other)
         expect(Role.count).to eq(0)
       end
     end
@@ -368,6 +369,7 @@ RSpec.describe RolesController do
         expect(enqueued_jobs.count).to eq(0)
         expect(Role.count).to eq(1)
         expect(response).to redirect_to roles_path
+        expect(response).to have_http_status(:see_other)
         expect(flash[:error]).to eq I18n.t(:error_can_not_remove_role)
       end
     end

--- a/spec/requests/admin/settings/work_package_priorities_spec.rb
+++ b/spec/requests/admin/settings/work_package_priorities_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe "Work package priorities",
       it "redirects to the priorities index" do
         delete(admin_settings_work_package_priority_path(priority), params:)
         expect(response).to redirect_to admin_settings_work_package_priorities_path
+        expect(response).to have_http_status(:see_other)
         expect { priority.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/68573

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

## Root Cause

When a Turbo link with `data-turbo-method="delete"` triggers a `destroy` action and the server responds with **302 Found**, HTTP spec says the client must repeat the request  ith the same method. Turbo obeys this — it issues another `DELETE` to the redirect target, which has no `destroy` route and returns 404.

<img width="1023" height="418" alt="68573 - Follows redirect with DELETE" src="https://github.com/user-attachments/assets/0e0e67d5-5ce3-4bed-bff0-840781b8b79d" />

This can get really messy (to say the least) with chain reactions like the [actual behaviour described over there](https://github.com/rails/rails/issues/45292).

The fix for **form** submissions was shipped in [turbo-rails#370](https://github.com/hotwired/turbo-rails/pull/370) (Turbo 7.x): forms encode non-GET/POST verbs as `POST` + `_method`, so a 302 is safe. But that fix never covered **links**; the open issue is [turbo-rails#259](https://github.com/hotwired/turbo-rails/issues/259).

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->


Add `status: :see_other` to every `redirect_to` inside a `destroy` action:

```ruby
# Before
redirect_to action: :index

# After
redirect_to action: :index, status: :see_other
```

HTTP **303 See Other** unconditionally instructs the client to follow the redirect with
`GET`, regardless of the original method ([detailed answer here](https://github.com/hotwired/turbo/issues/84#issuecomment-756189909)).

## Already Fixed

- `modules/calendar/app/controllers/calendar/calendars_controller.rb` (commit `5c2f2d9`)

## Warning

You won’t see the error in `development`, a `GET` request is immediately triggered after the 404:

<img width="938" height="74" alt="68573 - Follows redirect with DELETE then GET" src="https://github.com/user-attachments/assets/449d0002-f63c-487e-80ff-5b7bc91b8e04" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
