### PR TITLE
[#73473] Make whole Backlog card draggable

### DIFF
--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -38,9 +38,6 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
   align-items: center
 
-  &--collapsible
-    margin-left: calc(var(--stack-padding-normal) / 2)
-
   &--actions
     margin-left: var(--stack-gap-normal)
 
@@ -67,15 +64,12 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
 .op-backlogs-story
   display: grid
-  grid-template-columns: var(--control-xsmall-size) 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
+  grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
   grid-template-rows: auto auto
-  grid-template-areas: "drag_handle info_line points menu" ". subject subject subject"
+  grid-template-areas: "info_line points menu" "subject subject subject"
   align-items: center
   margin-top: calc(-1 * var(--base-size-4))
   margin-bottom: var(--base-size-4)
-
-.op-backlogs-story--drag_handle_button
-  padding: var(--base-size-4)
 
 .op-backlogs-story--points
   margin-left: var(--stack-gap-normal)
@@ -168,7 +162,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
     display: none
 
   .op-backlogs-story
-    grid-template-columns: var(--control-xsmall-size) 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
+    grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
 
   .op-backlogs-container, .op-sprint-planning-container
     height: unset

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -156,6 +156,12 @@ ul.SegmentedControl,
   .ActionListItem-label[class^="__hl_"], .ActionListItem-label[class*=" __hl_"]
     color: var(--control-fgColor-disabled) !important
 
+// hide hover when dragging with legacy Dragula implementation
+.Box-row--hover-gray,
+.Box-row--hover-blue
+  body[data-dragging="active"] &
+    background-color: unset
+
 .Box-row--focus-gray
   &:focus-visible
     background-color: var(--bgColor-muted)
@@ -169,6 +175,23 @@ ul.SegmentedControl,
 
 .Box-row--draggable:not(.Box-row--clickable)
   cursor: grab
+
+// `:is(.Box-row--clickable)` bumps selector specificity so these rules win
+// over Dragula's `.gu-*` transit styles; without it the mirror and source
+// rows render transparent mid-drag. Revisit once #74172 / #73729 replace the
+// legacy Dragula implementation.
+.Box-row:is(.Box-row--clickable)
+  &[data-dragging="mirror"]
+    background-color: var(--bgColor-default)
+    border: var(--borderWidth-default) solid var(--borderColor-default)
+    border-radius: var(--borderRadius-medium)
+    box-shadow: var(--shadow-floating-medium)
+    opacity: 1
+
+  &[data-dragging="source"]
+    opacity: 0.4
+    background-color: var(--bgColor-subtle)
+    box-shadow: inset 0 0 0 var(--borderWidth-default) var(--borderColor-muted)
 
 // Apply the mobile styles as soon as the banner itself is small
 // Styles are copied from the PVC repo

--- a/frontend/src/global_styles/primer/_overrides.sass
+++ b/frontend/src/global_styles/primer/_overrides.sass
@@ -167,8 +167,8 @@ ul.SegmentedControl,
 .Box-row--clickable
   cursor: pointer
 
-.Box-row:is(.Box-row--draggable)
-  padding-left: 0
+.Box-row--draggable:not(.Box-row--clickable)
+  cursor: grab
 
 // Apply the mobile styles as soon as the banner itself is small
 // Styles are copied from the PVC repo

--- a/frontend/src/global_styles/vendor/_dragula.sass
+++ b/frontend/src/global_styles/vendor/_dragula.sass
@@ -1,3 +1,6 @@
+body[data-dragging="active"] *
+  cursor: grabbing !important
+
 .gu-mirror
   position: fixed !important
   margin: 0 !important

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import GenericDragAndDropController from './generic-drag-and-drop.controller';
+
+describe('GenericDragAndDropController', () => {
+  let controller:GenericDragAndDropController;
+
+  beforeEach(() => {
+    controller = Object.create(GenericDragAndDropController.prototype) as GenericDragAndDropController;
+  });
+
+  function setValue(name:'handleValue'|'handleSelectorValue', value:boolean|string) {
+    Object.defineProperty(controller, name, { value, configurable: true });
+  }
+
+  function draggableRow() {
+    const row = document.createElement('li');
+    row.className = 'Box-row Box-row--draggable';
+    row.tabIndex = 0;
+    row.dataset.draggableId = '42';
+    row.dataset.draggableType = 'story';
+    row.dataset.dropUrl = '/drop';
+    return row;
+  }
+
+  function callCanStartDrag(el:Element|null|undefined, handle:Element|null|undefined):boolean {
+    const canStartDrag = Reflect.get(controller, 'canStartDrag') as (
+      this:GenericDragAndDropController,
+      el:Element|null|undefined,
+      handle:Element|null|undefined
+    ) => boolean;
+
+    return canStartDrag.call(controller, el, handle);
+  }
+
+  function callAriaPressedTarget(el:Element):Element|null {
+    const ariaPressedTarget = Reflect.get(controller, 'ariaPressedTarget') as (
+      this:GenericDragAndDropController,
+      el:Element
+    ) => Element|null;
+
+    return ariaPressedTarget.call(controller, el);
+  }
+
+  describe('canStartDrag', () => {
+    it('allows dragging a draggable row in handle-less mode', () => {
+      const row = draggableRow();
+
+      setValue('handleValue', false);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callCanStartDrag(row, row)).toBeTrue();
+    });
+
+    it('rejects rows that are not draggable in handle-less mode', () => {
+      const row = document.createElement('li');
+      row.className = 'Box-row';
+      row.tabIndex = 0;
+
+      setValue('handleValue', false);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callCanStartDrag(row, row)).toBeFalse();
+    });
+
+    it('rejects empty placeholder rows in handle-less mode', () => {
+      const row = draggableRow();
+      row.dataset.emptyListItem = 'true';
+
+      setValue('handleValue', false);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callCanStartDrag(row, row)).toBeFalse();
+    });
+
+    it('rejects interactive descendants in handle-less mode', () => {
+      const row = draggableRow();
+      const button = document.createElement('button');
+      row.appendChild(button);
+
+      setValue('handleValue', false);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callCanStartDrag(row, button)).toBeFalse();
+    });
+
+    it('allows drag handles in handle mode', () => {
+      const row = draggableRow();
+      const handle = document.createElement('button');
+      handle.className = 'DragHandle';
+      row.appendChild(handle);
+
+      setValue('handleValue', true);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callCanStartDrag(row, handle)).toBeTrue();
+    });
+  });
+
+  describe('ariaPressedTarget', () => {
+    it('returns null in handle-less mode', () => {
+      const row = draggableRow();
+
+      setValue('handleValue', false);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callAriaPressedTarget(row)).toBeNull();
+    });
+
+    it('returns the handle element in handle mode', () => {
+      const row = draggableRow();
+      const handle = document.createElement('button');
+      handle.className = 'DragHandle';
+      row.appendChild(handle);
+
+      setValue('handleValue', true);
+      setValue('handleSelectorValue', '.DragHandle');
+
+      expect(callAriaPressedTarget(row)).toBe(handle);
+    });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
@@ -70,6 +70,14 @@ describe('GenericDragAndDropController', () => {
     return ariaPressedTarget.call(controller, el);
   }
 
+  function callResolveMirrorContainer():Element {
+    const resolveMirrorContainer = Reflect.get(controller, 'resolveMirrorContainer') as (
+      this:GenericDragAndDropController
+    ) => Element;
+
+    return resolveMirrorContainer.call(controller);
+  }
+
   describe('canStartDrag', () => {
     it('allows dragging a draggable row in handle-less mode', () => {
       const row = draggableRow();
@@ -145,6 +153,23 @@ describe('GenericDragAndDropController', () => {
       setValue('handleSelectorValue', '.DragHandle');
 
       expect(callAriaPressedTarget(row)).toBe(handle);
+    });
+  });
+
+  describe('resolveMirrorContainer', () => {
+    it('returns the configured mirror container target when present', () => {
+      const mirrorContainer = document.createElement('div');
+
+      Object.defineProperty(controller, 'hasMirrorContainerTarget', { value: true, configurable: true });
+      Object.defineProperty(controller, 'mirrorContainerTarget', { value: mirrorContainer, configurable: true });
+
+      expect(callResolveMirrorContainer()).toBe(mirrorContainer);
+    });
+
+    it('falls back to document.body when no mirror container target exists', () => {
+      Object.defineProperty(controller, 'hasMirrorContainerTarget', { value: false, configurable: true });
+
+      expect(callResolveMirrorContainer()).toBe(document.body);
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -72,6 +72,9 @@ export default class GenericDragAndDropController extends Controller {
   }
 
   disconnect() {
+    // A Turbo morph mid-drag can replace the element tree without the
+    // dragend event firing, so clear the body-level cursor flag defensively.
+    document.body.removeAttribute('data-dragging');
     this.autoscroll?.destroy();
     this.autoscroll = null;
     this.drake?.destroy();
@@ -130,9 +133,11 @@ export default class GenericDragAndDropController extends Controller {
         this.dragOriginSource = source;
         this.dragOriginNextSibling = el.nextElementSibling;
 
+        document.body.setAttribute('data-dragging', 'active');
         this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'true');
       })
       .on('dragend', (el) => {
+        document.body.removeAttribute('data-dragging');
         this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'false');
       })
       // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -31,6 +31,7 @@
 import { Controller } from '@hotwired/stimulus';
 import { FetchRequest } from '@rails/request.js';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
+import { closestInteractiveElement } from 'core-stimulus/helpers/interactive-element-helper';
 import type { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
 import dragula, { Drake } from 'dragula';
 import invariant from 'tiny-invariant';
@@ -48,10 +49,12 @@ export default class GenericDragAndDropController extends Controller {
   scrollContainerTargets:HTMLElement[];
 
   static values = {
+    handle: { type: Boolean, default: true },
     handleSelector: { type: String, default: '.DragHandle' },
     positionMode: { type: String, default: 'index' },
   };
 
+  declare readonly handleValue:boolean;
   declare readonly handleSelectorValue:string;
   declare readonly positionModeValue:string;
 
@@ -118,7 +121,7 @@ export default class GenericDragAndDropController extends Controller {
     this.drake = dragula(
       this.containers,
       {
-        moves: (_el, _source, handle, _sibling) => !!handle && !!handle.closest(this.handleSelectorValue),
+        moves: (el, _source, handle, _sibling) => this.canStartDrag(el, handle),
         accepts: (el:Element, target:Element, source:Element, sibling:Element) => this.accepts(el, target, source, sibling),
         revertOnSpill: true, // enable reverting of elements if they are dropped outside of a valid target
       },
@@ -127,13 +130,11 @@ export default class GenericDragAndDropController extends Controller {
         this.dragOriginSource = source;
         this.dragOriginNextSibling = el.nextElementSibling;
 
-        const handle = el.querySelector(this.handleSelectorValue)!;
-        handle.setAttribute('aria-pressed', 'true');
+        this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'true');
       })
       .on('dragend', (el) => {
-        const handle = el.querySelector(this.handleSelectorValue)!;
-        handle.setAttribute('aria-pressed', 'false');
-       })
+        this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'false');
+      })
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       .on('drop', this.drop.bind(this));
 
@@ -215,6 +216,25 @@ export default class GenericDragAndDropController extends Controller {
     return data;
   }
 
+  private canStartDrag(el:Element|null|undefined, handle:Element|null|undefined):boolean {
+    if (!this.isDraggableElement(el)) {
+      return false;
+    }
+
+    if (!this.handleValue) {
+      return closestInteractiveElement(handle ?? null, el) == null;
+    }
+
+    return handle?.closest(this.handleSelectorValue) != null;
+  }
+
+  private isDraggableElement(el:Element|null|undefined):boolean {
+    return el instanceof HTMLElement
+      && el.getAttribute('data-empty-list-item') !== 'true'
+      && el.dataset.draggableType !== undefined
+      && el.dataset.dropUrl !== undefined;
+  }
+
   // if the target has a container accessor, use that as the container instead of the element itself
   // we need this e.g. in Primer's borderbox component as we cannot add required data attributes to the ul element there
   private resolveContainerElement(target:HTMLElement):HTMLElement {
@@ -244,5 +264,10 @@ export default class GenericDragAndDropController extends Controller {
     }
 
     return targetPosition + 1;
+  }
+
+  private ariaPressedTarget(el:Element):Element|null {
+    if (!this.handleValue) return null;
+    return el.querySelector(this.handleSelectorValue);
   }
 }

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -132,14 +132,19 @@ export default class GenericDragAndDropController extends Controller {
         mirrorContainer: this.resolveMirrorContainer(),
       },
     )
+      .on('cloned', (clone, _original, type) => {
+        clone.setAttribute('data-dragging', type);
+      })
       .on('drag', (el, source) => {
         this.dragOriginSource = source;
         this.dragOriginNextSibling = el.nextElementSibling;
 
+        el.setAttribute('data-dragging', 'source');
         document.body.setAttribute('data-dragging', 'active');
         this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'true');
       })
       .on('dragend', (el) => {
+        el.removeAttribute('data-dragging');
         document.body.removeAttribute('data-dragging');
         this.ariaPressedTarget(el)?.setAttribute('aria-pressed', 'false');
       })

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -43,10 +43,12 @@ interface TargetConfig {
 }
 
 export default class GenericDragAndDropController extends Controller {
-  static targets = ['container', 'scrollContainer'];
+  static targets = ['container', 'scrollContainer', 'mirrorContainer'];
 
   containerTargets:HTMLElement[];
   scrollContainerTargets:HTMLElement[];
+  declare readonly hasMirrorContainerTarget:boolean;
+  declare readonly mirrorContainerTarget:HTMLElement;
 
   static values = {
     handle: { type: Boolean, default: true },
@@ -127,6 +129,7 @@ export default class GenericDragAndDropController extends Controller {
         moves: (el, _source, handle, _sibling) => this.canStartDrag(el, handle),
         accepts: (el:Element, target:Element, source:Element, sibling:Element) => this.accepts(el, target, source, sibling),
         revertOnSpill: true, // enable reverting of elements if they are dropped outside of a valid target
+        mirrorContainer: this.resolveMirrorContainer(),
       },
     )
       .on('drag', (el, source) => {
@@ -250,6 +253,10 @@ export default class GenericDragAndDropController extends Controller {
     const container = target.querySelector<HTMLElement>(accessor);
     invariant(container, `Expected container element matching "${accessor}"`);
     return container;
+  }
+
+  private resolveMirrorContainer():Element {
+    return this.hasMirrorContainerTarget ? this.mirrorContainerTarget : document.body;
   }
 
   // Returns the data-draggable-id of the element preceding el in its container,

--- a/frontend/src/stimulus/helpers/interactive-element-helper.ts
+++ b/frontend/src/stimulus/helpers/interactive-element-helper.ts
@@ -1,0 +1,87 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+const ariaInteractiveRoles = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'link',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tab',
+  'textbox',
+  'treeitem',
+]);
+
+export function isInteractiveElement(el:Element|null):el is HTMLElement {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.hasAttribute('disabled')) return false;
+  if (el.getAttribute('aria-disabled') === 'true') return false;
+  if (el.hidden) return false;
+
+  const tag = el.tagName.toLowerCase();
+  const role = el.getAttribute('role');
+  const tabIndex = el.tabIndex;
+
+  const nativeInteractive = tag === 'button'
+    || tag === 'select'
+    || tag === 'textarea'
+    || tag === 'summary'
+    || (tag === 'input' && (el as HTMLInputElement).type !== 'hidden')
+    || (tag === 'a' && el.hasAttribute('href'))
+    || (tag === 'audio' && el.hasAttribute('controls'))
+    || (tag === 'video' && el.hasAttribute('controls'));
+
+  return nativeInteractive
+    || (role != null && ariaInteractiveRoles.has(role))
+    || el.isContentEditable
+    || tabIndex >= 0;
+}
+
+export function closestInteractiveElement(el:Element|null, stopAt:Element|null = null):HTMLElement|null {
+  let current = el;
+
+  while (current && current !== stopAt) {
+    if (isInteractiveElement(current)) {
+      return current;
+    }
+
+    current = current.parentElement;
+  }
+
+  return null;
+}

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -93,7 +93,7 @@ module Backlogs
 
     def drop_target_config
       {
-        generic_drag_and_drop_target: "container",
+        generic_drag_and_drop_target: "container mirrorContainer",
         target_container_accessor: ":scope > ul",
         target_id: "inbox",
         target_allowed_drag_type: "story"

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.html.erb
@@ -29,16 +29,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <% container.with_row(**row_options) do %>
   <%= grid_layout("op-backlogs-story", tag: :article) do |grid| %>
-    <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
-      <%= if draggable?
-            render(
-              Primer::OpenProject::DragHandle.new(
-                classes: "op-backlogs-story--drag_handle_button",
-                label: t(".label_drag_work_package", name: work_package.subject)
-              )
-            )
-          end %>
-    <% end %>
     <% grid.with_area(:info_line) do %>
       <%= render(WorkPackages::InfoLineComponent.new(work_package:)) %>
     <% end %>

--- a/modules/backlogs/app/components/backlogs/inbox_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_item_component.rb
@@ -60,20 +60,40 @@ module Backlogs
     def row_options
       {
         id: dom_id(work_package),
-        classes: "Box-row--hover-blue Box-row--focus-gray Box-row--clickable Box-row--draggable",
-        data: {
-          draggable_id: work_package.id,
-          draggable_type: "story",
-          drop_url: move_project_backlogs_inbox_path(project, work_package),
-          story: true,
-          controller: "backlogs--story",
-          backlogs__story_id_value: work_package.id,
-          backlogs__story_split_url_value: project_backlogs_backlog_details_path(project, work_package),
-          backlogs__story_full_url_value: work_package_path(work_package),
-          backlogs__story_selected_class: "Box-row--blue",
-          test_selector: card_test_selector
-        },
+        classes: row_classes,
+        data: row_data,
         tabindex: 0
+      }
+    end
+
+    def row_classes
+      class_names(
+        "Box-row--hover-blue",
+        "Box-row--focus-gray",
+        "Box-row--clickable",
+        "Box-row--draggable": draggable?
+      )
+    end
+
+    def row_data
+      draggable_item_config.merge(
+        story: true,
+        controller: "backlogs--story",
+        backlogs__story_id_value: work_package.id,
+        backlogs__story_split_url_value: project_backlogs_backlog_details_path(project, work_package),
+        backlogs__story_full_url_value: work_package_path(work_package),
+        backlogs__story_selected_class: "Box-row--blue",
+        test_selector: card_test_selector
+      )
+    end
+
+    def draggable_item_config
+      return {} unless draggable?
+
+      {
+        draggable_id: work_package.id,
+        draggable_type: "story",
+        drop_url: move_project_backlogs_inbox_path(project, work_package)
       }
     end
 

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -77,13 +77,12 @@ module Backlogs
     end
 
     def story_classes_attribute
-      classes = "Box-row--hover-blue Box-row--focus-gray Box-row--clickable"
-
-      if work_package_draggable?
-        classes += " Box-row--draggable"
-      end
-
-      classes
+      class_names(
+        "Box-row--hover-blue",
+        "Box-row--focus-gray",
+        "Box-row--clickable",
+        "Box-row--draggable": work_package_draggable?
+      )
     end
 
     def story_data_attribute(story)

--- a/modules/backlogs/app/components/backlogs/story_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_component.html.erb
@@ -28,17 +28,6 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%= grid_layout("op-backlogs-story", tag: :article) do |grid| %>
-  <% grid.with_area(:drag_handle, classes: "hide-when-print") do %>
-    <%= if draggable?
-          render(
-            Primer::OpenProject::DragHandle.new(
-              classes: "op-backlogs-story--drag_handle_button",
-              label: t(".label_drag_story", name: story.subject)
-            )
-          )
-        end %>
-  <% end %>
-
   <% grid.with_area(:info_line) do %>
     <%= render(WorkPackages::InfoLineComponent.new(work_package: story)) %>
   <% end %>

--- a/modules/backlogs/app/components/backlogs/story_component.rb
+++ b/modules/backlogs/app/components/backlogs/story_component.rb
@@ -49,10 +49,6 @@ module Backlogs
       story.story_points || 0
     end
 
-    def draggable?
-      current_user.allowed_in_project?(:manage_sprint_items, project)
-    end
-
     def menu_src
       menu_project_backlogs_work_package_path(project, sprint_id: sprint.id, id: story.id)
     end

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -29,7 +29,8 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= turbo_frame_tag "backlogs_container", refresh: :morph, class: "op-backlogs-page" do %>
   <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop"
-       data-generic-drag-and-drop-position-mode-value="prev_id">
+       data-generic-drag-and-drop-position-mode-value="prev_id"
+       data-generic-drag-and-drop-handle-value="false">
     <div id="owner_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
       <%= render Backlogs::InboxComponent.new(

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -133,13 +133,11 @@ en:
     inbox_component:
       blankslate_title: "Backlog inbox is empty"
       blankslate_description: "All open work packages in this project will automatically appear here."
-      label_drag_work_package: "Move %{name}"
       show_more:
         one: "Show 1 more item"
         other: "Show %{count} more items"
 
     inbox_item_component:
-      label_drag_work_package: "Move %{name}"
       label_actions: "Work package actions"
 
     inbox_menu_component:
@@ -192,7 +190,6 @@ en:
         add_work_package: "Add work package"
 
     story_component:
-      label_drag_story: "Move %{name}"
       label_actions: "Story actions"
 
     story_menu_list_component:

--- a/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
@@ -64,8 +64,6 @@ RSpec.describe Backlogs::InboxItemComponent, type: :component do
   it "rendering renders the Inbox Component", :aggregate_failures do
     # renders the work package subject
     expect(page).to have_text("Inbox Work Package")
-    # renders a drag handle
-    expect(page).to have_octicon(:grabber)
     # renders WorkPackages::InfoLineComponent with type and ID
     expect(page).to have_text("##{work_package.id}")
     # deferred action menu (kebab + include-fragment src)
@@ -95,6 +93,29 @@ RSpec.describe Backlogs::InboxItemComponent, type: :component do
     it "applies the correct row CSS classes" do
       expect(row[:class]).to include("Box-row--hover-blue", "Box-row--focus-gray",
                                      "Box-row--clickable", "Box-row--draggable")
+    end
+
+    it "sets draggable data attributes when the user can manage sprint items" do
+      expect(row["data-draggable-id"]).to eq(work_package.id.to_s)
+      expect(row["data-draggable-type"]).to eq("story")
+      expect(row["data-drop-url"])
+        .to end_with(move_project_backlogs_inbox_path(project, work_package))
+    end
+  end
+
+  context "when the user lacks the manage_sprint_items permission" do
+    let(:role) { create(:project_role, permissions: %i[view_sprints view_work_packages]) }
+    let(:user) { create(:user, member_with_roles: { project => role }) }
+
+    subject(:row) { page.find(".Box-row#work_package_#{work_package.id}") }
+
+    it "does not mark the row as draggable" do
+      expect(row[:class]).to include("Box-row--hover-blue", "Box-row--focus-gray",
+                                     "Box-row--clickable")
+      expect(row[:class]).not_to include("Box-row--draggable")
+      expect(row["data-draggable-id"]).to be_nil
+      expect(row["data-draggable-type"]).to be_nil
+      expect(row["data-drop-url"]).to be_nil
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -132,6 +132,33 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
     end
 
+    context "when the user lacks the manage_sprint_items permission" do
+      let(:role) { create(:project_role, permissions: %i[view_sprints view_work_packages]) }
+      let(:user) { create(:user, member_with_roles: { project => role }) }
+      let!(:story1) do
+        create(:work_package,
+               project:,
+               type: type_feature,
+               status: default_status,
+               priority: default_priority,
+               story_points: 5,
+               position: 1,
+               sprint: sprint)
+      end
+
+      it "does not mark story rows as draggable" do
+        render_component
+
+        story_row = page.find(".Box-row[id='work_package_#{story1.id}']")
+        expect(story_row[:class]).to include("Box-row--hover-blue", "Box-row--focus-gray",
+                                             "Box-row--clickable")
+        expect(story_row[:class]).not_to include("Box-row--draggable")
+        expect(story_row["data-draggable-id"]).to be_nil
+        expect(story_row["data-draggable-type"]).to be_nil
+        expect(story_row["data-drop-url"]).to be_nil
+      end
+    end
+
     context "without stories" do
       let(:rendered_component) { render_component }
 

--- a/modules/backlogs/spec/components/backlogs/story_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_component_spec.rb
@@ -92,35 +92,6 @@ RSpec.describe Backlogs::StoryComponent, type: :component do
     expect(page).to have_element(:button, id: /\Awork_package_#{story.id}_menu-button\z/)
   end
 
-  describe "drag handle behaviour" do
-    it "renders Primer::OpenProject::DragHandle" do
-      render_component
-
-      # DragHandle renders with grabber icon
-      expect(page).to have_octicon(:grabber)
-    end
-
-    it "renders a drag handle compatible with GenericDragAndDropController" do
-      render_component
-
-      expect(page).to have_css(".DragHandle[role='button'][tabindex='0']")
-      expect(page).to have_css(".DragHandle[aria-label='Move Test Story Subject']")
-    end
-
-    context "when user is not allowed to drag" do
-      let(:permissions) { [] }
-
-      it "does not render a drag handle" do
-        render_component
-
-        # DragHandle renders with grabber icon
-        expect(page).not_to have_octicon(:grabber)
-
-        expect(page).to have_no_css(".DragHandle")
-      end
-    end
-  end
-
   describe "story points handling" do
     context "when story_points is nil" do
       let(:story_points) { nil }

--- a/modules/backlogs/spec/requests/backlogs/backlog_spec.rb
+++ b/modules/backlogs/spec/requests/backlogs/backlog_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe "Backlogs::Backlog", :skip_csrf, type: :rails_request do
           expect(response.body).to include('id="sprint_backlogs_container"')
         end
       end
+
+      it "uses the inbox border box as the drag mirror container" do
+        get "/projects/#{project.identifier}/backlogs/backlog", headers: { "Turbo-Frame" => "backlogs_container" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(%(id="inbox_#{project.id}"))
+        expect(response.body).to include('data-generic-drag-and-drop-target="container mirrorContainer"')
+      end
     end
   end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -117,7 +117,7 @@ module Pages
     def drag_work_package(moved, before: nil, into: nil)
       raise ArgumentError, "You must specify a either before or into" unless before || into || (before && into)
 
-      moved_element = find("#{work_package_selector(moved)} .DragHandle")
+      moved_element = find(draggable_work_package_selector(moved))
       target_element = if before
                          find(work_package_selector(before))
                        else
@@ -133,7 +133,7 @@ module Pages
 
     def expect_work_package_not_draggable(work_package)
       expect(page)
-        .to have_no_css("#{work_package_selector(work_package)} .DragHandle")
+        .to have_no_css(draggable_work_package_selector(work_package))
     end
 
     def expect_inbox_blankslate
@@ -270,7 +270,7 @@ module Pages
     end
 
     def drag_inbox_item_to_sprint(work_package, sprint)
-      moved_element = find("#{inbox_item_selector(work_package)} .DragHandle")
+      moved_element = find(draggable_work_package_selector(work_package))
       target_element = find(sprint_selector(sprint))
       moved_element.native.drag_to(target_element.native, delay: 0.1)
     rescue Capybara::Cuprite::ObsoleteNode
@@ -278,7 +278,7 @@ module Pages
     end
 
     def drag_sprint_item_to_inbox(work_package)
-      moved_element = find("#{work_package_selector(work_package)} .DragHandle")
+      moved_element = find(draggable_work_package_selector(work_package))
       target_element = find("#inbox_#{project.id}")
       moved_element.native.drag_to(target_element.native, delay: 0.1)
     rescue Capybara::Cuprite::ObsoleteNode
@@ -477,6 +477,10 @@ module Pages
 
     def work_package_selector(work_package)
       test_selector("work-package-#{work_package.id}")
+    end
+
+    def draggable_work_package_selector(work_package)
+      "#{work_package_selector(work_package)}[data-draggable-id]"
     end
 
     def sprint_complete_modal_selector

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -115,7 +115,7 @@ module Pages
     end
 
     def drag_work_package(moved, before: nil, into: nil)
-      raise ArgumentError, "You must specify a either before or into" unless before || into || (before && into)
+      raise ArgumentError, "You must specify either before or into" unless before.present? ^ into.present?
 
       moved_element = find(draggable_work_package_selector(moved))
       target_element = if before

--- a/modules/backlogs/spec/support/pages/backlog_spec.rb
+++ b/modules/backlogs/spec/support/pages/backlog_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "backlog"
+
+RSpec.describe Pages::Backlog do
+  subject(:backlog_page) { described_class.new(project) }
+
+  let(:project) { build_stubbed(:project) }
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:sprint) { build_stubbed(:agile_sprint) }
+
+  describe "#drag_work_package" do
+    it "raises when neither before nor into is provided" do
+      expect { backlog_page.drag_work_package(work_package) }
+        .to raise_error(ArgumentError, "You must specify either before or into")
+    end
+
+    it "raises when both before and into are provided" do
+      expect { backlog_page.drag_work_package(work_package, before: work_package, into: sprint) }
+        .to raise_error(ArgumentError, "You must specify either before or into")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73473
https://community.openproject.org/wp/74194
https://community.openproject.org/wp/74195

# What are you trying to accomplish?

Make the entire Backlog work-package card the drag surface, in both the sprint backlogs and the inbox. Previously a dedicated `DragHandle` grabber on the left of each card was the only drag affordance. This PR removes the handle and lets users grab the card anywhere to reorder it or move it between sprints.

Permission gating is preserved: users without `:manage_sprint_items` still render non-draggable cards (no `Box-row--draggable` class, no `data-draggable-*` / `data-drop-url` attributes) and cannot initiate a drag.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1021" height="581" alt="Screenshot 2026-04-22 at 13 57 31" src="https://github.com/user-attachments/assets/c2b6a1aa-bb18-4ecd-b3c7-b1a3f0b8f769" /> | <img width="1021" height="581" alt="Screenshot 2026-04-22 at 13 55 57" src="https://github.com/user-attachments/assets/ebf8ec09-06bf-48b4-a112-9db41b59ca0d" /> |

# What approach did you choose and why?

Two additions to the existing Dragula-based `generic-drag-and-drop` Stimulus controller make it work without a dedicated handle:

- `handle-value` (Boolean, default `true`). When `false`, the whole element is the drag surface and `handle-selector-value` is ignored. A Boolean was preferred over interpreting an empty `handle-selector-value`, since empty HTML attributes are ambiguous.
- `isInteractiveElement` / `closestInteractiveElement` helpers, used on drag start to abort the gesture when the user is interacting with a button, link, input, or ActionMenu inside the card — so the kebab menu and WP detail links aren't hijacked.

Server-side, `Backlogs::InboxItemComponent` now gates the `Box-row--draggable` class and the `data-draggable-*` / `data-drop-url` attributes behind `:manage_sprint_items`, matching the pattern already used in `SprintComponent`. Removing the handle also lets us drop the `drag_handle` grid column, the `label_drag_*` translation keys, and the now-unused `StoryComponent#draggable?`.

# Merge checklist

- [x] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)