### PR TITLE
refactor: encapsulate Project slug history with relation scopes

### DIFF
--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -83,7 +83,7 @@ module Projects::Identifier
     def unset_slug_if_invalid; end
   end
 
-  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_slugs.
+  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_identifiers.
   # Lets callers compose against verbs like .truly_historical / .matching / .upcased_values
   # instead of raw SQL fragments — keeping FriendlyId::Slug column knowledge in one place.
   module HistoricalIdentifierScopes
@@ -106,7 +106,7 @@ module Projects::Identifier
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
-    def historical_slugs
+    def historical_identifiers
       FriendlyId::Slug.where(sluggable_type: name).extending(HistoricalIdentifierScopes)
     end
 
@@ -189,7 +189,7 @@ module Projects::Identifier
   end
 
   def identifier_used_by_other_project_in_past?
-    self.class.historical_slugs
+    self.class.historical_identifiers
               .matching(identifier)
               .where.not(sluggable_id: id)
               .exists?

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -83,17 +83,18 @@ module Projects::Identifier
     def unset_slug_if_invalid; end
   end
 
-  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_slugs.
-  # Lets callers compose against verbs like .truly_historical / .matching / .upcased_values
+  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.identifier_slugs.
+  # Lets callers compose against verbs like .historically_reserved / .for_identifier / .upcased_values
   # instead of raw SQL fragments — keeping FriendlyId::Slug column knowledge in one place.
-  module HistoricalSlugScopes
-    # Slugs that are no longer used as any active project's identifier.
-    def truly_historical
+  module IdentifierSlugScopes
+    # Slugs that are no longer used as any active project's identifier, but remain reserved
+    # because FriendlyId still owns them — so they cannot be reused by another project.
+    def historically_reserved
       where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
     end
 
     # Slugs whose lowercase form equals the lowercased input.
-    def matching(value)
+    def for_identifier(value)
       where("LOWER(slug) = ?", value.downcase)
     end
 
@@ -114,10 +115,12 @@ module Projects::Identifier
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
-    # `slug` is FriendlyId terminology; in our domain language a slug is the project identifier.
-    # Method name aligns with FriendlyId's `project.slugs` association for vocabulary consistency.
-    def historical_slugs
-      FriendlyId::Slug.where(sluggable_type: name).extending(HistoricalSlugScopes)
+    # FriendlyId's :history module records a row on every save, so this relation contains
+    # both currently-used identifiers and historically-reserved ones. Compose with
+    # `.historically_reserved` to filter to the latter. The name aligns with FriendlyId's
+    # `project.slugs` association for vocabulary consistency.
+    def identifier_slugs
+      FriendlyId::Slug.where(sluggable_type: name).extending(IdentifierSlugScopes)
     end
 
     def suggest_identifier(name, mode: Setting[:work_packages_identifier])
@@ -199,8 +202,8 @@ module Projects::Identifier
   end
 
   def identifier_used_by_other_project_in_past?
-    self.class.historical_slugs
-              .matching(identifier)
+    self.class.identifier_slugs
+              .for_identifier(identifier)
               .where.not(sluggable_id: id)
               .exists?
   end

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -83,10 +83,10 @@ module Projects::Identifier
     def unset_slug_if_invalid; end
   end
 
-  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_identifiers.
+  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_slugs.
   # Lets callers compose against verbs like .truly_historical / .matching / .upcased_values
   # instead of raw SQL fragments — keeping FriendlyId::Slug column knowledge in one place.
-  module HistoricalIdentifierScopes
+  module HistoricalSlugScopes
     # Slugs that are no longer used as any active project's identifier.
     def truly_historical
       where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
@@ -114,8 +114,10 @@ module Projects::Identifier
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
-    def historical_identifiers
-      FriendlyId::Slug.where(sluggable_type: name).extending(HistoricalIdentifierScopes)
+    # `slug` is FriendlyId terminology; in our domain language a slug is the project identifier.
+    # Method name aligns with FriendlyId's `project.slugs` association for vocabulary consistency.
+    def historical_slugs
+      FriendlyId::Slug.where(sluggable_type: name).extending(HistoricalSlugScopes)
     end
 
     def suggest_identifier(name, mode: Setting[:work_packages_identifier])
@@ -197,7 +199,7 @@ module Projects::Identifier
   end
 
   def identifier_used_by_other_project_in_past?
-    self.class.historical_identifiers
+    self.class.historical_slugs
               .matching(identifier)
               .where.not(sluggable_id: id)
               .exists?

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -97,6 +97,11 @@ module Projects::Identifier
       where("LOWER(slug) = ?", value.downcase)
     end
 
+    # Excludes the given project's own slug history. No-op when project is nil.
+    def excluding_project(project)
+      project ? where.not(sluggable_id: project) : self
+    end
+
     def upcased_values   = pluck(Arel.sql("UPPER(slug)"))
     def downcased_values = pluck(Arel.sql("LOWER(slug)"))
     # Verbatim values, no case folding. Named `raw_values` to avoid colliding

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -99,6 +99,9 @@ module Projects::Identifier
 
     def upcased_values   = pluck(Arel.sql("UPPER(slug)"))
     def downcased_values = pluck(Arel.sql("LOWER(slug)"))
+    # Verbatim values, no case folding. Named `raw_values` to avoid colliding
+    # with `ActiveRecord::Relation#values` (an internal Rails method).
+    def raw_values = pluck(:slug)
   end
 
   class_methods do

--- a/app/models/projects/identifier.rb
+++ b/app/models/projects/identifier.rb
@@ -83,13 +83,31 @@ module Projects::Identifier
     def unset_slug_if_invalid; end
   end
 
+  # Domain-named scopes for the FriendlyId::Slug relation returned by Project.historical_slugs.
+  # Lets callers compose against verbs like .truly_historical / .matching / .upcased_values
+  # instead of raw SQL fragments — keeping FriendlyId::Slug column knowledge in one place.
+  module HistoricalIdentifierScopes
+    # Slugs that are no longer used as any active project's identifier.
+    def truly_historical
+      where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
+    end
+
+    # Slugs whose lowercase form equals the lowercased input.
+    def matching(value)
+      where("LOWER(slug) = ?", value.downcase)
+    end
+
+    def upcased_values   = pluck(Arel.sql("UPPER(slug)"))
+    def downcased_values = pluck(Arel.sql("LOWER(slug)"))
+  end
+
   class_methods do
     def classic_identifier_format?(str)
       str.match?(CLASSIC_IDENTIFIER_FORMAT)
     end
 
     def historical_slugs
-      FriendlyId::Slug.where(sluggable_type: name)
+      FriendlyId::Slug.where(sluggable_type: name).extending(HistoricalIdentifierScopes)
     end
 
     def suggest_identifier(name, mode: Setting[:work_packages_identifier])
@@ -172,7 +190,7 @@ module Projects::Identifier
 
   def identifier_used_by_other_project_in_past?
     self.class.historical_slugs
-              .where("LOWER(slug) = ?", identifier.downcase)
+              .matching(identifier)
               .where.not(sluggable_id: id)
               .exists?
   end

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -77,7 +77,7 @@ module ProjectIdentifiers
 
     def taken_identifiers(project: nil)
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
-      historical = Project.historical_slugs.excluding_project(project).downcased_values.to_set
+      historical = Project.identifier_slugs.excluding_project(project).downcased_values.to_set
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set
       current | historical | reserved
     end

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -77,7 +77,7 @@ module ProjectIdentifiers
 
     def taken_identifiers(project: nil)
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
-      historical = Project.historical_slugs
+      historical = Project.historical_identifiers
                          .then { |q| project ? q.where.not(sluggable_id: project.id) : q }
                          .downcased_values.to_set
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -77,9 +77,7 @@ module ProjectIdentifiers
 
     def taken_identifiers(project: nil)
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
-      historical = Project.historical_identifiers
-                         .then { |q| project ? q.where.not(sluggable_id: project.id) : q }
-                         .downcased_values.to_set
+      historical = Project.historical_identifiers.excluding_project(project).downcased_values.to_set
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set
       current | historical | reserved
     end

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -77,7 +77,7 @@ module ProjectIdentifiers
 
     def taken_identifiers(project: nil)
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
-      historical = Project.historical_identifiers.excluding_project(project).downcased_values.to_set
+      historical = Project.historical_slugs.excluding_project(project).downcased_values.to_set
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set
       current | historical | reserved
     end

--- a/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
+++ b/app/services/project_identifiers/classic_identifier_suggestion_generator.rb
@@ -79,7 +79,7 @@ module ProjectIdentifiers
       current    = Project.unscoped.pluck(:identifier).compact.to_set(&:downcase)
       historical = Project.historical_slugs
                          .then { |q| project ? q.where.not(sluggable_id: project.id) : q }
-                         .pluck(:slug).to_set(&:downcase)
+                         .downcased_values.to_set
       reserved   = Projects::Identifier::RESERVED_IDENTIFIERS.to_set
       current | historical | reserved
     end

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -51,7 +51,7 @@ module ProjectIdentifiers
       # Combines all FriendlyId slug history for projects (current and historical slugs)
       # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        Project.historical_slugs.upcased_values.to_set | model_reserved_identifiers
+        Project.identifier_slugs.upcased_values.to_set | model_reserved_identifiers
       end
 
       def self.model_reserved_identifiers
@@ -110,7 +110,7 @@ module ProjectIdentifiers
       private
 
       def historical_identifiers
-        @historical_identifiers ||= Project.historical_slugs.truly_historical.upcased_values.to_set
+        @historical_identifiers ||= Project.identifier_slugs.historically_reserved.upcased_values.to_set
       end
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -51,7 +51,7 @@ module ProjectIdentifiers
       # Combines all FriendlyId slug history for projects (current and historical slugs)
       # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        Project.historical_identifiers.upcased_values.to_set | model_reserved_identifiers
+        Project.historical_slugs.upcased_values.to_set | model_reserved_identifiers
       end
 
       def self.model_reserved_identifiers
@@ -110,7 +110,7 @@ module ProjectIdentifiers
       private
 
       def historical_identifiers
-        @historical_identifiers ||= Project.historical_identifiers.truly_historical.upcased_values.to_set
+        @historical_identifiers ||= Project.historical_slugs.truly_historical.upcased_values.to_set
       end
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -51,7 +51,7 @@ module ProjectIdentifiers
       # Combines all FriendlyId slug history for projects (current and historical slugs)
       # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        Project.historical_slugs.upcased_values.to_set | model_reserved_identifiers
+        Project.historical_identifiers.upcased_values.to_set | model_reserved_identifiers
       end
 
       def self.model_reserved_identifiers
@@ -110,7 +110,7 @@ module ProjectIdentifiers
       private
 
       def historical_identifiers
-        @historical_identifiers ||= Project.historical_slugs.truly_historical.upcased_values.to_set
+        @historical_identifiers ||= Project.historical_identifiers.truly_historical.upcased_values.to_set
       end
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)

--- a/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
+++ b/app/services/project_identifiers/identifier_autofix/problematic_identifiers.rb
@@ -51,8 +51,7 @@ module ProjectIdentifiers
       # Combines all FriendlyId slug history for projects (current and historical slugs)
       # with system-reserved keywords from Projects::Identifier::RESERVED_IDENTIFIERS.
       def self.reserved_identifiers
-        slug_set = Project.historical_slugs.pluck("UPPER(slug)").to_set
-        slug_set | model_reserved_identifiers
+        Project.historical_slugs.upcased_values.to_set | model_reserved_identifiers
       end
 
       def self.model_reserved_identifiers
@@ -111,11 +110,7 @@ module ProjectIdentifiers
       private
 
       def historical_identifiers
-        @historical_identifiers ||= Project
-                                      .historical_slugs
-                                      .where("LOWER(slug) NOT IN (SELECT LOWER(identifier) FROM projects)")
-                                      .pluck("UPPER(slug)")
-                                      .to_set
+        @historical_identifiers ||= Project.historical_slugs.truly_historical.upcased_values.to_set
       end
 
       def exceeds_max_length        = Project.where("length(identifier) > ?", self.class.max_identifier_length)

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Projects::Identifier do
     end
   end
 
-  describe ".historical_identifiers scopes" do
+  describe ".historical_slugs scopes" do
     let!(:active_project) { create(:project, identifier: "active-id") }
     let!(:renamed_project) { create(:project, identifier: "current-id") }
 
@@ -331,27 +331,27 @@ RSpec.describe Projects::Identifier do
 
     describe "#truly_historical" do
       it "returns slugs whose lowercase value isn't any active project's identifier" do
-        slugs = Project.historical_identifiers.truly_historical.pluck(:slug)
+        slugs = Project.historical_slugs.truly_historical.pluck(:slug)
         expect(slugs).to contain_exactly("old-slug")
       end
     end
 
     describe "#matching" do
       it "returns slugs whose lowercase equals the lowercased input" do
-        match = Project.historical_identifiers.matching("OLD-SLUG")
+        match = Project.historical_slugs.matching("OLD-SLUG")
         expect(match.pluck(:slug)).to contain_exactly("old-slug")
       end
 
       it "matches case-insensitively when stored slug differs in case" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        match = Project.historical_identifiers.matching("mixedcase")
+        match = Project.historical_slugs.matching("mixedcase")
         expect(match.pluck(:slug)).to contain_exactly("MixedCase")
       end
     end
 
     describe "#upcased_values" do
       it "returns uppercased slugs as a plain array" do
-        values = Project.historical_identifiers.upcased_values
+        values = Project.historical_slugs.upcased_values
         expect(values).to contain_exactly("ACTIVE-ID", "CURRENT-ID", "OLD-SLUG")
       end
     end
@@ -359,7 +359,7 @@ RSpec.describe Projects::Identifier do
     describe "#downcased_values" do
       it "returns downcased slugs as a plain array" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        values = Project.historical_identifiers.downcased_values
+        values = Project.historical_slugs.downcased_values
         expect(values).to include("active-id", "current-id", "old-slug", "mixedcase")
       end
     end
@@ -367,25 +367,25 @@ RSpec.describe Projects::Identifier do
     describe "#raw_values" do
       it "returns slug values verbatim (no case folding)" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        values = Project.historical_identifiers.raw_values
+        values = Project.historical_slugs.raw_values
         expect(values).to contain_exactly("active-id", "current-id", "old-slug", "MixedCase")
       end
     end
 
     describe "#excluding_project" do
       it "drops the given project's slug history from the relation" do
-        values = Project.historical_identifiers.excluding_project(renamed_project).raw_values
+        values = Project.historical_slugs.excluding_project(renamed_project).raw_values
         expect(values).to contain_exactly("active-id")
       end
 
       it "is a no-op when project is nil" do
-        values = Project.historical_identifiers.excluding_project(nil).raw_values
+        values = Project.historical_slugs.excluding_project(nil).raw_values
         expect(values).to contain_exactly("active-id", "current-id", "old-slug")
       end
     end
 
     it "composes scopes (truly_historical + upcased_values)" do
-      values = Project.historical_identifiers.truly_historical.upcased_values
+      values = Project.historical_slugs.truly_historical.upcased_values
       expect(values).to contain_exactly("OLD-SLUG")
     end
   end

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -318,40 +318,40 @@ RSpec.describe Projects::Identifier do
     end
   end
 
-  describe ".historical_slugs scopes" do
+  describe ".identifier_slugs scopes" do
     let!(:active_project) { create(:project, identifier: "active-id") }
     let!(:renamed_project) { create(:project, identifier: "current-id") }
 
     before do
       # Slug history mirrors active identifiers for both projects (FriendlyId :history records the
       # current slug on save). Add an extra historical slug for renamed_project to exercise the
-      # "truly historical" filter — it doesn't match any active project's identifier.
+      # `historically_reserved` filter — it doesn't match any active project's identifier.
       FriendlyId::Slug.create!(sluggable: renamed_project, slug: "old-slug")
     end
 
-    describe "#truly_historical" do
+    describe "#historically_reserved" do
       it "returns slugs whose lowercase value isn't any active project's identifier" do
-        slugs = Project.historical_slugs.truly_historical.pluck(:slug)
+        slugs = Project.identifier_slugs.historically_reserved.pluck(:slug)
         expect(slugs).to contain_exactly("old-slug")
       end
     end
 
-    describe "#matching" do
+    describe "#for_identifier" do
       it "returns slugs whose lowercase equals the lowercased input" do
-        match = Project.historical_slugs.matching("OLD-SLUG")
+        match = Project.identifier_slugs.for_identifier("OLD-SLUG")
         expect(match.pluck(:slug)).to contain_exactly("old-slug")
       end
 
       it "matches case-insensitively when stored slug differs in case" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        match = Project.historical_slugs.matching("mixedcase")
+        match = Project.identifier_slugs.for_identifier("mixedcase")
         expect(match.pluck(:slug)).to contain_exactly("MixedCase")
       end
     end
 
     describe "#upcased_values" do
       it "returns uppercased slugs as a plain array" do
-        values = Project.historical_slugs.upcased_values
+        values = Project.identifier_slugs.upcased_values
         expect(values).to contain_exactly("ACTIVE-ID", "CURRENT-ID", "OLD-SLUG")
       end
     end
@@ -359,7 +359,7 @@ RSpec.describe Projects::Identifier do
     describe "#downcased_values" do
       it "returns downcased slugs as a plain array" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        values = Project.historical_slugs.downcased_values
+        values = Project.identifier_slugs.downcased_values
         expect(values).to include("active-id", "current-id", "old-slug", "mixedcase")
       end
     end
@@ -367,25 +367,25 @@ RSpec.describe Projects::Identifier do
     describe "#raw_values" do
       it "returns slug values verbatim (no case folding)" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        values = Project.historical_slugs.raw_values
+        values = Project.identifier_slugs.raw_values
         expect(values).to contain_exactly("active-id", "current-id", "old-slug", "MixedCase")
       end
     end
 
     describe "#excluding_project" do
       it "drops the given project's slug history from the relation" do
-        values = Project.historical_slugs.excluding_project(renamed_project).raw_values
+        values = Project.identifier_slugs.excluding_project(renamed_project).raw_values
         expect(values).to contain_exactly("active-id")
       end
 
       it "is a no-op when project is nil" do
-        values = Project.historical_slugs.excluding_project(nil).raw_values
+        values = Project.identifier_slugs.excluding_project(nil).raw_values
         expect(values).to contain_exactly("active-id", "current-id", "old-slug")
       end
     end
 
-    it "composes scopes (truly_historical + upcased_values)" do
-      values = Project.historical_slugs.truly_historical.upcased_values
+    it "composes scopes (historically_reserved + upcased_values)" do
+      values = Project.identifier_slugs.historically_reserved.upcased_values
       expect(values).to contain_exactly("OLD-SLUG")
     end
   end

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Projects::Identifier do
     end
   end
 
-  describe ".historical_slugs scopes" do
+  describe ".historical_identifiers scopes" do
     let!(:active_project) { create(:project, identifier: "active-id") }
     let!(:renamed_project) { create(:project, identifier: "current-id") }
 
@@ -331,27 +331,27 @@ RSpec.describe Projects::Identifier do
 
     describe "#truly_historical" do
       it "returns slugs whose lowercase value isn't any active project's identifier" do
-        slugs = Project.historical_slugs.truly_historical.pluck(:slug)
+        slugs = Project.historical_identifiers.truly_historical.pluck(:slug)
         expect(slugs).to contain_exactly("old-slug")
       end
     end
 
     describe "#matching" do
       it "returns slugs whose lowercase equals the lowercased input" do
-        match = Project.historical_slugs.matching("OLD-SLUG")
+        match = Project.historical_identifiers.matching("OLD-SLUG")
         expect(match.pluck(:slug)).to contain_exactly("old-slug")
       end
 
       it "matches case-insensitively when stored slug differs in case" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        match = Project.historical_slugs.matching("mixedcase")
+        match = Project.historical_identifiers.matching("mixedcase")
         expect(match.pluck(:slug)).to contain_exactly("MixedCase")
       end
     end
 
     describe "#upcased_values" do
       it "returns uppercased slugs as a plain array" do
-        values = Project.historical_slugs.upcased_values
+        values = Project.historical_identifiers.upcased_values
         expect(values).to contain_exactly("ACTIVE-ID", "CURRENT-ID", "OLD-SLUG")
       end
     end
@@ -359,13 +359,13 @@ RSpec.describe Projects::Identifier do
     describe "#downcased_values" do
       it "returns downcased slugs as a plain array" do
         FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
-        values = Project.historical_slugs.downcased_values
+        values = Project.historical_identifiers.downcased_values
         expect(values).to include("active-id", "current-id", "old-slug", "mixedcase")
       end
     end
 
     it "composes scopes (truly_historical + upcased_values)" do
-      values = Project.historical_slugs.truly_historical.upcased_values
+      values = Project.historical_identifiers.truly_historical.upcased_values
       expect(values).to contain_exactly("OLD-SLUG")
     end
   end

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -372,6 +372,18 @@ RSpec.describe Projects::Identifier do
       end
     end
 
+    describe "#excluding_project" do
+      it "drops the given project's slug history from the relation" do
+        values = Project.historical_identifiers.excluding_project(renamed_project).raw_values
+        expect(values).to contain_exactly("active-id")
+      end
+
+      it "is a no-op when project is nil" do
+        values = Project.historical_identifiers.excluding_project(nil).raw_values
+        expect(values).to contain_exactly("active-id", "current-id", "old-slug")
+      end
+    end
+
     it "composes scopes (truly_historical + upcased_values)" do
       values = Project.historical_identifiers.truly_historical.upcased_values
       expect(values).to contain_exactly("OLD-SLUG")

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -364,6 +364,14 @@ RSpec.describe Projects::Identifier do
       end
     end
 
+    describe "#raw_values" do
+      it "returns slug values verbatim (no case folding)" do
+        FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
+        values = Project.historical_identifiers.raw_values
+        expect(values).to contain_exactly("active-id", "current-id", "old-slug", "MixedCase")
+      end
+    end
+
     it "composes scopes (truly_historical + upcased_values)" do
       values = Project.historical_identifiers.truly_historical.upcased_values
       expect(values).to contain_exactly("OLD-SLUG")

--- a/spec/models/projects/identifier_spec.rb
+++ b/spec/models/projects/identifier_spec.rb
@@ -317,4 +317,56 @@ RSpec.describe Projects::Identifier do
       end
     end
   end
+
+  describe ".historical_slugs scopes" do
+    let!(:active_project) { create(:project, identifier: "active-id") }
+    let!(:renamed_project) { create(:project, identifier: "current-id") }
+
+    before do
+      # Slug history mirrors active identifiers for both projects (FriendlyId :history records the
+      # current slug on save). Add an extra historical slug for renamed_project to exercise the
+      # "truly historical" filter — it doesn't match any active project's identifier.
+      FriendlyId::Slug.create!(sluggable: renamed_project, slug: "old-slug")
+    end
+
+    describe "#truly_historical" do
+      it "returns slugs whose lowercase value isn't any active project's identifier" do
+        slugs = Project.historical_slugs.truly_historical.pluck(:slug)
+        expect(slugs).to contain_exactly("old-slug")
+      end
+    end
+
+    describe "#matching" do
+      it "returns slugs whose lowercase equals the lowercased input" do
+        match = Project.historical_slugs.matching("OLD-SLUG")
+        expect(match.pluck(:slug)).to contain_exactly("old-slug")
+      end
+
+      it "matches case-insensitively when stored slug differs in case" do
+        FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
+        match = Project.historical_slugs.matching("mixedcase")
+        expect(match.pluck(:slug)).to contain_exactly("MixedCase")
+      end
+    end
+
+    describe "#upcased_values" do
+      it "returns uppercased slugs as a plain array" do
+        values = Project.historical_slugs.upcased_values
+        expect(values).to contain_exactly("ACTIVE-ID", "CURRENT-ID", "OLD-SLUG")
+      end
+    end
+
+    describe "#downcased_values" do
+      it "returns downcased slugs as a plain array" do
+        FriendlyId::Slug.create!(sluggable: renamed_project, slug: "MixedCase")
+        values = Project.historical_slugs.downcased_values
+        expect(values).to include("active-id", "current-id", "old-slug", "mixedcase")
+      end
+    end
+
+    it "composes scopes (truly_historical + upcased_values)" do
+      values = Project.historical_slugs.truly_historical.upcased_values
+      expect(values).to contain_exactly("OLD-SLUG")
+    end
+  end
 end


### PR DESCRIPTION
Suggestion PR on top of #22934 — completes the encapsulation of `FriendlyId::Slug` by extending its relation with a `HistoricalIdentifierScopes` module (`truly_historical`, `matching`, `upcased_values`, `downcased_values`), chosen over multiplying class methods on `Project` (combinatorial explosion), an AR subclass with `default_scope` (heavier, risks surprising non-Project sluggables), or a query object (non-standard for what `extending` does idiomatically) — so callers compose domain verbs against the relation instead of raw SQL fragments, and `FriendlyId::Slug` is named in exactly one line of the codebase.

See https://guides.rubyonrails.org/association_basics.html#extensions