### PR TITLE
Implements the GET /work_packages/:id/wiki_page_links endpoint

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -58,4 +58,4 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/COPYRIGHT_short
+++ b/COPYRIGHT_short
@@ -20,6 +20,6 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 See COPYRIGHT and LICENSE files for more details.

--- a/modules/backlogs/app/contracts/backlog_buckets/base_contract.rb
+++ b/modules/backlogs/app/contracts/backlog_buckets/base_contract.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++

--- a/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
@@ -42,7 +42,7 @@ module Queries
           end
 
           def allowed_values
-            ::Wikis::Provider.enabled.pluck(:universal_identifier).map { |uid| [uid, uid.to_s] }
+            ::Wikis::Provider.enabled.pluck(:universal_identifier).map { |uid| [uid, uid] }
           end
 
           def left_outer_joins = :provider

--- a/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
@@ -42,11 +42,13 @@ module Queries
           end
 
           def allowed_values
-            ::Wikis::Provider.pluck(:id).map { |id| [id, id.to_s] }
+            ::Wikis::Provider.enabled.pluck(:universal_identifier).map { |uid| [uid, uid.to_s] }
           end
 
+          def left_outer_joins = :provider
+
           def where
-            operator_strategy.sql_for_field(values, ::Wikis::PageLink.table_name, "provider_id")
+            operator_strategy.sql_for_field(values, ::Wikis::Provider.table_name, "universal_identifier")
           end
         end
       end

--- a/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/filter/provider_filter.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries
+  module Wikis
+    module PageLinks
+      module Filter
+        class StorageFilter < Filters::Base
+          self.model = ::Wikis::PageLink
+
+          def type = :list
+
+          def human_name
+            ::Wikis::PageLink.human_attribute_name(name)
+          end
+
+          def allowed_values
+            ::Wikis::Provider.pluck(:id).map { |id| [id, id.to_s] }
+          end
+
+          def where
+            operator_strategy.sql_for_field(values, ::Storages::FileLink.table_name, "provider_id")
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
@@ -38,6 +38,10 @@ module Queries
         def self.model
           @model ||= ::Wikis::PageLink
         end
+
+        def default_scope
+          ::Wikis::PageLink.includes(:provider).all
+        end
       end
     end
   end

--- a/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries
+  module Wikis
+    module PageLinks
+      class PageLinkQuery
+        include BaseQuery
+        include UnpersistedQuery
+
+        def model
+          @model ||= ::Wikis::PageLink
+        end
+      end
+    end
+  end
+end

--- a/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/page_link_query.rb
@@ -35,7 +35,7 @@ module Queries
         include BaseQuery
         include UnpersistedQuery
 
-        def model
+        def self.model
           @model ||= ::Wikis::PageLink
         end
       end

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -60,25 +60,15 @@ module Wikis
 
     def enrich_models(metadata)
       identifier_title_map = metadata.sort_by(&:identifier).to_h { [it.identifier, it.title] }
-      variable_placeholders = build_placeholders(identifier_title_map.size)
-
-      result_scope(metadata_join_sql(variable_placeholders, identifier_title_map))
-    end
-
-    def result_scope(join_expression)
-      relation.joins(join_expression).select("wiki_page_links.*, metadata.title as title")
-    end
-
-    def metadata_join_sql(variable_placeholders, identifier_title_map)
-      ActiveRecord::Base.sanitize_sql_array([variable_placeholders, *identifier_title_map.flatten])
-    end
-
-    def build_placeholders(amount)
-      variable_placeholders = Array.new(amount, "(?,?)").join(",")
-      <<~SQL.squish
+      variable_placeholders = Array.new(identifier_title_map.size, "(?,?)").join(",")
+      join_string = <<~SQL.squish
         LEFT JOIN (VALUES #{variable_placeholders}) AS metadata(identifier, title)
           ON metadata.identifier = wiki_page_links.identifier
       SQL
+
+      join_expression = ActiveRecord::Base.sanitize_sql_array([join_string, *identifier_title_map.flatten])
+
+      relation.joins(join_expression).select("wiki_page_links.*, metadata.title as title")
     end
   end
 end

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Wikis
+  class PageLinkMetadataService
+    def initialize(page_links)
+      @page_links = page_links
+      @result = ServiceResult.success(errors: ActiveModel::Errors.new(self))
+    end
+
+    def call
+      metadata = @page_links.group_by(&:provider).filter_map do |provider, pages|
+        result = provider.resolve("queries.pages").call(provider:, page_identifiers: pages.map(&:identifiers))
+        result.value_or { add_wiki_error(it) and next }
+      end
+
+      @result.result = enrich_models(@page_links, metadata.flatten)
+      @result
+    end
+
+    private
+
+    def add_wiki_error(error)
+      @result.add_error(:base, error.message)
+    end
+
+    def enrich_models(page_links, metadata)
+      # Expectation is that the result from the PagesQuery is an array of "Result::Pages"
+      identifier_title_map = metadata.sort_by(&:identifier).to_h { [it.identifier, it.title] }
+      variable_placeholders = build_placeholders(identifier_title_map.size)
+
+      result_scope(page_links.pluck(:id), metadata_join_sql(variable_placeholders, identifier_title_map))
+    end
+
+    def result_scope(ids, join_expression)
+      PageLink.where(id: ids).order(:id).joins(join_expression).select("page_links.*, metadata.tile as title")
+    end
+
+    def metadata_join_sql(variable_placeholders, identifier_title_map)
+      ActiveRecord::Base.sanitize_sql_array([variable_placeholders, *identifier_title_map.flatten])
+    end
+
+    def build_placeholders(amount)
+      variable_placeholders = Array.new(amount, "(?,?)").join(",")
+      <<~SQL.squish
+        LEFT JOIN (VALUES #{variable_placeholders}) AS metadata (identifier, title)
+          ON metadata.tile = page_links.identifier
+      SQL
+    end
+  end
+end

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -36,8 +36,8 @@ module Wikis
     end
 
     def call
-      metadata = @page_links.group_by(&:provider).filter_map do |provider, pages|
-        result = provider.resolve("queries.pages").call(page_identifiers: pages.map(&:identifier))
+      metadata = @page_links.group_by(&:provider).filter_map do |provider, links|
+        result = provider.resolve("queries.pages").call(page_identifiers: links.map(&:identifier))
         result.value_or { add_wiki_error(it) and next }
       end
 

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -30,25 +30,39 @@
 
 module Wikis
   class PageLinkMetadataService
-    def initialize(page_links)
-      @page_links = page_links
+    # @param relation [ActiveRecord::Relation<Wikis::PageLink>]
+    # @return [ServiceResult<ActiveRecord::Relation<Wikis::PageLink>]
+    def self.call(relation) = new.call(relation)
+
+    def initialize
       @result = ServiceResult.success(errors: ActiveModel::Errors.new(self))
     end
 
-    def call
-      metadata = @page_links.group_by(&:provider).filter_map do |provider, links|
-        result = provider.resolve("queries.pages").call(page_identifiers: links.map(&:identifier))
-        result.value_or { add_wiki_error(it) and next }
+    def call(relation)
+      metadata = relation.group_by(&:provider).filter_map do |provider, page_links|
+        build_inputs(page_links).filter_map do |input_data|
+          provider.resolve("queries.page_info").call(input_data).value_or { add_wiki_error(it) and next }
+        end
       end
 
-      @result.result = enrich_models(@page_links, metadata.flatten)
+      @result.result = enrich_models(relation, metadata.flatten)
       @result
     end
 
     private
 
+    def build_inputs(page_links)
+      page_links.filter_map do |page_link|
+        Adapters::Input::PageInfo.build(identifier: page_link.identifier).value_or { add_validation_error(it) }
+      end
+    end
+
     def add_wiki_error(error)
-      @result.add_error(:base, error.message)
+      @result.errors.add(:base, error.code)
+    end
+
+    def add_validation_error(error)
+      @result.errors.add(:identifiers, error.message, options: error.to_h)
     end
 
     def enrich_models(page_links, metadata)

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -41,10 +41,7 @@ module Wikis
     def call(relation)
       metadata = relation.group_by(&:provider).flat_map do |provider, page_links|
         build_inputs(page_links).filter_map do |input_data|
-          provider.resolve("queries.page_info").call(input_data).value_or do |error|
-            add_wiki_error(error)
-            next
-          end
+          provider.resolve("queries.page_info").call(input_data).value_or(nil)
         end
       end
 
@@ -56,19 +53,8 @@ module Wikis
 
     def build_inputs(page_links)
       page_links.filter_map do |page_link|
-        Adapters::Input::PageInfo.build(identifier: page_link.identifier).value_or do |validation_failure|
-          add_validation_error(validation_failure)
-          next
-        end
+        Adapters::Input::PageInfo.build(identifier: page_link.identifier).value_or(nil)
       end
-    end
-
-    def add_wiki_error(error)
-      @result.errors.add(:base, error.code)
-    end
-
-    def add_validation_error(error)
-      @result.errors.add(:identifiers, error.message, options: error.to_h)
     end
 
     def enrich_models(page_links, metadata)

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -30,26 +30,27 @@
 
 module Wikis
   class PageLinkMetadataService
-    # @param relation [ActiveRecord::Relation<Wikis::PageLink>]
-    # @return [ServiceResult<ActiveRecord::Relation<Wikis::PageLink>]
-    def self.call(relation) = new.call(relation)
-
-    def initialize
+    # @param page_links [ActiveRecord::Relation<Wikis::PageLink>]
+    def initialize(page_links)
       @result = ServiceResult.success(errors: ActiveModel::Errors.new(self))
+      @relation = page_links
     end
 
-    def call(relation)
+    # @return [ServiceResult<ActiveRecord::Relation<Wikis::PageLink>]
+    def call
       metadata = relation.group_by(&:provider).flat_map do |provider, page_links|
         build_inputs(page_links).filter_map do |input_data|
           provider.resolve("queries.page_info").call(input_data).value_or(nil)
         end
       end
 
-      @result.result = enrich_models(relation, metadata)
+      @result.result = enrich_models(metadata)
       @result
     end
 
     private
+
+    attr_reader :relation
 
     def build_inputs(page_links)
       page_links.filter_map do |page_link|
@@ -57,15 +58,15 @@ module Wikis
       end
     end
 
-    def enrich_models(page_links, metadata)
+    def enrich_models(metadata)
       identifier_title_map = metadata.sort_by(&:identifier).to_h { [it.identifier, it.title] }
       variable_placeholders = build_placeholders(identifier_title_map.size)
 
-      result_scope(page_links, metadata_join_sql(variable_placeholders, identifier_title_map))
+      result_scope(metadata_join_sql(variable_placeholders, identifier_title_map))
     end
 
-    def result_scope(page_links, join_expression)
-      page_links.joins(join_expression).select("wiki_page_links.*, metadata.title as title")
+    def result_scope(join_expression)
+      relation.joins(join_expression).select("wiki_page_links.*, metadata.title as title")
     end
 
     def metadata_join_sql(variable_placeholders, identifier_title_map)

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -59,11 +59,11 @@ module Wikis
     end
 
     def enrich_models(metadata)
-      identifier_title_map = metadata.sort_by(&:identifier).to_h { [it.identifier, it.title] }
-      variable_placeholders = Array.new(identifier_title_map.size, "(?,?)").join(",")
+      identifier_title_map = metadata.map { [it.identifier, it.title, it.provider.id] }
+      variable_placeholders = Array.new(identifier_title_map.size, "(?,?,?)").join(",")
       join_string = <<~SQL.squish
-        LEFT JOIN (VALUES #{variable_placeholders}) AS metadata(identifier, title)
-          ON metadata.identifier = wiki_page_links.identifier
+        LEFT JOIN (VALUES #{variable_placeholders}) AS metadata(identifier, title, provider_id)
+          ON metadata.identifier = wiki_page_links.identifier AND metadata.provider_id = wiki_page_links.provider_id
       SQL
 
       join_expression = ActiveRecord::Base.sanitize_sql_array([join_string, *identifier_title_map.flatten])

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -37,7 +37,7 @@ module Wikis
 
     def call
       metadata = @page_links.group_by(&:provider).filter_map do |provider, pages|
-        result = provider.resolve("queries.pages").call(provider:, page_identifiers: pages.map(&:identifiers))
+        result = provider.resolve("queries.pages").call(page_identifiers: pages.map(&:identifier))
         result.value_or { add_wiki_error(it) and next }
       end
 
@@ -60,7 +60,7 @@ module Wikis
     end
 
     def result_scope(ids, join_expression)
-      PageLink.where(id: ids).order(:id).joins(join_expression).select("page_links.*, metadata.tile as title")
+      PageLink.where(id: ids).order(:id).joins(join_expression).select("wiki_page_links.*, metadata.title as title")
     end
 
     def metadata_join_sql(variable_placeholders, identifier_title_map)
@@ -70,8 +70,8 @@ module Wikis
     def build_placeholders(amount)
       variable_placeholders = Array.new(amount, "(?,?)").join(",")
       <<~SQL.squish
-        LEFT JOIN (VALUES #{variable_placeholders}) AS metadata (identifier, title)
-          ON metadata.tile = page_links.identifier
+        LEFT JOIN (VALUES #{variable_placeholders}) AS metadata(identifier, title)
+          ON metadata.identifier = wiki_page_links.identifier
       SQL
     end
   end

--- a/modules/wikis/app/services/wikis/page_link_metadata_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_metadata_service.rb
@@ -39,13 +39,16 @@ module Wikis
     end
 
     def call(relation)
-      metadata = relation.group_by(&:provider).filter_map do |provider, page_links|
+      metadata = relation.group_by(&:provider).flat_map do |provider, page_links|
         build_inputs(page_links).filter_map do |input_data|
-          provider.resolve("queries.page_info").call(input_data).value_or { add_wiki_error(it) and next }
+          provider.resolve("queries.page_info").call(input_data).value_or do |error|
+            add_wiki_error(error)
+            next
+          end
         end
       end
 
-      @result.result = enrich_models(relation, metadata.flatten)
+      @result.result = enrich_models(relation, metadata)
       @result
     end
 
@@ -53,7 +56,10 @@ module Wikis
 
     def build_inputs(page_links)
       page_links.filter_map do |page_link|
-        Adapters::Input::PageInfo.build(identifier: page_link.identifier).value_or { add_validation_error(it) }
+        Adapters::Input::PageInfo.build(identifier: page_link.identifier).value_or do |validation_failure|
+          add_validation_error(validation_failure)
+          next
+        end
       end
     end
 
@@ -66,15 +72,14 @@ module Wikis
     end
 
     def enrich_models(page_links, metadata)
-      # Expectation is that the result from the PagesQuery is an array of "Result::Pages"
       identifier_title_map = metadata.sort_by(&:identifier).to_h { [it.identifier, it.title] }
       variable_placeholders = build_placeholders(identifier_title_map.size)
 
-      result_scope(page_links.pluck(:id), metadata_join_sql(variable_placeholders, identifier_title_map))
+      result_scope(page_links, metadata_join_sql(variable_placeholders, identifier_title_map))
     end
 
-    def result_scope(ids, join_expression)
-      PageLink.where(id: ids).order(:id).joins(join_expression).select("wiki_page_links.*, metadata.title as title")
+    def result_scope(page_links, join_expression)
+      page_links.joins(join_expression).select("wiki_page_links.*, metadata.title as title")
     end
 
     def metadata_join_sql(variable_placeholders, identifier_title_map)

--- a/modules/wikis/app/services/wikis/page_link_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_service.rb
@@ -23,7 +23,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -2,6 +2,8 @@
 en:
   activerecord:
     attributes:
+      wikis/page_link:
+        provider: Wiki Provider
       wikis/xwiki_provider:
         authentication_method: Authentication method
         authentication_methods:

--- a/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module API
+  module V3
+    module PageLinks
+      class PageLinkCollectionRepresenter < Decorators::OffsetPaginatedCollection
+        property :count, getter: ->(*) { count(:id) }
+      end
+    end
+  end
+end

--- a/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
@@ -33,6 +33,8 @@ module API
     module PageLinks
       class PageLinkCollectionRepresenter < Decorators::OffsetPaginatedCollection
         property :count, getter: ->(*) { count(:id) }
+
+        def _type = "WikiPageLinkCollection"
       end
     end
   end

--- a/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_link_collection_representer.rb
@@ -32,8 +32,6 @@ module API
   module V3
     module PageLinks
       class PageLinkCollectionRepresenter < Decorators::OffsetPaginatedCollection
-        property :count, getter: ->(*) { count(:id) }
-
         def _type = "WikiPageLinkCollection"
       end
     end

--- a/modules/wikis/lib/api/v3/page_links/page_link_representer.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_link_representer.rb
@@ -31,6 +31,14 @@
 module API
   module V3
     module PageLinks
+      URN_INLINE_PAGE_LINK = "#{URN_PREFIX}wikiPageLinks:Inline".freeze
+      URN_RELATION_PAGE_LINK = "#{URN_PREFIX}wikiPageLinks:Relation".freeze
+
+      URN_PAGE_LINK_TYPE = {
+        "Wikis::RelationPageLink" => URN_RELATION_PAGE_LINK,
+        "Wikis::InlinePageLink" => URN_INLINE_PAGE_LINK
+      }.freeze
+
       class PageLinkRepresenter < Decorators::Single
         include Decorators::LinkedResource
         include Decorators::DateProperty
@@ -38,6 +46,7 @@ module API
 
         property :id
         property :identifier
+        property :wiki_page_link_type, exec_context: :decorator
 
         date_time_property :created_at
         date_time_property :updated_at
@@ -71,7 +80,9 @@ module API
                             representer: ::API::V3::WorkPackages::WorkPackageRepresenter,
                             skip_render: ->(*) { represented.linkable_id.nil? || represented.linkable_type != "WorkPackage" }
 
-        def _type = represented.class.name.demodulize
+        def _type = "WikiPageLink"
+
+        def wiki_page_link_type = URN_PAGE_LINK_TYPE[represented.class.name]
 
         private
 

--- a/modules/wikis/lib/api/v3/page_links/page_link_representer.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_link_representer.rb
@@ -61,7 +61,9 @@ module API
           }
         end
 
-        associated_resource :provider, v3_path: :wiki_provider
+        associated_resource :provider, v3_path: :wiki_provider, link: ->(*) {
+          { href: api_v3_paths.wiki_provider(represented.provider.universal_identifier), title: represented.provider.name }
+        }
 
         # TODO: Make this truly polymorphic - @mereghost 2026-04-13
         associated_resource :linkable,

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -32,8 +32,10 @@ module API
   module V3
     module PageLinks
       class WorkPackageWikiPageLinksAPI < OpenProjectAPI
-        def self.enrich_models_with_wiki_metadata(relation)
-          Wikis::PageLinkMetadataService.new(relation).call
+        helpers do
+          def enrich_models_with_wiki_metadata(relation)
+            Wikis::PageLinkMetadataService.call(relation)
+          end
         end
 
         resources :wiki_page_links do
@@ -56,7 +58,7 @@ module API
                        end
 
             PageLinkCollectionRepresenter.new(
-              relation,
+              enrich_models_with_wiki_metadata(relation).result,
               per_page: params[:pageSize],
               self_link: api_v3_paths.work_package_page_links(@work_package.id),
               current_user:

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -28,25 +28,39 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries
-  module Wikis
+module API
+  module V3
     module PageLinks
-      module Filter
-        class ProviderFilter < Filters::Base
-          self.model = ::Wikis::PageLink
+      class WorkPackageWikiPageLinksAPI < OpenProjectAPI
+        def self.enrich_models_with_wiki_metadata(relation)
+          Wikis::PageLinkMetadataService.new(relation).call
+        end
 
-          def type = :list
+        resources :wiki_page_links do
+          get do
+            query = ParamsToQueryService.new(
+              ::Wikis::PageLink,
+              current_user,
+              query_class: ::Queries::Wikis::PageLinks::PageLinkQuery
+            ).call(params)
 
-          def human_name
-            ::Wikis::PageLink.human_attribute_name(name)
-          end
+            unless query.valid?
+              message = I18n.t("api_v3.errors.missing_or_malformed_parameter", parameter: "filters")
+              raise ::API::Errors::InvalidQuery.new(message)
+            end
 
-          def allowed_values
-            ::Wikis::Provider.pluck(:id).map { |id| [id, id.to_s] }
-          end
+            relation = if current_user.allowed_in_project?(:view_wiki_page_links, @work_package.project)
+                         query.results.where(linkable: @work_package)
+                       else
+                         []
+                       end
 
-          def where
-            operator_strategy.sql_for_field(values, ::Wikis::PageLink.table_name, "provider_id")
+            PageLinkCollectionRepresenter.new(
+              relation,
+              per_page: params[:pageSize],
+              self_link: api_v3_paths.work_package_page_links(@work_package.id),
+              current_user:
+            )
           end
         end
       end

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -51,11 +51,7 @@ module API
               raise ::API::Errors::InvalidQuery.new(message)
             end
 
-            relation = if current_user.allowed_in_project?(:view_work_packages, @work_package.project)
-                         query.results.where(linkable: @work_package)
-                       else
-                         []
-                       end
+            relation = query.results.where(linkable: @work_package)
 
             PageLinkCollectionRepresenter.new(
               enrich_models_with_wiki_metadata(relation).result,

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -34,7 +34,7 @@ module API
       class WorkPackageWikiPageLinksAPI < OpenProjectAPI
         helpers do
           def enrich_models_with_wiki_metadata(relation)
-            Wikis::PageLinkMetadataService.call(relation)
+            Wikis::PageLinkMetadataService.new(relation).call
           end
         end
 

--- a/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/work_package_wiki_page_links_api.rb
@@ -51,7 +51,7 @@ module API
               raise ::API::Errors::InvalidQuery.new(message)
             end
 
-            relation = if current_user.allowed_in_project?(:view_wiki_page_links, @work_package.project)
+            relation = if current_user.allowed_in_project?(:view_work_packages, @work_package.project)
                          query.results.where(linkable: @work_package)
                        else
                          []

--- a/modules/wikis/lib/api/v3/providers/provider_representer.rb
+++ b/modules/wikis/lib/api/v3/providers/provider_representer.rb
@@ -35,13 +35,13 @@ module API
         include Decorators::LinkedResource
         include Decorators::DateProperty
 
-        property :id
+        property :universal_identifier
         property :name
 
         date_time_property :created_at
         date_time_property :updated_at
 
-        self_link(path: :wiki_provider)
+        self_link(path: :wiki_provider, id_attribute: :universal_identifier)
       end
     end
   end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -60,6 +60,11 @@ module OpenProject::Wikis
       )
 
       OpenProject::TextFormatting::Filters::PatternMatcherFilter.append_matcher ::Wikis::TextFormatting::WikiLinkMatcher
+
+      # Registering queries and filters
+      ::Queries::Register.register(::Queries::Wikis::PageLinks::PageLinkQuery) do
+        filter ::Queries::Wikis::PageLinks::Filter::ProviderFilter
+      end
     end
 
     replace_principal_references "Wikis::PageLink" => %i[author_id]
@@ -99,5 +104,10 @@ module OpenProject::Wikis
 
     add_api_path(:wiki_page_link) { |page_link_id| "#{root}/wiki_page_links/#{page_link_id}" }
     add_api_path(:wiki_provider) { |provider_id| "#{root}/wiki_providers/#{provider_id}" }
+    add_api_path(:work_package_page_links) { |work_package_id| "#{work_package(work_package_id)}/wiki_page_links" }
+
+    add_api_endpoint "API::V3::WorkPackages::WorkPackagesAPI", :id do
+      mount ::API::V3::PageLinks::WorkPackageWikiPageLinksAPI
+    end
   end
 end

--- a/modules/wikis/spec/lib/api/v3/page_links/page_link_representer_spec.rb
+++ b/modules/wikis/spec/lib/api/v3/page_links/page_link_representer_spec.rb
@@ -113,18 +113,34 @@ module API
         end
 
         describe "properties" do
+          describe "wiki_page_link_type" do
+            context "when InlinePageLink" do
+              let(:represented) { inline_page_link }
+
+              it_behaves_like "property", :wikiPageLinkType do
+                let(:value) { URN_INLINE_PAGE_LINK }
+              end
+            end
+
+            context "when RelationPageLink" do
+              it_behaves_like "property", :wikiPageLinkType do
+                let(:value) { URN_RELATION_PAGE_LINK }
+              end
+            end
+          end
+
           describe "_type" do
             context "when InlinePageLink" do
               let(:represented) { inline_page_link }
 
               it_behaves_like "property", :_type do
-                let(:value) { "InlinePageLink" }
+                let(:value) { "WikiPageLink" }
               end
             end
 
             context "when RelationPageLink" do
               it_behaves_like "property", :_type do
-                let(:value) { "RelationPageLink" }
+                let(:value) { "WikiPageLink" }
               end
             end
           end

--- a/modules/wikis/spec/lib/api/v3/page_links/page_link_representer_spec.rb
+++ b/modules/wikis/spec/lib/api/v3/page_links/page_link_representer_spec.rb
@@ -60,7 +60,7 @@ module API
           describe "provider" do
             it_behaves_like "has a titled link" do
               let(:link) { "provider" }
-              let(:href) { "/api/v3/wiki_providers/#{represented.provider_id}" }
+              let(:href) { "/api/v3/wiki_providers/#{represented.provider.universal_identifier}" }
               let(:title) { represented.provider.name }
             end
           end

--- a/modules/wikis/spec/lib/api/v3/providers/provider_representer_spec.rb
+++ b/modules/wikis/spec/lib/api/v3/providers/provider_representer_spec.rb
@@ -48,13 +48,21 @@ module API
           describe "self" do
             it_behaves_like "has a titled link" do
               let(:link) { "self" }
-              let(:href) { "/api/v3/wiki_providers/#{represented.id}" }
+              let(:href) { "/api/v3/wiki_providers/#{represented.universal_identifier}" }
               let(:title) { represented.name }
             end
           end
         end
 
         describe "properties" do
+          it_behaves_like "property", :name do
+            let(:value) { represented.name }
+          end
+
+          it_behaves_like "property", :universalIdentifier do
+            let(:value) { represented.universal_identifier }
+          end
+
           it_behaves_like "datetime property", :createdAt do
             let(:value) { represented.created_at }
           end

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "API v3 wiki page links resource" do
+  include API::V3::Utilities::PathHelper
+
+  let(:work_package) { create(:work_package) }
+  let(:internal_wiki) { create(:internal_wiki_provider) }
+
+  let(:project) { work_package.project }
+
+  let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages view_wiki_page_links) }) }
+
+  let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
+
+  before do
+    login_as user
+    relation_page_links
+  end
+
+  describe "GET /api/v3/work_packages/:id/wiki_page_links" do
+    let(:path) { api_v3_paths.work_package_page_links(work_package.id) }
+
+    context "with all preconditions met (happy path)" do
+      before { get path }
+
+      it_behaves_like "API V3 collection response", 3, 3, "RelationPageLink", "Collection" do
+        let(:elements) { relation_page_links.reverse }
+      end
+    end
+
+    context "when filtered by provider" do
+      let(:filter) { [{ provider: { operator: "=", values: [internal_wiki.id] } }] }
+
+      before do
+        create_list(:relation_wiki_page_link, 3, provider: create(:xwiki_provider), linkable: work_package)
+        get "#{path}?filters=#{CGI.escape(filter.to_json)}"
+      end
+
+      it_behaves_like "API V3 collection response", 3, 3, "RelationPageLink", "Collection" do
+        let(:elements) { relation_page_links.reverse }
+      end
+    end
+  end
+end

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "API v3 wiki page links resource" do
     end
 
     context "when filtered by provider" do
-      let(:filter) { [{ provider: { operator: "=", values: [internal_wiki.id] } }] }
+      let(:filter) { [{ provider: { operator: "=", values: [internal_wiki.universal_identifier] } }] }
 
       before do
         create_list(:relation_wiki_page_link, 3, provider: create(:xwiki_provider), linkable: work_package)

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "API v3 wiki page links resource" do
 
   let(:project) { work_package.project }
 
-  let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages view_wiki_page_links) }) }
+  let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages) }) }
 
   let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: xwiki_provider, linkable: work_package) }
   let(:inline_page_links) { create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
@@ -62,7 +62,7 @@ RSpec.describe "API v3 wiki page links resource" do
       before { get path }
 
       it_behaves_like "API V3 collection response", 6, 6, "WikiPageLink", "WikiPageLinkCollection" do
-        let(:elements) { Wikis::PageLink.where(linkable: work_package).order(id: :asc).all }
+        let(:elements) { Wikis::PageLink.where(linkable: work_package).order(id: :desc).all }
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe "API v3 wiki page links resource" do
       end
 
       it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
-        let(:elements) { Wikis::PageLink.where(linkable: work_package, provider: internal_wiki).order(id: :asc).all }
+        let(:elements) { Wikis::PageLink.where(linkable: work_package, provider: internal_wiki).order(id: :desc).all }
       end
     end
   end

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -29,22 +29,30 @@
 #++
 
 require "spec_helper"
+require_module_spec_helper
 
 RSpec.describe "API v3 wiki page links resource" do
   include API::V3::Utilities::PathHelper
 
   let(:work_package) { create(:work_package) }
   let(:internal_wiki) { create(:internal_wiki_provider) }
+  let(:xwiki_provider) { create(:xwiki_provider) }
 
   let(:project) { work_package.project }
 
   let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages view_wiki_page_links) }) }
 
-  let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
+  let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: xwiki_provider, linkable: work_package) }
+  let(:inline_page_links) { create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
+
+  let(:unrelated_page_links) do
+    create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: create(:work_package, project: project))
+  end
 
   before do
     login_as user
-    relation_page_links
+    stub_provider_queries
+    unrelated_page_links
   end
 
   describe "GET /api/v3/work_packages/:id/wiki_page_links" do
@@ -53,8 +61,8 @@ RSpec.describe "API v3 wiki page links resource" do
     context "with all preconditions met (happy path)" do
       before { get path }
 
-      it_behaves_like "API V3 collection response", 3, 3, "RelationPageLink", "Collection" do
-        let(:elements) { relation_page_links.reverse }
+      it_behaves_like "API V3 collection response", 6, 6, "WikiPageLink", "WikiPageLinkCollection" do
+        let(:elements) { Wikis::PageLink.where(linkable: work_package).order(id: :asc).all }
       end
     end
 
@@ -62,13 +70,44 @@ RSpec.describe "API v3 wiki page links resource" do
       let(:filter) { [{ provider: { operator: "=", values: [internal_wiki.universal_identifier] } }] }
 
       before do
-        create_list(:relation_wiki_page_link, 3, provider: create(:xwiki_provider), linkable: work_package)
         get "#{path}?filters=#{CGI.escape(filter.to_json)}"
       end
 
-      it_behaves_like "API V3 collection response", 3, 3, "RelationPageLink", "Collection" do
-        let(:elements) { relation_page_links.reverse }
+      it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
+        let(:elements) { Wikis::PageLink.where(linkable: work_package, provider: internal_wiki).order(id: :asc).all }
       end
     end
+  end
+
+  private
+
+  def stub_provider_queries
+    internal_class = class_double(Wikis::Adapters::Providers::Internal::Queries::PageInfo)
+    xwiki_class = class_double(Wikis::Adapters::Providers::XWiki::Queries::PageInfo)
+
+    internal_query = instance_double(Wikis::Adapters::Providers::Internal::Queries::PageInfo)
+    xwiki_query = instance_double(Wikis::Adapters::Providers::XWiki::Queries::PageInfo)
+
+    Wikis::Adapters::Registry.stub("internal.queries.page_info", internal_class)
+    Wikis::Adapters::Registry.stub("xwiki.queries.page_info", xwiki_class)
+
+    allow(internal_class).to receive(:new).and_return(internal_query)
+    allow(xwiki_class).to receive(:new).and_return(xwiki_query)
+    stub_query_calls(inline_page_links, internal_query)
+    stub_query_calls(relation_page_links, xwiki_query)
+  end
+
+  def stub_query_calls(links, query)
+    links.each do |link|
+      Wikis::Adapters::Input::PageInfo.build(identifier: link.identifier).bind do |input|
+        allow(query).to receive(:call).with(input).and_return(Success(build_page_info(link)))
+      end
+    end
+  end
+
+  def build_page_info(link)
+    Wikis::Adapters::Results::PageInfo.new(
+      identifier: link.identifier, href: "valid_uri", title: "Title of #{link.identifier}", provider: link.provider
+    )
   end
 end

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -34,6 +34,8 @@ require_module_spec_helper
 module Wikis
   RSpec.describe PageLinkMetadataService do
     let(:relation) { PageLink.limit(30) }
+    let(:query_double) { instance_double(Adapters::Providers::Internal::Queries::PageInfo) }
+    let(:query_class_double) { class_double(Adapters::Providers::Internal::Queries::PageInfo) }
 
     shared_let(:provider) { create(:internal_wiki_provider) }
     shared_let(:page_links) { create_list(:relation_wiki_page_link, 3, provider:) }
@@ -41,8 +43,7 @@ module Wikis
     subject(:service) { described_class.new(relation) }
 
     before do
-      query_double = instance_double(Adapters::Providers::Internal::Queries::PageInfo)
-      query_class_double = class_double(Adapters::Providers::Internal::Queries::PageInfo, new: query_double)
+      allow(query_class_double).to receive(:new).with(model: provider).and_return(query_double)
       Adapters::Registry.stub("internal.queries.page_info", query_class_double)
 
       build_inputs.each do |input|
@@ -73,10 +74,52 @@ module Wikis
       expect(page_links.first.title).to eq("Wikis, now with more cheese! Part #{page_links.first.identifier}")
     end
 
+    context "when page links have the same identifier but different providers" do
+      shared_let(:xwiki_provider) { create(:xwiki_provider) }
+      let(:new_page_links) do
+        page_links.map do |pl|
+          create(:relation_wiki_page_link, provider: xwiki_provider, identifier: pl)
+        end
+      end
+
+      before do
+        allow(query_class_double).to receive(:new).with(model: xwiki_provider).and_return(query_double)
+        Adapters::Registry.stub("xwiki.queries.page_info", query_class_double)
+
+        new_page_links.map do |pl|
+          input = Adapters::Input::PageInfo.build(identifier: pl.identifier).value_or(nil)
+          allow(query_double).to receive(:call).with(input).and_return(
+            Success(
+              Adapters::Results::PageInfo.new(title: "Wikis, now with more cheese! Part #{pl.id}",
+                                              identifier: input.identifier,
+                                              href: "totally_valid_url",
+                                              provider: pl.provider)
+            )
+          )
+        end
+      end
+
+      it "maps the titles to the correct page link" do
+        service_result = service.call
+
+        expect(service_result).to be_success
+        relation = service_result.result
+
+        relation.find_each do |page_link|
+          case page_link.provider_id
+          when xwiki_provider.id
+            expect(page_link.title).to eq("Wikis, now with more cheese! Part #{page_link.id}")
+          else
+            expect(page_link.title).to eq("Wikis, now with more cheese! Part #{page_link.identifier}")
+          end
+        end
+      end
+    end
+
     private
 
-    def build_inputs
-      page_links.filter_map { Adapters::Input::PageInfo.build(identifier: it.identifier).value_or(nil) }
+    def build_inputs(relation = page_links)
+      relation.filter_map { Adapters::Input::PageInfo.build(identifier: it.identifier).value_or(nil) }
     end
   end
 end

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_module_spec_helper
+
+module Wikis
+  FakeMetadata = Data.define(:title, :identifier)
+  RSpec.describe PageLinkMetadataService do
+    let(:relation) { PageLink.where(provider:) }
+
+    let(:provider) { create(:internal_wiki_provider) }
+    let(:page_links) { create_list(:relation_wiki_page_link, 3, provider:) }
+
+    let(:metadata) do
+      page_links.map { FakeMetadata.new("Wikis, now with more cheese! Part #{it.id}", it.identifier) }
+    end
+
+    subject(:service) { described_class.new(relation) }
+
+    before do
+      page_links
+
+      query_double = instance_double(Adapters::Providers::Internal::Queries::PageInfo)
+      allow(Adapters::Providers::Internal::Queries::PageInfo).to receive(:new).and_return(query_double)
+
+      allow(query_double).to receive(:call).and_return(Success(metadata))
+    end
+
+    it "returns a new relation" do
+      service_result = service.call
+
+      expect(service_result).to be_success
+      expect(service_result.errors).to be_empty
+      expect(service_result.result).to be_an(ActiveRecord::Relation)
+    end
+
+    it "adds the title attribute to the metadata association" do
+      service_result = service.call
+      expect(service_result).to be_success
+
+      page_links = service_result.result
+      expect(page_links.first.title).to match(/Wikis, now with more cheese! Part \d+/)
+    end
+  end
+end

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -38,7 +38,7 @@ module Wikis
     shared_let(:provider) { create(:internal_wiki_provider) }
     shared_let(:page_links) { create_list(:relation_wiki_page_link, 3, provider:) }
 
-    subject(:service) { described_class }
+    subject(:service) { described_class.new(relation) }
 
     before do
       query_double = instance_double(Adapters::Providers::Internal::Queries::PageInfo)
@@ -58,7 +58,7 @@ module Wikis
     end
 
     it "returns a new relation" do
-      service_result = service.call(relation)
+      service_result = service.call
 
       expect(service_result).to be_success
       expect(service_result.errors).to be_empty
@@ -66,7 +66,7 @@ module Wikis
     end
 
     it "adds the title attribute to the metadata association" do
-      service_result = service.call(relation)
+      service_result = service.call
       expect(service_result).to be_success
 
       page_links = service_result.result

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -78,22 +78,23 @@ module Wikis
       shared_let(:xwiki_provider) { create(:xwiki_provider) }
       let(:new_page_links) do
         page_links.map do |pl|
-          create(:relation_wiki_page_link, provider: xwiki_provider, identifier: pl)
+          create(:relation_wiki_page_link, provider: xwiki_provider, identifier: pl.identifier)
         end
       end
 
       before do
-        allow(query_class_double).to receive(:new).with(model: xwiki_provider).and_return(query_double)
+        new_double = instance_double(Adapters::Providers::Internal::Queries::PageInfo)
+        allow(query_class_double).to receive(:new).with(model: xwiki_provider).and_return(new_double)
         Adapters::Registry.stub("xwiki.queries.page_info", query_class_double)
 
         new_page_links.map do |pl|
           input = Adapters::Input::PageInfo.build(identifier: pl.identifier).value_or(nil)
-          allow(query_double).to receive(:call).with(input).and_return(
+          allow(new_double).to receive(:call).with(input).and_return(
             Success(
               Adapters::Results::PageInfo.new(title: "Wikis, now with more cheese! Part #{pl.id}",
                                               identifier: input.identifier,
                                               href: "totally_valid_url",
-                                              provider: pl.provider)
+                                              provider: xwiki_provider)
             )
           )
         end
@@ -103,9 +104,9 @@ module Wikis
         service_result = service.call
 
         expect(service_result).to be_success
-        relation = service_result.result
+        page_links = service_result.result
 
-        relation.find_each do |page_link|
+        page_links.find_each do |page_link|
           case page_link.provider_id
           when xwiki_provider.id
             expect(page_link.title).to eq("Wikis, now with more cheese! Part #{page_link.id}")

--- a/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
+++ b/modules/wikis/spec/services/wikis/page_link_metadata_service_spec.rb
@@ -32,30 +32,33 @@ require "spec_helper"
 require_module_spec_helper
 
 module Wikis
-  FakeMetadata = Data.define(:title, :identifier)
   RSpec.describe PageLinkMetadataService do
-    let(:relation) { PageLink.where(provider:) }
+    let(:relation) { PageLink.limit(30) }
 
-    let(:provider) { create(:internal_wiki_provider) }
-    let(:page_links) { create_list(:relation_wiki_page_link, 3, provider:) }
+    shared_let(:provider) { create(:internal_wiki_provider) }
+    shared_let(:page_links) { create_list(:relation_wiki_page_link, 3, provider:) }
 
-    let(:metadata) do
-      page_links.map { FakeMetadata.new("Wikis, now with more cheese! Part #{it.id}", it.identifier) }
-    end
-
-    subject(:service) { described_class.new(relation) }
+    subject(:service) { described_class }
 
     before do
-      page_links
-
       query_double = instance_double(Adapters::Providers::Internal::Queries::PageInfo)
-      allow(Adapters::Providers::Internal::Queries::PageInfo).to receive(:new).and_return(query_double)
+      query_class_double = class_double(Adapters::Providers::Internal::Queries::PageInfo, new: query_double)
+      Adapters::Registry.stub("internal.queries.page_info", query_class_double)
 
-      allow(query_double).to receive(:call).and_return(Success(metadata))
+      build_inputs.each do |input|
+        allow(query_double).to receive(:call).with(input).and_return(
+          Success(
+            Adapters::Results::PageInfo.new(title: "Wikis, now with more cheese! Part #{input.identifier}",
+                                            identifier: input.identifier,
+                                            href: "totally_valid_url",
+                                            provider:)
+          )
+        )
+      end
     end
 
     it "returns a new relation" do
-      service_result = service.call
+      service_result = service.call(relation)
 
       expect(service_result).to be_success
       expect(service_result.errors).to be_empty
@@ -63,11 +66,17 @@ module Wikis
     end
 
     it "adds the title attribute to the metadata association" do
-      service_result = service.call
+      service_result = service.call(relation)
       expect(service_result).to be_success
 
       page_links = service_result.result
-      expect(page_links.first.title).to match(/Wikis, now with more cheese! Part \d+/)
+      expect(page_links.first.title).to eq("Wikis, now with more cheese! Part #{page_links.first.identifier}")
+    end
+
+    private
+
+    def build_inputs
+      page_links.filter_map { Adapters::Input::PageInfo.build(identifier: it.identifier).value_or(nil) }
     end
   end
 end

--- a/modules/wikis/spec/spec_helper.rb
+++ b/modules/wikis/spec/spec_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "dry/container/stub"
+require "dry/monads"
+
+RSpec.configure do |config|
+  config.include Dry::Monads[:result]
+
+  config.prepend_before do
+    Wikis::Adapters::Registry.enable_stubs!
+  end
+  config.append_after do
+    Wikis::Adapters::Registry.unstub
+  end
+end


### PR DESCRIPTION
This PR covers work packages: [OP#73839](https://community.openproject.com/work_packages/73839), [OP#73865](https://community.openproject.com/work_packages/73865) and [OP#73866](https://community.openproject.com/work_packages/73866)

## What?

For the endpoint to be fully introduced a couple of new objects needed to be added: PageLinksQuery, ProviderFilters and a way to enrich the Models with some metadata, represented by the PageLinksMetadataService.

## How?

It follows the same patterns we used in storages, having services isolating the API and the same processes to build the data.

## What is missing?

1. An actual query to get the page titles
2. Some more error handling once this this available
3. Some assumptions where made, such that the commands would return a `Result` monad.
4. Some tests run on all pretend behaviour