### PR TITLE
Feature/73081 backlog buckets in backlog and sprints view left side hack

### DIFF
--- a/config/initializers/feature_decisions.rb
+++ b/config/initializers/feature_decisions.rb
@@ -76,4 +76,5 @@ OpenProject::FeatureDecisions.add :semantic_work_package_ids,
                                                "See #41855 for details."
 
 OpenProject::FeatureDecisions.add :backlog_buckets,
-                                  description: "Enables backlog buckets."
+                                  description: "Enables backlog buckets.",
+                                  force_active: true

--- a/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
@@ -76,9 +76,7 @@ See COPYRIGHT and LICENSE files for more details.
   %>
 
   <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
-    <% backlog_buckets.each do |backlog_bucket| %>
-      <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: project) %>
-    <% end %>
+    <%= render Backlogs::BacklogBucketComponent.with_collection(backlog_buckets, project:) %>
   <% end %>
 
   <%=

--- a/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
@@ -82,8 +82,7 @@ See COPYRIGHT and LICENSE files for more details.
   <%=
     render Backlogs::InboxComponent.new(
       work_packages: inbox_work_packages,
-      project: project,
-      show_all: show_all_backlog
+      project: project
     )
   %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
@@ -49,12 +49,12 @@ See COPYRIGHT and LICENSE files for more details.
                )
       end
 
-      if allow_backlog_bucket_creation?(@project) && OpenProject::FeatureDecisions.backlog_buckets_active?
+      if allow_backlog_bucket_creation?(project) && OpenProject::FeatureDecisions.backlog_buckets_active?
         head.with_actions do
           render Primer::Beta::Button.new(
             tag: :a,
             label: Agile::BacklogBucket.human_model_name,
-            href: new_dialog_project_backlogs_backlog_buckets_path(@project),
+            href: new_dialog_project_backlogs_backlog_buckets_path(project),
             data: {
               controller: "async-dialog",
               test_selector: "op-backlog-buckets--new-backlog-bucket-button"

--- a/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.html.erb
@@ -1,0 +1,91 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+<%= component_wrapper(tag: "turbo-frame", refresh: :morph, style: "display:contents") do %>
+  <%=
+    render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
+      head.with_heading(
+        tag: :h3,
+        size: :medium,
+        font_weight: :bold,
+        display: :inline_flex,
+        align_items: :center,
+        classes: "gap-2"
+      ) do
+        concat t(:label_backlog)
+        concat render(
+                 Primer::Beta::Counter.new(
+                   scheme: :default,
+                   count: total,
+                   round: true,
+                   limit: 1_000,
+                   hide_if_zero: true
+                 )
+               )
+      end
+
+      if allow_backlog_bucket_creation?(@project) && OpenProject::FeatureDecisions.backlog_buckets_active?
+        head.with_actions do
+          render Primer::Beta::Button.new(
+            tag: :a,
+            label: Agile::BacklogBucket.human_model_name,
+            href: new_dialog_project_backlogs_backlog_buckets_path(@project),
+            data: {
+              controller: "async-dialog",
+              test_selector: "op-backlog-buckets--new-backlog-bucket-button"
+            }
+          ) do |button|
+            button.with_leading_visual_icon(icon: :plus)
+            Agile::BacklogBucket.human_model_name
+          end
+        end
+      elsif allow_sprint_creation?(project)
+        # Ugly hack:
+        # This button will not be rendered, but still takes up space to push the left side down a bit.
+        # Remove as soon as the `+ Sprint` button moves from the Subhead into a SubHeader.
+        head.with_actions do
+          render(Primer::Beta::Button.new(tag: :a, visibility: :hidden)) { "spacer" }
+        end
+      end
+    end
+  %>
+
+  <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
+    <% backlog_buckets.each do |backlog_bucket| %>
+      <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: project) %>
+    <% end %>
+  <% end %>
+
+  <%=
+    render Backlogs::InboxComponent.new(
+      work_packages: inbox_work_packages,
+      project: project,
+      show_all: show_all_backlog
+    )
+  %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/backlogs_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.rb
@@ -34,19 +34,17 @@ module Backlogs
     include OpTurbo::Streamable
     include Backlogs::CommonHelper
 
-    attr_reader :inbox_work_packages, :backlog_buckets, :project, :current_user, :show_all
+    attr_reader :inbox_work_packages, :backlog_buckets, :project, :current_user
 
     def initialize(inbox_work_packages:,
                    backlog_buckets:,
                    project:,
-                   show_all: false,
                    current_user: User.current)
       super()
 
       @inbox_work_packages = inbox_work_packages
       @backlog_buckets = backlog_buckets
       @project = project
-      @show_all = show_all
       @current_user = current_user
     end
 

--- a/modules/backlogs/app/components/backlogs/backlogs_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.rb
@@ -40,8 +40,7 @@ module Backlogs
                    backlog_buckets:,
                    project:,
                    show_all: false,
-                   current_user: User.current,
-                   **system_arguments)
+                   current_user: User.current)
       super()
 
       @inbox_work_packages = inbox_work_packages
@@ -49,10 +48,6 @@ module Backlogs
       @project = project
       @show_all = show_all
       @current_user = current_user
-
-      @system_arguments = system_arguments
-      @system_arguments[:id] = dom_id
-      @system_arguments[:padding] = :condensed
     end
 
     def wrapper_uniq_by

--- a/modules/backlogs/app/components/backlogs/backlogs_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlogs_component.rb
@@ -28,17 +28,45 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class Agile::BacklogBucket < ApplicationRecord
-  self.table_name = "backlog_buckets"
+module Backlogs
+  class BacklogsComponent < ApplicationComponent
+    include Primer::AttributesHelper
+    include OpTurbo::Streamable
+    include Backlogs::CommonHelper
 
-  belongs_to :project
-  has_many :work_packages, -> { order_by_position }, inverse_of: :backlog_bucket, dependent: :nullify
+    attr_reader :inbox_work_packages, :backlog_buckets, :project, :current_user, :show_all
 
-  scope :order_alphabetically, -> { order(:name) }
+    def initialize(inbox_work_packages:,
+                   backlog_buckets:,
+                   project:,
+                   show_all: false,
+                   current_user: User.current,
+                   **system_arguments)
+      super()
 
-  validates :name, :project, presence: true
+      @inbox_work_packages = inbox_work_packages
+      @backlog_buckets = backlog_buckets
+      @project = project
+      @show_all = show_all
+      @current_user = current_user
 
-  def self.for_project(project)
-    where(project:).order_alphabetically.includes(:work_packages)
+      @system_arguments = system_arguments
+      @system_arguments[:id] = dom_id
+      @system_arguments[:padding] = :condensed
+    end
+
+    def wrapper_uniq_by
+      project
+    end
+
+    private
+
+    def dom_id
+      "backlogs_#{project.id}"
+    end
+
+    def total
+      @total ||= inbox_work_packages.count + (backlog_buckets&.sum { it.work_packages.size } || 0)
+    end
   end
 end

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -65,7 +65,11 @@ See COPYRIGHT and LICENSE files for more details.
             block: true,
             align_content: :start,
             underline: true,
-            href: project_backlogs_backlog_path(project, all: 1)
+            href: project_backlogs_backlog_path(project, all: 1),
+            # Replace the full backlog frame. Nested inbox turbo-frame would otherwise
+            # scope navigation to inbox only; sprint rows would stay stale without +all+
+            # on their URLs.
+            data: { turbo_frame: "backlogs_container", turbo_action: :advance }
           )
         ) { t(".show_more", count: middle_count) }
       %>
@@ -76,42 +80,5 @@ See COPYRIGHT and LICENSE files for more details.
           container: border_box,
           project:
         ) %>
-
-    <% if paginate? %>
-      <% border_box.with_row(
-           id: "inbox-more-row-#{project.id}", scheme: :neutral,
-           classes: "backlogs-inbox-component--show-more-row",
-           # This exists for the edge case of a user dragging a work package just below the fold.
-           # The dragged work package is then placed just after the last work package omitted
-           # by the placeholder.
-           data: {
-             draggable_id: id_of_last_omitted_in_middle
-           }
-         ) do %>
-        <%=
-          render(
-            Primer::Beta::Button.new(
-              scheme: :link,
-              tag: :a,
-              size: :large,
-              block: true,
-              align_content: :start,
-              underline: true,
-              href: project_backlogs_backlog_path(project, all: 1),
-              # Replace the full backlog frame. Nested inbox turbo-frame would otherwise
-              # scope navigation to inbox only; sprint rows would stay stale without +all+
-              # on their URLs.
-              data: { turbo_frame: "backlogs_container", turbo_action: :advance }
-            )
-          ) { t(".show_more", count: middle_count) }
-        %>
-      <% end %>
-
-      <%= render Backlogs::InboxItemComponent.with_collection(
-            last_page,
-            container: border_box,
-            project:
-          ) %>
-    <% end %>
   <% end %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -60,6 +60,12 @@ See COPYRIGHT and LICENSE files for more details.
     end
   %>
 
+  <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
+    <% backlog_buckets.each do |backlog_bucket| %>
+      <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
+    <% end %>
+  <% end %>
+
   <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
     <% if work_packages.empty? %>
       <% border_box.with_row(data: { empty_list_item: true }) do %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -26,61 +26,53 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++# %>
-<%= component_wrapper(tag: "turbo-frame", refresh: :morph, style: "display:contents") do %>
-  <%=
-    render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
-      head.with_heading(
-        tag: :h3,
-        size: :medium,
-        font_weight: :bold,
-        display: :inline_flex,
-        align_items: :center,
-        classes: "gap-2"
-      ) do
-        concat t(:label_backlog)
-        concat render(
-          Primer::Beta::Counter.new(
-            scheme: :default,
-            count: total,
-            round: true,
-            limit: 1_000,
-            hide_if_zero: true
-          )
-        )
-      end
-
-      if allow_sprint_creation?(project)
-        # Ugly hack:
-        # This button will not be rendered, but still takes up space to push the left side down a bit.
-        # Remove as soon as the `+ Sprint` button moves from the Subhead into a SubHeader.
-        head.with_actions do
-          render(Primer::Beta::Button.new(tag: :a, visibility: :hidden)) { "spacer" }
+<%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
+  <% if work_packages.empty? %>
+    <% border_box.with_row(data: { empty_list_item: true }) do %>
+      <%=
+        render Primer::Beta::Blankslate.new(spacious: true, role: "status", aria: { live: "polite" }) do |blankslate|
+          blankslate.with_visual_icon(icon: :"op-backlogs")
+          blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
+          blankslate.with_description_content(t(".blankslate_description"))
         end
-      end
-    end
-  %>
-
-  <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
-    <% backlog_buckets.each do |backlog_bucket| %>
-      <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
+      %>
     <% end %>
   <% end %>
 
-  <%= render(Primer::Beta::BorderBox.new(**@system_arguments)) do |border_box| %>
-    <% if work_packages.empty? %>
-      <% border_box.with_row(data: { empty_list_item: true }) do %>
-        <%=
-          render Primer::Beta::Blankslate.new(spacious: true, role: "status", aria: { live: "polite" }) do |blankslate|
-            blankslate.with_visual_icon(icon: :"op-backlogs")
-            blankslate.with_heading(tag: :h4).with_content(t(".blankslate_title"))
-            blankslate.with_description_content(t(".blankslate_description"))
-          end
-        %>
-      <% end %>
+  <%= render Backlogs::InboxItemComponent.with_collection(
+        paginate? ? first_page : work_packages,
+        container: border_box,
+        project:
+      ) %>
+
+  <% if paginate? %>
+    <% border_box.with_row(
+         id: "inbox-more-row-#{project.id}", scheme: :neutral,
+         classes: "backlogs-inbox-component--show-more-row",
+         # This exists for the edge case of a user dragging a work package just below the fold.
+         # The dragged work package is then placed just after the last work package omitted
+         # by the placeholder.
+         data: {
+           draggable_id: id_of_last_omitted_in_middle
+         }
+       ) do %>
+      <%=
+        render(
+          Primer::Beta::Button.new(
+            scheme: :link,
+            tag: :a,
+            size: :large,
+            block: true,
+            align_content: :start,
+            underline: true,
+            href: project_backlogs_backlog_path(project, all: 1)
+          )
+        ) { t(".show_more", count: middle_count) }
+      %>
     <% end %>
 
     <%= render Backlogs::InboxItemComponent.with_collection(
-          paginate? ? first_page : work_packages,
+          last_page,
           container: border_box,
           project:
         ) %>

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -50,6 +50,7 @@ module Backlogs
       @system_arguments = system_arguments
       @system_arguments[:id] = inbox_dom_id
       @system_arguments[:padding] = :condensed
+      @system_arguments[:test_selector] = test_selector
       @system_arguments[:data] = merge_data(
         @system_arguments,
         { data: drop_target_config }
@@ -64,6 +65,10 @@ module Backlogs
 
     def total
       @total ||= work_packages.count
+    end
+
+    def test_selector
+      "backlog-inbox"
     end
 
     def inbox_dom_id

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -38,12 +38,13 @@ module Backlogs
     FIRST_PAGE_SIZE = 50
     LAST_PAGE_SIZE = 10
 
-    attr_reader :work_packages, :project, :current_user
+    attr_reader :work_packages, :backlog_buckets, :project, :current_user
 
-    def initialize(work_packages:, project:, current_user: User.current, **system_arguments)
+    def initialize(work_packages:, backlog_buckets:, project:, current_user: User.current, **system_arguments)
       super()
 
       @work_packages = work_packages
+      @backlog_buckets = backlog_buckets
       @project = project
       @current_user = current_user
 

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -38,13 +38,12 @@ module Backlogs
     FIRST_PAGE_SIZE = 50
     LAST_PAGE_SIZE = 10
 
-    attr_reader :work_packages, :backlog_buckets, :project, :current_user
+    attr_reader :work_packages, :project, :current_user
 
-    def initialize(work_packages:, backlog_buckets:, project:, current_user: User.current, **system_arguments)
+    def initialize(work_packages:, project:, current_user: User.current, **system_arguments)
       super()
 
       @work_packages = work_packages
-      @backlog_buckets = backlog_buckets
       @project = project
       @current_user = current_user
 

--- a/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_controller.rb
@@ -66,8 +66,6 @@ module Backlogs
     def load_backlogs
       if OpenProject::FeatureDecisions.backlog_buckets_active?
         @backlog_buckets = Agile::BacklogBucket.for_project(@project)
-      else
-        @inbox_work_packages = Backlog.inbox_for(project: @project)
       end
 
       @sprints = Agile::Sprint.for_project(@project)
@@ -81,6 +79,7 @@ module Backlogs
                                .order_by_position
                                .group_by(&:sprint_id)
       @active_sprint_ids = @sprints.select(&:active?).map(&:id)
+      @inbox_work_packages = Backlog.inbox_for(project: @project)
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
@@ -93,11 +93,15 @@ module Backlogs
     end
 
     def replace_inbox_component_via_turbo_stream
-      work_packages = Backlog.inbox_for(project: @project)
+      inbox_work_packages = Backlog.inbox_for(project: @project)
+      backlog_buckets = if OpenProject::FeatureDecisions.backlog_buckets_active?
+                          Agile::BacklogBucket.for_project(@project)
+                        end
+
       replace_via_turbo_stream(
-        component: Backlogs::InboxComponent.new(
-          work_packages:,
-          backlog_buckets: Agile::BacklogBucket.for_project(@project),
+        component: Backlogs::BacklogsComponent.new(
+          inbox_work_packages:,
+          backlog_buckets:,
           project: @project
         ),
         method: :morph

--- a/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
@@ -97,6 +97,7 @@ module Backlogs
       replace_via_turbo_stream(
         component: Backlogs::InboxComponent.new(
           work_packages:,
+          backlog_buckets: Agile::BacklogBucket.for_project(@project),
           project: @project
         ),
         method: :morph

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -125,9 +125,15 @@ module Backlogs
       render_success_flash_message_via_turbo_stream(
         message: I18n.t(:notice_successful_move, from: @sprint.name, to: I18n.t(:label_inbox))
       )
-      work_packages = Backlog.inbox_for(project: @project)
+      inbox_work_packages = Backlog.inbox_for(project: @project)
+      backlog_buckets = if OpenProject::FeatureDecisions.backlog_buckets_active?
+                          Agile::BacklogBucket.for_project(@project)
+                        end
+
       replace_via_turbo_stream(
-        component: Backlogs::InboxComponent.new(work_packages:, backlog_buckets: Agile::BacklogBucket.for_project(@project), project: @project),
+        component: Backlogs::BacklogsComponent.new(inbox_work_packages:,
+                                                   backlog_buckets:,
+                                                   project: @project),
         method: :morph
       )
     end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -127,7 +127,7 @@ module Backlogs
       )
       work_packages = Backlog.inbox_for(project: @project)
       replace_via_turbo_stream(
-        component: Backlogs::InboxComponent.new(work_packages:, project: @project),
+        component: Backlogs::InboxComponent.new(work_packages:, backlog_buckets: Agile::BacklogBucket.for_project(@project), project: @project),
         method: :morph
       )
     end

--- a/modules/backlogs/app/models/agile/backlog_bucket.rb
+++ b/modules/backlogs/app/models/agile/backlog_bucket.rb
@@ -41,11 +41,11 @@ class Agile::BacklogBucket < ApplicationRecord
   def self.for_project(project)
     buckets = where(project:).order_alphabetically.includes(:work_packages)
 
-    inbox = new(
-      name: I18n.t("label_inbox"),
-      work_packages: WorkPackage.where(project:, sprint: nil, backlog_bucket: nil).order_by_position
-    )
+    #inbox = new(
+    #  name: I18n.t("label_inbox"),
+    #  work_packages: WorkPackage.where(project:, sprint: nil, backlog_bucket: nil).order_by_position
+    #)
 
-    buckets + [inbox]
+    buckets #+ [inbox]
   end
 end

--- a/modules/backlogs/app/models/backlog.rb
+++ b/modules/backlogs/app/models/backlog.rb
@@ -34,10 +34,16 @@ class Backlog
   delegate :id, to: :sprint, prefix: true
 
   def self.inbox_for(project:)
+    inbox_condition = if OpenProject::FeatureDecisions.backlog_buckets_active?
+                        { sprint_id: nil, backlog_bucket_id: nil }
+                      else
+                        { sprint_id: nil }
+                      end
+
     WorkPackage
       .visible
       .with_status_open
-      .where(project:, sprint_id: nil)
+      .where(project:, **inbox_condition)
       .includes(:type)
       .order_by_position
       .order(WorkPackage.arel_table[:id].asc)

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -33,60 +33,13 @@ See COPYRIGHT and LICENSE files for more details.
        data-generic-drag-and-drop-handle-value="false">
     <div id="owner_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
-      <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
-        <%#=
-          render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
-            head.with_heading(
-              tag: :h3,
-              size: :medium,
-              font_weight: :bold,
-              display: :inline_flex,
-              align_items: :center,
-              classes: "gap-2"
-            ) do
-              concat t(:label_backlog)
-              concat render(
-                Primer::Beta::Counter.new(
-                  scheme: :default,
-                  count: @backlog_buckets.sum { it.work_packages.length } + @inbox_work_packages.size,
-                  round: true,
-                  limit: 1_000,
-                  hide_if_zero: true
-                )
-              )
-            end
-
-            if allow_backlog_bucket_creation?(@project) && OpenProject::FeatureDecisions.backlog_buckets_active?
-              head.with_actions do
-                render Primer::Beta::Button.new(
-                  tag: :a,
-                  label: Agile::BacklogBucket.human_model_name,
-                  href: new_dialog_project_backlogs_backlog_buckets_path(@project),
-                  data: {
-                    controller: "async-dialog",
-                    test_selector: "op-backlog-buckets--new-backlog-bucket-button"
-                  }
-                ) do |button|
-                  button.with_leading_visual_icon(icon: :plus)
-                  Agile::BacklogBucket.human_model_name
-                end
-              end
-            end
-          end
-        %>
-
-        <% @backlog_buckets.each do |backlog_bucket| %>
-          <%#= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
-        <% end %>
-      <% else %>
-        <%=
-          render Backlogs::InboxComponent.new(
-            work_packages: @inbox_work_packages,
-            backlog_buckets: @backlog_buckets,
-            project: @project,
-          )
-        %>
-      <% end %>
+      <%=
+        render Backlogs::BacklogsComponent.new(
+          inbox_work_packages: @inbox_work_packages,
+          backlog_buckets: @backlog_buckets,
+          project: @project
+        )
+      %>
     </div>
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
     <div id="owner_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
       <% if OpenProject::FeatureDecisions.backlog_buckets_active? %>
-        <%=
+        <%#=
           render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
             head.with_heading(
               tag: :h3,
@@ -48,7 +48,7 @@ See COPYRIGHT and LICENSE files for more details.
               concat render(
                 Primer::Beta::Counter.new(
                   scheme: :default,
-                  count: @backlog_buckets.sum { it.work_packages.length },
+                  count: @backlog_buckets.sum { it.work_packages.length } + @inbox_work_packages.size,
                   round: true,
                   limit: 1_000,
                   hide_if_zero: true
@@ -56,7 +56,7 @@ See COPYRIGHT and LICENSE files for more details.
               )
             end
 
-            if allow_backlog_bucket_creation?(@project)
+            if allow_backlog_bucket_creation?(@project) && OpenProject::FeatureDecisions.backlog_buckets_active?
               head.with_actions do
                 render Primer::Beta::Button.new(
                   tag: :a,
@@ -74,13 +74,15 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
         %>
+
         <% @backlog_buckets.each do |backlog_bucket| %>
-          <%= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
+          <%#= render Backlogs::BacklogBucketComponent.new(backlog_bucket:, project: @project) %>
         <% end %>
       <% else %>
         <%=
           render Backlogs::InboxComponent.new(
             work_packages: @inbox_work_packages,
+            backlog_buckets: @backlog_buckets,
             project: @project,
           )
         %>

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -70,10 +70,6 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       expect(page).to have_css("h4", text: "Backlog inbox is empty")
       expect(page).to have_text("All open work packages in this project will automatically appear here.")
     end
-
-    it "hides the counter" do
-      expect(page).to have_css(".Counter", text: "0", visible: :hidden)
-    end
   end
 
   describe "with work packages" do
@@ -93,10 +89,6 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
 
       # does not show the blankslate
       expect(page).to have_no_css("h4", text: "Backlog inbox is empty")
-    end
-
-    it "shows the counter with the work package count" do
-      expect(page).to have_css(".Counter", text: "2")
     end
   end
 

--- a/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/backlog_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Backlogs::BacklogController do
           expect(response).to render_template(layout: false)
           expect(assigns(:project)).to eq(project)
           expect(assigns(:backlog_buckets)).to be_present
-          expect(assigns(:inbox_work_packages)).to be_nil
+          expect(assigns(:inbox_work_packages)).to match [work_package]
           expect(assigns(:sprints)).to be_present
         end
       end

--- a/modules/backlogs/spec/controllers/backlogs/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/inbox_controller_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe Backlogs::InboxController do
     end
 
     context "when service call succeeds" do
-      it "replaces the inbox component and responds with turbo streams", :aggregate_failures do
+      it "replaces the backlogs component and responds with turbo streams", :aggregate_failures do
         expect(response).to be_successful
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-inbox-component-#{project.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlogs-component-#{project.id}"
         expect(assigns(:project)).to eq(project)
         expect(assigns(:work_package)).to eq(work_package)
       end
@@ -124,7 +124,7 @@ RSpec.describe Backlogs::InboxController do
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace",
-                                                  target: "backlogs-inbox-component-#{project.id}"
+                                                  target: "backlogs-backlogs-component-#{project.id}"
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Backlogs::InboxController do
       it "replaces both the inbox and target sprint components", :aggregate_failures do
         expect(response).to be_successful
         expect(response).to have_turbo_stream action: "replace",
-                                              target: "backlogs-inbox-component-#{project.id}"
+                                              target: "backlogs-backlogs-component-#{project.id}"
         expect(response).to have_turbo_stream action: "replace",
                                               target: "backlogs-sprint-component-#{agile_sprint.id}"
 
@@ -175,7 +175,7 @@ RSpec.describe Backlogs::InboxController do
       it "replaces only the inbox component without a flash", :aggregate_failures do
         expect(response).to be_successful
         expect(response).to have_turbo_stream action: "replace",
-                                              target: "backlogs-inbox-component-#{project.id}"
+                                              target: "backlogs-backlogs-component-#{project.id}"
         expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
       end
 
@@ -237,7 +237,7 @@ RSpec.describe Backlogs::InboxController do
         expect(response).to have_http_status :unprocessable_entity
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(response).not_to have_turbo_stream action: "replace",
-                                                  target: "backlogs-inbox-component-#{project.id}"
+                                                  target: "backlogs-backlogs-component-#{project.id}"
       end
     end
 

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -150,9 +150,9 @@ RSpec.describe Backlogs::WorkPackagesController do
         expect(response).to be_successful
         expect(response).to have_http_status :ok
         expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
-        expect(response).to have_turbo_stream action: "replace", target: "backlogs-inbox-component-#{project.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlogs-component-#{project.id}"
         assert_select %(turbo-stream[action="replace"][target="backlogs-sprint-component-#{agile_sprint.id}"])
-        assert_select %(turbo-stream[action="replace"][target="backlogs-inbox-component-#{project.id}"][method="morph"])
+        assert_select %(turbo-stream[action="replace"][target="backlogs-backlogs-component-#{project.id}"][method="morph"])
         expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
         expect(assigns(:project)).to eq(project)
         expect(assigns(:sprint)).to eq(agile_sprint)

--- a/modules/backlogs/spec/features/backlog_buckets/create_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/create_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe "Backlog bucket creation",
 
   it "creates a new backlog bucket via the dialog" do
     backlogs_page.visit!
-    backlogs_page.expect_bucket_names_in_order("Inbox")
-
     backlogs_page.open_create_backlog_bucket_dialog
 
     within_dialog "New backlog bucket" do
@@ -61,7 +59,7 @@ RSpec.describe "Backlog bucket creation",
     end
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
-    backlogs_page.expect_bucket_names_in_order("Discovery work", "Inbox")
+    backlogs_page.expect_bucket_names_in_order("Discovery work")
 
     bucket = Agile::BacklogBucket.find_by!(project:, name: "Discovery work")
     expect(bucket.work_packages).to be_empty

--- a/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe "Backlog bucket deletion",
 
   it "deletes the bucket and moves its work packages to the Inbox" do
     backlogs_page.visit!
-    backlogs_page.expect_bucket_names_in_order("Deprecated bucket", "Inbox")
+    backlogs_page.expect_bucket_names_in_order("Deprecated bucket")
 
     accept_confirm do
+      sleep 0.5
       backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
     end
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
-    backlogs_page.expect_bucket_names_in_order("Inbox")
     backlogs_page.expect_no_backlog_bucket(bucket)
 
     backlogs_page.expect_work_packages_in_backlog_inbox_in_order(work_packages: [bucket_wp1, bucket_wp2])

--- a/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
@@ -58,14 +58,13 @@ RSpec.describe "Backlog bucket display",
            })
   end
 
-  it "lists buckets alphabetically with Inbox at the bottom" do
+  it "lists buckets alphabetically (inbox at the bottom is not named)" do
     backlogs_page.visit!
 
     backlogs_page.expect_bucket_names_in_order(
       "Alpha bucket",
       "Beta bucket",
-      "Gamma bucket",
-      "Inbox"
+      "Gamma bucket"
     )
   end
 

--- a/modules/backlogs/spec/features/backlog_buckets/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/edit_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Backlog bucket renaming",
 
   it "renames a backlog bucket via the menu" do
     backlogs_page.visit!
-    backlogs_page.expect_bucket_names_in_order("Draft bucket", "Inbox")
+    backlogs_page.expect_bucket_names_in_order("Draft bucket")
 
     backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
 
@@ -63,7 +63,7 @@ RSpec.describe "Backlog bucket renaming",
     end
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful update."
-    backlogs_page.expect_bucket_names_in_order("Polished bucket", "Inbox")
+    backlogs_page.expect_bucket_names_in_order("Polished bucket")
     expect(bucket.reload.name).to eq "Polished bucket"
   end
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
@@ -42,10 +42,12 @@ RSpec.describe "Dragging work packages in backlog buckets",
 
   shared_let(:bucket_alpha) { create(:backlog_bucket, project:, name: "Alpha bucket") }
   shared_let(:bucket_beta)  { create(:backlog_bucket, project:, name: "Beta bucket") }
+  shared_let(:bucket_gamma) { create(:backlog_bucket, project:, name: "Gamma bucket") }
 
   shared_let(:alpha_wp1) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 1) }
   shared_let(:alpha_wp2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2) }
   shared_let(:alpha_wp3) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 3) }
+  shared_let(:gamma_wp1) { create(:work_package, project:, backlog_bucket: bucket_gamma, position: 1) }
   shared_let(:inbox_wp1) { create(:work_package, project:, backlog_bucket: nil, sprint: nil, position: 1) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
@@ -108,6 +110,24 @@ RSpec.describe "Dragging work packages in backlog buckets",
     )
 
     expect(inbox_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)
+  end
+
+  it "hides the blankslate when dropping into a previously-empty bucket" do
+    backlogs_page.visit!
+    backlogs_page.expect_backlog_bucket_blankslate(bucket_beta)
+
+    backlogs_page.drag_work_package_to_backlog_bucket(alpha_wp1, bucket_beta)
+
+    backlogs_page.expect_no_backlog_bucket_blankslate(bucket_beta)
+  end
+
+  it "shows the blankslate after dragging the last work package out of a bucket" do
+    backlogs_page.visit!
+    backlogs_page.expect_no_backlog_bucket_blankslate(bucket_gamma)
+
+    backlogs_page.drag_work_package_to_backlog_inbox(gamma_wp1)
+
+    backlogs_page.expect_backlog_bucket_blankslate(bucket_gamma)
   end
 
   context "without the :manage_sprint_items permission" do

--- a/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
@@ -107,30 +107,15 @@ RSpec.describe Agile::BacklogBucket do
     subject(:result) { described_class.for_project(project) }
 
     it "returns the project buckets followed by the inbox" do
-      expect(result).to match([bucket1, bucket2, be_a(described_class).and(be_new_record)])
+      expect(result).to match([bucket1, bucket2])
     end
 
     it "does not include buckets from other projects" do
       expect(result).not_to include(other_bucket)
     end
 
-    it "appends an unsaved inbox bucket at the end" do
-      inbox = result.last
-      expect(inbox).to be_a(described_class)
-      expect(inbox).to be_new_record
-      expect(inbox).to have_attributes(name: I18n.t("label_inbox"))
-    end
-
-    it "inbox contains only unbucketed work packages from the project" do
-      expect(result.last.work_packages).to contain_exactly(wp_unbucketed2, wp_unbucketed1, wp_unbucketed_nil)
-    end
-
     it "orders work packages within a bucket by position, with nil position last" do
       expect(bucket1.work_packages.reload).to eq([wp1_in_bucket1_first, wp2_in_bucket1, wp_nil_in_bucket1])
-    end
-
-    it "orders inbox work packages by position, with nil position last" do
-      expect(result.last.work_packages.to_a).to eq([wp_unbucketed1, wp_unbucketed2, wp_unbucketed_nil])
     end
   end
 end

--- a/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Agile::BacklogBucket do
 
     subject(:result) { described_class.for_project(project) }
 
-    it "returns the project buckets followed by the inbox" do
+    it "returns the project buckets" do
       expect(result).to match([bucket1, bucket2])
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -407,6 +407,18 @@ module Pages
       end
     end
 
+    def expect_backlog_bucket_blankslate(bucket)
+      within_backlog_bucket(bucket) do
+        expect(page).to have_selector(:heading, level: 4, text: "Backlog bucket is empty")
+      end
+    end
+
+    def expect_no_backlog_bucket_blankslate(bucket)
+      within_backlog_bucket(bucket) do
+        expect(page).to have_no_selector(:heading, level: 4, text: "Backlog bucket is empty")
+      end
+    end
+
     def drag_work_package_to_backlog_bucket(work_package, bucket)
       moved_element = find(draggable_work_package_selector(work_package))
       target_element = find(bucket_selector(bucket))

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -335,7 +335,7 @@ module Pages
     end
 
     def bucket_names_in_order
-      page.find_all("#owner_backlogs_container > section .CollapsibleHeader-title").map(&:text)
+      page.find_all("#owner_backlogs_container section .CollapsibleHeader-title").map(&:text)
     end
 
     def expect_bucket_names_in_order(*bucket_names)
@@ -618,7 +618,7 @@ module Pages
     end
 
     def backlog_inbox_selector
-      "#new_agile_backlog_bucket"
+      test_selector("backlog-inbox")
     end
 
     def story_selector(story)


### PR DESCRIPTION
Applies a hack to get the backlogs feature working in time for 17.4. 

The whole left hand side of the "Backlogs and sprints" side are modelled as one component. It is thus rendered as a single entity both initially, but also when rerendering it after a drag&drop. Both the inbox component as well as the backlog bucket component are moved into the newly created `BacklogsComponent` which makes for an awkward interface.

The benefit is that refreshing after drag&drop works and so does the pagination of the inbox. 

As mentioned, this is a hack. The plan is to centralize:
* The controller action used on moving (currently there are two)
* The container component used for rendering the work packages (currently there are three)

That existing heterogeneity caused the problems we were facing.

Edit: [Ticket](https://community.openproject.org/wp/74317)