### PR TITLE
[69142] User is redirected to Attribute help text admin after editing a help text from Project overview page

### DIFF
--- a/app/controllers/attribute_help_texts_controller.rb
+++ b/app/controllers/attribute_help_texts_controller.rb
@@ -59,7 +59,9 @@ class AttributeHelpTextsController < ApplicationController
     @attribute_help_text = AttributeHelpText.new type: @attribute_scope
   end
 
-  def edit; end
+  def edit
+    @back_url = params[:back_url] || request.referer
+  end
 
   def create # rubocop:disable Metrics/AbcSize
     call = ::AttributeHelpTexts::CreateService
@@ -83,7 +85,7 @@ class AttributeHelpTextsController < ApplicationController
 
     if call.success?
       flash[:notice] = t(:notice_successful_update)
-      redirect_to attribute_help_texts_path(tab: @attribute_help_text.attribute_scope)
+      redirect_back_or_default(attribute_help_texts_path(tab: @attribute_help_text.attribute_scope))
     else
       flash.now[:error] = call.message || I18n.t("notice_internal_server_error")
       render action: :edit, status: :unprocessable_entity

--- a/app/views/attribute_help_texts/edit.html.erb
+++ b/app/views/attribute_help_texts/edit.html.erb
@@ -43,15 +43,14 @@ See COPYRIGHT and LICENSE files for more details.
 %>
 
 <div class="op-admin-settings-form-wrapper">
-<%=
-  primer_form_with(
-    model: @attribute_help_text,
-    scope: :attribute_help_text,
-    url: { action: :update },
-    method: :patch,
-    data: { turbo: false } # reload page to update previews
-  ) do |f|
-    render AttributeHelpTexts::Form.new(f)
-  end
-%>
+<%= primer_form_with(
+      model: @attribute_help_text,
+      scope: :attribute_help_text,
+      url: { action: :update },
+      method: :patch,
+      data: { turbo: false } # reload page to update previews
+    ) do |f| %>
+  <%= back_url_hidden_field_tag %>
+  <%= render AttributeHelpTexts::Form.new(f) %>
+<% end %>
 </div>


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/69142

# What are you trying to accomplish?
Navigate back to the original page after updating an attribute help text so that context is kept when triggered from within a dialog
