### PR TITLE
Fix a semantic identifier validation rule

### DIFF
--- a/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
@@ -58,7 +58,7 @@ module WorkPackages
       FORMAT_RULES = [
         [:too_long, ->(id, max) { id.length > max }],
         [:numerical, ->(id, _) { id.match?(/\A\d+\z/) }],
-        [:does_not_start_with_letter, ->(id, _) { !id.match?(/\A[A-Z]/) }],
+        [:does_not_start_with_letter, ->(id, _) { !id.match?(/\A[A-Za-z]/) }],
         [:special_characters, ->(id, _) { id.match?(/[^a-zA-Z0-9_]/) }],
         [:not_fully_uppercased, ->(id, _) { id != id.upcase }]
       ].freeze

--- a/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/work_packages/identifier_autofix/problematic_identifiers.rb
@@ -58,7 +58,7 @@ module WorkPackages
       FORMAT_RULES = [
         [:too_long, ->(id, max) { id.length > max }],
         [:numerical, ->(id, _) { id.match?(/\A\d+\z/) }],
-        [:starts_with_number, ->(id, _) { id.match?(/\A\d/) }],
+        [:does_not_start_with_letter, ->(id, _) { !id.match?(/\A[A-Z]/) }],
         [:special_characters, ->(id, _) { id.match?(/[^a-zA-Z0-9_]/) }],
         [:not_fully_uppercased, ->(id, _) { id != id.upcase }]
       ].freeze
@@ -83,7 +83,7 @@ module WorkPackages
       def scope
         @scope ||= exceeds_max_length
                       .or(contains_non_alphanumeric)
-                      .or(starts_with_digit)
+                      .or(does_not_start_with_letter)
                       .or(not_fully_uppercased)
       end
 
@@ -114,7 +114,7 @@ module WorkPackages
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)
       def contains_non_alphanumeric = Project.where("identifier ~ ?", "[^a-zA-Z0-9_]")
-      def starts_with_digit         = Project.where("identifier ~ ?", "^[0-9]")
+      def does_not_start_with_letter  = Project.where("identifier ~ ?", "^[^A-Za-z]")
       def not_fully_uppercased      = Project.where("identifier != UPPER(identifier)")
 
       def collision_error_reason(identifier)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -414,7 +414,7 @@ en:
         autofix_preview:
           error_too_long: Has to be 10 characters or fewer
           error_numerical: Cannot be purely numerical
-          error_starts_with_number: Cannot start with a number
+          error_does_not_start_with_letter: Must start with an uppercase letter
           error_special_characters: Special characters not allowed
           error_not_fully_uppercased: Must be uppercase
           error_in_use: Already in use as another project's active handle

--- a/spec/services/work_packages/identifier_autofix/preview_query_spec.rb
+++ b/spec/services/work_packages/identifier_autofix/preview_query_spec.rb
@@ -151,9 +151,9 @@ RSpec.describe WorkPackages::IdentifierAutofix::PreviewQuery do
       expect(result.projects_data.first[:error_reason]).to eq(:numerical)
     end
 
-    it "assigns :starts_with_number when identifier begins with a digit" do
+    it "assigns :does_not_start_with_letter when identifier begins with a digit" do
       create_project_with_raw_identifier(name: "Test", identifier: "1abc")
-      expect(result.projects_data.first[:error_reason]).to eq(:starts_with_number)
+      expect(result.projects_data.first[:error_reason]).to eq(:does_not_start_with_letter)
     end
 
     it "assigns :not_fully_uppercased when identifier is lowercase but otherwise valid" do

--- a/spec/services/work_packages/identifier_autofix/problematic_identifiers_spec.rb
+++ b/spec/services/work_packages/identifier_autofix/problematic_identifiers_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProblematicIdentifiers do
     end
 
     it "returns :special_characters when identifier has non-alphanumeric chars" do
-      expect(described_class.format_error_reason("ab-c")).to eq(:special_characters)
+      expect(described_class.format_error_reason("AB-C")).to eq(:special_characters)
     end
 
     it "returns :not_fully_uppercased when identifier is lowercase but otherwise valid" do

--- a/spec/services/work_packages/identifier_autofix/problematic_identifiers_spec.rb
+++ b/spec/services/work_packages/identifier_autofix/problematic_identifiers_spec.rb
@@ -55,8 +55,13 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProblematicIdentifiers do
       expect(analysis.scope).to include(Project.find(project.id))
     end
 
-    it "includes projects with identifiers starting with a digit" do
+    it "includes projects with identifiers not starting with a letter" do
       project = create_project_with_raw_identifier(name: "Test", identifier: "1abc")
+      expect(analysis.scope).to include(Project.find(project.id))
+    end
+
+    it "includes projects with identifiers starting with an underscore" do
+      project = create_project_with_raw_identifier(name: "Test", identifier: "_FOO")
       expect(analysis.scope).to include(Project.find(project.id))
     end
 
@@ -90,8 +95,12 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProblematicIdentifiers do
       expect(described_class.format_error_reason("12345")).to eq(:numerical)
     end
 
-    it "returns :starts_with_number when identifier begins with a digit" do
-      expect(described_class.format_error_reason("1abc")).to eq(:starts_with_number)
+    it "returns :does_not_start_with_letter when identifier begins with a digit" do
+      expect(described_class.format_error_reason("1abc")).to eq(:does_not_start_with_letter)
+    end
+
+    it "returns :does_not_start_with_letter when identifier begins with an underscore" do
+      expect(described_class.format_error_reason("_FOO")).to eq(:does_not_start_with_letter)
     end
 
     it "returns :special_characters when identifier has non-alphanumeric chars" do
@@ -139,7 +148,7 @@ RSpec.describe WorkPackages::IdentifierAutofix::ProblematicIdentifiers do
     end
 
     it "delegates format checks to .format_error_reason" do
-      expect(analysis.error_reason("ab-c")).to eq(:special_characters)
+      expect(analysis.error_reason("_FOO")).to eq(:does_not_start_with_letter)
     end
   end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The current ruleset contains a rule called `starts_with_number` with checks that the ID does not start with a number.

However, this does not rule out underscores -- these are allowed within semantic IDs, but _not_ at the beginning. 

Replace the rule with a more focused one.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
