### PR TITLE
fix: Adjust save button behaviour in identifier settings

### DIFF
--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
@@ -77,7 +77,7 @@
               scheme: :primary,
               type: :submit,
               form: form_id,
-              hidden: show_autofix_section?,
+              hidden: true,
               data: { admin__work_packages_identifier_target: "saveButton" }
             )
           ) { t("button_save") } %>

--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
@@ -101,7 +101,8 @@ module WorkPackages
           {
             data: {
               controller: "admin--work-packages-identifier",
-              admin__work_packages_identifier_has_problematic_projects_value: has_problematic_projects?
+              admin__work_packages_identifier_has_problematic_projects_value: has_problematic_projects?,
+              admin__work_packages_identifier_current_value_value: Setting[:work_packages_identifier]
             }
           }
         end

--- a/frontend/src/stimulus/controllers/dynamic/admin/work-packages-identifier.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/admin/work-packages-identifier.controller.ts
@@ -33,18 +33,30 @@ import { Controller } from '@hotwired/stimulus';
 export default class WorkPackagesIdentifierController extends Controller {
   static values = {
     hasProblematicProjects: Boolean,
+    currentValue: String,
   };
 
   static targets = ['autofixSection', 'saveButton', 'autofixButton'];
 
   declare readonly hasProblematicProjectsValue:boolean;
+  declare readonly currentValueValue:string;
 
   declare readonly autofixSectionTarget:HTMLElement;
   declare readonly saveButtonTarget:HTMLButtonElement;
   declare readonly autofixButtonTarget:HTMLButtonElement;
+  declare readonly hasSaveButtonTarget:boolean;
+
+  private readonly resetBeforeCache = ():void => {
+    if (this.hasSaveButtonTarget) this.saveButtonTarget.hidden = true;
+  };
 
   connect() {
+    document.addEventListener('turbo:before-cache', this.resetBeforeCache);
     this.updateVisibility();
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:before-cache', this.resetBeforeCache);
   }
 
   handleChange() {
@@ -52,17 +64,18 @@ export default class WorkPackagesIdentifierController extends Controller {
   }
 
   private updateVisibility() {
-    const showAutofix = this.isSemanticSelected() && this.hasProblematicProjectsValue;
+    const selectedValue = this.selectedValue();
+    const showAutofix   = selectedValue === 'semantic' && this.hasProblematicProjectsValue;
+    const isDirty       = selectedValue !== this.currentValueValue;
 
     this.autofixSectionTarget.hidden = !showAutofix;
-    this.saveButtonTarget.hidden     =  showAutofix;
+    this.saveButtonTarget.hidden     =  showAutofix || !isDirty;
     this.autofixButtonTarget.hidden  = !showAutofix;
   }
 
-  private isSemanticSelected():boolean {
-    const checked = this.element.querySelector<HTMLInputElement>(
+  private selectedValue():string | undefined {
+    return this.element.querySelector<HTMLInputElement>(
       'input[name="settings[work_packages_identifier]"]:checked',
-    );
-    return checked?.value === 'semantic';
+    )?.value;
   }
 }

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
       expect(ProjectIdentifiers::IdentifierAutofix::PreviewQuery).to have_received(:new).once
     end
 
-    it "renders the save button" do
+    it "renders the save button (hidden until a change is made)" do
       render_component(component)
-      expect(page).to have_button("Save")
+      expect(page).to have_button("Save", visible: :all)
     end
 
     it "does not render in-progress or success content" do

--- a/spec/features/admin/settings/work_packages_identifier_spec.rb
+++ b/spec/features/admin/settings/work_packages_identifier_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Work packages identifier admin settings", :js do
   context "when no projects have problematic identifiers" do
     it "saves the setting without showing a dialog" do
       visit_settings
+      choose "Project-based semantic identifiers"
 
       click_button "Save"
 
@@ -60,9 +61,10 @@ RSpec.describe "Work packages identifier admin settings", :js do
   context "when a project has a problematic identifier" do
     shared_let(:project) { create(:project, identifier: "bad-id", name: "Bad Project") }
 
-    context "when saving with the current classic setting" do
+    context "when switching from semantic to classic", with_settings: { work_packages_identifier: "semantic" } do
       it "saves without showing the confirmation dialog" do
         visit_settings
+        choose "Instance-wide numerical sequence (default)"
 
         # The autofix section is hidden when classic is selected
         expect(page).to have_css(

--- a/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
+++ b/spec/services/project_identifiers/identifier_autofix/problematic_identifiers_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers do
     end
   end
 
-  describe "#reserved_identifiers_by_error_reasons" do
+  describe "#reserved_identifiers_for_admin_preview" do
     subject(:exclusion) { analysis.reserved_identifiers_for_admin_preview }
 
     let!(:valid_project) { create_project_with_raw_identifier(name: "Alpha", identifier: "ALPHA") }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

https://community.openproject.org/wp/74623

# What are you trying to accomplish?
There were two issues with the `work_packages_identifier` setting page: 
* The Save button would always appear, even if the current option was the actual system one
* The Save button would just refresh the page if clicked after a conversion procedure had just finished.

# What approach did you choose and why?
Hide the button by default, then have the Stimulus controller surface it again under correct conditions.

<img width="877" height="312" alt="Screenshot 2026-04-26 at 14 24 59" src="https://github.com/user-attachments/assets/ed3f0e7d-79a0-4f77-82c8-5b0b219f05c5" />


Also, make sure to explicitly unload event listener in `disconnect` so that the page doesn't get messed up when navigating away from the admin section and then back.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
