### PR TITLE
Support multi-argument find with semantic identifiers

### DIFF
--- a/app/models/work_package/semantic_identifier/finder_methods.rb
+++ b/app/models/work_package/semantic_identifier/finder_methods.rb
@@ -43,17 +43,20 @@ module WorkPackage::SemanticIdentifier::FinderMethods
   def find(*args)
     ids = args.length == 1 && args.first.is_a?(Array) ? args.first : args
 
+    # Single semantic ID — fast path
     if ids.length == 1 && semantic_id?(ids.first)
       return find_by_id_or_identifier!(ids.first)
     end
 
-    if ids.any? { |id| semantic_id?(id) }
-      raise ArgumentError,
-            "Semantic identifiers in multi-argument find are not yet supported. " \
-            "Resolve each identifier individually via find_by(id:) instead."
-    end
+    # Multiple IDs — resolve any semantic IDs to numeric before delegating to AR
+    semantic_ids = ids.select { |id| semantic_id?(id) }
+    return super if semantic_ids.empty?
 
-    super
+    resolved = resolve_semantic_to_numeric(semantic_ids)
+    all_numeric = ids.map { |id| semantic_id?(id) ? resolved.fetch(id) : id }
+
+    # Preserve AR's calling convention: find([a, b]) vs find(a, b)
+    args.length == 1 && args.first.is_a?(Array) ? super(all_numeric) : super(*all_numeric)
   end
 
   # Override find_by to transparently resolve semantic identifiers when called
@@ -124,6 +127,38 @@ module WorkPackage::SemanticIdentifier::FinderMethods
 
     stripped = value.strip
     stripped.to_i.to_s != stripped
+  end
+
+  # Resolves an array of semantic identifiers to a hash of { "PROJ-42" => numeric_id }.
+  # Raises ActiveRecord::RecordNotFound if any identifier cannot be resolved.
+  def resolve_semantic_to_numeric(identifiers)
+    found = resolve_current_identifiers(identifiers)
+    found.merge!(resolve_alias_identifiers(identifiers - found.keys)) if found.size < identifiers.size
+
+    still_missing = identifiers - found.keys
+    raise_not_found_for(still_missing) if still_missing.any?
+
+    found
+  end
+
+  def resolve_current_identifiers(identifiers)
+    where(identifier: identifiers).pluck(:identifier, :id).to_h
+  end
+
+  def resolve_alias_identifiers(identifiers)
+    return {} if identifiers.empty?
+
+    joins(:semantic_aliases)
+      .where(work_package_semantic_aliases: { identifier: identifiers })
+      .pluck(Arel.sql("work_package_semantic_aliases.identifier"), :id)
+      .to_h
+  end
+
+  def raise_not_found_for(identifiers)
+    raise ActiveRecord::RecordNotFound.new(
+      "Couldn't find WorkPackage with identifier=#{identifiers.join(', ')}",
+      "WorkPackage", "identifier", identifiers
+    )
   end
 
   # Looks up by current identifier column first, then falls back to

--- a/spec/models/work_package/semantic_identifier_spec.rb
+++ b/spec/models/work_package/semantic_identifier_spec.rb
@@ -97,20 +97,26 @@ RSpec.describe WorkPackage::SemanticIdentifier do
     end
 
     context "with multiple ids" do
-      let(:work_package2) { create(:work_package, project:) }
+      let!(:work_package2) { create(:work_package, project:) }
 
-      it "delegates to standard AR find for numeric ids" do
+      it "finds multiple numeric ids via array" do
         expect(WorkPackage.find([work_package.id, work_package2.id])).to contain_exactly(work_package, work_package2)
       end
 
-      it "raises ArgumentError for multiple semantic ids" do
-        expect { WorkPackage.find("MYPROJ-1", "MYPROJ-2") }
-          .to raise_error(ArgumentError, /multi-argument find are not yet supported/)
+      it "finds multiple semantic ids via splat" do
+        expect(WorkPackage.find("MYPROJ-1", "MYPROJ-2")).to contain_exactly(work_package, work_package2)
       end
 
-      it "raises ArgumentError for mixed numeric and semantic ids" do
-        expect { WorkPackage.find([work_package.id, "MYPROJ-2"]) }
-          .to raise_error(ArgumentError, /multi-argument find are not yet supported/)
+      it "finds multiple semantic ids via array" do
+        expect(WorkPackage.find(["MYPROJ-1", "MYPROJ-2"])).to contain_exactly(work_package, work_package2)
+      end
+
+      it "finds mixed numeric and semantic ids" do
+        expect(WorkPackage.find([work_package.id, "MYPROJ-2"])).to contain_exactly(work_package, work_package2)
+      end
+
+      it "raises RecordNotFound when any semantic id is missing" do
+        expect { WorkPackage.find("MYPROJ-1", "MYPROJ-999") }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/73756

# What are you trying to accomplish?

Extend the semantic identifier `find` override to handle multi-argument calls — `find("PROJ-1", "PROJ-2")`, `find(["PROJ-1", "PROJ-2"])`, and mixed `find([1, "PROJ-2"])` — so that `WorkPackage.find` fully preserves the standard ActiveRecord interface contract.

Split out from #22718 for dedicated review as the complexity tradeoffs warrant separate discussion. The parent PR currently guards multi-arg semantic find with an `ArgumentError`.

# What approach did you choose and why?

Bulk-resolves semantic IDs to numeric IDs (current identifiers first, alias table fallback), then delegates to standard AR `find`. This preserves AR's contract: single query for the final lookup, raises `RecordNotFound` if any ID is missing, returns results matching the input order.

The resolution is split into `resolve_current_identifiers` and `resolve_alias_identifiers` to keep each method focused and respect the ABC size metric.

**Open questions for review:**
- Is the added complexity (~40 lines, 4 private methods) justified given no current production callers?
- Could a simpler per-ID resolution be acceptable, or is the N+1 risk too high for programmatically-built ID lists?
- Should this be deferred entirely until a concrete use case emerges?

# Merge checklist

- [x] Added/updated tests