### PR TITLE
[#73926] Add canonical meta tags to project & WP show pages

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -54,6 +54,21 @@ module MetaTagsHelper
         }.compact
   end
 
+  # Emits a <link rel="canonical"> pointing to the URL built from each record's
+  # current display identifier (the work package's display_id and the project's
+  # identifier), so search engines always see the most recent identifier even
+  # when the page was reached via an older alias.
+  def canonical_link_tag(work_package: nil, project: nil)
+    canonical_path =
+      if work_package && controller_name == "work_packages" && request.path_parameters[:id].present?
+        work_package_canonical_path(work_package)
+      elsif project && request.path.match?(%r{/projects/[^/]+})
+        project_canonical_path(project)
+      end
+
+    tag.link rel: :canonical, href: "#{request.base_url}#{canonical_path}" if canonical_path
+  end
+
   ##
   # Writer of html_title as string
   def html_title(*args)
@@ -70,5 +85,17 @@ module MetaTagsHelper
       parts << h(@project.name) if @project
       parts.concat @html_title.map(&:to_s) if @html_title
     end
+  end
+
+  private
+
+  def work_package_canonical_path(work_package)
+    request.path
+      .sub("/projects/#{request.path_parameters[:project_id]}", "/projects/#{work_package.project.identifier}")
+      .sub("/work_packages/#{request.path_parameters[:id]}", "/work_packages/#{work_package.display_id}")
+  end
+
+  def project_canonical_path(project)
+    request.path.sub(%r{/projects/[^/]+}, "/projects/#{project.identifier}")
   end
 end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -54,6 +54,19 @@ module MetaTagsHelper
         }.compact
   end
 
+  # Emits a <link rel="canonical"> pointing to the numeric-ID URL, normalising
+  # semantic identifiers and project slugs for search engines.
+  def canonical_link_tag
+    canonical_path =
+      if controller_name == "work_packages" && request.path_parameters[:id].present?
+        work_package_canonical_path
+      elsif @project && request.path.match?(%r{/projects/[^/]+})
+        project_canonical_path
+      end
+
+    tag.link rel: :canonical, href: "#{request.base_url}#{canonical_path}" if canonical_path
+  end
+
   ##
   # Writer of html_title as string
   def html_title(*args)
@@ -70,5 +83,17 @@ module MetaTagsHelper
       parts << h(@project.name) if @project
       parts.concat @html_title.map(&:to_s) if @html_title
     end
+  end
+
+  private
+
+  def work_package_canonical_path
+    request.path
+      .sub("/projects/#{request.path_parameters[:project_id]}", "/projects/#{@work_package.project_id}")
+      .sub("/work_packages/#{request.path_parameters[:id]}", "/work_packages/#{@work_package.id}")
+  end
+
+  def project_canonical_path
+    request.path.sub(%r{/projects/[^/]+}, "/projects/#{@project.id}")
   end
 end

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -1,6 +1,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">
 <%= output_title_and_meta_tags %>
+<%= canonical_link_tag(work_package: @work_package, project: @project) %>
 <%= appsignal_frontend_tag %>
 
 <% relative_url_root = OpenProject::Configuration["rails_relative_url_root"] || "" %>

--- a/app/views/layouts/_common_head.html.erb
+++ b/app/views/layouts/_common_head.html.erb
@@ -1,6 +1,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">
 <%= output_title_and_meta_tags %>
+<%= canonical_link_tag %>
 <%= appsignal_frontend_tag %>
 
 <% relative_url_root = OpenProject::Configuration["rails_relative_url_root"] || "" %>

--- a/modules/overviews/spec/requests/overviews/show_spec.rb
+++ b/modules/overviews/spec/requests/overviews/show_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "GET project overview", type: :rails_request do
+  let(:project) { create(:project) }
+
+  current_user { create(:admin) }
+
+  shared_examples "includes canonical link tag" do
+    it "renders a canonical link tag pointing to the current-identifier project URL" do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(<link rel="canonical" href="http://test.host/projects/#{project.identifier}">))
+    end
+  end
+
+  context "when accessed via the numeric ID" do
+    before { get "/projects/#{project.id}" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "when accessed via the string identifier" do
+    before { get "/projects/#{project.identifier}" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+
+    context "when accessed via the semantic identifier" do
+      before { get "/projects/#{project.identifier}" }
+
+      include_examples "includes canonical link tag"
+    end
+  end
+end

--- a/modules/overviews/spec/requests/overviews/show_spec.rb
+++ b/modules/overviews/spec/requests/overviews/show_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "GET project overview", type: :rails_request do
+  let(:project) { create(:project) }
+
+  current_user { create(:admin) }
+
+  shared_examples "includes canonical link tag" do
+    it "renders a canonical link tag pointing to the numeric-ID project URL" do
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(<link rel="canonical" href="http://test.host/projects/#{project.id}">))
+    end
+  end
+
+  context "when accessed via the numeric ID" do
+    before { get "/projects/#{project.id}" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "when accessed via the string identifier" do
+    before { get "/projects/#{project.identifier}" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+
+    context "when accessed via the semantic identifier" do
+      before { get "/projects/#{project.identifier}" }
+
+      include_examples "includes canonical link tag"
+    end
+  end
+end

--- a/spec/requests/projects/canonical_spec.rb
+++ b/spec/requests/projects/canonical_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "canonical meta tag on project-scoped pages", type: :rails_request do
+  let(:project) { create(:project) }
+
+  current_user { create(:admin) }
+
+  shared_examples "canonical points to numeric project ID" do |path_suffix|
+    it "renders a canonical link tag using the numeric project ID" do
+      get "/projects/#{project.identifier}#{path_suffix}"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(
+        %(<link rel="canonical" href="http://test.host/projects/#{project.id}#{path_suffix}">)
+      )
+    end
+  end
+
+  include_examples "canonical points to numeric project ID", ""
+  include_examples "canonical points to numeric project ID", "/members"
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+
+    include_examples "canonical points to numeric project ID", ""
+    include_examples "canonical points to numeric project ID", "/members"
+  end
+end

--- a/spec/requests/projects/canonical_spec.rb
+++ b/spec/requests/projects/canonical_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "canonical meta tag on project-scoped pages", type: :rails_request do
+  let(:project) { create(:project) }
+
+  current_user { create(:admin) }
+
+  shared_examples "canonical points to the current project identifier" do |path_suffix|
+    it "renders a canonical link tag using the current project identifier" do
+      get "/projects/#{project.id}#{path_suffix}"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(
+        %(<link rel="canonical" href="http://test.host/projects/#{project.identifier}#{path_suffix}">)
+      )
+    end
+  end
+
+  include_examples "canonical points to the current project identifier", ""
+  include_examples "canonical points to the current project identifier", "/members"
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+
+    include_examples "canonical points to the current project identifier", ""
+    include_examples "canonical points to the current project identifier", "/members"
+  end
+end

--- a/spec/requests/work_packages/show_spec.rb
+++ b/spec/requests/work_packages/show_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "GET work package show", type: :rails_request do
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+
+  current_user { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+  shared_examples "includes canonical link tag" do |tab: "activity"|
+    it "renders a canonical link tag pointing to the current-identifier URL" do
+      expect(response).to have_http_status(:ok)
+      expected_path = "/projects/#{project.identifier}/work_packages/#{work_package.display_id}/#{tab}"
+      expect(response.body).to include(%(<link rel="canonical" href="http://test.host#{expected_path}">))
+    end
+  end
+
+  context "when accessed via the project-scoped URL" do
+    before { get "/projects/#{project.id}/work_packages/#{work_package.id}/activity" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "when accessed via the project-scoped URL on the relations tab" do
+    before { get "/projects/#{project.id}/work_packages/#{work_package.id}/relations" }
+
+    include_examples "includes canonical link tag", tab: "relations"
+  end
+
+  context "when accessed via the global URL" do
+    before do
+      get "/work_packages/#{work_package.id}/activity"
+      follow_redirect!
+    end
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "when the work package does not exist" do
+    before { get "/projects/#{project.id}/work_packages/0/activity" }
+
+    it "renders a not-found response without raising" do
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include(%(<link rel="canonical"))
+    end
+  end
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+    let(:work_package) { create(:work_package, project:) }
+
+    context "when accessed via the semantic ID" do
+      before { get "/projects/#{project.id}/work_packages/#{work_package.identifier}/activity" }
+
+      include_examples "includes canonical link tag"
+    end
+  end
+end

--- a/spec/requests/work_packages/show_spec.rb
+++ b/spec/requests/work_packages/show_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe "GET work package show", type: :rails_request do
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+
+  current_user { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+  shared_examples "includes canonical link tag" do |tab: "activity"|
+    it "renders a canonical link tag pointing to the project-scoped DB-ID URL" do
+      expect(response).to have_http_status(:ok)
+      expected_path = "/projects/#{project.id}/work_packages/#{work_package.id}/#{tab}"
+      expect(response.body).to include(%(<link rel="canonical" href="http://test.host#{expected_path}">))
+    end
+  end
+
+  context "when accessed via the project-scoped URL" do
+    before { get "/projects/#{project.id}/work_packages/#{work_package.id}/activity" }
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "when accessed via the project-scoped URL on the relations tab" do
+    before { get "/projects/#{project.id}/work_packages/#{work_package.id}/relations" }
+
+    include_examples "includes canonical link tag", tab: "relations"
+  end
+
+  context "when accessed via the global URL" do
+    before do
+      get "/work_packages/#{work_package.id}/activity"
+      follow_redirect!
+    end
+
+    include_examples "includes canonical link tag"
+  end
+
+  context "in semantic instance mode", with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "PROJ") }
+    let(:work_package) { create(:work_package, project:) }
+
+    context "when accessed via the semantic ID" do
+      before { get "/projects/#{project.id}/work_packages/#{work_package.identifier}/activity" }
+
+      include_examples "includes canonical link tag"
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-jira-exit/work_packages/73926/activity

# Merge Pre-requirements
- https://github.com/opf/openproject/pull/22718

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
We have been implementing support for historical project URLs as well as semantic identifiers. A side effect of this is the fact that OP may now generate multiple links that lead to the exact same resource. 

We do not want to confuse crawlers, so let's group those multiple versions together via a single canonical meta tag. 


## Screenshots
Work package via canonical identifier:
<img width="849" height="296" alt="Screenshot 2026-06-16 at 18 15 19" src="https://github.com/user-attachments/assets/bc72735c-49f1-4aa0-94e2-2e0e3f06775e" />

Work package via old identifier:
<img width="859" height="292" alt="Screenshot 2026-06-16 at 18 17 56" src="https://github.com/user-attachments/assets/f2963e7d-0e76-4766-8391-b519281cb75e" />

Project via canonical identifier: 
<img width="592" height="293" alt="Screenshot 2026-06-16 at 18 15 30" src="https://github.com/user-attachments/assets/5b926047-e510-4522-afea-64bc48eedff0" />

Project via old identifier:
<img width="602" height="297" alt="Screenshot 2026-06-16 at 18 16 19" src="https://github.com/user-attachments/assets/ab4b4ad0-04e2-4a41-9f4c-dabfa495df91" />


# What approach did you choose and why?
The tag is present on top of every project/WP show page, no matter which URL was used to get to it or which tab is open in the UI.

The unified canonical format is `/projects/:numeric_db_id/work_packages/:numeric_db_id`, chosen as the most stable and yet explicit option out of multiple.

You may consult the work package to see the reasoning behind this specific format.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
