### PR TITLE
[73986] Prevent browser title truncation at 70 chars

### DIFF
--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+MetaTags.configure do |config|
+  config.title_limit = nil
+end

--- a/spec/helpers/meta_tags_helper_spec.rb
+++ b/spec/helpers/meta_tags_helper_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe MetaTagsHelper do
+  describe "#output_title_and_meta_tags" do
+    before do
+      allow(Setting).to receive(:app_title).and_return("OpenProject")
+    end
+
+    it "does not truncate titles longer than 70 characters" do
+      long_subject = "A very long work package subject that exceeds seventy characters in total length"
+      helper.html_title(long_subject)
+
+      expect(helper.output_title_and_meta_tags)
+        .to eq("<title>A very long work package subject that exceeds seventy characters in total length | OpenProject</title>")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73986

# What are you trying to accomplish?

The meta-tags gem truncates the page title to 70 characters by default, which caused the browser title bar to show incomplete page titles.

I want to have the full title so that I can use Command+Option+Shift+C to copy the url as markdown confidently with Zen browser.

# What approach did you choose and why?

Add initializer that disables the default limit of 70 chars in meta-tags gem so the full title is always displayed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
