### PR TITLE
Apply visible scope to move-to-sprint dialog sprints

### DIFF
--- a/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/move_to_sprint_dialog_component.rb
@@ -44,7 +44,7 @@ module Backlogs
       @work_package = work_package
       @project = project
       @move_action = move_action
-      @sprints = Agile::Sprint.for_project(@project).not_completed.order_by_date
+      @sprints = Agile::Sprint.for_project(@project).visible.not_completed.order_by_date
       @sprints = @sprints.where.not(id: work_package.sprint_id) if work_package.sprint_id
     end
   end

--- a/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/move_to_sprint_dialog_component_spec.rb
@@ -31,6 +31,9 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::MoveToSprintDialogComponent, type: :component do
+  shared_let(:admin) { create(:admin) }
+  current_user { admin }
+
   let(:project) { create(:project) }
   let(:work_package) { create(:work_package, project:) }
   let(:move_path) { Rails.application.routes.url_helpers.move_project_backlogs_inbox_path(project, work_package) }
@@ -128,6 +131,19 @@ RSpec.describe Backlogs::MoveToSprintDialogComponent, type: :component do
 
       expect(page).to have_no_css("option", text: "Current Sprint")
       expect(page).to have_css("option[value='sprint:#{target_sprint.id}']", text: "Target Sprint")
+    end
+  end
+
+  context "when the current user cannot view sprints in the project" do
+    let(:other_user) { create(:user) }
+    let!(:hidden_sprint) { create(:agile_sprint, project:, name: "Hidden Sprint") }
+
+    current_user { other_user }
+
+    it "does not list sprints the user is not permitted to see" do
+      render_component
+
+      expect(page).to have_no_css("option", text: "Hidden Sprint")
     end
   end
 end


### PR DESCRIPTION
# Ticket
N/A — defense-in-depth follow-up to #22757. No dedicated work package.

# What are you trying to accomplish?
`Backlogs::MoveToSprintDialogComponent` scoped its sprint options via `Agile::Sprint.for_project(@project).not_completed.order_by_date` without chaining `Agile::Sprint::Scopes::Visible`. The rest of the Backlogs module — e.g. `Backlogs::WorkPackagesController#menu` when computing `open_sprints_exist` — already applies `.visible`, so the dialog's sprint list was the odd one out.

In practice the dialog is only reachable through controller actions gated on `:manage_sprint_items` (which depends on `:view_sprints` for the current project), so with authorization in place there is no user-visible leak today. The concern is consistency and defense-in-depth: any future change that exposes the component in a different context — or any gap in authorization — would otherwise allow the select to list sprints the current user isn't permitted to see.

# What approach did you choose and why?
Chain `.visible` into the component's scope (`Agile::Sprint.for_project(@project).visible.not_completed.order_by_date`) so the select mirrors the controller-side guard. Added a component spec that renders the dialog as a user without `:view_sprints` on the project and asserts the dialog does not list its sprints. Existing spec cases now render under an admin user so `.visible` is a no-op for them — matches the pattern used in `story_menu_list_component_spec.rb`.

Based on `feature/73563-limited-move-options-for-work-packages-in-sprint` (#22757) so it can be reviewed on its own and merged independently.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)