### PR TITLE
Fix context menu spec: use uppercase project identifier in semantic mode

### DIFF
--- a/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
@@ -101,7 +101,12 @@ RSpec.shared_examples_for "provides a single WP context menu" do
             with_flag: { semantic_work_package_ids: true },
             with_settings: { work_packages_identifier: "semantic" } do
       it "uses numeric parent_id in the URL and sets the parent correctly" do
-        # Ensure the WP has a semantic identifier so we can verify the URL uses numeric PK
+        expect(Setting::WorkPackageIdentifier.semantic_mode_active?)
+          .to be(true), "expected semantic mode to be active via with_settings + with_flag metadata"
+
+        # In semantic mode project identifiers are uppercase; force that here since
+        # the shared project may have been created with a factory-generated lowercase slug.
+        work_package.project.update_columns(identifier: work_package.project.identifier.upcase)
         work_package.allocate_and_register_semantic_id if work_package.identifier.blank?
 
         open_context_menu.call


### PR DESCRIPTION
# Ticket

# What are you trying to accomplish?

The team planner context menu spec was failing with:

```
ActionController::UrlGenerationError: No route matches {action: "show", controller: "work_packages", id: "myproject_no_1-2", ...}
```

The test context `"with semantic identifiers enabled"` creates a project via factory which generates a lowercase slug (e.g. `myproject_no_1`). When the WP semantic identifier was allocated it used the lowercase slug directly (e.g. `myproject_no_1-2`), which does not match `ID_ROUTE_CONSTRAINT = /\d+|[A-Z][A-Z0-9_]*-\d+/` — causing route generation to fail when rendering the split-view full-screen link introduced in #22901.

In semantic mode, project identifiers are uppercase (e.g. `PROJ-42`). The test setup simply didn't reflect this invariant.

# What approach did you choose and why?

- Upcase the project identifier via `update_columns` before allocating the semantic WP id in the test, matching the production invariant
- Add an explicit assertion that `Setting::WorkPackageIdentifier.semantic_mode_active?` is `true`, so a misconfigured test context (e.g. missing flag or setting metadata) fails with a clear message rather than a confusing route error

The alternative — relaxing `ID_ROUTE_CONSTRAINT` to accept lowercase — was considered and rejected: the constraint is intentionally uppercase-only because that is the defined format for semantic WP identifiers.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)