### PR TITLE
[#74343] Make it obvious that Jira Migrator is in Beta status.

### DIFF
--- a/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.rb
+++ b/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.rb
@@ -52,7 +52,9 @@ module Admin::Import::Jira::ImportRuns
     end
 
     def description
-      I18n.t("admin.jira.run.wizard.import_dialog.description")
+      link_translate("admin.jira.run.wizard.import_dialog.description",
+                     links: { link: %i[backup_guide] },
+                     external: true)
     end
 
     def confirm_button_text

--- a/app/components/admin/import/jira/import_runs/info_list_box_component.rb
+++ b/app/components/admin/import/jira/import_runs/info_list_box_component.rb
@@ -34,11 +34,14 @@ module Admin::Import::Jira::ImportRuns
 
     attr_reader :title, :list, :system_arguments
 
-    def initialize(title:, list:, show_icon: true, **system_arguments)
+    def initialize(title:, list:, subtitle: nil, show_icon: true, icon: :"dot-fill", icon_color: :default, **system_arguments)
       super()
       @title = title
+      @subtitle = subtitle
       @list = list
       @show_icon = show_icon
+      @icon = icon
+      @icon_color = icon_color
       @system_arguments = system_arguments
     end
 
@@ -47,6 +50,11 @@ module Admin::Import::Jira::ImportRuns
         flex_layout do |flex|
           flex.with_row(mb: 1) do
             render(Primer::Beta::Text.new(font_weight: :bold)) { title }
+          end
+          if @subtitle
+            flex.with_row(mb: 1) do
+              @subtitle
+            end
           end
           list.each do |item|
             flex.with_row(mt: 2) do
@@ -59,12 +67,7 @@ module Admin::Import::Jira::ImportRuns
 
     def render_item(item)
       if @show_icon
-        concat(render(
-                 Primer::Beta::Octicon.new(
-                   icon: item[:checked] ? :"check-circle" : :"x-circle",
-                   color: item[:checked] ? :success : :danger
-                 )
-               ))
+        concat(render(Primer::Beta::Octicon.new(icon: @icon, color: @icon_color)))
       end
       if item[:url].present?
         concat(render(Primer::Beta::Link.new(href: item[:url], ml: 1, target: "_blank")) { item[:label] })

--- a/app/components/admin/import/jira/import_runs/wizard_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_component.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
            )
     ) do |component|
       component.with_row(scheme: :neutral, color: :muted, align_items: :center) do
-        render(Primer::Beta::Text.new(font_weight: :semibold)) {
+        render(Primer::Beta::Text.new(font_weight: :bold)) {
           I18n.t(:"admin.jira.run.wizard.groups.fetch.title")
         }
       end
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       component.with_row(scheme: :neutral, color: :muted, align_items: :center) do
-        render(Primer::Beta::Text.new(font_weight: :semibold)) {
+        render(Primer::Beta::Text.new(font_weight: :bold)) {
           I18n.t(:"admin.jira.run.wizard.groups.configuration.title")
         }
       end
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       component.with_row(scheme: :neutral, color: :muted, align_items: :center) do
-        render(Primer::Beta::Text.new(font_weight: :semibold)) {
+        render(Primer::Beta::Text.new(font_weight: :bold)) {
           I18n.t(:"admin.jira.run.wizard.groups.confirming.title")
         }
       end
@@ -61,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
       end
 
       component.with_row(scheme: :neutral, color: :muted, align_items: :center) do
-        render(Primer::Beta::Text.new(font_weight: :semibold)) {
+        render(Primer::Beta::Text.new(font_weight: :bold)) {
           I18n.t(:"admin.jira.run.wizard.groups.review.title")
         }
       end

--- a/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= flex_layout do |box|
   box.with_row do
-    concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+    concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
       I18n.t(:"admin.jira.run.wizard.sections.confirm_import.title")
     })
     if model.status_before?(:projects_meta_done)
@@ -52,7 +52,7 @@ See COPYRIGHT and LICENSE files for more details.
       render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
         title: I18n.t(:"admin.jira.run.wizard.sections.confirm_import.label_available_data"),
         list: import_selection,
-        show_icon: false
+        show_icon: true
       ))
     end
     if model.in_state?(:projects_meta_done)
@@ -80,7 +80,7 @@ See COPYRIGHT and LICENSE files for more details.
       render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
         title: I18n.t(:"admin.jira.run.wizard.sections.confirm_import.label_import_data"),
         list: import_selection,
-        show_icon: false
+        show_icon: true
       ))
     end
   end

--- a/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   box.with_row do
     flex_layout do |row|
       row.with_column(flex: 1) do
-        concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+        concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
           I18n.t(:"admin.jira.run.wizard.sections.fetch_data.title")
         })
         if model.status_equal_or_after?(:instance_meta_done)

--- a/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= flex_layout do |box|
   box.with_row do
-    concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+    concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
       I18n.t(:"admin.jira.run.wizard.sections.import_scope.title")
     })
     if model.status_before?(:instance_meta_done)
@@ -43,29 +43,13 @@ See COPYRIGHT and LICENSE files for more details.
     end
   end
   if model.in_state?(:instance_meta_done)
-    box.with_row(mb: 3, mt: 3) do
-      render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert)) {
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_info")
-      }
-    end
-    box.with_row(mb: 1) do
-      render(Primer::Beta::Text.new(font_size: :small, color: :muted)) {
-        server_info
-      }
-    end
     box.with_row(mb: 3) do
       flex_layout do |flex|
         flex.with_column(flex: 1, mr: 1) do
           render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
-            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_available_data"),
+            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_available_server_data",  server_info: model.jira.name),
+            subtitle: server_info,
             list: import_stats_available,
-            h: :full
-          ))
-        end
-        flex.with_column(flex: 1, ml: 1) do
-          render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
-            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_not_available_data"),
-            list: import_stats_unavailable,
             h: :full
           ))
         end

--- a/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.rb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.rb
@@ -43,25 +43,22 @@ module Admin::Import::Jira::ImportRuns
       ].map { |label| { label:, checked: true } }
     end
 
-    def import_stats_unavailable
-      [
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.relations"),
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.workflows"),
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.permissions"),
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.sprints"),
-        I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.schemes")
-      ].map { |label| { label:, checked: false } }
-    end
-
     def server_info
       info = model.available["server_info"]
-      return "" unless info
+      return nil unless info
 
-      [
-        info["serverTitle"],
-        info["version"],
-        "(#{info['baseUrl']})"
-      ].join(" ")
+      render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+        safe_join([
+                    info["serverTitle"],
+                    " ",
+                    info["version"],
+                    " ",
+                    render(Primer::Beta::Link.new(href: model.jira.url, target: "_blank")) do |link|
+                      link.with_trailing_visual_icon(icon: :"link-external")
+                      info["baseUrl"]
+                    end
+                  ])
+      end
     end
 
     def selected_projects_count

--- a/app/components/admin/import/jira/import_runs/wizard_step_review_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_review_component.html.erb
@@ -30,7 +30,7 @@ See COPYRIGHT and LICENSE files for more details.
 <%= flex_layout do |box|
   if model.in_state?(:reverting, :reverted, :revert_error)
     box.with_row do
-      concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+      concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
         I18n.t(:"admin.jira.run.wizard.sections.import_result.label_revert")
       })
     end
@@ -54,7 +54,7 @@ See COPYRIGHT and LICENSE files for more details.
     end
   elsif model.in_state?(:finalizing, :finalizing_done, :finalizing_error)
     box.with_row do
-      concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+      concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
         I18n.t(:"admin.jira.run.wizard.sections.import_result.label_finalize_import")
       })
     end
@@ -78,7 +78,7 @@ See COPYRIGHT and LICENSE files for more details.
     end
   else
     box.with_row do
-      concat(render(Primer::Beta::Text.new(font_weight: :semibold, tag: :div)) {
+      concat(render(Primer::Beta::Text.new(font_weight: :bold, tag: :div)) {
         I18n.t(:"admin.jira.run.wizard.sections.import_result.title")
       })
       if model.status_before?(:imported)
@@ -98,7 +98,8 @@ See COPYRIGHT and LICENSE files for more details.
       box.with_row(mt: 3, mb: 3) do
         render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
           title: I18n.t(:"admin.jira.run.wizard.sections.import_result.label_results"),
-          list: imported_data
+          list: imported_data,
+          show_icon: false
         ))
       end
     end

--- a/app/components/admin/import/jira/import_runs/wizard_step_review_component.rb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_review_component.rb
@@ -36,8 +36,7 @@ module Admin::Import::Jira::ImportRuns
     def imported_data
       [
         { label: projects_label(imported_projects.count), checked: true, url: imported_projects_url },
-        { label: work_packages_label(imported_work_packages.count), checked: true, url: imported_work_packages_url },
-        imported_users.none? ? nil : { label: users_label(imported_users.count), checked: true, url: imported_users_url }
+        { label: work_packages_label(imported_work_packages.count), checked: true, url: imported_work_packages_url }
       ].compact
     end
 
@@ -72,17 +71,6 @@ module Admin::Import::Jira::ImportRuns
         project_ids = imported_projects.pluck(:op_entity_id).map(&:to_s)
         helpers.work_packages_path(query_props: { f: [{ n: "project", o: "=", v: project_ids }] }.to_json)
       end
-    end
-
-    def imported_users
-      @imported_users ||= Import::JiraOpenProjectReference
-        .where(jira_import: model, op_entity_class: "User", uses_existing: false)
-    end
-
-    def imported_users_url
-      return nil if imported_users.none?
-
-      helpers.users_path
     end
   end
 end

--- a/app/controllers/admin/import/jira/instances_controller.rb
+++ b/app/controllers/admin/import/jira/instances_controller.rb
@@ -40,7 +40,7 @@ module Admin::Import::Jira
     before_action :set_jira, only: %i[show edit update destroy delete_token]
 
     def index
-      @jira_instances = Import::Jira.all
+      @jira_instances = Import::Jira.order(created_at: :desc)
     end
 
     def show

--- a/app/views/admin/import/jira/instances/index.html.erb
+++ b/app/views/admin/import/jira/instances/index.html.erb
@@ -54,14 +54,68 @@ See COPYRIGHT and LICENSE files for more details.
     }
   end
 %>
+
 <%=
-  render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert, mb: 3)) {
-    concat(render(Primer::Beta::Text.new(tag: :div, font_weight: :semibold)) {
-      I18n.t(:"admin.jira.banner.title")
-    })
-    concat(I18n.t(:"admin.jira.banner.description"))
-  }
-%>
-<%=
-  render(Admin::Import::Jira::TableComponent.new(rows: @jira_instances))
+  flex_layout(direction: :column) do |container|
+    container.with_row do
+      render(Primer::Alpha::Banner.new(scheme: :warning, icon: :alert, mb: 3)) {
+          concat(render(Primer::Beta::Text.new(tag: :p, font_weight: :bold)) {
+            I18n.t(:"admin.jira.banner.title")
+          })
+          concat(render(Primer::Beta::Text.new(tag: :p, font_weight: :normal)) {
+           I18n.t(:"admin.jira.banner.description")
+          })
+          concat(render(Primer::Beta::Text.new(tag: :p, font_weight: :normal)) {
+            link_translate("admin.jira.banner.contribution_callout",
+                            links: { link: %i[jira_migrator_project] },
+                            external: true)
+          })
+        }
+    end
+    container.with_row(pb: 3) do
+      flex_layout do |flex|
+        flex.with_column(flex: 1, mr: 1) do
+          render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
+            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_supported_data"),
+            list: [
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.projects"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.issues"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.issue_details"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.custom_fields"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.users"),
+            ].map { |label| { label:, checked: true } },
+            h: :full,
+            icon: :"check-circle",
+            icon_color: :success
+          ))
+        end
+        flex.with_column(flex: 1, ml: 1) do
+          render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
+            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_comming_soon"),
+            list: [
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.project_ids"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.issue_ids"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.relations"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.sprints"),
+            ].map { |label| { label:, checked: false } },
+            h: :full,
+          ))
+        end
+        flex.with_column(flex: 1, ml: 1) do
+          render(Admin::Import::Jira::ImportRuns::InfoListBoxComponent.new(
+            title: I18n.t(:"admin.jira.run.wizard.sections.import_scope.label_comming_later"),
+            list: [
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.workflows"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.permissions"),
+              I18n.t(:"admin.jira.run.wizard.sections.import_scope.elements.schemes")
+            ].map { |label| { label:, checked: false } },
+            h: :full,
+          ))
+        end
+      end
+    end
+    container.with_row do
+      render(Admin::Import::Jira::TableComponent.new(rows: @jira_instances))
+    end
+  end
 %>

--- a/app/workers/import/jira_instance_meta_data_job.rb
+++ b/app/workers/import/jira_instance_meta_data_job.rb
@@ -51,7 +51,7 @@ module Import
       jira_import.update!(job_id: nil, available:, error: nil)
       jira_import.transition_to!(:instance_meta_done)
     rescue StandardError => e
-      jira_import&.transition_to!(:instance_meta_error, error: e.message)
+      jira_import&.transition_to!(:instance_meta_error, error: e.message, error_backtrace: e.backtrace)
       jira_import&.update!(job_id: nil, error: e.message)
     end
 

--- a/app/workers/import/jira_projects_meta_data_job.rb
+++ b/app/workers/import/jira_projects_meta_data_job.rb
@@ -43,7 +43,7 @@ module Import
       jira_import = Import::JiraImport.find(jira_import_id)
       get_meta(jira_import)
     rescue StandardError => e
-      jira_import&.transition_to!(:projects_meta_error, error: e.message)
+      jira_import&.transition_to!(:projects_meta_error, error: e.message, error_backtrace: e.backtrace)
       jira_import&.update!(job_id: nil, error: e.message)
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,8 +133,11 @@ en:
         title: "Jira configuration"
         new: "New configuration"
       banner:
-        title: "Limited import capabilities"
-        description: "This Jira Migrator is currently in beta and can only import basic data: projects, issues (name, title, description, attachments), users (name, email, project membership), statuses, and types. It cannot import workflows, custom fields, issue relations, or permissions. We currently only support Jira Server/Data Center versions 10.x and 11.x. Cloud instances are not supported at this time."
+        title: "Beta - Try it out!"
+        description: "This Jira Migrator is currently in beta. We currently only support Jira Server/Data Center versions 10.x and 11.x. Cloud instances are not supported at this time."
+        contribution_callout: >
+          Please, help us improve the Jira Migrator with your feedback and private data donations. You can [join the development community](link) of the Jira Migrator. 
+        supported_versions: ""
       form:
         fields:
           name: "Name"
@@ -249,8 +252,10 @@ en:
               caption_done: "Completed"
               label_info: "Please note that this import tool is in beta and cannot import all types of data. Here is a summary of what the host Jira instance offers for import and what this tool is able to import right now."
               description: "Select what data you want to import from the available data fetched from the host Jira instance."
-              label_available_data: "Available data"
-              label_not_available_data: "Not available for import"
+              label_supported_data: "Supported data"
+              label_comming_soon: "Comming soon (Q2 2026)"
+              label_comming_later: "Comming later"
+              label_available_server_data: "Available data on %{server_info}"
               button_select_projects: "Select projects to import"
               button_continue: "Continue"
               label_import: "Select which projects you would like to import."
@@ -259,16 +264,22 @@ en:
               label_progress: "Fetching data from Jira..."
               elements:
                 relations: "Relations between issues"
+                project_ids: "Project identifiers"
+                issue_ids: "Issues identifiers"
+                sprints: "Sprint assignments"
                 workflows: "Project-level workflows"
-                users: "Users"
-                sprints: "Sprints"
                 schemes: "Schemas"
-                permissions: "User, group and project permissions"
+                permissions: "Permissions"
+                projects: "Projects"
+                issues: "Issues"
+                issue_details: "Issue description, history, comments and attachments"
+                custom_fields: "A subset of custom fields"
+                users: "Involved users and groups"
             confirm_import:
               title: "Import data"
               caption: "Review your import settings and start the import"
               caption_done: "Completed"
-              label_available_data: "Available data to import"
+              label_available_data: "Data to be imported"
               label_users_import_explanation: "Users that are involved in selected projects (group memberships included)"
               button_start: "Start import"
               description: "You are about to start an import run with the following settings."
@@ -277,34 +288,34 @@ en:
             import_result:
               title: "Import run results"
               caption: "Review import run or revert import"
-              info: "Import run successful."
+              info: "Import run was successful."
               label_results: "Imported"
               label_revert: "Revert import"
               button_revert: "Revert import"
-              button_done: "Finalize import"
-              preview_description: 'The imported data is currently in review mode. Click "Finalize import" to make the import permanent or "Revert import" to undo all changes made in this import run.'
-              label_finalize_import: "Finalize import"
-              label_finalizing: "Finalizing import..."
-              label_finalizing_done: "Import finalized."
+              button_done: "Approve import"
+              preview_description: 'The imported data is currently in review mode. Click "Approve import" to make the import permanent or "Revert import" to undo all changes made in this import run.'
+              label_finalize_import: "Approve import"
+              label_finalizing: "Approving import..."
+              label_finalizing_done: "Import approved."
               label_revert_progress: "Reverting import..."
               label_reverted: "Import reverted."
           select_dialog:
             filter_projects: "Filter by text"
           import_dialog:
-            title: "Start this import?"
+            title: "Please make sure you have a backup!"
             confirm_button: "Start import"
             description: >
-              This importer is an alpha feature. It is not yet able to import all data from Jira and might leave incomplete data on this OpenProject instance.
-
-              <b>Do not use a production environment and create a backup of your OpenProject data before starting.</b>
-            confirm: "I understand and made the necessary preparations"
+              Imports change your OpenProject configuration. After the import you will have the opportunity to review the changes.
+              While in review, you have an option to revert or approve the import. After approving the import reverting will no longer be possible.
+              Therefore, please, make sure that you have [a backup of your OpenProject instance](link) before proceeding.
+            confirm: "I understand and have a backup"
           revert_dialog:
             title: "Permanently revert this import?"
-            description: "This will delete all imported objects (including whole projects) even if there was user activity in those projects after the import on OpenProject."
+            description: "This will delete all imported objects (including whole projects)."
             confirm: "I understand that this reversion will delete data permanently"
           finalize_dialog:
-            title: "Finalize this import?"
-            description: "Once finalized, this import can no longer be reverted. All imported data will become permanently imported."
+            title: "Approve this import?"
+            description: "Once approved, this import can no longer be reverted. All imported data will become permanent."
             confirm: "I understand that this action cannot be undone"
             confirm_button: "Understood"
           select_projects:

--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -242,3 +242,7 @@ webinar_videos:
 website:
   href: https://www.openproject.org
   label: label_openproject_website
+jira_migrator_project:
+  href: https://community.openproject.org/projects/jira-migration/dashboard
+backup_guide:
+  href: https://www.openproject.org/docs/installation-and-operations/operation/backing-up/


### PR DESCRIPTION
https://community.openproject.org/wp/74343

## What

- rephrase a lot of text
- make sure backtrace is included in case of errors in all jira migrator related jobs.
- change InfoListBox component to support subheader and any icon
- remove link to users in review mode due to its uselessness
- sort jira configs by created_at (new configurations first)
