### PR TITLE
Code maintenance/74143 extract sprint lists into a backlogs sprintscomponent

### DIFF
--- a/modules/backlogs/app/components/backlogs/sprints_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.html.erb
@@ -1,0 +1,70 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%=
+  render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
+    head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Sprint.human_model_name.pluralize }
+
+    if allow_sprint_creation?(project)
+      head.with_actions do
+        render Primer::Beta::Button.new(
+          tag: :a,
+          label: Sprint.human_model_name,
+          href: new_dialog_project_backlogs_sprints_path(project, all_backlogs_params),
+          data: {
+            controller: "async-dialog",
+            test_selector: "op-sprints--new-sprint-button"
+          }
+        ) do |button|
+          button.with_leading_visual_icon(icon: :plus)
+          Sprint.human_model_name
+        end
+      end
+    end
+  end
+%>
+
+<% if sprints.empty? %>
+  <%=
+    render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
+      blankslate.with_visual_icon(icon: :zap)
+      blankslate.with_heading(tag: :h4).with_content(t(".blankslate.title"))
+      blankslate.with_description_content(blankslate_description)
+    end
+  %>
+<% else %>
+  <% sprints.each do |sprint| %>
+    <%= render Backlogs::SprintComponent.new(
+          sprint:,
+          project:,
+          stories: stories_by_sprint_id[sprint.id],
+          active_sprint_ids: active_sprint_ids
+        ) %>
+  <% end %>
+<% end %>

--- a/modules/backlogs/app/components/backlogs/sprints_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprints_component.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class SprintsComponent < ApplicationComponent
+    include Primer::AttributesHelper
+    include CommonHelper
+
+    attr_reader :sprints, :stories_by_sprint_id, :active_sprint_ids, :project, :current_user
+
+    def initialize(sprints:,
+                   stories_by_sprint_id:,
+                   active_sprint_ids:,
+                   project:,
+                   current_user: User.current)
+      super()
+
+      @sprints = sprints
+      @stories_by_sprint_id = stories_by_sprint_id
+      @active_sprint_ids = active_sprint_ids
+      @project = project
+      @current_user = current_user
+    end
+
+    private
+
+    def blankslate_description
+      if allow_sprint_management?(project)
+        description_with_settings_link
+      else
+        description
+      end
+    end
+
+    def description_with_settings_link
+      settings_link = link_to(
+        t(".blankslate.settings_link_text"),
+        project_settings_backlog_sharing_path(project)
+      )
+
+      if project.receive_shared_sprints?
+        t(".blankslate.receive_and_manage_description_html", settings_link:)
+      elsif allow_sprint_creation?(project)
+        t(".blankslate.create_and_manage_description_html", settings_link:)
+      else
+        t(".blankslate.manage_description_html", settings_link:)
+      end
+    end
+
+    def description
+      if project.receive_shared_sprints?
+        t(".blankslate.receive_description_text")
+      elsif allow_sprint_creation?(project)
+        t(".blankslate.create_description_text")
+      else
+        t(".blankslate.no_actions_description_text")
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/helpers/backlogs/common_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/common_helper.rb
@@ -39,6 +39,10 @@ module Backlogs
         !project.receive_shared_sprints?
     end
 
+    def allow_sprint_management?(project)
+      current_user.allowed_in_project?(:share_sprint, project)
+    end
+
     def show_all_backlog
       ActiveRecord::Type::Boolean.new.cast(params[:all]) || false
     end

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -44,91 +44,13 @@ See COPYRIGHT and LICENSE files for more details.
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
       <%=
-        render(Primer::Beta::Subhead.new(hide_border: true, pb: 0)) do |head|
-          head.with_heading(tag: :h3, size: :medium, font_weight: :bold) { Sprint.human_model_name.pluralize }
-
-          if allow_sprint_creation?(@project)
-            head.with_actions do
-              render Primer::Beta::Button.new(
-                tag: :a,
-                label: Sprint.human_model_name,
-                href: new_dialog_project_backlogs_sprints_path(@project, all_backlogs_params),
-                data: {
-                  controller: "async-dialog",
-                  test_selector: "op-sprints--new-sprint-button"
-                }
-              ) do |button|
-                button.with_leading_visual_icon(icon: :plus)
-                Sprint.human_model_name
-              end
-            end
-          end
-        end
+        render Backlogs::SprintsComponent.new(
+          sprints: @sprints,
+          project: @project,
+          stories_by_sprint_id: @stories_by_sprint_id,
+          active_sprint_ids: @active_sprint_ids
+        )
       %>
-
-      <%#= render(Primer::OpenProject::SubHeader.new) do |subheader|
-          if allow_sprint_creation?(@project)
-            subheader.with_action_button(
-              leading_icon: :plus,
-              label: Sprint.human_model_name,
-              tag: :a,
-              href: new_dialog_project_backlogs_sprints_path(@project),
-              data: {
-                controller: "async-dialog",
-                test_selector: "op-sprints--new-sprint-button"
-              }
-            ) do
-              Sprint.human_model_name
-            end
-          end
-        end %>
-
-      <% if @sprints.empty? %>
-        <% can_create_sprints = current_user.allowed_in_project?(:create_sprints, @project) %>
-        <% can_manage_sprint_sharing = current_user.allowed_in_project?(:share_sprint, @project) %>
-        <% description_key =
-             if @project.receive_shared_sprints?
-               can_manage_sprint_sharing ? "backlogs.backlog.blankslate.receive_shared_description_html" :
-                 "backlogs.backlog.blankslate.receive_shared_no_actions_description_text"
-             elsif can_create_sprints && can_manage_sprint_sharing
-               "backlogs.backlog.blankslate.description_html"
-             elsif can_create_sprints
-               "backlogs.backlog.blankslate.create_sprint_description_text"
-             elsif can_manage_sprint_sharing
-               "backlogs.backlog.blankslate.share_sprint_description_html"
-             else
-               "backlogs.backlog.blankslate.no_actions_description_text"
-             end %>
-        <% description_content =
-             if can_manage_sprint_sharing
-               t(
-                 description_key,
-                 settings_link: link_to(
-                   t("backlogs.backlog.blankslate.settings_link_text"),
-                   project_settings_backlog_sharing_path(@project)
-                 )
-               )
-             else
-               t(description_key)
-             end %>
-
-        <%=
-          render(Primer::Beta::Blankslate.new(border: true, spacious: true)) do |blankslate|
-            blankslate.with_visual_icon(icon: :zap)
-            blankslate.with_heading(tag: :h4).with_content(t("backlogs.backlog.blankslate.title"))
-            blankslate.with_description_content(description_content)
-          end
-        %>
-      <% else %>
-        <% @sprints.each do |sprint| %>
-          <%= render Backlogs::SprintComponent.new(
-                sprint:,
-                project: @project,
-                stories: @stories_by_sprint_id[sprint.id],
-                active_sprint_ids: @active_sprint_ids
-              ) %>
-        <% end %>
-      <% end %>
     </div>
   </div>
 <% end %>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -158,16 +158,16 @@ en:
       title: "Move to sprint"
       label_sprint: "Sprint"
 
-    backlog:
+    sprints_component:
       blankslate:
         title: "No sprints present yet"
-        description_html: "To start planning your sprint, create one here or go to the %{settings_link} to receive sprints from a different project."
-        create_sprint_description_text: "To start planning your sprint, create one here."
-        share_sprint_description_html: "To start planning your sprint, go to the %{settings_link} to receive sprints from a different project."
-        no_actions_description_text: "No sprints are available for this project yet."
-        receive_shared_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
-        receive_shared_no_actions_description_text: "This project receives shared sprints from a different project, but none are available right now."
         settings_link_text: "project settings"
+        receive_and_manage_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
+        receive_description_text: "This project receives shared sprints from a different project, but none are available right now."
+        create_and_manage_description_html: "To start planning your sprint, create one here or go to the %{settings_link} to receive sprints from a different project."
+        create_description_text: "To start planning your sprint, create one here."
+        manage_description_html: "To start planning your sprint, go to the %{settings_link} to receive sprints from a different project."
+        no_actions_description_text: "No sprints are available for this project yet."
 
     backlog_bucket_menu_component:
       label_actions: "Backlog bucket actions"

--- a/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprints_component_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::SprintsComponent, type: :component do
+  shared_let(:sprints) { [] }
+  shared_let(:stories_by_sprint_id) { WorkPackage.all.group_by(&:sprint_id) }
+  shared_let(:active_sprint_ids) { [] }
+
+  let(:permissions) { %i[create_sprints] }
+  let(:project) { create(:project) }
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+
+  current_user { user }
+
+  def render_component
+    render_inline(
+      described_class.new(
+        sprints:, stories_by_sprint_id:, active_sprint_ids:, project:, current_user:
+      )
+    )
+  end
+
+  before { render_component }
+
+  it "renders the sprints heading" do
+    expect(page).to have_css("h3", text: "Sprints")
+  end
+
+  describe "new sprint button" do
+    context "when the user can create sprints and the project does not receive shared sprints" do
+      let(:project) { create(:project, sprint_sharing: "no_sharing") }
+
+      it "renders the new sprint button" do
+        expect(page).to have_css("[data-test-selector='op-sprints--new-sprint-button']")
+      end
+    end
+
+    context "when the project receives shared sprints" do
+      let(:project) { create(:project, sprint_sharing: "receive_shared") }
+
+      it "does not render the new sprint button" do
+        expect(page).to have_no_css("[data-test-selector='op-sprints--new-sprint-button']")
+      end
+    end
+
+    context "when the user lacks create_sprints permission" do
+      let(:permissions) { %i[view_sprints] }
+
+      it "does not render the new sprint button" do
+        expect(page).to have_no_css("[data-test-selector='op-sprints--new-sprint-button']")
+      end
+    end
+  end
+
+  describe "with no sprints" do
+    it "renders the blankslate title" do
+      expect(page).to have_text("No sprints present yet")
+    end
+
+    context "when the user can manage sprint sharing" do
+      context "when the project receives shared sprints" do
+        let(:permissions) { %i[share_sprint] }
+        let(:project) { create(:project, sprint_sharing: "receive_shared") }
+
+        it "shows the receive_and_manage description with a settings link" do
+          expect(page).to have_text(/This project receives sprints/)
+          expect(page).to have_link("project settings")
+        end
+      end
+
+      context "when the user can create sprints and the project does not receive shared sprints" do
+        let(:permissions) { %i[share_sprint create_sprints] }
+
+        it "shows the create_and_manage description with a settings link" do
+          expect(page).to have_text(/To start planning your sprint, create one here/)
+          expect(page).to have_link("project settings")
+        end
+      end
+
+      context "when the user cannot create sprints" do
+        let(:permissions) { %i[share_sprint] }
+
+        it "shows the manage description with a settings link" do
+          expect(page).to have_text(/To start planning your sprint, go to the/)
+          expect(page).to have_link("project settings")
+        end
+      end
+    end
+
+    context "when the user cannot manage sprint sharing" do
+      context "when the project receives shared sprints" do
+        let(:permissions) { %i[view_sprints] }
+        let(:project) { create(:project, sprint_sharing: "receive_shared") }
+
+        it "shows the receive description without a settings link" do
+          expect(page).to have_text(/This project receives shared sprints/)
+          expect(page).to have_no_link("project settings")
+        end
+      end
+
+      context "when the user can create sprints" do
+        let(:permissions) { %i[create_sprints] }
+
+        it "shows the create description without a settings link" do
+          expect(page).to have_text("To start planning your sprint, create one here.")
+          expect(page).to have_no_link("project settings")
+        end
+      end
+
+      context "when the user cannot create sprints" do
+        let(:permissions) { %i[view_sprints] }
+
+        it "shows the no_actions description" do
+          expect(page).to have_text("No sprints are available for this project yet.")
+        end
+      end
+    end
+  end
+
+  describe "with sprints" do
+    let(:sprints) { create_list(:sprint, 2, project:) }
+
+    it "does not render the blankslate" do
+      expect(page).to have_no_text("No sprints present yet")
+    end
+
+    it "renders a SprintComponent for each sprint" do
+      sprints.each do |sprint|
+        expect(page).to have_css(".Box#sprint_#{sprint.id}")
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/features/empty_backlogs_spec.rb
+++ b/modules/backlogs/spec/features/empty_backlogs_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe "Empty backlogs project",
 
     it "shows blankslate with description" do
       within "#owner_backlogs_container .blankslate" do
-        expect(page).to have_heading(I18n.t(:"backlogs.inbox_component.blankslate_title"))
-        expect(page).to have_text(I18n.t(:"backlogs.inbox_component.blankslate_description"))
+        expect(page).to have_heading("Backlog inbox is empty")
+        expect(page).to have_text("All open work packages in this project will automatically appear here.")
       end
 
       within "#sprint_backlogs_container .blankslate" do
-        expect(page).to have_heading(I18n.t(:"backlogs.backlog.blankslate.title"))
-        expect(page).to have_text(I18n.t(:"backlogs.backlog.blankslate.description_html",
-                                         settings_link: "project settings"))
+        expect(page).to have_heading("No sprints present yet")
+        expect(page).to have_text("To start planning your sprint, create one here")
+        expect(page).to have_link("project settings")
       end
     end
   end
@@ -67,13 +67,13 @@ RSpec.describe "Empty backlogs project",
 
     it "shows a blankslate without description" do
       within "#owner_backlogs_container .blankslate" do
-        expect(page).to have_heading(I18n.t(:"backlogs.inbox_component.blankslate_title"))
-        expect(page).to have_text(I18n.t(:"backlogs.inbox_component.blankslate_description"))
+        expect(page).to have_heading("Backlog inbox is empty")
+        expect(page).to have_text("All open work packages in this project will automatically appear here.")
       end
 
       within "#sprint_backlogs_container .blankslate" do
-        expect(page).to have_heading(I18n.t(:"backlogs.backlog.blankslate.title"))
-        expect(page).to have_text(I18n.t(:"backlogs.backlog.blankslate.no_actions_description_text"))
+        expect(page).to have_heading("No sprints present yet")
+        expect(page).to have_text("No sprints are available for this project yet.")
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74143

# What are you trying to accomplish?
- [X] Extract the backlog sprints column into its own component `Backlogs::SprintsComponent`.
- [X] Clean sprints blankslate rendering logic.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
