### PR TITLE
fix: Properly validate saved projects during semantic conversion

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -122,7 +122,7 @@ module Projects::Identifier
   def validate_identifier
     validate_identifier_not_reserved_keyword
 
-    if Setting::WorkPackageIdentifier.semantic?
+    if Setting::WorkPackageIdentifier.semantic? || Array(validation_context).include?(:semantic_conversion)
       validate_identifier_semantic_format
     else
       validate_identifier_classic_format

--- a/app/services/project_identifiers/convert_project_to_semantic_service.rb
+++ b/app/services/project_identifiers/convert_project_to_semantic_service.rb
@@ -85,9 +85,8 @@ module ProjectIdentifiers
       raise "Generated identifier is blank for project #{project.id}" if new_identifier.blank?
 
       project.identifier = new_identifier
-      # Bypass validation, because we're technically still in classic mode, so the model would be applying
-      # validation for classic identifiers.
-      project.save!(validate: false)
+      # Save with the validation context that allows to save semantic ID while system is in classic mode
+      project.save!(context: :semantic_conversion)
     end
 
     def reset_stale_identifiers

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -201,6 +201,42 @@ RSpec.describe Projects::Identifier do
     end
   end
 
+  describe "semantic_conversion context", with_settings: { work_packages_identifier: "classic" } do
+    let!(:project) { create(:project, identifier: "classic-id") }
+
+    it "rejects a semantic identifier under normal classic-mode validation" do
+      project.identifier = "PROJ"
+      expect(project).not_to be_valid
+      expect(project.errors[:identifier]).to be_present
+    end
+
+    it "accepts a semantic identifier when validated with the :semantic_conversion context" do
+      project.identifier = "PROJ"
+      expect(project.valid?(:semantic_conversion)).to be(true)
+    end
+
+    it "persists the semantic identifier when saved with the :semantic_conversion context" do
+      project.identifier = "PROJ"
+      project.save!(context: :semantic_conversion)
+      expect(project.reload.identifier).to eq("PROJ")
+    end
+
+    it "still rejects an invalid semantic identifier under :semantic_conversion context" do
+      project.identifier = "bad-format"
+      expect(project.valid?(:semantic_conversion)).to be(false)
+      expect(project.errors[:identifier]).to be_present
+    end
+
+    it "rejects an identifier already used historically by another project" do
+      other = create(:project, identifier: "other-id")
+      FriendlyId::Slug.create!(sluggable: other, slug: "PROJ")
+
+      project.identifier = "PROJ"
+      expect(project.valid?(:semantic_conversion)).to be(false)
+      expect(project.errors[:identifier]).to include(I18n.t("activerecord.errors.messages.taken"))
+    end
+  end
+
   describe ".suggest_identifier" do
     context "with semantic identifiers", with_settings: { work_packages_identifier: "semantic" } do
       it "delegates to ProjectIdentifierSuggestionGenerator with an exclusion set" do


### PR DESCRIPTION
# What are you trying to accomplish?
The procedure to convert instance to `semantic` identifier mode hasn't been properly validating the newly generated identifiers. 

More specifically, the process allowed to create `semantic` identifiers that _case-insensitively_ clash with past `classic` identifiers. Example:
* Project "Test 1" has identifier `test` in classic mode.
* Project "Test" has identifier `whatever` in classic mode.

...conversion happens...

* Project "Test 1" now has identifier `TEST1`
* Project "Test" now has identifier `TEST` <== Incorrect, as it clashes with the old identifier of "Test 1"

 

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Step 1: Fix model validation (this PR)
* Use a custom [validation context](https://guides.rubyonrails.org/active_record_validations.html#custom-contexts), which is (among other things) an attribute settable at `save!` time and then reachable from within the validation methods. 

Step 2: Fix identifier generation (https://github.com/opf/openproject/pull/22933)
* Make sure the semantic identifier generator avoids historical IDs even if they had different casing.
* Avoid model-reserved keywords (such as `new`) 

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
