### PR TITLE
[73714] Doubled scrollbar on a Board

### DIFF
--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -26,10 +26,15 @@
       </div>
     }
     @if (showHiddenListWarning) {
-      <span
-        class="boards-list--tooltip tooltip--right"
-        [attr.data-tooltip]="text.hiddenListWarning">
-        <i class="icon icon-attention"></i>
+      <span class="boards-list--tooltip">
+        <i id="boards-list--warning" class="icon icon-attention"></i>
+        <tool-tip
+          class="sr-only position-absolute"
+          popover="manual"
+          for="boards-list--warning"
+          id="boards-list--warning-tooltip"
+          data-direction="s"
+        >{{ text.hiddenListWarning }}</tool-tip>
       </span>
     }
     @if (board.editable) {

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
@@ -44,6 +44,7 @@ $board-list-top-offset: 18px
 
   .boards-list--add-item-text
     padding: 5px 15px 0 15px
+    white-space: nowrap
 
   .boards-list--container.-free &
     margin-top: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73714

# What are you trying to accomplish?
Avoid doubled scrollbars on the boards page when there is a warning info about hidden lists.

## Screenshots
<img width="574" height="368" alt="Bildschirmfoto 2026-04-17 um 11 03 44" src="https://github.com/user-attachments/assets/7bd69586-8def-46d0-9099-a094b6c52b5d" />


# What approach did you choose and why?
The old tooltip was allocating a lot of additional space on the right side. That was replaced by a primer tooltip instead
