### PR TITLE
Actually prevent editing of closed meetings

### DIFF
--- a/modules/meeting/app/contracts/meetings/update_contract.rb
+++ b/modules/meeting/app/contracts/meetings/update_contract.rb
@@ -35,6 +35,7 @@ module Meetings
 
     validate :user_allowed_to_edit_in_source_project
     validate :user_allowed_to_edit_in_destination_project
+    validate :meeting_is_editable
     validate :valid_rescheduling_date, if: -> { check_reschedule? }
 
     attribute :lock_version do
@@ -55,6 +56,12 @@ module Meetings
       unless user.allowed_in_project?(:edit_meetings, model.project)
         errors.add :base, :error_unauthorized
       end
+    end
+
+    def meeting_is_editable
+      return unless user.allowed_in_project?(:edit_meetings, model.project)
+
+      errors.add :base, I18n.t(:text_meeting_not_editable_anymore) unless model.editable?(user)
     end
 
     def valid_rescheduling_date # rubocop:disable Metrics/AbcSize

--- a/modules/meeting/spec/contracts/meetings/update_contract_spec.rb
+++ b/modules/meeting/spec/contracts/meetings/update_contract_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Meetings::UpdateContract do
 
       it_behaves_like "contract is invalid", base: :error_conflict
     end
+
+    context "when meeting is closed" do
+      before do
+        meeting.update_column(:state, :closed)
+      end
+
+      it_behaves_like "contract is invalid", base: I18n.t(:text_meeting_not_editable_anymore)
+    end
   end
 
   context "without permission" do

--- a/modules/meeting/spec/requests/meetings_spec.rb
+++ b/modules/meeting/spec/requests/meetings_spec.rb
@@ -65,6 +65,38 @@ RSpec.describe "Meeting requests",
     end
   end
 
+  describe "update_details" do
+    let(:details_params) do
+      {
+        project_id: project.id,
+        id: meeting.id,
+        meeting: {
+          title: "Modified title",
+          start_date: Date.current.to_s,
+          duration: "1h",
+          location: "Modified location",
+          lock_version: meeting.lock_version
+        }
+      }
+    end
+
+    context "when meeting is closed" do
+      before do
+        meeting.update_column(:state, :closed)
+      end
+
+      it "rejects the update" do
+        expect do
+          put update_details_project_meeting_path(project, meeting),
+              params: details_params,
+              as: :turbo_stream
+        end.not_to change { meeting.reload.attributes.slice("title", "start_time", "duration", "location") }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+
   describe "copy" do
     let(:base_params) do
       {


### PR DESCRIPTION
We disable editing the meeting through the UI, but through API or modification of the request, an edit would still be possible.

This PR prevents edits at the contract level.


https://community.openproject.org/projects/meetings-stream/work_packages/74372/activity
