### PR TITLE
[#73081] Backlog buckets in "Backlog and sprints" view: feature specs

### DIFF
--- a/modules/backlogs/spec/features/backlog_buckets/create_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/create_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog bucket creation",
+               :js,
+               with_flag: { backlog_buckets: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints view_work_packages create_sprints]
+           })
+  end
+
+  it "creates a new backlog bucket via the dialog" do
+    backlogs_page.visit!
+    backlogs_page.expect_bucket_names_in_order("Inbox")
+
+    backlogs_page.open_create_backlog_bucket_dialog
+
+    within_dialog "New backlog bucket" do
+      fill_in "Name", with: "Discovery work"
+      click_on "Create"
+    end
+
+    expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
+    backlogs_page.expect_bucket_names_in_order("Discovery work", "Inbox")
+
+    bucket = Agile::BacklogBucket.find_by!(project:, name: "Discovery work")
+    expect(bucket.work_packages).to be_empty
+  end
+
+  it "validates that the name is present" do
+    backlogs_page.visit!
+
+    backlogs_page.open_create_backlog_bucket_dialog
+
+    within_dialog "New backlog bucket" do
+      fill_in "Name", with: ""
+      click_on "Create"
+
+      expect(page).to have_field "Name", validation_error: "can't be blank"
+    end
+
+    expect(Agile::BacklogBucket.where(project:)).to be_empty
+  end
+
+  context "without the :create_sprints permission" do
+    current_user do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_sprints view_work_packages]
+             })
+    end
+
+    it "does not show the create button" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_no_new_backlog_bucket_button
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog bucket deletion",
+               :js,
+               with_flag: { backlog_buckets: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+  shared_let(:bucket) { create(:backlog_bucket, project:, name: "Deprecated bucket") }
+
+  shared_let(:bucket_wp1) { create(:work_package, project:, backlog_bucket: bucket, position: 1) }
+  shared_let(:bucket_wp2) { create(:work_package, project:, backlog_bucket: bucket, position: 2) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints view_work_packages create_sprints]
+           })
+  end
+
+  it "deletes the bucket and moves its work packages to the Inbox" do
+    backlogs_page.visit!
+    backlogs_page.expect_bucket_names_in_order("Deprecated bucket", "Inbox")
+
+    accept_confirm do
+      backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
+    end
+
+    expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
+    backlogs_page.expect_bucket_names_in_order("Inbox")
+    backlogs_page.expect_no_backlog_bucket(bucket)
+
+    backlogs_page.expect_work_packages_in_backlog_inbox_in_order(work_packages: [bucket_wp1, bucket_wp2])
+
+    expect(Agile::BacklogBucket.where(id: bucket.id)).to be_empty
+    expect(bucket_wp1.reload.backlog_bucket_id).to be_nil
+    expect(bucket_wp2.reload.backlog_bucket_id).to be_nil
+  end
+
+  context "without the :create_sprints permission" do
+    current_user do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_sprints view_work_packages]
+             })
+    end
+
+    it "does not expose the delete action" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_no_backlog_bucket_menu(bucket)
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog bucket display",
+               :js,
+               with_flag: { backlog_buckets: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+
+  shared_let(:bucket_beta) { create(:backlog_bucket, project:, name: "Beta bucket") }
+  shared_let(:bucket_alpha) { create(:backlog_bucket, project:, name: "Alpha bucket") }
+  shared_let(:bucket_gamma) { create(:backlog_bucket, project:, name: "Gamma bucket") }
+
+  shared_let(:wp_alpha1) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 1) }
+  shared_let(:wp_alpha2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2) }
+  shared_let(:wp_beta1)  { create(:work_package, project:, backlog_bucket: bucket_beta,  position: 1) }
+  shared_let(:wp_inbox1) { create(:work_package, project:, backlog_bucket: nil, sprint: nil, position: 1) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints view_work_packages create_sprints manage_sprint_items]
+           })
+  end
+
+  it "lists buckets alphabetically with Inbox at the bottom" do
+    backlogs_page.visit!
+
+    backlogs_page.expect_bucket_names_in_order(
+      "Alpha bucket",
+      "Beta bucket",
+      "Gamma bucket",
+      "Inbox"
+    )
+  end
+
+  it "shows the work-package count on populated buckets" do
+    backlogs_page.visit!
+
+    backlogs_page.expect_backlog_bucket_work_package_count(bucket_alpha, 2)
+    backlogs_page.expect_backlog_bucket_work_package_count(bucket_beta, 1)
+  end
+
+  it "shows the '+ Backlog Bucket' button" do
+    backlogs_page.visit!
+
+    backlogs_page.expect_new_backlog_bucket_button
+  end
+
+  context "when the feature flag is disabled", with_flag: { backlog_buckets: false } do
+    it "shows the legacy inbox instead of backlog buckets" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_no_new_backlog_bucket_button
+      backlogs_page.expect_no_backlog_bucket(bucket_alpha)
+      expect(page).to have_css("#inbox_#{project.id}")
+    end
+  end
+
+  context "without the :create_sprints permission" do
+    current_user do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_sprints view_work_packages manage_sprint_items]
+             })
+    end
+
+    it "hides the '+ Backlog Bucket' button" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_no_new_backlog_bucket_button
+    end
+  end
+end

--- a/modules/backlogs/spec/features/backlog_buckets/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/edit_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Backlog bucket renaming",
+               :js,
+               with_flag: { backlog_buckets: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+  shared_let(:bucket) { create(:backlog_bucket, project:, name: "Draft bucket") }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints view_work_packages create_sprints]
+           })
+  end
+
+  it "renames a backlog bucket via the menu" do
+    backlogs_page.visit!
+    backlogs_page.expect_bucket_names_in_order("Draft bucket", "Inbox")
+
+    backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
+
+    within_dialog "Edit backlog bucket" do
+      expect(page).to have_field "Name", with: "Draft bucket"
+      fill_in "Name", with: "Polished bucket"
+      click_on "Save"
+    end
+
+    expect_and_dismiss_flash type: :success, exact_message: "Successful update."
+    backlogs_page.expect_bucket_names_in_order("Polished bucket", "Inbox")
+    expect(bucket.reload.name).to eq "Polished bucket"
+  end
+
+  it "validates that the name is present when saving" do
+    backlogs_page.visit!
+
+    backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
+
+    within_dialog "Edit backlog bucket" do
+      fill_in "Name", with: ""
+      click_on "Save"
+
+      expect(page).to have_field "Name", validation_error: "can't be blank"
+    end
+
+    expect(bucket.reload.name).to eq "Draft bucket"
+  end
+
+  context "without the :create_sprints permission" do
+    current_user do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_sprints view_work_packages]
+             })
+    end
+
+    it "does not expose the bucket actions menu" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_no_backlog_bucket_menu(bucket)
+    end
+  end
+end

--- a/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Dragging work packages in backlog buckets",
+               :js,
+               with_flag: { backlog_buckets: true } do
+  create_shared_association_defaults_for_work_package_factory
+
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+
+  shared_let(:bucket_alpha) { create(:backlog_bucket, project:, name: "Alpha bucket") }
+  shared_let(:bucket_beta)  { create(:backlog_bucket, project:, name: "Beta bucket") }
+
+  shared_let(:alpha_wp1) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 1) }
+  shared_let(:alpha_wp2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2) }
+  shared_let(:alpha_wp3) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 3) }
+  shared_let(:inbox_wp1) { create(:work_package, project:, backlog_bucket: nil, sprint: nil, position: 1) }
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_sprints view_work_packages create_sprints manage_sprint_items edit_work_packages]
+           })
+  end
+
+  it "reorders work packages within a bucket" do
+    backlogs_page.visit!
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp1, alpha_wp2, alpha_wp3]
+    )
+
+    backlogs_page.drag_work_package(alpha_wp1, before: alpha_wp3)
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp2, alpha_wp1, alpha_wp3]
+    )
+  end
+
+  it "moves a work package into another bucket" do
+    backlogs_page.visit!
+
+    backlogs_page.drag_work_package_to_backlog_bucket(alpha_wp1, bucket_beta)
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
+    )
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_beta, work_packages: [alpha_wp1]
+    )
+
+    expect(alpha_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)
+  end
+
+  it "moves a work package from a bucket into the Inbox" do
+    backlogs_page.visit!
+
+    backlogs_page.drag_work_package_to_backlog_inbox(alpha_wp1)
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_alpha, work_packages: [alpha_wp2, alpha_wp3]
+    )
+
+    expect(alpha_wp1.reload.backlog_bucket_id).to be_nil
+  end
+
+  it "moves a work package from the Inbox into a bucket" do
+    backlogs_page.visit!
+
+    backlogs_page.drag_work_package_to_backlog_bucket(inbox_wp1, bucket_beta)
+
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(
+      bucket_beta, work_packages: [inbox_wp1]
+    )
+
+    expect(inbox_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)
+  end
+
+  context "without the :manage_sprint_items permission" do
+    current_user do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_sprints view_work_packages edit_work_packages]
+             })
+    end
+
+    it "does not allow dragging bucketed work packages" do
+      backlogs_page.visit!
+
+      backlogs_page.expect_work_package_not_draggable(alpha_wp1)
+      backlogs_page.expect_work_package_not_draggable(alpha_wp2)
+    end
+  end
+end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -334,6 +334,101 @@ module Pages
       expect(sprint_names_in_order).to eq(sprint_names)
     end
 
+    def bucket_names_in_order
+      page.find_all("#owner_backlogs_container > section .CollapsibleHeader-title").map(&:text)
+    end
+
+    def expect_bucket_names_in_order(*bucket_names)
+      expect(bucket_names_in_order).to eq(bucket_names)
+    end
+
+    def expect_no_backlog_bucket(bucket)
+      expect(page).to have_no_css(bucket_selector(bucket))
+    end
+
+    def expect_backlog_bucket_work_package_count(bucket, count)
+      within_backlog_bucket(bucket) do
+        label = count == 1 ? "1 story in backlog bucket" : "#{count} stories in backlog bucket"
+        expect(page).to have_css(".Counter", accessible_name: label)
+      end
+    end
+
+    def expect_work_packages_in_backlog_bucket_in_order(bucket, work_packages: [])
+      within_backlog_bucket(bucket) do
+        expect_work_packages_in_order(work_packages:)
+      end
+    end
+
+    def expect_work_packages_in_backlog_inbox_in_order(work_packages: [])
+      within_backlog_inbox do
+        expect_work_packages_in_order(work_packages:)
+      end
+    end
+
+    def open_create_backlog_bucket_dialog
+      within_owner_backlogs do
+        click_on accessible_name: Agile::BacklogBucket.human_model_name
+      end
+    end
+
+    def expect_new_backlog_bucket_button
+      within_owner_backlogs do
+        expect(page).to have_link(Agile::BacklogBucket.human_model_name, exact: true)
+      end
+    end
+
+    def expect_no_new_backlog_bucket_button
+      within_owner_backlogs do
+        expect(page).to have_no_link(Agile::BacklogBucket.human_model_name, exact: true)
+      end
+    end
+
+    def expect_backlog_bucket_dialog
+      expect(page).to have_dialog(I18n.t(:label_backlog_bucket_new))
+    end
+
+    def within_backlog_bucket_menu(bucket, &)
+      within_backlog_bucket(bucket) do
+        button = find(:button, accessible_name: "Backlog bucket actions")
+        within(open_controlled_menu(button), &)
+      end
+      dismiss_menu(bucket)
+    end
+
+    def click_in_backlog_bucket_menu(bucket, item_name)
+      within_backlog_bucket_menu(bucket) do |menu|
+        menu.find(:menuitem, text: item_name).click
+      end
+    end
+
+    def expect_no_backlog_bucket_menu(bucket)
+      within_backlog_bucket(bucket) do
+        expect(page).to have_no_button(accessible_name: "Backlog bucket actions")
+      end
+    end
+
+    def drag_work_package_to_backlog_bucket(work_package, bucket)
+      moved_element = find(draggable_work_package_selector(work_package))
+      target_element = find(bucket_selector(bucket))
+
+      wait_for_turbo_stream do
+        moved_element.native.drag_to(target_element.native, delay: 0.1)
+      end
+    rescue Capybara::Cuprite::ObsoleteNode
+      retry
+    end
+
+    def drag_work_package_to_backlog_inbox(work_package)
+      moved_element = find(draggable_work_package_selector(work_package))
+      target_element = find(backlog_inbox_selector)
+
+      wait_for_turbo_stream do
+        moved_element.native.drag_to(target_element.native, delay: 0.1)
+      end
+    rescue Capybara::Cuprite::ObsoleteNode
+      retry
+    end
+
     def expect_story_in_sprint(story, sprint)
       within_sprint(sprint) do
         expect(page)
@@ -496,12 +591,34 @@ module Pages
       within("#inbox_#{project.id}", &)
     end
 
+    def within_backlog_bucket(bucket, &)
+      within(bucket_selector(bucket), &)
+    end
+
+    def within_backlog_inbox(&)
+      within(backlog_inbox_selector, &)
+    end
+
+    def within_owner_backlogs(&)
+      within("#owner_backlogs_container", &)
+    end
+
     def within_sprint_backlogs(&)
       within("#sprint_backlogs_container", &)
     end
 
     def sprint_selector(sprint)
       test_selector("sprint-#{sprint.id}")
+    end
+
+    def bucket_selector(bucket)
+      raise ArgumentError, "bucket must be persisted" unless bucket.persisted?
+
+      test_selector("backlog-bucket-#{bucket.id}")
+    end
+
+    def backlog_inbox_selector
+      "#new_agile_backlog_bucket"
     end
 
     def story_selector(story)
@@ -531,8 +648,13 @@ module Pages
       page.find(:menu, id: move_item["aria-controls"])
     end
 
-    def dismiss_menu(work_package)
-      find("#work_package_#{work_package.id}_menu-overlay").click
+    def dismiss_menu(menu_owner)
+      overlay_id = "#{ActionView::RecordIdentifier.dom_target(menu_owner, :menu)}-overlay"
+      selector = "##{overlay_id}"
+
+      return unless page.has_css?(selector, visible: true, wait: 0)
+
+      find(selector).click
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73081

# What are you trying to accomplish?

Adds initial feature-spec coverage for backlog buckets on the "Backlog and sprints" view, following up on the implementation PRs that merged without end-to-end specs:

- #22817 — display backlog buckets (+ drag-mirror infra)
- #22839 — create / edit / delete backlog buckets

Built on top of #22882 (drag-and-drop finalisation), which carries the existing request-spec coverage for the drag mirror.

Five new spec files + `Pages::Backlog` bucket helpers cover display/ordering, create, rename, delete (with WPs relocating to the Inbox), and drag within/between buckets and bucket ↔ Inbox — each gated behind `with_flag: { backlog_buckets: true }` and reusing the existing `Pages::Backlog` page object.

Out of scope: the "move into a backlog via a work-package menu submenu" branch of the acceptance criteria — `BacklogBucketMenuComponent` currently only exposes Edit/Delete, so there is no submenu target to exercise yet.

# Merge checklist

- [x] Added/updated tests