### PR TITLE
Force password change when sending out passwords via email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -404,6 +404,12 @@ class UsersController < ApplicationController
     elsif set_password? params
       update_params[:password] = params[:user][:password]
       update_params[:password_confirmation] = params[:user][:password_confirmation]
+      # Force a password change when the plain-text password will be emailed.
+      # - For invited users, the account-information email is always sent
+      # - For active users, it is only sent when the admin explicitly requests it.
+      if params[:send_information].present? || @user.invited?
+        update_params[:force_password_change] = true
+      end
     end
 
     update_params

--- a/app/views/users/form/authentication/_internal_password.html.erb
+++ b/app/views/users/form/authentication/_internal_password.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
                 data: {
-                  controller: "disable-when-checked",
+                  controller: "disable-when-checked password-force-change",
                   "admin--users-target": "passwordFields"
                 },
                 hidden: !@user.change_password_allowed? do %>
@@ -14,7 +14,8 @@
                                "1",
                                assign_random_password_enabled,
                                data: {
-                                 "disable-when-checked-target": "cause"
+                                 "disable-when-checked-target": "cause",
+                                 "password-force-change-target": "assignRandomPassword"
                                } %>
     </div>
   </div>
@@ -51,14 +52,22 @@
         <%= styled_check_box_tag(
               "send_information",
               "1",
-              true
+              false,
+              data: { "password-force-change-target": "sendInformationCheckbox" }
             ) %>
+      </div>
+      <div class="form--field-instructions">
+        <%= t("users.send_information_hint") %>
       </div>
     </div>
   <% end -%>
 
   <div class="form--field">
     <%= f.check_box :force_password_change,
-                    disabled: assign_random_password_enabled %>
+                    disabled: assign_random_password_enabled,
+                    data: { "password-force-change-target": "forceChangeCheckbox" } %>
+    <div class="form--field-instructions">
+      <%= t("users.force_password_change_hint") %>
+    </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1161,6 +1161,8 @@ en:
       matrix_check_uncheck_all_in_col_label_html: "Toggle all %{module} permissions for <em>%{role}</em> role"
 
   users:
+    force_password_change_hint: "The user must set a new password on their next login. Automatically enabled when sending credentials via email."
+    send_information_hint: "Emails the password in plain text. When checked, the user will be required to change their password on first login."
     autologins:
       prompt: "Stay logged in for %{num_days}"
     sessions:

--- a/frontend/src/stimulus/controllers/password-force-change.controller.ts
+++ b/frontend/src/stimulus/controllers/password-force-change.controller.ts
@@ -1,0 +1,85 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { ApplicationController } from 'stimulus-use';
+
+/**
+ * Enforces that "force password change on next login" is checked and
+ * non-editable whenever a plain-text password will be emailed to the user.
+ */
+export default class OpPasswordForceChangeController extends ApplicationController {
+  static targets = ['assignRandomPassword', 'sendInformationCheckbox', 'forceChangeCheckbox'];
+
+  declare readonly assignRandomPasswordTarget:HTMLInputElement;
+
+  declare readonly sendInformationCheckboxTarget:HTMLInputElement;
+
+  declare readonly hasAssignRandomPasswordTarget:boolean;
+
+  declare readonly hasSendInformationCheckboxTarget:boolean;
+
+  declare readonly forceChangeCheckboxTarget:HTMLInputElement;
+
+  declare readonly hasForceChangeCheckboxTarget:boolean;
+
+  private boundSyncSendInformation = this.syncSendInformation.bind(this);
+  private boundSyncRandomPassword = this.syncRandomPassword.bind(this);
+
+  assignRandomPasswordTargetConnected(target:HTMLInputElement) {
+    target.addEventListener('change', this.boundSyncRandomPassword);
+  }
+
+  assignRandomPasswordTargetDisconnected(target:HTMLInputElement) {
+    target.removeEventListener('change', this.boundSyncRandomPassword);
+  }
+
+  sendInformationCheckboxTargetConnected(target:HTMLInputElement) {
+    target.addEventListener('change', this.boundSyncSendInformation);
+  }
+
+  sendInformationCheckboxTargetDisconnected(target:HTMLInputElement) {
+    target.removeEventListener('change', this.boundSyncSendInformation);
+  }
+
+  private syncSendInformation():void {
+    const assignedRandomChecked = this.hasAssignRandomPasswordTarget && this.assignRandomPasswordTarget.checked;
+    if (!assignedRandomChecked && this.hasSendInformationCheckboxTarget) {
+      this.forceChangeCheckboxTarget.checked = this.sendInformationCheckboxTarget.checked;
+      this.forceChangeCheckboxTarget.disabled = this.sendInformationCheckboxTarget.checked;
+    }
+  }
+
+  private syncRandomPassword():void {
+    this.sendInformationCheckboxTarget.checked = this.assignRandomPasswordTarget.checked;
+    this.sendInformationCheckboxTarget.disabled = this.assignRandomPasswordTarget.checked;
+    this.forceChangeCheckboxTarget.checked = this.assignRandomPasswordTarget.checked;
+    this.forceChangeCheckboxTarget.disabled = this.assignRandomPasswordTarget.checked;
+  }
+}

--- a/frontend/src/stimulus/setup.ts
+++ b/frontend/src/stimulus/setup.ts
@@ -30,6 +30,7 @@ import WorkingHoursFormController from './controllers/dynamic/users/working-hour
 import DailyRemindersController from './controllers/dynamic/my/daily-reminders.controller';
 import NonWorkingTimesController from './controllers/dynamic/users/non-working-times.controller';
 import NonWorkingTimesFormController from './controllers/dynamic/users/non-working-times-form.controller';
+import OpPasswordForceChangeController from './controllers/password-force-change.controller';
 
 import AutoSubmit from '@stimulus-components/auto-submit';
 import RevealController from '@stimulus-components/reveal';
@@ -92,6 +93,7 @@ OpenProjectStimulusApplication.preregister('users--working-hours-form', WorkingH
 OpenProjectStimulusApplication.preregister('my--daily-reminders', DailyRemindersController);
 OpenProjectStimulusApplication.preregister('users--non-working-times', NonWorkingTimesController);
 OpenProjectStimulusApplication.preregister('users--non-working-times-form', NonWorkingTimesFormController);
+OpenProjectStimulusApplication.preregister('password-force-change', OpPasswordForceChangeController);
 OpenProjectStimulusApplication.preregister('check-all', CheckAllController);
 OpenProjectStimulusApplication.preregister('checkable', CheckableController);
 OpenProjectStimulusApplication.preregister('truncation', TruncationController);

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -936,6 +936,28 @@ RSpec.describe UsersController do
           expect(mail.body.encoded)
             .to include("newpassPASS!")
         end
+
+        it "forces a password change on next login because the password was emailed" do
+          expect(some_user.reload.force_password_change).to be(true)
+        end
+      end
+
+      context "when manually setting a password without send_information" do
+        let(:params) do
+          {
+            id: some_user.id,
+            user: { password: "newpassPASS!",
+                    password_confirmation: "newpassPASS!" }
+          }
+        end
+
+        it "does not force a password change (password was not emailed)" do
+          expect(some_user.reload.force_password_change).to be(false)
+        end
+
+        it "does not send any email" do
+          expect(ActionMailer::Base.deliveries).to be_empty
+        end
       end
 
       context "with invalid params" do

--- a/spec/features/users/edit_users_spec.rb
+++ b/spec/features/users/edit_users_spec.rb
@@ -64,6 +64,60 @@ RSpec.describe "edit users", :js do
 
       expect(page).to have_no_field("#user_password")
     end
+
+    # send_information defaults to unchecked — the admin must explicitly opt in
+    # to emailing the password.
+    context "when the admin is about to email credentials to the user" do
+      it "is not locked on page load because send_information defaults to unchecked" do
+        expect(find_by_id("user_force_password_change")).not_to be_disabled
+      end
+
+      it "locks force_password_change when send_information is checked" do
+        check "send_information"
+
+        expect(find_by_id("user_force_password_change")).to be_checked
+        expect(find_by_id("user_force_password_change")).to be_disabled
+      end
+
+      it "unlocks force_password_change when send_information is unchecked again" do
+        check "send_information"
+        expect(find_by_id("user_force_password_change")).to be_disabled
+
+        uncheck "send_information"
+        expect(find_by_id("user_force_password_change")).not_to be_disabled
+      end
+
+      it "locks force_password_change and forces send_information when assign_random_password is checked" do
+        check "user_assign_random_password"
+
+        expect(find_by_id("send_information")).to be_checked
+        expect(find_by_id("send_information")).to be_disabled
+        expect(find_by_id("user_force_password_change")).to be_checked
+        expect(find_by_id("user_force_password_change")).to be_disabled
+      end
+
+      it "saves force_password_change as true when the email is sent" do
+        check "send_information"
+
+        user_password.set("SomePass!123")
+        find_by_id("user_password_confirmation").set("SomePass!123")
+
+        click_on "Save"
+
+        expect_flash(message: I18n.t(:notice_successful_update))
+        expect(user.reload.force_password_change).to be(true)
+      end
+
+      it "does not force a password change when send_information is left unchecked" do
+        user_password.set("SomePass!123")
+        find_by_id("user_password_confirmation").set("SomePass!123")
+
+        click_on "Save"
+
+        expect_flash(message: I18n.t(:notice_successful_update))
+        expect(user.reload.force_password_change).to be(false)
+      end
+    end
   end
 
   context "with external authentication" do


### PR DESCRIPTION
Always set force_password_change: true when the plain-text password is actually going to be emailed. There are two cases when this happens.

- Active users: when send_information param is present
- Invited users: always (the controller always sends the account-information email when activating an invited user via password set, regardless of send_information param)

Also, when the user sets "Assign random password", the two fields (send information, force password change) are now consistently set in the UI to signal what's happening in the controller

https://community.openproject.org/work_packages/73849