### PR TITLE
Ensure position is updated on bucket deletion

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.html.erb
@@ -1,0 +1,37 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(Primer::OpenProject::DangerDialog.new(title:, test_selector: TEST_SELECTOR, form_arguments:)) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { title }
+    end
+    dialog.with_additional_details { details }
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.html.erb
@@ -31,7 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   render(Primer::OpenProject::DangerDialog.new(title:, test_selector: TEST_SELECTOR, form_arguments:)) do |dialog|
     dialog.with_confirmation_message do |message|
       message.with_heading(tag: :h2) { title }
+      message.with_description_content(details)
     end
-    dialog.with_additional_details { details }
   end
 %>

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module Backlogs
+  class BacklogBucketDestroyModalComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    TEST_SELECTOR = "backlog-bucket-destroy-modal-dialog"
+
+    attr_reader :backlog_bucket
+
+    def initialize(backlog_bucket:)
+      super
+      @backlog_bucket = backlog_bucket
+    end
+
+    private
+
+    def title
+      t(".title")
+    end
+
+    def details
+      t(".details", name: backlog_bucket.name)
+    end
+
+    def form_arguments
+      {
+        action: project_backlogs_backlog_bucket_path(backlog_bucket.project,
+                                                     backlog_bucket,
+                                                     helpers.all_backlogs_params),
+        method: :delete
+      }
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_destroy_modal_component.rb
@@ -38,7 +38,7 @@ module Backlogs
     attr_reader :backlog_bucket
 
     def initialize(backlog_bucket:)
-      super
+      super()
       @backlog_bucket = backlog_bucket
     end
 

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_menu_component.html.erb
@@ -51,11 +51,8 @@ See COPYRIGHT and LICENSE files for more details.
           id: dom_target(backlog_bucket, :menu, :delete_backlog_bucket),
           label: t(".action_menu.delete_backlog_bucket"),
           scheme: :danger,
-          href: project_backlogs_backlog_bucket_path(project, backlog_bucket, all_backlogs_params),
-          form_arguments: {
-            method: :delete,
-            data: { turbo_confirm: t("text_are_you_sure") }
-          }
+          href: destroy_dialog_project_backlogs_backlog_bucket_path(project, backlog_bucket, all_backlogs_params),
+          content_arguments: { data: { controller: "async-dialog" } }
         ) do |item|
           item.with_leading_visual_icon(icon: :trash)
         end

--- a/modules/backlogs/app/contracts/work_packages/move_to_backlog_contract.rb
+++ b/modules/backlogs/app/contracts/work_packages/move_to_backlog_contract.rb
@@ -29,11 +29,13 @@
 #++
 
 module WorkPackages
-  # Contract used for moving work packages to the product backlog (sprint = nil)
-  # at the end of a sprint. It does not enforce permissions as this change is
-  # carried out in the background.
+  # Contract used for moving work packages to the product backlog (sprint = nil, backlog_bucket = nil):
+  #   * at the end of a sprint
+  #   * upon bucket deletion
+  # It does not enforce permissions as this change is carried out in the background.
   class MoveToBacklogContract < ModelContract
     attribute :sprint
+    attribute :backlog_bucket
     attribute :position
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/backlog_buckets_controller.rb
@@ -33,7 +33,7 @@ module Backlogs
     include OpTurbo::ComponentStream
 
     before_action :check_feature_flag
-    before_action :find_backlog_bucket, only: %i[edit_dialog update destroy]
+    before_action :find_backlog_bucket, only: %i[edit_dialog destroy_dialog update destroy]
 
     def new_dialog
       backlog_bucket = Agile::BacklogBucket.new(project: @project)
@@ -43,6 +43,10 @@ module Backlogs
 
     def edit_dialog
       respond_with_dialog Backlogs::NewBacklogBucketDialogComponent.new(backlog_bucket: @backlog_bucket, state: :edit)
+    end
+
+    def destroy_dialog
+      respond_with_dialog Backlogs::BacklogBucketDestroyModalComponent.new(backlog_bucket: @backlog_bucket)
     end
 
     def create

--- a/modules/backlogs/app/services/backlog_buckets/delete_service.rb
+++ b/modules/backlogs/app/services/backlog_buckets/delete_service.rb
@@ -31,7 +31,7 @@
 class BacklogBuckets::DeleteService < BaseServices::Delete
   private
 
-  def before_perform(service_call)
+  def after_validate(service_call)
     move_to_backlog.each { |result| service_call.add_dependent!(result) }
 
     service_call

--- a/modules/backlogs/app/services/backlog_buckets/delete_service.rb
+++ b/modules/backlogs/app/services/backlog_buckets/delete_service.rb
@@ -29,4 +29,19 @@
 #++
 
 class BacklogBuckets::DeleteService < BaseServices::Delete
+  private
+
+  def before_perform(service_call)
+    move_to_backlog.each { |result| service_call.add_dependent!(result) }
+
+    service_call
+  end
+
+  def move_to_backlog
+    model.work_packages.order(position: :asc).map do |wp|
+      WorkPackages::UpdateService
+        .new(user:, model: wp, contract_class: WorkPackages::MoveToBacklogContract)
+        .call(backlog_bucket: nil)
+    end
+  end
 end

--- a/modules/backlogs/app/services/work_packages/rebuild_positions_service.rb
+++ b/modules/backlogs/app/services/work_packages/rebuild_positions_service.rb
@@ -46,7 +46,7 @@ class WorkPackages::RebuildPositionsService
         SELECT
           id,
           ROW_NUMBER() OVER (
-            PARTITION BY project_id, sprint_id
+            PARTITION BY project_id, backlog_bucket_id, sprint_id
             ORDER BY position, created_at
           ) AS new_position
         FROM work_packages

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -135,8 +135,8 @@ en:
       blankslate_description: "Drag items here to add them."
 
     backlog_bucket_destroy_modal_component:
-      title: "Delete backlog bucket"
-      details: "The backlog bucket '%{name}' will be deleted and all items will be moved to the backlog inbox. No work package will be deleted."
+      title: "Delete backlog bucket?"
+      details: "The backlog bucket '%{name}' will be deleted and all work packages will be moved to the backlog inbox. No work package will be deleted."
 
     backlog_bucket_item_component:
       label_actions: "Work package actions"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -134,6 +134,10 @@ en:
       blankslate_title: "Backlog bucket is empty"
       blankslate_description: "Drag items here to add them."
 
+    backlog_bucket_destroy_modal_component:
+      title: "Delete backlog bucket"
+      details: "The backlog bucket '%{name}' will be deleted and all items will be moved to the backlog inbox. No work package will be deleted."
+
     backlog_bucket_item_component:
       label_actions: "Work package actions"
 

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
         member do
           get :edit_dialog
+          get :destroy_dialog
         end
       end
 

--- a/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
+++ b/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
@@ -6,7 +6,7 @@ class RepositionWorkPackages < ActiveRecord::Migration[8.1]
       direction.up do
         # Used to be copied 1:1 from modules/backlogs/app/services/work_packages/rebuild_positions_service.rb.
         # In the meantime, the implementation of the service changed to accommodate backlog buckets.
-        # But those do not exist at the time this migration represents.
+        # But those did not exist at the time this migration represents.
         execute <<~SQL.squish
           UPDATE work_packages
           SET position = mapping.new_position

--- a/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
+++ b/modules/backlogs/db/migrate/20260325101553_reposition_work_packages.rb
@@ -4,8 +4,9 @@ class RepositionWorkPackages < ActiveRecord::Migration[8.1]
   def change
     reversible do |direction|
       direction.up do
-        # Copied 1:1 from modules/backlogs/app/services/work_packages/rebuild_positions_service.rb.
-        # The service could also have been called. But this way, there is no dependency between the two.
+        # Used to be copied 1:1 from modules/backlogs/app/services/work_packages/rebuild_positions_service.rb.
+        # In the meantime, the implementation of the service changed to accommodate backlog buckets.
+        # But those do not exist at the time this migration represents.
         execute <<~SQL.squish
           UPDATE work_packages
           SET position = mapping.new_position

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -69,7 +69,7 @@ module OpenProject::Backlogs
                    require: :member
 
         permission :create_sprints,
-                   { "backlogs/backlog_buckets": %i[new_dialog create edit_dialog update destroy],
+                   { "backlogs/backlog_buckets": %i[new_dialog create edit_dialog update destroy_dialog destroy],
                      "backlogs/sprints": %i[new_dialog refresh_form create edit_dialog update] },
                    permissible_on: :project,
                    require: :member,

--- a/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
@@ -60,9 +60,10 @@ RSpec.describe "Backlog bucket deletion",
     backlogs_page.visit!
     backlogs_page.expect_bucket_names_in_order("Deprecated bucket")
 
-    accept_confirm do
-      backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
-    end
+    backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
+
+    backlogs_page.expect_backlog_bucket_delete_modal
+    backlogs_page.confirm_backlog_bucket_delete_modal
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_backlog_bucket(bucket)

--- a/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
@@ -41,8 +41,11 @@ RSpec.describe "Backlog bucket deletion",
   end
   shared_let(:bucket) { create(:backlog_bucket, project:, name: "Deprecated bucket") }
 
-  shared_let(:bucket_wp1) { create(:work_package, project:, backlog_bucket: bucket, position: 1) }
-  shared_let(:bucket_wp2) { create(:work_package, project:, backlog_bucket: bucket, position: 2) }
+  shared_let(:inbox_wp1) { create(:work_package, project:) }
+  shared_let(:inbox_wp2) { create(:work_package, project:) }
+
+  shared_let(:bucket_wp1) { create(:work_package, project:, backlog_bucket: bucket) }
+  shared_let(:bucket_wp2) { create(:work_package, project:, backlog_bucket: bucket) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
 
@@ -58,14 +61,13 @@ RSpec.describe "Backlog bucket deletion",
     backlogs_page.expect_bucket_names_in_order("Deprecated bucket")
 
     accept_confirm do
-      sleep 0.5
       backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
     end
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_backlog_bucket(bucket)
 
-    backlogs_page.expect_work_packages_in_backlog_inbox_in_order(work_packages: [bucket_wp1, bucket_wp2])
+    backlogs_page.expect_work_packages_in_backlog_inbox_in_order(work_packages: [inbox_wp1, inbox_wp2, bucket_wp1, bucket_wp2])
 
     expect(Agile::BacklogBucket.where(id: bucket.id)).to be_empty
     expect(bucket_wp1.reload.backlog_bucket_id).to be_nil

--- a/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/delete_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe "Backlog bucket deletion",
 
     backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
 
-    backlogs_page.expect_backlog_bucket_delete_modal
-    backlogs_page.confirm_backlog_bucket_delete_modal
+    backlogs_page.expect_and_confirm_backlog_bucket_delete_modal
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_backlog_bucket(bucket)

--- a/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe "Backlog pagination state", :js do
     backlogs_page.expect_no_inbox_show_more
 
     # Delete backlog bucket
-    accept_confirm do
-      sleep 0.5
-      backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
-    end
+    backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
+
+    backlogs_page.expect_backlog_bucket_delete_modal
+    backlogs_page.confirm_backlog_bucket_delete_modal
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_inbox_show_more

--- a/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
@@ -97,8 +97,7 @@ RSpec.describe "Backlog pagination state", :js do
     # Delete backlog bucket
     backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
 
-    backlogs_page.expect_backlog_bucket_delete_modal
-    backlogs_page.confirm_backlog_bucket_delete_modal
+    backlogs_page.expect_and_confirm_backlog_bucket_delete_modal
 
     expect_and_dismiss_flash type: :success, exact_message: "Successful deletion."
     backlogs_page.expect_no_inbox_show_more

--- a/modules/backlogs/spec/models/work_packages/position_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/position_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   shared_let(:type) { create(:type) }
   shared_let(:sprint1) { create(:agile_sprint, project:, name: "Sprint 1") }
   shared_let(:sprint2) { create(:agile_sprint, project:, name: "Sprint 2") }
+  shared_let(:bucket1) { create(:backlog_bucket, project:, name: "Bucket 1") }
+  shared_let(:bucket2) { create(:backlog_bucket, project:, name: "Bucket 2") }
 
   let!(:sprint1_wp1) { create_work_package(subject: "Sprint 1 WorkPackage 1", sprint: sprint1) }
   let!(:sprint1_wp2) { create_work_package(subject: "Sprint 1 WorkPackage 2", sprint: sprint1) }
@@ -50,12 +52,30 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   let!(:sprint2_wp2) { create_work_package(subject: "Sprint 2 WorkPackage 2", sprint: sprint2) }
   let!(:sprint2_wp3) { create_work_package(subject: "Sprint 2 WorkPackage 3", sprint: sprint2) }
 
-  let!(:no_sprint_wp1) { create_work_package(subject: "No sprint WorkPackage 1", sprint: nil) }
-  let!(:no_sprint_wp2) { create_work_package(subject: "No sprint WorkPackage 2", sprint: nil) }
-  let!(:no_sprint_wp3) { create_work_package(subject: "No sprint WorkPackage 3", sprint: nil) }
+  let!(:inbox_wp1) { create_work_package(subject: "Inbox WorkPackage 1", sprint: nil) }
+  let!(:inbox_wp2) { create_work_package(subject: "Inbox WorkPackage 2", sprint: nil) }
+  let!(:inbox_wp3) { create_work_package(subject: "Inbox WorkPackage 3", sprint: nil) }
+
+  let!(:bucket1_wp1) { create_work_package(subject: "Bucket 1 WorkPackage 1", backlog_bucket: bucket1) }
+  let!(:bucket1_wp2) { create_work_package(subject: "Bucket 1 WorkPackage 2", backlog_bucket: bucket1) }
+  let!(:bucket1_wp3) { create_work_package(subject: "Bucket 1 WorkPackage 3", backlog_bucket: bucket1) }
+  let!(:bucket1_wp4) { create_work_package(subject: "Bucket 1 WorkPackage 4", backlog_bucket: bucket1) }
+  let!(:bucket1_wp5) { create_work_package(subject: "Bucket 1 WorkPackage 5", backlog_bucket: bucket1) }
+
+  let!(:bucket2_wp1) { create_work_package(subject: "Bucket 2 WorkPackage 1", backlog_bucket: bucket2) }
+  let!(:bucket2_wp2) { create_work_package(subject: "Bucket 2 WorkPackage 2", backlog_bucket: bucket2) }
+  let!(:bucket2_wp3) { create_work_package(subject: "Bucket 2 WorkPackage 3", backlog_bucket: bucket2) }
 
   def wp_of_sprint_by_id_and_position(sprint)
     WorkPackage.where(sprint:).pluck(:id, :position).to_h
+  end
+
+  def wp_of_inbox_by_id_and_position
+    WorkPackage.where(sprint: nil, backlog_bucket: nil).pluck(:id, :position).to_h
+  end
+
+  def wp_of_bucket_by_id_and_position(bucket)
+    WorkPackage.where(backlog_bucket: bucket).pluck(:id, :position).to_h
   end
 
   context "when creating a work_package in a sprint" do
@@ -72,15 +92,29 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     end
   end
 
-  context "when creating a work_package outside a sprint" do
+  context "when creating a work_package in the inbox" do
     it "puts them in order" do
       new_work_package = create_work_package(subject: "Newest WorkPackage", sprint: nil)
 
-      expect(wp_of_sprint_by_id_and_position(nil))
-        .to eq(no_sprint_wp1.id => 1,
-               no_sprint_wp2.id => 2,
-               no_sprint_wp3.id => 3,
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp1.id => 1,
+               inbox_wp2.id => 2,
+               inbox_wp3.id => 3,
                new_work_package.id => 4)
+    end
+  end
+
+  context "when creating a work_package in a backlog bucket" do
+    it "puts them in order" do
+      new_work_package = create_work_package(subject: "Newest WorkPackage", backlog_bucket: bucket1)
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp2.id => 2,
+               bucket1_wp3.id => 3,
+               bucket1_wp4.id => 4,
+               bucket1_wp5.id => 5,
+               new_work_package.id => 6)
     end
   end
 
@@ -104,7 +138,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   end
 
   context "when removing a work_package from a sprint" do
-    it "reorders the remaining work_packages and the ones outside of a sprint" do
+    it "reorders the remaining work_packages and the ones in the inbox" do
       sprint1_wp2.sprint = nil
       sprint1_wp2.save!
 
@@ -114,22 +148,22 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
                sprint1_wp4.id => 3,
                sprint1_wp5.id => 4)
 
-      expect(wp_of_sprint_by_id_and_position(nil))
-        .to eq(no_sprint_wp1.id => 1,
-               no_sprint_wp2.id => 2,
-               no_sprint_wp3.id => 3,
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp1.id => 1,
+               inbox_wp2.id => 2,
+               inbox_wp3.id => 3,
                sprint1_wp2.id => 4)
     end
   end
 
-  context "when moving a work_package into a sprint" do
-    it "reorders the remaining work_packages and the ones in the new sprint" do
-      no_sprint_wp2.sprint = sprint1
-      no_sprint_wp2.save!
+  context "when moving a work_package from the inbox into a sprint" do
+    it "reorders the remaining inbox work_packages and the ones in the new sprint" do
+      inbox_wp2.sprint = sprint1
+      inbox_wp2.save!
 
-      expect(wp_of_sprint_by_id_and_position(nil))
-        .to eq(no_sprint_wp1.id => 1,
-               no_sprint_wp3.id => 2)
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp1.id => 1,
+               inbox_wp3.id => 2)
 
       expect(wp_of_sprint_by_id_and_position(sprint1))
         .to eq(sprint1_wp1.id => 1,
@@ -137,7 +171,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
                sprint1_wp3.id => 3,
                sprint1_wp4.id => 4,
                sprint1_wp5.id => 5,
-               no_sprint_wp2.id => 6)
+               inbox_wp2.id => 6)
     end
   end
 
@@ -153,13 +187,126 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     end
   end
 
-  context "when deleting a work_package outside a sprint" do
+  context "when deleting a work_package in the inbox" do
     it "reorders the existing work_packages" do
-      no_sprint_wp1.destroy!
+      inbox_wp1.destroy!
 
-      expect(wp_of_sprint_by_id_and_position(nil))
-        .to eq(no_sprint_wp2.id => 1,
-               no_sprint_wp3.id => 2)
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp2.id => 1,
+               inbox_wp3.id => 2)
+    end
+  end
+
+  context "when moving a work_package to a different backlog bucket" do
+    it "reorders the remaining work_packages and the ones in the new bucket" do
+      bucket1_wp2.backlog_bucket = bucket2
+      bucket1_wp2.save!
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp3.id => 2,
+               bucket1_wp4.id => 3,
+               bucket1_wp5.id => 4)
+
+      expect(wp_of_bucket_by_id_and_position(bucket2))
+        .to eq(bucket2_wp1.id => 1,
+               bucket2_wp2.id => 2,
+               bucket2_wp3.id => 3,
+               bucket1_wp2.id => 4)
+    end
+  end
+
+  context "when removing a work_package from a backlog bucket" do
+    it "reorders the remaining work_packages and the ones in the inbox" do
+      bucket1_wp2.backlog_bucket = nil
+      bucket1_wp2.save!
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp3.id => 2,
+               bucket1_wp4.id => 3,
+               bucket1_wp5.id => 4)
+
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp1.id => 1,
+               inbox_wp2.id => 2,
+               inbox_wp3.id => 3,
+               bucket1_wp2.id => 4)
+    end
+  end
+
+  context "when moving a work_package from the inbox into a backlog bucket" do
+    it "reorders the remaining inbox work_packages and the ones in the bucket" do
+      inbox_wp2.backlog_bucket = bucket1
+      inbox_wp2.save!
+
+      expect(wp_of_inbox_by_id_and_position)
+        .to eq(inbox_wp1.id => 1,
+               inbox_wp3.id => 2)
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp2.id => 2,
+               bucket1_wp3.id => 3,
+               bucket1_wp4.id => 4,
+               bucket1_wp5.id => 5,
+               inbox_wp2.id => 6)
+    end
+  end
+
+  context "when deleting a work_package in a backlog bucket" do
+    it "reorders the existing work_packages" do
+      bucket1_wp3.destroy!
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp2.id => 2,
+               bucket1_wp4.id => 3,
+               bucket1_wp5.id => 4)
+    end
+  end
+
+  context "when moving a work_package from a sprint into a backlog bucket" do
+    it "reorders the remaining sprint work_packages and the ones in the bucket" do
+      sprint1_wp4.backlog_bucket = bucket1
+      sprint1_wp4.sprint = nil
+      sprint1_wp4.save!
+
+      expect(wp_of_sprint_by_id_and_position(sprint1))
+        .to eq(sprint1_wp1.id => 1,
+               sprint1_wp2.id => 2,
+               sprint1_wp3.id => 3,
+               sprint1_wp5.id => 4)
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp2.id => 2,
+               bucket1_wp3.id => 3,
+               bucket1_wp4.id => 4,
+               bucket1_wp5.id => 5,
+               sprint1_wp4.id => 6)
+    end
+  end
+
+  context "when moving a work_package from a backlog into a sprint bucket" do
+    it "reorders the remaining sprint work_packages and the ones in the bucket" do
+      bucket1_wp3.backlog_bucket = nil
+      bucket1_wp3.sprint = sprint1
+      bucket1_wp3.save!
+
+      expect(wp_of_bucket_by_id_and_position(bucket1))
+        .to eq(bucket1_wp1.id => 1,
+               bucket1_wp2.id => 2,
+               bucket1_wp4.id => 3,
+               bucket1_wp5.id => 4)
+
+      expect(wp_of_sprint_by_id_and_position(sprint1))
+        .to eq(sprint1_wp1.id => 1,
+               sprint1_wp2.id => 2,
+               sprint1_wp3.id => 3,
+               sprint1_wp4.id => 4,
+               sprint1_wp5.id => 5,
+               bucket1_wp3.id => 6)
     end
   end
 
@@ -307,124 +454,241 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       end
     end
 
-    context "when moving outside a sprint with a position of 1" do
+    context "when moving in the inbox with a position of 1" do
       it "moves the work_package to the beginning of the sprint" do
-        no_sprint_wp3.move_after(position: 1)
+        inbox_wp3.move_after(position: 1)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp3.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp3.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp2.id => 3)
       end
     end
 
-    context "when moving down outside a sprint with a position in the middle of the sprint" do
+    context "when moving down in the inbox with a position in the middle of the sprint" do
       it "moves the work_package to the middle of the sprint" do
-        no_sprint_wp1.move_after(position: 2)
+        inbox_wp1.move_after(position: 2)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp2.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp3.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp2.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp3.id => 3)
       end
     end
 
-    context "when moving up outside a sprint with a position in the middle of the sprint" do
+    context "when moving up in the inbox with a position in the middle of the sprint" do
       it "moves the work_package to the middle of the sprint" do
-        no_sprint_wp3.move_after(position: 2)
+        inbox_wp3.move_after(position: 2)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp1.id => 1,
-                 no_sprint_wp3.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp1.id => 1,
+                 inbox_wp3.id => 2,
+                 inbox_wp2.id => 3)
       end
     end
 
-    context "when moving outside a sprint with a position at the end of the sprint" do
+    context "when moving in the inbox with a position at the end of the sprint" do
       it "moves the work_package to the end of the sprint" do
-        no_sprint_wp1.move_after(position: 3)
+        inbox_wp1.move_after(position: 3)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp2.id => 1,
-                 no_sprint_wp3.id => 2,
-                 no_sprint_wp1.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp2.id => 1,
+                 inbox_wp3.id => 2,
+                 inbox_wp1.id => 3)
       end
     end
 
-    context "when moving outside a sprint with a position that is larger than the positions present in the sprint" do
+    context "when moving in the inbox with a position that is larger than the positions present in the sprint" do
       it "moves the work_package to the top of the sprint" do
-        no_sprint_wp2.move_after(position: 4)
+        inbox_wp2.move_after(position: 4)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp2.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp3.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp2.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp3.id => 3)
       end
     end
 
-    context "when moving outside a sprint with a previous that is nil" do
+    context "when moving in the inbox with a previous that is nil" do
       it "moves the work_package to the top of the sprint" do
-        no_sprint_wp3.move_after(prev_id: nil)
+        inbox_wp3.move_after(prev_id: nil)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp3.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp3.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp2.id => 3)
       end
     end
 
-    context "when moving outside a sprint with a previous that is the first element" do
+    context "when moving in the inbox with a previous that is the first element" do
       it "moves the work_package to the second position" do
-        no_sprint_wp3.move_after(prev_id: no_sprint_wp1.id)
+        inbox_wp3.move_after(prev_id: inbox_wp1.id)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp1.id => 1,
-                 no_sprint_wp3.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp1.id => 1,
+                 inbox_wp3.id => 2,
+                 inbox_wp2.id => 3)
       end
     end
 
-    context "when moving down outside a sprint with a previous in the middle" do
+    context "when moving down in the inbox with a previous in the middle" do
       it "moves the work_package after the previous" do
-        no_sprint_wp1.move_after(prev_id: no_sprint_wp2.id)
+        inbox_wp1.move_after(prev_id: inbox_wp2.id)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp2.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp3.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp2.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp3.id => 3)
       end
     end
 
-    context "when moving up outside a sprint with a previous in the middle" do
+    context "when moving up in the inbox with a previous in the middle" do
       it "moves the work_package after the previous" do
-        no_sprint_wp3.move_after(prev_id: no_sprint_wp1.id)
+        inbox_wp3.move_after(prev_id: inbox_wp1.id)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp1.id => 1,
-                 no_sprint_wp3.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp1.id => 1,
+                 inbox_wp3.id => 2,
+                 inbox_wp2.id => 3)
       end
     end
 
-    context "when outside a sprint with a previous at the bottom" do
+    context "when in the inbox with a previous at the bottom" do
       it "moves the work_package after the previous" do
-        no_sprint_wp1.move_after(prev_id: no_sprint_wp3.id)
+        inbox_wp1.move_after(prev_id: inbox_wp3.id)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp2.id => 1,
-                 no_sprint_wp3.id => 2,
-                 no_sprint_wp1.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp2.id => 1,
+                 inbox_wp3.id => 2,
+                 inbox_wp1.id => 3)
       end
     end
 
-    context "when outside a sprint with a previous that does not exist outside" do
+    context "when in the inbox with a previous that does not exist outside" do
       it "moves the work_package to the top position" do
-        no_sprint_wp3.move_after(prev_id: sprint2_wp2.id)
+        inbox_wp3.move_after(prev_id: sprint2_wp2.id)
 
-        expect(wp_of_sprint_by_id_and_position(nil))
-          .to eq(no_sprint_wp3.id => 1,
-                 no_sprint_wp1.id => 2,
-                 no_sprint_wp2.id => 3)
+        expect(wp_of_inbox_by_id_and_position)
+          .to eq(inbox_wp3.id => 1,
+                 inbox_wp1.id => 2,
+                 inbox_wp2.id => 3)
+      end
+    end
+
+    context "when moving inside a bucket with a position of 1" do
+      it "moves the work_package to the beginning of the bucket" do
+        bucket1_wp4.move_after(position: 1)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp4.id => 1,
+                 bucket1_wp1.id => 2,
+                 bucket1_wp2.id => 3,
+                 bucket1_wp3.id => 4,
+                 bucket1_wp5.id => 5)
+      end
+    end
+
+    context "when moving down inside a bucket with a position in the middle" do
+      it "moves the work_package to the middle of the bucket" do
+        bucket1_wp1.move_after(position: 3)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp2.id => 1,
+                 bucket1_wp3.id => 2,
+                 bucket1_wp1.id => 3,
+                 bucket1_wp4.id => 4,
+                 bucket1_wp5.id => 5)
+      end
+    end
+
+    context "when moving up inside a bucket with a position in the middle" do
+      it "moves the work_package to the middle of the bucket" do
+        bucket1_wp5.move_after(position: 3)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp1.id => 1,
+                 bucket1_wp2.id => 2,
+                 bucket1_wp5.id => 3,
+                 bucket1_wp3.id => 4,
+                 bucket1_wp4.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a position at the end" do
+      it "moves the work_package to the end of the bucket" do
+        bucket1_wp2.move_after(position: 5)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp1.id => 1,
+                 bucket1_wp3.id => 2,
+                 bucket1_wp4.id => 3,
+                 bucket1_wp5.id => 4,
+                 bucket1_wp2.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a previous that is the first element" do
+      it "moves the work_package to the second position" do
+        bucket1_wp4.move_after(prev_id: bucket1_wp1.id)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp1.id => 1,
+                 bucket1_wp4.id => 2,
+                 bucket1_wp2.id => 3,
+                 bucket1_wp3.id => 4,
+                 bucket1_wp5.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a previous in the middle" do
+      it "moves the work_package after the previous" do
+        bucket1_wp1.move_after(prev_id: bucket1_wp3.id)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp2.id => 1,
+                 bucket1_wp3.id => 2,
+                 bucket1_wp1.id => 3,
+                 bucket1_wp4.id => 4,
+                 bucket1_wp5.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a previous at the bottom" do
+      it "moves the work_package to the last position" do
+        bucket1_wp1.move_after(prev_id: bucket1_wp5.id)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp2.id => 1,
+                 bucket1_wp3.id => 2,
+                 bucket1_wp4.id => 3,
+                 bucket1_wp5.id => 4,
+                 bucket1_wp1.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a previous that is nil" do
+      it "moves the work_package to the top of the bucket" do
+        bucket1_wp4.move_after(prev_id: nil)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp4.id => 1,
+                 bucket1_wp1.id => 2,
+                 bucket1_wp2.id => 3,
+                 bucket1_wp3.id => 4,
+                 bucket1_wp5.id => 5)
+      end
+    end
+
+    context "when moving inside a bucket with a previous that does not exist in that bucket" do
+      it "moves the work_package to the top of the bucket" do
+        bucket1_wp4.move_after(prev_id: bucket2_wp2.id)
+
+        expect(wp_of_bucket_by_id_and_position(bucket1))
+          .to eq(bucket1_wp4.id => 1,
+                 bucket1_wp1.id => 2,
+                 bucket1_wp2.id => 3,
+                 bucket1_wp3.id => 4,
+                 bucket1_wp5.id => 5)
       end
     end
   end

--- a/modules/backlogs/spec/models/work_packages/position_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/position_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   let!(:sprint2_wp2) { create_work_package(subject: "Sprint 2 WorkPackage 2", sprint: sprint2) }
   let!(:sprint2_wp3) { create_work_package(subject: "Sprint 2 WorkPackage 3", sprint: sprint2) }
 
-  let!(:inbox_wp1) { create_work_package(subject: "Inbox WorkPackage 1", sprint: nil) }
-  let!(:inbox_wp2) { create_work_package(subject: "Inbox WorkPackage 2", sprint: nil) }
-  let!(:inbox_wp3) { create_work_package(subject: "Inbox WorkPackage 3", sprint: nil) }
+  let!(:inbox_wp1) { create_work_package(subject: "Inbox WorkPackage 1") }
+  let!(:inbox_wp2) { create_work_package(subject: "Inbox WorkPackage 2") }
+  let!(:inbox_wp3) { create_work_package(subject: "Inbox WorkPackage 3") }
 
   let!(:bucket1_wp1) { create_work_package(subject: "Bucket 1 WorkPackage 1", backlog_bucket: bucket1) }
   let!(:bucket1_wp2) { create_work_package(subject: "Bucket 1 WorkPackage 2", backlog_bucket: bucket1) }
@@ -94,7 +94,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
 
   context "when creating a work_package in the inbox" do
     it "puts them in order" do
-      new_work_package = create_work_package(subject: "Newest WorkPackage", sprint: nil)
+      new_work_package = create_work_package(subject: "Newest WorkPackage")
 
       expect(wp_of_inbox_by_id_and_position)
         .to eq(inbox_wp1.id => 1,
@@ -290,9 +290,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
 
   context "when moving a work_package from a backlog into a sprint bucket" do
     it "reorders the remaining sprint work_packages and the ones in the bucket" do
-      bucket1_wp3.backlog_bucket = nil
-      bucket1_wp3.sprint = sprint1
-      bucket1_wp3.save!
+      bucket1_wp3.update(backlog_bucket: nil, sprint: sprint1)
 
       expect(wp_of_bucket_by_id_and_position(bucket1))
         .to eq(bucket1_wp1.id => 1,
@@ -564,7 +562,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       end
     end
 
-    context "when in the inbox with a previous that does not exist outside" do
+    context "when in the inbox with a previous referencing a work package not in it" do
       it "moves the work_package to the top position" do
         inbox_wp3.move_after(prev_id: sprint2_wp2.id)
 

--- a/modules/backlogs/spec/routing/backlogs/backlog_buckets_routing_spec.rb
+++ b/modules/backlogs/spec/routing/backlogs/backlog_buckets_routing_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Backlogs::BacklogBucketsController do
+  describe "routing" do
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets"
+      expect(post(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                      action: "create",
+                                      project_id: "project_42")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/23"
+      expect(patch(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                       action: "update",
+                                       project_id: "project_42",
+                                       id: "23")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/23"
+      expect(delete(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                        action: "destroy",
+                                        project_id: "project_42",
+                                        id: "23")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/new_dialog"
+      expect(get(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                     action: "new_dialog",
+                                     project_id: "project_42")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/23/edit_dialog"
+      expect(get(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                     action: "edit_dialog",
+                                     project_id: "project_42",
+                                     id: "23")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/23/destroy_dialog"
+      expect(get(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                     action: "destroy_dialog",
+                                     project_id: "project_42",
+                                     id: "23")
+    }
+  end
+
+  describe "named routing" do
+    it {
+      expect(project_backlogs_backlog_bucket_path(project_id: "project_42", id: "23"))
+        .to eq("/projects/project_42/backlogs/backlog_buckets/23")
+    }
+
+    it {
+      expect(new_dialog_project_backlogs_backlog_buckets_path(project_id: "project_42"))
+        .to eq("/projects/project_42/backlogs/backlog_buckets/new_dialog")
+    }
+
+    it {
+      expect(edit_dialog_project_backlogs_backlog_bucket_path(project_id: "project_42", id: "23"))
+        .to eq("/projects/project_42/backlogs/backlog_buckets/23/edit_dialog")
+    }
+
+    it {
+      expect(destroy_dialog_project_backlogs_backlog_bucket_path(project_id: "project_42", id: "23"))
+        .to eq("/projects/project_42/backlogs/backlog_buckets/23/destroy_dialog")
+    }
+  end
+end

--- a/modules/backlogs/spec/routing/backlogs/backlog_buckets_routing_spec.rb
+++ b/modules/backlogs/spec/routing/backlogs/backlog_buckets_routing_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Backlogs::BacklogBucketsController do
 
     it {
       route = "/projects/project_42/backlogs/backlog_buckets/23"
+      expect(put(route)).to route_to(controller: "backlogs/backlog_buckets",
+                                     action: "update",
+                                     project_id: "project_42",
+                                     id: "23")
+    }
+
+    it {
+      route = "/projects/project_42/backlogs/backlog_buckets/23"
       expect(delete(route)).to route_to(controller: "backlogs/backlog_buckets",
                                         action: "destroy",
                                         project_id: "project_42",
@@ -80,6 +88,11 @@ RSpec.describe Backlogs::BacklogBucketsController do
   end
 
   describe "named routing" do
+    it {
+      expect(project_backlogs_backlog_buckets_path(project_id: "project_42"))
+        .to eq("/projects/project_42/backlogs/backlog_buckets")
+    }
+
     it {
       expect(project_backlogs_backlog_bucket_path(project_id: "project_42", id: "23"))
         .to eq("/projects/project_42/backlogs/backlog_buckets/23")

--- a/modules/backlogs/spec/services/backlog_buckets/delete_service_spec.rb
+++ b/modules/backlogs/spec/services/backlog_buckets/delete_service_spec.rb
@@ -32,5 +32,44 @@ require "spec_helper"
 require "services/base_services/behaves_like_delete_service"
 
 RSpec.describe BacklogBuckets::DeleteService, type: :model do
+  shared_let(:project) { create(:project, enabled_module_names: %w[backlogs work_package_tracking]) }
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+  shared_let(:no_bucket_wp1) { create(:work_package, project:) }
+  shared_let(:bucket_wp1) { create(:work_package, project:, backlog_bucket: bucket) }
+  shared_let(:bucket_wp2) { create(:work_package, project:, backlog_bucket: bucket) }
+
+  let(:permissions) { %i[view_sprints create_sprints] }
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+  let(:instance) { described_class.new(user:, model: bucket) }
+
+  subject { instance.call }
+
   it_behaves_like "BaseServices delete service"
+
+  context "when the contract is valid" do
+    it "moves the work packages to the inbox (no bucket - updating the positions)", :aggregate_failures do
+      expect(subject).to be_success
+
+      expect(bucket_wp1.reload.backlog_bucket).to be_nil
+      expect(bucket_wp2.reload.backlog_bucket).to be_nil
+
+      # 1 is already taken by no_bucket_wp1
+      expect(bucket_wp1.reload.position).to eq(2)
+      expect(bucket_wp2.reload.position).to eq(3)
+    end
+  end
+
+  context "when the contract is invalid" do
+    let(:permissions) { %i[view_sprints] }
+
+    it "leaves the work packages where they are", :aggregate_failures do
+      expect(subject).to be_failure
+
+      expect(bucket_wp1.reload.backlog_bucket).to eq bucket
+      expect(bucket_wp2.reload.backlog_bucket).to eq bucket
+
+      expect(bucket_wp1.reload.position).to eq(1)
+      expect(bucket_wp2.reload.position).to eq(2)
+    end
+  end
 end

--- a/modules/backlogs/spec/services/backlog_buckets/delete_service_spec.rb
+++ b/modules/backlogs/spec/services/backlog_buckets/delete_service_spec.rb
@@ -50,12 +50,9 @@ RSpec.describe BacklogBuckets::DeleteService, type: :model do
     it "moves the work packages to the inbox (no bucket - updating the positions)", :aggregate_failures do
       expect(subject).to be_success
 
-      expect(bucket_wp1.reload.backlog_bucket).to be_nil
-      expect(bucket_wp2.reload.backlog_bucket).to be_nil
-
       # 1 is already taken by no_bucket_wp1
-      expect(bucket_wp1.reload.position).to eq(2)
-      expect(bucket_wp2.reload.position).to eq(3)
+      expect(bucket_wp1.reload).to have_attributes(backlog_bucket: nil, position: 2)
+      expect(bucket_wp2.reload).to have_attributes(backlog_bucket: nil, position: 3)
     end
   end
 
@@ -65,11 +62,8 @@ RSpec.describe BacklogBuckets::DeleteService, type: :model do
     it "leaves the work packages where they are", :aggregate_failures do
       expect(subject).to be_failure
 
-      expect(bucket_wp1.reload.backlog_bucket).to eq bucket
-      expect(bucket_wp2.reload.backlog_bucket).to eq bucket
-
-      expect(bucket_wp1.reload.position).to eq(1)
-      expect(bucket_wp2.reload.position).to eq(2)
+      expect(bucket_wp1.reload).to have_attributes(backlog_bucket: bucket, position: 1)
+      expect(bucket_wp2.reload).to have_attributes(backlog_bucket: bucket, position: 2)
     end
   end
 end

--- a/modules/backlogs/spec/services/work_packages/rebuild_positions_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/rebuild_positions_service_integration_spec.rb
@@ -32,7 +32,8 @@ require "spec_helper"
 
 RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :model do
   def create_work_package(options)
-    create(:work_package, options.reverse_merge(project: options[:sprint]&.project, type_id: type.id)) do |wp|
+    create(:work_package, options.reverse_merge(project: options[:sprint]&.project || options[:backlog_bucket]&.project,
+                                                type_id: type.id)) do |wp|
       wp.update_column(:position, options[:position]) if options.key?(:position)
     end
   end
@@ -43,6 +44,8 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
   shared_let(:sprint1) { create(:agile_sprint, project: project1, name: "Sprint 1") }
   shared_let(:sprint2) { create(:agile_sprint, project: project1, name: "Sprint 2") }
   shared_let(:sprint3) { create(:agile_sprint, project: project2, name: "Sprint 2") }
+  shared_let(:bucket1) { create(:backlog_bucket, project: project1, name: "Bucket 1") }
+  shared_let(:bucket2) { create(:backlog_bucket, project: project2, name: "Bucket 2") }
 
   shared_let(:sprint1_wp1) { create_work_package(subject: "Sprint 1 WorkPackage 1", sprint: sprint1, position: nil) }
   shared_let(:sprint1_wp2) { create_work_package(subject: "Sprint 1 WorkPackage 2", sprint: sprint1, position: 1) }
@@ -71,22 +74,36 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
   shared_let(:sprint3_wp2) { create_work_package(subject: "Sprint 3 WorkPackage 2", sprint: sprint3, position: nil) }
   shared_let(:sprint3_wp3) { create_work_package(subject: "Sprint 3 WorkPackage 3", sprint: sprint3, position: nil) }
 
-  shared_let(:no_sprint_wp1) do
-    create_work_package(subject: "No sprint WorkPackage 1", project: project1, sprint: nil, position: nil)
+  shared_let(:inbox_wp1) do
+    create_work_package(subject: "Inbox WorkPackage 1", project: project1, sprint: nil, position: nil)
   end
-  shared_let(:no_sprint_wp2) do
-    create_work_package(subject: "No sprint WorkPackage 2", project: project1, sprint: nil, position: nil)
+  shared_let(:inbox_wp2) do
+    create_work_package(subject: "Inbox WorkPackage 2", project: project1, sprint: nil, position: nil)
   end
-  shared_let(:no_sprint_wp3) do
-    create_work_package(subject: "No sprint WorkPackage 3", project: project1, sprint: nil, position: nil)
+  shared_let(:inbox_wp3) do
+    create_work_package(subject: "Inbox WorkPackage 3", project: project1, sprint: nil, position: nil)
   end
+
+  shared_let(:bucket1_wp1) { create_work_package(subject: "Bucket 1 WorkPackage 1", backlog_bucket: bucket1, position: nil) }
+  shared_let(:bucket1_wp2) { create_work_package(subject: "Bucket 1 WorkPackage 2", backlog_bucket: bucket1, position: 2) }
+  shared_let(:bucket1_wp3) do
+    create_work_package(subject: "Bucket 1 WorkPackage 3", backlog_bucket: bucket1, position: 1).tap do
+      # acts_as_list inserts shift earlier siblings; restore them so
+      # the DB starts from the positions the test actually sets.
+      bucket1_wp2.update_column(:position, 2)
+    end
+  end
+
+  shared_let(:bucket2_wp1) { create_work_package(subject: "Bucket 2 WorkPackage 1", backlog_bucket: bucket2, position: nil) }
+  shared_let(:bucket2_wp2) { create_work_package(subject: "Bucket 2 WorkPackage 2", backlog_bucket: bucket2, position: nil) }
+  shared_let(:bucket2_wp3) { create_work_package(subject: "Bucket 2 WorkPackage 3", backlog_bucket: bucket2, position: nil) }
 
   context "with the project provided" do
     before do
       described_class.new(project: project1).call
     end
 
-    it "fixes the positions in that project while keeping those that have some in the same order" do # rubocop:disable Rspec/ExampleLength
+    it "fixes the positions in that project while keeping those that have some in the same order" do # rubocop:disable RSpec/ExampleLength
       expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
         .to eql(
           sprint1_wp2.subject => 1,
@@ -103,11 +120,11 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint2_wp1.subject => 3
         )
 
-      expect(WorkPackage.where(sprint: nil).to_h { [it.subject, it.position] })
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
         .to eql(
-          no_sprint_wp1.subject => 1,
-          no_sprint_wp2.subject => 2,
-          no_sprint_wp3.subject => 3
+          inbox_wp1.subject => 1,
+          inbox_wp2.subject => 2,
+          inbox_wp3.subject => 3
         )
 
       expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
@@ -115,6 +132,20 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint3_wp1.subject => nil,
           sprint3_wp2.subject => nil,
           sprint3_wp3.subject => nil
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket1_wp3.subject => 1,
+          bucket1_wp2.subject => 2,
+          bucket1_wp1.subject => 3
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket2_wp1.subject => nil,
+          bucket2_wp2.subject => nil,
+          bucket2_wp3.subject => nil
         )
     end
   end
@@ -124,7 +155,7 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
       described_class.new(project: project2).call
     end
 
-    it "fixes only the work packages in the other project" do # rubocop:disable Rspec/ExampleLength
+    it "fixes only the work packages in the other project" do # rubocop:disable RSpec/ExampleLength
       expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
         .to eql(
           sprint1_wp1.subject => nil,
@@ -141,11 +172,11 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint2_wp1.subject => 3
         )
 
-      expect(WorkPackage.where(sprint: nil).to_h { [it.subject, it.position] })
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
         .to eql(
-          no_sprint_wp1.subject => nil,
-          no_sprint_wp2.subject => nil,
-          no_sprint_wp3.subject => nil
+          inbox_wp1.subject => nil,
+          inbox_wp2.subject => nil,
+          inbox_wp3.subject => nil
         )
 
       expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
@@ -153,6 +184,20 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint3_wp1.subject => 1,
           sprint3_wp2.subject => 2,
           sprint3_wp3.subject => 3
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket1_wp1.subject => nil,
+          bucket1_wp2.subject => 2,
+          bucket1_wp3.subject => 1
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket2_wp1.subject => 1,
+          bucket2_wp2.subject => 2,
+          bucket2_wp3.subject => 3
         )
     end
   end
@@ -162,7 +207,7 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
       described_class.new(project: nil).call
     end
 
-    it "fixes the positions while keeping those that have some in the same order in all projects" do # rubocop:disable Rspec/ExampleLength
+    it "fixes the positions while keeping those that have some in the same order in all projects" do # rubocop:disable RSpec/ExampleLength
       expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
         .to eql(
           sprint1_wp2.subject => 1,
@@ -179,11 +224,11 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint2_wp1.subject => 3
         )
 
-      expect(WorkPackage.where(sprint: nil).to_h { [it.subject, it.position] })
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
         .to eql(
-          no_sprint_wp1.subject => 1,
-          no_sprint_wp2.subject => 2,
-          no_sprint_wp3.subject => 3
+          inbox_wp1.subject => 1,
+          inbox_wp2.subject => 2,
+          inbox_wp3.subject => 3
         )
 
       expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
@@ -191,6 +236,20 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
           sprint3_wp1.subject => 1,
           sprint3_wp2.subject => 2,
           sprint3_wp3.subject => 3
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket1_wp3.subject => 1,
+          bucket1_wp2.subject => 2,
+          bucket1_wp1.subject => 3
+        )
+
+      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
+        .to eql(
+          bucket2_wp1.subject => 1,
+          bucket2_wp2.subject => 2,
+          bucket2_wp3.subject => 3
         )
     end
   end

--- a/modules/backlogs/spec/services/work_packages/rebuild_positions_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/work_packages/rebuild_positions_service_integration_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe WorkPackages::RebuildPositionsService, "integration", type: :mode
   shared_let(:sprint3_wp3) { create_work_package(subject: "Sprint 3 WorkPackage 3", sprint: sprint3, position: nil) }
 
   shared_let(:inbox_wp1) do
-    create_work_package(subject: "Inbox WorkPackage 1", project: project1, sprint: nil, position: nil)
+    create_work_package(subject: "Inbox WorkPackage 1", project: project1, position: nil)
   end
   shared_let(:inbox_wp2) do
-    create_work_package(subject: "Inbox WorkPackage 2", project: project1, sprint: nil, position: nil)
+    create_work_package(subject: "Inbox WorkPackage 2", project: project1, position: nil)
   end
   shared_let(:inbox_wp3) do
-    create_work_package(subject: "Inbox WorkPackage 3", project: project1, sprint: nil, position: nil)
+    create_work_package(subject: "Inbox WorkPackage 3", project: project1, position: nil)
   end
 
   shared_let(:bucket1_wp1) { create_work_package(subject: "Bucket 1 WorkPackage 1", backlog_bucket: bucket1, position: nil) }

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -533,6 +533,10 @@ module Pages
       end
     end
 
+    def expect_backlog_bucket_delete_modal
+      expect(page).to have_selector backlog_bucket_destroy_modal_selector
+    end
+
     def within_sprint_menu(sprint, &)
       within_sprint(sprint) do
         button = find(:button, accessible_name: "Sprint actions")
@@ -582,6 +586,12 @@ module Pages
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_bottom_of_backlog")
 
         click_button "Complete sprint"
+      end
+    end
+
+    def confirm_backlog_bucket_delete_modal
+      within backlog_bucket_destroy_modal_selector do
+        click_button "Delete"
       end
     end
 
@@ -647,6 +657,10 @@ module Pages
 
     def sprint_complete_modal_selector
       "##{::Backlogs::FinishSprintDialogComponent::DIALOG_ID}"
+    end
+
+    def backlog_bucket_destroy_modal_selector
+      test_selector(Backlogs::BacklogBucketDestroyModalComponent::TEST_SELECTOR)
     end
 
     def open_controlled_menu(button)

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -533,8 +533,12 @@ module Pages
       end
     end
 
-    def expect_backlog_bucket_delete_modal
+    def expect_and_confirm_backlog_bucket_delete_modal
       expect(page).to have_selector backlog_bucket_destroy_modal_selector
+
+      within backlog_bucket_destroy_modal_selector do
+        click_button "Delete"
+      end
     end
 
     def within_sprint_menu(sprint, &)
@@ -586,12 +590,6 @@ module Pages
         choose I18n.t("backlogs.finish_sprint_dialog_component.actions.move_to_bottom_of_backlog")
 
         click_button "Complete sprint"
-      end
-    end
-
-    def confirm_backlog_bucket_delete_modal
-      within backlog_bucket_destroy_modal_selector do
-        click_button "Delete"
       end
     end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74369

# What are you trying to accomplish?

* [x] Upon deletion of a backlog bucket, the bucket's work packages are moved to the bottom
* [x] The `WorkPackages::RebuildPositionsService` includes `backlog_bucket_id` in the PARTITION BY 
* [x] A modal is displayed on bucket deletion

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
