### PR TITLE
[69210] Clicking work package tabs triggers page reload and flickering

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.html
@@ -1,6 +1,7 @@
 <op-scrollable-tabs
   [tabs]="tabs"
   [currentTabId]="currentTabId"
+  (tabSelected)="tabSelected.emit($event)"
   class="op-work-package-tabs"
   >
   @if (view === 'split') {

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Injector, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Injector, Input, OnInit, Output } from '@angular/core';
 import {
   KeepTabService,
 } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
@@ -28,6 +28,8 @@ export class WpTabsComponent implements OnInit {
   @Input() routedFromAngular = true;
 
   @Input() public currentTabId:string|null = null;
+
+  @Output() public tabSelected = new EventEmitter<TabDefinition>();
 
   public tabs:TabDefinition[];
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -28,6 +28,7 @@
 
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   HostListener,
   Injector,
@@ -36,6 +37,7 @@ import {
 } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
+import { TabDefinition } from 'core-app/shared/components/tabs/tab.interface';
 import { RecentItemsService } from 'core-app/core/recent-items.service';
 import { ProjectResource } from 'core-app/features/hal/resources/project-resource';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -84,8 +86,16 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
     public recentItemsService:RecentItemsService,
     readonly $state:StateService,
     readonly currentUserService:CurrentUserService,
+    readonly cdRef:ChangeDetectorRef,
   ) {
     super(injector);
+  }
+
+  public onTabSelected(tab:TabDefinition):void {
+    if (!this.routedFromAngular) {
+      this.activeTab = tab.id;
+      this.cdRef.markForCheck();
+    }
   }
 
   // enable other parts of the application to trigger an immediate update

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.html
@@ -69,13 +69,16 @@
           <op-wp-tabs [workPackage]="workPackage"
                       [currentTabId]="activeTab"
                       [view]="'full'"
-                      [routedFromAngular]="routedFromAngular"/>
+                      [routedFromAngular]="routedFromAngular"
+                      (tabSelected)="onTabSelected($event)"/>
           <div class="tabcontent"
             data-notification-selector='notification-scroll-container'>
-            <op-wp-tab
-              [workPackageId]="workPackage.id!"
-              [tabIdentifier]="activeTab"
-            ></op-wp-tab>
+            @for (tab of [activeTab]; track tab) {
+              <op-wp-tab
+                [workPackageId]="workPackage.id!"
+                [tabIdentifier]="tab"
+              ></op-wp-tab>
+            }
           </div>
         </div>
         <div class="work-packages-full-view--resizer hidden-for-mobile hide-when-print">

--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
@@ -135,7 +135,8 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
 
     // Override history to avoid that browser back leads you to a different tab instead of the page you originated from
     if (tab.path) {
-      Turbo.visit(tab.path, { action: document.referrer != '' ? 'replace' : 'advance' });
+      const historyMethod = document.referrer !== '' ? 'replaceState' : 'pushState';
+      history[historyMethod](null, '', tab.path);
     }
   }
 

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1456,10 +1456,6 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
 
     context "when the current user does not have the activity tab open the whole time" do
       it "raises a conflict warning when the work package is updated by another user while the current user is editing" do
-        pending "This has become obselete with the removal of uiRouter (#67007), because switching tabs now result in a
-               hard reload and no conflict appears like described in these examples.
-               Before removing this, please check the polling controller for possible cleanups.
-               Ticket: https://community.openproject.org/wp/68630"
         using_session(:admin) do
           login_as(admin)
 


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/69210

# What are you trying to accomplish?
Avoid flickering when switchting tabs in WP full view by not doing a full page revisit, but rather re-instantiating the tab component and thus the tab content 


