### PR TITLE
Add :semantic project factory trait, tighten WP context menu spec

### DIFF
--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -51,6 +51,14 @@ FactoryBot.define do
     sequence(:name) { |n| "My Project No. #{n}" }
     sequence(:identifier) { |n| "myproject_no_#{n}" }
 
+    # Use this trait for specs that exercise semantic-mode behaviour.
+    # Produces a deterministic uppercase identifier that satisfies
+    # Projects::Identifier's semantic format constraints
+    # (\A[A-Z][A-Z0-9_]*\z, max 10 chars).
+    trait :semantic do
+      sequence(:identifier) { |n| "PROJ#{n}".first(Projects::Identifier::SEMANTIC_IDENTIFIER_MAX_LENGTH) }
+    end
+
     callback(:after_build) do |_project, evaluator|
       is_build_strategy = evaluator.instance_eval { @build_strategy.is_a? FactoryBot::Strategy::Build }
       uses_member_association = evaluator.member_with_permissions.present? || evaluator.member_with_roles.present?

--- a/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
+++ b/spec/features/work_packages/table/context_menu/context_menu_shared_examples.rb
@@ -104,9 +104,14 @@ RSpec.shared_examples_for "provides a single WP context menu" do
         expect(Setting::WorkPackageIdentifier.semantic_mode_active?)
           .to be(true), "expected semantic mode to be active via with_settings + with_flag metadata"
 
-        # In semantic mode project identifiers are uppercase; force that here since
-        # the shared project may have been created with a factory-generated lowercase slug.
-        work_package.project.update_columns(identifier: work_package.project.identifier.upcase)
+        # Consumers of this shared example use shared_let(:project), which evaluates
+        # before per-example `with_settings:` activates semantic mode — so the project
+        # was created via the classic-mode factory path with a lowercase slug. Force
+        # an identifier that satisfies Projects::Identifier's semantic constraints
+        # (uppercase, [A-Z][A-Z0-9_]*, max 10 chars). For specs that create their own
+        # project per example, prefer the `:semantic` factory trait instead.
+        semantic_project_identifier = "PROJ#{work_package.project.id}".first(Projects::Identifier::SEMANTIC_IDENTIFIER_MAX_LENGTH)
+        work_package.project.update_columns(identifier: semantic_project_identifier)
         work_package.allocate_and_register_semantic_id if work_package.identifier.blank?
 
         open_context_menu.call


### PR DESCRIPTION
# Ticket

Spec-only follow-up to [PR #22975](https://github.com/opf/openproject/pull/22975). No new ticket — addresses the Copilot review at https://github.com/opf/openproject/pull/22975#discussion_r3156538601.

# What are you trying to accomplish?

The Copilot reviewer on #22975 correctly observed that upcasing the factory-default identifier (e.g. `MYPROJECT_NO_17`) puts the project into a state `Projects::Identifier` validators would reject in production: 14 chars exceeds `SEMANTIC_IDENTIFIER_MAX_LENGTH = 10`. The merged fix solved the route-generation error but left the spec setup at odds with production invariants.

Two improvements here:

1. **Project factory gains a `:semantic` trait** producing a short, deterministic uppercase identifier (`P#{n}`, capped at 10 chars). Future specs that create their own project per example under semantic mode can use the trait directly and skip the post-hoc `update_columns` dance entirely.

2. **The WP context menu shared example uses `"P#{project.id}".first(10)`** instead of `identifier.upcase`. This satisfies both the route constraint (uppercase) and the production length constraint (≤10), so the project state matches what `Projects::Identifier` would actually permit.

# What approach did you choose and why?

The shared example still mutates the existing project rather than using the new factory trait. The reason is that all three consumers of the shared example (WP table, team planner, BIM card view) use `shared_let(:project)` — evaluated once at suite setup, before per-example `with_settings:` activates semantic mode. A factory trait can't help retroactively. A comment in the shared example documents this constraint and points future readers at the trait for fresh-per-example specs.

`P` (rather than `PROJ`) prefix keeps 9 digits of headroom for `project.id`, avoiding silent truncation collisions on long-lived dev databases. `.first(SEMANTIC_IDENTIFIER_MAX_LENGTH)` is a defensive cap rather than a floor — typical CI runs won't hit it, but the constant reads better than a magic number.

The alternative — converting `shared_let(:project)` to per-example `let` and applying the trait at creation — was rejected as scope-creep: it would change classic-mode test characteristics across three consumers for no behavioural gain.

# Merge checklist

- [x] Added/updated tests (existing example refactored; trait usable by future specs)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)