### PR TITLE
hide closed work packages on backlog buckets

### DIFF
--- a/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
@@ -42,7 +42,7 @@ module Backlogs
       @backlog_bucket = backlog_bucket
       @project = project
       @current_user = current_user
-      @work_packages = backlog_bucket.work_packages
+      @work_packages = backlog_bucket.displayed_work_packages
 
       @system_arguments = system_arguments
       @system_arguments[:id] = dom_id(backlog_bucket)

--- a/modules/backlogs/app/models/agile/backlog_bucket.rb
+++ b/modules/backlogs/app/models/agile/backlog_bucket.rb
@@ -32,13 +32,17 @@ class Agile::BacklogBucket < ApplicationRecord
   self.table_name = "backlog_buckets"
 
   belongs_to :project
-  has_many :work_packages, -> { order_by_position }, inverse_of: :backlog_bucket, dependent: :nullify
+  has_many :work_packages, inverse_of: :backlog_bucket, dependent: :nullify
+  has_many :displayed_work_packages, # rubocop:disable Rails/HasManyOrHasOneDependent
+           -> { visible(User.current).with_status_open.order_by_position },
+           class_name: "WorkPackage",
+           inverse_of: :backlog_bucket
 
   scope :order_alphabetically, -> { order(:name) }
 
   validates :name, :project, presence: true
 
   def self.for_project(project)
-    where(project:).order_alphabetically.includes(:work_packages)
+    where(project:).order_alphabetically.includes(:displayed_work_packages)
   end
 end

--- a/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
+++ b/modules/backlogs/spec/features/backlog_buckets/display_spec.rb
@@ -36,17 +36,20 @@ RSpec.describe "Backlog bucket display",
                with_flag: { backlog_buckets: true } do
   create_shared_association_defaults_for_work_package_factory
 
-  shared_let(:project) do
-    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
-  end
+  shared_let(:closed_status) { create(:status, is_closed: true) }
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[work_package_tracking backlogs]) }
 
   shared_let(:bucket_beta) { create(:backlog_bucket, project:, name: "Beta bucket") }
   shared_let(:bucket_alpha) { create(:backlog_bucket, project:, name: "Alpha bucket") }
   shared_let(:bucket_gamma) { create(:backlog_bucket, project:, name: "Gamma bucket") }
 
   shared_let(:wp_alpha1) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 1) }
-  shared_let(:wp_alpha2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2) }
-  shared_let(:wp_beta1)  { create(:work_package, project:, backlog_bucket: bucket_beta,  position: 1) }
+  shared_let(:wp_alpha_closed) do
+    create(:work_package, project:, backlog_bucket: bucket_alpha, position: 2, status: closed_status)
+  end
+  shared_let(:wp_alpha2) { create(:work_package, project:, backlog_bucket: bucket_alpha, position: 3) }
+  shared_let(:wp_beta1)  { create(:work_package, project:, backlog_bucket: bucket_beta, position: 1) }
   shared_let(:wp_inbox1) { create(:work_package, project:, backlog_bucket: nil, sprint: nil, position: 1) }
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
@@ -68,11 +71,15 @@ RSpec.describe "Backlog bucket display",
     )
   end
 
-  it "shows the work-package count on populated buckets" do
+  it "shows the work-package count and work packages on populated buckets" do
     backlogs_page.visit!
 
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_alpha, 2)
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(bucket_alpha,
+                                                                  work_packages: [wp_alpha1, wp_alpha2])
     backlogs_page.expect_backlog_bucket_work_package_count(bucket_beta, 1)
+    backlogs_page.expect_work_packages_in_backlog_bucket_in_order(bucket_beta,
+                                                                  work_packages: [wp_beta1])
   end
 
   it "shows the '+ Backlog Bucket' button" do

--- a/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
+++ b/modules/backlogs/spec/models/agile/backlog_bucket_spec.rb
@@ -60,13 +60,37 @@ RSpec.describe Agile::BacklogBucket do
       backlog_bucket.destroy!
       expect(WorkPackage.find(work_package_id).backlog_bucket_id).to be_nil
     end
+  end
 
-    it "orders work packages by position" do
-      work_package_nil = create(:work_package, project:, backlog_bucket:).tap { it.update_columns(position: nil) }
-      work_package2 = create(:work_package, project:, backlog_bucket:, position: 2)
-      work_package1 = create(:work_package, project:, backlog_bucket:, position: 1)
+  describe "#displayed_work_packages" do
+    shared_let(:bucket) { create(:backlog_bucket, project:) }
+    shared_let(:bucket_work_package1) { create(:work_package, project:, backlog_bucket: bucket, position: 1) }
+    shared_let(:closed_bucket_work_package) do
+      create(:work_package, project:, backlog_bucket: bucket, status: create(:status, is_closed: true), position: 2)
+    end
+    shared_let(:bucket_work_package2) { create(:work_package, project:, backlog_bucket: bucket, position: 3) }
+    shared_let(:non_bucket_work_package) { create(:work_package, project:) }
+    shared_let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
+    shared_let(:user) { create(:user, member_with_roles: { project => role }) }
 
-      expect(backlog_bucket.work_packages.reload.to_a).to eq([work_package1, work_package2, work_package_nil])
+    before do
+      login_as user
+    end
+
+    context "when the user is allowed to view work packages" do
+      it "returns the work open work packages in the bucket ordered by position" do
+        expect(bucket.displayed_work_packages.reload).to eq([bucket_work_package1, bucket_work_package2])
+      end
+    end
+
+    context "when the user is not allowed to view work packages" do
+      before do
+        role.remove_permission! :view_work_packages
+      end
+
+      it "returns an empty list" do
+        expect(bucket.displayed_work_packages).to be_empty
+      end
     end
   end
 
@@ -90,8 +114,11 @@ RSpec.describe Agile::BacklogBucket do
     shared_let(:wp_nil_in_bucket1) do
       create(:work_package, project:, backlog_bucket: bucket1).tap { it.update_columns(position: nil) }
     end
-    shared_let(:wp2_in_bucket1) { create(:work_package, project:, backlog_bucket: bucket1, position: 2) }
-    shared_let(:wp1_in_bucket1_first) { create(:work_package, project:, backlog_bucket: bucket1, position: 1) }
+    shared_let(:wp2_in_bucket1) { create(:work_package, project:, backlog_bucket: bucket1, position: 3) }
+    shared_let(:wp1_in_bucket1) { create(:work_package, project:, backlog_bucket: bucket1, position: 2) }
+    shared_let(:closed_wp_in_bucket1) do
+      create(:work_package, project:, backlog_bucket: bucket1, position: 1, status: create(:status, is_closed: true))
+    end
 
     shared_let(:wp_in_bucket2) { create(:work_package, project:, backlog_bucket: bucket2) }
 
@@ -104,6 +131,12 @@ RSpec.describe Agile::BacklogBucket do
     shared_let(:wp_other_project) { create(:work_package, project: other_project, backlog_bucket: other_bucket) }
     shared_let(:wp_other_project_unbucketed) { create(:work_package, project: other_project, backlog_bucket: nil) }
 
+    shared_let(:user) { create(:user, member_with_permissions: { project => %i[view_work_packages] }) }
+
+    before do
+      login_as user
+    end
+
     subject(:result) { described_class.for_project(project) }
 
     it "returns the project buckets" do
@@ -115,7 +148,14 @@ RSpec.describe Agile::BacklogBucket do
     end
 
     it "orders work packages within a bucket by position, with nil position last" do
-      expect(bucket1.work_packages.reload).to eq([wp1_in_bucket1_first, wp2_in_bucket1, wp_nil_in_bucket1])
+      expect(result.first.displayed_work_packages).to eq([wp1_in_bucket1, wp2_in_bucket1, wp_nil_in_bucket1])
+    end
+
+    it "eager loads the displayed work packages" do
+      result.to_a
+
+      expect { result.first.displayed_work_packages }.to have_a_query_limit(0)
+      expect { result.last.displayed_work_packages }.to have_a_query_limit(0)
     end
   end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74563

# What are you trying to accomplish?

Hide closed work packages from backlog buckets.

There are a few shortcomings to this PR:
* When moving a work package into a bucket (e.g. drag & drop) it just vanishes. The message there isn't very good. The same problem exists with the inbox though. A cleanup of this would best be done once the move actions are consolidated.
* The solution relies on a view specific association (`displayed_work_packages`). This approach was chosen to get the eager loading already in place working again. However, this is different to how the data is loaded for sprints. Again, it was deemed best to wait until the component cleanup is done so that a consolidated loading strategy can be designed.

# Merge checklist

- [x] Added/updated tests