### PR TITLE
Fix recurring_meeting_move_to_next_spec.rb:250 on a monday

### DIFF
--- a/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
+++ b/modules/meeting/app/components/meeting_agenda_items/item_component/show_component.rb
@@ -233,8 +233,7 @@ module MeetingAgendaItems
     def next_meeting_action_item(menu, label:, action:, icon:)
       return unless has_next_occurrence?
 
-      from_time = @meeting.start_time.past? ? Time.current : (@meeting.recurrence_start_time || @meeting.start_time)
-      result = @series.first_available_occurrence(from_time:)
+      result = @series.first_available_occurrence(from_time: next_occurrence_from_time)
       return if result.nil?
 
       next_date = result[:occurrence]
@@ -263,8 +262,17 @@ module MeetingAgendaItems
       next_date.present?
     end
 
+    ##
+    # Find the next occurrence that we can move an item to.
+    # Even if meeting.start_time is in the past, its canonical reccurrence_start_time might be in the future.
+    # (when the meeting has been moved earlier than it recurrence time).
+    #
+    # In order to find the next valid slot, we need to skip:
+    # - at least past the recurrence_start_time (which may be sooner or later than the start_time)
+    # - the actual scheduled start_time of the meeting
+    # - the current time, to ensure we don't move to a past meeting.
     def next_occurrence_from_time
-      @meeting.start_time.past? ? Time.current : @meeting.start_time
+      [@meeting.recurrence_start_time, @meeting.start_time, Time.current].compact.max
     end
 
     def has_move_actions?

--- a/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
+++ b/modules/meeting/spec/features/recurring_meetings/recurring_meeting_move_to_next_spec.rb
@@ -232,41 +232,58 @@ RSpec.describe "Recurring meetings move to next meeting", :js do
 
     context "when the occurrence has been rescheduled to an earlier time (Bug #73741)" do
       let(:current_user) { user_with_manage_permissions }
-      let(:first_occurrence_time) { series.next_occurrence(from_time: Time.current) }
+      # Feb 4 is the second Tuesday in the series (series starts Jan 28), rescheduled to Feb 3 (Monday)
+      let(:scheduled_occurrence_time) { DateTime.parse("2025-02-04T10:30:00Z") }
 
       let!(:rescheduled_occurrence) do
         call = RecurringMeetings::InitOccurrenceService
           .new(user: User.system, recurring_meeting: series)
-          .call(start_time: first_occurrence_time)
+          .call(start_time: scheduled_occurrence_time)
         occurrence_meeting = call.result
 
         # Reschedule to an earlier time — recurrence_start_time stays unchanged as the canonical slot
-        occurrence_meeting.update!(start_time: first_occurrence_time - 1.day)
+        occurrence_meeting.update!(start_time: scheduled_occurrence_time - 1.day)
         occurrence_meeting
       end
 
       let(:meeting) { rescheduled_occurrence }
 
-      it "moves the item to the occurrence after the original scheduled time" do
-        meeting_page.expect_agenda_item(title: "Test notes")
+      shared_examples "moves to a different meeting" do
+        it do
+          meeting_page.expect_agenda_item(title: "Test notes")
 
-        meeting_page.select_action(agenda_item, "Move to next meeting")
-        expect(page).to have_text("Move to next meeting?")
+          meeting_page.select_action(agenda_item, "Move to next meeting")
+          expect(page).to have_text("Move to next meeting?")
 
-        page.within_modal "Move to next meeting?" do
-          click_on "Move"
+          page.within_modal "Move to next meeting?" do
+            click_on "Move"
+          end
+
+          expect_and_dismiss_flash(message: "Agenda item moved to the next meeting")
+
+          meeting_page.expect_no_agenda_item(title: "Test notes")
+
+          next_meeting = Meeting.find(agenda_item.reload.meeting_id)
+          expect(next_meeting.id).not_to eq(rescheduled_occurrence.id)
+
+          next_meeting_page = Pages::Meetings::Show.new(next_meeting)
+          next_meeting_page.visit!
+          next_meeting_page.expect_agenda_item(title: "Test notes")
         end
+      end
 
-        expect_and_dismiss_flash(message: "Agenda item moved to the next meeting")
+      context "when the rescheduled time is still in the future" do
+        # Passing case: frozen Mon 08:00, rescheduled start_time Mon 10:30 (future), canonical slot Tue 10:30 (future)
+        around { |example| travel_to(DateTime.parse("2025-02-03T08:00:00Z")) { example.run } }
 
-        meeting_page.expect_no_agenda_item(title: "Test notes")
+        include_examples "moves to a different meeting"
+      end
 
-        next_meeting = Meeting.find(agenda_item.reload.meeting_id)
-        expect(next_meeting.id).not_to eq(rescheduled_occurrence.id)
+      context "when the rescheduled time is past but the canonical slot is in the future" do
+        # Bug case: frozen Mon 12:00, rescheduled start_time Mon 10:30 (past), canonical slot Tue 10:30 (future)
+        around { |example| travel_to(DateTime.parse("2025-02-03T12:00:00Z")) { example.run } }
 
-        next_meeting_page = Pages::Meetings::Show.new(next_meeting)
-        next_meeting_page.visit!
-        next_meeting_page.expect_agenda_item(title: "Test notes")
+        include_examples "moves to a different meeting"
       end
     end
 


### PR DESCRIPTION
We create a rescheduled occurrence with `start_time = first_occurrence_time - 1.day (a Monday)` When the time is Monday 10:30+ UTC `@meeting.start_time.past?` becomes true, which trips the condition in this component:

app/components/meeting_agenda_items/item_component/show_component.rb:236