### PR TITLE
fix: Correctly avoid reserved identifiers in semantic identifier generation

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -88,8 +88,8 @@ module Projects::Identifier
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
-    def suggest_identifier(name)
-      if Setting::WorkPackageIdentifier.semantic?
+    def suggest_identifier(name, mode: Setting[:work_packages_identifier])
+      if mode == Setting::WorkPackageIdentifier::SEMANTIC
         exclude = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.reserved_identifiers
         ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator
           .suggest_identifier(name, exclude:)
@@ -97,6 +97,10 @@ module Projects::Identifier
         ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new.suggest_identifier(name)
       end
     end
+  end
+
+  def suggest_identifier(mode: Setting[:work_packages_identifier])
+    self.class.suggest_identifier(name, mode:)
   end
 
   # Override the `validation_context` getter to include the `default_validation_context` when the

--- a/app/services/project_identifiers/convert_project_to_semantic_service.rb
+++ b/app/services/project_identifiers/convert_project_to_semantic_service.rb
@@ -71,16 +71,11 @@ module ProjectIdentifiers
     end
 
     def assign_semantic_identifier
-      # Re-instantiate inside the lock so the exclusion set reflects all
-      # identifiers committed since this job started.
-      detector  = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.new
-      generator = ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator
-
       # Prefer restoring the project's last known semantic identifier (from
       # FriendlyId history) so that existing WP identifiers remain valid and
       # aliases need no update. Fall back to generating a fresh suggestion.
       new_identifier = project.previous_semantic_identifier ||
-                       generator.suggest_identifier(project.name, exclude: detector.exclusion_set)
+                       project.suggest_identifier(mode: Setting::WorkPackageIdentifier::SEMANTIC)
 
       raise "Generated identifier is blank for project #{project.id}" if new_identifier.blank?
 

--- a/app/services/project_identifiers/identifier_autofix/preview_query.rb
+++ b/app/services/project_identifiers/identifier_autofix/preview_query.rb
@@ -53,7 +53,7 @@ module ProjectIdentifiers
       def generate_suggestions(analysis)
         ProjectIdentifierSuggestionGenerator.call(
           preview_projects(analysis.scope),
-          exclude: analysis.exclusion_set.to_set(&:upcase)
+          exclude: analysis.reserved_identifiers_for_admin_preview.to_set(&:upcase)
         )
       end
 

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -37,7 +37,7 @@ module ProjectIdentifiers
     #
     # == Performance notes
     #
-    # * +#exclusion_set+ loads all non-problematic identifiers and historical slugs
+    # * +#reserved_identifiers_for_admin_preview+ loads all non-problematic identifiers and historical slugs
     #   into memory. Fine for a one-off admin migration; if this ever becomes a hot
     #   path, consider a DB-backed exclusion check instead.
     #
@@ -47,11 +47,16 @@ module ProjectIdentifiers
     #
     #
     class ProblematicIdentifiers
-      # Returns all project identifiers (current and historical) tracked by
-      # FriendlyId's slug history. Useful as an exclusion set when generating
-      # new identifiers, since any slug that was ever in use must not be reused.
+      # Returns a Set of uppercased identifiers that must not be reused.
+      # Combines all FriendlyId slug history for projects (current and historical slugs)
+      # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        FriendlyId::Slug.where(sluggable_type: Project.name).pluck(:slug).to_set
+        slug_set = FriendlyId::Slug.where(sluggable_type: Project.name).pluck("UPPER(slug)").to_set
+        slug_set | model_reserved_identifiers
+      end
+
+      def self.model_reserved_identifiers
+        Projects::Identifier::RESERVED_IDENTIFIERS.to_set(&:upcase)
       end
 
       # Priority-ordered format rules for identifier classification.
@@ -77,7 +82,7 @@ module ProjectIdentifiers
       end
 
       def self.max_identifier_length
-        ProjectIdentifierSuggestionGenerator::IDENTIFIER_LENGTH[:max]
+        Projects::Identifier::SEMANTIC_IDENTIFIER_MAX_LENGTH
       end
 
       def scope
@@ -96,10 +101,11 @@ module ProjectIdentifiers
       end
 
       # Returns a Set of identifiers that must not be suggested for new assignments.
-      # Combines currently active identifiers from non-problematic projects with
-      # historically reserved identifiers from FriendlyId slug history.
-      def exclusion_set
-        historical_identifiers | in_use_identifiers
+      # Unions currently active identifiers (non-problematic projects), historical FriendlyId slugs,
+      # and system-reserved keywords — the full exclusion set used by #collision_error_reason.
+      # Uses instance-level memoization so the same loaded sets power both this method and collision checks.
+      def reserved_identifiers_for_admin_preview
+        historical_identifiers | current_identifiers | self.class.model_reserved_identifiers
       end
 
       private
@@ -108,7 +114,7 @@ module ProjectIdentifiers
         @historical_identifiers ||= FriendlyId::Slug
                                     .where(sluggable_type: Project.name)
                                     .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                    .pluck(:slug)
+                                    .pluck("UPPER(slug)")
                                     .to_set
       end
 
@@ -118,17 +124,18 @@ module ProjectIdentifiers
       def not_fully_uppercased      = Project.where("identifier != UPPER(identifier)")
 
       def collision_error_reason(identifier)
-        if in_use_identifiers.include?(identifier)
+        if self.class.model_reserved_identifiers.include?(identifier)
+          :reserved_by_system
+        elsif current_identifiers.include?(identifier)
           :in_use
         elsif historical_identifiers.include?(identifier)
-          :reserved
+          :used_in_past
         end
       end
 
-      def in_use_identifiers
-        @in_use_identifiers ||= Project.where.not(id: scope.select(:id)).pluck(:identifier).to_set
+      def current_identifiers
+        @current_identifiers ||= Project.where.not(id: scope.select(:id)).pluck(:identifier).to_set
       end
-
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -420,7 +420,8 @@ en:
           error_special_characters: Special characters not allowed
           error_not_fully_uppercased: Must be uppercase
           error_in_use: Already in use as another project's active handle
-          error_reserved: Reserved by another project's handle history
+          error_used_in_past: Reserved by another project's handle history
+          error_reserved_by_system: Reserved as a system keyword
           error_unknown: Needs manual review
           remaining_projects:
             one: "... 1 more project"

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -258,5 +258,63 @@ RSpec.describe Projects::Identifier do
         expect(result).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
     end
+
+    context "with explicit mode: parameter" do
+      context "when mode: semantic overrides a classic setting",
+              with_settings: { work_packages_identifier: "classic" } do
+        it "uses the semantic generator" do
+          allow(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+            .to receive(:suggest_identifier).and_return("MP")
+
+          Project.suggest_identifier("My Project", mode: Setting::WorkPackageIdentifier::SEMANTIC)
+
+          expect(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+            .to have_received(:suggest_identifier).with("My Project", exclude: a_kind_of(Set))
+        end
+      end
+
+      context "when mode: classic overrides a semantic setting",
+              with_settings: { work_packages_identifier: "semantic" } do
+        it "uses the classic generator" do
+          generator = instance_double(ProjectIdentifiers::ClassicIdentifierSuggestionGenerator)
+          allow(ProjectIdentifiers::ClassicIdentifierSuggestionGenerator).to receive(:new).and_return(generator)
+          allow(generator).to receive(:suggest_identifier).and_return("my-project")
+
+          result = Project.suggest_identifier("My Project", mode: Setting::WorkPackageIdentifier::CLASSIC)
+
+          expect(result).to eq("my-project")
+        end
+      end
+    end
+  end
+
+  describe "#suggest_identifier" do
+    subject(:project) { build(:project, name: "My Project") }
+
+    context "with no mode argument", with_settings: { work_packages_identifier: "classic" } do
+      it "delegates to the class method using the current setting" do
+        expect(project.suggest_identifier).to eq(Project.suggest_identifier("My Project"))
+      end
+    end
+
+    context "with explicit mode: semantic", with_settings: { work_packages_identifier: "classic" } do
+      it "passes the mode through to the class method" do
+        allow(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+          .to receive(:suggest_identifier).and_return("MP")
+
+        project.suggest_identifier(mode: Setting::WorkPackageIdentifier::SEMANTIC)
+
+        expect(ProjectIdentifiers::IdentifierAutofix::ProjectIdentifierSuggestionGenerator)
+          .to have_received(:suggest_identifier).with("My Project", exclude: a_kind_of(Set))
+      end
+    end
+
+    context "with explicit mode: classic", with_settings: { work_packages_identifier: "semantic" } do
+      it "passes the mode through to the class method" do
+        result = project.suggest_identifier(mode: Setting::WorkPackageIdentifier::CLASSIC)
+
+        expect(result).to eq("my-project")
+      end
+    end
   end
 end

--- a/spec/services/project_identifiers/convert_project_to_semantic_service_spec.rb
+++ b/spec/services/project_identifiers/convert_project_to_semantic_service_spec.rb
@@ -67,6 +67,22 @@ RSpec.describe ProjectIdentifiers::ConvertProjectToSemanticService,
       end
     end
 
+    context "when the suggested identifier case-insensitively matches a historical classic identifier" do
+      let!(:project_one) do
+        create(:project, name: "Project 1", identifier: "project_one").tap do |p|
+          FriendlyId::Slug.create!(sluggable: p, slug: "toi")
+        end
+      end
+      let!(:project_two) { create(:project, name: "Test Old Identifier", identifier: "whatever") }
+
+      it "avoids the clashing suggestion and assigns an alternative semantic identifier" do
+        described_class.new(project_two).call
+        # "TOI" (initials of "Test Old Identifier") is the first candidate but is
+        # blocked by the FriendlyId slug history; the generator expands to "TEOI" next.
+        expect(project_two.reload.identifier).to eq("TEOI")
+      end
+    end
+
     context "when the generated identifier is blank" do
       let!(:project) do
         create(:project).tap { |p| p.update_columns(identifier: "my-app") }
@@ -96,6 +112,20 @@ RSpec.describe ProjectIdentifiers::ConvertProjectToSemanticService,
 
       it "backfills WPs using the new identifier" do
         expect(wp.reload.identifier).to eq("#{project.reload.identifier}-1")
+      end
+    end
+
+    context "when the only natural suggestion is a system-reserved keyword" do
+      let!(:project) do
+        # "New" produces "NEW" as the sole initial candidate, but "NEW" is in
+        # RESERVED_IDENTIFIERS; the generator falls back to the numeric suffix "NEW2".
+        create(:project, name: "New Project").tap { |p| p.update_columns(name: "New", identifier: "new") }
+      end
+
+      before { described_class.new(project).call }
+
+      it "steers to a non-reserved alternative" do
+        expect(project.reload.identifier).to eq("NEW2")
       end
     end
 

--- a/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
+++ b/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
@@ -136,11 +136,15 @@ RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
       expect(analysis.error_reason("TAKEN")).to eq(:in_use)
     end
 
-    it "returns :reserved when identifier is a historical slug of another project" do
+    it "returns :used_in_past when identifier is a historical slug of another project" do
       project = create_project_with_raw_identifier(name: "Gamma", identifier: "GAMMA")
       FriendlyId::Slug.create!(slug: "OLDIE", sluggable: project)
 
-      expect(analysis.error_reason("OLDIE")).to eq(:reserved)
+      expect(analysis.error_reason("OLDIE")).to eq(:used_in_past)
+    end
+
+    it "returns :reserved_by_system for model-reserved identifiers" do
+      expect(analysis.error_reason("NEW")).to eq(:reserved_by_system)
     end
 
     it "returns :unknown when no classification matches" do
@@ -156,8 +160,8 @@ RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
     end
   end
 
-  describe "#exclusion_set" do
-    subject(:exclusion) { analysis.exclusion_set }
+  describe "#reserved_identifiers_by_error_reasons" do
+    subject(:exclusion) { analysis.reserved_identifiers_for_admin_preview }
 
     let!(:valid_project) { create_project_with_raw_identifier(name: "Alpha", identifier: "ALPHA") }
 
@@ -173,7 +177,7 @@ RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
       expect(exclusion).to include("ALPHA")
     end
 
-    it "includes historical slugs (reserved identifiers)" do
+    it "includes historical slugs" do
       FriendlyId::Slug.create!(slug: "OLDALPHA", sluggable_id: valid_project.id, sluggable_type: "Project")
 
       expect(exclusion).to include("OLDALPHA")
@@ -181,6 +185,29 @@ RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
 
     it "excludes identifiers from problematic projects" do
       expect(exclusion).not_to include("beta-project")
+    end
+
+    it "includes model-reserved identifiers in uppercase" do
+      expect(exclusion).to include("NEW", "MENU", "FILTERS")
+    end
+  end
+
+  describe ".reserved_identifiers" do
+    subject(:reserved) { described_class.reserved_identifiers }
+
+    it "returns a Set" do
+      expect(reserved).to be_a(Set)
+    end
+
+    it "includes historical slugs in uppercase" do
+      project = create_project_with_raw_identifier(name: "Gamma", identifier: "GAMMA")
+      FriendlyId::Slug.create!(slug: "oldie", sluggable: project)
+
+      expect(reserved).to include("OLDIE")
+    end
+
+    it "includes model-reserved identifiers in uppercase" do
+      expect(reserved).to include("NEW", "MENU", "FILTERS")
     end
   end
 end


### PR DESCRIPTION
# What are you trying to accomplish?
The procedure to convert instance to `semantic` identifier mode hasn't been properly validating the newly generated identifiers. 

More specifically, the process allowed to create `semantic` identifiers that _case-insensitively_ clash with past `classic` identifiers. Example:
* Project "Test 1" has identifier `test` in classic mode.
* Project "Test" has identifier `whatever` in classic mode.

...conversion happens...

* Project "Test 1" now has identifier `TEST1`
* Project "Test" now has identifier `TEST` <== Incorrect, as it clashes with the old identifier of "Test 1"

 
## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
Step 1: Fix model validation (https://github.com/opf/openproject/pull/22932)
* Use a custom [validation context](https://guides.rubyonrails.org/active_record_validations.html#custom-contexts), which is (among other things) an attribute settable at `save!` time and then reachable from within the validation methods. 

Step 2: Fix identifier generation (this PR)
* Make sure the semantic identifier generator avoids historical IDs even if they had different casing.
* Avoid model-reserved keywords (such as `NEW`) 
* Make sure to call the ID generator service only from `suggest_identifier` in the model

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
