### PR TITLE
[#73844] 401 error does not help user during jira import.

### DIFF
--- a/app/services/import/jira_client.rb
+++ b/app/services/import/jira_client.rb
@@ -269,7 +269,7 @@ module Import
         parse_json(response)
       else
         raise ApiError.new(
-          I18n.t("admin.jira.client.api_error", status: response.status),
+          I18n.t("admin.jira.client.#{response.status}_error", status: response.status, default: :"admin.jira.client.api_error"),
           status: response.status,
           response_body: response.body.to_s
         )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
         connection_timeout: "Connection to Jira server timed out: %{message}"
         parse_error: "Failed to parse Jira API response: %{message}"
         api_error: "Jira API returned error status %{status}"
+        401_error: "Jira API returned a 401 error. Your authentication token may have expired or lack the required permissions. Please ensure the token belongs to a Jira administrator."
       columns:
         projects: "Projects"
         last_change: "Last change"


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/73844

## What?

New error message in case of 401 is returned. It should be more helpful.
<img width="2212" height="984" alt="image" src="https://github.com/user-attachments/assets/705b35d8-e278-4399-b56c-08ff6ee470bf" />



