### PR TITLE
fix: Patch flakiness in a project creation spec

### DIFF
--- a/spec/features/projects/create_spec.rb
+++ b/spec/features/projects/create_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe "Projects", "creation",
 
         it "enables custom fields with default values if not set to blank explicitly" do
           # don't touch the default value
-          click_on "Complete"
+          wait_for_turbo { click_on "Complete" }
 
           expect_and_dismiss_flash type: :success, message: "Successful creation."
 


### PR DESCRIPTION
```
1) Projects creation with optional and required custom fields with correct custom field activation with correct handling of default values enables custom fields with default values if not set to blank explicitly
     Failure/Error: expect(page).to have_css(expected_css, wait:, **{ text: message, exact_text: exact_message }.compact)
       expected to find css "[data-test-selector=\"op-primer-flash-message\"].Banner--success" but there were no matches
     # ./spec/support/flash/expectations.rb:7:in 'Flash::Expectations#expect_flash'
     # ./spec/support/flash/expectations.rb:16:in 'Flash::Expectations#expect_and_dismiss_flash'
     # ./spec/features/projects/create_spec.rb:433:in 'block (5 levels) in <top (required)>'
     # ./spec/support/capybara.rb:22:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/without_env.rb:52:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:60:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:197:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # ./spec/support/rspec_retry.rb:26:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:165:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in 'block (2 levels) in RSpec::Retry.setup'

```

Use `wait_for_turbo` to allow the flash message to appear first.