### PR TITLE
fix: Fix an edge case of instance identifier conversion

### DIFF
--- a/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
+++ b/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
@@ -39,7 +39,7 @@ class ProjectIdentifiers::RevertInstanceToClassicIdsJob < ApplicationJob
 
   # Raised when a pass completes but some projects were skipped due to transient
   # identifier conflicts. Retried immediately so the next pass can resolve them.
-  IdConflictsRemain = Class.new(StandardError)
+  class IdConflictsRemain < StandardError; end
 
   good_job_control_concurrency_with(total_limit: 1)
   retry_on StandardError, wait: :polynomially_longer, attempts: 8

--- a/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
+++ b/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
@@ -43,7 +43,7 @@ class ProjectIdentifiers::RevertInstanceToClassicIdsJob < ApplicationJob
 
   good_job_control_concurrency_with(total_limit: 1)
   retry_on StandardError, wait: :polynomially_longer, attempts: 8
-  retry_on IdConflictsRemain, wait: 0, attempts: 30
+  retry_on IdConflictsRemain, wait: 0, attempts: 10
 
   def perform
     raise "expected Setting.work_packages_identifier to be classic" unless Setting::WorkPackageIdentifier.classic?

--- a/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
+++ b/app/workers/project_identifiers/revert_instance_to_classic_ids_job.rb
@@ -37,16 +37,32 @@
 class ProjectIdentifiers::RevertInstanceToClassicIdsJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
 
+  # Raised when a pass completes but some projects were skipped due to transient
+  # identifier conflicts. Retried immediately so the next pass can resolve them.
+  IdConflictsRemain = Class.new(StandardError)
+
   good_job_control_concurrency_with(total_limit: 1)
   retry_on StandardError, wait: :polynomially_longer, attempts: 8
+  retry_on IdConflictsRemain, wait: 0, attempts: 30
 
   def perform
     raise "expected Setting.work_packages_identifier to be classic" unless Setting::WorkPackageIdentifier.classic?
 
+    had_conflicts = false
+
     Project.find_each do |project|
       next if Project.classic_identifier_format?(project.identifier)
 
-      ProjectIdentifiers::RevertProjectToClassicService.new(project).call
+      begin
+        ProjectIdentifiers::RevertProjectToClassicService.new(project).call
+      rescue ActiveRecord::RecordInvalid
+        # Another project's semantic identifier shadows this classic slug via the
+        # LOWER() unique index. Skip for now; the pass below will retry immediately
+        # once all blockers in this pass have been cleared.
+        had_conflicts = true
+      end
     end
+
+    raise IdConflictsRemain if had_conflicts
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Migrating the edge QA instance from `classic` to `semantic` and back to `classic` revealed an edge case:

When database contains the two following projects: 
* Project 1, `identifier: 'HELLO'`, `slugs: ['TEST', 'test']`
* Project 2, `identifier: 'TEST'`

...then the process gets stuck at rename of the first project, because at that point, `test` clashes with `TEST` due to case-insensitive index.

## Screenshots
<img width="1376" height="700" alt="Screenshot 2026-04-24 at 1 57 56" src="https://github.com/user-attachments/assets/9f619f6f-8014-4cd8-b869-a802eec449f5" />


# What approach did you choose and why?
Simply skip over these issues, then immediately re-run the job if we had skipped anything.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
