### PR TITLE
Bug/74166 sprint filter in work packages only loads 100 sprints

### DIFF
--- a/modules/backlogs/app/models/queries/sprints/filters/name_filter.rb
+++ b/modules/backlogs/app/models/queries/sprints/filters/name_filter.rb
@@ -28,12 +28,40 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Sprints
-  ::Queries::Register.register(SprintQuery) do
-    filter Filters::ProjectFilter
-    filter Filters::NameFilter
-    filter Filters::TypeaheadFilter
+class Queries::Sprints::Filters::NameFilter < Queries::Sprints::Filters::SprintFilter
+  def self.key
+    :name
+  end
 
-    order Orders::DefaultOrder
+  def type
+    :string
+  end
+
+  def human_name
+    I18n.t(:label_name)
+  end
+
+  def where
+    case operator
+    when "="
+      ["LOWER(sprints.name) IN (?)", sql_value]
+    when "!"
+      ["LOWER(sprints.name) NOT IN (?)", sql_value]
+    when "~", "**"
+      ["LOWER(sprints.name) LIKE ?", sql_value]
+    when "!~"
+      ["LOWER(sprints.name) NOT LIKE ?", sql_value]
+    end
+  end
+
+  private
+
+  def sql_value
+    case operator
+    when "=", "!"
+      values.map(&:downcase)
+    when "**", "~", "!~"
+      "%#{values.first.downcase}%"
+    end
   end
 end

--- a/modules/backlogs/app/models/queries/sprints/filters/typeahead_filter.rb
+++ b/modules/backlogs/app/models/queries/sprints/filters/typeahead_filter.rb
@@ -28,12 +28,16 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Sprints
-  ::Queries::Register.register(SprintQuery) do
-    filter Filters::ProjectFilter
-    filter Filters::NameFilter
-    filter Filters::TypeaheadFilter
+class Queries::Sprints::Filters::TypeaheadFilter < Queries::Sprints::Filters::NameFilter
+  def self.key
+    :typeahead
+  end
 
-    order Orders::DefaultOrder
+  def type
+    :search
+  end
+
+  def human_name
+    I18n.t(:label_search)
   end
 end

--- a/modules/backlogs/spec/models/queries/sprints/filters/name_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/sprints/filters/name_filter_spec.rb
@@ -28,12 +28,19 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Sprints
-  ::Queries::Register.register(SprintQuery) do
-    filter Filters::ProjectFilter
-    filter Filters::NameFilter
-    filter Filters::TypeaheadFilter
+require "spec_helper"
 
-    order Orders::DefaultOrder
+RSpec.describe Queries::Sprints::Filters::NameFilter do
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :name }
+    let(:human_name) { I18n.t(:label_name) }
+    let(:type) { :string }
+    let(:model) { Agile::Sprint }
+
+    describe "#allowed_values" do
+      it "is nil" do
+        expect(instance.allowed_values).to be_nil
+      end
+    end
   end
 end

--- a/modules/backlogs/spec/models/queries/sprints/filters/typeahead_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/sprints/filters/typeahead_filter_spec.rb
@@ -28,12 +28,13 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Sprints
-  ::Queries::Register.register(SprintQuery) do
-    filter Filters::ProjectFilter
-    filter Filters::NameFilter
-    filter Filters::TypeaheadFilter
+require "spec_helper"
 
-    order Orders::DefaultOrder
+RSpec.describe Queries::Sprints::Filters::TypeaheadFilter do
+  it_behaves_like "basic query filter" do
+    let(:class_key) { :typeahead }
+    let(:human_name) { I18n.t(:label_search) }
+    let(:type) { :search }
+    let(:model) { Agile::Sprint }
   end
 end

--- a/modules/backlogs/spec/models/queries/sprints/sprint_query_integration_spec.rb
+++ b/modules/backlogs/spec/models/queries/sprints/sprint_query_integration_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Queries::Sprints::SprintQuery, "integration" do
   shared_let(:project) { create(:project, public: false) }
   shared_let(:other_project) { create(:project, public: false) }
   shared_let(:project_without_permission) { create(:project, public: false) }
-  shared_let(:sprint) { create(:agile_sprint, project:) }
-  shared_let(:other_sprint) { create(:agile_sprint, project: other_project) }
+  shared_let(:sprint) { create(:agile_sprint, project:, name: "Alpha Sprint") }
+  shared_let(:other_sprint) { create(:agile_sprint, project: other_project, name: "Beta Sprint") }
   shared_let(:sprint_without_permission) { create(:agile_sprint, project: project_without_permission) }
 
   let(:instance) { described_class.new }
@@ -76,6 +76,58 @@ RSpec.describe Queries::Sprints::SprintQuery, "integration" do
       before { instance.where("defining_workspace", "!", [project.id.to_s]) }
 
       it "returns sprints not belonging to the given project" do
+        expect(instance.results).to contain_exactly(other_sprint)
+      end
+    end
+  end
+
+  context "with a name filter" do
+    context "when searching by a letter" do
+      before { instance.where("name", "~", ["a"]) }
+
+      it "returns all sprints matching the name" do
+        expect(instance.results).to contain_exactly(sprint, other_sprint)
+      end
+    end
+
+    context "when searching more precisely" do
+      before { instance.where("name", "~", ["alpha"]) }
+
+      it "returns only sprints matching the name" do
+        expect(instance.results).to contain_exactly(sprint)
+      end
+    end
+
+    context "when searching exactly" do
+      before { instance.where("name", "=", ["alpha sprint"]) }
+
+      it "returns only sprints matching the name" do
+        expect(instance.results).to contain_exactly(sprint)
+      end
+    end
+
+    context "when containing SQL intjection attempt" do
+      before { instance.where("name", "=", ["'); DROP TABLE sprints; --", "beta sprint"]) }
+
+      it "does not allow it" do
+        expect(instance.results).to contain_exactly(other_sprint)
+      end
+    end
+  end
+
+  context "with a typeahead filter" do
+    context "when searching by a letter" do
+      before { instance.where("typeahead", "**", ["a"]) }
+
+      it "returns only sprints matching the search term" do
+        expect(instance.results).to contain_exactly(sprint, other_sprint)
+      end
+    end
+
+    context "when searching more precisely" do
+      before { instance.where("typeahead", "**", ["Beta"]) }
+
+      it "returns only sprints matching the search term" do
         expect(instance.results).to contain_exactly(other_sprint)
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74166

# What are you trying to accomplish?
Allow filtering sprints when selecting them in a filter

# What approach did you choose and why?
Adapt name/typeahead filters from Project and Version

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
