### PR TITLE
include filter working with portfolios and programs

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit-form/work-package-filter-values.ts
@@ -41,8 +41,11 @@ export class WorkPackageFilterValues {
       if (filter.id === 'project') {
         if (operator !== '=') return;
 
+        const currentProjectId = this.currentProject.id;
         const projectFilter = _.find(filter.values, (resource:HalResource|string) => {
-          return ((resource instanceof HalResource) ? resource.href : resource) === this.currentProject.apiv3Path;
+          const href = (resource instanceof HalResource) ? resource.href : resource;
+          const hrefParts = href?.split('/');
+          return hrefParts?.[hrefParts.length - 1] === currentProjectId;
         });
         this.setValue(change, 'project', projectFilter || filter.values[0]);
 

--- a/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
+++ b/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
@@ -40,7 +40,7 @@
         slot="body"
         class="spot-body-small"
         >
-        @if (project.href === currentProjectHref) {
+        @if (project.href === queryWorkspaceHref) {
           <span>{{ text.current_project }}</span>
         } @else {
           @if (includeSubprojects && parentChecked) {
@@ -61,6 +61,7 @@
         [includeSubprojects]="includeSubprojects"
         [parentChecked]="parentChecked || isChecked(project.href)"
         [searchText]="searchText"
+        [queryWorkspaceHref]="queryWorkspaceHref"
         (update)="updateList($event)"
       ></ul>
     }

--- a/frontend/src/app/shared/components/project-include/list/project-include-list.component.ts
+++ b/frontend/src/app/shared/components/project-include/list/project-include-list.component.ts
@@ -72,9 +72,7 @@ export class OpProjectIncludeListComponent {
 
   @Input() parentChecked = false;
 
-  public get currentProjectHref():string|null {
-    return this.currentProjectService.apiv3Path;
-  }
+  @Input() queryWorkspaceHref:string|null = null;
 
   public text = {
     does_not_match_search: this.I18n.t('js.include_projects.tooltip.does_not_match_search'),

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -60,6 +60,7 @@
               [includeSubprojects]="includeSubprojects$ | async"
               [searchText]="searchableProjectListService.searchText"
               [root]="true"
+              [queryWorkspaceHref]="queryWorkspaceHref"
               (update)="selectedProjects = $event"
               data-test-selector="project-include-list"
               data-list-root="true"

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -56,7 +56,6 @@ import {
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
-import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { IProject } from 'core-app/core/state/projects/project.model';
 import {
   SearchableProjectListService,
@@ -131,6 +130,8 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
 
   private _selectedProjects:string[] = [];
 
+  private queryWorkspaceHref:string | null;
+
   public get selectedProjects():string[] {
     return this._selectedProjects;
   }
@@ -150,13 +151,12 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       map((queryFilters) => {
         const projectFilter = queryFilters.find((queryFilter) => queryFilter._type === 'ProjectQueryFilter');
         const selectedProjectHrefs = ((projectFilter?.values || []) as HalResource[]).map((p) => p.href);
-        const currentProjectHref = this.currentProjectService.apiv3Path;
-        if (selectedProjectHrefs.includes(currentProjectHref)) {
+        if (selectedProjectHrefs.includes(this.queryWorkspaceHref)) {
           return selectedProjectHrefs;
         }
         const selectedProjects = [...selectedProjectHrefs];
-        if (currentProjectHref) {
-          selectedProjects.push(currentProjectHref);
+        if (this.queryWorkspaceHref) {
+          selectedProjects.push(this.queryWorkspaceHref);
         }
         return selectedProjects;
       }),
@@ -234,7 +234,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
           return true;
         }
 
-        if (project.href === this.currentProjectService.apiv3Path) {
+        if (project.href === this.queryWorkspaceHref) {
           return true;
         }
 
@@ -263,7 +263,6 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
     readonly wpTableFilters:WorkPackageViewFiltersService,
     readonly wpIncludeSubprojects:WorkPackageViewIncludeSubprojectsService,
     readonly halResourceService:HalResourceService,
-    readonly currentProjectService:CurrentProjectService,
     readonly searchableProjectListService:SearchableProjectListService,
   ) {
     super();
@@ -289,6 +288,15 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
       )
       .subscribe((includeSubprojects) => {
         this.includeSubprojects = includeSubprojects;
+      });
+
+    this
+      .query$
+      .pipe(
+        this.untilDestroyed(),
+        take(1))
+      .subscribe((query) => {
+        this.queryWorkspaceHref = query.project?.href;
       });
 
     this.onTextInput = this.searchableProjectListService.queriedSearchText$.subscribe(() => this.loading$.next(true));
@@ -321,7 +329,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
   }
 
   public clearSelection():void {
-    this.selectedProjects = [this.currentProjectService.apiv3Path || ''];
+    this.selectedProjects = [this.queryWorkspaceHref ?? ''];
   }
 
   public onSubmit(e:Event):void {

--- a/lib/api/v3/queries/filters/query_filter_instance_representer.rb
+++ b/lib/api/v3/queries/filters/query_filter_instance_representer.rb
@@ -78,17 +78,8 @@ module API
                       next unless represented.ar_object_filter?
 
                       represented.value_objects.map do |value_object|
-                        href = begin
-                          path_name = value_object.class.name.demodulize.underscore
-
-                          api_v3_paths.send(path_name, value_object.id)
-                        rescue StandardError => e
-                          Rails.logger.error "Failed to get href for value_object #{value_object}: #{e}"
-                          nil
-                        end
-
                         link_object = {
-                          href:,
+                          href: api_v3_paths.path_for_object(value_object),
                           title: value_object.name
                         }
 

--- a/lib/api/v3/utilities/path_helper.rb
+++ b/lib/api/v3/utilities/path_helper.rb
@@ -765,6 +765,19 @@ module API
 
             root_url.gsub(duplicate_regexp, "") + send(path, arguments)
           end
+
+          def self.path_for_object(object)
+            strategy = if self.class.const_defined?("API::V3::Utilities::PathHelper::#{object.class}Strategy")
+                         "API::V3::Utilities::PathHelper::#{object.class}Strategy".constantize
+                       else
+                         API::V3::Utilities::PathHelper::DefaultStrategy
+                       end
+
+            send(strategy.path_name_for_object(object), object.id)
+          rescue StandardError => e
+            Rails.logger.error "Failed to get path for object #{object}: #{e}"
+            nil
+          end
         end
 
         def api_v3_paths

--- a/lib/api/v3/utilities/path_helper/default_strategy.rb
+++ b/lib/api/v3/utilities/path_helper/default_strategy.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module API
+  module V3
+    module Utilities
+      module PathHelper
+        module DefaultStrategy
+          def self.path_name_for_object(object)
+            object.class.name.demodulize.underscore
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/utilities/path_helper/project_strategy.rb
+++ b/lib/api/v3/utilities/path_helper/project_strategy.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module API
+  module V3
+    module Utilities
+      module PathHelper
+        module ProjectStrategy
+          def self.path_name_for_object(object)
+            if object.portfolio?
+              :portfolio
+            elsif object.program?
+              :program
+            else
+              :project
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/calendar/spec/features/calendar_project_include_spec.rb
+++ b/modules/calendar/spec/features/calendar_project_include_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Calendar project include", :js, :selenium do
   end
 
   it_behaves_like "has a project include dropdown" do
-    let(:work_package_view) { Pages::Calendar.new project }
+    let(:work_package_view) { Pages::Calendar.new portfolio }
     let(:dropdown) { Components::ProjectIncludeComponent.new }
 
     it "correctly filters work packages by project" do

--- a/modules/team_planner/spec/features/team_planner_project_include_spec.rb
+++ b/modules/team_planner/spec/features/team_planner_project_include_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Team planner project include",
   end
 
   it_behaves_like "has a project include dropdown" do
-    let(:work_package_view) { Pages::TeamPlanner.new(project) }
+    let(:work_package_view) { Pages::TeamPlanner.new(portfolio) }
     let(:dropdown) { Components::ProjectIncludeComponent.new }
 
     it "correctly filters work packages by project" do

--- a/spec/features/work_packages/project_include/project_include_shared_examples.rb
+++ b/spec/features/work_packages/project_include/project_include_shared_examples.rb
@@ -33,18 +33,18 @@ require "spec_helper"
 RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
   let(:dropdown) { Components::ProjectIncludeComponent.new }
 
-  shared_let(:project) do
-    create(:project, name: "Parent", enabled_module_names: enabled_modules)
+  shared_let(:portfolio) do
+    create(:portfolio, name: "Portfolio", enabled_module_names: enabled_modules)
   end
 
-  shared_let(:sub_project) do
-    create(:project, name: "Direct Child", parent: project, enabled_module_names: enabled_modules)
+  shared_let(:program) do
+    create(:program, name: "Program", parent: portfolio, enabled_module_names: enabled_modules)
   end
 
   # The user will not receive a membership in this project
   # which is why it is invisible to the user.
   shared_let(:sub_sub_project_invisible) do
-    create(:project, name: "Invisible Grandchild", parent: sub_project, enabled_module_names: enabled_modules)
+    create(:project, name: "Invisible Grandchild", parent: program, enabled_module_names: enabled_modules)
   end
 
   shared_let(:sub_sub_sub_project) do
@@ -70,8 +70,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
   shared_let(:user) do
     create(:user,
            member_with_permissions: {
-             project => permissions,
-             sub_project => permissions,
+             portfolio => permissions,
+             program => permissions,
              sub_sub_sub_project => permissions,
              other_project => permissions,
              other_sub_project => permissions,
@@ -85,8 +85,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
            firstname: "Other",
            lastname: "User",
            member_with_permissions: {
-             project => permissions,
-             sub_project => permissions,
+             portfolio => permissions,
+             program => permissions,
              sub_sub_sub_project => permissions,
              other_project => permissions,
              other_sub_project => permissions,
@@ -103,7 +103,7 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
 
   shared_let(:task) do
     create(:work_package,
-           project:,
+           project: portfolio,
            type: type_task,
            assigned_to: user,
            start_date: Time.zone.today - 2.days,
@@ -113,7 +113,7 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
 
   shared_let(:sub_bug) do
     create(:work_package,
-           project: sub_project,
+           project: program,
            type: type_bug,
            assigned_to: user,
            start_date: Time.zone.today - 10.days,
@@ -133,7 +133,7 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
 
   shared_let(:other_task) do
     create(:work_package,
-           project:,
+           project: portfolio,
            type: type_task,
            assigned_to: other_user,
            start_date: Time.zone.today,
@@ -152,10 +152,10 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
   end
 
   before do
-    project.types << type_bug
-    project.types << type_task
-    sub_project.types << type_bug
-    sub_project.types << type_task
+    portfolio.types << type_bug
+    portfolio.types << type_task
+    program.types << type_bug
+    program.types << type_task
     sub_sub_sub_project.types << type_bug
     sub_sub_sub_project.types << type_task
 
@@ -181,8 +181,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id, true)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id, true)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.toggle_include_all_subprojects
@@ -191,8 +191,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id)
 
     dropdown.toggle_checkbox(other_sub_project.id)
@@ -202,8 +202,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.toggle_checkbox(sub_sub_sub_project.id)
@@ -212,8 +212,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id)
 
     dropdown.click_button "Apply"
@@ -239,8 +239,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id, true)
     dropdown.expect_checkbox(another_sub_sub_project.id, true)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id, true)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id, true)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.toggle_include_all_subprojects
@@ -249,8 +249,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.toggle_checkbox(sub_sub_sub_project.id)
@@ -266,15 +266,17 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_open
 
     dropdown.toggle_checkbox(other_project.id)
-    dropdown.toggle_checkbox(project.id)
+    # Clicking here does not change anything as the checkbox is disabled.
+    # It is disabled because it is the current workspace.
+    dropdown.toggle_checkbox(portfolio.id)
     dropdown.toggle_checkbox(sub_sub_sub_project.id)
 
     dropdown.expect_checkbox(other_project.id, true)
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id, true)
     dropdown.expect_checkbox(another_sub_sub_project.id, true)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id, true)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id, true)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.click_button "Apply"
@@ -289,8 +291,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id, true)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id, true)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.toggle_include_all_subprojects
@@ -302,8 +304,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id, true)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id, true)
 
     dropdown.click_button "Apply"
@@ -318,8 +320,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
     dropdown.expect_checkbox(other_sub_project.id)
     dropdown.expect_checkbox(other_sub_sub_project.id)
     dropdown.expect_checkbox(another_sub_sub_project.id)
-    dropdown.expect_checkbox(project.id, true)
-    dropdown.expect_checkbox(sub_project.id)
+    dropdown.expect_checkbox(portfolio.id, true)
+    dropdown.expect_checkbox(program.id)
     dropdown.expect_checkbox(sub_sub_sub_project.id)
 
     dropdown.click_button "Apply"
@@ -339,8 +341,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_no_checkbox(other_sub_project.id)
       dropdown.expect_no_checkbox(other_sub_sub_project.id)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_checkbox(sub_project.id, true)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_checkbox(program.id, true)
       dropdown.expect_checkbox(sub_sub_sub_project.id, true)
     end
 
@@ -351,8 +353,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_no_checkbox(other_sub_project.id)
       dropdown.expect_no_checkbox(other_sub_sub_project.id)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_no_checkbox(project.id)
-      dropdown.expect_no_checkbox(sub_project.id)
+      dropdown.expect_no_checkbox(portfolio.id)
+      dropdown.expect_no_checkbox(program.id)
       dropdown.expect_no_checkbox(sub_sub_sub_project.id)
     end
 
@@ -363,8 +365,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_checkbox(other_sub_project.id)
       dropdown.expect_checkbox(other_sub_sub_project.id)
       dropdown.expect_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_checkbox(sub_project.id, true)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_checkbox(program.id, true)
       dropdown.expect_checkbox(sub_sub_sub_project.id, true)
     end
 
@@ -377,8 +379,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_checkbox(other_sub_project.id)
       dropdown.expect_checkbox(other_sub_sub_project.id, true)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_checkbox(sub_project.id, true)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_checkbox(program.id, true)
       dropdown.expect_checkbox(sub_sub_sub_project.id, true)
     end
 
@@ -398,8 +400,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_checkbox(other_sub_project.id, true)
       dropdown.expect_checkbox(other_sub_sub_project.id, true)
       dropdown.expect_checkbox(another_sub_sub_project.id, true)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_checkbox(sub_project.id, true)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_checkbox(program.id, true)
       dropdown.expect_checkbox(sub_sub_sub_project.id, true)
     end
 
@@ -412,8 +414,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_checkbox(other_sub_project.id)
       dropdown.expect_checkbox(other_sub_sub_project.id, true)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_no_checkbox(sub_project.id)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_no_checkbox(program.id)
       dropdown.expect_no_checkbox(sub_sub_sub_project.id)
     end
 
@@ -424,8 +426,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_no_checkbox(other_sub_project.id)
       dropdown.expect_no_checkbox(other_sub_sub_project.id)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_no_checkbox(project.id)
-      dropdown.expect_no_checkbox(sub_project.id)
+      dropdown.expect_no_checkbox(portfolio.id)
+      dropdown.expect_no_checkbox(program.id)
       dropdown.expect_no_checkbox(sub_sub_sub_project.id)
     end
 
@@ -436,8 +438,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_no_checkbox(other_sub_project.id)
       dropdown.expect_no_checkbox(other_sub_sub_project.id)
       dropdown.expect_no_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_no_checkbox(sub_project.id)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_no_checkbox(program.id)
       dropdown.expect_no_checkbox(sub_sub_sub_project.id)
     end
 
@@ -448,8 +450,8 @@ RSpec.shared_examples "has a project include dropdown", :js, type: :feature do
       dropdown.expect_checkbox(other_sub_project.id)
       dropdown.expect_checkbox(other_sub_sub_project.id, true)
       dropdown.expect_checkbox(another_sub_sub_project.id)
-      dropdown.expect_checkbox(project.id, true)
-      dropdown.expect_checkbox(sub_project.id)
+      dropdown.expect_checkbox(portfolio.id, true)
+      dropdown.expect_checkbox(program.id)
       dropdown.expect_checkbox(sub_sub_sub_project.id)
     end
   end

--- a/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
+++ b/spec/features/work_packages/table/work_packages_table_project_include_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Work package project include", :js, :selenium do
   shared_let(:permissions) { %i[view_work_packages edit_work_packages add_work_packages save_queries manage_public_queries] }
 
   it_behaves_like "has a project include dropdown" do
-    shared_let(:work_package_view) { Pages::WorkPackagesTable.new(project) }
+    shared_let(:work_package_view) { Pages::WorkPackagesTable.new(portfolio) }
 
     it "correctly filters work packages by project" do
       dropdown.expect_count 1
@@ -97,7 +97,7 @@ RSpec.describe "Work package project include", :js, :selenium do
       work_package_view.expect_work_package_subject "Foobar!"
 
       inline_created = WorkPackage.last
-      expect(inline_created.project).to eq(project)
+      expect(inline_created.project).to eq(portfolio)
     end
   end
 end

--- a/spec/lib/api/v3/utilities/path_helper_spec.rb
+++ b/spec/lib/api/v3/utilities/path_helper_spec.rb
@@ -732,4 +732,51 @@ RSpec.describe API::V3::Utilities::PathHelper do
       end
     end
   end
+
+  describe ".path_for_object" do
+    context "for a portfolio" do
+      let(:object) { build_stubbed(:portfolio) }
+
+      it "returns the path to the portfolio" do
+        expect(helper.path_for_object(object))
+          .to eql "/api/v3/portfolios/#{object.id}"
+      end
+    end
+
+    context "for a program" do
+      let(:object) { build_stubbed(:program) }
+
+      it "returns the path to the program" do
+        expect(helper.path_for_object(object))
+          .to eql "/api/v3/programs/#{object.id}"
+      end
+    end
+
+    context "for a project" do
+      let(:object) { build_stubbed(:project) }
+
+      it "returns the path to the project" do
+        expect(helper.path_for_object(object))
+          .to eql "/api/v3/projects/#{object.id}"
+      end
+    end
+
+    context "for a work_package" do
+      let(:object) { build_stubbed(:work_package) }
+
+      it "returns the path to the work_packages" do
+        expect(helper.path_for_object(object))
+          .to eql "/api/v3/work_packages/#{object.id}"
+      end
+    end
+
+    context "for a user" do
+      let(:object) { build_stubbed(:user) }
+
+      it "returns the path to the user" do
+        expect(helper.path_for_object(object))
+          .to eql "/api/v3/users/#{object.id}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74536

# What are you trying to accomplish?

Fix include projects with when portfolios and programs are involved

* [x] included portfolios and programs are checked
* [x] the current project is correctly identified by include project on hovering
* [x] creation of work packages after using include projects is applied happens in the intended project

The fixes in here try to strike a balance between fixing the bugs with limited effort and avoiding to worsen code quality. But the tendency here is minimize the effort meaning code quality is not the best in this PR. 

Ideally:
* The hack in [`work-package-filter-values`](https://github.com/opf/openproject/compare/release/17.4...bug/74536-errors-with-include-project-work-package-list-filter-with-a-portfolio?expand=1#diff-77a5cc5c79bc1882c3f3e379f5a95799e75bc02495c5ad6837ceff0ee592af20R44-R48) would be avoided.
* The strategy pattern started for the api v3 path helper would be extended to place all non default mappings (paths, property names from/to API/AR, ...) in the same place grouped by object type. 

# Merge checklist

- [x] Added/updated tests
