### PR TITLE
CSS improvements

### DIFF
--- a/app/components/op_primer/inline_macro_component.html.erb
+++ b/app/components/op_primer/inline_macro_component.html.erb
@@ -28,6 +28,8 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 
 <%= render(Primer::BaseComponent.new(tag: :span, **@system_arguments)) do %>
-  <%= leading_visual_icon %>
-  <%= content %>
+  <%= render(Primer::BaseComponent.new(tag: :span, display: :inline_flex, align_items: :center)) do %>
+    <%= leading_visual_icon %>
+    <%= content %>
+  <% end %>
 <% end %>

--- a/app/components/op_primer/inline_macro_component.rb
+++ b/app/components/op_primer/inline_macro_component.rb
@@ -31,7 +31,7 @@
 module OpPrimer
   class InlineMacroComponent < Primer::Component
     renders_one :leading_visual_icon, ->(icon:, color: :muted) do
-      Primer::Beta::Octicon.new(icon:, color:, mr: 2, vertical_align: :middle)
+      Primer::Beta::Octicon.new(icon:, color:, size: :xsmall, mr: 2)
     end
 
     def initialize(**system_arguments)

--- a/app/components/op_primer/inline_macro_component.sass
+++ b/app/components/op_primer/inline_macro_component.sass
@@ -1,7 +1,2 @@
-@media screen
-  .op-inline-macro
-    display: inline
-    background: var(--bgColor-muted)
-    border: 1px solid transparent
-    border-radius: var(--borderRadius-medium)
-    padding: 4px 8px
+.op-inline-macro
+  @include macro--text-style

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -276,9 +276,9 @@ $scrollbar-size: 10px
   @media screen
     display: inline
     background: var(--bgColor-muted)
-    border: 1px solid transparent
-    border-radius: var(--borderRadius-medium)
-    padding: 2px
+    border-radius: var(--borderRadius-default)
+    // 2px vertical ensures that line-height is not overflowed excessively
+    padding: 2px var(--control-xsmall-paddingInline-condensed)
 
     &:has(.-multiline)
       display: inline-flex

--- a/modules/documents/app/components/documents/show_edit_view/page_header/connection_status_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/connection_status_component.html.erb
@@ -48,25 +48,11 @@
       end
 
       flex.with_column(data: { "documents--connection-status-target": "offline" }, hidden: true) do
-        flex_layout(align_items: :center) do |row|
-          row.with_column(mr: 1) do
-            render(Primer::Beta::Octicon.new(icon: :alert, color: :attention, size: :small))
-          end
-          row.with_column do
-            render(Primer::Beta::Text.new(color: :attention)) { t("documents.info_line.currently_offline") }
-          end
-        end
+        render(Primer::OpenProject::InlineMessage.new(scheme: :warning)) { t("documents.info_line.currently_offline") }
       end
 
       flex.with_column(data: { "documents--connection-status-target": "recovered" }, hidden: true) do
-        flex_layout(align_items: :center) do |row|
-          row.with_column(mr: 1) do
-            render(Primer::Beta::Octicon.new(icon: :"check-circle", color: :success, size: :small))
-          end
-          row.with_column do
-            render(Primer::Beta::Text.new(color: :success)) { t("documents.info_line.connection_restored") }
-          end
-        end
+        render(Primer::OpenProject::InlineMessage.new(scheme: :success)) { t("documents.info_line.connection_restored") }
       end
     end
   end


### PR DESCRIPTION
Improve visual representation of inline macros, by ensuring they all use the same CSS attributes and have a reduced vertical padding, so they don't overlap as much.

We also improved the vertical alignment of the leading icon for these macros.

As a sidefind, we replaced a handcrafted version of the InlineMessage with the existing InlineMessage component. This also improved alignment of the icon.

# Ticket
https://community.openproject.org/wp/73928