### PR TITLE
Feature/73081 backlog buckets in backlog and sprints view

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -74,3 +74,6 @@ OpenProject::FeatureDecisions.add :semantic_work_package_ids,
                                   description: "Enables the use of semantic work package IDs, " \
                                                "in the schema <project identifier>-<sequence number>. " \
                                                "See #41855 for details."
+
+OpenProject::FeatureDecisions.add :backlog_buckets,
+                                  description: "Enables backlog buckets."

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_component.html.erb
@@ -1,0 +1,48 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= component_wrapper(tag: :section) do %>
+  <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
+    <% border_box.with_header(id: dom_target(backlog_bucket, :header)) do %>
+      <%= render(Backlogs::BacklogBucketHeaderComponent.new(backlog_bucket:, project:, work_packages:, folded: folded?)) %>
+    <% end %>
+    <% if work_packages.empty? %>
+      <% border_box.with_row(data: { empty_list_item: true }) do %>
+        <!-- TODO: separate inbox component also to have different blankslate titles? -->
+        <%=
+          render Primer::Beta::Blankslate.new(role: "status", aria: { live: "polite" }) do |blankslate|
+            blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
+            blankslate.with_description_content(t(".blankslate_description"))
+          end
+        %>
+      <% end %>
+    <% end %>
+    <%= render Backlogs::BacklogBucketItemComponent.with_collection(work_packages, container: border_box, project:) %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class BacklogBucketComponent < ApplicationComponent
+    include Primer::AttributesHelper
+    include OpTurbo::Streamable
+    include Backlogs::CommonHelper
+
+    attr_reader :backlog_bucket, :project, :work_packages, :current_user
+
+    def initialize(backlog_bucket:, project:, current_user: User.current, **system_arguments)
+      super()
+
+      @backlog_bucket = backlog_bucket
+      @project = project
+      @current_user = current_user
+      @work_packages = backlog_bucket.work_packages
+
+      @system_arguments = system_arguments
+      @system_arguments[:id] = dom_id(backlog_bucket)
+      @system_arguments[:list_id] = "#{@system_arguments[:id]}-list"
+      @system_arguments[:padding] = :condensed
+      @system_arguments[:data] = merge_data(
+        @system_arguments,
+        { data: drop_target_config },
+        { data: { test_selector: "backlog-bucket-#{backlog_bucket.id}" } }
+      )
+    end
+
+    def wrapper_uniq_by
+      backlog_bucket.id
+    end
+
+    private
+
+    def folded?
+      current_user.pref[:backlogs_versions_default_fold_state] == "closed"
+    end
+
+    def drop_target_config
+      {
+        generic_drag_and_drop_target: "container",
+        target_container_accessor: ":scope > ul",
+        target_id: backlog_bucket.persisted? ? "backlog_bucket:#{backlog_bucket.id}" : "inbox",
+        target_allowed_drag_type: "story"
+      }
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_header_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_header_component.html.erb
@@ -1,0 +1,76 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%= component_wrapper(tag: :header) do %>
+  <!-- TODO: define separate op-backlog-bucket-header -->
+  <%= grid_layout("op-sprint-header", tag: :div) do |grid| %>
+    <% grid.with_area(:collapsible) do %>
+      <%=
+        render(
+          Primer::OpenProject::BorderBox::CollapsibleHeader.new(
+            collapsible_id: "#{dom_id(backlog_bucket)}-list",
+            collapsed:,
+            multi_line: true
+          )
+        ) do |collapsible|
+      %>
+         <% collapsible.with_title { backlog_bucket.name } %>
+         <% collapsible.with_count(
+              scheme: :primary,
+              count: work_package_count,
+              round: true,
+              limit: 1_000,
+              hide_if_zero: true,
+              aria: {
+                label: t(".label_work_package_count", count: work_package_count),
+                live: "polite"
+              }
+            ) %>
+          <% collapsible.with_description do %>
+            <%=
+              render(
+                Primer::Beta::Text.new(
+                  color: :subtle,
+                  mr: 3,
+                  classes: "velocity",
+                  aria: { live: "polite" }
+                )
+              ) do
+            %>
+              <%= story_points %>&nbsp;<%= t(:"backlogs.points_label", count: story_points) %>
+            <% end %>
+          <% end %>
+       <% end %>
+    <% end %>
+
+    <% grid.with_area(:menu) do %>
+      <%= render(Backlogs::BacklogBucketMenuComponent.new(backlog_bucket:, project:)) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_header_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_header_component.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class BacklogBucketHeaderComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+    include OpTurbo::Streamable
+    include Primer::FetchOrFallbackHelper
+    include Redmine::I18n
+    include Backlogs::CommonHelper
+
+    attr_reader :backlog_bucket, :project, :work_packages, :collapsed, :current_user
+
+    def initialize(
+      backlog_bucket:,
+      project:,
+      work_packages:,
+      folded: false,
+      current_user: User.current
+    )
+      super()
+
+      @backlog_bucket = backlog_bucket
+      @project = project
+      @work_packages = work_packages
+      @collapsed = folded
+      @current_user = current_user
+    end
+
+    def wrapper_uniq_by
+      backlog_bucket.id
+    end
+
+    private
+
+    def story_points
+      @story_points ||= work_packages.sum { it.story_points || 0 }
+    end
+
+    def work_package_count
+      @work_package_count ||= work_packages.size
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.html.erb
@@ -1,0 +1,72 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<% container.with_row(**row_options) do %>
+  <%= grid_layout("op-backlogs-story", tag: :article) do |grid| %>
+    <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
+      <%= if draggable?
+            render(
+              Primer::OpenProject::DragHandle.new(
+                classes: "op-backlogs-story--drag_handle_button",
+                label: t(".label_drag_work_package", name: work_package.subject)
+              )
+            )
+          end %>
+    <% end %>
+    <% grid.with_area(:info_line) do %>
+      <%= render(WorkPackages::InfoLineComponent.new(work_package:)) %>
+    <% end %>
+    <% grid.with_area(:points) do %>
+      <%= render(Primer::Beta::Text.new(color: :subtle)) do %>
+        <%= story_points %>
+        <span class="op-backlogs-points-label"> <%= t(:"backlogs.points_label", count: story_points) %></span>
+      <% end %>
+    <% end %>
+    <% grid.with_area(:menu) do %>
+      <%= render(
+            Primer::Alpha::ActionMenu.new(
+              menu_id: dom_target(work_package, :menu),
+              src: menu_project_backlogs_inbox_path(project, work_package),
+              anchor_align: :end,
+              classes: "hide-when-print"
+            )
+          ) do |menu| %>
+        <% menu.with_show_button(
+             scheme: :invisible,
+             icon: :"kebab-horizontal",
+             "aria-label": t(".label_actions"),
+             tooltip_direction: :se
+           ) %>
+      <% end %>
+    <% end %>
+    <% grid.with_area(:subject) do %>
+      <%= render(Primer::Beta::Text.new(font_weight: :semibold)) { work_package.subject } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class BacklogBucketItemComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    with_collection_parameter :work_package
+
+    attr_reader :work_package, :project, :container, :current_user
+
+    def initialize(work_package:, project:, container:, current_user: User.current)
+      super()
+
+      @work_package = work_package
+      @project = project
+      @container = container
+      @current_user = current_user
+    end
+
+    private
+
+    def story_points
+      work_package.story_points || 0
+    end
+
+    def draggable?
+      current_user.allowed_in_project?(:manage_sprint_items, project)
+    end
+
+    def row_options
+      {
+        id: dom_id(work_package),
+        classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
+        data: {
+          draggable_id: work_package.id,
+          draggable_type: "story",
+          drop_url: move_project_backlogs_inbox_path(project, work_package),
+          story: true,
+          controller: "backlogs--story",
+          backlogs__story_id_value: work_package.id,
+          backlogs__story_split_url_value: project_backlogs_backlog_details_path(project, work_package),
+          backlogs__story_full_url_value: work_package_path(work_package),
+          backlogs__story_selected_class: "Box-row--blue",
+          test_selector: card_test_selector
+        },
+        tabindex: 0
+      }
+    end
+
+    def card_test_selector
+      "work-package-#{work_package.id}"
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.html.erb
@@ -1,0 +1,65 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%=
+  render(Primer::Alpha::ActionMenu.new(**@system_arguments)) do |menu|
+    menu.with_show_button(
+      scheme: :invisible,
+      icon: :"kebab-horizontal",
+      "aria-label": t(".label_actions"),
+      tooltip_direction: :se
+    )
+
+    with_item_group(menu) do
+      if backlog_bucket.persisted? && user_allowed?(:create_sprints)
+        menu.with_item(
+          id: dom_target(backlog_bucket, :menu, :edit_backlog_bucket),
+          label: t(".action_menu.edit_backlog_bucket"),
+          href: edit_dialog_project_backlogs_backlog_bucket_path(project, backlog_bucket),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :pencil)
+        end
+
+        menu.with_item(
+          id: dom_target(backlog_bucket, :menu, :delete_backlog_bucket),
+          label: t(".action_menu.delete_backlog_bucket"),
+          scheme: :danger,
+          href: project_backlogs_backlog_bucket_path(project, backlog_bucket),
+          form_arguments: {
+            method: :delete,
+            data: { turbo_confirm: t("text_are_you_sure") }
+          }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :trash)
+        end
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class BacklogBucketMenuComponent < ApplicationComponent
+    include OpPrimer::ComponentHelpers
+
+    attr_reader :backlog_bucket, :project, :current_user
+
+    def initialize(backlog_bucket:, project:, current_user: User.current, **system_arguments)
+      super()
+
+      @backlog_bucket = backlog_bucket
+      @project = project
+      @current_user = current_user
+
+      @system_arguments = system_arguments
+      @system_arguments[:menu_id] = dom_target(backlog_bucket, :menu)
+      @system_arguments[:anchor_align] = :end
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "hide-when-print"
+      )
+    end
+
+    private
+
+    def user_allowed?(permission)
+      current_user.allowed_in_project?(permission, project)
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/new_backlog_bucket_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/new_backlog_bucket_dialog_component.html.erb
@@ -1,0 +1,69 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(
+    Primer::Alpha::Dialog.new(
+      title:,
+      size: :large,
+      id: DIALOG_ID
+    )
+  ) do |d|
+    d.with_header(variant: :large)
+
+    d.with_body do
+      render(Backlogs::NewBacklogBucketFormComponent.new(backlog_bucket:))
+    end
+
+    d.with_footer do
+      component_collection do |buttons|
+        buttons.with_component(
+          Primer::Beta::Button.new(
+            data: {
+              close_dialog_id: DIALOG_ID
+            }
+          )
+        ) do
+          t("button_cancel")
+        end
+
+        buttons.with_component(
+          Primer::Beta::Button.new(
+            scheme: :primary,
+            form: FORM_ID,
+            data: { turbo: true },
+            type: :submit
+          )
+        ) do
+          button_caption
+        end
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/new_backlog_bucket_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/new_backlog_bucket_dialog_component.rb
@@ -29,16 +29,37 @@
 #++
 
 module Backlogs
-  module CommonHelper
-    def allow_sprint_creation?(project)
-      current_user.allowed_in_project?(:create_sprints, project) &&
-        !project.receive_shared_sprints?
+  class NewBacklogBucketDialogComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+    include Primer::FetchOrFallbackHelper
+
+    DIALOG_ID = "new-backlog-bucket-dialog"
+    FORM_ID = "new-backlog-bucket-dialog-form"
+    FOOTER_ID = "new-backlog-bucket-dialog-footer"
+
+    STATE_DEFAULT = :create
+    STATE_OPTIONS = [STATE_DEFAULT, :edit].freeze
+
+    attr_reader :backlog_bucket, :state
+
+    delegate :create?, :edit?, to: :state
+
+    def initialize(backlog_bucket:, state: STATE_DEFAULT)
+      super
+
+      @backlog_bucket = backlog_bucket
+      @state = ActiveSupport::StringInquirer.new(fetch_or_fallback(STATE_OPTIONS, state, STATE_DEFAULT).to_s)
     end
 
-    alias_method :allow_backlog_bucket_creation?, :allow_sprint_creation?
+    private
 
-    def show_all_backlog
-      ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
+    def title
+      create? ? t(:label_backlog_bucket_new) : t(:label_backlog_bucket_edit)
+    end
+
+    def button_caption
+      create? ? t(:button_create) : t(:button_save)
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/new_backlog_bucket_form_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/new_backlog_bucket_form_component.html.erb
@@ -1,0 +1,52 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  component_wrapper do
+    primer_form_with(
+      id: Backlogs::NewBacklogBucketFormComponent::FORM_ID,
+      model: backlog_bucket,
+      scope: :backlog_bucket,
+      method: http_verb,
+      class: "op-backlog-buckets--form",
+      url: form_url
+    ) do |f|
+      flex_layout(mb: 2) do |flex|
+        if @base_errors&.any?
+          flex.with_row do
+            render(Primer::Alpha::Banner.new(mb: 3, icon: :stop, scheme: :danger)) { @base_errors.join("\n") }
+          end
+        end
+        flex.with_row(mb: 3) do
+          render Backlogs::BacklogBuckets::DetailsForm.new(f)
+        end
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/new_backlog_bucket_form_component.rb
+++ b/modules/backlogs/app/components/backlogs/new_backlog_bucket_form_component.rb
@@ -29,16 +29,34 @@
 #++
 
 module Backlogs
-  module CommonHelper
-    def allow_sprint_creation?(project)
-      current_user.allowed_in_project?(:create_sprints, project) &&
-        !project.receive_shared_sprints?
+  class NewBacklogBucketFormComponent < ApplicationComponent
+    include ApplicationHelper
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    FORM_ID = NewBacklogBucketDialogComponent::FORM_ID
+
+    attr_reader :backlog_bucket
+
+    def initialize(backlog_bucket:, base_errors: nil)
+      super
+
+      @backlog_bucket = backlog_bucket
+      @base_errors = base_errors
     end
 
-    alias_method :allow_backlog_bucket_creation?, :allow_sprint_creation?
+    private
 
-    def show_all_backlog
-      ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
+    def http_verb
+      @backlog_bucket.new_record? ? :post : :put
+    end
+
+    def form_url
+      if @backlog_bucket.new_record?
+        project_backlogs_backlog_buckets_path(@backlog_bucket.project)
+      else
+        project_backlogs_backlog_bucket_path(@backlog_bucket.project, @backlog_bucket)
+      end
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
@@ -32,6 +32,7 @@ module Backlogs
   class BacklogBucketsController < BaseController
     include OpTurbo::ComponentStream
 
+    before_action :check_feature_flag
     before_action :find_backlog_bucket, only: %i[edit_dialog update destroy]
 
     def new_dialog
@@ -96,6 +97,10 @@ module Backlogs
         ),
         status: :bad_request
       )
+    end
+
+    def check_feature_flag
+      render_404 unless OpenProject::FeatureDecisions.backlog_buckets_active?
     end
 
     def find_backlog_bucket

--- a/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class BacklogBucketsController < BaseController
+    include OpTurbo::ComponentStream
+
+    def new_dialog
+      backlog_bucket = Agile::BacklogBucket.new(project: @project)
+
+      respond_with_dialog Backlogs::NewBacklogBucketDialogComponent.new(backlog_bucket:)
+    end
+
+    def create # rubocop:disable Metrics/AbcSize
+      call = ::BacklogBuckets::CreateService
+               .new(user: current_user)
+               .call(attributes: backlog_bucket_params)
+
+      if call.success?
+        flash[:notice] = I18n.t(:notice_successful_create)
+        render turbo_stream: turbo_stream.redirect_to(project_backlogs_backlog_path(@project))
+      else
+        update_new_backlog_bucket_form_component_via_turbo_stream(backlog_bucket: call.result, base_errors: call.errors[:base])
+        respond_with_turbo_streams
+      end
+    end
+
+    private
+
+    def update_new_backlog_bucket_form_component_via_turbo_stream(backlog_bucket:, base_errors: nil)
+      update_via_turbo_stream(
+        component: Backlogs::NewBacklogBucketFormComponent.new(
+          backlog_bucket:,
+          base_errors:
+        ),
+        status: :bad_request
+      )
+    end
+
+    def backlog_bucket_params
+      edit_backlog_bucket_params.merge(project: @project)
+    end
+
+    def edit_backlog_bucket_params
+      params.expect(backlog_bucket: %i[name])
+    end
+  end
+end

--- a/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
@@ -32,7 +32,7 @@ module Backlogs
   class BacklogBucketsController < BaseController
     include OpTurbo::ComponentStream
 
-    before_action :find_backlog_bucket, only: %i[edit_dialog update]
+    before_action :find_backlog_bucket, only: %i[edit_dialog update destroy]
 
     def new_dialog
       backlog_bucket = Agile::BacklogBucket.new(project: @project)
@@ -70,6 +70,20 @@ module Backlogs
         update_new_backlog_bucket_form_component_via_turbo_stream(backlog_bucket: call.result, base_errors: call.errors[:base])
         respond_with_turbo_streams
       end
+    end
+
+    def destroy
+      call = ::BacklogBuckets::DeleteService
+               .new(user: current_user, model: @backlog_bucket)
+               .call
+
+      if call.success?
+        flash[:notice] = I18n.t(:notice_successful_delete)
+      else
+        flash[:error] = call.errors.full_messages.join(", ")
+      end
+
+      render turbo_stream: turbo_stream.redirect_to(project_backlogs_backlog_path(@project))
     end
 
     private

--- a/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
@@ -32,10 +32,16 @@ module Backlogs
   class BacklogBucketsController < BaseController
     include OpTurbo::ComponentStream
 
+    before_action :find_backlog_bucket, only: %i[edit_dialog update]
+
     def new_dialog
       backlog_bucket = Agile::BacklogBucket.new(project: @project)
 
       respond_with_dialog Backlogs::NewBacklogBucketDialogComponent.new(backlog_bucket:)
+    end
+
+    def edit_dialog
+      respond_with_dialog Backlogs::NewBacklogBucketDialogComponent.new(backlog_bucket: @backlog_bucket, state: :edit)
     end
 
     def create # rubocop:disable Metrics/AbcSize
@@ -45,6 +51,20 @@ module Backlogs
 
       if call.success?
         flash[:notice] = I18n.t(:notice_successful_create)
+        render turbo_stream: turbo_stream.redirect_to(project_backlogs_backlog_path(@project))
+      else
+        update_new_backlog_bucket_form_component_via_turbo_stream(backlog_bucket: call.result, base_errors: call.errors[:base])
+        respond_with_turbo_streams
+      end
+    end
+
+    def update # rubocop:disable Metrics/AbcSize
+      call = ::BacklogBuckets::UpdateService
+               .new(user: current_user, model: @backlog_bucket)
+               .call(attributes: edit_backlog_bucket_params)
+
+      if call.success?
+        flash[:notice] = I18n.t(:notice_successful_update)
         render turbo_stream: turbo_stream.redirect_to(project_backlogs_backlog_path(@project))
       else
         update_new_backlog_bucket_form_component_via_turbo_stream(backlog_bucket: call.result, base_errors: call.errors[:base])
@@ -62,6 +82,10 @@ module Backlogs
         ),
         status: :bad_request
       )
+    end
+
+    def find_backlog_bucket
+      @backlog_bucket = Agile::BacklogBucket.where(project: @project).find(params[:id])
     end
 
     def backlog_bucket_params

--- a/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
@@ -64,6 +64,12 @@ module Backlogs
     end
 
     def load_backlogs
+      if OpenProject::FeatureDecisions.backlog_buckets_active?
+        @backlog_buckets = Agile::BacklogBucket.for_project(@project)
+      else
+        @inbox_work_packages = Backlog.inbox_for(project: @project)
+      end
+
       @sprints = Agile::Sprint.for_project(@project)
                               .not_completed
                               .order_by_date
@@ -75,7 +81,6 @@ module Backlogs
                                .order_by_position
                                .group_by(&:sprint_id)
       @active_sprint_ids = @sprints.select(&:active?).map(&:id)
-      @inbox_work_packages = Backlog.inbox_for(project: @project)
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
@@ -36,11 +36,11 @@ module Backlogs
       :backlog
     end
 
-    before_action :load_backlogs, only: :show
-
     def show
       case turbo_frame_request_id
       when "backlogs_container"
+        load_backlogs
+
         render partial: "backlogs/backlog/backlog_list", layout: false
       else
         render "backlogs/backlog/show"
@@ -52,6 +52,7 @@ module Backlogs
         render "work_packages/split_view", layout: false
       else
         load_backlogs
+
         render "backlogs/backlog/show"
       end
     end

--- a/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
@@ -31,6 +31,7 @@
 module Backlogs
   class InboxController < BaseController
     include OpTurbo::ComponentStream
+    include Backlogs::Move
 
     before_action :load_work_package
 
@@ -69,8 +70,7 @@ module Backlogs
 
     # Move a work package from the Inbox to a Sprint, or reorder it within the Inbox.
     def move
-      target_type, sprint_id = move_params[:target_id].split(":", 2)
-      attributes = target_type == "sprint" ? { sprint_id: } : {}
+      attributes = move_attributes_from_target
 
       call = Stories::UpdateService
         .new(user: current_user, story: @work_package)
@@ -79,7 +79,7 @@ module Backlogs
       return failure_response(call.message) unless call.success?
 
       replace_inbox_component_via_turbo_stream
-      replace_sprint_component_via_turbo_stream(sprint_id) if target_type == "sprint"
+      replace_sprint_component_via_turbo_stream(attributes[:sprint_id]) if attributes[:sprint_id]
       respond_with_turbo_streams
     end
 

--- a/modules/backlogs/app/controllers/backlogs/move.rb
+++ b/modules/backlogs/app/controllers/backlogs/move.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  # TODO: remove this very temporary concern
+  module Move
+    extend ActiveSupport::Concern
+
+    private
+
+    def move_attributes_from_target
+      target_type, target_id = move_params[:target_id].split(":", 2)
+
+      case target_type
+      when "sprint"
+        { backlog_bucket_id: nil, sprint_id: target_id }
+      when "backlog_bucket"
+        { backlog_bucket_id: target_id, sprint_id: nil }
+      when "inbox"
+        { backlog_bucket_id: nil, sprint_id: nil }
+      else
+        raise ArgumentError, "target_type must be one of: backlog_bucket, sprint, inbox."
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -31,6 +31,7 @@
 module Backlogs
   class WorkPackagesController < BaseController
     include OpTurbo::ComponentStream
+    include Backlogs::Move
 
     before_action :load_story
 
@@ -54,7 +55,7 @@ module Backlogs
       # so we memoize the previous sprint_id before the call.
       sprint_id_was = @story.sprint_id
 
-      move_attributes = infer_attributes_from_target
+      move_attributes = move_attributes_from_target
       unless move_work_package(move_attributes).success?
         return respond_with_turbo_streams(status: :unprocessable_entity)
       end
@@ -130,19 +131,6 @@ module Backlogs
 
       # Update the target component so that the moved story shows up
       replace_sprint_component_via_turbo_stream(sprint: new_sprint)
-    end
-
-    def infer_attributes_from_target
-      target_type, target_id = move_params[:target_id].split(":")
-
-      case target_type
-      when "sprint"
-        { sprint_id: target_id }
-      when "inbox"
-        { sprint_id: nil }
-      else
-        raise ArgumentError, "target_type must include one of: sprint, inbox."
-      end
     end
 
     def target_sprint?(move_attributes)

--- a/modules/backlogs/app/forms/backlogs/backlog_buckets/details_form.rb
+++ b/modules/backlogs/app/forms/backlogs/backlog_buckets/details_form.rb
@@ -29,16 +29,19 @@
 #++
 
 module Backlogs
-  module CommonHelper
-    def allow_sprint_creation?(project)
-      current_user.allowed_in_project?(:create_sprints, project) &&
-        !project.receive_shared_sprints?
-    end
+  module BacklogBuckets
+    class DetailsForm < ApplicationForm
+      form do |f|
+        f.hidden(name: :id)
 
-    alias_method :allow_backlog_bucket_creation?, :allow_sprint_creation?
-
-    def show_all_backlog
-      ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
+        f.text_field(
+          label: attribute_name(:name),
+          name: :name,
+          required: true,
+          autofocus: true,
+          w: :full
+        )
+      end
     end
   end
 end

--- a/modules/backlogs/app/helpers/backlogs/common_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/common_helper.rb
@@ -30,12 +30,14 @@
 
 module Backlogs
   module CommonHelper
-    def allow_sprint_creation?(project)
-      current_user.allowed_in_project?(:create_sprints, project) &&
-        !project.receive_shared_sprints?
+    def allow_backlog_bucket_creation?(project)
+      current_user.allowed_in_project?(:create_sprints, project)
     end
 
-    alias_method :allow_backlog_bucket_creation?, :allow_sprint_creation?
+    def allow_sprint_creation?(project)
+      allow_backlog_bucket_creation?(project) &&
+        !project.receive_shared_sprints?
+    end
 
     def show_all_backlog
       ActiveRecord::Type::Boolean.new.cast(params[:all]) || false

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -32,11 +32,59 @@ See COPYRIGHT and LICENSE files for more details.
        data-generic-drag-and-drop-position-mode-value="prev_id">
     <div id="owner_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
-      <%= render Backlogs::InboxComponent.new(
+      <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
+        <%=
+          render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
+            head.with_heading(
+              tag: :h3,
+              size: :medium,
+              font_weight: :bold,
+              display: :inline_flex,
+              align_items: :center,
+              classes: "gap-2"
+            ) do
+              concat t(:label_backlog)
+              concat render(
+                Primer::Beta::Counter.new(
+                  scheme: :default,
+                  count: 1 / 0.0,
+                  round: true,
+                  limit: 1_000,
+                  hide_if_zero: true
+                )
+              )
+            end
+
+            if allow_backlog_bucket_creation?(@project)
+              head.with_actions do
+                render Primer::Beta::Button.new(
+                  tag: :a,
+                  label: Agile::BacklogBucket.human_model_name,
+                  href: new_dialog_project_backlogs_backlog_buckets_path(@project),
+                  data: {
+                    controller: "async-dialog",
+                    test_selector: "op-backlog-buckets--new-backlog-bucket-button"
+                  }
+                ) do |button|
+                  button.with_leading_visual_icon(icon: :plus)
+                  Agile::BacklogBucket.human_model_name
+                end
+              end
+            end
+          end
+        %>
+        <% @backlog_buckets.each do |backlog_bucket| %>
+          <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
+        <% end %>
+      <% else %>
+        <%=
+          render Backlogs::InboxComponent.new(
             work_packages: @inbox_work_packages,
             project: @project,
             show_all: show_all_backlog
-          ) %>
+          )
+        %>
+      <% end %>
     </div>
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -47,7 +47,7 @@ See COPYRIGHT and LICENSE files for more details.
               concat render(
                 Primer::Beta::Counter.new(
                   scheme: :default,
-                  count: 1 / 0.0,
+                  count: @backlog_buckets.sum { it.work_packages.length },
                   round: true,
                   limit: 1_000,
                   hide_if_zero: true

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -215,6 +215,8 @@ en:
     story_points_ideal: "Story points (ideal)"
 
   label_backlog: "Backlog"
+  label_backlog_bucket_edit: "Edit backlog bucket"
+  label_backlog_bucket_new: "New backlog bucket"
   label_inbox: "Inbox"
   label_backlogs: "Backlogs"
   label_burndown_chart: "Burndown chart"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -130,6 +130,14 @@ en:
       title: "Backlog admin settings are evolving"
       text: "We are currently redesigning the Backlogs module. Admin settings for sprints and backlogs will be visible here in the near future. Project-level settings remain available."
 
+    backlog_bucket_component:
+      blankslate_title: "Backlog bucket is empty"
+      blankslate_description: "Drag items here to add them."
+
+    backlog_bucket_item_component:
+      label_drag_work_package: "Move %{name}"
+      label_actions: "Work package actions"
+
     sprint_component:
       blankslate_title: "%{name} is empty"
       blankslate_description: "No items planned yet. Drag items here to add them."
@@ -167,6 +175,18 @@ en:
         receive_shared_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
         receive_shared_no_actions_description_text: "This project receives shared sprints from a different project, but none are available right now."
         settings_link_text: "project settings"
+
+    backlog_bucket_menu_component:
+      label_actions: "Backlog bucket actions"
+      action_menu:
+        edit_backlog_bucket: "Edit backlog bucket"
+        delete_backlog_bucket: "Delete backlog bucket"
+
+    backlog_bucket_header_component:
+      label_work_package_count:
+        zero: "No stories in backlog bucket"
+        one: "%{count} story in backlog bucket"
+        other: "%{count} stories in backlog bucket"
 
     sprint_header_component:
       label_start_sprint: "Start"

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
           work_package_split_view: true,
           defaults: { tab: :overview }
 
-      resources :backlog_buckets, only: %i[create update] do
+      resources :backlog_buckets, only: %i[create update destroy] do
         collection do
           get :new_dialog
         end

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -66,6 +66,12 @@ Rails.application.routes.draw do
           work_package_split_view: true,
           defaults: { tab: :overview }
 
+      resources :backlog_buckets, only: %i[create] do
+        collection do
+          get :new_dialog
+        end
+      end
+
       resources :sprints, param: :sprint_id, only: %i[create update] do
         collection do
           get :new_dialog

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -66,9 +66,13 @@ Rails.application.routes.draw do
           work_package_split_view: true,
           defaults: { tab: :overview }
 
-      resources :backlog_buckets, only: %i[create] do
+      resources :backlog_buckets, only: %i[create update] do
         collection do
           get :new_dialog
+        end
+
+        member do
+          get :edit_dialog
         end
       end
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -69,7 +69,7 @@ module OpenProject::Backlogs
                    require: :member
 
         permission :create_sprints,
-                   { "backlogs/backlog_buckets": %i[new_dialog create edit_dialog update],
+                   { "backlogs/backlog_buckets": %i[new_dialog create edit_dialog update destroy],
                      "backlogs/sprints": %i[new_dialog refresh_form create edit_dialog update] },
                    permissible_on: :project,
                    require: :member,

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -69,7 +69,8 @@ module OpenProject::Backlogs
                    require: :member
 
         permission :create_sprints,
-                   { "backlogs/sprints": %i[new_dialog refresh_form create edit_dialog update] },
+                   { "backlogs/backlog_buckets": %i[new_dialog create],
+                     "backlogs/sprints": %i[new_dialog refresh_form create edit_dialog update] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: :view_sprints

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -69,7 +69,7 @@ module OpenProject::Backlogs
                    require: :member
 
         permission :create_sprints,
-                   { "backlogs/backlog_buckets": %i[new_dialog create],
+                   { "backlogs/backlog_buckets": %i[new_dialog create edit_dialog update],
                      "backlogs/sprints": %i[new_dialog refresh_form create edit_dialog update] },
                    permissible_on: :project,
                    require: :member,

--- a/modules/backlogs/lib/open_project/backlogs/list.rb
+++ b/modules/backlogs/lib/open_project/backlogs/list.rb
@@ -32,7 +32,7 @@ module OpenProject::Backlogs::List
   extend ActiveSupport::Concern
 
   included do
-    acts_as_list touch_on_update: false, scope: %i[project_id sprint_id]
+    acts_as_list touch_on_update: false, scope: %i[project_id backlog_bucket_id sprint_id]
 
     # acts as list adds a before destroy hook which messes
     # with the parent_id_was value

--- a/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Backlogs::BacklogController do
   shared_let(:project) { create(:project) }
   shared_let(:status) { create(:status, name: "status 1", is_default: true) }
   shared_let(:sprint) { create(:agile_sprint, project:) }
+  shared_let(:backlog_bucket) { create(:backlog_bucket, project:) }
+  shared_let(:work_package) { create(:work_package, project:, status:) }
 
   current_user { user }
 
@@ -47,10 +49,41 @@ RSpec.describe Backlogs::BacklogController do
       expect(response).to be_successful
       expect(response).to render_template("backlogs/backlog/show")
       expect(assigns(:project)).to eq(project)
-      expect(assigns(:sprints)).to be_present
       expect(controller.controller_path).to eq("backlogs/backlog")
       expect(controller.action_name).to eq("show")
       expect(controller.current_menu_item).to eq(:backlog)
+    end
+
+    context "for turbo frame request with frame id backlogs_container" do
+      context "with backlog_buckets enabled", with_flag: { backlog_buckets: true } do
+        it "renders the backlog_list partial without layout", :aggregate_failures do
+          request.headers["Turbo-Frame"] = "backlogs_container"
+          get :show, params: { project_id: project.id }, format: :html
+
+          expect(response).to be_successful
+          expect(response).to render_template("backlogs/backlog/_backlog_list")
+          expect(response).to render_template(layout: false)
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:backlog_buckets)).to be_present
+          expect(assigns(:inbox_work_packages)).to be_nil
+          expect(assigns(:sprints)).to be_present
+        end
+      end
+
+      context "with backlog_buckets disabled", with_flag: { backlog_buckets: false } do
+        it "renders the backlog_list partial without layout", :aggregate_failures do
+          request.headers["Turbo-Frame"] = "backlogs_container"
+          get :show, params: { project_id: project.id }, format: :html
+
+          expect(response).to be_successful
+          expect(response).to render_template("backlogs/backlog/_backlog_list")
+          expect(response).to render_template(layout: false)
+          expect(assigns(:project)).to eq(project)
+          expect(assigns(:backlog_buckets)).to be_nil
+          expect(assigns(:inbox_work_packages)).to be_present
+          expect(assigns(:sprints)).to be_present
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73081

# What are you trying to accomplish?
Allow creating, using and deleting backlog buckets

# What approach did you choose and why?
* Behind a feature flag `backlog_buckets`
* Backlog buckets and sprints not yet updated when moving work packages
* Inbox is not compacted
* No specs

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
