### PR TITLE
Removed mention of false tag in Synology docu

### DIFF
--- a/docs/installation-and-operations/installation/synology/README.md
+++ b/docs/installation-and-operations/installation/synology/README.md
@@ -13,7 +13,6 @@ Launching OpenProject works like launching any other container in [Synology](htt
 
 First you have to go to the **Registry** section and download the OpenProject image.
 It's best to choose the specific tag of the latest stable version (`openproject/openproject:17` at the time of writing).
-You can use `:latest` too but it might lead to surprises when a major version upgrade happens.
 
 Below are some settings you have to pay attention to when launching the container.
 


### PR DESCRIPTION
removed mention of a `:latest` tag. This tag is not provided anymore. We recommend to use the stable version tag.

Reviewers: Docs team

# What are you trying to accomplish?
Remove a mention of an image tag which is no longer published and caused confusion amongst Synology NAS users.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
