### PR TITLE
Fix clipboard formatting loss in BlockNote editor inside Shadow DOM

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,6 +121,7 @@
     "@rails/request.js": "^0.0.13",
     "@stimulus-components/auto-submit": "^6.0.0",
     "@stimulus-components/reveal": "^5.0.0",
+    "@tiptap/extensions": "^3.20.0",
     "@uirouter/angular": "^17.0.0",
     "@uirouter/core": "^6.1.0",
     "@uirouter/rx": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,7 +121,6 @@
     "@rails/request.js": "^0.0.13",
     "@stimulus-components/auto-submit": "^6.0.0",
     "@stimulus-components/reveal": "^5.0.0",
-    "@tiptap/extensions": "^3.20.0",
     "@uirouter/angular": "^17.0.0",
     "@uirouter/core": "^6.1.0",
     "@uirouter/rx": "^1.0.0",

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -28,7 +28,7 @@
  * ++
  */
 
-import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { BlockNoteEditorOptions, BlockNoteSchema, selectedFragmentToHTML } from '@blocknote/core';
 import { User } from '@blocknote/core/comments';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import { BlockNoteView } from '@blocknote/mantine';
@@ -107,6 +107,41 @@ export function OpBlockNoteEditor({
   const editor = useCreateBlockNote(editorParams, [activeUser]);
   type EditorType = typeof editor;
   const theme = useOpTheme();
+
+  useEffect(() => {
+    const view = editor._tiptapEditor.view;
+
+    const handleCopy = (event: ClipboardEvent) => {
+      if (editor.prosemirrorState.selection.empty) return;
+
+      const { clipboardHTML, externalHTML, markdown } = selectedFragmentToHTML(view, editor);
+      event.clipboardData?.setData('blocknote/html', clipboardHTML);
+      event.clipboardData?.setData('text/html', externalHTML);
+      event.clipboardData?.setData('text/plain', markdown);
+      event.preventDefault();
+    };
+
+    const handleCut = (event: ClipboardEvent) => {
+      if (editor.prosemirrorState.selection.empty) return;
+
+      const { clipboardHTML, externalHTML, markdown } = selectedFragmentToHTML(view, editor);
+      event.clipboardData?.setData('blocknote/html', clipboardHTML);
+      event.clipboardData?.setData('text/html', externalHTML);
+      event.clipboardData?.setData('text/plain', markdown);
+      event.preventDefault();
+
+      if (view.editable) {
+        view.dispatch(view.state.tr.deleteSelection());
+      }
+    };
+
+    view.dom.addEventListener('copy', handleCopy);
+    view.dom.addEventListener('cut', handleCut);
+    return () => {
+      view.dom.removeEventListener('copy', handleCopy);
+      view.dom.removeEventListener('cut', handleCut);
+    };
+  }, [editor]);
 
   const getCustomSlashMenuItems = useCallback((editorInstance:EditorType) => [
     ...getDefaultReactSlashMenuItems(editorInstance),


### PR DESCRIPTION
## Summary

When users copy content from the documents module's BlockNote editor and paste into external applications (Google Docs, LibreOffice Writer, Gmail), formatting is lost — bullets appear as plain text, headings lose their styling, etc. Vanilla BlockNote does not have this problem.

## Root Cause

OpenProject mounts the BlockNote editor inside a **Shadow DOM** (`attachShadow({ mode: 'open' })`). BlockNote's copy handler guards against firing on non-editable content using `window.getSelection()`:

```typescript
const checkIfSelectionInNonEditableBlock = () => {
  const selection = window.getSelection(); // returns null in Shadow DOM!
  if (!selection || selection.isCollapsed) {
    return true; // SHORT-CIRCUITS — clipboard write is skipped entirely
  }
  // ...
};
```

In Shadow DOM, `window.getSelection()` returns `null` or a collapsed selection even when text is selected (Firefox all versions, Safari ≤16.3, Chromium edge cases). The guard misfires, so BlockNote's `copyToClipboard()` is never called. The browser's default copy fires instead, producing raw ProseMirror HTML (`<div class="bn-block-content">`) with no semantic structure — formatting is lost.

## Fix

Register `copy`/`cut` handlers directly on the ProseMirror view's DOM node that call BlockNote's public `selectedFragmentToHTML()` API. This function reads from `view.state.selection` (ProseMirror internal state — always accurate regardless of Shadow DOM) and returns all three required MIME type payloads.

```typescript
useEffect(() => {
  const view = editor._tiptapEditor.view;

  const handleCopy = (event: ClipboardEvent) => {
    if (editor.prosemirrorState.selection.empty) return;
    const { clipboardHTML, externalHTML, markdown } = selectedFragmentToHTML(view, editor);
    event.clipboardData?.setData('blocknote/html', clipboardHTML);
    event.clipboardData?.setData('text/html', externalHTML);
    event.clipboardData?.setData('text/plain', markdown);
    event.preventDefault();
  };
  // ... cut handler similarly
  view.dom.addEventListener('copy', handleCopy);
  // ...
}, [editor]);
```

All three MIME types are written:
- `blocknote/html` — editor-to-editor paste fidelity
- `text/html` — semantic HTML (`<ul><li>`, `<h1>`, etc.) for external apps
- `text/plain` — Markdown for plain-text targets

## Upstream

The root cause is a deficiency in BlockNote itself. A fix to `checkIfSelectionInNonEditableBlock` in `@blocknote/core` to use `view.state.selection.empty` instead of `window.getSelection()` will be contributed upstream.

## Test plan

- [ ] Open a document, add an unordered list, numbered list, heading, bold/italic text
- [ ] Select all (Ctrl+A), copy (Ctrl+C), paste into Google Docs / LibreOffice Writer — verify bullets, numbering, heading style, bold/italic are preserved
- [ ] Paste into a Markdown editor — verify `* item` format for bullet lists
- [ ] Paste back into the BlockNote editor — verify lossless round-trip via `blocknote/html`
- [ ] Cut (Ctrl+X): verify clipboard is correct AND original text is removed
- [ ] Partial selection: verify only selected blocks appear in clipboard

---
_Generated by [Claude Code](https://claude.ai/code/session_0168sLru4wM6mXfSmsaLw4Qd)_