### PR TITLE
fix: Patch flakiness in a WP activities spec

### DIFF
--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -285,16 +285,15 @@ module Components
           check_internal_comment_checkbox if internal
 
           if save
-            page.find_test_selector("op-submit-work-package-journal-form").click
-            wait_for_network_idle
+            wait_for_turbo_stream do
+              page.find_test_selector("op-submit-work-package-journal-form").click
+            end
           end
         end
 
         if save
-          page.within_test_selector("op-wp-journals-container") do
-            # wait for the comment to be loaded
-            expect(page).to have_test_selector("op-journal-notes-body", text:, wait: 10)
-          end
+          # wait for the comment to be loaded
+          expect(page).to have_test_selector("op-journal-notes-body", text:, wait: 10)
         end
 
         wait_for_network_idle


### PR DESCRIPTION
```
  1) Work package activity filtering when the work package has comments and changesets resets an only_changes filter if a comment is added by the user
     Failure/Error: expect(page).to have_test_selector("op-journal-notes-body", text:, wait: 10)
       expected page to have test selector op-journal-notes-body with text "Third comment by admin". Also found: "First comment by admin", "Second comment by admin", which matched the selector but not all filters.

```

Previous:
- Submit click → `wait_for_network_idle` catches the POST completing
- Turbo Stream renders the updated container asynchronously after network idle
- within_test_selector("op-wp-journals-container") scopes to the old container node, which Turbo is about to replace
- The new comment is inserted into the new container — old scoped node never sees it

=> Fix: wrap the click in `wait_for_turbo_stream` and drop the stale `within_test_selector` scope on the assertion.