### PR TITLE
Fix rendering of providers index

### DIFF
--- a/modules/wikis/app/components/wikis/admin/wiki_provider_list_component.rb
+++ b/modules/wikis/app/components/wikis/admin/wiki_provider_list_component.rb
@@ -35,7 +35,7 @@ module Wikis::Admin
     alias_method :wiki_providers, :model
 
     def provider_url(wiki_provider)
-      wiki_provider.url.presence
+      wiki_provider.respond_to?(:url) && wiki_provider.url
     end
   end
 end


### PR DESCRIPTION
Rendering the view failed when the internal provider existed, because it doesn't respond to `url`.