### PR TITLE
[#73876] Eliminate N+1 queries on the backlogs sprints list.

### DIFF
--- a/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
@@ -63,7 +63,11 @@ module Backlogs
     end
 
     def load_backlogs
-      @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+      @sprints = Agile::Sprint.for_project(@project)
+                              .not_completed
+                              .order_by_date
+                              .includes(:project, :task_boards)
+
       @stories_by_sprint_id = WorkPackage
                                .where(sprint: @sprints, project: @project)
                                .includes(:type, :status)

--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -86,7 +86,7 @@ module Agile
     end
 
     def task_board_for(project)
-      task_boards.find_by(project:)
+      task_boards.find { it.project_id == project.id }
     end
 
     def work_packages_for(project)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73876

# What are you trying to accomplish?
Eliminate N+1 queries related to loading stories.

<details><summary>See logs</summary>
<p>


```bash
↳ app/models/project.rb:295:in 'Project#allowed_permissions'
Boards::Grid Load (0.5ms)  SELECT "grids".* FROM "grids" WHERE "grids"."type" = $1 AND "grids"."linked_id" = $2 AND "grids"."linked_type" = $3 AND "grids"."project_id" = $4 LIMIT $5  [["type", "Boards::Grid"], ["linked_id", 81], ["linked_type", "Agile::Sprint"], ["project_id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/models/agile/sprint.rb:89:in 'Agile::Sprint#task_board_for'
CACHE Project Load (0.1ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/contracts/sprints/start_contract.rb:39:in 'Sprints::StartContract.can_start_or_complete?'
CACHE EnabledModule Pluck (0.0ms)  SELECT "enabled_modules"."name" FROM "enabled_modules" WHERE "enabled_modules"."project_id" = $1  [["project_id", 5]]
↳ app/models/project.rb:295:in 'Project#allowed_permissions'
Boards::Grid Load (0.2ms)  SELECT "grids".* FROM "grids" WHERE "grids"."type" = $1 AND "grids"."linked_id" = $2 AND "grids"."linked_type" = $3 AND "grids"."project_id" = $4 LIMIT $5  [["type", "Boards::Grid"], ["linked_id", 82], ["linked_type", "Agile::Sprint"], ["project_id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/models/agile/sprint.rb:89:in 'Agile::Sprint#task_board_for'
CACHE Project Load (0.1ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/contracts/sprints/start_contract.rb:39:in 'Sprints::StartContract.can_start_or_complete?'
CACHE EnabledModule Pluck (0.0ms)  SELECT "enabled_modules"."name" FROM "enabled_modules" WHERE "enabled_modules"."project_id" = $1  [["project_id", 5]]
↳ app/models/project.rb:295:in 'Project#allowed_permissions'
Boards::Grid Load (4.9ms)  SELECT "grids".* FROM "grids" WHERE "grids"."type" = $1 AND "grids"."linked_id" = $2 AND "grids"."linked_type" = $3 AND "grids"."project_id" = $4 LIMIT $5  [["type", "Boards::Grid"], ["linked_id", 83], ["linked_type", "Agile::Sprint"], ["project_id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/models/agile/sprint.rb:89:in 'Agile::Sprint#task_board_for'
CACHE Project Load (0.1ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
↳ modules/backlogs/app/contracts/sprints/start_contract.rb:39:in 'Sprints::StartContract.can_start_or_complete?'
```
</p>
</details> 

# What approach did you choose and why?

Eager load projects and task boards when retrieving sprints.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
