### PR TITLE
refactor: Add `Project.historical_slugs`

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -88,6 +88,10 @@ module Projects::Identifier
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
+    def historical_slugs
+      FriendlyId::Slug.where(sluggable_type: name)
+    end
+
     def suggest_identifier(name, mode: Setting[:work_packages_identifier])
       if mode == Setting::WorkPackageIdentifier::SEMANTIC
         exclude = ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.reserved_identifiers
@@ -167,11 +171,10 @@ module Projects::Identifier
   end
 
   def identifier_used_by_other_project_in_past?
-    FriendlyId::Slug
-      .where("LOWER(slug) = ?", identifier.downcase)
-      .where(sluggable_type: self.class.to_s)
-      .where.not(sluggable_id: id)
-      .exists?
+    self.class.historical_slugs
+              .where("LOWER(slug) = ?", identifier.downcase)
+              .where.not(sluggable_id: id)
+              .exists?
   end
 
   def generate_semantic_identifier

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -77,9 +77,9 @@ module ProjectIdentifiers
 
     def taken_identifiers(project: nil)
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
-      historical = FriendlyId::Slug.where(sluggable_type: "Project")
-                                   .then { |q| project ? q.where.not(sluggable_id: project.id) : q }
-                                   .pluck(:slug).to_set(&:downcase)
+      historical = Project.historical_slugs
+                         .then { |q| project ? q.where.not(sluggable_id: project.id) : q }
+                         .pluck(:slug).to_set(&:downcase)
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set
       current | historical | reserved
     end

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -51,7 +51,7 @@ module ProjectIdentifiers
       # Combines all FriendlyId slug history for projects (current and historical slugs)
       # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        slug_set = FriendlyId::Slug.where(sluggable_type: Project.name).pluck("UPPER(slug)").to_set
+        slug_set = Project.historical_slugs.pluck("UPPER(slug)").to_set
         slug_set | model_reserved_identifiers
       end
 
@@ -111,11 +111,11 @@ module ProjectIdentifiers
       private
 
       def historical_identifiers
-        @historical_identifiers ||= FriendlyId::Slug
-                                    .where(sluggable_type: Project.name)
-                                    .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                    .pluck("UPPER(slug)")
-                                    .to_set
+        @historical_identifiers ||= Project
+                                      .historical_slugs
+                                      .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
+                                      .pluck("UPPER(slug)")
+                                      .to_set
       end
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)


### PR DESCRIPTION
Get rid of some nasty `FriendlyId::Slug` calls.

There's definitely ways to make all this even nicer, but this is a quick win for now.