### PR TITLE
[74320] Details tab navigation arrow / symbol disappears after first selection

### DIFF
--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
@@ -59,6 +59,8 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
 
   private pane:Element;
 
+  private resizeObserver:ResizeObserver;
+
   private debouncedTabActivationTimeout:ReturnType<typeof setTimeout>|null;
 
   private dragTargetStack = 0;
@@ -75,7 +77,9 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
     this.container = this.scrollContainer.nativeElement as HTMLElement;
     this.pane = this.scrollPane.nativeElement as HTMLElement;
 
-    this.updateScrollableArea();
+    this.resizeObserver = new ResizeObserver(() => this.updateScrollableArea());
+    this.resizeObserver.observe(this.container);
+
     this
       .uiRouterGlobals
       .params$
@@ -87,6 +91,11 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
           this.currentTabId = params.tabIdentifier as string;
         }
       });
+  }
+
+  override ngOnDestroy():void {
+    this.resizeObserver?.disconnect();
+    super.ngOnDestroy();
   }
 
   ngOnChanges(_changes:SimpleChanges):void {
@@ -107,7 +116,11 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
     return this.counters[tab.id];
   }
 
-  private updateScrollableArea() {
+  private updateScrollableArea():void {
+    if (!this.pane || !this.container) {
+      return;
+    }
+
     this.determineScrollButtonVisibility();
     if (this.currentTabId != null) {
       this.scrollIntoVisibleArea(this.currentTabId);
@@ -192,7 +205,11 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
   }
 
   private scrollIntoVisibleArea(tabId:string) {
-    const tab = this.pane.querySelector<HTMLElement>(`[data-tab-id=${tabId}]`)!;
+    const tab = this.pane.querySelector<HTMLElement>(`[data-tab-id=${tabId}]`);
+    if (!tab) {
+      return;
+    }
+
     const position = getPosition(tab);
     const tabRightBorderAt = position.left + tab.offsetWidth;
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74320

# What are you trying to accomplish?
Use ResizeObserver to defer scroll area initialization until the container has been laid out by the browser


# What approach did you choose and why?
When clicking a tab that triggers a `Turbo.visit()`, the `ScrollableTabsComponent` was re-initialized before the browser had computed the layout of the new DOM elements. As a result, `clientWidth`, `scrollWidth` and `scrollLeft` were all 0, causing the scroll buttons to always be hidden and the active tab not being scrolled into view.

The fix introduces a `ResizeObserver` on the container element. The observer fires as soon as the browser has computed the layout and guarantees that dimension reads are accurate regardless of
how long Turbo needs to finish rendering. As a side effect, the component now also correctly recalculates scroll button visibility on window resize.