### PR TITLE
[57633] Default configuration for Work packages assigned to me on My Page is wrong

### DIFF
--- a/frontend/src/app/shared/components/grids/grid/area.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/area.service.ts
@@ -144,6 +144,16 @@ export class GridAreaService {
 
     Object.assign(payloadWidget, changeset.changes);
 
+    /* Special case for the initial creation of the MyPage with two widgets:
+     * Synchronously update the in-memory widget resource so that concurrent
+     * saveWidgetChangeset calls see the updated state before the async save completes.
+     * Without this, the second call reads stale widget options and overwrites the
+     * first widget's queryId/queryProps with the old values, permanently breaking it. */
+    const inMemoryWidget = this.resource.widgets.find((w) => w.id === changeset.pristineResource.id);
+    if (inMemoryWidget) {
+      Object.assign(inMemoryWidget, changeset.changes);
+    }
+
     // Adding the id so that the url can be deduced
     payload.id = gridId;
 

--- a/modules/my_page/lib/my_page/grid_registration.rb
+++ b/modules/my_page/lib/my_page/grid_registration.rb
@@ -77,7 +77,7 @@ module MyPage
               queryProps: {
                 "columns[]": %w(id project type subject),
                 filters: JSON.dump([{ status: { operator: "o", values: [] } },
-                                    { assigned_to: { operator: "=", values: ["me"] } }])
+                                    { assignee: { operator: "=", values: ["me"] } }])
               }
             }
           },

--- a/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
+++ b/modules/my_page/spec/requests/api/v3/grids/grids_create_form_resource_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
         }
       end
 
+      # rubocop:disable Metrics/Layout/LineLength
       it "contains default data in the payload" do # rubocop:disable RSpec/ExampleLength
         expected = {
           rowCount: 1,
@@ -89,7 +90,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
                 name: "Work packages assigned to me",
                 queryProps: {
                   "columns[]": %w(id project type subject),
-                  filters: "[{\"status\":{\"operator\":\"o\",\"values\":[]}},{\"assigned_to\":{\"operator\":\"=\",\"values\":[\"me\"]}}]"
+                  filters: "[{\"status\":{\"operator\":\"o\",\"values\":[]}},{\"assignee\":{\"operator\":\"=\",\"values\":[\"me\"]}}]"
                 }
               },
               startRow: 1,
@@ -126,6 +127,7 @@ RSpec.describe "POST /api/v3/grids/form", content_type: :json do
           .to be_json_eql(expected.to_json)
           .at_path("_embedded/payload")
       end
+      # rubocop:enable Metrics/Layout/LineLength
 
       it "has no validationErrors" do
         expect(subject.body)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/57633

# What are you trying to accomplish?
Avoid the the initial creation of widgets on the MyPage creates a race condition

This _might_ also fix the flaky spec `./modules/my_page/spec/features/my/work_package_table_spec.rb:81` which could have revealed a real issue here.

# What approach did you choose and why?
Both default widgets ("assigned to me" and "created by me") call `createInitial()` on first load, which creates a  persistent query from queryProps and then calls `saveWidgetChangeset` with the resulting queryId. Since both saves run concurrently and `saveWidgetChangeset` reads from `this.resource.widgets` before either PATCH response arrives, the second save's payload contains the first widget without its queryId. The last PATCH wins, permanently removing both `queryId` and `queryProps` from the first widget.
 
