### PR TITLE
[#72242] Workflows UX improvement: Allow multi-selection of roles in workflow  

### DIFF
--- a/app/components/workflows/blankslate_component.html.erb
+++ b/app/components/workflows/blankslate_component.html.erb
@@ -31,9 +31,8 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
     blankslate.with_heading(tag: :h2).with_content(t("admin.workflows.blankslate.title"))
     blankslate.with_description_content(t("admin.workflows.blankslate.description"))
-    # TODO: pass all roles once BlankslateComponent accepts roles: and StatusDialogComponent supports multi-role natively.
     blankslate.with_primary_action(
-      href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_ids: [@role.id]),
+      href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id)),
       scheme: :secondary,
       data: { controller: "async-dialog" }
     ) do |button|

--- a/app/components/workflows/blankslate_component.html.erb
+++ b/app/components/workflows/blankslate_component.html.erb
@@ -31,8 +31,9 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::Beta::Blankslate.new(border: true)) do |blankslate|
     blankslate.with_heading(tag: :h2).with_content(t("admin.workflows.blankslate.title"))
     blankslate.with_description_content(t("admin.workflows.blankslate.description"))
+    # TODO: pass all roles once BlankslateComponent accepts roles: and StatusDialogComponent supports multi-role natively.
     blankslate.with_primary_action(
-      href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_id: @role.id),
+      href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_ids: [@role.id]),
       scheme: :secondary,
       data: { controller: "async-dialog" }
     ) do |button|

--- a/app/components/workflows/blankslate_component.rb
+++ b/app/components/workflows/blankslate_component.rb
@@ -32,9 +32,9 @@ module Workflows
   class BlankslateComponent < ApplicationComponent
     include OpPrimer::ComponentHelpers
 
-    def initialize(role:, type:, tab:)
+    def initialize(roles:, type:, tab:)
       super
-      @role = role
+      @roles = roles
       @type = type
       @tab = tab
     end

--- a/app/components/workflows/page_headers/edit_component.rb
+++ b/app/components/workflows/page_headers/edit_component.rb
@@ -30,7 +30,7 @@
 
 module Workflows::PageHeaders
   class EditComponent < BaseComponent
-    options :tabs, :role
+    options :tabs, :roles
 
     def type = model
 
@@ -49,7 +49,7 @@ module Workflows::PageHeaders
         mobile_icon: :copy,
         mobile_label: t(:button_copy),
         size: :medium,
-        href: new_workflow_copy_path(type, source_role_id: role&.id),
+        href: new_workflow_copy_path(type, source_role_id: roles&.first&.id),
         aria: { label: helpers.t(:button_copy) },
         title: helpers.t(:button_copy)
       ) do |button|

--- a/app/components/workflows/status_dialog_component.html.erb
+++ b/app/components/workflows/status_dialog_component.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
         Workflows::StatusFormComponent.new(
           all_statuses: @all_statuses,
           current_statuses: @current_statuses,
-          role: @role,
+          roles: @roles,
           type: @type,
           tab: @tab
         )

--- a/app/components/workflows/status_dialog_component.rb
+++ b/app/components/workflows/status_dialog_component.rb
@@ -35,11 +35,11 @@ module Workflows
 
     DIALOG_ID = "workflows-status-dialog"
 
-    def initialize(all_statuses:, current_statuses:, role:, type:, tab:)
+    def initialize(all_statuses:, current_statuses:, roles:, type:, tab:)
       super
       @all_statuses = all_statuses
       @current_statuses = current_statuses
-      @role = role
+      @roles = roles
       @type = type
       @tab = tab
     end

--- a/app/components/workflows/status_form_component.html.erb
+++ b/app/components/workflows/status_form_component.html.erb
@@ -28,9 +28,8 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
-  # TODO: pass all roles once StatusFormComponent and confirm_statuses support multi-role natively.
   primer_form_with(
-    url: helpers.confirm_statuses_workflow_tab_path(@type, @tab, role_ids: [@role.id]),
+    url: helpers.confirm_statuses_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id)),
     method: :post,
     id: FORM_ID,
     data: { turbo_frame: "workflow-table" }
@@ -40,7 +39,6 @@ See COPYRIGHT and LICENSE files for more details.
         f,
         all_statuses: @all_statuses,
         current_statuses: @current_statuses,
-        role: @role,
         type: @type,
         tab: @tab,
         dialog_id:

--- a/app/components/workflows/status_form_component.html.erb
+++ b/app/components/workflows/status_form_component.html.erb
@@ -28,8 +28,9 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%=
+  # TODO: pass all roles once StatusFormComponent and confirm_statuses support multi-role natively.
   primer_form_with(
-    url: helpers.confirm_statuses_workflow_tab_path(@type, @tab, role_id: @role.id),
+    url: helpers.confirm_statuses_workflow_tab_path(@type, @tab, role_ids: [@role.id]),
     method: :post,
     id: FORM_ID,
     data: { turbo_frame: "workflow-table" }

--- a/app/components/workflows/status_form_component.rb
+++ b/app/components/workflows/status_form_component.rb
@@ -32,11 +32,11 @@ module Workflows
   class StatusFormComponent < ApplicationComponent
     FORM_ID = "status-selection-form"
 
-    def initialize(all_statuses:, current_statuses:, role:, type:, tab:)
+    def initialize(all_statuses:, current_statuses:, roles:, type:, tab:)
       super
       @all_statuses = all_statuses
       @current_statuses = current_statuses
-      @role = role
+      @roles = roles
       @type = type
       @tab = tab
     end

--- a/app/components/workflows/status_matrix_form_component.html.erb
+++ b/app/components/workflows/status_matrix_form_component.html.erb
@@ -57,6 +57,14 @@ See COPYRIGHT and LICENSE files for more details.
                 item_id: available_role.id
               )
             end
+            panel.with_footer(show_divider: true) do
+              render(
+                Primer::Beta::Button.new(
+                  scheme: :primary,
+                  data: { action: "click->admin--workflow-role-select#apply" }
+                )
+              ) { t(:button_save) }
+            end
           end
         end
       end

--- a/app/components/workflows/status_matrix_form_component.html.erb
+++ b/app/components/workflows/status_matrix_form_component.html.erb
@@ -44,8 +44,8 @@ See COPYRIGHT and LICENSE files for more details.
               button.with_trailing_visual_icon(icon: :"triangle-down")
               if @roles.many?
                 t("admin.workflows.role_selector.roles", count: @roles.size)
-              elsif @role
-                t("admin.workflows.role_selector.label", role: @role.name)
+              elsif @roles.one?
+                t("admin.workflows.role_selector.label", role: @roles.first.name)
               else
                 t("admin.workflows.role_selector.no_role")
               end
@@ -66,8 +66,6 @@ See COPYRIGHT and LICENSE files for more details.
         scheme: :secondary,
         leading_icon: :plus,
         label: t("admin.workflows.status_button"),
-        # TODO: status_dialog and StatusDialogComponent currently work with a single role (@role = @roles.first);
-        # update when they support multi-role natively.
         href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id), status_ids: @statuses.pluck(:id).presence),
         data: { controller: "async-dialog" }
       ) do
@@ -132,6 +130,6 @@ See COPYRIGHT and LICENSE files for more details.
         %>
       <% end %>
   <% else %>
-    <%= render Workflows::BlankslateComponent.new(role: @role, type: @type, tab: @tab) %>
+    <%= render Workflows::BlankslateComponent.new(roles: @roles, type: @type, tab: @tab) %>
   <% end %>
 <% end %>

--- a/app/components/workflows/status_matrix_form_component.html.erb
+++ b/app/components/workflows/status_matrix_form_component.html.erb
@@ -77,7 +77,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% if @statuses.any? %>
     <%= form_tag(
           workflow_tab_path(@type),
-          id: "workflow_form",
+          id: form_id,
           method: :patch,
           autocomplete: "off",
           data: {

--- a/app/components/workflows/status_matrix_form_component.html.erb
+++ b/app/components/workflows/status_matrix_form_component.html.erb
@@ -32,19 +32,29 @@ See COPYRIGHT and LICENSE files for more details.
     render Primer::OpenProject::SubHeader.new do |subheader|
       if @type && @available_roles.any?
         subheader.with_filter_component do
-          render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
-            menu.with_show_button(scheme: :secondary) do |button|
+          render(
+            Primer::Alpha::SelectPanel.new(
+              select_variant: :multiple,
+              fetch_strategy: :local,
+              title: t("admin.workflows.role_selector.title"),
+              data: data_attributes
+            )
+          ) do |panel|
+            panel.with_show_button(scheme: :secondary) do |button|
               button.with_trailing_visual_icon(icon: :"triangle-down")
-              @role ? t("admin.workflows.role_selector.label", role: @role.name) : t("admin.workflows.role_selector.no_role")
+              if @roles.many?
+                t("admin.workflows.role_selector.roles", count: @roles.size)
+              elsif @role
+                t("admin.workflows.role_selector.label", role: @role.name)
+              else
+                t("admin.workflows.role_selector.no_role")
+              end
             end
             @available_roles.each do |available_role|
-              menu.with_item(
+              panel.with_item(
                 label: available_role.name,
-                active: available_role == @role,
-                tag: :a,
-                href: helpers.edit_workflow_tab_path(@type, @tab, role_id: available_role.id),
-                content_arguments: { data: { "admin--workflow-checkbox-state-confirmation-trigger": "click",
-                                             turbo_action: "advance" } }
+                active: @roles.include?(available_role),
+                item_id: available_role.id
               )
             end
           end
@@ -56,7 +66,9 @@ See COPYRIGHT and LICENSE files for more details.
         scheme: :secondary,
         leading_icon: :plus,
         label: t("admin.workflows.status_button"),
-        href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_id: @role&.id, status_ids: @statuses.pluck(:id).presence),
+        # TODO: status_dialog and StatusDialogComponent currently work with a single role (@role = @roles.first);
+        # update when they support multi-role natively.
+        href: helpers.status_dialog_workflow_tab_path(@type, @tab, role_ids: @roles.map(&:id), status_ids: @statuses.pluck(:id).presence),
         data: { controller: "async-dialog" }
       ) do
         t("admin.workflows.status_button")
@@ -76,7 +88,9 @@ See COPYRIGHT and LICENSE files for more details.
           }
         ) do %>
         <%= hidden_field_tag "type_id", @type.id %>
-        <%= hidden_field_tag "role_id", @role.id %>
+        <% @roles.each do |role| %>
+          <%= hidden_field_tag "role_ids[]", role.id %>
+        <% end %>
         <%= hidden_field_tag "tab", @tab %>
 
         <%= helpers.render_tabs helpers.workflow_tabs(@type) %>
@@ -94,7 +108,7 @@ See COPYRIGHT and LICENSE files for more details.
             Primer::OpenProject::FeedbackDialog.new(
               title: t("admin.workflows.leave_confirmation.title"),
               data: {
-                "admin--workflow-checkbox-state-target": "confirmationDialog",
+                "admin--workflow-checkbox-state-target": "confirmationDialog"
               }
             )
           ) do |dialog|

--- a/app/components/workflows/status_matrix_form_component.rb
+++ b/app/components/workflows/status_matrix_form_component.rb
@@ -48,7 +48,7 @@ module Workflows
     def data_attributes
       {
         controller: "admin--workflow-role-select",
-        "admin--workflow-role-select-base-url-value": helpers.edit_workflow_path(@type),
+        "admin--workflow-role-select-base-url-value": helpers.edit_workflow_tab_path(@type, @tab),
         "admin--workflow-role-select-current-role-ids-value": @roles.map(&:id).join(","),
         "admin--workflow-role-select-admin--workflow-checkbox-state-outlet": "#workflow_form"
       }

--- a/app/components/workflows/status_matrix_form_component.rb
+++ b/app/components/workflows/status_matrix_form_component.rb
@@ -33,6 +33,8 @@ module Workflows
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
+    FORM_ID = "workflow_form"
+
     def initialize(tab:, roles:, type:, available_roles:, statuses:, has_status_changes:)
       super
       @tab = tab
@@ -45,12 +47,14 @@ module Workflows
 
     private
 
+    def form_id = FORM_ID
+
     def data_attributes
       {
         controller: "admin--workflow-role-select",
         "admin--workflow-role-select-base-url-value": helpers.edit_workflow_tab_path(@type, @tab),
-        "admin--workflow-role-select-current-role-ids-value": @roles.map(&:id).join(","),
-        "admin--workflow-role-select-admin--workflow-checkbox-state-outlet": "#workflow_form"
+        "admin--workflow-role-select-current-role-ids-value": @roles.map(&:id),
+        "admin--workflow-role-select-admin--workflow-checkbox-state-outlet": "##{form_id}"
       }
     end
   end

--- a/app/components/workflows/status_matrix_form_component.rb
+++ b/app/components/workflows/status_matrix_form_component.rb
@@ -37,7 +37,6 @@ module Workflows
       super
       @tab = tab
       @roles = roles
-      @role = @roles.first
       @type = type
       @available_roles = available_roles
       @statuses = statuses

--- a/app/components/workflows/status_matrix_form_component.rb
+++ b/app/components/workflows/status_matrix_form_component.rb
@@ -33,14 +33,26 @@ module Workflows
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
 
-    def initialize(tab:, role:, type:, available_roles:, statuses:, has_status_changes:)
+    def initialize(tab:, roles:, type:, available_roles:, statuses:, has_status_changes:)
       super
       @tab = tab
-      @role = role
+      @roles = roles
+      @role = @roles.first
       @type = type
       @available_roles = available_roles
       @statuses = statuses
       @has_status_changes = has_status_changes
+    end
+
+    private
+
+    def data_attributes
+      {
+        controller: "admin--workflow-role-select",
+        "admin--workflow-role-select-base-url-value": helpers.edit_workflow_path(@type),
+        "admin--workflow-role-select-current-role-ids-value": @roles.map(&:id).join(","),
+        "admin--workflow-role-select-admin--workflow-checkbox-state-outlet": "#workflow_form"
+      }
     end
   end
 end

--- a/app/components/workflows/status_removal_danger_dialog_component.html.erb
+++ b/app/components/workflows/status_removal_danger_dialog_component.html.erb
@@ -46,8 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
     # The reason this is done here is because the submit is not a DELETE, and GET form submissions
     # strip url params
     dialog.with_additional_details do
-      # TODO: pass all roles once StatusRemovalDangerDialogComponent supports multi-role natively.
-      concat(hidden_field_tag("role_ids[]", @role.id))
+      @roles.each { |role| concat(hidden_field_tag("role_ids[]", role.id)) }
       @status_ids.each { |id| concat(hidden_field_tag("status_ids[]", id)) }
     end
   end

--- a/app/components/workflows/status_removal_danger_dialog_component.html.erb
+++ b/app/components/workflows/status_removal_danger_dialog_component.html.erb
@@ -46,7 +46,8 @@ See COPYRIGHT and LICENSE files for more details.
     # The reason this is done here is because the submit is not a DELETE, and GET form submissions
     # strip url params
     dialog.with_additional_details do
-      concat(hidden_field_tag(:role_id, @role.id))
+      # TODO: pass all roles once StatusRemovalDangerDialogComponent supports multi-role natively.
+      concat(hidden_field_tag("role_ids[]", @role.id))
       @status_ids.each { |id| concat(hidden_field_tag("status_ids[]", id)) }
     end
   end

--- a/app/components/workflows/status_removal_danger_dialog_component.rb
+++ b/app/components/workflows/status_removal_danger_dialog_component.rb
@@ -35,9 +35,9 @@ module Workflows
 
     DIALOG_ID = "workflows-status-removal-dialog"
 
-    def initialize(role:, type:, tab:, status_ids:, removed_count:)
+    def initialize(roles:, type:, tab:, status_ids:, removed_count:)
       super
-      @role = role
+      @roles = roles
       @type = type
       @tab = tab
       @status_ids = Array(status_ids).flatten.map(&:to_i)

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -57,9 +57,12 @@ class Workflows::TabsController < ApplicationController
     success = false
     Workflow.transaction do
       success = true
+      base_params = permitted_status_params
+      indeterminate = permitted_indeterminate_params
       @roles.each do |role|
+        role_params = indeterminate.empty? ? base_params : role_specific_params(base_params, indeterminate, role)
         result = Workflows::BulkUpdateService.new(role:, type: @type, tab: @tab)
-                                             .call(permitted_status_params)
+                                             .call(role_params)
         success = false unless result.success?
       end
       raise ActiveRecord::Rollback unless success
@@ -200,10 +203,40 @@ class Workflows::TabsController < ApplicationController
   end
 
   def permitted_status_params
-    return {} if params["status"].blank?
+    status_params("status")
+  end
 
-    params["status"]
+  def permitted_indeterminate_params
+    status_params("indeterminate_status")
+  end
+
+  def status_params(key)
+    return {} if params[key].blank?
+
+    params[key]
       .to_unsafe_h
-      .select { |key, value| /\A\d+\z/.match?(key) && value.keys.all? { /\A\d+\z/.match?(it) } }
+      .select { |k, value| /\A\d+\z/.match?(k) && value.keys.all? { /\A\d+\z/.match?(it) } }
+  end
+
+  def role_specific_params(base_params, indeterminate, role)
+    params = base_params.deep_dup
+    indeterminate.each do |old_id, new_ids|
+      new_ids.each_key do |new_id|
+        # Restore from DB so that it isn't overwritten by indeterminate state (unchecked)
+        had_transition = Workflow.exists?(
+          role_id: role.id,
+          type_id: @type.id,
+          old_status_id: old_id.to_i,
+          new_status_id: new_id.to_i,
+          author: @tab == "author",
+          assignee: @tab == "assignee"
+        )
+        if had_transition
+          params[old_id] ||= {}
+          params[old_id][new_id] = "1"
+        end
+      end
+    end
+    params
   end
 end

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -102,7 +102,7 @@ class Workflows::TabsController < ApplicationController
     all_statuses = Status.order(:position)
     current_statuses = if params[:status_ids].present?
                          Status.where(id: params[:status_ids].map(&:to_i)).order(:position)
-                       elsif @type && @role
+                       elsif @type && @roles.any?
                          statuses_for_roles_and_type
                        else
                          Status.none
@@ -111,7 +111,7 @@ class Workflows::TabsController < ApplicationController
     respond_with_dialog Workflows::StatusDialogComponent.new(
       all_statuses:,
       current_statuses:,
-      role: @role,
+      roles: @roles,
       type: @type,
       tab: @tab
     )
@@ -124,7 +124,7 @@ class Workflows::TabsController < ApplicationController
 
     if removed_count > 0
       respond_with_dialog Workflows::StatusRemovalDangerDialogComponent.new(
-        role: @role,
+        roles: @roles,
         type: @type,
         tab: @tab,
         status_ids: current_status_ids,
@@ -162,9 +162,6 @@ class Workflows::TabsController < ApplicationController
 
   def set_roles
     @roles = @eligible_roles.where(id: params[:role_ids])
-    # TODO: remove @role once the matrix form and all dependent components
-    # (dialogs, status selectors, page headers) work natively with @roles (multi-role).
-    @role = @roles.first
   end
 
   def statuses_for_form

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -162,6 +162,7 @@ class Workflows::TabsController < ApplicationController
 
   def set_roles
     @roles = @eligible_roles.where(id: params[:role_ids])
+    @roles = [@eligible_roles.first] if @roles.empty?
   end
 
   def statuses_for_form

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -48,7 +48,7 @@ class Workflows::TabsController < ApplicationController
 
     statuses_for_form
 
-    if @type && @role && @statuses.any?
+    if @type && @roles.any? && @statuses.any?
       workflows_for_form
     end
   end
@@ -100,7 +100,7 @@ class Workflows::TabsController < ApplicationController
     current_statuses = if params[:status_ids].present?
                          Status.where(id: params[:status_ids].map(&:to_i)).order(:position)
                        elsif @type && @role
-                         statuses_for_role_and_type
+                         statuses_for_roles_and_type
                        else
                          Status.none
                        end
@@ -169,8 +169,8 @@ class Workflows::TabsController < ApplicationController
     @has_status_changes = false
     @statuses = if @type && params[:status_ids].present?
                   statuses_from_params
-                elsif @type && @role
-                  statuses_for_role_and_type
+                elsif @type && @roles.any?
+                  statuses_for_roles_and_type
                 elsif @type
                   @type.statuses
                 else
@@ -180,18 +180,19 @@ class Workflows::TabsController < ApplicationController
 
   def statuses_from_params
     status_ids = params[:status_ids].map(&:to_i)
-    saved_ids = statuses_for_role_and_type.pluck(:id)
+    saved_ids = statuses_for_roles_and_type.pluck(:id)
     @added_status_ids = status_ids - saved_ids
     @has_status_changes = @added_status_ids.any? || (saved_ids - status_ids).any?
     Status.where(id: status_ids).order(:position)
   end
 
-  def statuses_for_role_and_type
-    @type.statuses(role: @role, tab: @tab)
+  def statuses_for_roles_and_type
+    status_ids = @roles.map { |role| @type.statuses(role:, tab: @tab).pluck(:id) }.flatten.uniq
+    Status.where(id: status_ids)
   end
 
   def workflows_for_form
-    workflows = Workflow.where(role_id: @role.id, type_id: @type.id)
+    workflows = Workflow.where(role_id: @roles.map(&:id), type_id: @type.id)
     @workflows = {}
     @workflows["always"] = workflows.select { |w| !w.author && !w.assignee }
     @workflows["author"] = workflows.select(&:author)

--- a/app/controllers/workflows/tabs_controller.rb
+++ b/app/controllers/workflows/tabs_controller.rb
@@ -38,11 +38,11 @@ class Workflows::TabsController < ApplicationController
   before_action :set_type
   before_action :set_tab
   before_action :set_eligible_roles
-  before_action :set_role
+  before_action :set_roles
 
   def edit
     unless turbo_frame_request?
-      redirect_to edit_workflow_path(@type, role_id: params[:role_id], tab: @tab)
+      redirect_to edit_workflow_path(@type, role_ids: params[:role_ids], tab: @tab)
       return
     end
 
@@ -53,12 +53,19 @@ class Workflows::TabsController < ApplicationController
     end
   end
 
-  def update
-    call = Workflows::BulkUpdateService
-           .new(role: @role, type: @type, tab: @tab)
-           .call(permitted_status_params)
+  def update # rubocop:disable Metrics/AbcSize
+    success = false
+    Workflow.transaction do
+      success = true
+      @roles.each do |role|
+        result = Workflows::BulkUpdateService.new(role:, type: @type, tab: @tab)
+                                             .call(permitted_status_params)
+        success = false unless result.success?
+      end
+      raise ActiveRecord::Rollback unless success
+    end
 
-    if call.success?
+    if success
       render_flash_message_via_turbo_stream(
         message: I18n.t(:notice_successful_update),
         scheme: :success
@@ -69,7 +76,7 @@ class Workflows::TabsController < ApplicationController
         update_via_turbo_stream(
           component: Workflows::StatusMatrixFormComponent.new(
             tab: @tab,
-            role: @role,
+            roles: @roles,
             type: @type,
             available_roles: @eligible_roles,
             statuses:,
@@ -125,7 +132,7 @@ class Workflows::TabsController < ApplicationController
       update_via_turbo_stream(
         component: Workflows::StatusMatrixFormComponent.new(
           tab: @tab,
-          role: @role,
+          roles: @roles,
           type: @type,
           available_roles: @eligible_roles,
           statuses:,
@@ -150,8 +157,11 @@ class Workflows::TabsController < ApplicationController
     @eligible_roles = Workflow.eligible_roles.order(:builtin, :position)
   end
 
-  def set_role
-    @role = @eligible_roles.find(params[:role_id])
+  def set_roles
+    @roles = @eligible_roles.where(id: params[:role_ids])
+    # TODO: remove @role once the matrix form and all dependent components
+    # (dialogs, status selectors, page headers) work natively with @roles (multi-role).
+    @role = @roles.first
   end
 
   def statuses_for_form

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -68,9 +68,6 @@ class WorkflowsController < ApplicationController
     ordered = eligible_roles.order(:builtin, :position)
     @roles = ordered.where(id: params[:role_ids])
     @roles = [ordered.first] if @roles.empty?
-    # TODO: remove @role once the matrix form and all dependent components
-    # (dialogs, status selectors, page headers) work natively with @roles (multi-role).
-    @role = @roles.first
   end
 
   def eligible_roles

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -56,10 +56,6 @@ class WorkflowsController < ApplicationController
     @types = ::Type.order(:position)
   end
 
-  def find_role
-    @role = eligible_roles.find(params[:role_id])
-  end
-
   def find_type
     @type = ::Type.find(params[:type_id])
   end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -38,7 +38,7 @@ class WorkflowsController < ApplicationController
   before_action :find_types, only: %i[index]
 
   before_action :find_type, only: %i[edit]
-  before_action :find_optional_role, only: %i[edit]
+  before_action :find_optional_roles, only: %i[edit]
 
   def index; end
 
@@ -64,8 +64,13 @@ class WorkflowsController < ApplicationController
     @type = ::Type.find(params[:type_id])
   end
 
-  def find_optional_role
-    @role = eligible_roles.find_by(id: params[:role_id]) || eligible_roles.order(:builtin, :position).first
+  def find_optional_roles
+    ordered = eligible_roles.order(:builtin, :position)
+    @roles = ordered.where(id: params[:role_ids])
+    @roles = [ordered.first] if @roles.empty?
+    # TODO: remove @role once the matrix form and all dependent components
+    # (dialogs, status selectors, page headers) work natively with @roles (multi-role).
+    @role = @roles.first
   end
 
   def eligible_roles

--- a/app/forms/workflows/status_select_form.rb
+++ b/app/forms/workflows/status_select_form.rb
@@ -30,18 +30,16 @@
 
 module Workflows
   class StatusSelectForm < ApplicationForm
-    def initialize(all_statuses:, current_statuses:, role:, type:, tab:, dialog_id:)
+    def initialize(all_statuses:, current_statuses:, type:, tab:, dialog_id:)
       super()
       @all_statuses = all_statuses
       @current_statuses = current_statuses
-      @role = role
       @type = type
       @tab = tab
       @dialog_id = dialog_id
     end
 
     form do |f|
-      f.hidden(name: :role_id, value: @role.id)
       f.hidden(name: :type_id, value: @type.id)
       f.hidden(name: :tab, value: @tab || "always")
       @current_statuses.each { |status| f.hidden(name: "original_status_ids[]", value: status.id) }

--- a/app/helpers/workflow_helper.rb
+++ b/app/helpers/workflow_helper.rb
@@ -37,7 +37,7 @@ module WorkflowHelper
     ].map do |tab|
       tab.merge(
         partial: "workflows/form",
-        path: edit_workflow_tab_path(type, tab[:name], params.permit(:role_id)),
+        path: edit_workflow_tab_path(type, tab[:name], params.permit(role_ids: [])),
         data: { "admin--workflow-checkbox-state-confirmation-trigger": "click",
                 turbo_frame: "workflow-table",
                 turbo_action: "advance" }

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -191,6 +191,7 @@ See COPYRIGHT and LICENSE files for more details.
                  newly_added_status = @added_status_ids.include?(old_status.id) || @added_status_ids.include?(new_status.id)
                  some_roles = !transition_role_ids.empty? && transition_role_ids.size < @roles.size && !newly_added_status %>
               <td>
+                <%= hidden_field_tag "indeterminate_status[#{old_status.id}][#{new_status.id}]", "1" if some_roles %>
                 <%=
                   render(Primer::BaseComponent.new(tag: :div, display: :flex, align_items: :center, mx: 1)) do
                     render(
@@ -199,7 +200,7 @@ See COPYRIGHT and LICENSE files for more details.
                         name: "status[#{old_status.id}][#{new_status.id}]",
                         id: "status_#{old_status.id}_#{new_status.id}", # See BUG https://github.com/primer/view_components/issues/3811
                         value: name,
-                        checked: transition_role_ids.any? || newly_added_status,
+                        checked: !some_roles && (transition_role_ids.any? || newly_added_status),
                         label: t(".matrix_checkbox_label", old_status: old_status.name, new_status: new_status.name),
                         visually_hide_label: true,
                         data: {

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -187,8 +187,9 @@ See COPYRIGHT and LICENSE files for more details.
               <% end %>
             </th>
             <% @statuses.each do |new_status| -%>
-              <% transition_saved = workflows.any? { it.old_status_id == old_status.id && it.new_status_id == new_status.id }
-                 newly_added_status = @added_status_ids.include?(old_status.id) || @added_status_ids.include?(new_status.id) %>
+              <% transition_role_ids = workflows.select { it.old_status_id == old_status.id && it.new_status_id == new_status.id }.map(&:role_id).uniq
+                 newly_added_status = @added_status_ids.include?(old_status.id) || @added_status_ids.include?(new_status.id)
+                 some_roles = !transition_role_ids.empty? && transition_role_ids.size < @roles.size && !newly_added_status %>
               <td>
                 <%=
                   render(Primer::BaseComponent.new(tag: :div, display: :flex, align_items: :center, mx: 1)) do
@@ -198,13 +199,14 @@ See COPYRIGHT and LICENSE files for more details.
                         name: "status[#{old_status.id}][#{new_status.id}]",
                         id: "status_#{old_status.id}_#{new_status.id}", # See BUG https://github.com/primer/view_components/issues/3811
                         value: name,
-                        checked: transition_saved || newly_added_status,
+                        checked: transition_role_ids.any? || newly_added_status,
                         label: t(".matrix_checkbox_label", old_status: old_status.name, new_status: new_status.name),
                         visually_hide_label: true,
                         data: {
                           checkable_target: "checkbox",
                           old_status: old_status.id,
-                          new_status: new_status.id
+                          new_status: new_status.id,
+                          indeterminate: (true if some_roles)
                         }
                       )
                     )

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_administration), t(:label_workflow_plural), @type.name -%>
 <% content_for :content_header do %>
-  <%= render Workflows::PageHeaders::EditComponent.new(@type, role: @role, tabs: workflow_tabs(@type)) %>
+  <%= render Workflows::PageHeaders::EditComponent.new(@type, roles: @roles, tabs: workflow_tabs(@type)) %>
 <% end %>
 
 <% if @type && @roles.any? %>

--- a/app/views/workflows/edit.html.erb
+++ b/app/views/workflows/edit.html.erb
@@ -31,6 +31,6 @@ See COPYRIGHT and LICENSE files for more details.
   <%= render Workflows::PageHeaders::EditComponent.new(@type, role: @role, tabs: workflow_tabs(@type)) %>
 <% end %>
 
-<% if @type && @role %>
-  <%= turbo_frame_tag "workflow-table", src: edit_workflow_tab_path(@type, @current_tab, role_id: @role.id, status_ids: params[:status_ids]) %>
+<% if @type && @roles.any? %>
+  <%= turbo_frame_tag "workflow-table", src: edit_workflow_tab_path(@type, @current_tab, role_ids: @roles.map(&:id), status_ids: params[:status_ids]) %>
 <% end %>

--- a/app/views/workflows/summaries/show.html.erb
+++ b/app/views/workflows/summaries/show.html.erb
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
                 <td><%= h type %></td>
                 <% roles.each do |role, count| -%>
                   <td>
-                    <%= link_to((count > 0 ? count : content_tag(:span, "", class: "icon-close icon-context icon-button")), edit_workflow_path(type, role_id: role), title: t(:button_edit)) %>
+                    <%= link_to((count > 0 ? count : content_tag(:span, "", class: "icon-close icon-context icon-button")), edit_workflow_path(type, role_ids: [role]), title: t(:button_edit)) %>
                   </td>
                 <% end -%>
               </tr>

--- a/app/views/workflows/tabs/edit.html.erb
+++ b/app/views/workflows/tabs/edit.html.erb
@@ -30,6 +30,6 @@ See COPYRIGHT and LICENSE files for more details.
 <%= turbo_frame_tag "workflow-table", data: { turbo_cache: false } do %>
   <%= render Workflows::StatusMatrixFormComponent.new(tab: @tab, roles: @roles, type: @type, available_roles: @eligible_roles, statuses: @statuses, has_status_changes: @has_status_changes) %>
   <%= turbo_stream.replace(Workflows::PageHeaders::EditComponent.wrapper_key) do %>
-    <%= render Workflows::PageHeaders::EditComponent.new(@type, role: @role, tabs: workflow_tabs(@type)) %>
+    <%= render Workflows::PageHeaders::EditComponent.new(@type, roles: @roles, tabs: workflow_tabs(@type)) %>
   <% end %>
 <% end %>

--- a/app/views/workflows/tabs/edit.html.erb
+++ b/app/views/workflows/tabs/edit.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= turbo_frame_tag "workflow-table", data: { turbo_cache: false } do %>
-  <%= render Workflows::StatusMatrixFormComponent.new(tab: @tab, role: @role, type: @type, available_roles: @eligible_roles, statuses: @statuses, has_status_changes: @has_status_changes) %>
+  <%= render Workflows::StatusMatrixFormComponent.new(tab: @tab, roles: @roles, type: @type, available_roles: @eligible_roles, statuses: @statuses, has_status_changes: @has_status_changes) %>
   <%= turbo_stream.replace(Workflows::PageHeaders::EditComponent.wrapper_key) do %>
     <%= render Workflows::PageHeaders::EditComponent.new(@type, role: @role, tabs: workflow_tabs(@type)) %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,8 +461,12 @@ en:
         ignore: "Ignore changes"
         save: "Save changes and continue"
       role_selector:
+        title: "Select roles"
         label: "Role: %{role}"
         no_role: "Select role"
+        roles:
+          one: "%{count} role selected"
+          other: "%{count} roles selected"
       blankslate:
         title: "No status transitions configured"
         description: "Add statuses to start configuring workflows for this role"

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -208,3 +208,13 @@ ul.SegmentedControl,
 
       & .Banner-actions
         margin: var(--base-size-8) 0 0 var(--base-size-8)
+
+// Bug in @openproject/primer-view-components: .FormControl-checkbox:indeterminate
+// has no background rule, and :indeterminate:before doesn't cancel checkmarkOut.
+.FormControl-checkbox:indeterminate
+  background: var(--control-checked-bgColor-rest, var(--color-accent-fg))
+  border-color: var(--control-checked-borderColor-rest, var(--color-accent-fg))
+
+  &:before
+    animation: none
+    clip-path: inset(0)

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -313,7 +313,7 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     if (this.isDirtyValue) {
       this.confirmThenNavigate(url);
     } else {
-      Turbo.visit(url);
+      this.frameNavigateTo(url);
     }
   }
 
@@ -323,14 +323,27 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
         this.hasCheckboxChangesValue = false;
         this.hasStatusChangesValue = false;
         this.confirmationDialogTarget.close();
-        setTimeout(() => { Turbo.visit(url); }, 0);
+        setTimeout(() => { this.frameNavigateTo(url); }, 0);
       },
       () => {
         this.element.requestSubmit();
         this.confirmationDialogTarget.close();
         // Delay to allow the flash message from the form submission to appear.
-        setTimeout(() => { Turbo.visit(url); }, 1000);
+        setTimeout(() => { this.frameNavigateTo(url); }, 1000);
       },
     );
+  }
+
+  // This keeps the url in the /tabs/:tab/edit format consistently,
+  // rather than doing a Turbo.visit which changes the format.
+  // It also keeps history usable, similar to data-turbo-action="advance".
+  private frameNavigateTo(url:string) {
+    const turboFrame = this.element.closest('turbo-frame') as HTMLElement | null;
+    if (turboFrame) {
+      turboFrame.setAttribute('src', url);
+      history.pushState({}, '', url);
+    } else {
+      Turbo.visit(url);
+    }
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -82,7 +82,7 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     if (statusCheckboxes) {
       this.applyState(statusCheckboxes);
       // Recompute dirty flag: the restored state may differ from DB pristine.
-      this.onCheckboxChange();
+      this.recomputeDirtyFlag();
     } else {
       // Apply indeterminate checkboxes only on fresh server rendered content.
       this.initIndeterminateCheckboxes();
@@ -264,12 +264,24 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     window.OpenProject.pageState = hasChanges ? 'edited' : 'pristine';
   }
 
-  private onCheckboxChange = () => {
+  private onCheckboxChange = (event:Event) => {
+    this.removeIndeterminateMarker(event.target as HTMLInputElement);
+    this.recomputeDirtyFlag();
+  };
+
+  private recomputeDirtyFlag() {
     const current = this.captureState();
     const hasChanges = Object.keys(current).some((key) => current[key] !== this.initialCheckboxState[key]);
 
     this.hasCheckboxChangesValue = hasChanges;
-  };
+  }
+
+  private removeIndeterminateMarker(checkbox:HTMLInputElement):void {
+    const { oldStatus, newStatus } = checkbox.dataset;
+    this.element.querySelector<HTMLInputElement>(
+      `input[name="indeterminate_status[${oldStatus}][${newStatus}]"]`,
+    )?.remove();
+  }
 
   private captureState():Record<string, boolean> {
     const checkboxes:Record<string, boolean> = {};

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -83,6 +83,9 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
       this.applyState(statusCheckboxes);
       // Recompute dirty flag: the restored state may differ from DB pristine.
       this.onCheckboxChange();
+    } else {
+      // Apply indeterminate checkboxes only on fresh server rendered content.
+      this.initIndeterminateCheckboxes();
     }
 
     // Use document-level delegation so this works even when the EditComponent
@@ -281,6 +284,12 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
       const key = `${cb.dataset.oldStatus}:${cb.dataset.newStatus}:${cb.value}`;
 
       cb.checked = checkboxes[key] ?? defaultValue ?? true;
+    });
+  }
+
+  private initIndeterminateCheckboxes():void {
+    this.element.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-indeterminate="true"]').forEach((cb) => {
+      cb.indeterminate = true;
     });
   }
 

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-checkbox-state.controller.ts
@@ -113,11 +113,19 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
   };
 
   private get formKey():string {
-    return `${this.formValue('type_id')}-${this.formValue('role_id')}`;
+    const typeId = this.formValue('type_id');
+    const roleIds = this.formValues('role_ids[]').sort().join(',');
+    return `${typeId}-${roleIds}`;
   }
 
   private formValue(name:string):string {
     return this.element.querySelector<HTMLInputElement>(`input[name="${name}"]`)!.value;
+  }
+
+  private formValues(name:string):string[] {
+    return Array.from(
+      this.element.querySelectorAll<HTMLInputElement>(`input[name="${name}"]`),
+    ).map((el) => el.value);
   }
 
   private pushState(key:string, state:CheckboxesState) {
@@ -155,7 +163,7 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
       event.preventDefault();
       event.stopImmediatePropagation();
 
-      this.showDialog(target, event);
+      this.confirmThenResubmit(target, event);
     }
     else {
       // Reset confirmation status for next time
@@ -167,19 +175,21 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
     }
   };
 
-  private showDialog = (target:HTMLElement, event:Event) => {
-    const onIgnoreCallback = this.onIgnoreChanges(target, event);
-    this.ignoreButtonTarget.addEventListener('click', onIgnoreCallback);
-
-    const onSaveCallback = this.onSaveChanges(target, event);
-    this.saveButtonTarget.addEventListener('click', onSaveCallback);
-
+  private openConfirmationDialog(onIgnore:() => void, onSave:() => void) {
+    this.ignoreButtonTarget.addEventListener('click', onIgnore);
+    this.saveButtonTarget.addEventListener('click', onSave);
     this.confirmationDialogTarget.addEventListener('close', () => {
-      this.ignoreButtonTarget.removeEventListener('click', onIgnoreCallback);
-      this.saveButtonTarget.removeEventListener('click', onSaveCallback);
+      this.ignoreButtonTarget.removeEventListener('click', onIgnore);
+      this.saveButtonTarget.removeEventListener('click', onSave);
     });
-
     this.confirmationDialogTarget.showModal();
+  }
+
+  private confirmThenResubmit = (target:HTMLElement, event:Event) => {
+    this.openConfirmationDialog(
+      this.onIgnoreChanges(target, event),
+      this.onSaveChanges(target, event),
+    );
   };
 
   private onIgnoreChanges = (originalTarget:HTMLElement, originalEvent:Event) => {
@@ -193,7 +203,7 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
       const url = new URL(src);
       // Reload only with original params
       const params = new URLSearchParams();
-      params.set('role_id', url.searchParams.get('role_id') ?? '');
+      url.searchParams.getAll('role_ids[]').forEach((id) => params.append('role_ids[]', id));
       url.search = params.toString();
       turboFrame.setAttribute('src', url.toString());
 
@@ -272,5 +282,34 @@ export default class WorkflowCheckboxStateController extends Controller<HTMLForm
 
       cb.checked = checkboxes[key] ?? defaultValue ?? true;
     });
+  }
+
+  //
+  // Trigger navigation with dirty-state confirmation.
+  //
+
+  navigateTo(url:string) {
+    if (this.isDirtyValue) {
+      this.confirmThenNavigate(url);
+    } else {
+      Turbo.visit(url);
+    }
+  }
+
+  private confirmThenNavigate(url:string) {
+    this.openConfirmationDialog(
+      () => {
+        this.hasCheckboxChangesValue = false;
+        this.hasStatusChangesValue = false;
+        this.confirmationDialogTarget.close();
+        setTimeout(() => { Turbo.visit(url); }, 0);
+      },
+      () => {
+        this.element.requestSubmit();
+        this.confirmationDialogTarget.close();
+        // Delay to allow the flash message from the form submission to appear.
+        setTimeout(() => { Turbo.visit(url); }, 1000);
+      },
+    );
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -45,15 +45,7 @@ export default class WorkflowRoleSelectController extends Controller {
   declare baseUrlValue:string;
   declare currentRoleIdsValue:unknown[];
 
-  connect() {
-    this.element.addEventListener('panelClosed', this.handlePanelClosed);
-  }
-
-  disconnect() {
-    this.element.removeEventListener('panelClosed', this.handlePanelClosed);
-  }
-
-  private handlePanelClosed = () => {
+  apply() {
     const panel = this.element as HTMLElement as SelectPanelElement;
     const selectedIds = panel.items
       .filter((item) => panel.isItemChecked(item))
@@ -69,8 +61,8 @@ export default class WorkflowRoleSelectController extends Controller {
     if (selectedIds.slice().sort().join(',') === this.currentRoleIdsValue.slice().sort().join(',')) return;
 
     this.navigateTo(this.buildUrl(selectedIds as string[]));
-  };
-  
+  }
+
   private buildUrl(roleIds:string[]):string {
     const url = new URL(this.baseUrlValue, window.location.origin);
     roleIds.forEach((id) => url.searchParams.append('role_ids[]', id));

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -33,7 +33,6 @@ import type { SelectPanelElement } from '@primer/view-components/app/components/
 import WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
 
 /**
- * Mounted on the <select-panel> element for role selection in the workflow quick filters.
  * When the panel closes, it navigates to the workflow edit page with the selected role IDs.
  * Delegates dirty-state confirmation to the workflow-checkbox-state controller via an outlet.
  */
@@ -61,9 +60,19 @@ export default class WorkflowRoleSelectController extends Controller {
       .map((item) => item.getAttribute('data-item-id'))
       .filter(Boolean);
 
-    if (!selectedIds.length) return;
+    // For when all roles are deselected
+    if (!selectedIds.length) {
+      const url = new URL(this.baseUrlValue, window.location.origin);
+      if (this.hasAdminWorkflowCheckboxStateOutlet) {
+        this.adminWorkflowCheckboxStateOutlet.navigateTo(url.toString());
+      } else {
+        Turbo.visit(url.toString());
+      }
+      return;
+    }
 
     const currentIds = this.currentRoleIdsValue.split(',').filter(Boolean);
+
     if (selectedIds.slice().sort().join(',') === currentIds.slice().sort().join(',')) return;
 
     const url = new URL(this.baseUrlValue, window.location.origin);

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -38,12 +38,12 @@ import WorkflowCheckboxStateController from './workflow-checkbox-state.controlle
  */
 export default class WorkflowRoleSelectController extends Controller {
   static outlets = ['admin--workflow-checkbox-state'];
-  static values = { baseUrl: String, currentRoleIds: String };
+  static values = { baseUrl: String, currentRoleIds: Array };
 
   declare readonly adminWorkflowCheckboxStateOutlet:WorkflowCheckboxStateController;
   declare readonly hasAdminWorkflowCheckboxStateOutlet:boolean;
   declare baseUrlValue:string;
-  declare currentRoleIdsValue:string;
+  declare currentRoleIdsValue:unknown[];
 
   connect() {
     this.element.addEventListener('panelClosed', this.handlePanelClosed);
@@ -66,8 +66,7 @@ export default class WorkflowRoleSelectController extends Controller {
       return;
     }
 
-    const currentIds = this.currentRoleIdsValue.split(',').filter(Boolean);
-    if (selectedIds.slice().sort().join(',') === currentIds.slice().sort().join(',')) return;
+    if (selectedIds.slice().sort().join(',') === this.currentRoleIdsValue.slice().sort().join(',')) return;
 
     this.navigateTo(this.buildUrl(selectedIds as string[]));
   };

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -62,26 +62,27 @@ export default class WorkflowRoleSelectController extends Controller {
 
     // For when all roles are deselected
     if (!selectedIds.length) {
-      const url = new URL(this.baseUrlValue, window.location.origin);
-      if (this.hasAdminWorkflowCheckboxStateOutlet) {
-        this.adminWorkflowCheckboxStateOutlet.navigateTo(url.toString());
-      } else {
-        Turbo.visit(url.toString());
-      }
+      this.navigateTo(this.buildUrl([]));
       return;
     }
 
     const currentIds = this.currentRoleIdsValue.split(',').filter(Boolean);
-
     if (selectedIds.slice().sort().join(',') === currentIds.slice().sort().join(',')) return;
 
-    const url = new URL(this.baseUrlValue, window.location.origin);
-    selectedIds.forEach((id) => url.searchParams.append('role_ids[]', id!));
-
-    if (this.hasAdminWorkflowCheckboxStateOutlet) {
-      this.adminWorkflowCheckboxStateOutlet.navigateTo(url.toString());
-    } else {
-      Turbo.visit(url.toString());
-    }
+    this.navigateTo(this.buildUrl(selectedIds as string[]));
   };
+  
+  private buildUrl(roleIds:string[]):string {
+    const url = new URL(this.baseUrlValue, window.location.origin);
+    roleIds.forEach((id) => url.searchParams.append('role_ids[]', id));
+    return url.toString();
+  }
+
+  private navigateTo(url:string) {
+    if (this.hasAdminWorkflowCheckboxStateOutlet) {
+      this.adminWorkflowCheckboxStateOutlet.navigateTo(url);
+    } else {
+      Turbo.visit(url);
+    }
+  }
 }

--- a/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/workflow-role-select.controller.ts
@@ -1,0 +1,78 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+import type { SelectPanelElement } from '@primer/view-components/app/components/primer/alpha/select_panel_element';
+import WorkflowCheckboxStateController from './workflow-checkbox-state.controller';
+
+/**
+ * Mounted on the <select-panel> element for role selection in the workflow quick filters.
+ * When the panel closes, it navigates to the workflow edit page with the selected role IDs.
+ * Delegates dirty-state confirmation to the workflow-checkbox-state controller via an outlet.
+ */
+export default class WorkflowRoleSelectController extends Controller {
+  static outlets = ['admin--workflow-checkbox-state'];
+  static values = { baseUrl: String, currentRoleIds: String };
+
+  declare readonly adminWorkflowCheckboxStateOutlet:WorkflowCheckboxStateController;
+  declare readonly hasAdminWorkflowCheckboxStateOutlet:boolean;
+  declare baseUrlValue:string;
+  declare currentRoleIdsValue:string;
+
+  connect() {
+    this.element.addEventListener('panelClosed', this.handlePanelClosed);
+  }
+
+  disconnect() {
+    this.element.removeEventListener('panelClosed', this.handlePanelClosed);
+  }
+
+  private handlePanelClosed = () => {
+    const panel = this.element as HTMLElement as SelectPanelElement;
+    const selectedIds = panel.items
+      .filter((item) => panel.isItemChecked(item))
+      .map((item) => item.getAttribute('data-item-id'))
+      .filter(Boolean);
+
+    if (!selectedIds.length) return;
+
+    const currentIds = this.currentRoleIdsValue.split(',').filter(Boolean);
+    if (selectedIds.slice().sort().join(',') === currentIds.slice().sort().join(',')) return;
+
+    const url = new URL(this.baseUrlValue, window.location.origin);
+    selectedIds.forEach((id) => url.searchParams.append('role_ids[]', id!));
+
+    if (this.hasAdminWorkflowCheckboxStateOutlet) {
+      this.adminWorkflowCheckboxStateOutlet.navigateTo(url.toString());
+    } else {
+      Turbo.visit(url.toString());
+    }
+  };
+}

--- a/spec/controllers/workflows/tabs_controller_spec.rb
+++ b/spec/controllers/workflows/tabs_controller_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Workflows::TabsController do
             .with(role.id.to_s)
             .and_return(role)
 
+    allow(role_scope)
+      .to receive(:where)
+            .with(id: [role.id.to_s])
+            .and_return([role])
+
     role_scope
   end
 
@@ -68,32 +73,58 @@ RSpec.describe Workflows::TabsController do
 
   describe "#edit" do
     context "when not a turbo frame request" do
-      it "redirects to the parent workflow edit path" do
-        get :edit,
-            params: {
-              role_id: role.id.to_s,
-              workflow_type_id: type.id.to_s,
-              tab: "always"
-            }
+      context "with a single role" do
+        it "redirects to the parent workflow edit path" do
+          get :edit,
+              params: {
+                role_ids: [role.id.to_s],
+                workflow_type_id: type.id.to_s,
+                tab: "always"
+              }
 
-        expect(response).to redirect_to(
-          edit_workflow_path(type, role_id: role.id.to_s, tab: "always")
-        )
+          expect(response).to redirect_to(
+            edit_workflow_path(type, role_ids: [role.id.to_s], tab: "always")
+          )
+        end
+
+        it "does not forward status_ids to the redirect" do
+          get :edit,
+              params: {
+                role_ids: [role.id.to_s],
+                workflow_type_id: type.id.to_s,
+                tab: "always",
+                status_ids: ["1", "2"]
+              }
+
+          expect(response).to redirect_to(
+            edit_workflow_path(type, role_ids: [role.id.to_s], tab: "always")
+          )
+          expect(response.location).not_to include("status_ids")
+        end
       end
 
-      it "does not forward status_ids to the redirect" do
-        get :edit,
-            params: {
-              role_id: role.id.to_s,
-              workflow_type_id: type.id.to_s,
-              tab: "always",
-              status_ids: ["1", "2"]
-            }
+      context "with multiple roles" do
+        let(:role2) { build_stubbed(:project_role) }
 
-        expect(response).to redirect_to(
-          edit_workflow_path(type, role_id: role.id.to_s, tab: "always")
-        )
-        expect(response.location).not_to include("status_ids")
+        before do
+          allow(role_scope)
+            .to receive(:where)
+                  .with(id: [role.id.to_s, role2.id.to_s])
+                  .and_return([role, role2])
+        end
+
+        it "redirects preserving all role ids" do
+          get :edit,
+              params: {
+                role_ids: [role.id.to_s, role2.id.to_s],
+                workflow_type_id: type.id.to_s,
+                tab: "always"
+              }
+
+          expect(response).to redirect_to(
+            edit_workflow_path(type, role_ids: [role.id.to_s, role2.id.to_s], tab: "always")
+          )
+        end
       end
     end
   end
@@ -114,7 +145,7 @@ RSpec.describe Workflows::TabsController do
 
         post :confirm_statuses,
              params: {
-               role_id: role.id.to_s,
+               role_ids: [role.id.to_s],
                workflow_type_id: type.id.to_s,
                status_ids: ["1", "2"],
                original_status_ids: ["1", "2"],
@@ -133,7 +164,7 @@ RSpec.describe Workflows::TabsController do
       before do
         post :confirm_statuses,
              params: {
-               role_id: role.id.to_s,
+               role_ids: [role.id.to_s],
                workflow_type_id: type.id.to_s,
                status_ids: ["1"],
                original_status_ids: ["1", "2"],
@@ -152,33 +183,74 @@ RSpec.describe Workflows::TabsController do
 
   describe "#update" do
     let(:status_params) { { "1" => { "2" => ["always"] } } }
-    let(:service) do
-      instance_double(Workflows::BulkUpdateService).tap do |dbl|
-        allow(Workflows::BulkUpdateService)
-          .to receive(:new)
-                .with(role: role, type: type, tab: "always")
-                .and_return(dbl)
+    let(:call_result) { ServiceResult.success }
+
+    context "with a single role" do
+      let(:service) do
+        instance_double(Workflows::BulkUpdateService).tap do |dbl|
+          allow(Workflows::BulkUpdateService)
+            .to receive(:new)
+                  .with(role: role, type: type, tab: "always")
+                  .and_return(dbl)
+        end
+      end
+
+      before do
+        allow(service).to receive(:call).with(status_params).and_return(call_result)
+        allow(controller).to receive(:statuses_for_form).and_return([build_stubbed(:status)])
+        post :update,
+             params: { role_ids: [role.id.to_s], workflow_type_id: type.id, tab: "always", status: status_params },
+             format: :turbo_stream
+      end
+
+      it "calls the service and renders a flash turbo stream" do
+        expect(service).to have_received(:call).with(status_params)
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
       end
     end
-    let(:call_result) { ServiceResult.success }
-    let(:params) do
-      {
-        role_id: role.id,
-        workflow_type_id: type.id,
-        tab: "always",
-        status: status_params
-      }
-    end
 
-    before do
-      allow(service).to receive(:call).with(status_params).and_return(call_result)
-      allow(controller).to receive(:statuses_for_form).and_return([build_stubbed(:status)])
-      post :update, params:, format: :turbo_stream
-    end
+    context "with multiple roles" do
+      let(:role2) { build_stubbed(:project_role) }
+      let(:service1) do
+        instance_double(Workflows::BulkUpdateService).tap do |dbl|
+          allow(Workflows::BulkUpdateService)
+            .to receive(:new)
+                  .with(role: role, type: type, tab: "always")
+                  .and_return(dbl)
+        end
+      end
+      let(:service2) do
+        instance_double(Workflows::BulkUpdateService).tap do |dbl|
+          allow(Workflows::BulkUpdateService)
+            .to receive(:new)
+                  .with(role: role2, type: type, tab: "always")
+                  .and_return(dbl)
+        end
+      end
 
-    it "renders a flash turbo stream" do
-      expect(service).to have_received(:call).with(status_params)
-      expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      before do
+        allow(role_scope)
+          .to receive(:where)
+                .with(id: [role.id.to_s, role2.id.to_s])
+                .and_return([role, role2])
+        allow(service1).to receive(:call).with(status_params).and_return(call_result)
+        allow(service2).to receive(:call).with(status_params).and_return(call_result)
+        allow(controller).to receive(:statuses_for_form).and_return([build_stubbed(:status)])
+        post :update,
+             params: {
+               role_ids: [role.id.to_s, role2.id.to_s],
+               workflow_type_id: type.id,
+               tab: "always",
+               status: status_params
+             },
+             format: :turbo_stream
+      end
+
+      it "calls the service for each role and renders a flash turbo stream" do
+        expect(service1).to have_received(:call).with(status_params)
+        expect(service2).to have_received(:call).with(status_params)
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      end
     end
   end
 end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe WorkflowsController do
             .and_return(role_scope)
 
     allow(role_scope)
-      .to receive_messages(order: role_scope, find_by: nil)
+      .to receive_messages(order: role_scope, find_by: nil, first: role)
 
     allow(role_scope)
       .to receive(:find)
@@ -51,6 +51,11 @@ RSpec.describe WorkflowsController do
       .to receive(:find_by)
             .with(id: role.id.to_s)
             .and_return(role)
+
+    allow(role_scope)
+      .to receive(:where)
+            .with(id: nil)
+            .and_return([])
 
     role_scope
   end
@@ -90,10 +95,6 @@ RSpec.describe WorkflowsController do
       allow(Status)
         .to receive(:all)
               .and_return [type_status, non_type_status]
-
-      allow(role_scope)
-        .to receive(:order)
-              .and_return([role])
     end
 
     context "without parameters" do
@@ -111,9 +112,10 @@ RSpec.describe WorkflowsController do
           .to render_template :edit
       end
 
-      it "assigns the first role" do
-        expect(assigns[:role])
-          .to eq role
+      # TODO: @role is a temporary single-role fallback; remove once components support multi-role natively
+      it "assigns the first role as fallback for @role, with @roles as the canonical collection" do
+        expect(assigns[:role]).to eq role
+        expect(assigns[:roles]).to contain_exactly(role)
       end
 
       it "does assign type" do
@@ -122,40 +124,65 @@ RSpec.describe WorkflowsController do
       end
     end
 
-    context "with role and type params" do
+    context "with a single role param" do
       before do
-        get :edit, params: { role_id: role.id.to_s, type_id: type.id.to_s }
-      end
+        allow(role_scope)
+          .to receive(:where)
+                .with(id: [role.id.to_s])
+                .and_return([role])
 
-      it "responds with the role type statuses", :aggregate_failures do
-        expect(response)
-          .to have_http_status(:ok)
-        expect(response)
-          .to render_template :edit
-        expect(assigns[:role])
-          .to eq role
-        expect(assigns[:type])
-          .to eq type
+        get :edit, params: { role_ids: [role.id.to_s], type_id: type.id.to_s }
       end
 
       it "is successful" do
-        expect(response)
-          .to have_http_status(:ok)
+        expect(response).to have_http_status(:ok)
       end
 
       it "renders the edit template" do
-        expect(response)
-          .to render_template :edit
+        expect(response).to render_template :edit
       end
 
-      it "assigns role" do
-        expect(assigns[:role])
-          .to eq role
+      it "assigns the selected role" do
+        expect(assigns[:roles]).to contain_exactly(role)
+        expect(assigns[:role]).to eq role
       end
 
-      it "assign type" do
-        expect(assigns[:type])
-          .to eq type
+      it "assigns type" do
+        expect(assigns[:type]).to eq type
+      end
+    end
+
+    context "with multiple role params" do
+      let(:role2) { build_stubbed(:project_role) }
+
+      before do
+        allow(role_scope)
+          .to receive(:where)
+                .with(id: [role.id.to_s, role2.id.to_s])
+                .and_return([role, role2])
+
+        get :edit, params: { role_ids: [role.id.to_s, role2.id.to_s], type_id: type.id.to_s }
+      end
+
+      it "is successful" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the edit template" do
+        expect(response).to render_template :edit
+      end
+
+      it "assigns all selected roles" do
+        expect(assigns[:roles]).to contain_exactly(role, role2)
+      end
+
+      # TODO: @role is a temporary single-role fallback; remove once components support multi-role natively
+      it "assigns the first role as a temporary single-role fallback for @role" do
+        expect(assigns[:role]).to eq role
+      end
+
+      it "assigns type" do
+        expect(assigns[:type]).to eq type
       end
     end
   end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -112,9 +112,7 @@ RSpec.describe WorkflowsController do
           .to render_template :edit
       end
 
-      # TODO: @role is a temporary single-role fallback; remove once components support multi-role natively
-      it "assigns the first role as fallback for @role, with @roles as the canonical collection" do
-        expect(assigns[:role]).to eq role
+      it "assigns @roles as the canonical collection" do
         expect(assigns[:roles]).to contain_exactly(role)
       end
 
@@ -144,7 +142,6 @@ RSpec.describe WorkflowsController do
 
       it "assigns the selected role" do
         expect(assigns[:roles]).to contain_exactly(role)
-        expect(assigns[:role]).to eq role
       end
 
       it "assigns type" do
@@ -174,11 +171,6 @@ RSpec.describe WorkflowsController do
 
       it "assigns all selected roles" do
         expect(assigns[:roles]).to contain_exactly(role, role2)
-      end
-
-      # TODO: @role is a temporary single-role fallback; remove once components support multi-role natively
-      it "assigns the first role as a temporary single-role fallback for @role" do
-        expect(assigns[:role]).to eq role
       end
 
       it "assigns type" do

--- a/spec/features/roles/create_spec.rb
+++ b/spec/features/roles/create_spec.rb
@@ -111,8 +111,11 @@ RSpec.describe "Role creation", :js do
       click_link type.name
     end
 
+    new_role = Role.find_by!(name: "New role name")
     click_button existing_role.name
-    click_link "New role name"
+    find("[data-item-id='#{new_role.id}']").click
+    find("[data-item-id='#{existing_role.id}']").click
+    page.send_keys :escape
 
     old_status = existing_workflow.old_status.name
     new_status = existing_workflow.new_status.name

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -251,4 +251,22 @@ RSpec.describe "Workflow edit with multiple roles", :js do
       expect_flash(message: "Successful update.")
     end
   end
+
+  context "when modifying statuses" do
+    before { visit_workflow_edit(roles: [role, role2]) }
+
+    it "preserves all selected roles after adding a status" do
+      add_status_via_dialog(statuses[2])
+
+      expect(page).to have_text("2 roles selected")
+    end
+
+    it "preserves all selected roles after removing a status via the danger dialog" do
+      remove_status_via_dialog(statuses[1])
+
+      within_dialog("Remove statuses") { click_button "Remove" }
+
+      expect(page).to have_text("2 roles selected")
+    end
+  end
 end

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe "Workflow edit with multiple roles", :js do
+  include Toasts::Expectations
+  include Workflows::EditHelpers
+
+  let(:role)  { create(:project_role) }
+  let(:role2) { create(:project_role) }
+  let(:type)  { create(:type) }
+  let(:admin) { create(:admin) }
+  let(:statuses) { (1..3).map { create(:status) } }
+
+  # workflow for 0 -> 1 for 'role'
+  let!(:role_workflow) do
+    create(:workflow, role_id: role.id, type_id: type.id,
+                      old_status_id: statuses[0].id, new_status_id: statuses[1].id,
+                      author: false, assignee: false)
+  end
+
+  current_user { admin }
+
+  context "when displaying checkboxes" do
+    context "when all selected roles have a transition" do
+      let!(:role2_workflow) do
+        create(:workflow, role_id: role2.id, type_id: type.id,
+                          old_status_id: statuses[0].id, new_status_id: statuses[1].id,
+                          author: false, assignee: false)
+      end
+
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "shows the checkbox as checked" do
+        expect(page).to have_field workflow_checkbox(0, 1), checked: true
+        expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+      end
+    end
+
+    context "when no selected roles have a transition" do
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "shows the checkbox as unchecked" do
+        expect(page).to have_field workflow_checkbox(1, 0), checked: false
+        expect(indeterminate?(workflow_checkbox(1, 0))).to be false
+      end
+    end
+
+    context "when only some selected roles have a transition" do
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "shows the checkbox as indeterminate" do
+        expect(page).to have_field workflow_checkbox(0, 1), checked: false
+        expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+      end
+    end
+
+    context "when roles have different statuses in their workflows" do
+      let!(:role2_workflow) do
+        create(:workflow, role_id: role2.id, type_id: type.id,
+                          old_status_id: statuses[1].id, new_status_id: statuses[2].id,
+                          author: false, assignee: false)
+      end
+
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "shows the union of statuses from all selected roles" do
+        expect(page).to have_field workflow_checkbox(0, 2)
+        expect(page).to have_field workflow_checkbox(1, 2)
+      end
+    end
+
+    context "with a single role selected" do
+      before { visit_workflow_edit(roles: [role]) }
+
+      it "does not show indeterminate checkboxes" do
+        expect(page).to have_field workflow_checkbox(0, 1), checked: true
+        expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+      end
+    end
+  end
+
+  context "when saving" do
+    before { visit_workflow_edit(roles: [role, role2]) }
+
+    it "adds the transition for all roles when checking an unchecked checkbox" do
+      expect_transition(role, 1, 0, exist: false)
+      expect_transition(role2, 1, 0, exist: false)
+
+      check workflow_checkbox(1, 0)
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 1, 0, exist: true)
+      expect_transition(role2, 1, 0, exist: true)
+    end
+
+    it "preserves state for each role when saving an untouched indeterminate checkbox" do
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: false)
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: false)
+
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+    end
+
+    it "adds the transition for all roles when checking an indeterminate checkbox" do
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: false)
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      check workflow_checkbox(0, 1)
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: true)
+
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+    end
+
+    it "removes the transition from all roles when unchecking an indeterminate checkbox" do
+      expect_transition(role, 0, 1, exist: true)
+      expect_transition(role2, 0, 1, exist: false)
+
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      check workflow_checkbox(0, 1)
+      uncheck workflow_checkbox(0, 1)
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+
+      expect_transition(role, 0, 1, exist: false)
+      expect_transition(role2, 0, 1, exist: false)
+
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be false
+    end
+
+    context "when all roles have the transition" do
+      let!(:role2_workflow) do
+        create(:workflow, role_id: role2.id, type_id: type.id,
+                          old_status_id: statuses[0].id, new_status_id: statuses[1].id,
+                          author: false, assignee: false)
+      end
+
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "removes the transition from all roles when unchecking a fully checked checkbox" do
+        expect_transition(role, 0, 1, exist: true)
+        expect_transition(role2, 0, 1, exist: true)
+
+        uncheck workflow_checkbox(0, 1)
+        click_button "Save"
+        expect_flash(message: "Successful update.")
+
+        expect_transition(role, 0, 1, exist: false)
+        expect_transition(role2, 0, 1, exist: false)
+      end
+    end
+
+    context "with multiple indeterminate checkboxes" do
+      let!(:role_workflow2) do
+        create(:workflow, role_id: role.id, type_id: type.id,
+                          old_status_id: statuses[0].id, new_status_id: statuses[2].id,
+                          author: false, assignee: false)
+      end
+
+      before { visit_workflow_edit(roles: [role, role2]) }
+
+      it "handles touched and untouched indeterminate checkboxes independently" do
+        # Both 0 -> 1 and 0 -> 2 are indeterminate
+        expect_transition(role, 0, 1, exist: true)
+        expect_transition(role2, 0, 1, exist: false)
+        expect_transition(role, 0, 2, exist: true)
+        expect_transition(role2, 0, 2, exist: false)
+
+        check workflow_checkbox(0, 1) # explicitly check for all roles
+
+        click_button "Save"
+        expect_flash(message: "Successful update.")
+
+        # role2 now has this workflow
+        expect_transition(role2, 0, 1, exist: true)
+
+        # 0 -> 2 stays indeterminate
+        expect_transition(role, 0, 2, exist: true)
+        expect_transition(role2, 0, 2, exist: false)
+      end
+    end
+
+    it "marks the form dirty when interacting with an indeterminate checkbox" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      check workflow_checkbox(0, 1)
+
+      click_link "User is author"
+      expect(page).to have_dialog("Save changes before continuing?")
+    end
+
+    it "succeeds when saving with no changes to indeterminate checkboxes" do
+      expect(page).to have_field workflow_checkbox(0, 1), checked: false
+      expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+
+      click_button "Save"
+      expect_flash(message: "Successful update.")
+    end
+  end
+end

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe "Workflow edit with multiple roles", :js do
         expect(page).to have_field workflow_checkbox(0, 2)
         expect(page).to have_field workflow_checkbox(1, 2)
       end
+
+      it "pre-selects the union of statuses from all selected roles in the status dialog" do
+        within "#workflow-table" do
+          click_link "Status"
+        end
+
+        expect(page).to have_dialog("Statuses")
+        within_dialog "Statuses" do
+          expect(page).to have_css(".ng-value-label", text: statuses[0].name)
+          expect(page).to have_css(".ng-value-label", text: statuses[1].name)
+          expect(page).to have_css(".ng-value-label", text: statuses[2].name)
+        end
+      end
     end
 
     context "with a single role selected" do
@@ -267,6 +280,40 @@ RSpec.describe "Workflow edit with multiple roles", :js do
       within_dialog("Remove statuses") { click_button "Remove" }
 
       expect(page).to have_text("2 roles selected")
+    end
+
+    it "checks all new status checkboxes as fully checked, not indeterminate, when adding a status" do
+      add_status_via_dialog(statuses[2])
+
+      [workflow_checkbox(2, 0), workflow_checkbox(0, 2), workflow_checkbox(2, 1),
+       workflow_checkbox(1, 2), workflow_checkbox(2, 2)].each do |cb|
+        expect(page).to have_field cb, checked: true
+        expect(indeterminate?(cb)).to be false
+      end
+    end
+
+    context "when no statuses are configured" do
+      let(:empty_role1) { create(:project_role) }
+      let(:empty_role2) { create(:project_role) }
+
+      before { visit_workflow_edit(roles: [empty_role1, empty_role2]) }
+
+      it "shows a blankslate" do
+        expect(page).to have_text("No status transitions configured")
+      end
+
+      it "preserves all selected roles when adding statuses from the blankslate" do
+        within "#workflow-table" do
+          all(:link, "Status").last.click
+        end
+        within_dialog "Statuses" do
+          find(".ng-arrow-wrapper").click
+          find(".ng-option", text: statuses[0].name).click
+          click_button "Apply"
+        end
+
+        expect(page).to have_text("2 roles selected")
+      end
     end
   end
 end

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -265,6 +265,20 @@ RSpec.describe "Workflow edit with multiple roles", :js do
     end
   end
 
+  context "when deselecting all roles in the select panel" do
+    before { visit_workflow_edit(roles: [role, role2]) }
+
+    it "falls back to the first eligible role instead of leaving the page stuck" do
+      click_button "2 roles selected"
+      find("[data-item-id='#{role.id}']").click
+      find("[data-item-id='#{role2.id}']").click
+      page.send_keys :escape
+
+      expect(page).to have_no_text("2 roles selected")
+      expect(page).to have_button(role.name)
+    end
+  end
+
   context "when modifying statuses" do
     before { visit_workflow_edit(roles: [role, role2]) }
 

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "Workflow edit with multiple roles", :js do
       click_button "2 roles selected"
       find("[data-item-id='#{role.id}']").click
       find("[data-item-id='#{role2.id}']").click
-      page.send_keys :escape
+      within("select-panel") { click_button "Save" }
 
       expect(page).to have_no_text("2 roles selected")
       expect(page).to have_button(role.name)

--- a/spec/features/workflows/edit_multi_role_spec.rb
+++ b/spec/features/workflows/edit_multi_role_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe "Workflow edit with multiple roles", :js do
         expect(page).to have_field workflow_checkbox(0, 1), checked: false
         expect(indeterminate?(workflow_checkbox(0, 1))).to be true
       end
+
+      it "the checkbox is visible as indeterminate" do
+        expect(page).to have_field workflow_checkbox(0, 1), checked: false
+
+        expect(indeterminate?(workflow_checkbox(0, 1))).to be true
+        expect(indeterminate_visible?(workflow_checkbox(0, 1))).to be true
+      end
     end
 
     context "when roles have different statuses in their workflows" do

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -53,10 +53,17 @@ RSpec.describe "Workflow edit", :js do
   end
 
   def visit_workflow_edit(role: nil, tab: nil)
-    params = { controller: "/workflows", action: :edit, type_id: type.id }
-    params[:role_id] = role.id if role
+    params = {}
+    params[:role_ids] = [role.id] if role
     params[:tab] = tab if tab
-    visit url_for(params)
+    visit edit_workflow_path(type, **params)
+  end
+
+  def switch_role_via_panel(from_role, to_role)
+    click_button from_role.name
+    find("[data-item-id='#{to_role.id}']").click
+    find("[data-item-id='#{from_role.id}']").click
+    page.send_keys :escape
   end
 
   def add_status_via_dialog(status)
@@ -322,8 +329,7 @@ RSpec.describe "Workflow edit", :js do
     end
 
     it "loads the matrix for a different role after switching" do
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 2)
@@ -336,8 +342,7 @@ RSpec.describe "Workflow edit", :js do
         check workflow_checkbox(1, 0)
       end
 
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       within_dialog "Save changes before continuing?" do
         click_button "Ignore changes"
@@ -347,8 +352,7 @@ RSpec.describe "Workflow edit", :js do
         expect(page).to have_field workflow_checkbox(1, 2)
       end
 
-      click_button other_role.name
-      click_link role.name
+      switch_role_via_panel(other_role, role)
 
       within "#workflow_form_always" do
         expect(page).to have_field workflow_checkbox(1, 0), checked: false
@@ -360,8 +364,7 @@ RSpec.describe "Workflow edit", :js do
         check workflow_checkbox(1, 0)
       end
 
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       within_dialog "Save changes before continuing?" do
         click_button "Save changes and continue"
@@ -383,8 +386,7 @@ RSpec.describe "Workflow edit", :js do
         check workflow_checkbox(1, 0)
       end
 
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       within_dialog "Save changes before continuing?" do
         find(".close-button").click
@@ -402,8 +404,7 @@ RSpec.describe "Workflow edit", :js do
       add_status_via_dialog(statuses[2])
       expect(page).to have_field workflow_checkbox(0, 2)
 
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       expect(page).to have_dialog("Save changes before continuing?")
     end
@@ -417,8 +418,7 @@ RSpec.describe "Workflow edit", :js do
 
       expect(page).to have_no_field workflow_checkbox(0, 1)
 
-      click_button role.name
-      click_link other_role.name
+      switch_role_via_panel(role, other_role)
 
       expect(page).to have_dialog("Save changes before continuing?")
     end

--- a/spec/features/workflows/edit_spec.rb
+++ b/spec/features/workflows/edit_spec.rb
@@ -32,6 +32,7 @@ require "spec_helper"
 
 RSpec.describe "Workflow edit", :js do
   include Toasts::Expectations
+  include Workflows::EditHelpers
 
   let(:role) { create(:project_role) }
   let(:type) { create(:type) }
@@ -48,51 +49,12 @@ RSpec.describe "Workflow edit", :js do
 
   current_user { admin }
 
-  def workflow_checkbox(from_index, to_index)
-    "status_#{statuses[from_index].id}_#{statuses[to_index].id}"
-  end
-
-  def visit_workflow_edit(role: nil, tab: nil)
-    params = {}
-    params[:role_ids] = [role.id] if role
-    params[:tab] = tab if tab
-    visit edit_workflow_path(type, **params)
-  end
-
-  def switch_role_via_panel(from_role, to_role)
-    click_button from_role.name
-    find("[data-item-id='#{to_role.id}']").click
-    find("[data-item-id='#{from_role.id}']").click
-    page.send_keys :escape
-  end
-
-  def add_status_via_dialog(status)
-    within "#workflow-table" do # Otherwise, click on "Statuses" menu item
-      click_link "Status"
-    end
-    within_dialog "Statuses" do
-      find(".ng-arrow-wrapper").click
-      find(".ng-option", text: status.name).click
-      click_button "Apply"
-    end
-  end
-
-  def remove_status_via_dialog(status)
-    within "#workflow-table" do # Otherwise, click on "Statuses" menu item
-      click_link "Status"
-    end
-    within_dialog "Statuses" do
-      find(".ng-value", text: status.name).find(".ng-value-icon").click
-      click_button "Apply"
-    end
-  end
-
   before do
     visit_workflow_edit
   end
 
   it "allows adding another workflow" do
-    visit_workflow_edit(role:)
+    visit_workflow_edit(roles: [role])
 
     check workflow_checkbox(1, 0)
 
@@ -121,7 +83,7 @@ RSpec.describe "Workflow edit", :js do
                       old_status_id: statuses[0].id, new_status_id: statuses[1].id,
                       author: true, assignee: false)
 
-    visit_workflow_edit(role:, tab: "author")
+    visit_workflow_edit(roles: [role], tab: "author")
 
     within "#workflow_form_author" do
       check workflow_checkbox(1, 0)
@@ -157,7 +119,7 @@ RSpec.describe "Workflow edit", :js do
                       old_status_id: statuses[0].id, new_status_id: statuses[1].id,
                       author: false, assignee: true)
 
-    visit_workflow_edit(role:, tab: "assignee")
+    visit_workflow_edit(roles: [role], tab: "assignee")
 
     within "#workflow_form_assignee" do
       check workflow_checkbox(1, 0)
@@ -201,7 +163,7 @@ RSpec.describe "Workflow edit", :js do
     end
 
     before do
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
     end
 
     it "shows the always tab by default" do
@@ -261,9 +223,7 @@ RSpec.describe "Workflow edit", :js do
 
       expect(page).to have_css("#workflow_form_author")
 
-      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
-                              old_status_id: statuses[1].id, new_status_id: statuses[0].id,
-                              author: false, assignee: false)).to be true
+      expect_transition(role, 1, 0, exist: true)
     end
 
     it "keeps unsaved changes and stays on the same tab when closing the dialog via 'X'" do
@@ -318,7 +278,7 @@ RSpec.describe "Workflow edit", :js do
     end
 
     before do
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
     end
 
     it "shows the matrix for the first role" do
@@ -376,9 +336,7 @@ RSpec.describe "Workflow edit", :js do
         expect(page).to have_field workflow_checkbox(1, 2)
       end
 
-      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
-                              old_status_id: statuses[1].id, new_status_id: statuses[0].id,
-                              author: false, assignee: false)).to be true
+      expect_transition(role, 1, 0, exist: true)
     end
 
     it "keeps unsaved changes and stays on the same role when closing the dialog via 'X'" do
@@ -426,7 +384,7 @@ RSpec.describe "Workflow edit", :js do
 
   context "when reloading the page with unsaved changes", :js do
     before do
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
     end
 
     it "shows a browser confirmation when reloading with unsaved checkbox changes" do
@@ -466,7 +424,7 @@ RSpec.describe "Workflow edit", :js do
 
   context "with status dialog", :js do
     before do
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
     end
 
     it "shows only role-specific statuses in the matrix by default" do
@@ -474,7 +432,7 @@ RSpec.describe "Workflow edit", :js do
       create(:workflow, role_id: other_role.id, type_id: type.id,
                         old_status_id: statuses[0].id, new_status_id: statuses[2].id)
 
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
 
       expect(page).to have_field workflow_checkbox(0, 1)
       expect(page).to have_no_field workflow_checkbox(2, 0)
@@ -573,8 +531,7 @@ RSpec.describe "Workflow edit", :js do
 
       expect_flash(message: "Successful update.")
 
-      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
-                              old_status_id: statuses[0].id, new_status_id: statuses[2].id)).to be true
+      expect_transition(role, 0, 2, exist: true)
 
       expect(page).to have_field workflow_checkbox(0, 2)
 
@@ -590,7 +547,7 @@ RSpec.describe "Workflow edit", :js do
 
       expect(page).to have_field workflow_checkbox(2, 0)
 
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
 
       expect(page).to have_no_field workflow_checkbox(2, 0)
     end
@@ -637,7 +594,7 @@ RSpec.describe "Workflow edit", :js do
 
       expect_flash(message: "Successful update.")
 
-      visit_workflow_edit(role:)
+      visit_workflow_edit(roles: [role])
 
       expect(page).to have_no_field workflow_checkbox(2, 0)
       expect(page).to have_no_field workflow_checkbox(0, 2)
@@ -698,9 +655,7 @@ RSpec.describe "Workflow edit", :js do
 
         expect_flash(message: "Successful update.")
 
-        expect(Workflow.exists?(role_id: role.id, type_id: type.id,
-                                old_status_id: statuses[1].id, new_status_id: statuses[0].id,
-                                author: false, assignee: false)).to be true
+        expect_transition(role, 1, 0, exist: true)
 
         expect(page).to have_dialog "Copy workflow"
       end

--- a/spec/support/workflows/edit_helpers.rb
+++ b/spec/support/workflows/edit_helpers.rb
@@ -73,6 +73,16 @@ module Workflows
       page.evaluate_script("document.getElementById('#{checkbox_id}')?.indeterminate ?? false")
     end
 
+    def indeterminate_visible?(checkbox_id)
+      page.evaluate_script(<<~JS)
+        (() => {
+          const el = document.getElementById('#{checkbox_id}');
+          const bg = window.getComputedStyle(el).backgroundColor;
+          return bg !== 'rgba(0, 0, 0, 0)' && bg !== 'rgb(255, 255, 255)';
+        })()
+      JS
+    end
+
     def expect_transition(role, from_index, to_index, exist:, author: false, assignee: false)
       expect(Workflow.exists?(role_id: role.id, type_id: type.id,
                               old_status_id: statuses[from_index].id,

--- a/spec/support/workflows/edit_helpers.rb
+++ b/spec/support/workflows/edit_helpers.rb
@@ -45,7 +45,7 @@ module Workflows
       click_button from_role.name
       find("[data-item-id='#{to_role.id}']").click
       find("[data-item-id='#{from_role.id}']").click
-      page.send_keys :escape
+      within("select-panel") { click_button "Save" }
     end
 
     def add_status_via_dialog(status)

--- a/spec/support/workflows/edit_helpers.rb
+++ b/spec/support/workflows/edit_helpers.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Workflows
+  module EditHelpers
+    def workflow_checkbox(from_index, to_index)
+      "status_#{statuses[from_index].id}_#{statuses[to_index].id}"
+    end
+
+    def visit_workflow_edit(roles: [], tab: nil)
+      params = {}
+      params[:role_ids] = roles.map(&:id) if roles.any?
+      params[:tab] = tab if tab
+      visit edit_workflow_path(type, **params)
+    end
+
+    def switch_role_via_panel(from_role, to_role)
+      click_button from_role.name
+      find("[data-item-id='#{to_role.id}']").click
+      find("[data-item-id='#{from_role.id}']").click
+      page.send_keys :escape
+    end
+
+    def add_status_via_dialog(status)
+      within "#workflow-table" do # Otherwise, click on "Statuses" menu item
+        click_link "Status"
+      end
+      within_dialog "Statuses" do
+        find(".ng-arrow-wrapper").click
+        find(".ng-option", text: status.name).click
+        click_button "Apply"
+      end
+    end
+
+    def remove_status_via_dialog(status)
+      within "#workflow-table" do # Otherwise, click on "Statuses" menu item
+        click_link "Status"
+      end
+      within_dialog "Statuses" do
+        find(".ng-value", text: status.name).find(".ng-value-icon").click
+        click_button "Apply"
+      end
+    end
+
+    def indeterminate?(checkbox_id)
+      page.evaluate_script("document.getElementById('#{checkbox_id}')?.indeterminate ?? false")
+    end
+
+    def expect_transition(role, from_index, to_index, exist:, author: false, assignee: false)
+      expect(Workflow.exists?(role_id: role.id, type_id: type.id,
+                              old_status_id: statuses[from_index].id,
+                              new_status_id: statuses[to_index].id,
+                              author:, assignee:)).to be exist
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/72242

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Change the role selector from an ActionMenu to multi-select SelectPanel
- Make all components expect and work with multiple roles instead of just one

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Indeterminate checkboxes need some special handling, and the main case is that the form submits the checkboxes based on their default state (checked/unchecked) and the indeterminate state doesn't affect this. This is why there's some more logic in the tabs controller to manage checkbox state per role. Indeterminate checkboxes are read back from the DB to prevent them from being overridden by the default unchecked state

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
