### PR TITLE
(Blocknote): Add screen-reader hint for external links

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -53,12 +53,6 @@ class BlockNoteElement extends HTMLElement {
     if (browserSpecificClasses.length > 0) {
       this.editorRoot.classList.add(...browserSpecificClasses);
     }
-    // Clone the blank-target link description into the shadow DOM
-    // so aria-describedby references resolve for links inside the editor
-    const blankLinkDesc = document.getElementById('open-blank-target-link-description');
-    if (blankLinkDesc) {
-      this.editorRoot.appendChild(blankLinkDesc.cloneNode(true));
-    }
 
     this.editorMount = document.createElement('div');
     this.editorRoot.appendChild(this.editorMount);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -29,6 +29,7 @@
  */
 
 import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
 import { User } from '@blocknote/core/comments';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
@@ -114,11 +115,10 @@ export function OpBlockNoteEditor({
       },
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
-      // When external link capture is enabled, intercept clicks on external
-      // links via a ProseMirror plugin and route through /external_redirect.
-      ...(captureExternalLinks && {
-        extensions: [ExternalLinkCaptureExtension],
-      }),
+      extensions: [
+        ExternalLinkA11yExtension,
+        ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
+      ],
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -172,16 +172,23 @@ function sliceContainsLinkMark(slice:Slice):boolean {
  * Decides whether a step warrants rebuilding the widget set, vs. just
  * shifting existing decorations forward.
  *
- * Plain typing or moving content around merely shifts link runs — the
- * widget at the end of each run rides along correctly via decoration
- * mapping. The expensive doc walk is only needed when a step adds,
- * removes, or moves a link mark.
+ * Pure typing inserts content without touching link boundaries; the widget
+ * at the end of each run rides along correctly via decoration mapping, so
+ * the doc walk can be skipped. A rebuild is needed when:
+ *   - a link mark is added, removed, or moved by a mark step;
+ *   - an inserted slice itself carries a link mark (paste of linked HTML);
+ *   - any range is deleted or replaced. Deletions whose right edge meets a
+ *     link's trailing widget make `WidgetType.map` report the widget as
+ *     deleted (PM's mapping forces `side=1` at the deletion's right edge,
+ *     which clashes with our `assoc=-1`). The simplest robust answer is to
+ *     reseat the widget set whenever a range is removed.
  */
 function stepAffectsLinks(step:Step):boolean {
   if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
     return step.mark.type.name === 'link';
   }
   if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {
+    if (step.from !== step.to) return true;
     return sliceContainsLinkMark(step.slice);
   }
   return false;

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -108,7 +108,13 @@ function buildWidget():HTMLElement {
   span.setAttribute('contenteditable', 'false');
   // Reuse the same translated string the body-level ExternalLinksController
   // references via aria-describedby, keeping i18n centralised in Rails.
-  span.textContent = readDescription();
+  // Captured at decoration-creation time, so a mid-session locale change
+  // keeps stale text until the next rebuild. Leading NBSP is a separator
+  // for the link's computed accessible name — without it, AT can announce
+  // "Link textOpen link in a new tab" because descendant text-node
+  // concatenation isn't guaranteed to insert whitespace, especially in
+  // contenteditable.
+  span.textContent = `\u00A0${readDescription()}`;
   return span;
 }
 

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -39,8 +39,27 @@ import type { Step } from 'prosemirror-transform';
 import type { Node as PmNode, Mark, Slice } from 'prosemirror-model';
 import { isHrefExternal } from 'core-stimulus/helpers/external-link-helpers';
 
+// ProseMirror primer
+// ------------------
+// • Transaction (`tr`): an immutable description of an edit. Editor state
+//   moves forward by applying transactions, not by direct DOM mutation.
+// • Step: the atomic operation a transaction is built from. Relevant ones
+//   are ReplaceStep (replace a range with a Slice of content) and
+//   AddMarkStep / RemoveMarkStep (toggle a mark like `link` on a range).
+// • Slice: the chunk of content carried by a ReplaceStep — what is being
+//   pasted, typed, or otherwise inserted.
+// • Mapping (`tr.mapping`): ProseMirror's position translator. After an
+//   insert of N characters at position 10, mapping rewrites later
+//   positions to account for the shift. Decorations can be mapped through
+//   it to stay in sync without being rebuilt.
+// • Decoration / DecorationSet: non-mutating overlays (widgets, attrs)
+//   rendered alongside the document. The sr-only hint here is a widget
+//   decoration — invisible to the model, visible (audible) in the DOM.
+
 const pluginKey = new PluginKey('externalLinkA11y');
 const DESCRIPTION_ID = 'open-blank-target-link-description';
+
+// --- Decoration construction ------------------------------------------------
 
 function findExternalLinkMark(node:PmNode):Mark|null {
   for (const mark of node.marks) {
@@ -93,80 +112,6 @@ function buildWidget():HTMLElement {
   return span;
 }
 
-// ProseMirror primer for the gating logic below
-// ----------------------------------------------
-// • Transaction (`tr`): an immutable description of an edit. Editor state
-//   moves forward by applying transactions, not by direct DOM mutation.
-// • Step: the atomic operation a transaction is built from. Relevant ones
-//   are ReplaceStep (replace a range with a Slice of content) and
-//   AddMarkStep / RemoveMarkStep (toggle a mark like `link` on a range).
-// • Slice: the chunk of content carried by a ReplaceStep — what is being
-//   pasted, typed, or otherwise inserted.
-// • Mapping (`tr.mapping`): ProseMirror's position translator. After an
-//   insert of N characters at position 10, mapping rewrites later
-//   positions to account for the shift. Decorations can be mapped through
-//   it to stay in sync without being rebuilt.
-// • Decoration / DecorationSet: non-mutating overlays (widgets, attrs)
-//   rendered alongside the document. The sr-only hint here is a widget
-//   decoration — invisible to the model, visible (audible) in the DOM.
-// • `tr.setMeta(key, value)`: stash arbitrary data on a transaction
-//   without producing a doc edit. Used here to hand a freshly-built
-//   DecorationSet from the post-batch hook back into plugin state.
-
-function sliceContainsLinkMark(slice:Slice):boolean {
-  let found = false;
-  slice.content.descendants((node) => {
-    if (found) return false;
-    if (node.marks.some((m) => m.type.name === 'link')) {
-      found = true;
-      return false;
-    }
-    return true;
-  });
-  return found;
-}
-
-function rangeContainsLinkMark(doc:PmNode, from:number, to:number):boolean {
-  if (from >= to) return false;
-  let found = false;
-  doc.nodesBetween(from, to, (node) => {
-    if (found) return false;
-    if (node.marks.some((m) => m.type.name === 'link')) {
-      found = true;
-      return false;
-    }
-    return true;
-  });
-  return found;
-}
-
-/**
- * Decides whether a transaction's steps actually change the *set* of link
- * runs in the doc, vs. just shifting their positions.
- *
- * Plain typing or moving content around merely shifts link runs — the
- * existing widget at the end of each run rides along correctly via
- * decoration mapping. The expensive doc walk is only needed when the set
- * of links changes: paste with linked content, toolbar mark application,
- * or deletion of marked content.
- *
- * For ReplaceStep we have to inspect both ends. The inserted Slice may
- * carry link marks INTO the doc; the range being replaced may carry link
- * marks OUT of it (e.g. deleting a whole link). Missing the second check
- * would leave the link's widget stranded at a position that no longer has
- * a link.
- */
-function stepAffectsLinks(step:Step, oldDoc:PmNode):boolean {
-  if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
-    return step.mark.type.name === 'link';
-  }
-  if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {
-    if (sliceContainsLinkMark(step.slice)) return true;
-    return rangeContainsLinkMark(oldDoc, step.from, step.to);
-  }
-  return false;
-}
-
 function buildDecorations(doc:PmNode):DecorationSet {
   const decorations:Decoration[] = [];
 
@@ -200,6 +145,49 @@ function buildDecorations(doc:PmNode):DecorationSet {
   });
 
   return DecorationSet.create(doc, decorations);
+}
+
+// --- Transaction gating -----------------------------------------------------
+
+function sliceContainsLinkMark(slice:Slice):boolean {
+  let found = false;
+  slice.content.descendants((node) => {
+    if (found) return false;
+    if (node.marks.some((m) => m.type.name === 'link')) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
+/**
+ * Decides whether a step warrants rebuilding the widget set, vs. just
+ * shifting existing decorations forward.
+ *
+ * Plain typing or moving content around merely shifts link runs — the
+ * widget at the end of each run rides along correctly via decoration
+ * mapping. The expensive doc walk is only needed when a step adds,
+ * removes, or moves a link mark.
+ *
+ * Limitation: deleting a whole link's text leaves the slice empty, and
+ * we don't have cheap access to the old range here to detect that the
+ * removed range carried a link mark. The orphaned widget gets cleaned
+ * up by the next link-affecting transaction (e.g. typing nearby with a
+ * stored link mark, or any subsequent paste). The visible cost between
+ * those events is a sr-only span at a position that no longer has a
+ * link wrapper around it — invisible to sighted users, briefly noisy
+ * for screen readers if they navigate before the next rebuild.
+ */
+function stepAffectsLinks(step:Step):boolean {
+  if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
+    return step.mark.type.name === 'link';
+  }
+  if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {
+    return sliceContainsLinkMark(step.slice);
+  }
+  return false;
 }
 
 /**
@@ -236,47 +224,23 @@ export const ExternalLinkA11yExtension = createExtension({
         init(_, { doc }) {
           return buildDecorations(doc);
         },
-        // `apply` runs once per transaction to advance plugin state. It is
-        // the hot path during typing — must stay cheap.
-        //   1. If a transaction carries a meta payload from us, install it
-        //      verbatim. That's how the post-batch hook below hands a freshly
-        //      rebuilt DecorationSet back into state.
-        //   2. If the doc didn't change, decorations are still valid as-is.
-        //   3. Otherwise, just shift existing decorations forward through the
-        //      transaction's position mapping. No doc walk, O(decoration count).
+        // `apply` runs once per transaction to advance plugin state and is
+        // the hot path during typing. Three branches:
+        //   1. Doc unchanged: decorations are still valid as-is.
+        //   2. Doc changed but no step affects link runs: shift existing
+        //      decorations forward through the transaction's position
+        //      mapping. O(decoration count); no doc walk.
+        //   3. A step adds, removes, or moves a link mark: rebuild.
+        //
+        // The rebuild lives here in `apply` rather than in `appendTransaction`
+        // because dispatching a chained meta-only tx from there interferes
+        // with y-prosemirror's PM↔Y.Doc sync — paste content gets applied
+        // locally but never reaches the rendered view.
         apply(tr, oldDecos) {
-          const meta = tr.getMeta(pluginKey) as DecorationSet | undefined;
-          if (meta instanceof DecorationSet) return meta;
           if (!tr.docChanged) return oldDecos;
+          if (tr.steps.some(stepAffectsLinks)) return buildDecorations(tr.doc);
           return oldDecos.map(tr.mapping, tr.doc);
         },
-      },
-      // `appendTransaction` is a ProseMirror plugin hook that runs after a
-      // batch of transactions has been applied but before the view re-renders.
-      // It receives the array of dispatched transactions and may return one
-      // additional transaction to chain. We use it as the gate for the
-      // expensive rebuild: only when at least one step in the batch actually
-      // changes which link runs exist do we walk the doc and dispatch a
-      // meta-only transaction with the fresh DecorationSet (picked up by
-      // `apply` above).
-      //
-      // Why here and not in `view.update` with rAF (`requestAnimationFrame`,
-      // a browser API that defers a callback to the next paint, ~16ms):
-      // `appendTransaction` is synchronous and lifecycle-safe. An rAF callback
-      // can fire after the editor has unmounted (Turbo navigation, React
-      // teardown), at which point dispatching into a destroyed view throws.
-      // Running this hook synchronously sidesteps that class of bug entirely.
-      //
-      // This path covers all edit sources uniformly: local typing, remote
-      // y-prosemirror updates from collaborators, and Hocuspocus reconnect
-      // backlogs all flow through the same transaction pipeline.
-      appendTransaction(trs, oldState, newState) {
-        const linkAffecting = trs.some((tr) =>
-          tr.docChanged
-          && tr.steps.some((step) => stepAffectsLinks(step, oldState.doc)),
-        );
-        if (!linkAffecting) return null;
-        return newState.tr.setMeta(pluginKey, buildDecorations(newState.doc));
       },
       props: {
         decorations(state) {

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -29,7 +29,14 @@
 import { createExtension } from '@blocknote/core';
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { Decoration, DecorationSet } from 'prosemirror-view';
-import type { Node as PmNode, Mark } from 'prosemirror-model';
+import {
+  AddMarkStep,
+  RemoveMarkStep,
+  ReplaceStep,
+  ReplaceAroundStep,
+} from 'prosemirror-transform';
+import type { Step } from 'prosemirror-transform';
+import type { Node as PmNode, Mark, Slice } from 'prosemirror-model';
 import { isHrefExternal } from 'core-stimulus/helpers/external-link-helpers';
 
 const pluginKey = new PluginKey('externalLinkA11y');
@@ -84,6 +91,80 @@ function buildWidget():HTMLElement {
   // references via aria-describedby, keeping i18n centralised in Rails.
   span.textContent = readDescription();
   return span;
+}
+
+// ProseMirror primer for the gating logic below
+// ----------------------------------------------
+// • Transaction (`tr`): an immutable description of an edit. Editor state
+//   moves forward by applying transactions, not by direct DOM mutation.
+// • Step: the atomic operation a transaction is built from. Relevant ones
+//   are ReplaceStep (replace a range with a Slice of content) and
+//   AddMarkStep / RemoveMarkStep (toggle a mark like `link` on a range).
+// • Slice: the chunk of content carried by a ReplaceStep — what is being
+//   pasted, typed, or otherwise inserted.
+// • Mapping (`tr.mapping`): ProseMirror's position translator. After an
+//   insert of N characters at position 10, mapping rewrites later
+//   positions to account for the shift. Decorations can be mapped through
+//   it to stay in sync without being rebuilt.
+// • Decoration / DecorationSet: non-mutating overlays (widgets, attrs)
+//   rendered alongside the document. The sr-only hint here is a widget
+//   decoration — invisible to the model, visible (audible) in the DOM.
+// • `tr.setMeta(key, value)`: stash arbitrary data on a transaction
+//   without producing a doc edit. Used here to hand a freshly-built
+//   DecorationSet from the post-batch hook back into plugin state.
+
+function sliceContainsLinkMark(slice:Slice):boolean {
+  let found = false;
+  slice.content.descendants((node) => {
+    if (found) return false;
+    if (node.marks.some((m) => m.type.name === 'link')) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
+function rangeContainsLinkMark(doc:PmNode, from:number, to:number):boolean {
+  if (from >= to) return false;
+  let found = false;
+  doc.nodesBetween(from, to, (node) => {
+    if (found) return false;
+    if (node.marks.some((m) => m.type.name === 'link')) {
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  return found;
+}
+
+/**
+ * Decides whether a transaction's steps actually change the *set* of link
+ * runs in the doc, vs. just shifting their positions.
+ *
+ * Plain typing or moving content around merely shifts link runs — the
+ * existing widget at the end of each run rides along correctly via
+ * decoration mapping. The expensive doc walk is only needed when the set
+ * of links changes: paste with linked content, toolbar mark application,
+ * or deletion of marked content.
+ *
+ * For ReplaceStep we have to inspect both ends. The inserted Slice may
+ * carry link marks INTO the doc; the range being replaced may carry link
+ * marks OUT of it (e.g. deleting a whole link). Missing the second check
+ * would leave the link's widget stranded at a position that no longer has
+ * a link.
+ */
+function stepAffectsLinks(step:Step, oldDoc:PmNode):boolean {
+  if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
+    return step.mark.type.name === 'link';
+  }
+  if (step instanceof ReplaceStep || step instanceof ReplaceAroundStep) {
+    if (sliceContainsLinkMark(step.slice)) return true;
+    return rangeContainsLinkMark(oldDoc, step.from, step.to);
+  }
+  return false;
 }
 
 function buildDecorations(doc:PmNode):DecorationSet {
@@ -155,12 +236,47 @@ export const ExternalLinkA11yExtension = createExtension({
         init(_, { doc }) {
           return buildDecorations(doc);
         },
+        // `apply` runs once per transaction to advance plugin state. It is
+        // the hot path during typing — must stay cheap.
+        //   1. If a transaction carries a meta payload from us, install it
+        //      verbatim. That's how the post-batch hook below hands a freshly
+        //      rebuilt DecorationSet back into state.
+        //   2. If the doc didn't change, decorations are still valid as-is.
+        //   3. Otherwise, just shift existing decorations forward through the
+        //      transaction's position mapping. No doc walk, O(decoration count).
         apply(tr, oldDecos) {
-          if (tr.docChanged) {
-            return buildDecorations(tr.doc);
-          }
+          const meta = tr.getMeta(pluginKey) as DecorationSet | undefined;
+          if (meta instanceof DecorationSet) return meta;
+          if (!tr.docChanged) return oldDecos;
           return oldDecos.map(tr.mapping, tr.doc);
         },
+      },
+      // `appendTransaction` is a ProseMirror plugin hook that runs after a
+      // batch of transactions has been applied but before the view re-renders.
+      // It receives the array of dispatched transactions and may return one
+      // additional transaction to chain. We use it as the gate for the
+      // expensive rebuild: only when at least one step in the batch actually
+      // changes which link runs exist do we walk the doc and dispatch a
+      // meta-only transaction with the fresh DecorationSet (picked up by
+      // `apply` above).
+      //
+      // Why here and not in `view.update` with rAF (`requestAnimationFrame`,
+      // a browser API that defers a callback to the next paint, ~16ms):
+      // `appendTransaction` is synchronous and lifecycle-safe. An rAF callback
+      // can fire after the editor has unmounted (Turbo navigation, React
+      // teardown), at which point dispatching into a destroyed view throws.
+      // Running this hook synchronously sidesteps that class of bug entirely.
+      //
+      // This path covers all edit sources uniformly: local typing, remote
+      // y-prosemirror updates from collaborators, and Hocuspocus reconnect
+      // backlogs all flow through the same transaction pipeline.
+      appendTransaction(trs, oldState, newState) {
+        const linkAffecting = trs.some((tr) =>
+          tr.docChanged
+          && tr.steps.some((step) => stepAffectsLinks(step, oldState.doc)),
+        );
+        if (!linkAffecting) return null;
+        return newState.tr.setMeta(pluginKey, buildDecorations(newState.doc));
       },
       props: {
         decorations(state) {

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -1,0 +1,172 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { createExtension } from '@blocknote/core';
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import type { Node as PmNode, Mark } from 'prosemirror-model';
+import { isHrefExternal } from 'core-stimulus/helpers/external-link-helpers';
+
+const pluginKey = new PluginKey('externalLinkA11y');
+const DESCRIPTION_ID = 'open-blank-target-link-description';
+
+function findExternalLinkMark(node:PmNode):Mark|null {
+  for (const mark of node.marks) {
+    if (mark.type.name === 'link' && isHrefExternal(String(mark.attrs.href ?? ''))) {
+      return mark;
+    }
+  }
+  return null;
+}
+
+// Detects whether the next inline node belongs to the same contiguous link
+// run. Assumes every inline node inside a link carries the link mark. This
+// holds for the current BlockNote schema, which has no inline custom nodes
+// that opt out of marks. If a mention/inline-embed node is ever added that
+// permits a link mark to wrap it without inheriting, revisit this — you will
+// need to walk link runs explicitly instead of relying on nodeAfter.
+function sameLinkContinues(next:PmNode|null|undefined, href:string):boolean {
+  if (!next) return false;
+  return next.marks.some(
+    (m) => m.type.name === 'link' && String(m.attrs.href ?? '') === href,
+  );
+}
+
+let missingDescriptionWarned = false;
+
+function readDescription():string {
+  const source = document.getElementById(DESCRIPTION_ID);
+  const text = source?.textContent?.trim() ?? '';
+  if (!text && !missingDescriptionWarned) {
+    missingDescriptionWarned = true;
+    // The sr-only span is rendered in base.html.erb and also referenced by
+    // ExternalLinksController. If it goes missing, external-link hints silently
+    // become empty — warn once so the regression surfaces during development.
+    console.warn(
+      `[ExternalLinkA11yExtension] #${DESCRIPTION_ID} not found; external-link hints will be empty.`,
+    );
+  }
+  return text;
+}
+
+function buildWidget():HTMLElement {
+  const span = document.createElement('span');
+  span.className = 'sr-only';
+  // contenteditable=false keeps the hint inert inside ProseMirror's editable
+  // region, so users cannot place their caret inside it or delete it.
+  span.setAttribute('contenteditable', 'false');
+  // Reuse the same translated string the body-level ExternalLinksController
+  // references via aria-describedby, keeping i18n centralised in Rails.
+  span.textContent = readDescription();
+  return span;
+}
+
+function buildDecorations(doc:PmNode):DecorationSet {
+  const decorations:Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    const linkMark = findExternalLinkMark(node);
+    if (!linkMark) return;
+
+    const href = String(linkMark.attrs.href ?? '');
+    const end = pos + node.nodeSize;
+    const next = doc.resolve(end).nodeAfter;
+
+    // Only emit the hint at the end of a contiguous link run. Adjacent inline
+    // nodes (e.g. text with an extra bold mark) carrying the same href are
+    // rendered as one <a>, so we emit a single hint per link, not per node.
+    if (sameLinkContinues(next, href)) return;
+
+    decorations.push(
+      Decoration.widget(end, buildWidget, {
+        // Wrap the widget in the link mark so the sr-only span is rendered
+        // INSIDE the <a> tag. This makes the hint part of the link's
+        // accessible name — the only approach that is reliably announced by
+        // VoiceOver/NVDA in a contenteditable context, where aria-describedby
+        // is widely ignored.
+        marks: [linkMark],
+        // Negative side keeps the widget attached to the preceding link run
+        // when content is inserted at the same position.
+        side: -1,
+        ignoreSelection: true,
+      }),
+    );
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+/**
+ * BlockNote extension that adds a screen-reader-only "opens in new tab" hint
+ * to external links inside the editor.
+ *
+ * The hint is injected as a ProseMirror widget decoration wrapped in the link
+ * mark, so the resulting DOM looks like:
+ *
+ *   <a href="..." target="_blank" rel="...">
+ *     Link text
+ *     <span class="sr-only" contenteditable="false">Open link in a new tab</span>
+ *   </a>
+ *
+ * Putting the text inside the anchor makes it part of the link's accessible
+ * name, which screen readers announce in every mode — including the edit mode
+ * they switch into inside contenteditable regions. The previous approach of
+ * using `aria-describedby` on an inline decoration span did not work in
+ * contenteditable: VoiceOver and NVDA ignore aria-describedby there, and the
+ * inline decoration landed the attribute on a generic span rather than the
+ * anchor anyway.
+ *
+ * Decorations never mutate the document model, so ProseMirror does not
+ * re-render and there is no DOMObserver mutation loop (the reason direct DOM
+ * rewriting was abandoned for this attribute).
+ */
+export const ExternalLinkA11yExtension = createExtension({
+  key: 'externalLinkA11y',
+
+  prosemirrorPlugins: [
+    new Plugin({
+      key: pluginKey,
+      state: {
+        init(_, { doc }) {
+          return buildDecorations(doc);
+        },
+        apply(tr, oldDecos) {
+          if (tr.docChanged) {
+            return buildDecorations(tr.doc);
+          }
+          return oldDecos.map(tr.mapping, tr.doc);
+        },
+      },
+      props: {
+        decorations(state) {
+          return pluginKey.getState(state) as DecorationSet;
+        },
+      },
+    }),
+  ],
+});

--- a/frontend/src/react/extensions/external-link-a11y.ts
+++ b/frontend/src/react/extensions/external-link-a11y.ts
@@ -176,15 +176,6 @@ function sliceContainsLinkMark(slice:Slice):boolean {
  * widget at the end of each run rides along correctly via decoration
  * mapping. The expensive doc walk is only needed when a step adds,
  * removes, or moves a link mark.
- *
- * Limitation: deleting a whole link's text leaves the slice empty, and
- * we don't have cheap access to the old range here to detect that the
- * removed range carried a link mark. The orphaned widget gets cleaned
- * up by the next link-affecting transaction (e.g. typing nearby with a
- * stored link mark, or any subsequent paste). The visible cost between
- * those events is a sr-only span at a position that no longer has a
- * link wrapper around it — invisible to sighted users, briefly noisy
- * for screen readers if they navigate before the next rebuild.
  */
 function stepAffectsLinks(step:Step):boolean {
   if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {

--- a/frontend/src/stimulus/helpers/external-link-helpers.ts
+++ b/frontend/src/stimulus/helpers/external-link-helpers.ts
@@ -29,7 +29,7 @@
 /**
  * Shared utilities for external link handling. Used by both
  * ExternalLinksController (DOM rewriting for server-rendered pages) and
- * ProseMirrorExternalLinksController (click interception for BlockNote editors).
+ * BlockNote editor extensions (click interception and accessibility).
  */
 
 /**
@@ -42,23 +42,32 @@ export function isLinkBlank(link:HTMLAnchorElement) {
 }
 
 /**
- * Returns true when the link points to a different origin than the current page.
- * External links receive special treatment for security (noopener/noreferrer)
- * and, when capture is enabled, are routed through `/external_redirect` for
- * phishing prevention.
+ * Returns true when the given href string points to a different origin than
+ * the current page. Works with plain URL strings (e.g. from ProseMirror mark
+ * attrs) where no HTMLAnchorElement is available.
  *
  * Only considers http/https URLs — non-web protocols (mailto:, tel:,
  * javascript:, etc.) return false because they don't navigate to an
  * external origin.
  */
-export function isLinkExternal(link:HTMLAnchorElement) {
+export function isHrefExternal(href:string):boolean {
   try {
-    const linkUrl = new URL(link.href, window.location.origin);
+    const linkUrl = new URL(href, window.location.origin);
     if (!linkUrl.protocol.startsWith('http')) return false;
     return linkUrl.origin !== window.location.origin;
   } catch {
     return false;
   }
+}
+
+/**
+ * Returns true when the link points to a different origin than the current page.
+ * External links receive special treatment for security (noopener/noreferrer)
+ * and, when capture is enabled, are routed through `/external_redirect` for
+ * phishing prevention.
+ */
+export function isLinkExternal(link:HTMLAnchorElement) {
+  return isHrefExternal(link.href);
 }
 
 /**
@@ -76,8 +85,8 @@ export function isExternalLinkCandidate(link:HTMLAnchorElement) {
 /**
  * Builds the `/external_redirect` URL that the server uses for external link
  * capture. The ExternalLinksController rewrites hrefs directly; the
- * ProseMirrorExternalLinksController passes this URL to `window.open` on click
- * to avoid corrupting the ProseMirror document model.
+ * ExternalLinkCaptureExtension passes this URL to `window.open` on click
+ * to avoid corrupting the BlockNote/ProseMirror document model.
  */
 export function buildExternalRedirectUrl(href:string):string {
   const basePath = window.appBasePath ?? '';

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -30,11 +30,64 @@
 
 require "rails_helper"
 
+# Low-level browser actions for driving the BlockNote editor's contenteditable
+# inside its shadow root. Capybara cannot enter the shadow root for selection,
+# nor does its `send_keys` propagate Delete/Backspace into ProseMirror's
+# editable in this setup, so each helper drops to the Selenium driver: either
+# running JS via `execute_script` or issuing raw keystrokes via the W3C
+# actions API.
+module BlockNoteEditorBrowserActions
+  # Selects a text range inside the first external link in the editor.
+  # `start_offset` and `end_offset` follow String-slicing conventions: a
+  # non-negative integer is an absolute offset from the start of the link's
+  # text node; a negative integer counts back from the end; `nil` maps to the
+  # text length. Default arguments select the entire link text.
+  def select_text_in_external_link(start_offset: 0, end_offset: nil)
+    page.execute_script(<<~JS, start_offset, end_offset)
+      const root = document.querySelector('op-block-note').shadowRoot;
+      const a = root.querySelector('a[target="_blank"]');
+      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
+      const len = textNode.textContent.length;
+      const resolve = (v) => (v == null ? len : (v < 0 ? len + v : v));
+      const range = document.createRange();
+      range.setStart(textNode, resolve(arguments[0]));
+      range.setEnd(textNode, resolve(arguments[1]));
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    JS
+  end
+
+  # Forward Delete via the W3C actions API; pair with a selection helper.
+  def send_forward_delete
+    page.driver.browser.action.send_keys(:delete).perform
+  end
+
+  # Fires a paste ClipboardEvent on the editor with both HTML and plain-text
+  # payloads. Exercises ProseMirror's `transformPasted` path, which behaves
+  # differently from typed input.
+  def paste_clipboard_into(editor_element, html:, plain:)
+    editor_element.click
+    page.execute_script(<<~JS, editor_element.native, html, plain)
+      const target = arguments[0];
+      const dt = new DataTransfer();
+      dt.setData('text/html', arguments[1]);
+      dt.setData('text/plain', arguments[2]);
+      target.dispatchEvent(new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      }));
+    JS
+  end
+end
+
 RSpec.describe "External links in BlockNote editor",
                :js,
                :selenium,
                with_settings: { real_time_text_collaboration_enabled: true } do
   include_context "with hocuspocus"
+  include BlockNoteEditorBrowserActions
 
   let(:admin) { create(:admin) }
   let(:document) { create(:document, :collaborative) }
@@ -100,15 +153,11 @@ RSpec.describe "External links in BlockNote editor",
     # text nodes ("hello " with only the link mark, "world" with link+bold).
     # This exercises the sameLinkContinues coalescing path — without it we'd
     # get a spurious hint after "hello " mid-link.
-    el = editor.element
-    el.click
-    page.execute_script(<<~JS, el.native)
-      const el = arguments[0];
-      const dt = new DataTransfer();
-      dt.setData('text/html', '<a href="https://example.com/split">hello <strong>world</strong></a>');
-      dt.setData('text/plain', 'hello world');
-      el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
-    JS
+    paste_clipboard_into(
+      editor.element,
+      html: '<a href="https://example.com/split">hello <strong>world</strong></a>',
+      plain: "hello world"
+    )
 
     link = editor.shadow_root.find("a[target='_blank']", text: /hello\s*world/, wait: 5)
     hints = link.all("span.sr-only", visible: :all)
@@ -123,36 +172,13 @@ RSpec.describe "External links in BlockNote editor",
     link = editor.shadow_root.find("a[target='_blank']", text: "Doomed Link", wait: 5)
     expect(link).to have_css("span.sr-only", visible: :all)
 
-    # Regression: a single-transaction delete of a linked range must
-    # leave no orphan widget. The widget is registered with `side: -1`,
-    # so PM's `WidgetType.map` resolves its position with `assoc = -1`
-    # when the link is replaced with an empty slice, finds the anchor
-    # inside the deleted content, and reports `deleted: true`. PM drops
-    # the decoration automatically — no rebuild in this plugin is
-    # needed.
-    #
-    # If `side`, the apply gate, or buildDecorations ever stops
-    # preserving this, a phantom empty <a> with the sr-only hint would
-    # survive at the deletion seam and screen readers would announce a
-    # link to nowhere. This test fails before that ships.
-    #
-    # Selection uses a DOM Range over the link's text node (the widget
-    # span is contenteditable=false and excluded). Delete goes through
-    # the W3C actions API because Selenium's send_keys doesn't
-    # propagate Backspace/Delete to PM's editable in this shadow-DOM
-    # setup.
-    page.execute_script(<<~JS)
-      const root = document.querySelector('op-block-note').shadowRoot;
-      const a = root.querySelector('a[target="_blank"]');
-      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
-      const range = document.createRange();
-      range.setStart(textNode, 0);
-      range.setEnd(textNode, textNode.textContent.length);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
-    JS
-    page.driver.browser.action.send_keys(:delete).perform
+    # Deleting an entire link must leave no orphan widget at the deletion
+    # seam. The apply gate reseats the widget set on any range deletion, so
+    # buildDecorations runs on the post-delete doc, finds no link, and emits
+    # no widget. A regression here would render a phantom empty <a> hosting
+    # the sr-only hint, and screen readers would announce a link to nowhere.
+    select_text_in_external_link
+    send_forward_delete
 
     expect(editor.element).to have_no_css("a[target='_blank']", visible: :all)
     expect(editor.element).to have_no_css("span.sr-only", visible: :all)
@@ -163,26 +189,13 @@ RSpec.describe "External links in BlockNote editor",
     link = editor.shadow_root.find("a[target='_blank']", text: "Trim Me Tail", wait: 5)
     expect(link).to have_css("span.sr-only", visible: :all)
 
-    # Edits inside an existing link produce a ReplaceStep whose slice carries
-    # no link mark (the mark is inherited from stored marks, not the slice),
-    # so the apply gate routes through decoration mapping rather than a
-    # rebuild. The widget sits at the end of the link run with `side: -1`;
-    # the mapping must shrink the run from the right and keep the widget
-    # attached to the new tail. If that ever regresses, the hint either
-    # disappears or ends up orphaned at a stale position.
-    page.execute_script(<<~JS)
-      const root = document.querySelector('op-block-note').shadowRoot;
-      const a = root.querySelector('a[target="_blank"]');
-      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
-      const len = textNode.textContent.length;
-      const range = document.createRange();
-      range.setStart(textNode, len - 4);
-      range.setEnd(textNode, len);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
-    JS
-    page.driver.browser.action.send_keys(:delete).perform
+    # Tail-deletion inside a link must leave exactly one hint at the new
+    # link end. Mapping the existing widget through the deletion is unsafe:
+    # PM treats the widget's position as deleted when it coincides with the
+    # deletion's right edge. The apply gate's deletion rule reseats the
+    # widget on the post-delete doc instead.
+    select_text_in_external_link(start_offset: -4)
+    send_forward_delete
 
     surviving = editor.shadow_root.find("a[target='_blank']", text: "Trim Me", wait: 5)
     hints = surviving.all("span.sr-only", visible: :all)

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe "External links in BlockNote editor",
     # ignore in edit mode.
     link = editor.shadow_root.find("a[target='_blank']", text: "Accessible Link", wait: 5)
     hint = link.find("span.sr-only", visible: :all)
-    expect(hint.text(:all)).to eq(I18n.t(:open_link_in_a_new_tab))
+    # The widget text is prefixed with a separator (NBSP) so the link's
+    # computed accessible name doesn't concatenate as "Accessible LinkOpen…".
+    # We assert containment rather than equality so the separator detail
+    # stays an implementation concern of the extension, not the spec.
+    expect(hint.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))
   end
 
   it "emits exactly one hint when a link spans multiple inline nodes" do
@@ -109,7 +113,7 @@ RSpec.describe "External links in BlockNote editor",
     link = editor.shadow_root.find("a[target='_blank']", text: /hello\s*world/, wait: 5)
     hints = link.all("span.sr-only", visible: :all)
     expect(hints.size).to eq(1)
-    expect(hints.first.text(:all)).to eq(I18n.t(:open_link_in_a_new_tab))
+    expect(hints.first.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))
   end
 
   it_behaves_like "does not freeze when pasting multiple external links"

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -78,20 +78,49 @@ RSpec.describe "External links in BlockNote editor",
     expect(link[:rel]).to include("noreferrer")
   end
 
-  it "does not set aria-describedby inside contenteditable to avoid ProseMirror re-render loop" do
+  it "embeds the 'opens in new tab' hint inside external links for screen readers" do
     editor.paste_links(text: "Accessible Link", url: "https://example.com")
 
+    # The hint is a ProseMirror widget decoration wrapped in the link mark, so
+    # it is rendered as a sr-only child of the <a>. This makes it part of the
+    # link's accessible name, which screen readers announce reliably even
+    # inside contenteditable — unlike aria-describedby, which VoiceOver/NVDA
+    # ignore in edit mode.
     link = editor.shadow_root.find("a[target='_blank']", text: "Accessible Link", wait: 5)
-    expect(link[:"aria-describedby"]).to be_nil.or eq("")
+    hint = link.find("span.sr-only", visible: :all)
+    expect(hint.text(:all)).to eq(I18n.t(:open_link_in_a_new_tab))
+  end
+
+  it "emits exactly one hint when a link spans multiple inline nodes" do
+    # Paste HTML with a nested mark so the resulting <a> contains two adjacent
+    # text nodes ("hello " with only the link mark, "world" with link+bold).
+    # This exercises the sameLinkContinues coalescing path — without it we'd
+    # get a spurious hint after "hello " mid-link.
+    el = editor.element
+    el.click
+    page.execute_script(<<~JS, el.native)
+      const el = arguments[0];
+      const dt = new DataTransfer();
+      dt.setData('text/html', '<a href="https://example.com/split">hello <strong>world</strong></a>');
+      dt.setData('text/plain', 'hello world');
+      el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+    JS
+
+    link = editor.shadow_root.find("a[target='_blank']", text: /hello\s*world/, wait: 5)
+    hints = link.all("span.sr-only", visible: :all)
+    expect(hints.size).to eq(1)
+    expect(hints.first.text(:all)).to eq(I18n.t(:open_link_in_a_new_tab))
   end
 
   it_behaves_like "does not freeze when pasting multiple external links"
 
-  it "does not rewrite internal links" do
+  it "does not rewrite internal links or attach the sr-only hint" do
     editor.paste_links(text: "Internal Link", url: root_url)
 
     link = editor.shadow_root.find("a", text: "Internal Link", wait: 5)
     expect(link.native.property("href")).not_to include("/external_redirect")
+    # Internal links should not receive the "opens in new tab" hint.
+    expect(link).to have_no_css("span.sr-only", visible: :all)
   end
 
   context "with capture enabled",

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -118,6 +118,46 @@ RSpec.describe "External links in BlockNote editor",
 
   it_behaves_like "does not freeze when pasting multiple external links"
 
+  it "leaves no orphan hint when a linked range is deleted in one transaction" do
+    editor.paste_links(text: "Doomed Link", url: "https://example.com")
+    link = editor.shadow_root.find("a[target='_blank']", text: "Doomed Link", wait: 5)
+    expect(link).to have_css("span.sr-only", visible: :all)
+
+    # Regression: a single-transaction delete of a linked range must
+    # leave no orphan widget. The widget is registered with `side: -1`,
+    # so PM's `WidgetType.map` resolves its position with `assoc = -1`
+    # when the link is replaced with an empty slice, finds the anchor
+    # inside the deleted content, and reports `deleted: true`. PM drops
+    # the decoration automatically — no rebuild in this plugin is
+    # needed.
+    #
+    # If `side`, the apply gate, or buildDecorations ever stops
+    # preserving this, a phantom empty <a> with the sr-only hint would
+    # survive at the deletion seam and screen readers would announce a
+    # link to nowhere. This test fails before that ships.
+    #
+    # Selection uses a DOM Range over the link's text node (the widget
+    # span is contenteditable=false and excluded). Delete goes through
+    # the W3C actions API because Selenium's send_keys doesn't
+    # propagate Backspace/Delete to PM's editable in this shadow-DOM
+    # setup.
+    page.execute_script(<<~JS)
+      const root = document.querySelector('op-block-note').shadowRoot;
+      const a = root.querySelector('a[target="_blank"]');
+      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, textNode.textContent.length);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    JS
+    page.driver.browser.action.send_keys(:delete).perform
+
+    expect(editor.element).to have_no_css("a[target='_blank']", visible: :all)
+    expect(editor.element).to have_no_css("span.sr-only", visible: :all)
+  end
+
   it "does not rewrite internal links or attach the sr-only hint" do
     editor.paste_links(text: "Internal Link", url: root_url)
 

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -158,6 +158,38 @@ RSpec.describe "External links in BlockNote editor",
     expect(editor.element).to have_no_css("span.sr-only", visible: :all)
   end
 
+  it "preserves the hint when text is deleted from the end of a surviving link" do
+    editor.paste_links(text: "Trim Me Tail", url: "https://example.com/tail")
+    link = editor.shadow_root.find("a[target='_blank']", text: "Trim Me Tail", wait: 5)
+    expect(link).to have_css("span.sr-only", visible: :all)
+
+    # Edits inside an existing link produce a ReplaceStep whose slice carries
+    # no link mark (the mark is inherited from stored marks, not the slice),
+    # so the apply gate routes through decoration mapping rather than a
+    # rebuild. The widget sits at the end of the link run with `side: -1`;
+    # the mapping must shrink the run from the right and keep the widget
+    # attached to the new tail. If that ever regresses, the hint either
+    # disappears or ends up orphaned at a stale position.
+    page.execute_script(<<~JS)
+      const root = document.querySelector('op-block-note').shadowRoot;
+      const a = root.querySelector('a[target="_blank"]');
+      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
+      const len = textNode.textContent.length;
+      const range = document.createRange();
+      range.setStart(textNode, len - 4);
+      range.setEnd(textNode, len);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    JS
+    page.driver.browser.action.send_keys(:delete).perform
+
+    surviving = editor.shadow_root.find("a[target='_blank']", text: "Trim Me", wait: 5)
+    hints = surviving.all("span.sr-only", visible: :all)
+    expect(hints.size).to eq(1)
+    expect(hints.first.text(:all)).to include(I18n.t(:open_link_in_a_new_tab))
+  end
+
   it "does not rewrite internal links or attach the sr-only hint" do
     editor.paste_links(text: "Internal Link", url: root_url)
 

--- a/modules/documents/spec/features/external_links_in_block_note_spec.rb
+++ b/modules/documents/spec/features/external_links_in_block_note_spec.rb
@@ -30,64 +30,12 @@
 
 require "rails_helper"
 
-# Low-level browser actions for driving the BlockNote editor's contenteditable
-# inside its shadow root. Capybara cannot enter the shadow root for selection,
-# nor does its `send_keys` propagate Delete/Backspace into ProseMirror's
-# editable in this setup, so each helper drops to the Selenium driver: either
-# running JS via `execute_script` or issuing raw keystrokes via the W3C
-# actions API.
-module BlockNoteEditorBrowserActions
-  # Selects a text range inside the first external link in the editor.
-  # `start_offset` and `end_offset` follow String-slicing conventions: a
-  # non-negative integer is an absolute offset from the start of the link's
-  # text node; a negative integer counts back from the end; `nil` maps to the
-  # text length. Default arguments select the entire link text.
-  def select_text_in_external_link(start_offset: 0, end_offset: nil)
-    page.execute_script(<<~JS, start_offset, end_offset)
-      const root = document.querySelector('op-block-note').shadowRoot;
-      const a = root.querySelector('a[target="_blank"]');
-      const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
-      const len = textNode.textContent.length;
-      const resolve = (v) => (v == null ? len : (v < 0 ? len + v : v));
-      const range = document.createRange();
-      range.setStart(textNode, resolve(arguments[0]));
-      range.setEnd(textNode, resolve(arguments[1]));
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
-    JS
-  end
-
-  # Forward Delete via the W3C actions API; pair with a selection helper.
-  def send_forward_delete
-    page.driver.browser.action.send_keys(:delete).perform
-  end
-
-  # Fires a paste ClipboardEvent on the editor with both HTML and plain-text
-  # payloads. Exercises ProseMirror's `transformPasted` path, which behaves
-  # differently from typed input.
-  def paste_clipboard_into(editor_element, html:, plain:)
-    editor_element.click
-    page.execute_script(<<~JS, editor_element.native, html, plain)
-      const target = arguments[0];
-      const dt = new DataTransfer();
-      dt.setData('text/html', arguments[1]);
-      dt.setData('text/plain', arguments[2]);
-      target.dispatchEvent(new ClipboardEvent('paste', {
-        clipboardData: dt,
-        bubbles: true,
-        cancelable: true,
-      }));
-    JS
-  end
-end
-
 RSpec.describe "External links in BlockNote editor",
                :js,
                :selenium,
                with_settings: { real_time_text_collaboration_enabled: true } do
   include_context "with hocuspocus"
-  include BlockNoteEditorBrowserActions
+  include FormFields::Primerized::BlockNoteEditorBrowserActions
 
   let(:admin) { create(:admin) }
   let(:document) { create(:document, :collaborative) }

--- a/spec/support/form_fields/primerized/block_note_editor_browser_actions.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_browser_actions.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module FormFields
+  module Primerized
+    # Low-level browser actions for driving the BlockNote editor's
+    # contenteditable inside its shadow root. Capybara cannot enter the shadow
+    # root for selection, nor does its `send_keys` propagate Delete/Backspace
+    # into ProseMirror's editable in this setup, so each helper drops to the
+    # Selenium driver: either running JS via `execute_script` or issuing raw
+    # keystrokes via the W3C actions API.
+    #
+    # Sibling to BlockNoteEditorInput (the high-level page object): keep
+    # raw-driver concerns here so the page object stays focused on semantic
+    # actions like `paste_links` or `attach_file`.
+    module BlockNoteEditorBrowserActions
+      # Selects a text range inside the first external link in the editor.
+      # `start_offset` and `end_offset` follow String-slicing conventions: a
+      # non-negative integer is an absolute offset from the start of the
+      # link's text node; a negative integer counts back from the end; `nil`
+      # maps to the text length. Default arguments select the entire link
+      # text.
+      def select_text_in_external_link(start_offset: 0, end_offset: nil)
+        page.execute_script(<<~JS, start_offset, end_offset)
+          const root = document.querySelector('op-block-note').shadowRoot;
+          const a = root.querySelector('a[target="_blank"]');
+          const textNode = [...a.childNodes].find((n) => n.nodeType === 3);
+          const len = textNode.textContent.length;
+          const resolve = (v) => (v == null ? len : (v < 0 ? len + v : v));
+          const range = document.createRange();
+          range.setStart(textNode, resolve(arguments[0]));
+          range.setEnd(textNode, resolve(arguments[1]));
+          const sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+        JS
+      end
+
+      # Forward Delete via the W3C actions API; pair with a selection helper.
+      def send_forward_delete
+        page.driver.browser.action.send_keys(:delete).perform
+      end
+
+      # Fires a paste ClipboardEvent on the editor with both HTML and
+      # plain-text payloads. Exercises ProseMirror's `transformPasted` path,
+      # which behaves differently from typed input.
+      def paste_clipboard_into(editor_element, html:, plain:)
+        editor_element.click
+        page.execute_script(<<~JS, editor_element.native, html, plain)
+          const target = arguments[0];
+          const dt = new DataTransfer();
+          dt.setData('text/html', arguments[1]);
+          dt.setData('text/plain', arguments[2]);
+          target.dispatchEvent(new ClipboardEvent('paste', {
+            clipboardData: dt,
+            bubbles: true,
+            cancelable: true,
+          }));
+        JS
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73721

Stacked on top of #22696 so it can ship independently once that lands.

# What are you trying to accomplish?

Make external links inside the BlockNote editor announce "opens in new tab" to screen readers. Today, VoiceOver and NVDA don't announce anything when a user focuses one of those links inside the editor, so blind users get no warning that a click will open a new window.

Reviewer @bsatarnejad [flagged this on the predecessor PR](https://github.com/opf/openproject/pull/22696#issuecomment-4251424835) after testing with both VoiceOver and NVDA: `aria-describedby` was not announced in either screen reader, even when the attribute was moved directly onto the `<a>` element.

# What approach did you choose and why?

`aria-describedby` is unreliable inside `contenteditable`. Both VoiceOver and NVDA switch to edit mode there and stop announcing supplementary ARIA attributes — this is well-documented AT behavior, not a BlockNote-specific bug. The only approach that survives edit mode is to make the hint part of the link's **accessible name**, i.e. include it in the `<a>` tag's text content.

We use a BlockNote native extension (`ExternalLinkA11yExtension`) that adds a ProseMirror widget decoration wrapped in the link mark:

```html
<a href="..." target="_blank" rel="...">
  Link text
  <span class="sr-only" contenteditable="false">Open link in a new tab</span>
</a>
```

Because the widget has `marks: [linkMark]`, ProseMirror renders it inside the anchor. Because widget decorations don't mutate the document model, there's no DOMObserver re-render loop and the hint text never enters the Y.Doc or HTML export — it's a render-time concern, not persisted content. `side: -1` keeps the widget attached to the preceding link run on insertion.

The extension handles a few edge cases:
- Links split across multiple inline nodes (e.g. link text with a nested bold mark) get exactly one hint, via a `sameLinkContinues` coalescing check.
- A one-time `console.warn` surfaces regressions if `#open-blank-target-link-description` (rendered in `base.html.erb`, source of the translated hint string) goes missing.
- The shadow-DOM clone of that span is removed — widget text reads from the main-document span, so the IDREF resolution trick is no longer needed.

## Collaboration safety

Reviewed by the local-first architect agent: widget decorations are view-layer only, so Y.Doc state, awareness cursors, remote selections, and Hocuspocus sync are all unaffected. The sr-only text is never serialized.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)