### PR TITLE
Support multi-substring search in project selector

### DIFF
--- a/app/models/queries/projects/filters/name_filter.rb
+++ b/app/models/queries/projects/filters/name_filter.rb
@@ -40,7 +40,9 @@ class Queries::Projects::Filters::NameFilter < Queries::Projects::Filters::Base
     when "!"
       ["LOWER(projects.name) NOT IN (?)", sql_value]
     when "~", "**"
-      ["LOWER(projects.name) LIKE ?", "%#{sql_value}%"]
+      terms = values.first.downcase.split
+      conditions = Array.new(terms.size, "LOWER(projects.name) LIKE ?").join(" AND ")
+      [conditions, *terms.map { |t| "%#{t}%" }]
     when "!~"
       ["LOWER(projects.name) NOT LIKE ?", "%#{sql_value}%"]
     end

--- a/app/models/queries/projects/filters/name_filter.rb
+++ b/app/models/queries/projects/filters/name_filter.rb
@@ -39,7 +39,9 @@ class Queries::Projects::Filters::NameFilter < Queries::Projects::Filters::Base
       ["LOWER(projects.name) IN (?)", sql_value]
     when "!"
       ["LOWER(projects.name) NOT IN (?)", sql_value]
-    when "~", "**"
+    when "~"
+      ["LOWER(projects.name) LIKE ?", "%#{sql_value}%"]
+    when "**"
       terms = values.first.downcase.split
       conditions = Array.new(terms.size, "LOWER(projects.name) LIKE ?").join(" AND ")
       [conditions, *terms.map { |t| "%#{t}%" }]

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -81,7 +81,8 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
           (project) => {
             const searchText = this.searchableProjectListService.searchText;
             if (searchText.length) {
-              const matches = project.name.toLowerCase().includes(searchText.toLowerCase());
+              const terms = searchText.toLowerCase().split(/\s+/).filter((t) => t.length > 0);
+              const matches = terms.every((term) => project.name.toLowerCase().includes(term));
 
               if (!matches) {
                 return false;

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -84,12 +84,12 @@ export class SearchableProjectListService {
         return of([[] as IProject[], searchText, loadingEnabled as boolean, favoriteIds]);
       }
 
-      const nameFilter:ApiV3ListFilter[] = [];
+      const searchFilter:ApiV3ListFilter[] = [];
       if (searchText.length > 0) {
-        nameFilter.push(['name', '~', [searchText]]);
+        searchFilter.push(['typeahead', '**', [searchText]]);
       }
 
-      return this.fetchProjects(nameFilter)
+      return this.fetchProjects(searchFilter)
                  .pipe(map((collection) => [collection._embedded.elements, searchText, loadingEnabled as boolean, favoriteIds]));
     }),
     switchMap(([projects, searchText, loadingEnabled, favoriteIds]:[IProject[],string,boolean,string[]]) => {

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe "Projects autocomplete page", :js do
       create(:project, name:, identifier:, members: { user => role })
     end
   end
+  
   shared_let(:non_member_project) { create(:project) }
   shared_let(:public_project) { create(:public_project) }
 
@@ -110,10 +111,10 @@ RSpec.describe "Projects autocomplete page", :js do
       expect(page).to have_no_css("strong")
     end
 
-    # Expect fuzzy matches for plain
+    # Expect fuzzy matches for multiple substrings
     top_menu.search "Plain pr"
     top_menu.expect_result "Plain project"
-    top_menu.expect_no_result "Plain other project"
+    top_menu.expect_result "Plain other project"
 
     # Expect search to match names only and not the identifier
     top_menu.clear_search

--- a/spec/features/projects/project_autocomplete_spec.rb
+++ b/spec/features/projects/project_autocomplete_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe "Projects autocomplete page", :js do
       create(:project, name:, identifier:, members: { user => role })
     end
   end
-  
   shared_let(:non_member_project) { create(:project) }
   shared_let(:public_project) { create(:public_project) }
 
@@ -115,6 +114,7 @@ RSpec.describe "Projects autocomplete page", :js do
     top_menu.search "Plain pr"
     top_menu.expect_result "Plain project"
     top_menu.expect_result "Plain other project"
+    top_menu.expect_no_result "Project with different name and identifier"
 
     # Expect search to match names only and not the identifier
     top_menu.clear_search


### PR DESCRIPTION
I was a bit fed up with the UX of the project selector. I usually search by multiple "gorilla" words and not just by one.

Implementation:

Split the search query on whitespace and require each token to appear
in the project name, so e.g. "big fish" matches "the big beautiful fish"
and "big fi" matches as a partial-word substring.

- Backend: 
  - Differentiate between the "~" and the "**" operator.
  - For the "**" operator generate AND-connected LIKE clauses, one per
    space-separated token, for the ~ and ** operators
- Frontend:
  - Instead of the `name` filter use the more flexible/wider `typeahead` filter with the extended "**" operator (The typeahead filter is currently inheriting from the name filter and I didn't touch that). This will become handy in the future when we likely want to also search for project identifiers, soon.
  - mirror the same logic of splitting the query in multiple terms for the client-side post-filter that removes non-matching ancestors


Closes https://community.openproject.org/work_packages/74199