### PR TITLE
[#70319] Deep linking to a meeting outcome does not highlight it  

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.sass
+++ b/modules/meeting/app/components/meeting_agenda_items/outcomes/outcome_component.sass
@@ -10,6 +10,14 @@
   grid-template-columns: auto fit-content(40px)
   grid-template-areas: "title actions" "content content"
 
+  &:target
+    scroll-margin: 100px
+
+.outcome-container
+  &:has(.op-meeting-outcome-notes:target)
+    outline: 2px solid var(--borderColor-accent-emphasis)
+    border-radius: 2px
+
   &--content
     overflow: auto
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/70319