### PR TITLE
Don't call strip tags on the entire wiki content, just the first bit

### DIFF
--- a/app/views/wiki/show.html.erb
+++ b/app/views/wiki/show.html.erb
@@ -41,7 +41,8 @@ See COPYRIGHT and LICENSE files for more details.
 <%# Set meta tags %>
 <% title "#{t(:project_module_wiki)} | #{title}" %>
 <% @formatted_text = format_text @page, :text, attachments: @page.attachments %>
-<% description strip_tags(@formatted_text) %>
+<%# Prevent passing the entire formatted text to strip_tags, as that would be quite slow. Numbers used are arbitrary. %>
+<% description strip_tags(@formatted_text.to_s.first(500)).truncate(160) %>
 
 <% if params[:version] %>
   <hr>


### PR DESCRIPTION
This got introduced in https://github.com/opf/openproject/commit/8bec9d22ea3f274d7bc4c1bcb140f624ba9ea0f8

https://community.openproject.org/projects/openproject/work_packages/74151/activity