### PR TITLE
Rename label of instance identifier conversion button

### DIFF
--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
@@ -80,7 +80,7 @@
               hidden: true,
               data: { admin__work_packages_identifier_target: "saveButton" }
             )
-          ) { t("button_save") } %>
+          ) { t("admin.settings.work_packages_identifier.button_save") } %>
 
       <%= render(
             Primer::Beta::Button.new(

--- a/config/locales/crowdin/no.yml
+++ b/config/locales/crowdin/no.yml
@@ -404,7 +404,7 @@
         page_header:
           description: Choose between classic numerical work package IDs or semantic project-specific ones that prepend the project identifier to the work package ID.
         banner:
-          existing_identifiers_notice: 'Existing identifiers for %{project_count} projects don''t meet requirements for project-based semantic identifiers. OpenProject can automatically update these so that they are valid as in the examples below. Click on ''Convert instance'' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
+          existing_identifiers_notice: 'Existing identifiers for %{project_count} projects don''t meet requirements for project-based semantic identifiers. OpenProject can automatically update these so that they are valid as in the examples below. Click on ''Autofix and save'' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
 
             '
         box_header:

--- a/config/locales/crowdin/no.yml
+++ b/config/locales/crowdin/no.yml
@@ -404,7 +404,7 @@
         page_header:
           description: Choose between classic numerical work package IDs or semantic project-specific ones that prepend the project identifier to the work package ID.
         banner:
-          existing_identifiers_notice: 'Existing identifiers for %{project_count} projects don''t meet requirements for project-based semantic identifiers. OpenProject can automatically update these so that they are valid as in the examples below. Click on ''Autofix and save'' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
+          existing_identifiers_notice: 'Existing identifiers for %{project_count} projects don''t meet requirements for project-based semantic identifiers. OpenProject can automatically update these so that they are valid as in the examples below. Click on ''Convert instance'' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
 
             '
         box_header:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -427,7 +427,7 @@ en:
           existing_identifiers_notice: >
             Existing identifiers for %{project_count} projects don't meet requirements for project-based semantic identifiers.
             OpenProject can automatically update these so that they are valid as in the examples below.
-            Click on 'Autofix and save' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
+            Click on 'Convert identifiers' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
         box_header:
           label_project: Project
           label_previous_identifier: Previous identifier
@@ -446,7 +446,8 @@ en:
           remaining_projects:
             one: "... 1 more project"
             other: "... %{count} more projects"
-        button_autofix: Autofix and save
+        button_autofix: Convert identifiers
+        button_save: Convert identifiers
         dialog:
           title: Change work package identifiers
           heading: Enable project-based work package IDs?

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not render the save or autofix buttons" do
       render_component(component)
-      expect(page).to have_no_button("Save")
-      expect(page).to have_no_link("Autofix and save")
+      expect(page).to have_no_button("Convert identifiers")
+      expect(page).to have_no_link("Convert identifiers")
     end
 
     it "does not call PreviewQuery" do
@@ -132,7 +132,7 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "renders the save button (hidden until a change is made)" do
       render_component(component)
-      expect(page).to have_button("Save", visible: :all)
+      expect(page).to have_button("Convert identifiers", visible: :all)
     end
 
     it "does not render in-progress or success content" do
@@ -160,12 +160,12 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
       it "hides the plain save button" do
         render_component(component)
-        expect(page).to have_no_button("Save")
+        expect(page).to have_no_button("Convert identifiers")
       end
 
       it "renders the autofix button" do
         render_component(component)
-        expect(page).to have_link("Autofix and save")
+        expect(page).to have_link("Convert identifiers")
       end
     end
   end

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
       visit_settings
       choose "Project-based semantic identifiers"
 
-      click_button "Save"
+      click_button "Convert identifiers"
 
       expect(page).to have_current_path(settings_path)
       expect(page).to have_no_dialog
@@ -71,7 +71,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
           "[data-admin--work-packages-identifier-target=autofixSection][hidden]",
           visible: :all
         )
-        click_button "Save"
+        click_button "Convert identifiers"
 
         expect(page).to have_current_path(settings_path)
         expect(page).to have_no_dialog
@@ -91,14 +91,14 @@ RSpec.describe "Work packages identifier admin settings", :js do
         )
       end
 
-      it "opens the confirmation dialog when 'Autofix and save' is clicked" do
-        click_on "Autofix and save"
+      it "opens the confirmation dialog when 'Convert identifiers' is clicked" do
+        click_on "Convert identifiers"
 
         expect(page).to have_dialog "Change work package identifiers"
       end
 
       it "shows the dialog heading and checkbox" do
-        click_on "Autofix and save"
+        click_on "Convert identifiers"
 
         within_dialog "Change work package identifiers" do
           expect(page).to have_text("Enable project-based work package IDs?")
@@ -110,7 +110,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
       end
 
       it "enables the confirm button only after checking the checkbox" do
-        click_on "Autofix and save"
+        click_on "Convert identifiers"
 
         within "[role=alertdialog]" do
           expect(page).to have_button("Change identifiers", disabled: true)
@@ -122,8 +122,8 @@ RSpec.describe "Work packages identifier admin settings", :js do
       end
 
       it "hides the plain Save button when autofix section is visible" do
-        expect(page).to have_no_button("Save")
-        expect(page).to have_link("Autofix and save")
+        expect(page).to have_no_button("Convert identifiers")
+        expect(page).to have_link("Convert identifiers")
       end
     end
   end


### PR DESCRIPTION
As per request coming from @wielinde: Change the "Autofix and save" label to something a bit more understandable to the end user. 

The operation is colloquially described as "conversion" => let's change the label to **Convert identifiers**.

<img width="514" height="809" alt="Screenshot 2026-05-17 at 21 26 17" src="https://github.com/user-attachments/assets/ca9e75ea-aaaa-4f1a-82c8-7f977988cca9" />
<img width="806" height="349" alt="Screenshot 2026-05-17 at 21 31 20" src="https://github.com/user-attachments/assets/55c1d45d-9732-409b-a2b4-d478fd0fae65" />
