### PR TITLE
[#74356] All backlog state is not passed to backlog buckets

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_item_component.rb
@@ -79,8 +79,8 @@ module Backlogs
         story: true,
         controller: "backlogs--story",
         backlogs__story_id_value: work_package.id,
-        backlogs__story_split_url_value: project_backlogs_backlog_details_path(project, work_package),
-        backlogs__story_full_url_value: work_package_path(work_package),
+        backlogs__story_split_url_value: split_url,
+        backlogs__story_full_url_value: full_url,
         backlogs__story_selected_class: "Box-row--blue",
         test_selector: card_test_selector
       )
@@ -92,8 +92,20 @@ module Backlogs
       {
         draggable_id: work_package.id,
         draggable_type: "story",
-        drop_url: move_project_backlogs_inbox_path(project, work_package)
+        drop_url:
       }
+    end
+
+    def drop_url
+      move_project_backlogs_inbox_path(project, work_package, all_backlogs_params)
+    end
+
+    def split_url
+      project_backlogs_backlog_details_path(project, work_package, all_backlogs_params)
+    end
+
+    def full_url
+      work_package_path(work_package)
     end
 
     def card_test_selector

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -90,9 +90,8 @@ module Backlogs
         story: true,
         controller: "backlogs--story",
         backlogs__story_id_value: story.id,
-        backlogs__story_split_url_value: project_backlogs_backlog_details_path(project, story,
-                                                                               all_backlogs_params),
-        backlogs__story_full_url_value: work_package_path(story),
+        backlogs__story_split_url_value: split_url(story),
+        backlogs__story_full_url_value: full_url(story),
         backlogs__story_selected_class: "Box-row--blue",
         test_selector: card_test_selector(story)
       )
@@ -104,8 +103,20 @@ module Backlogs
       {
         draggable_id: story.id,
         draggable_type: "story",
-        drop_url: move_project_backlogs_work_package_path(project, sprint, story, all_backlogs_params)
+        drop_url: drop_url(story)
       }
+    end
+
+    def drop_url(story)
+      move_project_backlogs_work_package_path(project, sprint, story, all_backlogs_params)
+    end
+
+    def split_url(story)
+      project_backlogs_backlog_details_path(project, story, all_backlogs_params)
+    end
+
+    def full_url(story)
+      work_package_path(story)
     end
 
     def card_test_selector(story)

--- a/modules/backlogs/spec/components/backlogs/backlog_bucket_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/backlog_bucket_item_component_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Backlogs::BacklogBucketItemComponent, type: :component do
 
   let(:project) { create(:project) }
   let(:backlog_bucket) { create(:backlog_bucket, project:) }
-  let(:work_package) do
+  let(:show_all_backlog) { false }
+  let!(:work_package) do
     create(:work_package,
            subject: "Bucket Work Package",
            project:,
@@ -51,19 +52,18 @@ RSpec.describe Backlogs::BacklogBucketItemComponent, type: :component do
            priority: default_priority,
            position: 1)
   end
-  let(:show_all_backlog) { false }
 
-  before do
+  def render_component
     vc_test_controller.params[:all] = "1" if show_all_backlog
-    work_package
-    render_inline(
-      Backlogs::BacklogBucketComponent.new(
-        backlog_bucket:,
-        project:,
-        current_user: user
-      )
+
+    render_inline Backlogs::BacklogBucketComponent.new(
+      backlog_bucket:,
+      project:,
+      current_user: user
     )
   end
+
+  before { render_component }
 
   it "renders the work package card", :aggregate_failures do
     expect(page).to have_text("Bucket Work Package")
@@ -104,6 +104,24 @@ RSpec.describe Backlogs::BacklogBucketItemComponent, type: :component do
     end
   end
 
+  context "when show_all_backlog is active" do
+    let(:show_all_backlog) { true }
+
+    subject(:row) { page.find(".Box-row#work_package_#{work_package.id}") }
+
+    it "includes all=1 in the split-view URL" do
+      expect(row["data-backlogs--story-split-url-value"]).to include("all=1")
+    end
+
+    it "includes all=1 in the drop URL" do
+      expect(row["data-drop-url"]).to include("all=1")
+    end
+
+    it "includes all=1 in the action-menu src" do
+      expect(row).to have_css(%(include-fragment[src*="all=1"]))
+    end
+  end
+
   context "when the user lacks the manage_sprint_items permission" do
     let(:role) { create(:project_role, permissions: %i[view_sprints view_work_packages]) }
     let(:user) { create(:user, member_with_roles: { project => role }) }
@@ -117,16 +135,6 @@ RSpec.describe Backlogs::BacklogBucketItemComponent, type: :component do
       expect(row["data-draggable-id"]).to be_nil
       expect(row["data-draggable-type"]).to be_nil
       expect(row["data-drop-url"]).to be_nil
-    end
-  end
-
-  describe "with show_all_backlog true" do
-    let(:show_all_backlog) { true }
-
-    subject(:row) { page.find(".Box-row#work_package_#{work_package.id}") }
-
-    it "adds the all query to the menu fragment URL" do
-      expect(row).to have_css(%(include-fragment[src*="all=1"]))
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_item_component_spec.rb
@@ -52,16 +52,16 @@ RSpec.describe Backlogs::InboxItemComponent, type: :component do
   let(:work_packages) { WorkPackage.where(id: work_package.id).order(:position, :id) }
   let(:show_all_backlog) { false }
 
-  before do
+  def render_component
     vc_test_controller.params[:all] = "1" if show_all_backlog
-    render_inline(
-      Backlogs::InboxComponent.new(
-        work_packages:,
-        project:,
-        current_user: user
-      )
+    render_inline Backlogs::InboxComponent.new(
+      work_packages:,
+      project:,
+      current_user: user
     )
   end
+
+  before { render_component }
 
   it "rendering renders the Inbox Component", :aggregate_failures do
     # renders the work package subject

--- a/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_menu_component_spec.rb
@@ -59,14 +59,12 @@ RSpec.describe Backlogs::InboxMenuComponent, type: :component do
   def render_component(position: 2, max_position: 3, open_sprints_exist: true, show_all_backlog: false)
     work_package.update!(position:)
     vc_test_controller.params[:all] = "1" if show_all_backlog
-    render_inline(
-      described_class.new(
-        work_package:,
-        project:,
-        max_position:,
-        open_sprints_exist:,
-        current_user: user
-      )
+    render_inline described_class.new(
+      work_package:,
+      project:,
+      max_position:,
+      open_sprints_exist:,
+      current_user: user
     )
   end
 

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
 
       context "when params[:all] is true" do
-        before { vc_test_controller.params.merge!(all: "1") }
+        before { vc_test_controller.params[:all] = "1" }
 
         it "includes the all param on story drop URLs" do
           render_component

--- a/modules/backlogs/spec/components/backlogs/story_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_component_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Backlogs::StoryComponent, type: :component do
   end
 
   context "when params[:all] is true" do
-    before { vc_test_controller.params.merge!(all: "1") }
+    before { vc_test_controller.params[:all] = "1" }
 
     it "includes the all param on the deferred menu src" do
       render_component

--- a/modules/backlogs/spec/components/backlogs/story_menu_list_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/story_menu_list_component_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Backlogs::StoryMenuListComponent, type: :component do
     end
 
     context "when params[:all] is true" do
-      before { vc_test_controller.params.merge!(all: "1") }
+      before { vc_test_controller.params[:all] = "1" }
 
       it "adds the all param to the open details href" do
         render_component
@@ -256,7 +256,7 @@ RSpec.describe Backlogs::StoryMenuListComponent, type: :component do
     end
 
     context "when params[:all] is true" do
-      before { vc_test_controller.params.merge!(all: "1") }
+      before { vc_test_controller.params[:all] = "1" }
 
       it "adds the all param to the move to sprint href" do
         render_component(open_sprints_exist: true)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74356

# What are you trying to accomplish?
Maintain the Backlog expanded state when manipulating Backlog Bucket items.

# What approach did you choose and why?
Apply the `"all"` parameter to the `BacklogBucketItemComponent` in order to maintain the expanded state.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
