### PR TITLE
[#74192] Clear semantic identifier when moving a work package

### DIFF
--- a/app/services/work_packages/set_attributes_service.rb
+++ b/app/services/work_packages/set_attributes_service.rb
@@ -268,9 +268,15 @@ class WorkPackages::SetAttributesService < BaseServices::SetAttributes
       set_version_to_nil
       reassign_category
       set_parent_to_nil
+      clear_semantic_identifier
 
       assign_default_type unless work_package.type
     end
+  end
+
+  def clear_semantic_identifier
+    work_package.sequence_number = nil
+    work_package.identifier = nil
   end
 
   def update_dates

--- a/spec/services/work_packages/semantic_ids/integration_spec.rb
+++ b/spec/services/work_packages/semantic_ids/integration_spec.rb
@@ -130,6 +130,40 @@ RSpec.describe "SemanticIds registry integration", type: :model do
     end
   end
 
+  describe "WP move in classic mode when sequence numbers linger from semantic mode" do
+    # The outer before block stubs semantic?: true, so both WPs automatically receive
+    # sequence_number = 1 in their respective projects — simulating the state after the
+    # user enabled semantic IDs and then switched back to classic.
+    let!(:work_package) { create(:work_package, project:) }
+    let!(:conflict_wp)  { create(:work_package, project: target_project) }
+
+    before do
+      # Simulate the user switching back to classic mode after semantic IDs were active.
+      allow(Setting::WorkPackageIdentifier).to receive_messages(semantic?: false, classic?: true)
+    end
+
+    it "succeeds without PG::UniqueViolation and clears the sequence number" do
+      result = WorkPackages::UpdateService.new(user:, model: work_package).call(project: target_project)
+
+      expect(result).to be_success
+      expect(work_package.reload.project).to eq(target_project)
+      expect(work_package.reload.sequence_number).to be_nil
+    end
+
+    it "also clears sequence numbers on descendants to avoid conflicts" do
+      child = create(:work_package, project:, parent: work_package)
+      # Manually assign a sequence_number to the child to simulate leftover semantic state,
+      # then create a conflicting WP in the target project with the same sequence number.
+      child.update_columns(sequence_number: 2, identifier: "PROJ-2")
+      create(:work_package, project: target_project).tap { |wp| wp.update_columns(sequence_number: 2) }
+
+      result = WorkPackages::UpdateService.new(user:, model: work_package).call(project: target_project)
+
+      expect(result).to be_success
+      expect(child.reload.sequence_number).to be_nil
+    end
+  end
+
   describe "Project rename via Projects::UpdateService" do
     # after_create auto-registers wp1 as "PROJ-1" (seq=1) and wp2 as "PROJ-2" (seq=2)
     let!(:wp1) { create(:work_package, project:) }

--- a/spec/services/work_packages/set_attributes_service_spec.rb
+++ b/spec/services/work_packages/set_attributes_service_spec.rb
@@ -1957,6 +1957,24 @@ RSpec.describe WorkPackages::SetAttributesService,
           end
         end
       end
+
+      context "for semantic identifier" do
+        let(:work_package) do
+          build_stubbed(:work_package, project:, sequence_number: 7, identifier: "OLD-7")
+        end
+
+        it "clears sequence_number" do
+          subject
+
+          expect(work_package.sequence_number).to be_nil
+        end
+
+        it "clears identifier" do
+          subject
+
+          expect(work_package.identifier).to be_nil
+        end
+      end
     end
 
     context "when updating project before calling the service" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-jira-exit/work_packages/74192/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When a user switches from semantic identifier mode to classic, the WPs retain their semantic ID fields (`identifier` + `sequence_number`). 

These can cause clashing behaviour when we move a package from one project to another, and the project already has a WP with the same combination of (`project_id` + `sequence_number`).

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Clear the semantic ID fields before move, so that they are re-populated on the next conversion to semantic.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
