### PR TITLE
Fix small wiki errors

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/base_query.rb
+++ b/modules/wikis/app/services/wikis/adapters/base_query.rb
@@ -34,8 +34,8 @@ module Wikis::Adapters
 
     attr_reader :provider
 
-    def initialize(provider)
-      @provider = provider
+    def initialize(model:)
+      @provider = model
     end
 
     def call(_input_data)

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/page_info.rb
@@ -43,7 +43,7 @@ module Wikis
                 "Syntax overview",
                 "Getting help",
                 "Enterprise support"
-              ].sample
+              ]
               title = titles[Random.new(input_data.identifier.hash).rand(titles.size)]
 
               success(

--- a/modules/wikis/spec/services/wikis/adapters/providers/internal/queries/page_info_query_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/internal/queries/page_info_query_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 
 RSpec.describe Wikis::Adapters::Providers::Internal::Queries::PageInfo do
-  subject { described_class.new(provider).call(input_data) }
+  subject { described_class.new(model: provider).call(input_data) }
 
   let(:provider) { create(:internal_wiki_provider) }
   let(:input_data) { Wikis::Adapters::Input::PageInfo.build(identifier:).value! }


### PR DESCRIPTION
* faked wiki titles were wrongly shortened to a single letter
* provider was not correctly passed to BaseQuery (Provider#resolve
  passed it as `model: self`)