### PR TITLE
[67643] Wiki menu visible when using the browser's print function/print dialog

### DIFF
--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -14,7 +14,8 @@
   .Overlay action-list,
   anchored-position,
   .PageHeader-actions,
-  sub-header *:has(.Button)
+  sub-header .Button,
+  sub-header .SegmentedControl
     display: none !important
 
   .op-toast:not(.show-when-print)

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -12,7 +12,9 @@
   .ui-helper-hidden-accessible,
   #wiki_add_attachment,
   .Overlay action-list,
-  anchored-position
+  anchored-position,
+  .PageHeader-actions,
+  sub-header .Button
     display: none !important
 
   .op-toast:not(.show-when-print)

--- a/frontend/src/global_styles/layout/_print.sass
+++ b/frontend/src/global_styles/layout/_print.sass
@@ -14,7 +14,7 @@
   .Overlay action-list,
   anchored-position,
   .PageHeader-actions,
-  sub-header .Button
+  sub-header *:has(.Button)
     display: none !important
 
   .op-toast:not(.show-when-print)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/67643

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Hide page header and sub header buttons for pringting.

