### PR TITLE
fix: Patch flakiness in an admin department test

### DIFF
--- a/spec/support/pages/admin/departments.rb
+++ b/spec/support/pages/admin/departments.rb
@@ -84,8 +84,8 @@ module Pages
 
       def expect_breadcrumbs(*names)
         within_detail_component do
-          breadcrumb_items = page.all("li.breadcrumb-item")
-          actual = breadcrumb_items.map(&:text)
+          expect(page).to have_css("li.breadcrumb-item", text: names.last)
+          actual = page.all("li.breadcrumb-item").map(&:text)
           expect(actual).to eq(names)
         end
       end


### PR DESCRIPTION
```
  1) Departments admin viewing departments lists child departments and supports tree navigation
     Failure/Error: expect(actual).to eq(names)

       expected: ["My Organization", "Engineering", "Backend"]
            got: ["My Organization", "Engineering"]

       (compared using ==)
     # ./spec/support/pages/admin/departments.rb:89:in 'block in Pages::Admin::Departments#expect_breadcrumbs'
```

Add `have_css` assertion to make sure the page gets loaded before we scan its content.