### PR TITLE
[#74311] Use displayId on primerized split-view full-screen link icon

### DIFF
--- a/app/components/work_packages/details/tab_component.html.erb
+++ b/app/components/work_packages/details/tab_component.html.erb
@@ -70,7 +70,7 @@
           icon: :"screen-full",
           tag: :a,
           classes: "hidden-for-small-laptops",
-          href: work_package_path(work_package.id, full_screen_tab),
+          href: work_package_path(work_package.display_id, full_screen_tab),
           target: "_top",
           scheme: :invisible,
           test_selector: "wp-details-tab-component--full-screen",

--- a/spec/components/work_packages/details/tab_component_spec.rb
+++ b/spec/components/work_packages/details/tab_component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPackages::Details::TabComponent, type: :component do
+  include OpenProject::StaticRouting::UrlHelpers
+
+  let(:project)      { create(:project, identifier: "MYPROJ") }
+  let(:work_package) { create(:work_package, project:) }
+
+  before do
+    allow(Setting::WorkPackageIdentifier).to receive_messages(semantic?: true, classic?: false)
+    work_package # realize before render so after_create registration runs
+  end
+
+  subject do
+    with_controller_class(NotificationsController) do
+      with_request_url("/notifications/details/:work_package_id") do
+        render_inline(described_class.new(work_package:, base_route: notifications_path))
+      end
+    end
+  end
+
+  describe "full-screen link" do
+    it "uses the semantic displayId in the href" do
+      subject
+
+      expect(work_package.display_id).to eq("MYPROJ-1")
+      full_screen = page.find("[data-test-selector='wp-details-tab-component--full-screen']")
+      expect(full_screen[:href]).to include("/work_packages/MYPROJ-1")
+      expect(full_screen[:href]).not_to include("/work_packages/#{work_package.id}/")
+    end
+  end
+end

--- a/spec/components/work_packages/details/tab_component_spec.rb
+++ b/spec/components/work_packages/details/tab_component_spec.rb
@@ -8,10 +8,7 @@ RSpec.describe WorkPackages::Details::TabComponent, type: :component do
   let(:project)      { create(:project, identifier: "MYPROJ") }
   let(:work_package) { create(:work_package, project:) }
 
-  before do
-    allow(Setting::WorkPackageIdentifier).to receive_messages(semantic?: true, classic?: false)
-    work_package # realize before render so after_create registration runs
-  end
+  before { work_package } # realize before render so after_create registration runs
 
   subject do
     with_controller_class(NotificationsController) do
@@ -22,13 +19,17 @@ RSpec.describe WorkPackages::Details::TabComponent, type: :component do
   end
 
   describe "full-screen link" do
-    it "uses the semantic displayId in the href" do
-      subject
+    context "in semantic mode",
+            with_flag: { semantic_work_package_ids: true },
+            with_settings: { work_packages_identifier: "semantic" } do
+      it "uses the semantic displayId in the href" do
+        subject
 
-      expect(work_package.display_id).to eq("MYPROJ-1")
-      full_screen = page.find("[data-test-selector='wp-details-tab-component--full-screen']")
-      expect(full_screen[:href]).to include("/work_packages/MYPROJ-1")
-      expect(full_screen[:href]).not_to include("/work_packages/#{work_package.id}/")
+        expect(work_package.display_id).to eq("MYPROJ-1")
+        full_screen = page.find("[data-test-selector='wp-details-tab-component--full-screen']")
+        expect(full_screen[:href]).to include("/work_packages/MYPROJ-1")
+        expect(full_screen[:href]).not_to include("/work_packages/#{work_package.id}/")
+      end
     end
   end
 end

--- a/spec/components/work_packages/details/tab_component_spec.rb
+++ b/spec/components/work_packages/details/tab_component_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe WorkPackages::Details::TabComponent, type: :component do
   include OpenProject::StaticRouting::UrlHelpers
 
-  let(:project)      { create(:project, identifier: "MYPROJ") }
   let(:work_package) { create(:work_package, project:) }
 
   before { work_package } # realize before render so after_create registration runs
@@ -22,6 +21,8 @@ RSpec.describe WorkPackages::Details::TabComponent, type: :component do
     context "in semantic mode",
             with_flag: { semantic_work_package_ids: true },
             with_settings: { work_packages_identifier: "semantic" } do
+      let(:project) { create(:project, identifier: "MYPROJ") }
+
       it "uses the semantic displayId in the href" do
         subject
 
@@ -29,6 +30,20 @@ RSpec.describe WorkPackages::Details::TabComponent, type: :component do
         full_screen = page.find("[data-test-selector='wp-details-tab-component--full-screen']")
         expect(full_screen[:href]).to include("/work_packages/MYPROJ-1")
         expect(full_screen[:href]).not_to include("/work_packages/#{work_package.id}/")
+      end
+    end
+
+    context "in classic mode",
+            with_flag: { semantic_work_package_ids: false },
+            with_settings: { work_packages_identifier: "classic" } do
+      let(:project) { create(:project, identifier: "myproj") }
+
+      it "uses the numeric id in the href" do
+        subject
+
+        expect(work_package.display_id).to eq(work_package.id)
+        full_screen = page.find("[data-test-selector='wp-details-tab-component--full-screen']")
+        expect(full_screen[:href]).to include("/work_packages/#{work_package.id}/")
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/74311

Follow-up from the PR 22733 review: https://github.com/opf/openproject/pull/22733#pullrequestreview-4152467748

## Screenshots

Verified at `/notifications/details/10244` — primerized split-view (notifications inbox).

**Before** — full-screen icon points to the numeric PK:

<img width="1800" height="1000" alt="pr22901-before-numeric" src="https://github.com/user-attachments/assets/67629bc5-4251-4af6-8365-748cf0737178" />

**After** — full-screen icon points to the semantic `displayId`:

<img width="1800" height="1000" alt="pr22901-after-semantic" src="https://github.com/user-attachments/assets/8b226ded-bd84-4e20-8aa7-13ef56bb5463" />


## Fix

The full-screen icon link in the shared `WorkPackages::Details::TabComponent` passed `work_package.id`; switched to `work_package.display_id`. Single partial, so every primerized split-view host (Boards, Notifications, …) is covered. Component spec asserts the href carries the semantic identifier in semantic mode and the numeric id in classic mode.