### PR TITLE
Create reverse page links from internal wiki to WorkPackages

### DIFF
--- a/lib/open_project/plugins/acts_as_op_engine.rb
+++ b/lib/open_project/plugins/acts_as_op_engine.rb
@@ -112,17 +112,16 @@ module OpenProject::Plugins
         end
       end
 
-      def patch_with_namespace(*args)
+      def patch_with_namespace(*namespace, class_name)
         plugin_module = self.class.to_s.deconstantize
         self.class.config.to_prepare do
-          klass_name = args.last
+          qualified_class_name = (namespace + [class_name]).join("::")
           patch = begin
-            "#{plugin_module}::Patches::#{args[0..-2].join('::')}::#{klass_name}Patch".constantize
+            "#{plugin_module}::Patches::#{qualified_class_name}Patch".constantize
           rescue NameError
-            "#{plugin_module}::Patches::#{klass_name}Patch".constantize
+            "#{plugin_module}::Patches::#{class_name}Patch".constantize
           end
 
-          qualified_class_name = args.map(&:to_s).join("::")
           klass = qualified_class_name.to_s.constantize
           klass.send(:include, patch) unless klass.included_modules.include?(patch)
         end

--- a/modules/wikis/app/models/wikis/inline_page_link.rb
+++ b/modules/wikis/app/models/wikis/inline_page_link.rb
@@ -29,6 +29,9 @@
 #++
 
 module Wikis
+  # A page link from a linkable to a wiki page that can be found inside the text of
+  # the linkable (e.g. description of a work package).
+  # Persisted for all wiki providers.
   class InlinePageLink < PageLink
     def inline? = true
   end

--- a/modules/wikis/app/models/wikis/relation_page_link.rb
+++ b/modules/wikis/app/models/wikis/relation_page_link.rb
@@ -29,6 +29,9 @@
 #++
 
 module Wikis
+  # An explicit, user-created link between a linkable and a wiki page.
+  # This link has no implied direction.
+  # Not persisted for all wiki providers.
   class RelationPageLink < PageLink
     belongs_to :author, class_name: "User"
 

--- a/modules/wikis/app/models/wikis/reverse_inline_page_link.rb
+++ b/modules/wikis/app/models/wikis/reverse_inline_page_link.rb
@@ -28,24 +28,11 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject::Wikis::Patches::UpdateServicePatch
-  def self.included(base)
-    base.prepend InstanceMethods
-    base.include Wikis::Concerns::UpdateInlineWikiPageLinks
-  end
-
-  module InstanceMethods
-    private
-
-    def after_perform(_)
-      service_call = super
-
-      work_package = service_call.result
-      if service_call.success? && work_package.changed_attribute_keys_before_last_save.include?(:description)
-        update_inline_wiki_page_links(work_package, work_package.description)
-      end
-
-      service_call
-    end
+module Wikis
+  # Like an InlinePageLink, but it's not the linkable that's referencing the wiki page,
+  # but the wiki page that's referencing the linkable.
+  # Not persisted for all wiki providers.
+  class ReverseInlinePageLink < PageLink
+    def inline? = true
   end
 end

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/queries/referencing_pages.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/queries/referencing_pages.rb
@@ -34,10 +34,20 @@ module Wikis
       module Internal
         module Queries
           class ReferencingPages < BaseQuery
-            def call(_input_data)
-              # noop
+            def call(input_data)
+              success(
+                provider.page_links
+                        .merge(ReverseInlinePageLink.all)
+                        .where(linkable: input_data.linkable)
+                        .order(created_at: :desc)
+                        .map { page_info(provider:, identifier: it.identifier) }
+              )
+            end
 
-              success([])
+            private
+
+            def page_info(provider:, identifier:)
+              Adapters::Input::PageInfo.build(identifier:).bind { provider.resolve("queries.page_info").call(it) }
             end
           end
         end

--- a/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
@@ -28,23 +28,32 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :wiki_page_link, class: "Wikis::PageLink" do
-    linkable factory: :work_package
-    provider factory: :internal_wiki_provider
+module Wikis::Concerns
+  module UpdateReverseInlineWikiPageLinks
+    extend ActiveSupport::Concern
 
-    sequence(:identifier) { |i| "/path/#{i}" }
-  end
+    def update_reverse_inline_wiki_page_links(wiki_page)
+      provider = Wikis::InternalProvider.enabled.first
+      return if provider.nil?
 
-  factory :inline_wiki_page_link, class: "Wikis::InlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+      Wikis::ReverseInlinePageLink.where(provider:, identifier: wiki_page.id).delete_all
 
-  factory :reverse_inline_wiki_page_link, class: "Wikis::ReverseInlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+      find_wp_links(wiki_page.text).uniq.each do |wp_id|
+        wp = WorkPackage.find_by(id: wp_id)
+        next if wp.nil?
 
-  factory :relation_wiki_page_link, class: "Wikis::RelationPageLink", parent: :wiki_page_link do
-    author factory: :user
+        Wikis::ReverseInlinePageLink.create!(linkable: wp, provider:, identifier: wiki_page.id)
+      end
+    end
+
+    private
+
+    def find_wp_links(text)
+      return [] if text.blank?
+
+      # extracted prefix from lib/open_project/text_formatting/matchers/resource_links_matcher.rb
+      # adding # as additional prefix
+      text.scan(/(?:[[:space:],~>#\(\[\-]|^)#([0-9]+)/) # rubocop:disable Style/RedundantRegexpEscape
+    end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -98,6 +98,8 @@ module OpenProject::Wikis
            icon: "browser"
     end
 
+    patch_with_namespace :WikiPages, :CreateService
+    patch_with_namespace :WikiPages, :UpdateService
     patch_with_namespace :WorkPackages, :CreateService
     patch_with_namespace :WorkPackages, :UpdateService
 

--- a/modules/wikis/lib/open_project/wikis/patches/wiki_pages/create_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/wiki_pages/create_service_patch.rb
@@ -28,23 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :wiki_page_link, class: "Wikis::PageLink" do
-    linkable factory: :work_package
-    provider factory: :internal_wiki_provider
-
-    sequence(:identifier) { |i| "/path/#{i}" }
+module OpenProject::Wikis::Patches::WikiPages::CreateServicePatch
+  def self.included(base)
+    base.prepend InstanceMethods
+    base.include Wikis::Concerns::UpdateReverseInlineWikiPageLinks
   end
 
-  factory :inline_wiki_page_link, class: "Wikis::InlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+  module InstanceMethods
+    def perform
+      result = super
+      update_reverse_inline_wiki_page_links(result.result) if result.success?
 
-  factory :reverse_inline_wiki_page_link, class: "Wikis::ReverseInlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
-
-  factory :relation_wiki_page_link, class: "Wikis::RelationPageLink", parent: :wiki_page_link do
-    author factory: :user
+      result
+    end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/patches/wiki_pages/update_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/wiki_pages/update_service_patch.rb
@@ -28,23 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :wiki_page_link, class: "Wikis::PageLink" do
-    linkable factory: :work_package
-    provider factory: :internal_wiki_provider
-
-    sequence(:identifier) { |i| "/path/#{i}" }
+module OpenProject::Wikis::Patches::WikiPages::UpdateServicePatch
+  def self.included(base)
+    base.prepend InstanceMethods
+    base.include Wikis::Concerns::UpdateReverseInlineWikiPageLinks
   end
 
-  factory :inline_wiki_page_link, class: "Wikis::InlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+  module InstanceMethods
+    private
 
-  factory :reverse_inline_wiki_page_link, class: "Wikis::ReverseInlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+    def after_perform(_)
+      service_call = super
 
-  factory :relation_wiki_page_link, class: "Wikis::RelationPageLink", parent: :wiki_page_link do
-    author factory: :user
+      wiki_page = service_call.result
+      if service_call.success? && wiki_page.changed_attribute_keys_before_last_save.include?(:text)
+        update_reverse_inline_wiki_page_links(wiki_page)
+      end
+
+      service_call
+    end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/patches/work_packages/create_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/work_packages/create_service_patch.rb
@@ -28,23 +28,18 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-FactoryBot.define do
-  factory :wiki_page_link, class: "Wikis::PageLink" do
-    linkable factory: :work_package
-    provider factory: :internal_wiki_provider
-
-    sequence(:identifier) { |i| "/path/#{i}" }
+module OpenProject::Wikis::Patches::WorkPackages::CreateServicePatch
+  def self.included(base)
+    base.prepend InstanceMethods
+    base.include Wikis::Concerns::UpdateInlineWikiPageLinks
   end
 
-  factory :inline_wiki_page_link, class: "Wikis::InlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
+  module InstanceMethods
+    def create(_attributes, work_package)
+      result = super
+      update_inline_wiki_page_links(work_package, work_package.description) if result.success?
 
-  factory :reverse_inline_wiki_page_link, class: "Wikis::ReverseInlinePageLink", parent: :wiki_page_link do
-    # ...
-  end
-
-  factory :relation_wiki_page_link, class: "Wikis::RelationPageLink", parent: :wiki_page_link do
-    author factory: :user
+      result
+    end
   end
 end

--- a/modules/wikis/lib/open_project/wikis/patches/work_packages/update_service_patch.rb
+++ b/modules/wikis/lib/open_project/wikis/patches/work_packages/update_service_patch.rb
@@ -28,18 +28,24 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module OpenProject::Wikis::Patches::CreateServicePatch
+module OpenProject::Wikis::Patches::WorkPackages::UpdateServicePatch
   def self.included(base)
     base.prepend InstanceMethods
     base.include Wikis::Concerns::UpdateInlineWikiPageLinks
   end
 
   module InstanceMethods
-    def create(_attributes, work_package)
-      result = super
-      update_inline_wiki_page_links(work_package, work_package.description) if result.success?
+    private
 
-      result
+    def after_perform(_)
+      service_call = super
+
+      work_package = service_call.result
+      if service_call.success? && work_package.changed_attribute_keys_before_last_save.include?(:description)
+        update_inline_wiki_page_links(work_package, work_package.description)
+      end
+
+      service_call
     end
   end
 end

--- a/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WikiPages::CreateService do
+  let(:instance) { described_class.new(user:) }
+  let(:user) { create(:admin) }
+  let(:wiki) { create(:wiki) }
+  let(:internal_provider) { create(:internal_wiki_provider, enabled: true) }
+
+  let(:work_package) { create(:work_package) }
+
+  let(:reverse_link_finder) do
+    Wikis::ReverseInlinePageLink.where(linkable: work_package, provider: internal_provider)
+  end
+
+  let(:attributes) do
+    {
+      wiki:,
+      text:,
+      title: "The test page"
+    }
+  end
+
+  let(:text) do
+    <<~TXT
+      The Wiki page references work package ##{work_package.id}.
+    TXT
+  end
+
+  subject { instance.call(**attributes) }
+
+  before do
+    wiki
+    internal_provider
+  end
+
+  it "succeeds" do
+    expect(subject).to be_success
+  end
+
+  it "creates a reverse page link" do
+    subject
+
+    expect(reverse_link_finder.count).to eq(1)
+  end
+
+  it "references the created wiki page" do
+    subject
+
+    expect(Wikis::ReverseInlinePageLink.first.identifier).to eq(WikiPage.first.id.to_s)
+  end
+
+  context "when the same reference is made twice" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ##{work_package.id} + ##{work_package.id}.
+      TXT
+    end
+
+    it "creates the link once" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is the only content (no suffix or prefix)" do
+    let(:text) { "##{work_package.id}" }
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is parenthesized" do
+    let(:text) { "(##{work_package.id})" }
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is escaped" do
+    let(:text) { "!##{work_package.id}" }
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when the reference is made using ## syntax" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ###{work_package.id}.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is made using ### syntax" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ####{work_package.id}.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is made inside a <mention> element" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package <mention class="mention" data-id="#{work_package.id}" data-type="work_package" data-text="##{work_package.id}">##{work_package.id}</mention>.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when there is a link with a fragment" do
+    let(:text) do
+      <<~TXT
+        And a weird [link](https://example.com/##{work_package.id}-blubb).
+      TXT
+    end
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when the internal provider is disabled" do
+    let(:internal_provider) { create(:internal_wiki_provider, enabled: false) }
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when a work package with the given ID does not exist" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ##{work_package.id + 10}.
+      TXT
+    end
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+end

--- a/modules/wikis/spec/services/wiki_pages/update_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/update_service_spec.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe WikiPages::UpdateService do
+  let(:instance) { described_class.new(user:, model: wiki_page) }
+  let(:user) { create(:admin) }
+  let(:wiki_page) { create(:wiki_page) }
+  let(:internal_provider) { create(:internal_wiki_provider, enabled: true) }
+
+  let(:work_package) { create(:work_package) }
+
+  let(:reverse_link_finder) do
+    Wikis::ReverseInlinePageLink.where(linkable: work_package, provider: internal_provider)
+  end
+
+  let(:attributes) { { text: } }
+
+  let(:text) do
+    <<~TXT
+      The Wiki page references work package ##{work_package.id}.
+    TXT
+  end
+
+  subject { instance.call(**attributes) }
+
+  before do
+    internal_provider
+  end
+
+  it "succeeds" do
+    expect(subject).to be_success
+  end
+
+  it "creates a reverse page link" do
+    subject
+
+    expect(reverse_link_finder.count).to eq(1)
+  end
+
+  it "references the created wiki page" do
+    subject
+
+    expect(Wikis::ReverseInlinePageLink.first.identifier).to eq(WikiPage.first.id.to_s)
+  end
+
+  context "when the same reference is made twice" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ##{work_package.id} + ##{work_package.id}.
+      TXT
+    end
+
+    it "creates the link once" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is the only content (no suffix or prefix)" do
+    let(:text) { "##{work_package.id}" }
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is parenthesized" do
+    let(:text) { "(##{work_package.id})" }
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is escaped" do
+    let(:text) { "!##{work_package.id}" }
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when the reference is made using ## syntax" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ###{work_package.id}.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is made using ### syntax" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ####{work_package.id}.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when the reference is made inside a <mention> element" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package <mention class="mention" data-id="#{work_package.id}" data-type="work_package" data-text="##{work_package.id}">##{work_package.id}</mention>.
+      TXT
+    end
+
+    it "creates a reverse page link" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
+  context "when there is a link with a fragment" do
+    let(:text) do
+      <<~TXT
+        And a weird [link](https://example.com/##{work_package.id}-blubb).
+      TXT
+    end
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when the internal provider is disabled" do
+    let(:internal_provider) { create(:internal_wiki_provider, enabled: false) }
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when a work package with the given ID does not exist" do
+    let(:text) do
+      <<~TXT
+        The Wiki page references work package ##{work_package.id + 10}.
+      TXT
+    end
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
+
+  context "when other page links already exist" do
+    let(:fake_wp_id) { work_package.id + 100 }
+
+    before do
+      create(
+        :reverse_inline_wiki_page_link,
+        provider: internal_provider,
+        linkable_type: WorkPackage.name,
+        linkable_id: fake_wp_id,
+        identifier: wiki_page.id
+      )
+    end
+
+    it "deletes existing page links" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.pluck(:linkable_id)).to contain_exactly(work_package.id)
+    end
+
+    context "and when the description does not change" do
+      let(:attributes) { { title: "This is a new subject" } }
+
+      it "keeps existing page links" do
+        subject
+
+        expect(Wikis::ReverseInlinePageLink.pluck(:linkable_id)).to contain_exactly(fake_wp_id)
+      end
+    end
+  end
+end

--- a/modules/wikis/spec/services/wikis/adapters/providers/internal/queries/referencing_pages_query_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/internal/queries/referencing_pages_query_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Wikis::Adapters::Providers::Internal::Queries::ReferencingPages do
+  subject { described_class.new(model: provider).call(input_data) }
+
+  let(:provider) { create(:internal_wiki_provider) }
+  let(:input_data) { Wikis::Adapters::Input::ReferencingPages.build(linkable:).value! }
+  let(:linkable) { create(:work_package) }
+
+  let(:wiki_page) { create(:wiki_page) }
+  let(:wiki_project) { wiki_page.project }
+  let(:wiki_project_permissions) { %i[view_wiki_pages] }
+
+  let(:reverse_page_links) do
+    [
+      create(:reverse_inline_wiki_page_link, provider:, linkable:, identifier: wiki_page.id)
+    ]
+  end
+
+  current_user { create(:user) }
+
+  before do
+    create(:member, project: wiki_project,
+                    user: current_user,
+                    roles: [create(:project_role, permissions: wiki_project_permissions)])
+
+    reverse_page_links.each(&:save!)
+  end
+
+  it { is_expected.to be_success }
+
+  it "returns pages indicated by reverse links" do
+    results = subject.value!
+    expect(results).to all(be_success)
+    infos = results.map(&:value!)
+    expect(infos.map(&:title)).to contain_exactly(wiki_page.title)
+  end
+
+  context "when there are no reverse links" do
+    let(:reverse_page_links) { [] }
+
+    it { is_expected.to be_success }
+
+    it "returns an empty result" do
+      expect(subject.value!).to eq([])
+    end
+  end
+
+  context "when there are reverse links to other linkables" do
+    let(:reverse_page_links) do
+      [
+        create(:reverse_inline_wiki_page_link, provider:, identifier: wiki_page.id)
+      ]
+    end
+
+    it "does not return them" do
+      expect(subject.value!).to eq([])
+    end
+  end
+
+  context "when user can't see linked wiki page" do
+    let(:wiki_project_permissions) { %i[] }
+
+    it { is_expected.to be_success }
+
+    it "returns a result with a failure" do
+      results = subject.value!
+      expect(results).to all(be_failure)
+      errors = results.map(&:failure)
+      expect(errors.map(&:code)).to contain_exactly(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
Allowing internal wiki pages to also show up in the
"referenced in" list of page links.