### PR TITLE
Remove hover styling from inline macros

### DIFF
--- a/app/components/op_primer/inline_macro_component.sass
+++ b/app/components/op_primer/inline_macro_component.sass
@@ -5,7 +5,3 @@
     border: 1px solid transparent
     border-radius: var(--borderRadius-medium)
     padding: 4px 8px
-
-    &:hover
-      cursor: default
-      border-color: var(--borderColor-emphasis)

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -283,10 +283,6 @@ $scrollbar-size: 10px
     &:has(.-multiline)
       display: inline-flex
 
-    &:hover
-      cursor: default
-      border-color: var(--borderColor-emphasis)
-
 @mixin unset-button-styles
   padding: 0
   margin: 0


### PR DESCRIPTION
We agreed that a hover effect doesn't make sense for these, because the macros themselves are not interactive. They may contain interactive elements, but these have their own hover effect.

# Ticket
https://community.openproject.org/wp/73928