### PR TITLE
Fix DynamicFindBy issues in our Codebase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -183,6 +183,7 @@ Rails/DynamicFindBy:
     - find_by_plaintext_value
     - find_by_rss_key
     - find_by_unique
+    - find_by_unique!
     - find_by_api_key
 
 # Allow reorder to prevent find each cop triggering

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,7 +60,7 @@ Layout/MultilineOperationIndentation:
   Enabled: false
 
 Lint/AmbiguousBlockAssociation:
-  AllowedMethods: [change]
+  AllowedMethods: [ change ]
 
 Lint/AmbiguousOperator:
   Enabled: false
@@ -147,9 +147,9 @@ Naming/PredicatePrefix:
 
 Naming/VariableNumber:
   AllowedPatterns:
-    - '\w_20\d\d' # allow dates like christmas_2022 or date_2034_04_12
-    - '\w\d++(_\d++)+' # allow hierarchical data like child1_2_5 (second + in regex is possessive qualifier)
-    - 'custom_field_\d+' # allow custom field method names to be called with send :custom_field_1001
+    - "\\w_20\\d\\d" # allow dates like christmas_2022 or date_2034_04_12
+    - "\\w\\d++(_\\d++)+" # allow hierarchical data like child1_2_5 (second + in regex is possessive qualifier)
+    - "custom_field_\\d+" # allow custom field method names to be called with send :custom_field_1001
 
 OpenProject/AddPreviewForViewComponent:
   Include:
@@ -181,6 +181,9 @@ Rails/DynamicFindBy:
     - find_by_login
     - find_by_mail
     - find_by_plaintext_value
+    - find_by_rss_key
+    - find_by_unique
+    - find_by_api_key
 
 # Allow reorder to prevent find each cop triggering
 Rails/FindEach:
@@ -402,7 +405,7 @@ Style/FormatString:
   Enabled: false
 
 Style/FormatStringToken:
-  AllowedMethods: [redirect]
+  AllowedMethods: [ redirect ]
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,7 +60,8 @@ Layout/MultilineOperationIndentation:
   Enabled: false
 
 Lint/AmbiguousBlockAssociation:
-  AllowedMethods: [ change ]
+  AllowedMethods:
+    - change
 
 Lint/AmbiguousOperator:
   Enabled: false
@@ -406,7 +407,8 @@ Style/FormatString:
   Enabled: false
 
 Style/FormatStringToken:
-  AllowedMethods: [ redirect ]
+  AllowedMethods:
+    - redirect
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/app/contracts/users/base_contract.rb
+++ b/app/contracts/users/base_contract.rb
@@ -102,13 +102,11 @@ module Users
       errors.add(:identity_url, :error_readonly) if model.user_auth_provider_links.any?(&:changed?)
     end
 
-    # rubocop:disable Rails/DynamicFindBy
     def existing_auth_source
       if ldap_auth_source_id && LdapAuthSource.find_by_unique(ldap_auth_source_id).nil?
         errors.add :auth_source, :error_not_found
       end
     end
-    # rubocop:enable Rails/DynamicFindBy
 
     def can_create_or_manage_users?
       user.allowed_globally?(:manage_user) || user.allowed_globally?(:create_user)

--- a/app/controllers/my/sessions_controller.rb
+++ b/app/controllers/my/sessions_controller.rb
@@ -52,7 +52,7 @@ module My
 
       token = cookies[OpenProject::Configuration["autologin_cookie_name"]]
       if token
-        @current_token = @autologin_tokens.find_by_plaintext_value(token) # rubocop:disable Rails/DynamicFindBy
+        @current_token = @autologin_tokens.find_by_plaintext_value(token)
       end
     end
 

--- a/app/models/work_packages/costs.rb
+++ b/app/models/work_packages/costs.rb
@@ -118,7 +118,7 @@ module WorkPackages::Costs
       reassign_to = ::WorkPackage
                       .joins(:project)
                       .merge(Project.allowed_to(user, :edit_cost_entries))
-                      .find_by_id(ids)
+                      .find_by(id: ids)
 
       if reassign_to.nil?
         work_packages.each do |wp|

--- a/app/services/mcp_resources/user.rb
+++ b/app/services/mcp_resources/user.rb
@@ -37,7 +37,7 @@ module McpResources
     default_description "Access users of this OpenProject instance."
 
     def read(id:)
-      user = ::User.visible(current_user).find_by_unique(id) # rubocop:disable Rails/DynamicFindBy
+      user = ::User.visible(current_user).find_by_unique(id)
       return nil if user.nil?
 
       API::V3::Users::UserRepresenter.create(user, current_user:)

--- a/lib/api/v3/users/user_representer.rb
+++ b/lib/api/v3/users/user_representer.rb
@@ -191,7 +191,7 @@ module API
           ldap_auth_source_id = parse_auth_source_id(data, "authSource") || parse_auth_source_id(data, "auth_source")
 
           if ldap_auth_source_id
-            auth_source = LdapAuthSource.find_by_unique(ldap_auth_source_id) # rubocop:disable Rails/DynamicFindBy
+            auth_source = LdapAuthSource.find_by_unique(ldap_auth_source_id)
             id = auth_source ? auth_source.id : 0
 
             # set id to 0 (as opposed to nil) to produce an auth source not found

--- a/lib/api/v3/users/users_api.rb
+++ b/lib/api/v3/users/users_api.rb
@@ -86,7 +86,7 @@ module API
                 if params[:id] == "me"
                   User.current
                 else
-                  User.visible.find_by_unique!(params[:id]) # rubocop:disable Rails/DynamicFindBy
+                  User.visible.find_by_unique!(params[:id])
                 end
             end
 

--- a/lib_static/open_project/authentication/strategies/warden/user_api_token.rb
+++ b/lib_static/open_project/authentication/strategies/warden/user_api_token.rb
@@ -51,7 +51,7 @@ module OpenProject
           end
 
           def authenticate!
-            token = ::Token::API.find_by_plaintext_value(@access_token) # rubocop:disable Rails/DynamicFindBy
+            token = ::Token::API.find_by_plaintext_value(@access_token)
             return fail_with_header!(error: "invalid_token") if token.nil?
 
             authentication_result(token.user)

--- a/modules/bim/app/models/bim/bcf/viewpoint.rb
+++ b/modules/bim/app/models/bim/bcf/viewpoint.rb
@@ -58,7 +58,7 @@ module Bim::Bcf
       if attachments.loaded?
         attachments.detect { |a| a.description == "snapshot" }
       else
-        attachments.find_by_description("snapshot")
+        attachments.find_by(description: "snapshot")
       end
     end
 

--- a/modules/bim/app/models/bim/ifc_models/ifc_model.rb
+++ b/modules/bim/app/models/bim/ifc_models/ifc_model.rb
@@ -60,7 +60,7 @@ module Bim
         if attachments.loaded?
           attachments.detect { |a| a.description == key.to_s && !a.marked_for_destruction? }
         else
-          attachments.find_by_description(key.to_s)
+          attachments.find_by(description: key.to_s)
         end
       end
 

--- a/modules/budgets/spec/models/budget_spec.rb
+++ b/modules/budgets/spec/models/budget_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Budget do
       budget.destroy
     end
 
-    it { expect(Budget.find_by_id(budget.id)).to be_nil }
-    it { expect(WorkPackage.find_by_id(work_package.id)).to eq(work_package) }
+    it { expect(described_class.find_by(id: budget.id)).to be_nil }
+    it { expect(WorkPackage.find_by(id: work_package.id)).to eq(work_package) }
     it { expect(work_package.reload.budget).to be_nil }
   end
 

--- a/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
+++ b/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
@@ -34,9 +34,7 @@ module Calendar
         raise ActiveRecord::RecordNotFound
       end
 
-      # rubocop:disable Rails/DynamicFindBy
       token = Token::ICal.find_by_plaintext_value(ical_token_string)
-      # rubocop:enable Rails/DynamicFindBy
 
       if token.present?
         ServiceResult.success(result: token)

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/issue_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/issue_hook.rb
@@ -36,9 +36,9 @@ module OpenProject::GitlabIntegration
 
       def process(payload_params) # rubocop:disable Metrics/AbcSize
         @payload = wrap_payload(payload_params)
-        user = User.find_by_id(payload.open_project_user_id)
+        user = User.find_by(id: payload.open_project_user_id)
         text = [payload.object_attributes.title, payload.object_attributes.description]
-          .select(&:present?)
+          .compact_blank
           .join(" - ")
         work_packages = find_mentioned_work_packages(text, user)
         notes = generate_notes(payload)

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/merge_request_hook.rb
@@ -47,9 +47,9 @@ module OpenProject::GitlabIntegration
         @payload = wrap_payload(payload_params)
         return unless (accepted_actions.include? payload.object_attributes.action) || (accepted_states.include? payload.object_attributes.state)
 
-        user = User.find_by_id(payload.open_project_user_id)
+        user = User.find_by(id: payload.open_project_user_id)
         text = [payload.object_attributes.title, payload.object_attributes.description]
-          .select(&:present?)
+          .compact_blank
           .join(" - ")
         work_packages = find_mentioned_work_packages(text, user)
         notes = generate_notes(payload)

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
@@ -38,8 +38,9 @@ module OpenProject::GitlabIntegration
         @payload = wrap_payload(payload_params)
         return nil unless payload.object_kind == "push"
 
+        user = User.find_by(id: payload.open_project_user_id)
+
         payload.commits.each do |commit|
-          user = User.find_by(id: payload.open_project_user_id)
           text = [commit["title"], commit["message"]]
             .compact_blank
             .join(" - ")

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/push_hook.rb
@@ -39,9 +39,9 @@ module OpenProject::GitlabIntegration
         return nil unless payload.object_kind == "push"
 
         payload.commits.each do |commit|
-          user = User.find_by_id(payload.open_project_user_id)
+          user = User.find_by(id: payload.open_project_user_id)
           text = [commit["title"], commit["message"]]
-            .select(&:present?)
+            .compact_blank
             .join(" - ")
           work_packages = find_mentioned_work_packages(text, user)
           notes = generate_notes(commit, payload)

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
@@ -38,8 +38,9 @@ module OpenProject::GitlabIntegration
         @payload = wrap_payload(payload_params)
         return nil unless payload.object_kind == "push"
 
+        user = User.find_by(id: payload.open_project_user_id)
+
         payload.commits.each do |commit|
-          user = User.find_by(id: payload.open_project_user_id)
           text = [commit["title"], commit["message"]]
             .compact_blank
             .join(" - ")

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/system_hook.rb
@@ -39,9 +39,9 @@ module OpenProject::GitlabIntegration
         return nil unless payload.object_kind == "push"
 
         payload.commits.each do |commit|
-          user = User.find_by_id(payload.open_project_user_id)
+          user = User.find_by(id: payload.open_project_user_id)
           text = [commit["title"], commit["message"]]
-            .select(&:present?)
+            .compact_blank
             .join(" - ")
           work_packages = find_mentioned_work_packages(text, user)
           notes = generate_notes(commit, payload)

--- a/spec/models/token/ical_token_spec.rb
+++ b/spec/models/token/ical_token_spec.rb
@@ -152,9 +152,7 @@ RSpec.describe Token::ICal do
 
         ical_token1 = described_class.where(user_id: user.id).last
 
-        # rubocop:disable Rails/DynamicFindBy
         expect(described_class.find_by_plaintext_value(ical_token1_value)).to eq ical_token1
-        # rubocop:enable Rails/DynamicFindBy
 
         expect(ical_token1.query).to eq query
         expect(ical_token1.ical_token_query_assignment.name).to eq name
@@ -185,9 +183,7 @@ RSpec.describe Token::ICal do
 
         ical_token1 = described_class.where(user_id: user.id).last
 
-        # rubocop:disable Rails/DynamicFindBy
         expect(described_class.find_by_plaintext_value(ical_token1_value)).to eq ical_token1
-        # rubocop:enable Rails/DynamicFindBy
       end
     end
 
@@ -277,10 +273,8 @@ RSpec.describe Token::ICal do
       end
 
       it "finds using the plaintext value" do
-        # rubocop:disable Rails/DynamicFindBy
         expect(described_class.find_by_plaintext_value(subject.plain_value)).to eq subject
         expect(described_class.find_by_plaintext_value("foobar")).to be_nil
-        # rubocop:enable Rails/DynamicFindBy
       end
     end
   end


### PR DESCRIPTION
Just stumbled upon rupocop complaining about the `find_by_api_key`, etc methods. We have whitelisted some of them. This PR attempts to whitelist all custom `find_by_XXX` methods we have defined and gets rid of all other usages of the dynamic methods