### PR TITLE
[#74200] Use displayId in work package breadcrumbs

### DIFF
--- a/frontend/src/app/features/hal/hal-link/hal-link.ts
+++ b/frontend/src/app/features/hal/hal-link/hal-link.ts
@@ -42,6 +42,7 @@ export interface HalLinkInterface {
   payload?:any;
   type?:string;
   identifier?:string;
+  displayId?:string;
 }
 
 export interface HalLinkSource {
@@ -62,7 +63,8 @@ export class HalLink implements HalLinkInterface {
     public templated = false,
     public payload?:any,
     public type = 'application/json',
-    public identifier?:string) {
+    public identifier?:string,
+    public displayId?:string) {
   }
 
   /**
@@ -78,6 +80,7 @@ export class HalLink implements HalLinkInterface {
       link.payload,
       link.type,
       link.identifier,
+      link.displayId,
     );
   }
 
@@ -114,6 +117,7 @@ export class HalLink implements HalLinkInterface {
       this.payload,
       this.type,
       this.identifier,
+      this.displayId,
     ).$callable();
   }
 
@@ -134,6 +138,7 @@ export class HalLink implements HalLinkInterface {
       payload: this.payload,
       type: this.type,
       identifier: this.identifier,
+      displayId: this.displayId,
     });
 
     return linkFunc;

--- a/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
@@ -141,6 +141,25 @@ describe('WorkPackage', () => {
       });
     });
 
+    describe('when displayId is absent but present on the self link (linked ancestor/child)', () => {
+      beforeEach(() => {
+        source = {
+          _links: {
+            self: {
+              href: '/api/v3/work_packages/11099',
+              title: 'subj child',
+              displayId: 'ACSMT-15',
+            },
+          },
+        };
+        createWorkPackage();
+      });
+
+      it('should fall back to the semantic identifier on the self link', () => {
+        expect(workPackage.displayId).toEqual('ACSMT-15');
+      });
+    });
+
 });
 
   describe('formattedId', () => {

--- a/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
@@ -95,7 +95,14 @@ describe('WorkPackage', () => {
     injector = TestBed.inject(Injector);
     halResourceNotification = injector.get(HalResourceNotificationService);
 
-    halResourceService.registerResource('WorkPackage', { cls: WorkPackageResource });
+    halResourceService.registerResource('WorkPackage', {
+      cls: WorkPackageResource,
+      attrTypes: {
+        parent: 'WorkPackage',
+        ancestors: 'WorkPackage',
+        children: 'WorkPackage',
+      },
+    });
   });
 
   describe('when creating an empty work package', () => {

--- a/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.spec.ts
@@ -160,6 +160,33 @@ describe('WorkPackage', () => {
       });
     });
 
+    describe('when built from a parent work package _links.ancestors array', () => {
+      // Mirrors the real HAL pipeline: the parent exposes an ancestors link
+      // array; each entry carries displayId alongside href/title; the builder
+      // creates an ancestor WorkPackageResource through HalLink, which must
+      // preserve displayId end-to-end.
+      beforeEach(() => {
+        source = {
+          _links: {
+            self: { href: '/api/v3/work_packages/42' },
+            ancestors: [
+              {
+                href: '/api/v3/work_packages/11099',
+                title: 'subj child',
+                displayId: 'ACSMT-15',
+              },
+            ],
+          },
+        };
+        createWorkPackage();
+      });
+
+      it('surfaces the semantic displayId on each ancestor resource', () => {
+        const ancestor = (workPackage as any).ancestors[0] as WorkPackageResource;
+        expect(ancestor.displayId).toEqual('ACSMT-15');
+      });
+    });
+
 });
 
   describe('formattedId', () => {

--- a/frontend/src/app/features/hal/resources/work-package-resource.ts
+++ b/frontend/src/app/features/hal/resources/work-package-resource.ts
@@ -137,11 +137,18 @@ export class WorkPackageBaseResource extends HalResource {
    * (primary key) should only appear in data attributes and internal
    * state management (selection, focus, hover).
    *
-   * Falls back to `id` when `displayId` is absent from the API response
-   * (defensive against stale cache during rolling deploys).
+   * Falls back to the self link's `displayId` — ancestor/children links
+   * in the API expose `displayId` alongside `href`/`title` because those
+   * HAL resources are built from a link payload alone, without a
+   * top-level `displayId`. Finally falls back to `id` (defensive against
+   * stale cache during rolling deploys, and for resources built from
+   * bare hrefs).
    */
   public get displayId():string {
-    return this.$source.displayId?.toString() ?? this.id?.toString() ?? '';
+    return this.$source.displayId?.toString()
+      ?? this.$source._links?.self?.displayId?.toString()
+      ?? this.id?.toString()
+      ?? '';
   }
 
   /**

--- a/lib/api/v3/work_packages/eager_loading/hierarchy.rb
+++ b/lib/api/v3/work_packages/eager_loading/hierarchy.rb
@@ -41,7 +41,7 @@ module API
           def children(id)
             @children ||= WorkPackage
                           .where(parent_id: work_packages.map(&:id))
-                          .select(:id, :subject, :project_id, :parent_id)
+                          .select(:id, :identifier, :subject, :project_id, :parent_id)
                           .group_by(&:parent_id)
                           .to_h
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -327,7 +327,8 @@ module API
           visible_children.map do |child|
             {
               href: api_v3_paths.work_package(child.id),
-              title: child.subject
+              title: child.subject,
+              displayId: child.display_id.to_s
             }
           end
         end
@@ -337,7 +338,8 @@ module API
           represented.visible_ancestors(current_user).map do |ancestor|
             {
               href: api_v3_paths.work_package(ancestor.id),
-              title: ancestor.subject
+              title: ancestor.subject,
+              displayId: ancestor.display_id.to_s
             }
           end
         end

--- a/spec/lib/api/v3/work_packages/eager_loading/hierarchy_integration_spec.rb
+++ b/spec/lib/api/v3/work_packages/eager_loading/hierarchy_integration_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "eager_loading_mock_wrapper"
+
+RSpec.describe API::V3::WorkPackages::EagerLoading::Hierarchy do
+  let!(:parent_work_package) { create(:work_package) }
+  let!(:child_work_package) { create(:work_package, parent: parent_work_package) }
+
+  describe ".apply" do
+    subject(:wrapped_children) do
+      wrapped = EagerLoadingMockWrapper.wrap(described_class, [parent_work_package])
+      wrapped.first.children
+    end
+
+    it "preloads the children association" do
+      wrapped = EagerLoadingMockWrapper.wrap(described_class, [parent_work_package])
+
+      expect(wrapped.first.association(:children)).to be_loaded
+      expect(wrapped_children.map(&:id)).to eq([child_work_package.id])
+    end
+
+    # Regression: children are loaded with a partial SELECT for performance,
+    # so the set of columns must cover everything the representer reads from
+    # each child — including `identifier`, which `display_id` consults to
+    # render the `_links.children[].displayId` payload in semantic mode.
+    it "includes identifier in the partial SELECT so display_id is available" do
+      child = wrapped_children.first
+
+      expect(child).to have_attribute(:identifier)
+      expect { child.display_id }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1121,6 +1121,12 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
               .to eq(intermediate.subject)
             expect(work_package).to have_received(:visible_ancestors)
           end
+
+          it "exposes displayId on each ancestor link" do
+            links = parse_json(subject)["_links"]["ancestors"]
+            expect(links[0]["displayId"]).to eq(root.display_id.to_s)
+            expect(links[1]["displayId"]).to eq(intermediate.display_id.to_s)
+          end
         end
 
         context "when ancestors are invisible" do
@@ -1158,6 +1164,10 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
 
           it do
             expect(parse_json(subject)["_links"]["children"][0]["title"]).to eq(child.subject)
+          end
+
+          it "exposes displayId on each child link" do
+            expect(parse_json(subject)["_links"]["children"][0]["displayId"]).to eq(child.display_id.to_s)
           end
         end
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74200

# What are you trying to accomplish?

In semantic mode, the work package breadcrumb shows numeric IDs where the rest of the UI shows the semantic identifier. The URL in the breadcrumb also uses the numeric ID, which defeats the point of the `use displayId in work package URLs` work.

Root cause: the work package representer's `ancestors` and `children` links only carry `href` and `title`. When the frontend builds a HAL resource from one of those link entries, `$source.displayId` is undefined, so the `displayId` getter falls through to `this.id` — which is the numeric id parsed out of the href.

## Screenshots

Before: breadcrumb renders `subj child` → `/projects/ACSMT/work_packages/11099/activity`
After: breadcrumb renders `subj child` → `/projects/ACSMT/work_packages/ACSMT-15/activity`

<img width="1610" height="982" alt="Screenshot 2026-04-22 at 4 06 49 PM" src="https://github.com/user-attachments/assets/7d358966-f884-4e88-b630-b02cf6f39d4f" />


# What approach did you choose and why?

Two tiny, paired changes:

- **Rails:** the `ancestors` and `children` link blocks in `WorkPackageRepresenter` now emit `displayId: wp.display_id.to_s` alongside `href` and `title`. HAL permits arbitrary key/value pairs on a link object, so this is additive.
- **Frontend:** `WorkPackageResource#displayId` now falls back to `$source._links.self.displayId` before `this.id`. `HalResourceService#createLinkedResource` stores the raw link payload at `$source._links.self`, so extra keys survive even though `HalLink.fromObject` only copies a fixed set into `$link`. Reading the raw link keeps the change scoped to the one getter and avoids extending `HalLink` itself.

Considered but rejected: embedding full ancestor payloads (too much data, unrelated to the fix) and switching the API href to a semantic path (breaking change to `api_v3_paths.work_package`, out of scope).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)