### PR TITLE
[#73081] Refresh affected buckets on drop

### DIFF
--- a/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/inbox_controller.rb
@@ -73,6 +73,7 @@ module Backlogs
 
     # Move a work package from the Inbox to a Sprint, or reorder it within the Inbox.
     def move
+      previous_bucket_id = @work_package.backlog_bucket_id
       attributes = move_attributes_from_target
 
       call = Stories::UpdateService
@@ -81,8 +82,7 @@ module Backlogs
 
       return failure_response(call.message) unless call.success?
 
-      replace_inbox_component_via_turbo_stream
-      replace_sprint_component_via_turbo_stream(attributes[:sprint_id]) if attributes[:sprint_id]
+      replace_components_after_move(attributes:, previous_bucket_id:)
       respond_with_turbo_streams
     end
 
@@ -90,6 +90,14 @@ module Backlogs
 
     def load_work_package
       @work_package = WorkPackage.visible.where(project: @project).find(params[:id])
+    end
+
+    def replace_components_after_move(attributes:, previous_bucket_id:)
+      replace_inbox_component_via_turbo_stream
+      replace_sprint_component_via_turbo_stream(attributes[:sprint_id]) if attributes[:sprint_id]
+      [attributes[:backlog_bucket_id], previous_bucket_id].compact.map(&:to_s).uniq.each do |bucket_id|
+        replace_bucket_component_via_turbo_stream(bucket_id)
+      end
     end
 
     def replace_inbox_component_via_turbo_stream
@@ -107,6 +115,16 @@ module Backlogs
       sprint = Agile::Sprint.for_project(@project).visible.find(sprint_id)
       replace_via_turbo_stream(
         component: Backlogs::SprintComponent.new(sprint:, project: @project),
+        method: :morph
+      )
+    end
+
+    def replace_bucket_component_via_turbo_stream(bucket_id)
+      bucket = Agile::BacklogBucket.where(project: @project).find_by(id: bucket_id)
+      return unless bucket
+
+      replace_via_turbo_stream(
+        component: Backlogs::BacklogBucketComponent.new(backlog_bucket: bucket, project: @project),
         method: :morph
       )
     end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -51,7 +51,8 @@ module Backlogs
              layout: false)
     end
 
-    # Move a story from an Agile::Sprint to another Agile::Sprint, or the Inbox.
+    # Move a story from an Agile::Sprint to another Agile::Sprint, the Inbox,
+    # or an Agile::BacklogBucket.
     def move
       # The update service reloads the story internally (via #move_after),
       # so we memoize the previous sprint_id before the call.
@@ -62,7 +63,9 @@ module Backlogs
         return respond_with_turbo_streams(status: :unprocessable_entity)
       end
 
-      if target_inbox?(move_attributes)
+      if target_bucket?(move_attributes)
+        moved_to_bucket(move_attributes[:backlog_bucket_id])
+      elsif target_inbox?(move_attributes)
         moved_to_inbox
       elsif target_sprint?(move_attributes) && @story.sprint_id != sprint_id_was
         moved_to_sprint
@@ -132,6 +135,19 @@ module Backlogs
       )
     end
 
+    def moved_to_bucket(bucket_id)
+      bucket = Agile::BacklogBucket.where(project: @project).find_by(id: bucket_id)
+      return unless bucket
+
+      render_success_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_successful_move, from: @sprint.name, to: bucket.name)
+      )
+      replace_via_turbo_stream(
+        component: Backlogs::BacklogBucketComponent.new(backlog_bucket: bucket, project: @project),
+        method: :morph
+      )
+    end
+
     def moved_to_sprint
       moved_to(new_sprint: @story.sprint)
     end
@@ -149,8 +165,14 @@ module Backlogs
       move_attributes[:sprint_id].present?
     end
 
+    def target_bucket?(move_attributes)
+      move_attributes[:backlog_bucket_id].present?
+    end
+
     def target_inbox?(move_attributes)
-      move_attributes.key?(:sprint_id) && move_attributes[:sprint_id].nil?
+      move_attributes.key?(:sprint_id) &&
+        move_attributes[:sprint_id].nil? &&
+        move_attributes[:backlog_bucket_id].nil?
     end
 
     def replace_sprint_component_via_turbo_stream(sprint:)

--- a/modules/backlogs/spec/controllers/backlogs/inbox_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/inbox_controller_spec.rb
@@ -168,6 +168,48 @@ RSpec.describe Backlogs::InboxController do
       end
     end
 
+    context "when moving to an Agile::BacklogBucket" do
+      let!(:bucket) { create(:backlog_bucket, project:) }
+      let(:target_id) { "backlog_bucket:#{bucket.id}" }
+
+      it "replaces both the inbox and target bucket components", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-inbox-component-#{project.id}"
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-backlog-bucket-component-#{bucket.id}"
+      end
+    end
+
+    context "when moving out of a bucket into the Inbox" do
+      let!(:bucket) { create(:backlog_bucket, project:) }
+      let(:work_package) { create(:work_package, project:, backlog_bucket: bucket) }
+      let(:target_id) { "inbox" }
+
+      it "replaces both the inbox and source bucket components", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-inbox-component-#{project.id}"
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-backlog-bucket-component-#{bucket.id}"
+      end
+    end
+
+    context "when moving between two buckets" do
+      let!(:source_bucket) { create(:backlog_bucket, project:, name: "Source") }
+      let!(:target_bucket) { create(:backlog_bucket, project:, name: "Target") }
+      let(:work_package) { create(:work_package, project:, backlog_bucket: source_bucket) }
+      let(:target_id) { "backlog_bucket:#{target_bucket.id}" }
+
+      it "replaces both affected bucket components", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-backlog-bucket-component-#{source_bucket.id}"
+        expect(response).to have_turbo_stream action: "replace",
+                                              target: "backlogs-backlog-bucket-component-#{target_bucket.id}"
+      end
+    end
+
     context "when reordering within the Inbox" do
       let(:target_id) { "inbox" }
       let(:prev_id) { work_packages.first.id }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -134,6 +134,31 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with an Agile::BacklogBucket as target" do
+      let(:bucket) { create(:backlog_bucket, project:, name: "Target bucket") }
+
+      it "responds with success and moves story to the bucket", :aggregate_failures do
+        put :move, params: {
+                     project_id: project.id,
+                     sprint_id: agile_sprint.id,
+                     id: story_in_agile_sprint.id,
+                     target_id: "backlog_bucket:#{bucket.id}",
+                     prev_id: nil
+                   },
+                   format: :turbo_stream
+
+        expect(response).to be_successful
+        expect(response).to have_http_status :ok
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{agile_sprint.id}"
+        expect(response).to have_turbo_stream action: "replace", target: "backlogs-backlog-bucket-component-#{bucket.id}"
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-inbox-component-#{project.id}"
+        story_in_agile_sprint.reload
+        expect(story_in_agile_sprint.backlog_bucket_id).to eq(bucket.id)
+        expect(story_in_agile_sprint.sprint_id).to be_nil
+      end
+    end
+
     context "with Inbox as target" do
       let!(:existing_inbox_item) { create(:work_package, project:, status:, position: 1) }
 

--- a/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
@@ -42,10 +42,12 @@ RSpec.describe "Dragging work packages in backlog buckets",
 
   shared_let(:bucket_alpha) { create(:backlog_bucket, project:, name: "Alpha bucket") }
   shared_let(:bucket_beta)  { create(:backlog_bucket, project:, name: "Beta bucket") }
+  shared_let(:bucket_gamma) { create(:backlog_bucket, project:, name: "Gamma bucket") }
 
   shared_let(:alpha_wp1) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 1) }
   shared_let(:alpha_wp2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2) }
   shared_let(:alpha_wp3) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 3) }
+  shared_let(:gamma_wp1) { create(:work_package, project:, backlog_bucket: bucket_gamma, position: 1) }
   shared_let(:inbox_wp1) { create(:work_package, project:, backlog_bucket: nil, sprint: nil, position: 1) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
@@ -108,6 +110,24 @@ RSpec.describe "Dragging work packages in backlog buckets",
     )
 
     expect(inbox_wp1.reload.backlog_bucket_id).to eq(bucket_beta.id)
+  end
+
+  it "hides the blankslate when dropping into a previously-empty bucket" do
+    backlogs_page.visit!
+    backlogs_page.expect_backlog_bucket_blankslate(bucket_beta)
+
+    backlogs_page.drag_work_package_to_backlog_bucket(alpha_wp1, bucket_beta)
+
+    backlogs_page.expect_no_backlog_bucket_blankslate(bucket_beta)
+  end
+
+  it "shows the blankslate after dragging the last work package out of a bucket" do
+    backlogs_page.visit!
+    backlogs_page.expect_no_backlog_bucket_blankslate(bucket_gamma)
+
+    backlogs_page.drag_work_package_to_backlog_bucket(gamma_wp1, backlogs_page.inbox_backlog_bucket)
+
+    backlogs_page.expect_backlog_bucket_blankslate(bucket_gamma)
   end
 
   context "without the :manage_sprint_items permission" do

--- a/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/drag_in_backlog_bucket_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Dragging work packages in backlog buckets",
     backlogs_page.visit!
     backlogs_page.expect_no_backlog_bucket_blankslate(bucket_gamma)
 
-    backlogs_page.drag_work_package_to_backlog_bucket(gamma_wp1, backlogs_page.inbox_backlog_bucket)
+    backlogs_page.drag_work_package_to_backlog_inbox(gamma_wp1)
 
     backlogs_page.expect_backlog_bucket_blankslate(bucket_gamma)
   end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -407,6 +407,18 @@ module Pages
       end
     end
 
+    def expect_backlog_bucket_blankslate(bucket)
+      within_backlog_bucket(bucket) do
+        expect(page).to have_selector(:heading, level: 4, text: "Backlog bucket is empty")
+      end
+    end
+
+    def expect_no_backlog_bucket_blankslate(bucket)
+      within_backlog_bucket(bucket) do
+        expect(page).to have_no_selector(:heading, level: 4, text: "Backlog bucket is empty")
+      end
+    end
+
     def drag_work_package_to_backlog_bucket(work_package, bucket)
       moved_element = find(draggable_work_package_selector(work_package))
       target_element = find(bucket_selector(bucket))


### PR DESCRIPTION
> [!NOTE]
> This PR is based off #22884. Please review/merge that PR first. 

# Ticket

https://community.openproject.org/wp/73081

# What are you trying to accomplish?

Fixes stale-blankslate behaviour on the "Backlog and sprints" view when backlog buckets are enabled:

- dropping a work package into a previously-empty bucket left the blankslate visible below the dropped card;
- dragging the last work package out of a bucket left an empty shell until a full page refresh.

Root cause: the move actions never refreshed the affected bucket components over Turbo Streams, so the conditional blankslate row in `BacklogBucketComponent` never toggled.

Also incidentally fixes a flash regression where sprint → bucket drops produced a "moved to Inbox" message (the controller mis-classified bucket drops as inbox drops).

# Screenshots

| Before | After |
|--------|--------|
| <img width="604" height="295" alt="Screenshot 2026-04-22 at 22 17 31" src="https://github.com/user-attachments/assets/8f1059fb-4a00-47d2-bbc7-906e18c08e69" /> | <img width="604" height="295" alt="Screenshot 2026-04-22 at 22 17 31" src="https://github.com/user-attachments/assets/258706ab-a6fa-41b8-8a3c-b6b78ddee04b" />|

# What approach did you choose and why?

Each move controller now emits a Turbo Stream replace for every affected bucket (target + source), mirroring the existing per-controller `replace_{inbox,sprint}_component_via_turbo_stream` duplication. `WorkPackagesController` also gains a `target_bucket?` branch so bucket and inbox drops no longer collide. Regression coverage added at both controller-spec and feature-spec levels.

## Merge checklist

- [x] Added/updated tests
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)