### PR TITLE
[#74313] Use displayId on notification center work package click

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -19,7 +19,7 @@
         [class.spot-link_inactive]="isMobile()"
         [attr.title]="workPackage.subject"
         [textContent]="workPackage.formattedId"
-        [attr.href]="fullScreenLink()"
+        [attr.href]="pathHelper.workPackagePath(workPackage.displayId)"
         (click)="onLinkClick($event)"
         >
       </a>

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.html
@@ -7,7 +7,7 @@
   (keydown.space)="$event.preventDefault(); onClick()"
   (dblclick)="onDoubleClick()"
   >
-  @if (workPackage$ && (workPackage$ | async); as workPackage) {
+  @if (workPackage$ | async; as workPackage) {
     <div
       class="op-ian-item--top-line"
       >
@@ -108,7 +108,7 @@
 </div>
 } @else {
   <div class="op-ian-item--loading">
-    @if (workPackage$) {
+    @if (workPackageId) {
       <op-content-loader
         class="op-ian-item--loading-indicator"
         viewBox="0 0 200 20"

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -11,8 +12,6 @@ import { INotification } from 'core-app/core/state/in-app-notifications/in-app-n
 import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { UrlParamsService } from 'core-app/core/navigation/url-params.service';
-import { States } from 'core-app/core/states/states.service';
-import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-package-id-resolvers';
 
 @Component({
   selector: 'op-in-app-notification-entry',
@@ -51,6 +50,11 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   private workPackageId:string|null;
 
+  // The loaded work package, captured via tap() on workPackage$. Click handlers
+  // prefer this.workPackage.displayId so the URL carries the semantic identifier;
+  // fall back to the numeric PK if the resource hasn't emitted yet.
+  private workPackage:WorkPackageResource|null = null;
+
   constructor(
     readonly apiV3Service:ApiV3Service,
     readonly I18n:I18nService,
@@ -59,15 +63,11 @@ export class InAppNotificationEntryComponent implements OnInit {
     readonly pathHelper:PathHelperService,
     readonly deviceService:DeviceService,
     readonly urlParams:UrlParamsService,
-    readonly states:States,
   ) {
   }
 
-  // The notification's HAL link gives us the numeric primary key. For URL
-  // construction we prefer the semantic displayId so the user-visible URL
-  // carries the readable identifier once the WP is cached.
   private routingId():string {
-    return this.workPackageId ? resolveRoutingId(this.states, this.workPackageId) : '';
+    return this.workPackage?.displayId ?? this.workPackageId ?? '';
   }
 
   ngOnInit():void {
@@ -92,7 +92,8 @@ export class InAppNotificationEntryComponent implements OnInit {
         .apiV3Service
         .work_packages
         .id(this.workPackageId)
-        .requireAndStream();
+        .requireAndStream()
+        .pipe(tap((wp) => { this.workPackage = wp; }));
     }
   }
 
@@ -126,10 +127,6 @@ export class InAppNotificationEntryComponent implements OnInit {
 
     const link = this.pathHelper.workPackagePath(this.routingId()) + window.location.search;
     Turbo.visit(link, { action: 'advance' });
-  }
-
-  fullScreenLink():string {
-    return this.workPackageId ? this.pathHelper.workPackagePath(this.routingId()) : this.pathHelper.workPackagesPath(null);
   }
 
   onLinkClick(e:Event):void {

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -12,6 +12,7 @@ import { INotification } from 'core-app/core/state/in-app-notifications/in-app-n
 import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { UrlParamsService } from 'core-app/core/navigation/url-params.service';
+import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 
 @Component({
   selector: 'op-in-app-notification-entry',
@@ -21,14 +22,22 @@ import { UrlParamsService } from 'core-app/core/navigation/url-params.service';
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
-export class InAppNotificationEntryComponent implements OnInit {
+export class InAppNotificationEntryComponent extends UntilDestroyedMixin implements OnInit {
   @HostBinding('class.op-ian-item') className = true;
 
   @Input() notification:INotification;
 
   @Input() aggregatedNotifications:INotification[];
 
-  workPackage$:Observable<WorkPackageResource>|null = null;
+  // Single source of truth for the loaded work package. Fed explicitly from
+  // ngOnInit's subscription (not via template subscription) so click handlers
+  // can read .value synchronously regardless of whether the template has
+  // subscribed to workPackage$ yet.
+  private workPackageSubject = new BehaviorSubject<WorkPackageResource|null>(null);
+
+  workPackage$:Observable<WorkPackageResource> = this.workPackageSubject.pipe(
+    filter((wp):wp is WorkPackageResource => wp !== null),
+  );
 
   showDateAlert = false;
   hasReminderAlert = false;
@@ -48,12 +57,7 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   private clickTimer:ReturnType<typeof setTimeout>;
 
-  private workPackageId:string|null;
-
-  // The loaded work package, captured via tap() on workPackage$. Click handlers
-  // prefer this.workPackage.displayId so the URL carries the semantic identifier;
-  // fall back to the numeric PK if the resource hasn't emitted yet.
-  private workPackage:WorkPackageResource|null = null;
+  workPackageId:string|null;
 
   constructor(
     readonly apiV3Service:ApiV3Service,
@@ -64,10 +68,7 @@ export class InAppNotificationEntryComponent implements OnInit {
     readonly deviceService:DeviceService,
     readonly urlParams:UrlParamsService,
   ) {
-  }
-
-  private routingId():string {
-    return this.workPackage?.displayId ?? this.workPackageId ?? '';
+    super();
   }
 
   ngOnInit():void {
@@ -87,14 +88,17 @@ export class InAppNotificationEntryComponent implements OnInit {
 
   private loadWorkPackage() {
     // not a work package reference
-    if (this.workPackageId) {
-      this.workPackage$ = this
-        .apiV3Service
-        .work_packages
-        .id(this.workPackageId)
-        .requireAndStream()
-        .pipe(tap((wp) => { this.workPackage = wp; }));
+    if (!this.workPackageId) {
+      return;
     }
+
+    this
+      .apiV3Service
+      .work_packages
+      .id(this.workPackageId)
+      .requireAndStream()
+      .pipe(this.untilDestroyed())
+      .subscribe((wp) => this.workPackageSubject.next(wp));
   }
 
   onClick():void {
@@ -112,7 +116,8 @@ export class InAppNotificationEntryComponent implements OnInit {
     }
 
     const tab = this.showDateAlert ? 'overview' : 'activity';
-    this.storeService.openSplitScreen(this.routingId(), tab);
+    const id = this.workPackageSubject.value?.displayId ?? this.workPackageId;
+    this.storeService.openSplitScreen(id, tab);
   }
 
   onDoubleClick():void {
@@ -125,7 +130,8 @@ export class InAppNotificationEntryComponent implements OnInit {
       return;
     }
 
-    const link = this.pathHelper.workPackagePath(this.routingId()) + window.location.search;
+    const id = this.workPackageSubject.value?.displayId ?? this.workPackageId;
+    const link = this.pathHelper.workPackagePath(id) + window.location.search;
     Turbo.visit(link, { action: 'advance' });
   }
 

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -29,15 +29,11 @@ export class InAppNotificationEntryComponent extends UntilDestroyedMixin impleme
 
   @Input() aggregatedNotifications:INotification[];
 
-  // Single source of truth for the loaded work package. Fed explicitly from
-  // ngOnInit's subscription (not via template subscription) so click handlers
-  // can read .value synchronously regardless of whether the template has
-  // subscribed to workPackage$ yet.
-  private workPackageSubject = new BehaviorSubject<WorkPackageResource|null>(null);
+  workPackage$:Observable<WorkPackageResource>|null = null;
 
-  workPackage$:Observable<WorkPackageResource> = this.workPackageSubject.pipe(
-    filter((wp):wp is WorkPackageResource => wp !== null),
-  );
+  // Latest streamed work package, cached for synchronous reads from click
+  // handlers (which need displayId to build the URL).
+  private latestWorkPackage:WorkPackageResource|null = null;
 
   showDateAlert = false;
   hasReminderAlert = false;
@@ -92,13 +88,15 @@ export class InAppNotificationEntryComponent extends UntilDestroyedMixin impleme
       return;
     }
 
-    this
+    this.workPackage$ = this
       .apiV3Service
       .work_packages
       .id(this.workPackageId)
       .requireAndStream()
-      .pipe(this.untilDestroyed())
-      .subscribe((wp) => this.workPackageSubject.next(wp));
+      .pipe(
+        tap((wp) => { this.latestWorkPackage = wp; }),
+        this.untilDestroyed(),
+      );
   }
 
   onClick():void {
@@ -116,7 +114,7 @@ export class InAppNotificationEntryComponent extends UntilDestroyedMixin impleme
     }
 
     const tab = this.showDateAlert ? 'overview' : 'activity';
-    const id = this.workPackageSubject.value?.displayId ?? this.workPackageId;
+    const id = this.latestWorkPackage?.displayId ?? this.workPackageId;
     this.storeService.openSplitScreen(id, tab);
   }
 
@@ -130,7 +128,7 @@ export class InAppNotificationEntryComponent extends UntilDestroyedMixin impleme
       return;
     }
 
-    const id = this.workPackageSubject.value?.displayId ?? this.workPackageId;
+    const id = this.latestWorkPackage?.displayId ?? this.workPackageId;
     const link = this.pathHelper.workPackagePath(id) + window.location.search;
     Turbo.visit(link, { action: 'advance' });
   }

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -11,6 +11,8 @@ import { INotification } from 'core-app/core/state/in-app-notifications/in-app-n
 import { IanCenterService } from 'core-app/features/in-app-notifications/center/state/ian-center.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { UrlParamsService } from 'core-app/core/navigation/url-params.service';
+import { States } from 'core-app/core/states/states.service';
+import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-package-id-resolvers';
 
 @Component({
   selector: 'op-in-app-notification-entry',
@@ -57,7 +59,15 @@ export class InAppNotificationEntryComponent implements OnInit {
     readonly pathHelper:PathHelperService,
     readonly deviceService:DeviceService,
     readonly urlParams:UrlParamsService,
+    readonly states:States,
   ) {
+  }
+
+  // The notification's HAL link gives us the numeric primary key. For URL
+  // construction we prefer the semantic displayId so the user-visible URL
+  // carries the readable identifier once the WP is cached.
+  private routingId():string {
+    return this.workPackageId ? resolveRoutingId(this.states, this.workPackageId) : '';
   }
 
   ngOnInit():void {
@@ -101,7 +111,7 @@ export class InAppNotificationEntryComponent implements OnInit {
     }
 
     const tab = this.showDateAlert ? 'overview' : 'activity';
-    this.storeService.openSplitScreen(this.workPackageId, tab);
+    this.storeService.openSplitScreen(this.routingId(), tab);
   }
 
   onDoubleClick():void {
@@ -114,12 +124,12 @@ export class InAppNotificationEntryComponent implements OnInit {
       return;
     }
 
-    const link = this.pathHelper.workPackagePath(this.workPackageId) + window.location.search;
+    const link = this.pathHelper.workPackagePath(this.routingId()) + window.location.search;
     Turbo.visit(link, { action: 'advance' });
   }
 
   fullScreenLink():string {
-    return this.workPackageId ? this.pathHelper.workPackagePath(this.workPackageId) : this.pathHelper.workPackagesPath(null);
+    return this.workPackageId ? this.pathHelper.workPackagePath(this.routingId()) : this.pathHelper.workPackagesPath(null);
   }
 
   onLinkClick(e:Event):void {

--- a/spec/features/notifications/semantic_id_navigation_spec.rb
+++ b/spec/features/notifications/semantic_id_navigation_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Notification center uses displayId when navigating to the work package",
+               :js,
+               :with_cuprite,
+               with_flag: { semantic_work_package_ids: true },
+               with_settings: { work_packages_identifier: "semantic" } do
+  # Classic mode is a behavioural no-op: the URL helpers and the
+  # resolveRoutingId bridge both collapse to the numeric id when semantic
+  # mode is off. Covering semantic-only where the bug actually manifests.
+
+  let(:project)      { create(:project, identifier: "NOTIFNAV") }
+  let(:work_package) { create(:work_package, project:, subject: "Semantic notif WP") }
+  let(:recipient) do
+    create(:user, member_with_permissions: { project => %i[view_work_packages] })
+  end
+  let(:notification) do
+    create(:notification,
+           recipient:,
+           resource: work_package,
+           journal: work_package.journals.last)
+  end
+
+  let(:center) { Pages::Notifications::Center.new }
+  let(:split_screen) { Pages::PrimerizedSplitWorkPackage.new(work_package) }
+
+  current_user { recipient }
+
+  before do
+    work_package.allocate_and_register_semantic_id
+    notification # realise
+  end
+
+  it "opens the split view at the semantic identifier URL" do
+    semantic_id = work_package.reload.identifier
+    visit notifications_path
+
+    center.click_item(notification)
+    split_screen.expect_open
+
+    expect(page).to have_current_path(
+      "/notifications/details/#{semantic_id}/activity"
+    )
+  end
+
+  it "renders the notification's WP link with the semantic identifier in its href" do
+    semantic_id = work_package.reload.identifier
+    visit notifications_path
+
+    # Wait for the entry to finish loading the WP
+    expect(page).to have_css(".op-ian-item--work-package-id-link", text: semantic_id)
+    link = page.find(".op-ian-item--work-package-id-link")
+
+    expect(link[:href]).to include("/work_packages/#{semantic_id}")
+    expect(link[:href]).not_to include("/work_packages/#{work_package.id}")
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/74313

Follow-up from the PR 22733 review: https://github.com/opf/openproject/pull/22733#pullrequestreview-4152467748

## Screenshots

Verified manually in semantic mode against the local dev edge.

**Notification entry — WP link `href`** uses the semantic identifier:

<!-- drop pr22904-notification-href screenshot here -->

<img width="1598" height="830" alt="Screenshot 2026-04-28 at 3 43 30 PM" src="https://github.com/user-attachments/assets/14ade14c-8234-4f60-9b1a-5f117e4e207e" />


**Click → split view URL** uses the semantic identifier:

<!-- drop pr22904-notification-split-click screenshot here -->

<img width="1596" height="669" alt="Screenshot 2026-04-28 at 3 43 45 PM" src="https://github.com/user-attachments/assets/58aa01df-8a79-4fbc-b595-134c93e60a99" />

## Fix

The in-app notification entry was leaking the numeric primary key into the split-view URL, full-view navigation, and `<a href>`. First attempt used `resolveRoutingId`, but that reads the global Akita states cache — and the notification entry's `apiV3Service.work_packages.id(...).requireAndStream()` streams through the API layer without priming that cache, so it returned the numeric input unchanged.

Current fix captures the streamed resource into a `BehaviorSubject<WorkPackageResource | null>` from `ngOnInit` (cleanup via `UntilDestroyedMixin`); click handlers read `subject.value?.displayId ?? workPackageId` synchronously with the numeric fallback inlined at the call site, the template renders from the same subject, and the loading gate becomes the more honest `@if (workPackageId)`. Feature spec covers click and href in semantic mode (classic is a no-op since `displayId` collapses to `id`).

## Note for the next reader

The root cause is that `requireAndStream()` doesn't prime the Akita states cache; if it did, every component in this bundle could use `resolveRoutingId` uniformly. Out of scope here, flagged so it isn't silently re-discovered.