### PR TITLE
fix: Do not trigger notifications during project identifier migration

### DIFF
--- a/app/services/project_identifiers/convert_project_to_semantic_service.rb
+++ b/app/services/project_identifiers/convert_project_to_semantic_service.rb
@@ -80,8 +80,11 @@ module ProjectIdentifiers
       raise "Generated identifier is blank for project #{project.id}" if new_identifier.blank?
 
       project.identifier = new_identifier
-      # Save with the validation context that allows to save semantic ID while system is in classic mode
-      project.save!(context: :semantic_conversion)
+      # Save with the validation context that allows to save semantic ID while system is in classic mode.
+      # Suppress notifications: this is a background system operation, not a user edit.
+      Journal::NotificationConfiguration.with(false) do
+        project.save!(context: :semantic_conversion)
+      end
     end
 
     def reset_stale_identifiers

--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -53,7 +53,10 @@ module ProjectIdentifiers
     def restore_classic_identifier
       generator = ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
       classic = generator.restore_identifier(project) || generator.suggest_identifier(project.name)
-      project.update!(identifier: classic)
+      # Suppress notifications: this is a background system operation, not a user edit.
+      Journal::NotificationConfiguration.with(false) do
+        project.update!(identifier: classic)
+      end
     end
   end
 end

--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -41,10 +41,11 @@ Rails.application.config.after_initialize do
     # A job is scheduled immediately that creates notifications (in-app if
     # supported) right away and schedules jobs to be run for mail and digest
     # mails.
-    Notifications::WorkflowJob
-      .perform_later(:create_notifications,
-                     journal,
-                     send_notifications)
+    if send_notifications
+      Notifications::WorkflowJob.perform_later(:create_notifications,
+                                               journal,
+                                               send_notifications)
+    end
 
     # A job is scheduled for the end of the journal aggregation time. If the
     # journal still exists with a matching updated_at value (it might be updated

--- a/spec/services/project_identifiers/convert_project_to_semantic_service_spec.rb
+++ b/spec/services/project_identifiers/convert_project_to_semantic_service_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe ProjectIdentifiers::ConvertProjectToSemanticService,
       it "backfills WPs using the new identifier" do
         expect(wp.reload.identifier).to eq("#{project.reload.identifier}-1")
       end
+
+      it "does not enqueue Notifications::WorkflowJob for the identifier change" do
+        project2 = create(:project, name: "Another Project")
+        expect { described_class.new(project2).call }
+          .not_to have_enqueued_job(Notifications::WorkflowJob)
+      end
     end
 
     context "when the only natural suggestion is a system-reserved keyword" do

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
       it "restores the classic identifier" do
         expect(project.reload.identifier).to eq("my-app")
       end
+
+      it "does not enqueue Notifications::WorkflowJob for the identifier change" do
+        project2 = create(:project).tap do |p|
+          p.update_columns(identifier: "OTHER", wp_sequence_counter: 0)
+          FriendlyId::Slug.create!(sluggable: p, slug: "other-name")
+        end
+        expect { described_class.new(project2).call }
+          .not_to have_enqueued_job(Notifications::WorkflowJob)
+      end
     end
 
     context "when the project has multiple slugs in FriendlyId history" do


### PR DESCRIPTION
https://community.openproject.org/projects/stream-jira-exit/work_packages/71645

# What are you trying to accomplish?
The identifier mode migration requires updating the `identifier` values of all `Projects`.

This sets off a deluge of `Notifications::WorkflowJob`. We definitely want to opt out of any notifications for projects, as people may easily get flooded. 

## Screenshots
<img width="1177" height="1117" alt="Screenshot 2026-04-26 at 20 17 42" src="https://github.com/user-attachments/assets/e1956a42-8b3a-4128-ab60-ca43204c4715" />


# What approach did you choose and why?
* Use the established block pattern to silence notifications for the update actions.
* Even with the above, we still ended up with tons of no-op `Notifications::WorkflowJobs` in the queue. So, we're also tweaking `subscribe_listeners.rb` to actually skip the job altogether if there are no notifications to generate. Cc @oliverguenther 


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
