### PR TITLE
[62585] Some macros cannot be used (displayed behind modal) while creating a new child via relations tab

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component.ts
@@ -26,6 +26,7 @@ import {
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { firstValueFrom } from 'rxjs';
 import { QueryRequestParams } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
+import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outlet-target.enum';
 
 @Component({
   selector: 'wp-embedded-table',
@@ -103,8 +104,9 @@ export class WorkPackageEmbeddedTableComponent extends WorkPackageEmbeddedBaseCo
   public async openConfigurationModal(onUpdated:() => void):Promise<void> {
     await this.querySpace.query.valuesPromise();
 
+    const target = document.querySelector('opce-custom-modal-overlay') ? PortalOutletTarget.Custom : PortalOutletTarget.Default;
     this.opModalService
-      .show(WpTableConfigurationModalComponent, this.injector)
+      .show(WpTableConfigurationModalComponent, this.injector, {}, false, false, target)
       // Detach this component when the modal closes and pass along the query data
       .subscribe((modal) => modal.onDataUpdated.subscribe(onUpdated));
   }

--- a/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
+++ b/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
@@ -55,11 +55,16 @@ export class EditorMacrosService {
    * Used from within ckeditor-augmented-textarea.
    */
   public configureWorkPackageButton(typeName?:string, classes?:string):Promise<{ type:string, classes:string }> {
+    const target = document.querySelector('opce-custom-modal-overlay') ? PortalOutletTarget.Custom : PortalOutletTarget.Default;
+
     return new Promise<{ type:string, classes:string }>((resolve, _) => {
       this.opModalService.show(
         WpButtonMacroModalComponent,
         this.injector,
         { type: typeName, classes },
+        false,
+        false,
+        target,
       ).subscribe((modal) => modal.closingEvent.subscribe(() => {
         if (modal.changed) {
           resolve({ type: modal.type, classes: modal.classes });


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/62585

Might possibly also fix https://community.openproject.org/wp/73117

# What are you trying to accomplish?
Add portal targets for the editor macros to be displayed in front of an exisiting primer dialog

## Screenshots
<img width="1752" height="644" alt="Bildschirmfoto 2026-04-20 um 08 41 44" src="https://github.com/user-attachments/assets/e9d52ea7-8806-4403-afd1-c5d1dd003d52" />
