### PR TITLE
[#74195] Fix incorrect indentation on drag preview

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
@@ -67,7 +67,7 @@ module Backlogs
 
     def drop_target_config
       {
-        generic_drag_and_drop_target: "container",
+        generic_drag_and_drop_target: "container mirrorContainer",
         target_container_accessor: ":scope > ul",
         target_id: backlog_bucket.persisted? ? "backlog_bucket:#{backlog_bucket.id}" : "inbox",
         target_allowed_drag_type: "story"


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74195

# What are you trying to accomplish?

Reapplies fix for `InboxComponent` to `BacklogBucketComponent`:

The (first) bucket wires its own list element as both `container` and `mirrorContainer`, which keeps the dragged card visually aligned with the rest of the inbox rather than jumping to the page edge.

See 62105d97523a72bad6763db7ad8db522de8783b7
See #22838

## Screenshots

See #22838

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
