### PR TITLE
Inline references improvements

### DIFF
--- a/modules/wikis/app/services/wikis/concerns/update_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_inline_wiki_page_links.rb
@@ -34,13 +34,11 @@ module Wikis::Concerns
 
     def update_inline_wiki_page_links(linkable, *texts)
       Wikis::InlinePageLink.where(linkable:).delete_all
-      texts.each do |text|
-        find_wiki_links(text).each do |provider_id, identifier|
-          provider = Wikis::Provider.find_by(id: provider_id)
-          next if provider.nil?
+      texts.flat_map { |text| find_wiki_links(text) }.uniq.each do |provider_id, identifier|
+        provider = Wikis::Provider.find_by(id: provider_id)
+        next if provider.nil?
 
-          Wikis::InlinePageLink.create!(linkable:, provider:, identifier:)
-        end
+        Wikis::InlinePageLink.create!(linkable:, provider:, identifier:)
       end
     end
 

--- a/modules/wikis/app/services/wikis/page_link_service.rb
+++ b/modules/wikis/app/services/wikis/page_link_service.rb
@@ -50,7 +50,7 @@ module Wikis
 
     def inline_page_link_infos_for(linkable:)
       InlinePageLink.where(linkable:)
-                    .order(created_at: :desc)
+                    .order(created_at: :asc)
                     .map { page_info(provider: it.provider, identifier: it.identifier) }
     end
 

--- a/modules/wikis/spec/services/work_packages/create_service_spec.rb
+++ b/modules/wikis/spec/services/work_packages/create_service_spec.rb
@@ -43,14 +43,18 @@ RSpec.describe WorkPackages::CreateService do
       project:,
       status: default_status,
       priority:,
-      description: <<~TXT
-        The work package description contains inline links to wiki pages (e.g. [[[#{provider.id}:abc]]]).
-        It also contains links in a list:
-
-        * [[[#{provider.id}:def]]]
-        * [[[#{provider.id + 100}:ghi]]]
-      TXT
+      description:
     }
+  end
+
+  let(:description) do
+    <<~TXT
+      The work package description contains inline links to wiki pages (e.g. [[[#{provider.id}:abc]]]).
+      It also contains links in a list:
+
+      * [[[#{provider.id}:def]]]
+      * [[[#{provider.id + 100}:ghi]]]
+    TXT
   end
 
   subject { instance.call(**attributes) }
@@ -81,5 +85,20 @@ RSpec.describe WorkPackages::CreateService do
     subject
 
     expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc", "def")
+  end
+
+  context "when the same reference is made twice" do
+    let(:description) do
+      <<~TXT
+        * [[[#{provider.id}:abc]]]
+        * [[[#{provider.id}:abc]]]
+      TXT
+    end
+
+    it "creates the link once" do
+      subject
+
+      expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc")
+    end
   end
 end

--- a/modules/wikis/spec/services/work_packages/update_service_spec.rb
+++ b/modules/wikis/spec/services/work_packages/update_service_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe WorkPackages::UpdateService do
     expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc", "def")
   end
 
+  context "when the same reference is made twice" do
+    let(:attributes) do
+      {
+        description: <<~TXT
+          * [[[#{provider.id}:abc]]]
+          * [[[#{provider.id}:abc]]]
+        TXT
+      }
+    end
+
+    it "creates the link once" do
+      subject
+
+      expect(Wikis::InlinePageLink.pluck(:identifier)).to contain_exactly("abc")
+    end
+  end
+
   context "when other page links already exist" do
     before do
       create(:inline_wiki_page_link, provider:, linkable: work_package, identifier: "123")


### PR DESCRIPTION
Improve inline page references:

* Deduplicate them (referencing the same page twice, does not list it twice)
* Sort their list view according to occurence in text (technically according to creation time)

# Ticket
https://community.openproject.org/wp/72986

# Screenshot

<img width="1162" height="287" alt="image" src="https://github.com/user-attachments/assets/c95791ba-2b4c-4f13-ab61-e39f13f512cc" />
