### PR TITLE
[#71354] NoMethodError in Calendar::ICalController#show  

### DIFF
--- a/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
+++ b/modules/calendar/app/services/calendar/resolve_ical_token_service.rb
@@ -38,7 +38,7 @@ module Calendar
       token = Token::ICal.find_by_plaintext_value(ical_token_string)
       # rubocop:enable Rails/DynamicFindBy
 
-      if token.present?
+      if token.present? && token.user&.active?
         ServiceResult.success(result: token)
       else
         raise ActiveRecord::RecordNotFound

--- a/modules/calendar/spec/controllers/ical_controller_spec.rb
+++ b/modules/calendar/spec/controllers/ical_controller_spec.rb
@@ -329,6 +329,41 @@ RSpec.describe Calendar::ICalController do
       it_behaves_like "failure"
     end
 
+    # The token still exists until Principals::DeleteJob has run to clean it up
+    context "when the token's user has been soft-deleted but the token still exists" do
+      before do
+        valid_ical_token_value
+        user.update_column(:status, Principal.statuses[:deleted])
+
+        get :show, params: {
+          project_id: project.id,
+          id: query.id,
+          ical_token: valid_ical_token_value
+        }
+      end
+
+      it "returns 404, not 500" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when the token's user is locked" do
+      before do
+        valid_ical_token_value
+        user.locked!
+
+        get :show, params: {
+          project_id: project.id,
+          id: query.id,
+          ical_token: valid_ical_token_value
+        }
+      end
+
+      it "returns 404, not 500" do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context "with invalid query" do
       before do
         get :show, params: {


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/71354

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Prevent `NoMethodError in Calendar::ICalController#show`

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- I believe the error only happens in the window between which the user is soft deleted and the actual `Principals::DeleteJob` runs in `Users::DeleteService`, which handles token deletion properly via two paths:
   - `delete_associated` -> `delete_tokens`
   - `principal.destroy` -> `has_many :ical_tokens, class_name: "::Token::ICal", dependent: :destroy` in User
- Checking if the user exists and is active in `resolve_ical_token_service` makes it return a 404 straight away and prevents the 500 when `user = ical_token_instance.user` is reached in `ICalResponseService`, which returns nil for a user with `status: 5`, ie, deleted

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
