### PR TITLE
Fix relative url breaking recognize_route

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -102,7 +102,9 @@ module WorkPackagesHelper
   end
 
   def back_url_is_wp_show?
-    route = Rails.application.routes.recognize_path(params[:back_url] || request.env["HTTP_REFERER"])
+    route = OpenProject::StaticRouting.recognize_route(params[:back_url] || request.env["HTTP_REFERER"])
+    return false if route.nil?
+
     route[:controller] == "work_packages" && route[:action] == "index" && route[:state]&.match?(/^\d+/)
   end
 


### PR DESCRIPTION
Use recognize_route helper that correctly applies relative_url_root.

The internal error was this:
No route matches "/foo/projects/oliver-meetings/work_packages"

and originating here:

```
  def back_url_is_wp_show?
    route = Rails.application.routes.recognize_path(params[:back_url] ||
request.env["HTTP_REFERER"])
    route[:controller] == "work_packages" && route[:action] == "index"
&& route[:state]&.match?(/^\d+/)
  end
```

https://community.openproject.org/work_packages/72857