### PR TITLE
fix: Patch flakiness in a work package table spec

### DIFF
--- a/modules/my_page/spec/features/my/work_package_table_spec.rb
+++ b/modules/my_page/spec/features/my/work_package_table_spec.rb
@@ -114,6 +114,11 @@ RSpec.describe "Arbitrary WorkPackage query table widget on my page",
 
       # Wait for the filter save to complete before opening the column configuration,
       # otherwise the two saves can race and only one change gets persisted.
+      # The first wait_for_network_idle catches the query-form GET; the sleep gives
+      # JavaScript time to process the form response and start the filter PATCH,
+      # and the second wait_for_network_idle catches that PATCH completing.
+      wait_for_network_idle
+      sleep(0.2)
       wait_for_network_idle
 
       filter_area.configure_wp_table


### PR DESCRIPTION
```
1) Arbitrary WorkPackage query table widget on my page with the permission to save queries can add the widget and see the work packages of the filtered for types
     Failure/Error: Retriable.retriable(on_retry: log_errors, **args, &)
       expected not to find visible css ".subject" with text "WorkPackage No. 10" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[2]/DIV[1]/MAIN[1]/DIV[1]/DIV[1]/OPCE-MY-PAGE[1]/GRID[1]/DIV[1]/DIV[3]">, found 3 matches: "Work package leaf at level 0.\nWorkPackage No. 10", "WorkPackage No. 10", "WorkPackage No. 10". Also found "Work package leaf at level 0.\nWorkPackage No. 11", "WorkPackage No. 11", "WorkPackage No. 11", which matched the selector but not all filters. 
```

Add a small wait to give time for JavaScript to process form response.