### PR TITLE
Cleanup split routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1131,9 +1131,16 @@ Rails.application.routes.draw do
         work_package_split_view: true
   end
 
+  concern :with_split_create do
+    get "details/new",
+        action: :split_create,
+        as: :split_create,
+        work_package_split_create: true
+  end
+
   resources :notifications, only: :index do
     collection do
-      concerns :with_split_view, base_route: :notifications_path
+      concerns :with_split_view
 
       post :mark_all_read
       resource :menu, module: :notifications, only: %i[show], as: :notifications_menu

--- a/modules/boards/config/routes.rb
+++ b/modules/boards/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
             as: :details,
             work_package_split_view: true
       end
-      get "(/*state)" => "boards/boards#show", on: :member, as: "", constraints: { id: /\d+/ }
     end
   end
 end

--- a/modules/team_planner/config/routes.rb
+++ b/modules/team_planner/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   scope "projects/:project_id", as: "project" do
     resources :team_planners,
               controller: "team_planner/team_planner",
-              only: %i[index destroy],
+              only: %i[index destroy show],
               as: :team_planners do
       collection do
         get "menu" => "team_planner/menus#show"
@@ -35,7 +35,6 @@ Rails.application.routes.draw do
             defaults: { tab: "overview" },
             as: :details,
             work_package_split_view: true
-        get "(/*state)" => "team_planner/team_planner#show", as: ""
       end
     end
   end


### PR DESCRIPTION

# Ticket
None

# What are you trying to accomplish?
Create a concern for split create routes and remove old angular route references
