### PR TITLE
Add 'datetime' custom field type (model layer)

### DIFF
--- a/app/forms/custom_fields/custom_field_rendering.rb
+++ b/app/forms/custom_fields/custom_field_rendering.rb
@@ -38,6 +38,7 @@ module CustomFields::CustomFieldRendering
     "float" => "CustomFields::Inputs::Float",
     %w[hierarchy weighted_item_list list] => "CustomFields::Inputs::SingleSelectList",
     "date" => "CustomFields::Inputs::Date",
+    "datetime" => "CustomFields::Inputs::Datetime",
     "bool" => "CustomFields::Inputs::Bool",
     "user" => "CustomFields::Inputs::SingleUserSelectList",
     "version" => "CustomFields::Inputs::SingleVersionSelectList",

--- a/app/forms/custom_fields/inputs/datetime.rb
+++ b/app/forms/custom_fields/inputs/datetime.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CustomFields::Inputs::Datetime < CustomFields::Inputs::Base::Input
+  form do |custom_value_form|
+    custom_value_form.text_field(**input_attributes)
+  end
+
+  def input_attributes
+    super.merge({ input_width: :xsmall, type: "datetime-local" })
+  end
+end

--- a/app/models/custom_actions/actions/strategies/datetime.rb
+++ b/app/models/custom_actions/actions/strategies/datetime.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module CustomActions::Actions::Strategies::Datetime
+  def values=(values)
+    super(Array(values).map { |v| to_datetime_or_nil(v) }.uniq)
+  end
+
+  def type
+    :datetime_property
+  end
+
+  def apply(work_package)
+    accessor = :"#{self.class.key}="
+    if work_package.respond_to? accessor
+      work_package.send(accessor, datetime_to_apply)
+    end
+  end
+
+  private
+
+  def datetime_to_apply
+    if values.first == "%CURRENT_DATETIME%"
+      Time.current
+    else
+      values.first
+    end
+  end
+
+  def to_datetime_or_nil(value)
+    case value
+    when nil, "%CURRENT_DATETIME%"
+      value
+    else
+      value.to_time
+    end
+  rescue TypeError, ArgumentError
+    nil
+  end
+end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -93,7 +93,7 @@ class CustomField < ApplicationRecord
 
   # make sure int, float, date, and bool are not searchable
   def check_searchability
-    self.searchable = false if %w(int float date bool user version).include?(field_format)
+    self.searchable = false if %w(int float date datetime bool user version).include?(field_format)
     true
   end
 
@@ -240,6 +240,12 @@ class CustomField < ApplicationRecord
     when "date"
       begin
         value.to_date
+      rescue StandardError
+        nil
+      end
+    when "datetime"
+      begin
+        DateTime.iso8601(value)
       rescue StandardError
         nil
       end

--- a/app/models/custom_field/order_statements.rb
+++ b/app/models/custom_field/order_statements.rb
@@ -30,7 +30,7 @@
 
 module CustomField::OrderStatements
   ORDER_JOIN_METHOD_BY_FIELD_FORMAT = OpenProject::MultiKeyHash.expand(
-    %w[string date bool link] => :join_for_order_by_string_sql,
+    %w[string date datetime bool link] => :join_for_order_by_string_sql,
     "int" => :join_for_order_by_int_sql,
     %w[float calculated_value] => :join_for_order_by_float_sql,
     "list" => :join_for_order_by_list_sql,
@@ -87,7 +87,7 @@ module CustomField::OrderStatements
 
   private
 
-  def can_be_used_for_grouping? = field_format.in?(%w[list date bool int float string link hierarchy])
+  def can_be_used_for_grouping? = field_format.in?(%w[list date datetime bool int float string link hierarchy])
 
   # Template for all the join statements.
   #

--- a/app/models/custom_value/datetime_strategy.rb
+++ b/app/models/custom_value/datetime_strategy.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class CustomValue::DatetimeStrategy < CustomValue::FormatStrategy
+  include Redmine::I18n
+
+  def typed_value
+    return if value.blank?
+
+    DateTime.iso8601(value)
+  rescue Date::Error, ArgumentError
+    nil
+  end
+
+  def formatted_value
+    return nil unless value.present?
+
+    format_time(DateTime.iso8601(value).to_time)
+  rescue StandardError
+    value.to_s
+  end
+
+  def validate_type_of_value
+    return nil if value.is_a?(Time) || value.is_a?(DateTime)
+
+    begin
+      DateTime.iso8601(value)
+      nil
+    rescue StandardError
+      :not_a_datetime
+    end
+  end
+end

--- a/app/models/queries/filters/shared/custom_fields/base.rb
+++ b/app/models/queries/filters/shared/custom_fields/base.rb
@@ -91,6 +91,8 @@ module Queries::Filters::Shared
           :text
         when "date"
           :date
+        when "datetime"
+          :datetime
         when "hierarchy", "weighted_item_list"
           :hierarchy
         else

--- a/app/models/queries/filters/strategies/datetime.rb
+++ b/app/models/queries/filters/strategies/datetime.rb
@@ -28,28 +28,39 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Filters
-  STRATEGIES = {
-    list: Queries::Filters::Strategies::List,
-    list_all: Queries::Filters::Strategies::ListAll,
-    list_optional: Queries::Filters::Strategies::ListOptional,
-    shared_with_user_list_optional: Queries::Filters::Strategies::WorkPackages::SharedWithUser::ListOptional,
-    integer: Queries::Filters::Strategies::Integer,
-    date: Queries::Filters::Strategies::Date,
-    datetime: Queries::Filters::Strategies::Datetime,
-    datetime_past: Queries::Filters::Strategies::DateTimePast,
-    string: Queries::Filters::Strategies::String,
-    text: Queries::Filters::Strategies::Text,
-    search: Queries::Filters::Strategies::Search,
-    float: Queries::Filters::Strategies::Float,
-    inexistent: Queries::Filters::Strategies::Inexistent,
-    empty_value: Queries::Filters::Strategies::EmptyValue,
-    hierarchy: Queries::Filters::Strategies::Hierarchy
-  }.freeze
+module Queries::Filters::Strategies
+  class Datetime < Queries::Filters::Strategies::Integer
+    self.supported_operators = ["<t+", ">t+", "t+", "t", "w", ">t-", "<t-", "t-", "=d", "<>d", "!*"]
+    self.default_operator = "t"
 
-  ##
-  # Wrapper class for invalid filters being created
-  class InvalidError < StandardError; end
+    def validate
+      if operator == Queries::Operators::OnDateTime ||
+         operator == Queries::Operators::BetweenDateTime
+        validate_values_all_datetime
+      else
+        super
+      end
+    end
 
-  class MissingError < StandardError; end
+    private
+
+    def operator_map
+      super_value = super.dup
+      super_value["=d"] = Queries::Operators::OnDateTime
+      super_value["<>d"] = Queries::Operators::BetweenDateTime
+      super_value
+    end
+
+    def validate_values_all_datetime
+      unless values.all? { |value| value.blank? || datetime?(value) }
+        errors.add(:values, I18n.t("activerecord.errors.messages.not_a_datetime"))
+      end
+    end
+
+    def datetime?(str)
+      true if ::DateTime.parse(str)
+    rescue ArgumentError
+      false
+    end
+  end
 end

--- a/config/initializers/custom_field_format.rb
+++ b/config/initializers/custom_field_format.rb
@@ -58,35 +58,39 @@ OpenProject::CustomFieldFormat.map do |fields|
                                                      label: :label_date,
                                                      order: 7,
                                                      formatter: "CustomValue::DateStrategy")
+  fields.register OpenProject::CustomFieldFormat.new("datetime",
+                                                     label: :label_datetime,
+                                                     order: 8,
+                                                     formatter: "CustomValue::DatetimeStrategy")
   fields.register OpenProject::CustomFieldFormat.new("bool",
                                                      label: :label_boolean,
-                                                     order: 8,
+                                                     order: 9,
                                                      formatter: "CustomValue::BoolStrategy")
   fields.register OpenProject::CustomFieldFormat.new("user",
                                                      label: Proc.new { User.model_name.human },
                                                      only: %w(WorkPackage TimeEntry Version Project),
                                                      edit_as: "list",
-                                                     order: 9,
+                                                     order: 10,
                                                      multi_value_possible: true,
                                                      formatter: "CustomValue::UserStrategy")
   fields.register OpenProject::CustomFieldFormat.new("version",
                                                      label: Proc.new { Version.model_name.human },
                                                      only: %w(WorkPackage TimeEntry Version Project),
                                                      edit_as: "list",
-                                                     order: 10,
+                                                     order: 11,
                                                      multi_value_possible: true,
                                                      formatter: "CustomValue::VersionStrategy")
   # This is an internal formatter used as a fallback in case a value is not found.
   # Setting the label to nil in order to avoid it becoming available for selection as a custom value format.
   fields.register OpenProject::CustomFieldFormat.new("empty",
                                                      label: nil,
-                                                     order: 11,
+                                                     order: 12,
                                                      formatter: "CustomValue::EmptyStrategy")
 
   fields.register OpenProject::CustomFieldFormat.new("hierarchy",
                                                      label: :label_hierarchy,
                                                      only: %w(Project WorkPackage),
-                                                     order: 12,
+                                                     order: 13,
                                                      multi_value_possible: true,
                                                      enterprise_feature: :custom_field_hierarchies,
                                                      formatter: "CustomValue::HierarchyStrategy")
@@ -94,14 +98,14 @@ OpenProject::CustomFieldFormat.map do |fields|
   fields.register OpenProject::CustomFieldFormat.new("weighted_item_list",
                                                      label: :label_weighted_item_list,
                                                      only: %w(Project WorkPackage),
-                                                     order: 13,
+                                                     order: 14,
                                                      enterprise_feature: :weighted_item_lists,
                                                      formatter: "CustomValue::WeightedItemListStrategy")
 
   fields.register OpenProject::CustomFieldFormat.new("calculated_value",
                                                      label: :label_calculated_value,
                                                      only: %w(Project),
-                                                     order: 14,
+                                                     order: 15,
                                                      enabled: lambda do
                                                        OpenProject::FeatureDecisions.calculated_value_project_attribute_active?
                                                      end,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3898,6 +3898,7 @@ en:
   label_date: "Date"
   label_dates: "Dates"
   label_date_and_time: "Date and time"
+  label_datetime: "Datetime"
   label_date_format: "Date format"
   label_date_from: "From"
   label_date_from_to: "From %{start} to %{end}"

--- a/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.initializer.ts
@@ -50,6 +50,9 @@ import {
   DateEditFieldComponent,
 } from 'core-app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.component';
 import {
+  DatetimeEditFieldComponent,
+} from 'core-app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.component';
+import {
   FormattableEditFieldComponent,
 } from 'core-app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.component';
 import {
@@ -114,6 +117,7 @@ export function initializeCoreEditFields(editFieldService:EditFieldService, sele
       .addFieldType(WorkPackageEditFieldComponent, 'workPackage', ['WorkPackage'])
       .addFieldType(BooleanEditFieldComponent, 'boolean', ['Boolean'])
       .addFieldType(DateEditFieldComponent, 'date', ['Date'])
+      .addFieldType(DatetimeEditFieldComponent, 'datetime', ['DateTime'])
       .addFieldType(FormattableEditFieldComponent, 'wiki-textarea', ['Formattable']);
 
     editFieldService

--- a/frontend/src/app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.component.ts
@@ -1,0 +1,69 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import moment from 'moment-timezone';
+import { EditFieldComponent } from 'core-app/shared/components/fields/edit/edit-field.component';
+import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
+import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+
+@Component({
+  template: `
+    <input type="datetime-local"
+           class="inline-edit--field op-input"
+           [attr.aria-required]="required"
+           [attr.required]="required"
+           [disabled]="inFlight"
+           [(ngModel)]="value"
+           (keydown)="handler.handleUserKeydown($event)"
+           [id]="handler.htmlId" />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class DatetimeEditFieldComponent extends EditFieldComponent {
+  @InjectField() readonly timezoneService:TimezoneService;
+
+  public get value():string {
+    const raw = this.resource[this.name] as string|null;
+    if (!raw) return '';
+    return this.timezoneService.parseDatetime(raw).format('YYYY-MM-DDTHH:mm');
+  }
+
+  public set value(inputVal:string) {
+    this.resource[this.name] = this.parseValue(inputVal);
+  }
+
+  public parseValue(data:string):string|null {
+    if (!moment(data, 'YYYY-MM-DDTHH:mm', true).isValid()) {
+      return null;
+    }
+    const tz = this.timezoneService.userTimezone();
+    return moment.tz(data, 'YYYY-MM-DDTHH:mm', tz).utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+  }
+}

--- a/frontend/src/app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.module.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DatetimeEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.component';
+import { OpSharedModule } from 'core-app/shared/shared.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    OpSharedModule,
+  ],
+  declarations: [
+    DatetimeEditFieldComponent,
+  ],
+  exports: [
+    DatetimeEditFieldComponent,
+  ],
+})
+export class DatetimeEditFieldModule { }

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -56,6 +56,7 @@ import { BooleanEditFieldModule } from 'core-app/shared/components/fields/edit/f
 import { IntegerEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/integer-edit-field/integer-edit-field.module';
 import { TextEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/text-edit-field/text-edit-field.module';
 import { DateEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/date-edit-field/date-edit-field.module';
+import { DatetimeEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/datetime-edit-field/datetime-edit-field.module';
 import { SelectEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/select-edit-field/select-edit-field.module';
 import { FormattableEditFieldModule } from 'core-app/shared/components/fields/edit/field-types/formattable-edit-field/formattable-edit-field.module';
 import { EditFieldControlsModule } from 'core-app/shared/components/fields/edit/field-controls/edit-field-controls.module';
@@ -86,6 +87,7 @@ import { FormsModule } from '@angular/forms';
     IntegerEditFieldModule,
     TextEditFieldModule,
     DateEditFieldModule,
+    DatetimeEditFieldModule,
     SelectEditFieldModule,
     FormattableEditFieldModule,
     EditFieldControlsModule,

--- a/lib/api/v3/queries/schemas/datetime_filter_dependency_representer.rb
+++ b/lib/api/v3/queries/schemas/datetime_filter_dependency_representer.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -28,28 +26,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Filters
-  STRATEGIES = {
-    list: Queries::Filters::Strategies::List,
-    list_all: Queries::Filters::Strategies::ListAll,
-    list_optional: Queries::Filters::Strategies::ListOptional,
-    shared_with_user_list_optional: Queries::Filters::Strategies::WorkPackages::SharedWithUser::ListOptional,
-    integer: Queries::Filters::Strategies::Integer,
-    date: Queries::Filters::Strategies::Date,
-    datetime: Queries::Filters::Strategies::Datetime,
-    datetime_past: Queries::Filters::Strategies::DateTimePast,
-    string: Queries::Filters::Strategies::String,
-    text: Queries::Filters::Strategies::Text,
-    search: Queries::Filters::Strategies::Search,
-    float: Queries::Filters::Strategies::Float,
-    inexistent: Queries::Filters::Strategies::Inexistent,
-    empty_value: Queries::Filters::Strategies::EmptyValue,
-    hierarchy: Queries::Filters::Strategies::Hierarchy
-  }.freeze
-
-  ##
-  # Wrapper class for invalid filters being created
-  class InvalidError < StandardError; end
-
-  class MissingError < StandardError; end
+module API
+  module V3
+    module Queries
+      module Schemas
+        class DatetimeFilterDependencyRepresenter <
+          DateTimeFilterDependencyRepresenter
+        end
+      end
+    end
+  end
 end

--- a/lib/api/v3/utilities/custom_field_injector.rb
+++ b/lib/api/v3/utilities/custom_field_injector.rb
@@ -40,6 +40,7 @@ module API
           "int" => "Integer",
           "float" => "Float",
           "date" => "Date",
+          "datetime" => "DateTime",
           "bool" => "Boolean",
           "user" => "User",
           "version" => "Version",

--- a/spec/factories/custom_field_factory.rb
+++ b/spec/factories/custom_field_factory.rb
@@ -106,6 +106,10 @@ FactoryBot.define do
       field_format { "date" }
     end
 
+    trait :datetime do
+      field_format { "datetime" }
+    end
+
     trait :list do
       transient do
         default_option { nil }
@@ -264,6 +268,7 @@ FactoryBot.define do
       %w[
         boolean
         date
+        datetime
         float
         hierarchy multi_hierarchy
         integer

--- a/spec/models/custom_value/datetime_strategy_spec.rb
+++ b/spec/models/custom_value/datetime_strategy_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe CustomValue::DatetimeStrategy do
+  let(:instance) { described_class.new(custom_value) }
+  let(:custom_value) { instance_double(CustomValue, value:) }
+
+  describe "#typed_value" do
+    subject { instance.typed_value }
+
+    context "when value is a UTC datetime string" do
+      let(:value) { "2015-01-03T12:00:00Z" }
+
+      it { is_expected.to eql(DateTime.iso8601(value)) }
+    end
+
+    context "when value is a datetime string with offset" do
+      let(:value) { "2015-01-03T14:00:00+02:00" }
+
+      it { is_expected.to eql(DateTime.iso8601(value)) }
+    end
+
+    context "when value is not a datetime" do
+      let(:value) { "hello, world!" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#formatted_value" do
+    subject { instance.formatted_value }
+
+    context "when value is a valid datetime string", with_settings: { time_format: "%Y-%m-%d %H:%M" } do
+      let(:value) { "2015-01-03T00:00:00Z" }
+
+      it "returns a formatted string" do
+        expect(subject).to be_a(String)
+        expect(subject).not_to be_empty
+      end
+    end
+
+    context "when value is blank" do
+      let(:value) { "" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#validate_type_of_value" do
+    subject { instance.validate_type_of_value }
+
+    context "when value is valid UTC datetime string" do
+      let(:value) { "2015-01-03T12:00:00Z" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is valid datetime string with offset" do
+      let(:value) { "2015-01-03T14:00:00+02:00" }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is a nonsense string" do
+      let(:value) { "chicken" }
+
+      it "rejects" do
+        expect(subject).to be(:not_a_datetime)
+      end
+    end
+
+    context "when value is a Time object" do
+      let(:value) { Time.now }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "when value is a DateTime object" do
+      let(:value) { DateTime.now }
+
+      it "accepts" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/queries/filters/strategies/datetime_spec.rb
+++ b/spec/models/queries/filters/strategies/datetime_spec.rb
@@ -28,28 +28,36 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Queries::Filters
-  STRATEGIES = {
-    list: Queries::Filters::Strategies::List,
-    list_all: Queries::Filters::Strategies::ListAll,
-    list_optional: Queries::Filters::Strategies::ListOptional,
-    shared_with_user_list_optional: Queries::Filters::Strategies::WorkPackages::SharedWithUser::ListOptional,
-    integer: Queries::Filters::Strategies::Integer,
-    date: Queries::Filters::Strategies::Date,
-    datetime: Queries::Filters::Strategies::Datetime,
-    datetime_past: Queries::Filters::Strategies::DateTimePast,
-    string: Queries::Filters::Strategies::String,
-    text: Queries::Filters::Strategies::Text,
-    search: Queries::Filters::Strategies::Search,
-    float: Queries::Filters::Strategies::Float,
-    inexistent: Queries::Filters::Strategies::Inexistent,
-    empty_value: Queries::Filters::Strategies::EmptyValue,
-    hierarchy: Queries::Filters::Strategies::Hierarchy
-  }.freeze
+require "spec_helper"
 
-  ##
-  # Wrapper class for invalid filters being created
-  class InvalidError < StandardError; end
+RSpec.describe Queries::Filters::Strategies::Datetime do
+  let(:filter) { double("filter", values: [], errors: ActiveModel::Errors.new(double)) }
+  let(:strategy) { described_class.new(filter) }
 
-  class MissingError < StandardError; end
+  describe ".supported_operators" do
+    it "includes all date-like relative operators" do
+      expect(described_class.supported_operators)
+        .to include("<t+", ">t+", "t+", "t", "w", ">t-", "<t-", "t-")
+    end
+
+    it "includes exact and between datetime operators" do
+      expect(described_class.supported_operators).to include("=d", "<>d")
+    end
+
+    it "includes not-set operator" do
+      expect(described_class.supported_operators).to include("!*")
+    end
+  end
+
+  describe "operator_map" do
+    subject { strategy.send(:operator_map) }
+
+    it "maps =d to OnDateTime (not OnDate)" do
+      expect(subject["=d"]).to eq(Queries::Operators::OnDateTime)
+    end
+
+    it "maps <>d to BetweenDateTime (not BetweenDate)" do
+      expect(subject["<>d"]).to eq(Queries::Operators::BetweenDateTime)
+    end
+  end
 end

--- a/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
+++ b/spec/models/queries/work_packages/filter/custom_fields/custom_field_filter_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
   let(:user_wp_custom_field) { build_stubbed(:user_wp_custom_field) }
   let(:version_wp_custom_field) { build_stubbed(:version_wp_custom_field) }
   let(:date_wp_custom_field) { build_stubbed(:date_wp_custom_field) }
+  let(:datetime_wp_custom_field) { build_stubbed(:datetime_wp_custom_field) }
   let(:string_wp_custom_field) { build_stubbed(:string_wp_custom_field) }
   let(:link_wp_custom_field) { build_stubbed(:link_wp_custom_field) }
   let(:hierarchy_wp_custom_field) { build_stubbed(:wp_custom_field, :hierarchy) }
@@ -52,6 +53,7 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
      user_wp_custom_field,
      version_wp_custom_field,
      date_wp_custom_field,
+     datetime_wp_custom_field,
      string_wp_custom_field,
      link_wp_custom_field,
      hierarchy_wp_custom_field]
@@ -206,6 +208,15 @@ RSpec.describe Queries::WorkPackages::Filter::CustomFieldFilter do
       it "is date for a date" do
         expect(instance.type)
           .to be(:date)
+      end
+    end
+
+    describe "datetime" do
+      let(:cf_accessor) { datetime_wp_custom_field.column_name }
+
+      it "is datetime for a datetime" do
+        expect(instance.type)
+          .to be(:datetime)
       end
     end
 


### PR DESCRIPTION
For migrating from Jira to OpenProject we need to add a couple of custom field types to OpenProject that are available in Jira but not in OpenProject. This PR aims at adding the the custom field type "datetime".

The new custom field format that stores UTC ISO 8601
datetime strings. The implementation mirrors the existing "date" type with DateTime.iso8601
parsing and format_time display. Registers the type in the custom field
format registry, excludes it from full-text search, adds cast_value
support, and provides the i18n label. Includes a custom_actions strategy
and unit specs.

Implements https://community.openproject.org/wp/32646