### PR TITLE
[74398] Admin does not save all-unchecked password requirements

### DIFF
--- a/app/views/admin/settings/authentication_settings/_passwords.html.erb
+++ b/app/views/admin/settings/authentication_settings/_passwords.html.erb
@@ -56,9 +56,9 @@ See COPYRIGHT and LICENSE files for more details.
                       input_width: :small
 
 
-      form.hidden(name: "settings[password_active_rules][]", value: "", scope_name_to_model: false)
       form.check_box_group(name: :password_active_rules,
                            disabled:,
+                           include_hidden: true,
                            label: I18n.t(:setting_password_active_rules)) do |group|
         OpenProject::Passwords::Evaluator.known_rules.each do |value|
           group.check_box(value:,

--- a/app/views/admin/settings/authentication_settings/_passwords.html.erb
+++ b/app/views/admin/settings/authentication_settings/_passwords.html.erb
@@ -55,6 +55,8 @@ See COPYRIGHT and LICENSE files for more details.
                       min: 1,
                       input_width: :small
 
+
+      form.hidden(name: "settings[password_active_rules][]", value: "", scope_name_to_model: false)
       form.check_box_group(name: :password_active_rules,
                            disabled:,
                            label: I18n.t(:setting_password_active_rules)) do |group|

--- a/lib/primer/open_project/forms/dsl/input_methods.rb
+++ b/lib/primer/open_project/forms/dsl/input_methods.rb
@@ -19,7 +19,8 @@ module Primer
             super(**decorate_options(**), &)
           end
 
-          def check_box_group(**, &)
+          def check_box_group(include_hidden: false, **, &)
+            add_input Primer::Forms::Dsl::HiddenInput.new(builder:, form:, multiple: true, value: "", **) if include_hidden
             super(**decorate_options(**), &)
           end
 

--- a/lookbook/previews/open_project/common/advanced_form_inputs_preview.rb
+++ b/lookbook/previews/open_project/common/advanced_form_inputs_preview.rb
@@ -39,6 +39,22 @@ module OpenProject
       def advanced_check_box_group
         render_with_template
       end
+
+      # `check_box_group` with `include_hidden: true`
+      #
+      # HTML forms do not submit unchecked checkboxes, so when every option in an
+      # array-valued `check_box_group` is unchecked, the field key is absent from
+      # the request params entirely. The server then has no way to distinguish
+      # "user cleared all selections" from "this field was not part of the form",
+      # and the previous value is silently preserved.
+      #
+      # Pass `include_hidden: true` to emit a hidden sentinel field before the
+      # checkboxes. This mirrors the behaviour of Rails' own `check_box` helper
+      # and ensures the key is always present in params — as an empty array when
+      # nothing is checked — so the server can save the empty selection correctly.
+      def check_box_group_with_include_hidden
+        render_with_template
+      end
     end
   end
 end

--- a/lookbook/previews/open_project/common/advanced_form_inputs_preview/check_box_group_with_include_hidden.html.erb
+++ b/lookbook/previews/open_project/common/advanced_form_inputs_preview/check_box_group_with_include_hidden.html.erb
@@ -1,0 +1,22 @@
+<%
+  the_form = Class.new(ApplicationForm) do
+    form do |f|
+      f.check_box_group(name: :colors, include_hidden: true, label: "Favorite colors") do |group|
+        group.check_box(value: "red",   label: "Red")
+        group.check_box(value: "green", label: "Green")
+        group.check_box(value: "blue",  label: "Blue")
+      end
+
+      f.submit(name: "submit", label: "Save")
+    end
+  end
+%>
+
+<%=
+  primer_form_with(
+    url: "/abc",
+    method: :post
+  ) do |f|
+    render(the_form.new(f))
+  end
+%>

--- a/spec/features/admin/settings/authentication_settings_spec.rb
+++ b/spec/features/admin/settings/authentication_settings_spec.rb
@@ -135,6 +135,30 @@ RSpec.describe "Authentication Settings", :js do
     end
   end
 
+  describe "passwords settings" do
+    let(:passwords_page) { Pages::Admin::Authentication::Passwords.new }
+
+    before do
+      Setting.password_active_rules = %w[lowercase uppercase numeric special]
+      passwords_page.visit!
+    end
+
+    it "allows unchecking all password requirements" do
+      OpenProject::Passwords::Evaluator.known_rules.each do |rule|
+        passwords_page.expect_rule_checked(rule)
+        uncheck I18n.t("label_password_rule_#{rule}")
+      end
+
+      passwords_page.save
+      Setting.clear_cache
+      passwords_page.reload!
+
+      OpenProject::Passwords::Evaluator.known_rules.each do |rule|
+        passwords_page.expect_rule_unchecked(rule)
+      end
+    end
+  end
+
   describe "self registration settings" do
     let(:registration_page) { Pages::Admin::Authentication::Registration.new }
 

--- a/spec/requests/admin/settings/authentication_settings_spec.rb
+++ b/spec/requests/admin/settings/authentication_settings_spec.rb
@@ -68,4 +68,18 @@ RSpec.describe "Authentication Settings",
       end
     end
   end
+
+  describe "PATCH /admin/settings/authentication?tab=passwords" do
+    context "when all password requirement checkboxes are unchecked" do
+      before do
+        Setting.password_active_rules = %w[lowercase uppercase]
+        patch "/admin/settings/authentication.html?tab=passwords",
+              params: { settings: { password_active_rules: [""] } }
+      end
+
+      it "saves an empty list of active rules" do
+        expect(Setting.password_active_rules).to eq([])
+      end
+    end
+  end
 end

--- a/spec/support/pages/admin/authentication/passwords.rb
+++ b/spec/support/pages/admin/authentication/passwords.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "support/pages/page"
+
+module Pages
+  module Admin
+    module Authentication
+      class Passwords < ::Pages::Page
+        def path
+          admin_settings_authentication_path(tab: "passwords")
+        end
+
+        def save
+          click_button "Save"
+          expect_and_dismiss_flash(message: "Successful update.")
+        end
+
+        def expect_rule_checked(rule)
+          expect(page).to have_checked_field I18n.t("label_password_rule_#{rule}")
+        end
+
+        def expect_rule_unchecked(rule)
+          expect(page).to have_unchecked_field I18n.t("label_password_rule_#{rule}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/74398

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Save that the Admin unchecked all the password rules.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The same as Rails, with a sentinel hidden field:

* That’s what the first commit does;
* The second commit introduces a new argument for checkbox groups, `include_hidden`, to mimic Rails [checkbox](https://apidock.com/rails/ActionView/Helpers/FormHelper/check_box) convenient API.

I haven’t updated every use of this technic in the codebase, but there are others, for instance:

```diff
diff --git a/app/forms/admin/settings/repositories_settings_form.rb b/app/forms/admin/settings/repositories_settings_form.rb
index 840c09213ee..c54b09eafd9 100644
--- a/app/forms/admin/settings/repositories_settings_form.rb
+++ b/app/forms/admin/settings/repositories_settings_form.rb
@@ -87,16 +87,9 @@ module Admin
           end
         end
 
-        # Primer, unlike Rails' check_box helper, does not render this auxilary hidden field for us.
-        sf.hidden(
-          name: "settings[enabled_scm][]",
-          value: "",
-          scope_name_to_model: false,
-          scope_id_to_model: false
-        )
-
         sf.check_box_group(
           name: :enabled_scm,
+          include_hidden: true,
           values: available_scms
         )
 
diff --git a/app/forms/projects/copy_options_form.rb b/app/forms/projects/copy_options_form.rb
index 2978b2fa465..40ef9dad969 100644
--- a/app/forms/projects/copy_options_form.rb
+++ b/app/forms/projects/copy_options_form.rb
@@ -35,10 +35,7 @@ module Projects
     option :dependencies_label
 
     form do |f|
-      # Primer, unlike Rails' check_box helper, does not render this auxilary hidden field for us.
-      f.hidden name: "copy_options[dependencies][]", value: "", scope_name_to_model: false
-
-      f.check_box_group(name: :dependencies, label: dependencies_label) do |group|
+      f.check_box_group(name: :dependencies, include_hidden: true, label: dependencies_label) do |group|
         CopyOptions.all_dependencies.each do |value, label|
           group.check_box label:, value:
         end
```

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
