### PR TITLE
Bug/74521 work package on closed sprint cannot be edited

### DIFF
--- a/modules/backlogs/app/models/agile/sprint.rb
+++ b/modules/backlogs/app/models/agile/sprint.rb
@@ -45,7 +45,8 @@ module Agile
              inverse_of: :linked,
              dependent: :nullify
 
-    scopes :for_project,
+    scopes :assignable,
+           :for_project,
            :not_completed,
            :order_by_date,
            :receiving_projects,

--- a/modules/backlogs/app/models/agile/sprints/scopes/assignable.rb
+++ b/modules/backlogs/app/models/agile/sprints/scopes/assignable.rb
@@ -28,23 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module API
-  module V3
-    module Sprints
-      class SprintsByProjectAPI < ::API::OpenProjectAPI
-        resources :sprints do
-          after_validation do
-            authorize_in_project(:view_sprints, project: @project)
-          end
+module Agile::Sprints::Scopes::Assignable
+  extend ActiveSupport::Concern
 
-          get &::API::V3::Utilities::Endpoints::Index
-                 .new(
-                   model: Agile::Sprint,
-                   scope: -> { Agile::Sprint.for_project(@project).visible }
-                 )
-                 .mount
-        end
-      end
+  class_methods do
+    def assignable(project:, user: User.current)
+      for_project(project)
+        .visible(user)
+        .not_completed
     end
   end
 end

--- a/modules/backlogs/app/models/queries/sprints/filters/status_filter.rb
+++ b/modules/backlogs/app/models/queries/sprints/filters/status_filter.rb
@@ -28,13 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 # ++
 
-module Queries::Sprints
-  ::Queries::Register.register(SprintQuery) do
-    filter Filters::NameFilter
-    filter Filters::ProjectFilter
-    filter Filters::StatusFilter
-    filter Filters::TypeaheadFilter
+class Queries::Sprints::Filters::StatusFilter < Queries::Sprints::Filters::SprintFilter
+  def allowed_values
+    Agile::Sprint.statuses.map do |key, value|
+      [I18n.t(:"activerecord.attributes.agile/sprint.statuses.#{key}"), value]
+    end
+  end
 
-    order Orders::DefaultOrder
+  def type
+    :list
   end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -80,7 +80,7 @@ en:
             version_id:
               task_version_must_be_the_same_as_story_version: "must be the same as the parent story's version."
             sprint:
-              not_shared_with_project: "is not shared with the project the work package is in."
+              not_assignable: "is not assignable since it is either not shared with the project or already finished."
               not_eligible_for_moving: "is not an active sprint in the project which holds the sprint the work package is moved out of."
         agile/sprint:
           attributes:

--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
@@ -59,7 +59,12 @@ module OpenProject::Backlogs
                                          backlogs_constraint_passed?(:sprint)
                                      },
                                      href_callback: ->(*) {
-                                       "#{api_v3_paths.project_sprints(represented.project_id)}?pageSize=-1"
+                                       filters = CGI.escape(JSON.dump(
+                                                              [{ status: { operator: "!",
+                                                                           values: [Agile::Sprint.statuses["completed"]] } }]
+                                                            ))
+
+                                       "#{api_v3_paths.project_sprints(represented.project_id)}?filters=#{filters}&pageSize=-1"
                                      }
 
             define_method :backlogs_constraint_passed? do |attribute|

--- a/modules/backlogs/lib/open_project/backlogs/patches/base_contract_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/base_contract_patch.rb
@@ -42,11 +42,14 @@ module OpenProject::Backlogs::Patches::BaseContractPatch
 
     validate :backlog_bucket_xor_sprint
     validate :backlog_bucket_belongs_to_project
-    validate :sprint_shared_with_project
     validate :validate_sprint_is_assignable
 
     def assignable_sprints
-      model.try(:assignable_sprints)
+      if model.project
+        Agile::Sprint.assignable(project: model.project, user:)
+      else
+        Agile::Sprint.none
+      end
     end
 
     private
@@ -65,16 +68,11 @@ module OpenProject::Backlogs::Patches::BaseContractPatch
     end
 
     def validate_sprint_is_assignable
-      if model.sprint_id && model.sprint_id_changed? && model.assignable_sprints.map(&:id).exclude?(model.sprint_id)
-        errors.add :sprint_id, :inclusion
+      if model.sprint_id &&
+         model.sprint_id_changed? &&
+         !assignable_sprints.exists?(id: model.sprint_id)
+        errors.add :sprint, :not_assignable
       end
-    end
-
-    def sprint_shared_with_project
-      return if model.sprint.nil? ||
-                Agile::Sprint.for_project(model.project).exists?(id: model.sprint_id)
-
-      errors.add :sprint, :not_shared_with_project
     end
   end
 end

--- a/modules/backlogs/lib/open_project/backlogs/patches/base_contract_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/base_contract_patch.rb
@@ -65,7 +65,7 @@ module OpenProject::Backlogs::Patches::BaseContractPatch
     end
 
     def validate_sprint_is_assignable
-      if model.sprint_id && model.assignable_sprints.map(&:id).exclude?(model.sprint_id)
+      if model.sprint_id && model.sprint_id_changed? && model.assignable_sprints.map(&:id).exclude?(model.sprint_id)
         errors.add :sprint_id, :inclusion
       end
     end

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
@@ -41,10 +41,6 @@ module OpenProject::Backlogs::Patches::ProjectPatch
   def backlogs_enabled?
     module_enabled? "backlogs"
   end
-
-  def assignable_sprints
-    @assignable_sprints ||= Agile::Sprint.for_project(self).visible.not_completed
-  end
 end
 
 Project.include OpenProject::Backlogs::Patches::ProjectPatch

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -63,10 +63,6 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     def backlogs_enabled?
       project&.backlogs_enabled?
     end
-
-    def assignable_sprints
-      project.try(:assignable_sprints)
-    end
   end
 end
 

--- a/modules/backlogs/spec/contracts/work_packages/create_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/create_contract_spec.rb
@@ -55,10 +55,5 @@ RSpec.describe WorkPackages::CreateContract do
     ]
   end
 
-  before do
-    allow(work_package_project).to receive(:assignable_sprints)
-                                     .and_return(shared_sprints)
-  end
-
   it_behaves_like "work package contract with backlogs extensions"
 end

--- a/modules/backlogs/spec/contracts/work_packages/shared_contract_examples.rb
+++ b/modules/backlogs/spec/contracts/work_packages/shared_contract_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples "work package contract with backlogs extensions" do
   let(:work_package_story_points) { 5 }
   let(:work_package_sprint) { build_stubbed(:agile_sprint) }
   let(:work_package_position) { 5 }
-  let(:shared_sprints) { [work_package_sprint] }
+  let(:assignable_sprints) { [work_package_sprint] }
   let(:backlogs_enabled) { true }
   let(:work_package_project) do
     build_stubbed(:project, types: [work_package_type]) do |project|
@@ -59,16 +59,16 @@ RSpec.shared_examples "work package contract with backlogs extensions" do
   let(:effective_permissions) { permissions }
 
   before do
-    shared_sprints_scope = instance_double(ActiveRecord::Relation)
+    assignable_sprints_scope = instance_double(ActiveRecord::Relation)
 
     allow(Agile::Sprint)
-      .to receive(:for_project)
-            .with(work_package.project)
-            .and_return(shared_sprints_scope)
+      .to receive(:assignable)
+            .with(project: work_package.project, user:)
+            .and_return(assignable_sprints_scope)
 
-    allow(shared_sprints_scope)
+    allow(assignable_sprints_scope)
       .to receive(:exists?) do |id:|
-      shared_sprints.map(&:id).include?(id.to_i)
+      assignable_sprints.map(&:id).include?(id.to_i)
     end
   end
 
@@ -119,25 +119,10 @@ RSpec.shared_examples "work package contract with backlogs extensions" do
       it_behaves_like "contract is valid"
     end
 
-    context "when sprint is set to a sprint not shared with the wp's project" do
-      let(:shared_sprints) { [] }
+    context "when sprint is set to a sprint not assignable" do
+      let(:assignable_sprints) { [] }
 
-      it_behaves_like "contract is invalid", sprint: :not_shared_with_project
-    end
-
-    context "when sprint is completed (shared with project but not assignable)" do
-      let(:completed_sprint) { build_stubbed(:agile_sprint, status: :completed) }
-      let(:work_package_sprint) { completed_sprint }
-
-      before do
-        # The sprint is still shared with the project (the outer before mock makes
-        # `Agile::Sprint.for_project.exists?` return true), so `sprint_shared_with_project`
-        # passes. We stub assignable_sprints to exclude it, simulating the `.not_completed`
-        # scope, so only `validate_sprint_is_assignable` fires.
-        allow(work_package_project).to receive(:assignable_sprints).and_return([])
-      end
-
-      it_behaves_like "contract is invalid", sprint_id: :inclusion
+      it_behaves_like "contract is invalid", sprint: :not_assignable
     end
 
     context "when sprint is set while the user lacks the :manage_sprint_items permission" do

--- a/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe WorkPackages::UpdateContract do
                         subject: :error_readonly,
                         story_points: :error_readonly
       end
+
+      context "when sprint is completed (shared with project but not assignable) but the assignment did not change" do
+        let(:completed_sprint) { build_stubbed(:agile_sprint, status: :completed) }
+        let(:work_package_sprint) { completed_sprint }
+
+        before do
+          # So that the changes look like they came out of the database
+          work_package.clear_changes_information
+
+          # The mocks in the shared context need to be taken into account.
+          allow(work_package_project).to receive(:assignable_sprints).and_return([])
+        end
+
+        it_behaves_like "contract is valid"
+      end
     end
 
     describe "writable_attributes" do

--- a/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
+++ b/modules/backlogs/spec/contracts/work_packages/update_contract_spec.rb
@@ -53,9 +53,6 @@ RSpec.describe WorkPackages::UpdateContract do
   end
 
   before do
-    allow(work_package_project).to receive(:assignable_sprints)
-                        .and_return(shared_sprints)
-
     visible_scope = instance_double(ActiveRecord::Relation)
 
     allow(WorkPackage)
@@ -95,16 +92,14 @@ RSpec.describe WorkPackages::UpdateContract do
                         story_points: :error_readonly
       end
 
-      context "when sprint is completed (shared with project but not assignable) but the assignment did not change" do
+      context "when sprint is not assignable but the assignment did not change" do
         let(:completed_sprint) { build_stubbed(:agile_sprint, status: :completed) }
         let(:work_package_sprint) { completed_sprint }
+        let(:assignable_sprints) { [] }
 
         before do
           # So that the changes look like they came out of the database
           work_package.clear_changes_information
-
-          # The mocks in the shared context need to be taken into account.
-          allow(work_package_project).to receive(:assignable_sprints).and_return([])
         end
 
         it_behaves_like "contract is valid"

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -299,7 +299,10 @@ RSpec.describe "Inbox column in sprint planning view", :js do
             click_button "Move"
           end
 
-          planning_page.expect_and_dismiss_error("Update failed: Sprint is not set to one of the allowed values.")
+          planning_page
+            .expect_and_dismiss_error(
+              "Update failed: Sprint is not assignable since it is either not shared with the project or already finished."
+            )
 
           # Item was *not* moved:
           planning_page.expect_inbox_item(inbox_wp1)

--- a/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/sprints_on_wp_view_spec.rb
@@ -31,9 +31,12 @@
 require "spec_helper"
 
 RSpec.describe "Sprint displayed and selectable on work package view", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
   shared_let(:project) { create(:project) }
-  shared_let(:sprint) { create(:agile_sprint, project:) }
-  shared_let(:other_sprint) { create(:agile_sprint, project:) }
+  shared_let(:sprint) { create(:agile_sprint, project:, name: "Current sprint") }
+  shared_let(:next_sprint) { create(:agile_sprint, project:, name: "Next sprint") }
+  shared_let(:completed_sprint) { create(:agile_sprint, project:, status: "completed", name: "Completed sprint") }
   shared_let(:work_package) { create(:work_package, project:, sprint:) }
 
   let(:permissions) { %i(view_work_packages view_sprints manage_sprint_items) }
@@ -46,13 +49,20 @@ RSpec.describe "Sprint displayed and selectable on work package view", :js do
 
     wp_page.expect_attributes sprint: sprint.name
 
-    wp_page.set_attributes({ sprint: other_sprint.name })
+    field = wp_page.work_package_field(:sprint)
+    field.activate!
+
+    # Completed sprints are not offered as options
+    expect_no_ng_option(field, completed_sprint.name)
+
+    field.autocomplete(next_sprint.name, select: true)
+
     wp_page.expect_and_dismiss_toaster message: I18n.t(:notice_successful_update)
 
     # Ensure the sprint association is persisted
     wp_page.visit!
 
-    wp_page.expect_attributes sprint: other_sprint.name
+    wp_page.expect_attributes sprint: next_sprint.name
   end
 
   context "when lacking the permission to see sprints" do

--- a/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         expect(subject).not_to have_json_path("storyPoints")
       end
     end
-
   end
 
   describe "position" do
@@ -96,7 +95,6 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         expect(subject).not_to have_json_path("position")
       end
     end
-
   end
 
   describe "sprint" do
@@ -111,7 +109,10 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     it_behaves_like "links to allowed values via collection link" do
-      let(:href) { "#{api_v3_paths.project_sprints(project.id)}?pageSize=-1" }
+      let(:filters) do
+        CGI.escape(JSON.dump([{ status: { operator: "!", values: [Agile::Sprint.statuses["completed"]] } }]))
+      end
+      let(:href) { "#{api_v3_paths.project_sprints(project.id)}?filters=#{filters}&pageSize=-1" }
     end
 
     context "when lacking permission to set the sprint" do
@@ -133,6 +134,5 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
         expect(subject).not_to have_json_path(path)
       end
     end
-
   end
 end

--- a/modules/backlogs/spec/models/agile/sprints/scopes/assignable_spec.rb
+++ b/modules/backlogs/spec/models/agile/sprints/scopes/assignable_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an in_planning source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Agile::Sprints::Scopes::Assignable do
+  shared_let(:project) { create(:project) }
+  shared_let(:other_project) { create(:project) }
+  shared_let(:in_planning_sprint_in_project) { create(:agile_sprint, project:, status: "in_planning") }
+  shared_let(:active_sprint_in_project) { create(:agile_sprint, project:, status: "active") }
+  shared_let(:completed_sprint_in_project) { create(:agile_sprint, project:, status: "completed") }
+  shared_let(:in_planning_sprint_in_other_project) { create(:agile_sprint, project: other_project, status: "in_planning") }
+  shared_let(:active_sprint_in_other_project) { create(:agile_sprint, project: other_project, status: "active") }
+  shared_let(:completed_sprint_in_other_project) { create(:agile_sprint, project: other_project, status: "completed") }
+  # WPs only exist so that the sharing aspect is (rudimentarily) tested.
+  # It is not the goal of this spec to retest the whole of .for_project
+  shared_let(:wp_in_other_project_in_planning_sprint) do
+    create(:work_package, sprint: in_planning_sprint_in_other_project, project:)
+  end
+  shared_let(:wp_in_other_project_in_active_sprint) do
+    create(:work_package, sprint: active_sprint_in_other_project, project:)
+  end
+  shared_let(:wp_in_other_project_in_completed_sprint) do
+    create(:work_package, sprint: completed_sprint_in_other_project, project:)
+  end
+  shared_let(:role) { create(:project_role, permissions: %i[view_sprints view_work_packages]) }
+  shared_let(:user) do
+    create(:user,
+           member_with_roles: { project => role, other_project => role })
+  end
+
+  context "when the user has permission to view sprints in the project" do
+    it "returns sprints that are in_planning or active and shared or native to the project" do
+      expect(Agile::Sprint.assignable(project:,
+                                      user:))
+        .to contain_exactly(in_planning_sprint_in_project,
+                            active_sprint_in_project,
+                            in_planning_sprint_in_other_project,
+                            active_sprint_in_other_project)
+    end
+
+    it "returns sprints that are in_planning or active and native to the project" do
+      expect(Agile::Sprint.assignable(project: other_project,
+                                      user:))
+        .to contain_exactly(in_planning_sprint_in_other_project,
+                            active_sprint_in_other_project)
+    end
+  end
+
+  context "when the user lacks permission to view sprints in the project" do
+    before do
+      role.remove_permission!(:view_sprints)
+    end
+
+    it "returns no sprints" do
+      expect(Agile::Sprint.assignable(project:,
+                                      user:))
+        .to be_empty
+    end
+  end
+end

--- a/modules/backlogs/spec/requests/api/v3/sprints/project_index_resource_spec.rb
+++ b/modules/backlogs/spec/requests/api/v3/sprints/project_index_resource_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "API v3 Sprint resource on project", content_type: :json do
   shared_let(:other_project) { create(:project, public: false) }
   shared_let(:project_without_permission) { create(:project, public: false) }
   shared_let(:sprint) { create(:agile_sprint, project:) }
+  shared_let(:finished_sprint) { create(:agile_sprint, project:, status: :completed) }
   shared_let(:other_sprint) { create(:agile_sprint, project: other_project) }
   shared_let(:sprint_without_permission) { create(:agile_sprint, project: project_without_permission) }
 
@@ -60,8 +61,8 @@ RSpec.describe "API v3 Sprint resource on project", content_type: :json do
     end
 
     context "for a user with view_sprints permission" do
-      it_behaves_like "API V3 collection response", 1, 1, "Sprint" do
-        let(:elements) { [sprint] }
+      it_behaves_like "API V3 collection response", 2, 2, "Sprint" do
+        let(:elements) { [finished_sprint, sprint] }
       end
     end
 

--- a/modules/backlogs/spec/requests/api/v3/work_packages/create_resource_spec.rb
+++ b/modules/backlogs/spec/requests/api/v3/work_packages/create_resource_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "API v3 Work package resource",
       let(:permissions) { %i[add_work_packages view_work_packages manage_sprint_items] }
 
       it_behaves_like "constraint violation" do
-        let(:message) { "Sprint is not set to one of the allowed values." }
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe "API v3 Work package resource",
       end
 
       it_behaves_like "constraint violation" do
-        let(:message) { "Sprint is not set to one of the allowed values." }
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
 
@@ -148,11 +148,8 @@ RSpec.describe "API v3 Work package resource",
         }
       end
 
-      it_behaves_like "multiple errors of the same type with messages" do
-        let(:message) do
-          ["Sprint is not shared with the project the work package is in.",
-           "Sprint is not set to one of the allowed values."]
-        end
+      it_behaves_like "constraint violation" do
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
   end

--- a/modules/backlogs/spec/requests/api/v3/work_packages/update_resource_spec.rb
+++ b/modules/backlogs/spec/requests/api/v3/work_packages/update_resource_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "API v3 Work package resource",
       let(:permissions) { %i[edit_work_packages view_work_packages manage_sprint_items] }
 
       it_behaves_like "constraint violation" do
-        let(:message) { "Sprint is not set to one of the allowed values." }
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
 
@@ -153,7 +153,7 @@ RSpec.describe "API v3 Work package resource",
       end
 
       it_behaves_like "constraint violation" do
-        let(:message) { "Sprint is not set to one of the allowed values." }
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
 
@@ -171,11 +171,8 @@ RSpec.describe "API v3 Work package resource",
         }
       end
 
-      it_behaves_like "multiple errors of the same type with messages" do
-        let(:message) do
-          ["Sprint is not shared with the project the work package is in.",
-           "Sprint is not set to one of the allowed values."]
-        end
+      it_behaves_like "constraint violation" do
+        let(:message) { "Sprint is not assignable since it is either not shared with the project or already finished." }
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74521

# What are you trying to accomplish?

* [x] Work packages can still not be assigned to finished/completed sprints
* [x] BUT if they are assigned to a finished sprint, modifying other attributes does not cause a validation error.
* [x] Consolidate validations on sprints in the work package contract into a single one.
* [x] Drive by fix: Sprints that are completed/finished should still be available via the sprints by project api so that one can e.g., filter by them.
  * at the same time, completed filters should not be selectable as options on the work package full/split view. 
 
The PR extracts the assignability of sprints into a scope.    

# Merge checklist

- [x] Added/updated tests