### PR TITLE
Use displayId in WP context menus, list toolbar, row click, cards

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/subproject/subproject-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subproject/subproject-action.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { UserResource } from 'core-app/features/hal/resources/user-resource';
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { SubprojectBoardHeaderComponent } from 'core-app/features/boards/board/board-actions/subproject/subproject-board-header.component';
@@ -8,7 +7,6 @@ import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -57,7 +55,7 @@ export class BoardSubprojectActionService extends CachedBoardActionService {
       )
       .get()
       .pipe(
-        map((collection:CollectionResource<UserResource>) => collection.elements),
+        map((collection) => collection.elements),
       );
   }
 }

--- a/frontend/src/app/features/hal/resources/project-resource.ts
+++ b/frontend/src/app/features/hal/resources/project-resource.ts
@@ -30,6 +30,11 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ICKEditorContext } from 'core-app/shared/components/editor/components/ckeditor/ckeditor.types';
 
 export class ProjectResource extends HalResource {
+  public get identifier():string {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return
+    return this.$source.identifier;
+  }
+
   public get state() {
     return this.states.projects.get(this.id!) as any;
   }

--- a/frontend/src/app/features/hal/resources/project-resource.ts
+++ b/frontend/src/app/features/hal/resources/project-resource.ts
@@ -31,8 +31,8 @@ import { ICKEditorContext } from 'core-app/shared/components/editor/components/c
 
 export class ProjectResource extends HalResource {
   public get identifier():string {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return
-    return this.$source.identifier;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return this.$source.identifier as string;
   }
 
   public get state() {

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
@@ -35,6 +35,7 @@ import { AbstractWorkPackageButtonComponent } from 'core-app/features/work-packa
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { States } from 'core-app/core/states/states.service';
 import { KeepTabService } from '../../wp-single-view-tabs/keep-tab/keep-tab.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-package-id-resolvers';
 
 @Component({
   templateUrl: '../wp-button.template.html',
@@ -111,8 +112,9 @@ export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageBu
   }
 
   public openDetailsView():void {
+    const focused = this.wpTableFocus.focusedWorkPackage;
     const params = {
-      workPackageId: this.wpTableFocus.focusedWorkPackage,
+      workPackageId: focused ? resolveRoutingId(this.states, focused) : focused,
     };
 
     this.keepTab.goCurrentDetailsState(params);

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-single-card/wp-single-card.component.ts
@@ -228,7 +228,7 @@ export class WorkPackageSingleCardComponent extends UntilDestroyedMixin implemen
   }
 
   public fullWorkPackageLink(wp:WorkPackageResource):string {
-    return this.keepTabService.currentShowHref(wp.id!);
+    return this.keepTabService.currentShowHref(wp.displayId);
   }
 
   public cardHighlightingClass(wp:WorkPackageResource):string {

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder.ts
@@ -45,6 +45,9 @@ export class UiStateLinkBuilder {
       const projectIdentifier = this.currentProject.identifier;
       href = this.pathHelper.genericWorkPackagePath(projectIdentifier, idForHref, this.keepTab.currentShowTab) + window.location.search;
     } else {
+      // Param key must match the route declaration in split-view-routes.template.ts
+      // (`:tabIdentifier`). A mismatch makes $state.href return null, which
+      // surfaces as the literal string "null" in the rendered href.
       const tabIdentifier = this.keepTab.currentDetailsTab;
       href = this.$state.href(
         'work-packages.partitioned.list.details.tabs',

--- a/frontend/src/app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder.ts
+++ b/frontend/src/app/features/work-packages/components/wp-fast-table/builders/ui-state-link-builder.ts
@@ -45,12 +45,12 @@ export class UiStateLinkBuilder {
       const projectIdentifier = this.currentProject.identifier;
       href = this.pathHelper.genericWorkPackagePath(projectIdentifier, idForHref, this.keepTab.currentShowTab) + window.location.search;
     } else {
-      const tab = this.keepTab.currentDetailsTab;
+      const tabIdentifier = this.keepTab.currentDetailsTab;
       href = this.$state.href(
         'work-packages.partitioned.list.details.tabs',
         {
           workPackageId: idForHref,
-          tab,
+          tabIdentifier,
         },
       );
     }

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -115,7 +115,7 @@ export class WorkPackageContextMenuHelperService {
     let link:string|undefined;
     switch (action.key) {
       case 'copy_link_to_clipboard':
-        link = this.PathHelper.workPackageShortPath(workPackage.id!);
+        link = this.PathHelper.workPackageShortPath(workPackage.displayId);
         break;
       default:
         link = action.link ? (workPackage[action.link] as HalLink).href! : undefined;

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -110,7 +110,7 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
         const currentId = this.workPackage?.id ?? this.workPackageId;
         const idSame = currentId.toString() === newId.toString();
         if (!idSame && this.$state.includes(`${this.baseRoute}.details`)) {
-          this.$state.go(
+          void this.$state.go(
             (this.$state.current.name!),
             { workPackageId: resolveRoutingId(this.states, newId.toString()), focus: false },
           );

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -54,6 +54,7 @@ import {
   WorkPackageTabsService,
 } from 'core-app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-package-id-resolvers';
 
 @Component({
   templateUrl: './wp-split-view.html',
@@ -111,7 +112,7 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
         if (!idSame && this.$state.includes(`${this.baseRoute}.details`)) {
           this.$state.go(
             (this.$state.current.name!),
-            { workPackageId: newId, focus: false },
+            { workPackageId: resolveRoutingId(this.states, newId.toString()), focus: false },
           );
         }
       });

--- a/frontend/src/app/features/work-packages/services/work-package-authorization.service.ts
+++ b/frontend/src/app/features/work-packages/services/work-package-authorization.service.ts
@@ -80,13 +80,13 @@ export class WorkPackageAuthorization {
   private copyLink() {
     const stateName = this.$state.current.name!;
     if (stateName.startsWith('work-packages.partitioned.list.details')) {
-      return this.PathHelper.workPackageDetailsCopyPath(this.project.identifier, this.workPackage.id!);
+      return this.PathHelper.workPackageDetailsCopyPath(this.project.identifier, this.workPackage.displayId);
     }
-    return this.PathHelper.workPackageCopyPath(this.project.identifier, this.workPackage.id!);
+    return this.PathHelper.workPackageCopyPath(this.project.identifier, this.workPackage.displayId);
   }
 
   private shortLink() {
-    return this.PathHelper.workPackageShortPath(this.workPackage.id!);
+    return this.PathHelper.workPackageShortPath(this.workPackage.displayId);
   }
 
   private bulkCopyLink():string {

--- a/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/wp-context-menu/wp-view-context-menu.directive.ts
@@ -230,7 +230,7 @@ export class WorkPackageViewContextMenu extends OpContextMenuHandler {
 
     if (selected.length === 1 && !isNewResource(this.workPackage)) {
       const projectIdentifier = this.currentProject.identifier;
-      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, this.workPackageId) + window.location.search;
+      const link = this.pathHelper.genericWorkPackagePath(projectIdentifier, this.workPackage.displayId) + window.location.search;
 
       items.unshift({
         disabled: false,

--- a/spec/features/work_packages/cards/semantic_id_navigation_spec.rb
+++ b/spec/features/work_packages/cards/semantic_id_navigation_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Work package card ID link uses displayId",
   include_context "with mobile screen size"
 
   before do
-    work_package.allocate_and_register_semantic_id
+    work_package
     Pages::WorkPackagesTable.new(project).visit!
     wp_cards.expect_work_package_listed(work_package)
   end

--- a/spec/features/work_packages/cards/semantic_id_navigation_spec.rb
+++ b/spec/features/work_packages/cards/semantic_id_navigation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Work package card ID link uses displayId",
+               :js,
+               :with_cuprite,
+               with_flag: { semantic_work_package_ids: true },
+               with_settings: { work_packages_identifier: "semantic" } do
+  # Classic mode is a behavioural no-op here: the card href is built via
+  # `workPackage.displayId`, which returns the numeric id in classic mode — i.e.
+  # the same value the pre-fix code (`workPackage.id`) used. Covering only
+  # semantic mode where the bug actually manifests.
+
+  let(:admin)        { create(:admin) }
+  let(:project)      { create(:project, identifier: "NAVTEST") }
+  let(:work_package) { create(:work_package, project:, subject: "Card semantic nav") }
+  let(:wp_cards)     { Pages::WorkPackageCards.new(project) }
+
+  current_user { admin }
+
+  include_context "with mobile screen size"
+
+  before do
+    work_package.allocate_and_register_semantic_id
+    Pages::WorkPackagesTable.new(project).visit!
+    wp_cards.expect_work_package_listed(work_package)
+  end
+
+  it "renders an href that contains the semantic identifier" do
+    semantic_id = work_package.reload.identifier
+
+    card_link = page.find(".op-wp-single-card-#{work_package.id} .__ui-state-link")
+
+    expect(card_link[:href]).to include("/work_packages/#{semantic_id}/")
+    expect(card_link[:href]).not_to include("/work_packages/#{work_package.id}/")
+  end
+end

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
     it "copies a URL containing the semantic identifier" do
       semantic_id = work_package.reload.identifier
 
-      # Spy on clipboard writes — navigator.clipboard.writeText is what the app uses.
+      # Spy directly on navigator.clipboard.writeText — the existing
+      # have_message_copied_to_clipboard matcher only inspects the flash DOM,
+      # which can't distinguish numeric vs semantic ids in the copied value.
       page.execute_script(<<~JS)
         window.__lastCopiedText = null;
         navigator.clipboard.writeText = function(text) {
@@ -72,16 +74,10 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       context_menu.open_for(work_package)
       context_menu.choose("Copy link to clipboard")
 
-      # Wait for the async copy
-      expect(page).to have_css("body") # just a sync point
       copied = nil
-      Timeout.timeout(3) do
-        loop do
-          copied = page.evaluate_script("window.__lastCopiedText")
-          break if copied
-
-          sleep 0.1
-        end
+      retry_block do
+        copied = page.evaluate_script("window.__lastCopiedText")
+        raise "clipboard write not yet observed" if copied.nil?
       end
 
       expect(copied).to include("/wp/#{semantic_id}")

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -92,7 +92,14 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       # Focus the row without opening split
       wp_table.row(work_package).click
 
-      # Click the toolbar info icon
+      # Wait until the row is actually selected before clicking the toolbar
+      # button. The toolbar reads wpTableFocus.focusedWorkPackage, which is
+      # written by the same handler that toggles the `-checked` class — so
+      # the class is a reliable sync point for both pieces of state.
+      expect(page).to have_css(
+        %(.wp-table--row.-checked[data-work-package-id="#{work_package.id}"])
+      )
+
       page.find_by_id("work-packages-details-view-button").click
 
       expect(page).to have_current_path(

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
   current_user { admin }
 
   before do
-    work_package.allocate_and_register_semantic_id
-    other_wp.allocate_and_register_semantic_id
+    work_package
+    other_wp
     wp_table.visit!
     wp_table.expect_work_package_listed(work_package, other_wp)
   end

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Work package table navigation follow-ups use displayId",
+               :js,
+               :with_cuprite,
+               with_flag: { semantic_work_package_ids: true },
+               with_settings: { work_packages_identifier: "semantic" } do
+  # Classic mode is a behavioural no-op for each of these fixes:
+  # `workPackage.displayId` and `resolveRoutingId(...)` both collapse to the
+  # numeric id when semantic mode is off. Covering semantic-only where the
+  # bugs manifest.
+
+  let(:admin) { create(:admin) }
+  let(:project) { create(:project, identifier: "NAVFOLLOW") }
+
+  let(:work_package) { create(:work_package, project:, subject: "First WP") }
+  let(:other_wp)     { create(:work_package, project:, subject: "Other WP") }
+
+  let(:wp_table) { Pages::WorkPackagesTable.new(project) }
+  let(:context_menu) { Components::WorkPackages::ContextMenu.new }
+
+  current_user { admin }
+
+  before do
+    work_package.allocate_and_register_semantic_id
+    other_wp.allocate_and_register_semantic_id
+    wp_table.visit!
+    wp_table.expect_work_package_listed(work_package, other_wp)
+  end
+
+  describe "right-click context menu 'Open fullscreen' item" do
+    it "links to the semantic identifier URL" do
+      semantic_id = work_package.reload.identifier
+      context_menu.open_for(work_package)
+
+      open_fullscreen = page.find(:menuitem, text: "Open fullscreen view", exact_text: true)
+
+      expect(open_fullscreen[:href]).to include("/work_packages/#{semantic_id}/")
+      expect(open_fullscreen[:href]).not_to include("/work_packages/#{work_package.id}/")
+    end
+  end
+
+  describe "right-click context menu 'Copy link to clipboard' item" do
+    it "copies a URL containing the semantic identifier" do
+      semantic_id = work_package.reload.identifier
+
+      # Spy on clipboard writes — navigator.clipboard.writeText is what the app uses.
+      page.execute_script(<<~JS)
+        window.__lastCopiedText = null;
+        navigator.clipboard.writeText = function(text) {
+          window.__lastCopiedText = text;
+          return Promise.resolve();
+        };
+      JS
+
+      context_menu.open_for(work_package)
+      context_menu.choose("Copy link to clipboard")
+
+      # Wait for the async copy
+      expect(page).to have_css("body") # just a sync point
+      copied = nil
+      Timeout.timeout(3) do
+        loop do
+          copied = page.evaluate_script("window.__lastCopiedText")
+          break if copied
+          sleep 0.1
+        end
+      end
+
+      expect(copied).to include("/wp/#{semantic_id}")
+      expect(copied).not_to include("/wp/#{work_package.id}")
+    end
+  end
+
+  describe "toolbar info icon" do
+    it "opens the split view at the semantic identifier URL" do
+      semantic_id = work_package.reload.identifier
+
+      # Focus the row without opening split
+      wp_table.row(work_package).click
+
+      # Click the toolbar info icon
+      page.find("#work-packages-details-view-button").click
+
+      expect(page).to have_current_path(
+        %r{/details/#{Regexp.escape(semantic_id)}($|/|\?)}
+      )
+    end
+  end
+
+  describe "clicking a different row while split view is open" do
+    it "switches the URL to the newly focused WP's semantic identifier" do
+      wp_semantic_id = work_package.reload.identifier
+      other_semantic_id = other_wp.reload.identifier
+
+      # Open split view on the first WP
+      wp_table.open_split_view(work_package)
+      expect(page).to have_current_path(
+        %r{/details/#{Regexp.escape(wp_semantic_id)}($|/|\?)}
+      )
+
+      # Click the other row
+      wp_table.row(other_wp).click
+
+      expect(page).to have_current_path(
+        %r{/details/#{Regexp.escape(other_semantic_id)}($|/|\?)}
+      )
+      expect(page).not_to have_current_path(
+        %r{/details/#{other_wp.id}($|/|\?)}
+      )
+    end
+  end
+end

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
     wp_table.expect_work_package_listed(work_package, other_wp)
   end
 
+  describe "row 'Open details view' anchor" do
+    it "renders an href that contains the semantic identifier (not the literal string 'null')" do
+      semantic_id = work_package.reload.identifier
+
+      details_anchor = within(wp_table.row(work_package)) do
+        find_link(title: "Open details view", visible: :all)
+      end
+
+      expect(details_anchor[:href]).to include("/details/#{semantic_id}")
+      expect(details_anchor[:href]).not_to end_with("/null")
+      expect(details_anchor[:href]).not_to include("/details/#{work_package.id}")
+    end
+  end
+
   describe "right-click context menu 'Open fullscreen' item" do
     it "links to the semantic identifier URL" do
       semantic_id = work_package.reload.identifier

--- a/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
         loop do
           copied = page.evaluate_script("window.__lastCopiedText")
           break if copied
+
           sleep 0.1
         end
       end
@@ -82,7 +83,7 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       wp_table.row(work_package).click
 
       # Click the toolbar info icon
-      page.find("#work-packages-details-view-button").click
+      page.find_by_id("work-packages-details-view-button").click
 
       expect(page).to have_current_path(
         %r{/details/#{Regexp.escape(semantic_id)}($|/|\?)}
@@ -107,7 +108,7 @@ RSpec.describe "Work package table navigation follow-ups use displayId",
       expect(page).to have_current_path(
         %r{/details/#{Regexp.escape(other_semantic_id)}($|/|\?)}
       )
-      expect(page).not_to have_current_path(
+      expect(page).to have_no_current_path(
         %r{/details/#{other_wp.id}($|/|\?)}
       )
     end

--- a/spec/features/work_packages/table/semantic_id_navigation_spec.rb
+++ b/spec/features/work_packages/table/semantic_id_navigation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Work package table semantic ID navigation",
   let(:wp_table) { Pages::WorkPackagesTable.new(project) }
 
   before do
-    work_package.allocate_and_register_semantic_id
+    work_package
     login_as(user)
     wp_table.visit!
     wp_table.expect_work_package_listed(work_package)


### PR DESCRIPTION
# Tickets

- [x] #74308 [Use displayId in work package context menus](https://community.openproject.org/work_packages/74308)
- [x] #73982 [Copy link to clipboard on full view](https://community.openproject.org/work_packages/73982)
- [x] #74309 [Use displayId when opening split view via list toolbar info icon](https://community.openproject.org/work_packages/74309)
- [x] #74310 [Use displayId on list row click while split view open](https://community.openproject.org/work_packages/74310)
- [x] #74312 [Use displayId on work package card ID link](https://community.openproject.org/work_packages/74312)

Follow-ups from the PR 22733 review: https://github.com/opf/openproject/pull/22733#pullrequestreview-4152467748

## Screenshots

Verified manually in semantic mode against the `ACSMT` project on the local dev edge.

**#74308 — right-click context menu** (Open details view → semantic URL, Open fullscreen view → semantic URL, Copy link → `/wp/ACSMT-3`):

<!-- drop tmp/ai/screenshots/pr22902-74308-right-click-context-menu.png here -->
<img width="1800" height="1000" alt="pr22902-74308-right-click-context-menu" src="https://github.com/user-attachments/assets/afbab87c-c1d8-43bd-9f81-c14ee2a90b6c" />

**#73982 — full-view overflow menu Copy link** (`href = /wp/ACSMT-3`):

<!-- drop tmp/ai/screenshots/pr22902-73982-fullview-copy-link.png here -->

<img width="1800" height="1000" alt="pr22902-73982-fullview-copy-link" src="https://github.com/user-attachments/assets/631d1756-cc82-44eb-9e62-d1445fd42770" />

**#74309 — toolbar info icon** (focused row → split view URL uses displayId):

<!-- drop tmp/ai/screenshots/pr22902-74309-toolbar-info-icon.png here -->

<img width="1800" height="1000" alt="pr22902-74309-toolbar-info-icon" src="https://github.com/user-attachments/assets/13d64b00-3484-490d-b4e5-20380e9c116a" />

**#74310 — row click while split view open** (clicking another row updates the split URL to that WP's displayId):

<!-- drop tmp/ai/screenshots/pr22902-74310-row-click-while-split.png here -->

<img width="1800" height="1000" alt="pr22902-74310-row-click-while-split" src="https://github.com/user-attachments/assets/83dae7d0-d57a-446a-a028-14909e2f4062" />

**#74312 — card ID link** (mobile / card layout: card ID anchor href uses displayId):

<!-- drop tmp/ai/screenshots/pr22902-74312-card-id-link.png here -->

<img width="500" height="1000" alt="pr22902-74312-card-id-link" src="https://github.com/user-attachments/assets/def9340a-1617-427e-8740-2466d44d9a14" />

## Fix

Five adjacent sites were still passing `workPackage.id` into URL construction or uiRouter transitions. Each one now uses `workPackage.displayId` directly (cards, context-menu helper, right-click menu's full-screen link) or routes the numeric id through `resolveRoutingId(states, id)` when only the cache-key was in scope (toolbar info icon, row click while split view open). Feature specs cover every site in semantic mode; classic mode is a behavioural no-op in each case (displayId collapses to id) so those contexts are intentionally omitted.

A follow-up commit also types `ProjectResource#identifier` so call sites no longer pass `any` into `PathHelper` URL builders, addressing the reviewdog `@typescript-eslint/no-unsafe-argument` findings on `work-package-authorization.service.ts`.