### PR TITLE
[73910] Onboarding tour breaks at Team planner if EE is missing

### DIFF
--- a/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/onboarding_tour.ts
@@ -95,14 +95,11 @@ function workPackageFullViewTour() {
 function ganttTour(_configuration:ConfigurationService) {
   initializeTour('ganttTourFinished');
 
-  const boardsDemoDataAvailable = getMetaContent('boards_demo_data_available') === 'true';
-  const teamPlannerDemoDataAvailable = getMetaContent('demo_view_of_type_team_planner_seeded') === 'true';
-
   waitForElement('.work-package--results-tbody', '#content', () => {
     let steps:OnboardingStep[] = ganttOnboardingTourSteps();
-    if (boardsDemoDataAvailable && moduleVisible('boards')) {
-      steps = steps.concat(navigateToBoardStep('enterprise'));
-    } else if (teamPlannerDemoDataAvailable && moduleVisible('team-planner-view')) {
+    if (showBoardsTour()) {
+      steps = steps.concat(navigateToBoardStep());
+    } else if (showTeamPlannerTour(_configuration)) {
       steps = steps.concat(navigateToTeamPlannerStep());
     } else {
       steps = steps.concat(menuTourSteps());
@@ -115,14 +112,13 @@ function ganttTour(_configuration:ConfigurationService) {
 function boardTour(_configuration:ConfigurationService) {
   initializeTour('boardsTourFinished');
 
-  const teamPlannerDemoDataAvailable = getMetaContent('demo_view_of_type_team_planner_seeded') === 'true';
 
   waitForElement('wp-single-card', '#content', () => {
-    let steps:OnboardingStep[] = boardTourSteps('enterprise');
+    let steps:OnboardingStep[] = boardTourSteps();
 
     // Available seed data of team planner.
     // Then add Team planner to the tour, otherwise skip it.
-    if (teamPlannerDemoDataAvailable && moduleVisible('team-planner-view')) {
+    if (showTeamPlannerTour(_configuration)) {
       steps = steps.concat(navigateToTeamPlannerStep());
     } else {
       steps = steps.concat(menuTourSteps());
@@ -140,6 +136,19 @@ function teamPlannerTour() {
 
     startTour(steps);
   });
+}
+
+function showBoardsTour():boolean {
+  const boardsDemoDataAvailable = getMetaContent('boards_demo_data_available') === 'true';
+
+  return boardsDemoDataAvailable && moduleVisible('boards');
+}
+
+function showTeamPlannerTour(configuration:ConfigurationService):boolean {
+  const eeTokenAvailable = configuration.availableFeatures.includes('team_planner_view');
+  const teamPlannerDemoDataAvailable = getMetaContent('demo_view_of_type_team_planner_seeded') === 'true';
+
+  return eeTokenAvailable && teamPlannerDemoDataAvailable && moduleVisible('team-planner-view');
 }
 
 export function start(name:OnboardingTourNames, configuration:ConfigurationService):void {

--- a/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
+++ b/frontend/src/app/core/setup/globals/onboarding/tours/boards_tour.ts
@@ -3,8 +3,8 @@ import {
 } from 'core-app/core/setup/globals/onboarding/helpers';
 import { OnboardingStep } from 'core-app/core/setup/globals/onboarding/onboarding_tour';
 
-export function boardTourSteps(edition:'basic'|'enterprise'):OnboardingStep[] {
-  const listExplanation = edition === 'basic' ? 'basic' : 'kanban';
+export function boardTourSteps():OnboardingStep[] {
+  const listExplanation = 'kanban';
 
   return [
     {
@@ -36,13 +36,8 @@ export function boardTourSteps(edition:'basic'|'enterprise'):OnboardingStep[] {
   ];
 }
 
-export function navigateToBoardStep(edition:'basic'|'enterprise'):OnboardingStep {
-  let boardName:string;
-  if (edition === 'basic') {
-    boardName = 'Basic board';
-  } else {
-    boardName = 'Kanban';
-  }
+export function navigateToBoardStep():OnboardingStep {
+  const boardName= 'Kanban';
 
   return {
     'next #boards-wrapper>.boards-menu-item': I18n.t('js.onboarding.steps.boards.overview'),

--- a/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
+++ b/modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb
@@ -32,7 +32,6 @@ require_relative "../../support/onboarding/onboarding_steps"
 RSpec.describe "team planner onboarding tour",
                :js,
                :selenium,
-               with_ee: %i[team_planner_view board_view],
                # We decrease the notification polling interval because some portions
                # of the JS code rely on something triggering the Angular change detection.
                # This is usually done by the notification polling, but we don't want to wait
@@ -84,15 +83,28 @@ RSpec.describe "team planner onboarding tour",
   end
 
   context "as a new user" do
-    it "I see the team planner onboarding tour in the demo project" do
-      # Set the tour parameter so that we can start on the wp page
-      visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
+    context "without EE" do
+      it "I can finish the tour without the team planner" do
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
 
-      step_through_onboarding_wp_tour demo_project, wp1
+        step_through_onboarding_wp_tour demo_project, wp1
 
-      step_through_onboarding_team_planner_tour
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
+    end
 
-      step_through_onboarding_main_menu_tour has_full_capabilities: true
+    context "with EE", with_ee: %i[team_planner_view board_view] do
+      it "I see the team planner onboarding tour in the demo project" do
+        # Set the tour parameter so that we can start on the wp page
+        visit "/projects/#{demo_project.identifier}/work_packages?start_onboarding_tour=true"
+
+        step_through_onboarding_wp_tour demo_project, wp1
+
+        step_through_onboarding_team_planner_tour
+
+        step_through_onboarding_main_menu_tour has_full_capabilities: true
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/73910

# What are you trying to accomplish?
* Skip TeamPlanner in onboarding tour when there is no EE token available
* Remove outdated parameters for the boards tour

