### PR TITLE
Optimize lookup procedure for WP filter `value_objects`

### DIFF
--- a/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
+++ b/app/models/queries/work_packages/filter/filter_for_wp_mixin.rb
@@ -38,7 +38,8 @@ module Queries::WorkPackages::Filter::FilterForWpMixin
   end
 
   def value_objects
-    objects = visible_scope.find(no_templated_values)
+    ids = no_templated_values
+    objects = ids.empty? ? [] : visible_scope.where(id: ids).to_a
 
     if has_templated_value?
       objects << ::Queries::Filters::TemplatedValue.new(WorkPackage)

--- a/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/ancestor_filter_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
 
       it "returns the work package for the values" do
         allow(WorkPackage)
-          .to receive_message_chain(:visible, :for_projects, :find) # rubocop:disable RSpec/MessageChain
+          .to receive_message_chain(:visible, :for_projects, :where) # rubocop:disable RSpec/MessageChain
           .with(no_args)
           .with(project)
-          .with(instance.values)
+          .with(id: instance.values)
           .and_return([visible_wp])
 
         expect(instance.value_objects)
@@ -122,13 +122,6 @@ RSpec.describe Queries::WorkPackages::Filter::AncestorFilter do
       context "with the 'templated' value" do
         before do
           instance.values = ["templated"]
-
-          allow(WorkPackage)
-            .to receive_message_chain(:visible, :for_projects, :find) # rubocop:disable RSpec/MessageChain
-            .with(no_args)
-            .with(project)
-            .with([])
-            .and_return([])
         end
 
         it "returns a TemplatedValue object" do

--- a/spec/models/queries/work_packages/filter/parent_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/parent_filter_spec.rb
@@ -109,10 +109,10 @@ RSpec.describe Queries::WorkPackages::Filter::ParentFilter do
 
       it "returns the work package for the values" do
         allow(WorkPackage)
-          .to receive_message_chain(:visible, :for_projects, :find)
+          .to receive_message_chain(:visible, :for_projects, :where)
           .with(no_args)
           .with(project)
-          .with(instance.values)
+          .with(id: instance.values)
           .and_return([visible_wp])
 
         expect(instance.value_objects)
@@ -122,13 +122,6 @@ RSpec.describe Queries::WorkPackages::Filter::ParentFilter do
       context "with the 'templated' value" do
         before do
           instance.values = ["templated"]
-
-          allow(WorkPackage)
-            .to receive_message_chain(:visible, :for_projects, :find)
-            .with(no_args)
-            .with(project)
-            .with([])
-            .and_return([])
         end
 
         it "returns a TemplatedValue object" do

--- a/spec/support/queries/filters/shared_filter_examples.rb
+++ b/spec/support/queries/filters/shared_filter_examples.rb
@@ -564,10 +564,10 @@ RSpec.shared_examples_for "filter by work package id" do
 
       it "returns the work package for the values" do
         allow(WorkPackage)
-          .to receive_message_chain(:visible, :for_projects, :find)
+          .to receive_message_chain(:visible, :for_projects, :where)
           .with(no_args)
           .with(project)
-          .with(instance.values)
+          .with(id: instance.values)
           .and_return([visible_wp])
 
         expect(instance.value_objects)


### PR DESCRIPTION
`value_objects` was using `find(ids)` to bulk-load work packages for filter rendering. Upcoming changes to `WorkPackage.find` break this pattern (as array-based lookups are no longer supported), so let's switch to `where(id: ids).to_a` which is unaffected.

Also, skip the DB query attempt entirely when `no_templated_values` is empty (the common case for relation tab filters that use only the `{id}` templated value).

This change has one side effect: Querying with non-existent IDs no longer raises an exception. like it would with `find`. This change shouldn't impact end-user behaviour. 
* There is no test dealing with this specific scenario.
* When I tested this out by attempting to query WPs with an invalid DB WP ID in the UI, the site returned a validation error, which was generated from `app/models/queries/filters/strategies/huge_list.rb:36-51.` -- which means that these invalid cases are handled by prior validation and never make it to the line in this PR. However, we could still guard for this manually if we really want to be on the safe side.