### PR TITLE
[73684] Harmonize the meeting module on home page and project overview

### DIFF
--- a/modules/meeting/app/components/meetings/widgets/meetings.rb
+++ b/modules/meeting/app/components/meetings/widgets/meetings.rb
@@ -45,7 +45,11 @@ module Meetings
       def meetings
         @meetings ||=
           if project_scoped?
-            project.meetings.visible(current_user).upcoming
+            project
+              .meetings
+              .visible(current_user)
+              .participated_by(current_user)
+              .upcoming
           else
             ::Meeting
               .visible(current_user)
@@ -56,7 +60,7 @@ module Meetings
       end
 
       def title
-        global_scoped? ? t(:label_my_meetings) : t(:label_meeting_plural)
+        t(:label_my_meetings)
       end
 
       def render?
@@ -99,7 +103,7 @@ module Meetings
         if global_scoped?
           meetings_path
         else
-          project_meetings_path(project, filters: [{ invited_user_id: { operator: "*", values: [] } }].to_json)
+          project_meetings_path(project)
         end
       end
 

--- a/modules/meeting/spec/components/meetings/widgets/meetings_spec.rb
+++ b/modules/meeting/spec/components/meetings/widgets/meetings_spec.rb
@@ -110,17 +110,25 @@ RSpec.describe Meetings::Widgets::Meetings, type: :component do
 
   context "with project" do
     let(:project) { project_red }
-    # these meetings from another project should not be visible
-    let!(:other_project_meeting) { create(:meeting, project: project_blue, author:) }
+    # this meeting from another project should not be visible
+    let!(:other_project_meeting) do
+      create(:meeting, project: project_blue, author:, start_time: 1.week.from_now, duration: 1) do |meeting|
+        create(:meeting_participant, meeting:, user: admin, invited: true)
+      end
+    end
 
     context "with no meetings in this project" do
       it_behaves_like "empty-state with action"
     end
 
     context "with meetings" do
-      let!(:meeting_red) { create(:meeting, project: project_red, author:, start_time: 1.week.from_now, duration: 1) }
+      let!(:meeting_red) do
+        create(:meeting, project: project_red, author:, start_time: 1.week.from_now, duration: 1).tap do |meeting|
+          create(:meeting_participant, meeting:, user: admin, invited: true)
+        end
+      end
 
-      it "renders only this project’s meetings" do
+      it "renders only this project’s meetings which the user participates in" do
         expect(rendered_component).to have_list_item(count: 2)
         expect(rendered_component).to have_list_item(position: 1) do |item|
           expect(item).to have_link href: project_meeting_path(project_red, meeting_red)
@@ -129,9 +137,7 @@ RSpec.describe Meetings::Widgets::Meetings, type: :component do
         end
 
         expect(rendered_component).to have_list_item(position: 2) do |item|
-          expect(item).to have_link href: project_meetings_path(project_red,
-                                                                filters: [{ invited_user_id: { operator: "*",
-                                                                                               values: [] } }].to_json)
+          expect(item).to have_link href: project_meetings_path(project_red)
           expect(item).to have_content("View all meetings")
         end
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73684

# What are you trying to accomplish?

* Both show "My meetings" as title
* Both link to the MyMeetings page of their scope
* Both show only meetings the user is participating in
