### PR TITLE
Bust WP representer JSON cache when identifier mode flips

### DIFF
--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -805,7 +805,7 @@ module API
            Setting.work_package_done_ratio,
            Setting.show_work_package_attachments,
            Setting.feeds_enabled?,
-           Setting.work_packages_identifier]
+           Setting::WorkPackageIdentifier.semantic_mode_active?]
         end
 
         def load_complete_model(model)

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -804,7 +804,8 @@ module API
            represented.cache_checksum,
            Setting.work_package_done_ratio,
            Setting.show_work_package_attachments,
-           Setting.feeds_enabled?]
+           Setting.feeds_enabled?,
+           Setting.work_packages_identifier]
         end
 
         def load_complete_model(model)

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1734,6 +1734,21 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
         end.to change(representer, :json_cache_key)
       end
 
+      it "changes when the work package identifier mode is toggled" do
+        # Without this, JSON rendered while in classic mode keeps serving
+        # numeric `displayId` values after an admin switches to semantic mode,
+        # because nothing else in the cache key reflects the setting flip.
+        with_flags(semantic_work_package_ids: true)
+
+        with_settings(work_packages_identifier: "classic")
+        classic_key = representer.json_cache_key
+
+        with_settings(work_packages_identifier: "semantic")
+        semantic_key = representer.json_cache_key
+
+        expect(semantic_key).not_to eq(classic_key)
+      end
+
       it "factors in the eager loaded cache_checksum" do
         without_partial_double_verification do
           allow(work_package)


### PR DESCRIPTION
https://community.openproject.org/wp/74525

After an admin flips the work-package identifier mode from classic to semantic, the work-package table renders a mix of stale numeric IDs and fresh semantic IDs.

Add `Setting::WorkPackageIdentifier.semantic_mode_active?` to `WorkPackageRepresenter`'s `json_cache_key` so that a change in setting or feature flag, resets the cache.
