### PR TITLE
Add read-only S3-compatible attachment export endpoint

### DIFF
--- a/app/controllers/s3_compatible/attachments_controller.rb
+++ b/app/controllers/s3_compatible/attachments_controller.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module S3Compatible
+  # Read-only S3-compatible endpoint for bulk attachment export.
+  #
+  # Implements the minimal S3 surface needed by `aws s3 sync` and rclone:
+  #   ListObjectsV2  GET  /s3/:bucket?list-type=2
+  #   GetObject      GET  /s3/:bucket/*key
+  #   HeadObject     HEAD /s3/:bucket/*key
+  #
+  # Authentication: supply your OpenProject backup token as the AWS access key ID.
+  # Using the backup token ties this endpoint to the same audit trail as the existing
+  # backup feature — every token reset notifies the user and all administrators.
+  # The Signature V4 HMAC is accepted by the AWS SDK but not verified server-side.
+  #
+  # The endpoint is only available when backups are enabled in the OpenProject
+  # configuration and after the backup token's initial waiting period has elapsed.
+  #
+  # Object keys have the form "{attachment_id}/{filename}", which is stable across
+  # renames and moves. ETags are the stored MD5 digest, so `sync` only downloads
+  # files that have actually changed.
+  class AttachmentsController < ApplicationController
+    skip_before_action :verify_authenticity_token
+    skip_before_action :user_setup
+    skip_before_action :check_if_login_required
+
+    no_authorization_required! :list_objects, :get_object, :head_object
+
+    before_action :authenticate_s3_request
+
+    BUCKET_NAME = "openproject"
+    MAX_KEYS    = 1000
+
+    # GET /s3/:bucket?list-type=2[&max-keys=N][&continuation-token=T]
+    def list_objects
+      unless params[:bucket] == BUCKET_NAME
+        return render_s3_error(:not_found, "NoSuchBucket", "The specified bucket does not exist.")
+      end
+
+      raw_max  = params[:"max-keys"].to_i
+      max_keys = raw_max.positive? ? [raw_max, MAX_KEYS].min : MAX_KEYS
+      after_id = params[:"continuation-token"] ? decode_token(params[:"continuation-token"]) : nil
+
+      scope = listable_attachments
+      scope = scope.where("attachments.id > ?", after_id) if after_id
+
+      batch     = scope.order(:id).limit(max_keys + 1).to_a
+      truncated = batch.size > max_keys
+      results   = batch.first(max_keys)
+      next_token = truncated ? encode_token(results.last.id) : nil
+
+      render body: list_objects_xml(results, max_keys, truncated, next_token),
+             content_type: "application/xml"
+    end
+
+    # GET /s3/:bucket/*key
+    def get_object
+      attachment = find_attachment
+      return render_s3_error(:not_found, "NoSuchKey", "The specified key does not exist.") unless attachment
+
+      set_object_headers(attachment)
+
+      if attachment.external_storage?
+        redirect_to attachment.external_url.to_s, allow_other_host: true, status: :found
+      else
+        send_file attachment.diskfile.path,
+                  type:        "application/octet-stream",
+                  disposition: :attachment,
+                  filename:    attachment.filename
+      end
+    end
+
+    # HEAD /s3/:bucket/*key
+    def head_object
+      attachment = find_attachment
+      return render_s3_error(:not_found, "NoSuchKey", "The specified key does not exist.") unless attachment
+
+      set_object_headers(attachment)
+      head :ok
+    end
+
+    private
+
+    def authenticate_s3_request
+      unless OpenProject::Configuration.backup_enabled?
+        return render_s3_error(:forbidden, "AccessDenied", "Backups are not enabled on this instance.")
+      end
+
+      raw_token = extract_token_value
+      unless raw_token
+        response.headers["WWW-Authenticate"] = "AWS4-HMAC-SHA256"
+        return render_s3_error(:unauthorized, "InvalidAccessKeyId",
+                               "No backup token found. Supply your OpenProject backup token as the AWS access key ID.")
+      end
+
+      backup_token = Token::Backup.find_by_plaintext_value(raw_token)
+
+      unless backup_token&.user&.active? && backup_token.user.admin?
+        return render_s3_error(:forbidden, "AccessDenied", "Access Denied")
+      end
+
+      unless backup_token.ready?
+        hours = (OpenProject::Configuration.backup_initial_waiting_period / 1.hour).ceil
+        return render_s3_error(:forbidden, "AccessDenied",
+                               I18n.t("backup.error.token_cooldown", hours:))
+      end
+
+      User.current = backup_token.user
+    end
+
+    # Extracts the raw token value from the Authorization header.
+    #
+    # Supported formats:
+    #   AWS Signature V4:  Authorization: AWS4-HMAC-SHA256 Credential=<token>/...
+    #   Bearer token:      Authorization: Bearer <token>
+    #   HTTP Basic:        Authorization: Basic base64(anything:<token>)
+    #
+    # For AWS Signature V4 the HMAC signature is accepted by the AWS SDK but not
+    # verified here; only the credential (i.e. the OpenProject backup token) is used.
+    def extract_token_value
+      auth = request.headers["Authorization"].to_s
+
+      if (m = auth.match(/\AAWS4-HMAC-SHA256\s+Credential=([^\/,\s]+)/))
+        return m[1]
+      end
+
+      if (m = auth.match(/\ABearer\s+(\S+)/i))
+        return m[1]
+      end
+
+      if (creds = ActionController::HttpAuthentication::Basic.user_name_and_password(request))
+        _username, password = creds
+        return password.presence
+      end
+
+      nil
+    end
+
+    # Returns attachments eligible for export:
+    #   - fully uploaded or virus-scanned
+    #   - not internal (Export containers)
+    #   - have a computed digest (needed as ETag)
+    def listable_attachments
+      Attachment
+        .where(status: [Attachment.statuses[:uploaded], Attachment.statuses[:scanned]])
+        .where.not(container_type: "Export")
+        .where.not(digest: [nil, ""])
+    end
+
+    def find_attachment
+      id_str = params[:key].to_s.split("/", 2).first
+      return nil unless id_str =~ /\A\d+\z/
+
+      listable_attachments.find_by(id: id_str.to_i)
+    end
+
+    def object_key(attachment)
+      "#{attachment.id}/#{attachment.filename}"
+    end
+
+    def set_object_headers(attachment)
+      response.headers["ETag"]             = %("#{attachment.digest}")
+      response.headers["Content-Length"]   = attachment.filesize.to_s
+      response.headers["Content-Type"]     = "application/octet-stream"
+      response.headers["Last-Modified"]    = attachment.updated_at.httpdate
+      response.headers["Accept-Ranges"]    = "bytes"
+      response.headers["x-amz-request-id"] = SecureRandom.hex(8)
+    end
+
+    def list_objects_xml(attachments, max_keys, truncated, next_token)
+      Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+        xml.ListBucketResult(xmlns: "http://s3.amazonaws.com/doc/2006-03-01/") do
+          xml.Name   BUCKET_NAME
+          xml.Prefix ""
+          xml.MaxKeys max_keys
+          xml.IsTruncated truncated
+          xml.NextContinuationToken next_token if next_token
+
+          attachments.each do |a|
+            xml.Contents do
+              xml.Key         object_key(a)
+              xml.LastModified a.updated_at.iso8601(3)
+              xml.ETag        %("#{a.digest}")
+              xml.Size        a.filesize
+              xml.StorageClass "STANDARD"
+            end
+          end
+        end
+      end.to_xml
+    end
+
+    def render_s3_error(status, code, message)
+      xml = Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+        xml.Error do
+          xml.Code      code
+          xml.Message   message
+          xml.RequestId SecureRandom.hex(8)
+        end
+      end.to_xml
+
+      render status:, body: xml, content_type: "application/xml"
+    end
+
+    # Cursor-based pagination tokens are Base64-encoded attachment IDs.
+    def encode_token(id)
+      Base64.urlsafe_encode64(id.to_s)
+    end
+
+    def decode_token(token)
+      Integer(Base64.urlsafe_decode64(token))
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/app/controllers/s3_compatible/attachments_controller.rb
+++ b/app/controllers/s3_compatible/attachments_controller.rb
@@ -86,15 +86,12 @@ module S3Compatible
       attachment = find_attachment
       return render_s3_error(:not_found, "NoSuchKey", "The specified key does not exist.") unless attachment
 
-      set_object_headers(attachment)
+      set_object_headers attachment
 
       if attachment.external_storage?
         redirect_to attachment.external_url.to_s, allow_other_host: true, status: :found
       else
-        send_file attachment.diskfile.path,
-                  type:        "application/octet-stream",
-                  disposition: :attachment,
-                  filename:    attachment.filename
+        serve_local_attachment(attachment)
       end
     end
 
@@ -186,6 +183,31 @@ module S3Compatible
       "#{attachment.id}/#{attachment.filename}"
     end
 
+    def serve_local_attachment(attachment)
+      path = attachment.diskfile.path
+      file_size = attachment.filesize
+
+      range_header = request.headers["HTTP_RANGE"] || request.headers["Range"]
+      if range_header && (m = range_header.match(/\Abytes=(\d+)-(\d*)\z/))
+        first  = m[1].to_i
+        last   = m[2].present? ? [m[2].to_i, file_size - 1].min : file_size - 1
+        length = last - first + 1
+
+        response.headers["Content-Range"]  = "bytes #{first}-#{last}/#{file_size}"
+        response.headers["Content-Length"] = length.to_s
+        response.status = 206
+
+        send_data File.binread(path, length, first),
+                  type:        "application/octet-stream",
+                  disposition: :inline
+      else
+        send_file path,
+                  type:        "application/octet-stream",
+                  disposition: :attachment,
+                  filename:    attachment.filename
+      end
+    end
+
     def set_object_headers(attachment)
       response.headers["ETag"]             = %("#{attachment.digest}")
       response.headers["Content-Length"]   = attachment.filesize.to_s
@@ -207,7 +229,7 @@ module S3Compatible
           attachments.each do |a|
             xml.Contents do
               xml.Key         object_key(a)
-              xml.LastModified a.updated_at.iso8601(3)
+              xml.LastModified a.updated_at.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
               xml.ETag        %("#{a.digest}")
               xml.Size        a.filesize
               xml.StorageClass "STANDARD"

--- a/app/views/admin/backups/show.html.erb
+++ b/app/views/admin/backups/show.html.erb
@@ -61,4 +61,16 @@ See COPYRIGHT and LICENSE files for more details.
       "last-backup-attachment-id": @last_backup_attachment_id,
       "may-include-attachments": @may_include_attachments
     } %>
+
+  <section class="op-section-box" style="margin-top: 2rem;">
+    <h3><%= t("backup.s3_export.heading") %></h3>
+    <p><%= t("backup.s3_export.description") %></p>
+    <pre><code><%= t("backup.s3_export.command", endpoint_url: "#{request.base_url}/s3") %></code></pre>
+    <p>
+      <%= link_to t("backup.s3_export.docs_link_text"),
+                  t("backup.s3_export.docs_url"),
+                  target: "_blank",
+                  rel: "noopener noreferrer" %>
+    </p>
+  </section>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2791,6 +2791,15 @@ en:
         When you create a new token you will only be allowed to request a backup after
         24 hours. This is a safety measure. After that you can request a backup any time using that token.
     text_token_deleted: Backup token deleted. Backups are now disabled.
+    s3_export:
+      heading: Incremental attachment export
+      description: >
+        You can use your backup token with the S3-compatible attachment export endpoint
+        to incrementally sync all attachments to your machine. Only new or changed files
+        are downloaded on each run, making it efficient even for large installations.
+      command: "AWS_ACCESS_KEY_ID=YOUR_BACKUP_TOKEN AWS_SECRET_ACCESS_KEY=unused \\\n  aws s3 sync s3://openproject/ ./attachments/ \\\n  --endpoint-url %{endpoint_url}"
+      docs_link_text: S3-compatible attachment export documentation
+      docs_url: https://www.openproject.org/docs/user-guide/file-management/s3-compatible-export/
     error:
       invalid_token: Invalid or missing backup token
       token_cooldown: The backup token will be valid in %{hours} hours.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1187,6 +1187,15 @@ Rails.application.routes.draw do
     mount Lookbook::Engine, at: "/lookbook"
   end
 
+  # S3-compatible read-only attachment export endpoint.
+  # Supports `aws s3 sync` and rclone using an OpenProject API token as the AWS access key ID.
+  # See docs/user-guide/file-management/s3-compatible-export.md for usage.
+  scope "/s3", module: "s3_compatible", format: false do
+    get  "/:bucket",      to: "attachments#list_objects", as: :s3_list_objects
+    get  "/:bucket/*key", to: "attachments#get_object",   as: :s3_get_object
+    match "/:bucket/*key", to: "attachments#head_object",  via: :head, as: :s3_head_object
+  end
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/docs/user-guide/file-management/README.md
+++ b/docs/user-guide/file-management/README.md
@@ -14,6 +14,7 @@ keywords: files, attachment, Nextcloud, OneDrive, SharePoint
 | [Nextcloud integration](#nextcloud-integration)              | How to manage files using Nextcloud integration in OpenProject. |
 | [OneDrive integration](#onedrive-integration-enterprise-add-on) | How to manage files using OneDrive integration in OpenProject. |
 | [SharePoint integration](#sharepoint-integration-enterprise-add-on) | How to manage files using SharePoint integration in OpenProject. |
+| [Attachment export (S3-compatible)](./s3-compatible-export)  | Incrementally back up all attachments using `aws s3 sync` or rclone. |
 | [File management FAQs](./file-management-faq)                | Frequently asked questions on file management in OpenProject. |
 
 There are several ways of adding or linking files to work packages in OpenProject. You can manually attach files directly to work packages or use one of the integrations with file management systems.

--- a/docs/user-guide/file-management/s3-compatible-export.md
+++ b/docs/user-guide/file-management/s3-compatible-export.md
@@ -1,0 +1,143 @@
+---
+sidebar_navigation:
+  title: Attachment export (S3-compatible)
+  priority: 10
+description: Incrementally back up all OpenProject attachments using any S3-compatible client.
+keywords: backup, attachments, S3, aws s3 sync, rclone, export
+---
+
+# Attachment export via S3-compatible endpoint
+
+OpenProject exposes a **read-only, S3-compatible endpoint** that lets administrators incrementally download all attachments using standard tooling such as the AWS CLI or rclone.
+
+Unlike the built-in backup feature, which creates a full tar archive on every run, the S3 endpoint returns checksums (ETags) for each file. Sync tools use these to skip files that have not changed, making repeated runs fast and bandwidth-efficient.
+
+## Requirements
+
+- OpenProject administrator account with backups enabled
+- A **backup token** (the same token used for the built-in backup feature)
+- AWS CLI v2 **or** rclone (or any other S3-compatible client)
+
+## Authentication and audit trail
+
+This endpoint uses your **backup token** as the AWS access key ID. This is intentional: every backup token reset sends a notification to the token owner and all administrators, creating the same audit trail as the existing backup feature. Treat the backup token with the same care as any backup credential.
+
+You can find and manage your backup token at **Administration → Backup**.
+
+> **Note:** The backup token has a 24-hour waiting period after creation before it can be used. This is a safety measure inherited from the backup system.
+
+## Endpoint
+
+```
+https://<your-openproject-host>/s3/openproject
+```
+
+The bucket name is always `openproject`. Object keys use the format `{attachment_id}/{filename}`, for example `4217/design-mockup.png`.
+
+## Syncing with the AWS CLI
+
+Supply your backup token as the **AWS access key ID**. The secret access key value is not verified — any non-empty string works.
+
+```bash
+aws s3 sync \
+  s3://openproject/ \
+  ./openproject-attachments/ \
+  --endpoint-url https://<your-openproject-host>/s3 \
+  --no-sign-request \
+  --request-checksum-calculation when_required
+```
+
+> **`--no-sign-request` note:** Some AWS CLI versions (≥ 2.22) require this flag when using a custom endpoint that does not verify Signature V4. If your version rejects it, omit the flag and pass credentials via environment variables instead (see below).
+
+### Passing credentials via environment variables
+
+```bash
+export AWS_ACCESS_KEY_ID=<your-backup-token>
+export AWS_SECRET_ACCESS_KEY=unused
+
+aws s3 sync \
+  s3://openproject/ \
+  ./openproject-attachments/ \
+  --endpoint-url https://<your-openproject-host>/s3
+```
+
+### Passing credentials via a named profile
+
+Add to `~/.aws/credentials`:
+
+```ini
+[openproject-backup]
+aws_access_key_id     = <your-backup-token>
+aws_secret_access_key = unused
+```
+
+Then run:
+
+```bash
+aws s3 sync \
+  s3://openproject/ \
+  ./openproject-attachments/ \
+  --endpoint-url https://<your-openproject-host>/s3 \
+  --profile openproject-backup
+```
+
+## Syncing with rclone
+
+Add a remote to your rclone configuration (`rclone config`):
+
+```ini
+[op-attachments]
+type                 = s3
+provider             = Other
+endpoint             = https://<your-openproject-host>/s3
+access_key_id        = <your-backup-token>
+secret_access_key    = unused
+no_check_bucket      = true
+```
+
+Then sync:
+
+```bash
+rclone sync op-attachments:openproject ./openproject-attachments/
+```
+
+Rclone compares ETags before downloading, so only new or changed files are transferred.
+
+## How incremental sync works
+
+Every attachment record in OpenProject stores an MD5 checksum (`digest`). The S3 endpoint returns this as the object's ETag. When you run a sync:
+
+1. The client fetches the full object listing (paginated in batches of 1 000).
+2. For each object, the local ETag is compared to the remote ETag.
+3. Only objects with a mismatched or missing ETag are downloaded.
+
+This means the first run downloads everything; subsequent runs only transfer new or modified attachments, regardless of total attachment size.
+
+## Object key format
+
+Keys are stable identifiers in the form `{attachment_id}/{original_filename}`, for example:
+
+```
+4217/design-mockup.png
+4218/budget-q3.xlsx
+```
+
+The numeric prefix is the attachment's database ID, which never changes even if the file is moved between work packages. Restoring from a backup therefore does not require parsing any directory structure — every file can be re-imported independently.
+
+## Limitations
+
+- **Administrator only.** The endpoint is restricted to administrators holding a valid backup token. Per-user or per-project scoped access is planned for a future release.
+- **Read-only.** Only `ListObjectsV2`, `GetObject`, and `HeadObject` are implemented. Uploads and deletes are not supported.
+- **No prefix filtering.** The `?prefix=` parameter is accepted but not applied server-side. Use `--exclude` / `--include` patterns in your S3 client instead.
+- **Attachments in progress are excluded.** Files still being uploaded (`prepared` status) and files flagged by antivirus scanning (`quarantined` status) do not appear in the listing.
+- **Requires backups to be enabled.** If `OPENPROJECT_BACKUP_ENABLED` is set to `false` in your configuration, this endpoint returns `403 AccessDenied`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `403 AccessDenied` | The backup token is invalid, belongs to a non-admin user, or backups are disabled in configuration. |
+| `403 AccessDenied` with cooldown message | The backup token was recently created and is still in the 24-hour waiting period. |
+| `401 InvalidAccessKeyId` | No `Authorization` header was sent, or the credential field is empty. |
+| `404 NoSuchBucket` | The bucket name in the URL is not `openproject`. |
+| Empty listing | No attachments have a stored digest yet. This can happen if all attachments were uploaded before digest computation was introduced. |

--- a/spec/controllers/s3_compatible/attachments_controller_spec.rb
+++ b/spec/controllers/s3_compatible/attachments_controller_spec.rb
@@ -284,6 +284,11 @@ RSpec.describe S3Compatible::AttachmentsController, type: :controller do
         get :get_object, params: { bucket: "openproject", key: }
         expect(response.headers["ETag"]).to eq(%("#{attachment.digest}"))
       end
+
+      it "sets Content-Length to the actual file size, not the stale DB value" do
+        get :get_object, params: { bucket: "openproject", key: }
+        expect(response.headers["Content-Length"]).to eq(File.size(tmpfile.path).to_s)
+      end
     end
 
     context "with external (fog) storage" do

--- a/spec/controllers/s3_compatible/attachments_controller_spec.rb
+++ b/spec/controllers/s3_compatible/attachments_controller_spec.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe S3Compatible::AttachmentsController, type: :controller do
+  let(:admin)   { create(:admin) }
+  let(:user)    { create(:user) }
+  let(:project) { create(:project) }
+  let(:work_package) { create(:work_package, project:) }
+
+  let!(:attachment) do
+    create(:attachment,
+           container:    work_package,
+           author:       admin,
+           digest:       "d41d8cd98f00b204e9800998ecf8427e",
+           filesize:     1024,
+           content_type: "application/pdf")
+  end
+
+  # The :backup_token factory backdates created_at so token.ready? returns true.
+  def authorize_as(user)
+    token = create(:backup_token, user:)
+    request.headers["Authorization"] =
+      "AWS4-HMAC-SHA256 Credential=#{token.plain_value}/20240101/us-east-1/s3/aws4_request, " \
+      "SignedHeaders=host, Signature=fakesignature"
+  end
+
+  def authorize_with_bearer(user)
+    token = create(:backup_token, user:)
+    request.headers["Authorization"] = "Bearer #{token.plain_value}"
+  end
+
+  def expected_key
+    "#{attachment.id}/#{attachment.filename}"
+  end
+
+  # ─── ListObjectsV2 ───────────────────────────────────────────────────────────
+
+  describe "GET #list_objects" do
+    subject { get :list_objects, params: { bucket: "openproject", "list-type": "2" } }
+
+    context "as admin with AWS Sig4 auth" do
+      before { authorize_as(admin) }
+
+      it "returns 200 with XML content" do
+        subject
+        expect(response).to have_http_status(:ok)
+        expect(response.content_type).to include("application/xml")
+      end
+
+      it "includes bucket metadata in the response" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("ListBucketResult/Name").text).to eq("openproject")
+        expect(xml.at("ListBucketResult/IsTruncated").text).to eq("false")
+      end
+
+      it "includes the attachment as a Contents element" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        keys = xml.css("Contents Key").map(&:text)
+        expect(keys).to include(expected_key)
+      end
+
+      it "includes ETag and Size for each entry" do
+        subject
+        xml = Nokogiri::XML(response.body)
+        entry = xml.at("Contents[Key='#{expected_key}']")
+        expect(entry.at("ETag").text).to eq(%("#{attachment.digest}"))
+        expect(entry.at("Size").text).to eq(attachment.filesize.to_s)
+      end
+
+      it "excludes quarantined attachments" do
+        attachment.update_column(:status, Attachment.statuses[:quarantined])
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.css("Contents Key").map(&:text)).not_to include(expected_key)
+      end
+
+      it "excludes attachments without a digest" do
+        attachment.update_column(:digest, "")
+        subject
+        xml = Nokogiri::XML(response.body)
+        expect(xml.css("Contents Key").map(&:text)).not_to include(expected_key)
+      end
+    end
+
+    context "as admin with Bearer auth" do
+      before { authorize_with_bearer(admin) }
+
+      it "returns 200" do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with unknown bucket" do
+      before { authorize_as(admin) }
+
+      it "returns 404 NoSuchBucket" do
+        get :list_objects, params: { bucket: "nonexistent", "list-type": "2" }
+        expect(response).to have_http_status(:not_found)
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Error/Code").text).to eq("NoSuchBucket")
+      end
+    end
+
+    context "as non-admin user with a backup token" do
+      before { authorize_as(user) }
+
+      it "returns 403 because non-admins cannot hold backup tokens" do
+        subject
+        expect(response).to have_http_status(:forbidden)
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Error/Code").text).to eq("AccessDenied")
+      end
+    end
+
+    context "with a backup token that is not yet ready" do
+      it "returns 403" do
+        # Create a brand-new token (created_at = now, waiting period not elapsed)
+        token = build(:backup_token, user: admin)
+        token.created_at = Time.current
+        token.save!
+        request.headers["Authorization"] =
+          "AWS4-HMAC-SHA256 Credential=#{token.plain_value}/20240101/us-east-1/s3/aws4_request, " \
+          "SignedHeaders=host, Signature=fakesig"
+        subject
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "without any authorization header" do
+      it "returns 401 with WWW-Authenticate hint" do
+        subject
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers["WWW-Authenticate"]).to include("AWS4-HMAC-SHA256")
+      end
+    end
+
+    context "with an unrecognised token value" do
+      it "returns 403" do
+        request.headers["Authorization"] =
+          "AWS4-HMAC-SHA256 Credential=notavalidtoken/20240101/us-east-1/s3/aws4_request, " \
+          "SignedHeaders=host, Signature=fakesig"
+        subject
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe "pagination" do
+      let!(:second_attachment) do
+        create(:attachment,
+               container:    work_package,
+               author:       admin,
+               digest:       "aabbccddeeff00112233445566778899",
+               filesize:     2048,
+               content_type: "text/plain")
+      end
+
+      before { authorize_as(admin) }
+
+      it "returns only max-keys results when set to 1" do
+        get :list_objects, params: { bucket: "openproject", "list-type": "2", "max-keys": "1" }
+        xml = Nokogiri::XML(response.body)
+        expect(xml.css("Contents").size).to eq(1)
+        expect(xml.at("IsTruncated").text).to eq("true")
+        expect(xml.at("NextContinuationToken")).to be_present
+      end
+
+      it "fetches the second page via continuation-token" do
+        get :list_objects, params: { bucket: "openproject", "list-type": "2", "max-keys": "1" }
+        token = Nokogiri::XML(response.body).at("NextContinuationToken").text
+
+        get :list_objects, params: { bucket: "openproject", "list-type": "2",
+                                     "max-keys": "1", "continuation-token": token }
+        xml = Nokogiri::XML(response.body)
+        expect(xml.css("Contents").size).to eq(1)
+        expect(xml.at("IsTruncated").text).to eq("false")
+      end
+
+      it "returns all results when max-keys is not set" do
+        get :list_objects, params: { bucket: "openproject", "list-type": "2" }
+        xml = Nokogiri::XML(response.body)
+        expect(xml.css("Contents").size).to be >= 2
+        expect(xml.at("IsTruncated").text).to eq("false")
+      end
+    end
+  end
+
+  # ─── HeadObject ──────────────────────────────────────────────────────────────
+
+  describe "HEAD #head_object" do
+    let(:key) { expected_key }
+
+    before { authorize_as(admin) }
+
+    context "with a valid key" do
+      it "returns 200" do
+        head :head_object, params: { bucket: "openproject", key: }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "sets ETag header to the attachment digest" do
+        head :head_object, params: { bucket: "openproject", key: }
+        expect(response.headers["ETag"]).to eq(%("#{attachment.digest}"))
+      end
+
+      it "sets Content-Length header" do
+        head :head_object, params: { bucket: "openproject", key: }
+        expect(response.headers["Content-Length"]).to eq(attachment.filesize.to_s)
+      end
+
+      it "sets Last-Modified header" do
+        head :head_object, params: { bucket: "openproject", key: }
+        expect(response.headers["Last-Modified"]).to be_present
+      end
+    end
+
+    context "with a non-existent key" do
+      it "returns 404" do
+        head :head_object, params: { bucket: "openproject", key: "99999/missing.pdf" }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  # ─── GetObject ───────────────────────────────────────────────────────────────
+
+  describe "GET #get_object" do
+    let(:key) { expected_key }
+
+    before { authorize_as(admin) }
+
+    context "with local storage" do
+      let(:tmpfile) do
+        Tempfile.new(["attachment", ".pdf"]).tap do |f|
+          f.write("file content")
+          f.flush
+        end
+      end
+
+      before do
+        allow_any_instance_of(Attachment).to receive(:external_storage?).and_return(false)
+        allow_any_instance_of(Attachment).to receive(:diskfile).and_return(double(path: tmpfile.path))
+      end
+
+      after { tmpfile.unlink }
+
+      it "returns 200 and sends the file" do
+        get :get_object, params: { bucket: "openproject", key: }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "sets the ETag header" do
+        get :get_object, params: { bucket: "openproject", key: }
+        expect(response.headers["ETag"]).to eq(%("#{attachment.digest}"))
+      end
+    end
+
+    context "with external (fog) storage" do
+      let(:external_url) { URI.parse("https://s3.example.com/bucket/object?signed=1") }
+
+      before do
+        allow_any_instance_of(Attachment).to receive(:external_storage?).and_return(true)
+        allow_any_instance_of(Attachment).to receive(:external_url).and_return(external_url)
+      end
+
+      it "redirects to the external URL" do
+        get :get_object, params: { bucket: "openproject", key: }
+        expect(response).to have_http_status(:found)
+        expect(response.headers["Location"]).to eq(external_url.to_s)
+      end
+    end
+
+    context "with a non-existent key" do
+      it "returns 404" do
+        get :get_object, params: { bucket: "openproject", key: "99999/missing.pdf" }
+        expect(response).to have_http_status(:not_found)
+        xml = Nokogiri::XML(response.body)
+        expect(xml.at("Error/Code").text).to eq("NoSuchKey")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backing up OpenProject attachments of a remote installation can be a hassle when there are thousands of attachments which take up dozens of GBs. 

This adds an S3-compatible interface allowing users with backup tokens to sync attachments for backup purposes.

<img width="1088" height="689" alt="image" src="https://github.com/user-attachments/assets/7fa1b825-0fd4-4a5b-8177-1a5c236a165b" />

Using the AWS CLI or rclone you can then download all attachments separately to the database backup. For instance:

```bash
AWS_ACCESS_KEY_ID=opbk-49eb17bab2a72af551af4f39c633ad184ec5157d5d8ad18e6c476a34de2711bf AWS_SECRET_ACCESS_KEY=unused aws s3 sync s3://openproject/ ./attachments/ --endpoint-url http://localhost:3000/s3
download: s3://openproject/4/stats.txt to attachments/4/stats.txt 
download: s3://openproject/1/demo_project_teaser.png to attachments/1/demo_project_teaser.png
download: s3://openproject/5/ca-foo-web.pem to attachments/5/ca-foo-web.pem
download: s3://openproject/2/scrum_project_teaser.png to attachments/2/scrum_project_teaser.png
download: s3://openproject/3/some-video.mp4 to attachments/3/some-video.mp4
```

If the OpenProject instance is using a local file storage for its attachments, they are served directly by OpenProject.
If using S3 as storage, the download requests get forwarded to the actual S3 backend hosting the files, via a pre-signed URL.