### PR TITLE
[73736] Jira migrator: invalid byte sequence in utf 8

### DIFF
--- a/app/services/import/jira_wiki_markup/parser.rb
+++ b/app/services/import/jira_wiki_markup/parser.rb
@@ -515,7 +515,9 @@ module Import
         return if inner[-1] == " "
         return if followed_by_word?(rest, close_idx)
 
-        scanner.pos += 1 + close_idx + 1
+        # StringScanner#pos is byte-based; advance by byte length, not char count,
+        # so multi-byte UTF-8 content inside the delimiters does not land pos mid-character.
+        scanner.pos += inner.bytesize + 2
         inner
       end
 
@@ -549,7 +551,8 @@ module Import
         after = rest[(close_idx + 1)..]
         return if after.present? && after[0] == "~"
 
-        scanner.pos += 1 + close_idx + 1
+        # StringScanner#pos is byte-based; advance by byte length to stay on a char boundary.
+        scanner.pos += inner.bytesize + 2
         inner
       end
 

--- a/app/services/import/jira_wiki_markup/parser.rb
+++ b/app/services/import/jira_wiki_markup/parser.rb
@@ -46,10 +46,16 @@ module Import
       )
 
       def initialize(text)
-        @text = text.dup
+        # Normalize any input into a safe, mutable UTF-8 string: nil becomes "",
+        # and invalid byte sequences are dropped so downstream regex/StringScanner
+        # operations cannot raise ArgumentError on malformed input.
+        @text = text.to_s.dup
+        @text.scrub!("") unless @text.valid_encoding?
       end
 
       def parse
+        return N::Document.new(children: []) if @text.blank?
+
         preprocess
         blocks = parse_blocks
         N::Document.new(children: blocks)

--- a/app/services/import/jira_wiki_markup/parser.rb
+++ b/app/services/import/jira_wiki_markup/parser.rb
@@ -50,7 +50,7 @@ module Import
         # and invalid byte sequences are dropped so downstream regex/StringScanner
         # operations cannot raise ArgumentError on malformed input.
         @text = text.to_s.dup
-        @text.scrub!("") unless @text.valid_encoding?
+        @text.scrub!("?") unless @text.valid_encoding?
       end
 
       def parse

--- a/app/services/import/jira_wiki_markup/parser.rb
+++ b/app/services/import/jira_wiki_markup/parser.rb
@@ -535,7 +535,7 @@ module Import
       def scan_subscript(scanner, buffer, nodes)
         return unless scanner.rest[0] == "~"
 
-        scanned = scanner.string[0...scanner.pos]
+        scanned = scanner.string.byteslice(0, scanner.pos)
         return if (scanned + buffer).end_with?("~")
 
         inner = extract_subscript_content(scanner)

--- a/app/services/import/jira_wiki_markup_converter.rb
+++ b/app/services/import/jira_wiki_markup_converter.rb
@@ -35,8 +35,6 @@ module Import
     end
 
     def convert
-      return "" if @text.blank?
-
       ast = JiraWikiMarkup::Parser.new(@text).parse
       JiraWikiMarkup::Renderer.new(ast).render
     end

--- a/app/workers/import/jira_fetch_and_import_projects_job.rb
+++ b/app/workers/import/jira_fetch_and_import_projects_job.rb
@@ -102,8 +102,6 @@ module Import
     end
 
     def collect_markup_mentions(text, mention_usernames)
-      return if text.blank?
-
       ast = JiraWikiMarkup::Parser.new(text).parse
       collect_mentions_from_node(ast, mention_usernames)
     end

--- a/spec/services/import/jira_wiki_markup_converter_spec.rb
+++ b/spec/services/import/jira_wiki_markup_converter_spec.rb
@@ -51,6 +51,38 @@ RSpec.describe Import::JiraWikiMarkupConverter do
 
       it { is_expected.to eq("This is not {code} and not [a link]") }
     end
+
+    context "with invalid UTF-8 byte sequences in the input" do
+      it "drops a stray invalid byte and keeps the surrounding text" do
+        input = "Hello \xFF world".dup
+        expect(input.valid_encoding?).to be(false)
+        expect(described_class.new(input).convert).to eq("Hello  world")
+      end
+
+      it "drops a stray continuation byte" do
+        input = "abc \x80 def".dup
+        expect(input.valid_encoding?).to be(false)
+        expect(described_class.new(input).convert).to eq("abc  def")
+      end
+
+      it "drops a truncated multi-byte sequence" do
+        input = "pre \xC3 post".dup
+        expect(input.valid_encoding?).to be(false)
+        expect(described_class.new(input).convert).to eq("pre  post")
+      end
+
+      it "preserves valid multi-byte characters while dropping only the invalid byte" do
+        input = "héllo \xFF world".dup
+        expect(input.valid_encoding?).to be(false)
+        expect(described_class.new(input).convert).to eq("héllo  world")
+      end
+
+      it "still parses formatting around invalid bytes inside delimiters" do
+        input = "*bold\xFFtext*".dup
+        expect(input.valid_encoding?).to be(false)
+        expect(described_class.new(input).convert).to eq("**boldtext**")
+      end
+    end
   end
 
   describe "line ending normalization" do

--- a/spec/services/import/jira_wiki_markup_converter_spec.rb
+++ b/spec/services/import/jira_wiki_markup_converter_spec.rb
@@ -241,6 +241,38 @@ RSpec.describe Import::JiraWikiMarkupConverter do
 
       it { is_expected.to eq("H<sub>2</sub>O") }
     end
+
+    context "with multi-byte UTF-8 characters inside formatting delimiters" do
+      it "handles bold with multi-byte characters" do
+        expect(described_class.new("This is *héllo* text.").convert)
+          .to eq("This is **héllo** text.")
+      end
+
+      it "handles italic with multi-byte characters" do
+        expect(described_class.new("This is _äöü_ text.").convert)
+          .to eq("This is *äöü* text.")
+      end
+
+      it "handles strikethrough with multi-byte characters" do
+        expect(described_class.new("This is -déléted- text.").convert)
+          .to eq("This is ~~déléted~~ text.")
+      end
+
+      it "handles underline with multi-byte characters" do
+        expect(described_class.new("This is +éàü+ text.").convert)
+          .to eq("This is <u>éàü</u> text.")
+      end
+
+      it "handles subscript with multi-byte characters" do
+        expect(described_class.new("H~äö~O").convert)
+          .to eq("H<sub>äö</sub>O")
+      end
+
+      it "handles multiple formatted multi-byte segments in one line" do
+        expect(described_class.new("*éé* and _öü_").convert)
+          .to eq("**éé** and *öü*")
+      end
+    end
   end
 
   describe "links" do

--- a/spec/services/import/jira_wiki_markup_converter_spec.rb
+++ b/spec/services/import/jira_wiki_markup_converter_spec.rb
@@ -304,6 +304,38 @@ RSpec.describe Import::JiraWikiMarkupConverter do
         expect(described_class.new("*éé* and _öü_").convert)
           .to eq("**éé** and *öü*")
       end
+
+      it "handles Arabic inside bold" do
+        expect(described_class.new("*مرحبا*").convert).to eq("**مرحبا**")
+      end
+
+      it "handles Chinese inside bold" do
+        expect(described_class.new("*你好*").convert).to eq("**你好**")
+      end
+
+      it "handles Japanese inside italic" do
+        expect(described_class.new("_日本語_").convert).to eq("*日本語*")
+      end
+
+      it "handles Cyrillic inside bold" do
+        expect(described_class.new("*Привет*").convert).to eq("**Привет**")
+      end
+
+      it "handles Hebrew inside bold" do
+        expect(described_class.new("*שלום*").convert).to eq("**שלום**")
+      end
+
+      it "handles 4-byte emoji inside bold" do
+        expect(described_class.new("*🎉*").convert).to eq("**🎉**")
+      end
+
+      it "handles subscript after a macro preceded by a multi-byte character" do
+        # Regression: scanner.string[0...scanner.pos] mixed byte-pos with char-slicing,
+        # causing "é*x*~2~" to spuriously "see" the closing ~ in the already-scanned
+        # prefix and skip subscript parsing.
+        expect(described_class.new("é*x*~2~").convert).to eq("é**x**<sub>2</sub>")
+        expect(described_class.new("🎉*x*~2~").convert).to eq("🎉**x**<sub>2</sub>")
+      end
     end
   end
 

--- a/spec/services/import/jira_wiki_markup_converter_spec.rb
+++ b/spec/services/import/jira_wiki_markup_converter_spec.rb
@@ -56,31 +56,31 @@ RSpec.describe Import::JiraWikiMarkupConverter do
       it "drops a stray invalid byte and keeps the surrounding text" do
         input = "Hello \xFF world".dup
         expect(input.valid_encoding?).to be(false)
-        expect(described_class.new(input).convert).to eq("Hello  world")
+        expect(described_class.new(input).convert).to eq("Hello ? world")
       end
 
       it "drops a stray continuation byte" do
         input = "abc \x80 def".dup
         expect(input.valid_encoding?).to be(false)
-        expect(described_class.new(input).convert).to eq("abc  def")
+        expect(described_class.new(input).convert).to eq("abc ? def")
       end
 
       it "drops a truncated multi-byte sequence" do
         input = "pre \xC3 post".dup
         expect(input.valid_encoding?).to be(false)
-        expect(described_class.new(input).convert).to eq("pre  post")
+        expect(described_class.new(input).convert).to eq("pre ? post")
       end
 
       it "preserves valid multi-byte characters while dropping only the invalid byte" do
         input = "héllo \xFF world".dup
         expect(input.valid_encoding?).to be(false)
-        expect(described_class.new(input).convert).to eq("héllo  world")
+        expect(described_class.new(input).convert).to eq("héllo ? world")
       end
 
       it "still parses formatting around invalid bytes inside delimiters" do
         input = "*bold\xFFtext*".dup
         expect(input.valid_encoding?).to be(false)
-        expect(described_class.new(input).convert).to eq("**boldtext**")
+        expect(described_class.new(input).convert).to eq("**bold?text**")
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/jira-migration/work_packages/73736/activity

# What are you trying to achieve?
The import fails and stops because the wiki-markup converter struggles with some strings. Unfortunately, we don't know what exact string causes this issue.

## Screenshots
<img width="800" height="97" alt="image" src="https://github.com/user-attachments/assets/60705c39-c737-4c4d-adbb-30c70057cd77" />

# What approach did you choose and why?
1. make sure our own text wrangling does not produce invalid sequences
2. make sure the converter can handle all kinds of multi-byte languages
3. strip (`scrub`) all invalid sequences before starting the parsing coming from the Jira input

# Merge checklist

- [x] Added/updated tests
