### PR TITLE
Extract inline wiki page links from WP description

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
@@ -38,7 +38,11 @@ module Wikis
               titles = [
                 "What makes XWiki special?",
                 "API documentation",
-                "A brief introduction on configuring your own XWiki instance and connect it to OpenProject."
+                "A brief introduction on configuring your own XWiki instance and connect it to OpenProject.",
+                "Security considerations for API design",
+                "Syntax overview",
+                "Getting help",
+                "Enterprise support"
               ].sample
               title = titles[Random.new(input_data.identifier.hash).rand(titles.size)]
 

--- a/modules/wikis/app/services/wikis/concerns/update_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_inline_wiki_page_links.rb
@@ -28,32 +28,30 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  module Adapters
-    module Providers
-      module XWiki
-        module Queries
-          class PageInfo < BaseQuery
-            def call(input_data)
-              titles = [
-                "What makes XWiki special?",
-                "API documentation",
-                "A brief introduction on configuring your own XWiki instance and connect it to OpenProject."
-              ].sample
-              title = titles[Random.new(input_data.identifier.hash).rand(titles.size)]
+module Wikis::Concerns
+  module UpdateInlineWikiPageLinks
+    extend ActiveSupport::Concern
 
-              success(
-                Results::PageInfo.new(
-                  identifier: input_data.identifier,
-                  provider:,
-                  title:,
-                  href: "#"
-                )
-              )
-            end
-          end
+    def update_inline_wiki_page_links(linkable, *texts)
+      Wikis::InlinePageLink.where(linkable:).delete_all
+      texts.each do |text|
+        find_wiki_links(text).each do |provider_id, identifier|
+          provider = Wikis::Provider.find_by(id: provider_id)
+          next if provider.nil?
+
+          Wikis::InlinePageLink.create!(linkable:, provider:, identifier:)
         end
       end
+    end
+
+    private
+
+    def find_wiki_links(text)
+      return [] if text.blank?
+
+      # The text is markdown that escapes literal [ and ] characters. We unescape them first.
+      text = text.gsub("\\[", "[").gsub("\\]", "]")
+      text.scan(Wikis::TextFormatting::WikiLinkMatcher.regexp)
     end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -98,6 +98,9 @@ module OpenProject::Wikis
            icon: "browser"
     end
 
+    patch_with_namespace :WorkPackages, :CreateService
+    patch_with_namespace :WorkPackages, :UpdateService
+
     add_api_path(:wiki_page_link) { |page_link_id| "#{root}/wiki_page_links/#{page_link_id}" }
     add_api_path(:wiki_provider) { |provider_id| "#{root}/wiki_providers/#{provider_id}" }
   end

--- a/modules/wikis/lib/open_project/wikis/patches/create_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/create_service_patch.rb
@@ -28,32 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  module Adapters
-    module Providers
-      module XWiki
-        module Queries
-          class PageInfo < BaseQuery
-            def call(input_data)
-              titles = [
-                "What makes XWiki special?",
-                "API documentation",
-                "A brief introduction on configuring your own XWiki instance and connect it to OpenProject."
-              ].sample
-              title = titles[Random.new(input_data.identifier.hash).rand(titles.size)]
+module OpenProject::Wikis::Patches::CreateServicePatch
+  def self.included(base)
+    base.prepend InstanceMethods
+    base.include Wikis::Concerns::UpdateInlineWikiPageLinks
+  end
 
-              success(
-                Results::PageInfo.new(
-                  identifier: input_data.identifier,
-                  provider:,
-                  title:,
-                  href: "#"
-                )
-              )
-            end
-          end
-        end
-      end
+  module InstanceMethods
+    def create(_attributes, work_package)
+      result = super
+      update_inline_wiki_page_links(work_package, work_package.description) if result.success?
+
+      result
     end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/patches/update_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/update_service_patch.rb
@@ -28,32 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  module Adapters
-    module Providers
-      module XWiki
-        module Queries
-          class PageInfo < BaseQuery
-            def call(input_data)
-              titles = [
-                "What makes XWiki special?",
-                "API documentation",
-                "A brief introduction on configuring your own XWiki instance and connect it to OpenProject."
-              ].sample
-              title = titles[Random.new(input_data.identifier.hash).rand(titles.size)]
+module OpenProject::Wikis::Patches::UpdateServicePatch
+  def self.included(base)
+    base.prepend InstanceMethods
+    base.include Wikis::Concerns::UpdateInlineWikiPageLinks
+  end
 
-              success(
-                Results::PageInfo.new(
-                  identifier: input_data.identifier,
-                  provider:,
-                  title:,
-                  href: "#"
-                )
-              )
-            end
-          end
-        end
+  module InstanceMethods
+    private
+
+    def after_perform(_)
+      service_call = super
+
+      work_package = service_call.result
+      if service_call.success? && work_package.changed_attribute_keys_before_last_save.include?(:description)
+        update_inline_wiki_page_links(work_package, work_package.description)
       end
+
+      service_call
     end
   end
 end

--- a/modules/wikis/spec/services/work_packages/create_service_spec.rb
+++ b/modules/wikis/spec/services/work_packages/create_service_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::CreateService do
+  let(:instance) { described_class.new(user:) }
+  let(:user) { create(:admin) }
+  let(:project) { create(:project) }
+  let(:default_status) { create(:default_status) }
+  let(:priority) { create(:priority) }
+  let(:provider) { create(:xwiki_provider) }
+  let(:attributes) do
+    {
+      subject: "A test work package",
+      project:,
+      status: default_status,
+      priority:,
+      description: <<~TXT
+        The work package description contains inline links to wiki pages (e.g. [[[#{provider.id}:abc]]]).
+        It also contains links in a list:
+
+        * [[[#{provider.id}:def]]]
+        * [[[#{provider.id + 100}:ghi]]]
+      TXT
+    }
+  end
+
+  subject { instance.call(**attributes) }
+
+  before do
+    project
+    default_status
+    priority
+  end
+
+  it "succeeds" do
+    expect(subject).to be_success
+  end
+
+  it "creates inline page links for the existing provider" do
+    subject
+
+    expect(Wikis::InlinePageLink.where(provider:).count).to eq(2)
+  end
+
+  it "links wiki pages to the freshly created work package" do
+    subject
+
+    expect(Wikis::InlinePageLink.where(linkable: WorkPackage.first).count).to eq(2)
+  end
+
+  it "only creates links that had a valid provider id" do
+    subject
+
+    expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc", "def")
+  end
+end

--- a/modules/wikis/spec/services/work_packages/update_service_spec.rb
+++ b/modules/wikis/spec/services/work_packages/update_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::UpdateService do
+  let(:instance) { described_class.new(user:, model: work_package) }
+  let(:user) { create(:admin) }
+  let(:work_package) { create(:work_package) }
+  let(:provider) { create(:xwiki_provider) }
+  let(:attributes) do
+    {
+      description: <<~TXT
+        The work package description contains inline links to wiki pages (e.g. [[[#{provider.id}:abc]]]).
+        It also contains links in a list:
+
+        * [[[#{provider.id}:def]]]
+        * [[[#{provider.id + 100}:ghi]]]
+      TXT
+    }
+  end
+
+  subject { instance.call(**attributes) }
+
+  it "succeeds" do
+    expect(subject).to be_success
+  end
+
+  it "creates inline page links for the existing provider" do
+    subject
+
+    expect(Wikis::InlinePageLink.where(provider:).count).to eq(2)
+  end
+
+  it "links wiki pages to the freshly created work package" do
+    subject
+
+    expect(Wikis::InlinePageLink.where(linkable: WorkPackage.first).count).to eq(2)
+  end
+
+  it "only creates links that had a valid provider id" do
+    subject
+
+    expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc", "def")
+  end
+
+  context "when other page links already exist" do
+    before do
+      create(:inline_wiki_page_link, provider:, linkable: work_package, identifier: "123")
+    end
+
+    it "deletes existing page links" do
+      subject
+
+      expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc", "def")
+    end
+
+    context "and when the description does not change" do
+      let(:attributes) { { subject: "This is a new subject" } }
+
+      it "keeps existing page links" do
+        subject
+
+        expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("123")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates inline page links the way they are intended to exist: When a work package contains a link to a wiki page in its description, these links should also be represented as inline wiki page links.

# Ticket
Part of https://community.openproject.org/wp/72986