### PR TITLE
Add the category to persisted view

### DIFF
--- a/app/models/persisted_view.rb
+++ b/app/models/persisted_view.rb
@@ -38,10 +38,20 @@ class PersistedView < ApplicationRecord
 
   acts_as_favoritable
 
+  enum :category, {
+    work_package: "work_package",
+    project: "project",
+    resource_management: "resource_management"
+  }, validate: { allow_nil: true }
+
   validates :name, presence: true, length: { maximum: 255 }
 
   scope :public_views, -> { where(public: true) }
   scope :private_views, ->(principal: User.current) { where(public: false, principal:) }
+
+  scope :visible, (lambda do |principal: User.current|
+    public_views.or(private_views(principal:))
+  end)
 
   after_destroy :destroy_query_if_orphaned
 

--- a/db/migrate/20260424094655_add_category_to_persisted_view.rb
+++ b/db/migrate/20260424094655_add_category_to_persisted_view.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCategoryToPersistedView < ActiveRecord::Migration[8.1]
+  def change
+    add_column :persisted_views, :category, :string, null: true
+    add_index :persisted_views, :category
+  end
+end

--- a/spec/models/persisted_view_spec.rb
+++ b/spec/models/persisted_view_spec.rb
@@ -73,6 +73,59 @@ RSpec.describe PersistedView do
         expect(described_class.private_views).to contain_exactly(own_private_view)
       end
     end
+
+    describe ".visible" do
+      it "returns public views and the principal's own private views" do
+        expect(described_class.visible(principal: user)).to contain_exactly(public_view, own_private_view)
+      end
+
+      it "excludes other principals' private views" do
+        expect(described_class.visible(principal: user)).not_to include(other_private_view)
+      end
+
+      it "defaults to User.current when no principal is given" do
+        login_as(user)
+        expect(described_class.visible).to contain_exactly(public_view, own_private_view)
+      end
+    end
+  end
+
+  describe "category enum" do
+    it "allows the defined category values" do
+      %w[work_package project resource_management].each do |value|
+        view = described_class.new(name: "V", category: value)
+        expect(view).to be_valid
+        expect(view.category).to eq(value)
+      end
+    end
+
+    it "allows nil as a category" do
+      persisted_view.category = nil
+      expect(persisted_view).to be_valid
+    end
+
+    it "rejects unknown category values" do
+      persisted_view.category = "unknown"
+      expect(persisted_view).not_to be_valid
+      expect(persisted_view.errors[:category]).to be_present
+    end
+
+    it "exposes predicate methods for each category" do
+      view = described_class.new(name: "V", category: "work_package")
+      expect(view).to be_work_package
+      expect(view).not_to be_project
+      expect(view).not_to be_resource_management
+    end
+
+    it "exposes scopes for each category" do
+      wp_view = described_class.create!(name: "WP", category: "work_package")
+      project_view = described_class.create!(name: "P", category: "project")
+      rm_view = described_class.create!(name: "RM", category: "resource_management")
+
+      expect(described_class.work_package).to contain_exactly(wp_view)
+      expect(described_class.project).to contain_exactly(project_view)
+      expect(described_class.resource_management).to contain_exactly(rm_view)
+    end
   end
 
   describe "#effective_query" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/73920/activity

# What are you trying to accomplish?
- Add a `category` to the views so that we can display all views for one section (i.e. in the projects list show all views for projects regardless of type)

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
