### PR TITLE
[73501] FieldsetGroups are missing descriptions

### DIFF
--- a/app/components/my/notifications/show_page_component.html.erb
+++ b/app/components/my/notifications/show_page_component.html.erb
@@ -59,6 +59,7 @@ See COPYRIGHT and LICENSE files for more details.
 <% else %>
   <%= render(Primer::Beta::Subhead.new(mt: 3)) do |component|
         component.with_heading(size: :medium) { t("my_account.notifications.date_alerts.title") }
+        component.with_description { t("my_account.notifications.date_alerts.description") }
       end %>
   <%= render(EnterpriseEdition::BannerComponent.new(:date_alerts, variant: :inline)) %>
 <% end %>
@@ -78,6 +79,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= render(Primer::BaseComponent.new(tag: :div, classes: "op-admin-settings-form-wrapper")) do %>
   <%= render(Primer::Beta::Subhead.new(mt: 3)) do |component|
         component.with_heading(size: :medium) { t("my_account.notifications.project_specific_settings.title") }
+        component.with_description { t("my_account.notifications.project_specific_settings.description") }
       end %>
 
   <% if project_notification_settings.any? %>

--- a/app/forms/my/notifications/date_alerts_form.rb
+++ b/app/forms/my/notifications/date_alerts_form.rb
@@ -38,7 +38,9 @@ class My::Notifications::DateAlertsForm < ApplicationForm
   end
 
   form do |f|
-    f.fieldset_group(title: helpers.t("my_account.notifications.date_alerts.title"), mt: 3) do |fg|
+    f.fieldset_group(title: helpers.t("my_account.notifications.date_alerts.title"),
+                     description: helpers.t("my_account.notifications.date_alerts.description"),
+                     mt: 3) do |fg|
       %i[start_date due_date].each do |field|
         active = model.send(:"#{field}_active")
 

--- a/app/forms/my/notifications/non_participating_form.rb
+++ b/app/forms/my/notifications/non_participating_form.rb
@@ -35,7 +35,9 @@ class My::Notifications::NonParticipatingForm < ApplicationForm
   end
 
   form do |f|
-    f.fieldset_group(title: helpers.t("my_account.notifications.non_participating.title"), mt: 3) do |fg|
+    f.fieldset_group(title: helpers.t("my_account.notifications.non_participating.title"),
+                     description: helpers.t("my_account.notifications.non_participating.description"),
+                     mt: 3) do |fg|
       NotificationSetting.non_participating_settings.each do |setting|
         fg.check_box(
           name: setting,

--- a/app/forms/my/notifications/participating_form.rb
+++ b/app/forms/my/notifications/participating_form.rb
@@ -35,7 +35,9 @@ class My::Notifications::ParticipatingForm < ApplicationForm
   end
 
   form do |f|
-    f.fieldset_group(title: helpers.t("my_account.notifications.participating.title"), mt: 2) do |fg|
+    f.fieldset_group(title: helpers.t("my_account.notifications.participating.title"),
+                     description: helpers.t("my_account.notifications.participating.description"),
+                     mt: 2) do |fg|
       fg.check_box(
         name: :mentioned,
         label: helpers.t("my_account.notifications.participating.mentioned"),

--- a/app/forms/my/reminders/daily_reminders_form.rb
+++ b/app/forms/my/reminders/daily_reminders_form.rb
@@ -32,7 +32,9 @@ class My::Reminders::DailyRemindersForm < ApplicationForm
   DailyRemindersFormModel = Data.define(:enabled, :times)
 
   form do |f|
-    f.fieldset_group(title: helpers.t("my_account.email_reminders.daily_reminders.title"), mt: 3) do |fg|
+    f.fieldset_group(title: helpers.t("my_account.email_reminders.daily_reminders.title"),
+                     description: helpers.t("my_account.email_reminders.daily_reminders.description"),
+                     mt: 3) do |fg|
       fg.check_box(
         name: :enabled,
         label: helpers.t("my_account.email_reminders.daily_reminders.enabled"),

--- a/app/forms/my/reminders/email_alerts_form.rb
+++ b/app/forms/my/reminders/email_alerts_form.rb
@@ -30,7 +30,9 @@
 
 class My::Reminders::EmailAlertsForm < ApplicationForm
   form do |f|
-    f.fieldset_group(title: helpers.t("my_account.email_reminders.email_alerts.title"), mt: 3) do |fg|
+    f.fieldset_group(title: helpers.t("my_account.email_reminders.email_alerts.title"),
+                     description: helpers.t("my_account.email_reminders.email_alerts.description"),
+                     mt: 3) do |fg|
       NotificationSetting.email_settings.each do |setting|
         fg.check_box(
           name: setting,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3657,7 +3657,7 @@ en:
         personal_reminder: "Notify me for personal reminders"
       daily_reminders:
         title: "Send me daily email reminders for unread notifications"
-        caption: "You will receive these reminders only for unread notifications and only at hours you specify. Until you configure a time zone for your account, the times will be interpreted to be in UTC."
+        description: "You will receive these reminders only for unread notifications and only at hours you specify. Until you configure a time zone for your account, the times will be interpreted to be in UTC."
         enabled: "Enable daily email reminders"
         add_time: "Add time"
         remove_time: "Remove time"
@@ -3671,6 +3671,7 @@ en:
         date_range: "Pause period"
       email_alerts:
         title: "Email alerts for other items that are not work packages"
+        description: "Notifications today are limited to work packages. You can choose to continue receiving email alerts for these events until they are included in notifications."
         news_added: "News added"
         news_commented: "Comment on a news item"
         document_added: "Document added"
@@ -3683,6 +3684,7 @@ en:
     notifications:
       participating:
         title: "Participating"
+        description: "Notifications for all activities in work packages you are involved in (assignee, accountable or watcher)."
         submit_button: "Update preferences"
         mentioned: "Mentioned"
         watched: "Watching"
@@ -3691,6 +3693,7 @@ en:
         shared: "Shared with me"
       date_alerts:
         title: "Date alerts"
+        description: "Automatic notifications when important dates are approaching for open work packages you are involved in (assignee, accountable or watcher)."
         submit_button: "Update date alerts"
         start_date: "Start date"
         due_date: "Finish date"
@@ -3705,6 +3708,7 @@ en:
           seven_days_after: "7 days after"
       non_participating:
         title: "Non-participating"
+        description: "Additional notifications for activities in all projects."
         submit_button: "Update preferences"
         work_package_created: "New work packages"
         work_package_commented: "All new comments"
@@ -3713,6 +3717,7 @@ en:
         work_package_scheduled: "All date changes"
       project_specific_settings:
         title: "Project-specific notification settings"
+        description: "These project-specific settings override default settings above."
         add_button: "Add project-specific notifications"
         dialog_title: "Add project-specific notifications"
         list_header: "Projects with specific notifications"


### PR DESCRIPTION
⚠️ Based on https://github.com/opf/openproject/pull/22832 ⚠️ 

# Ticket
https://community.openproject.org/wp/73501

# What are you trying to accomplish?
Add description texts to  Email and Reminder settings page

## Screenshots
<img width="1062" height="1198" alt="Bildschirmfoto 2026-04-22 um 10 17 54" src="https://github.com/user-attachments/assets/433d8f7a-1f7e-4aa5-8659-b1833a70954b" />

<img width="864" height="1228" alt="Bildschirmfoto 2026-04-22 um 10 17 45" src="https://github.com/user-attachments/assets/ee4c9bfa-9bdd-49aa-b718-77bc7c9ce5e4" />

