### PR TITLE
Update op-blocknote-extensions to version 0.0.24 for improvements in the search input

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.1.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.24/op-blocknote-extensions-0.0.24.tgz",
         "openapi-explorer": "^2.4.788",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -20127,9 +20127,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.0.23",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
-      "integrity": "sha512-QMGmGYt4KXooWRuYN8bVV+6oJVoeMmXBrQ8qlPaVeIzqS4fx7aWHQ6WU2vLuQAXVOF7SQweRTPnRKfpLG6O4eg==",
+      "version": "0.0.24",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.24/op-blocknote-extensions-0.0.24.tgz",
+      "integrity": "sha512-9y6EsPKUgDAQHpXvFGV1vJYgv3fOW5XhkJCN+3jee2l6SxCcYBwSEc9ZibuwhgBXpazXPGNC8IMt6E6FhBt5jQ==",
       "dependencies": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",
@@ -38941,8 +38941,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
-      "integrity": "sha512-QMGmGYt4KXooWRuYN8bVV+6oJVoeMmXBrQ8qlPaVeIzqS4fx7aWHQ6WU2vLuQAXVOF7SQweRTPnRKfpLG6O4eg==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.24/op-blocknote-extensions-0.0.24.tgz",
+      "integrity": "sha512-9y6EsPKUgDAQHpXvFGV1vJYgv3fOW5XhkJCN+3jee2l6SxCcYBwSEc9ZibuwhgBXpazXPGNC8IMt6E6FhBt5jQ==",
       "requires": {
         "@blocknote/core": "^0.44.2",
         "@blocknote/mantine": "^0.44.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -162,7 +162,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.1.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.23/op-blocknote-extensions-0.0.23.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.0.24/op-blocknote-extensions-0.0.24.tgz",
     "openapi-explorer": "^2.4.788",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
       expect(page).to have_test_selector("blocknote-document-description")
 
       editor.open_add_work_package_dialog
-      editor.element.fill_in("Link existing work package", with: "test")
+      editor.search_work_package("test")
       expect(editor.element).to have_content("AAA test") # wait for dropdown to open
       expect(editor.element.text).to match(/AAA test.*CCC test.*BBB test/m)
     end
@@ -114,10 +114,10 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
       expect(page).to have_test_selector("blocknote-document-description")
 
       editor.open_add_work_package_dialog
-      editor.element.fill_in("Link existing work package", with: "tiger")
-      editor.element.all("div", text: "pet a tiger").last.click
+      editor.search_and_select_work_package("tiger", "pet a tiger")
 
-      expect(editor.element).to have_no_content("Link existing work package") # search dialog is closed
+      expect(editor.element).to have_no_text("Link existing work package") # search dialog is closed
+      expect(editor.element).to have_no_text("Loading") # work package is loaded
       expect(editor.element.text).to match(/LIFE GOALS\s#\d+\sOpen\spet a tiger/)
 
       # Capybara's have_link seems not to work in a shadow dom, so it's tested via the property

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -28,6 +28,19 @@ module FormFields
         input.attach_file(path, make_visible: true)
       end
 
+      def search_work_package(text)
+        page.execute_script(fill_in_work_package_search_input(text))
+      end
+
+      def search_and_select_work_package(search_term, subject)
+        # These two actions have to be done together in one execution,
+        # because otherwise the onBlur of the search input triggers and
+        # removes the whole search input from the DOM
+        page.evaluate_async_script(<<~JS)
+          #{fill_in_work_package_search_input(search_term)}
+          #{select_from_work_package_dropdown(subject)}
+        JS
+      end
       def content
         # capybara does not yet support getting content directly
         # on shadow roots
@@ -52,6 +65,76 @@ module FormFields
       # as cuprite does not support shadow dom (yet).
       def send_keys_to_editor(keys)
         element.send_keys(keys)
+      end
+
+      def shadow_root_observe_js
+        <<~JS
+          function shadowRootWaitFor(shadowRoot, tryFunction, done) {
+            if (tryFunction()) {
+              if (done) done();
+              return;
+            }
+            var observer = new MutationObserver(function() {
+              if (tryFunction()) {
+                observer.disconnect();
+                if (done) done();
+              }
+            });
+            observer.observe(shadowRoot, { childList: true, subtree: true });
+          }
+        JS
+      end
+
+      # Unfortunately, the search input is removed on every blur event (starting with op-blocknote-extensions 0.0.24).
+      # Capybara triggers those and therefore leads to always red tests.
+      # The input needs to be operated completely by javascript to avoid any blurring.
+      def fill_in_work_package_search_input(text)
+        <<~JS
+          (function() {
+            var value = #{text.to_json};
+            var shadowRoot = #{shadow_root_query};
+            #{shadow_root_observe_js}
+
+            // One does not simply call `.value=` on a react input element
+            shadowRootWaitFor(shadowRoot, function() {
+              var input = shadowRoot.querySelector("input[placeholder='Search by work package ID or subject']");
+              if (!input) return false;
+              var valueSetter = Object.getOwnPropertyDescriptor(input, 'value').set;
+              var prototype = Object.getPrototypeOf(input);
+              var prototypeValueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+              prototypeValueSetter.call(input, value);
+              input.dispatchEvent(new Event('change', { bubbles: true }));
+              return true;
+            });
+          })();
+        JS
+      end
+
+      # Unfortunately, the search input is removed on every blur event (starting with op-blocknote-extensions 0.0.24).
+      # Capybara triggers those and therefore leads to always red tests.
+      # The input needs to be operated completely by javascript to avoid any blurring.
+      def select_from_work_package_dropdown(text)
+        <<~JS
+          (function(done) {
+            var shadowRoot = #{shadow_root_query};
+            var textToClick = #{text.to_json}.trim();
+            #{shadow_root_observe_js}
+
+            shadowRootWaitFor(shadowRoot, function() {
+              var element = Array.prototype.slice.call(shadowRoot.querySelectorAll("div"))
+                .find(function(div) { return div.textContent.trim() === textToClick; });
+              if (element) {
+                element.dispatchEvent(new Event("mousedown", { bubbles: true }));
+                return true;
+              }
+              return false;
+            }, done);
+          })(arguments[arguments.length - 1]);
+        JS
+      end
+
+      def shadow_root_query
+        "document.querySelector('op-block-note').shadowRoot;"
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69706

# What are you trying to accomplish?
Fix tests that broke with version 0.0.24 of op-blocknote-extensions.
Most tests for the link work package blocks are in the op-blocknote-extensions repository but we should have some smoke tests here as well.

# What approach did you choose and why?
Doing all interactions with the search input with javascript, because capybara triggers the blur event which removes the whole element from the DOM. This is not nice and I'm sorry. I tried to challenge the requirements for this but it was decided to keep it like this at least for now.

# Merge checklist

- [x] Added/updated tests
