### PR TITLE
fix: Adjust check of historical Project identifiers upon saving

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -162,7 +162,7 @@ module Projects::Identifier
     return if errors.any? { |error| error.attribute == :identifier && error.type == :taken }
 
     already_existing = FriendlyId::Slug
-                         .where("LOWER(slug) = LOWER(?)", identifier)
+                         .where(identifier:)
                          .where(sluggable_type: self.class.to_s)
                          .where.not(sluggable_id: id)
                          .exists?

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -162,7 +162,7 @@ module Projects::Identifier
     return if errors.any? { |error| error.attribute == :identifier && error.type == :taken }
 
     already_existing = FriendlyId::Slug
-                         .where(identifier:)
+                         .where(slug: identifier)
                          .where(sluggable_type: self.class.to_s)
                          .where.not(sluggable_id: id)
                          .exists?

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -103,17 +103,6 @@ RSpec.describe Projects::Identifier do
       expect(project.errors[:identifier]).to include("has already been taken.")
     end
 
-    it "is not allowed to clash with a former identifier of another project case-insensitively" do
-      other_project = create(:project, identifier: "former-id")
-      other_project.update!(identifier: "new-id")
-
-      # Bypass format validation to test the LOWER() slug check directly
-      project = create(:project)
-      project.identifier = "FORMER-ID"
-      project.valid?
-      expect(project.errors[:identifier]).to include("has already been taken.")
-    end
-
     it "is allowed to be the same as its own former identifier" do
       project = create(:project, identifier: "old-id")
       project.update!(identifier: "new-id")


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Migrating the edge QA instance from `classic` to `semantic` and back to `classic` revealed an edge case:

When database contains the two following projects: 
* Project 1, `identifier: 'TEST'`, `slugs: ['TEST, 'testrobin812345']`
* Project 2, `identifier: 'SP2'`, `slugs: ['SP2', 'test']`

...then the process gets stuck at rename of the second project, since renaming to `test` fails the `identifier_not_historically_reserved` validation due to conflict with `TEST` (even thought at that point, that's no longer the current identifier).


# What approach did you choose and why?
The easy solution is to relax the `slugs` lookup from case-insensitive to case-sensitive. The sets of Ids from each of the two modes shouldn't affect each other in terms of uniqueness.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
