### PR TITLE
[#71645] Improve interface of WP identifier setting controller

### DIFF
--- a/app/controllers/admin/settings/work_packages_identifier_controller.rb
+++ b/app/controllers/admin/settings/work_packages_identifier_controller.rb
@@ -43,17 +43,10 @@ module Admin::Settings
     end
 
     def update
-      return render_400 unless params[:settings]
-
-      if autofix_requested?
-        call = update_service.new(user: current_user).call(settings_params)
-        call.on_success do
-          WorkPackages::IdentifierAutofix::ApplyHandlesJob.perform_later
-          redirect_to action: "show"
-        end
-        call.on_failure { failure_callback(call) }
-      else
-        super
+      case params.dig(:settings, :work_packages_identifier)
+      when Setting::WorkPackageIdentifier::SEMANTIC  then switch_to_semantic
+      when Setting::WorkPackageIdentifier::CLASSIC   then switch_to_classic
+      else                                                render_400
       end
     end
 
@@ -74,12 +67,27 @@ module Admin::Settings
 
     private
 
-    def check_feature_flag
-      render_404 unless OpenProject::FeatureDecisions.semantic_work_package_ids_active?
+    def switch_to_semantic
+      unless WorkPackages::IdentifierAutofix.job_in_progress?
+        ProjectIdentifiers::ConvertInstanceToSemanticIdsJob.perform_later
+      end
+      redirect_to action: "show"
     end
 
-    def autofix_requested?
-      ActiveRecord::Type::Boolean.new.cast(params[:confirm_dangerous_action])
+    def switch_to_classic
+      call = update_service.new(user: current_user)
+                                    .call(work_packages_identifier: Setting::WorkPackageIdentifier::CLASSIC)
+      call.on_success do
+        unless WorkPackages::IdentifierAutofix.job_in_progress?
+          ProjectIdentifiers::RevertInstanceToClassicIdsJob.perform_later
+        end
+        redirect_to action: "show"
+      end
+      call.on_failure { failure_callback(call) }
+    end
+
+    def check_feature_flag
+      render_404 unless OpenProject::FeatureDecisions.semantic_work_package_ids_active?
     end
   end
 end

--- a/app/workers/project_identifiers/convert_instance_to_semantic_ids_job.rb
+++ b/app/workers/project_identifiers/convert_instance_to_semantic_ids_job.rb
@@ -28,15 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module WorkPackages
-  module IdentifierAutofix
-    def self.job_in_progress?
-      GoodJob::Job
-        .where(job_class: [
-                 ProjectIdentifiers::ConvertInstanceToSemanticIdsJob.name,
-                 ProjectIdentifiers::RevertInstanceToClassicIdsJob.name
-               ])
-        .exists?(finished_at: nil)
-    end
-  end
+class ProjectIdentifiers::ConvertInstanceToSemanticIdsJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(total_limit: 1)
+
+  def perform(*); end
 end

--- a/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
+++ b/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
@@ -28,13 +28,10 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class WorkPackages::IdentifierAutofix::ApplyHandlesJob < ApplicationJob
-  # FIXME: The admin UI's job_in_progress? query and :change_in_progress state
-  # assume at most one active instance of this job at any given time.
-  # Enforce this with good_job_control_concurrency_with(perform_limit: 1)
-  # when the real migration body is implemented.
-  def perform
-    # FIXME: replace with actual project handle migration
-    sleep 5
-  end
+class ProjectIdentifiers::RevertInstanceToClassicIdsJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  good_job_control_concurrency_with(total_limit: 1)
+
+  def perform(*); end
 end

--- a/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
+++ b/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
+               with_flag: { semantic_work_package_ids: true } do
+  shared_let(:user) { create(:admin) }
+
+  current_user { user }
+
+  describe "PATCH #update" do
+    context "when work_packages_identifier is 'semantic'" do
+      it "enqueues ProjectIdentifiers::ConvertInstanceToSemanticIdsJob and redirects" do
+        expect do
+          patch :update, params: { settings: { work_packages_identifier: "semantic" } }
+        end.to have_enqueued_job(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob)
+
+        expect(response).to redirect_to(action: "show")
+      end
+
+      context "when a migration job is already in progress" do
+        before do
+          allow(WorkPackages::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
+        end
+
+        it "does not enqueue another job but still redirects" do
+          expect do
+            patch :update, params: { settings: { work_packages_identifier: "semantic" } }
+          end.not_to have_enqueued_job(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob)
+
+          expect(response).to redirect_to(action: "show")
+        end
+      end
+    end
+
+    context "when work_packages_identifier is 'classic'" do
+      it "updates the setting to classic, enqueues RevertInstanceToClassicIdsJob, and redirects" do
+        expect do
+          patch :update, params: { settings: { work_packages_identifier: "classic" } }
+        end.to have_enqueued_job(ProjectIdentifiers::RevertInstanceToClassicIdsJob)
+
+        expect(Setting.work_packages_identifier).to eq("classic")
+        expect(response).to redirect_to(action: "show")
+      end
+
+      context "when a migration job is already in progress" do
+        before do
+          allow(WorkPackages::IdentifierAutofix).to receive(:job_in_progress?).and_return(true)
+        end
+
+        it "does not enqueue another job but still updates the setting and redirects" do
+          expect do
+            patch :update, params: { settings: { work_packages_identifier: "classic" } }
+          end.not_to have_enqueued_job(ProjectIdentifiers::RevertInstanceToClassicIdsJob)
+
+          expect(Setting.work_packages_identifier).to eq("classic")
+          expect(response).to redirect_to(action: "show")
+        end
+      end
+    end
+
+    context "when work_packages_identifier is missing" do
+      it "renders 400 without enqueuing a job" do
+        patch :update, params: {}
+
+        expect(response).to have_http_status(:bad_request)
+        expect(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob).not_to have_been_enqueued
+        expect(ProjectIdentifiers::RevertInstanceToClassicIdsJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when work_packages_identifier is an unknown value" do
+      it "renders 400 without enqueuing a job" do
+        patch :update, params: { settings: { work_packages_identifier: "unknown_value" } }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob).not_to have_been_enqueued
+        expect(ProjectIdentifiers::RevertInstanceToClassicIdsJob).not_to have_been_enqueued
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/71645/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

Replace the single `update` action (with boolean `confirm_dangerous_action` guard) with an explicit case dispatch to `switch_to_semantic` / `switch_to_classic`. Each branch enqueues the matching instance-level job and redirects; an unrecognised setting parameter yields 400.

The two new job classes are introduced as no-op stubs here; their real bodies land in the next two commits.

`WorkPackages::IdentifierAutofix.job_in_progress?` is updated to check GoodJob for the new job class names instead of the old `ApplyHandlesJob` (which is deleted here).


## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
