### PR TITLE
Fix a regression preventing groups to be assigned to labor cost items…

### DIFF
--- a/modules/budgets/app/models/budget.rb
+++ b/modules/budgets/app/models/budget.rb
@@ -258,8 +258,7 @@ class Budget < ApplicationRecord
   def valid_labor_budget_attributes?(attributes)
     attributes &&
       attributes[:hours].to_f.positive? &&
-      attributes[:user_id].to_i.positive? &&
-      Principal.possible_assignee(project).where(id: attributes[:user_id].to_i).exists?
+      attributes[:user_id].to_i.positive?
   end
 
   def valid_material_budget_attributes?(attributes)

--- a/modules/budgets/app/models/labor_budget_item.rb
+++ b/modules/budgets/app/models/labor_budget_item.rb
@@ -76,7 +76,7 @@ class LaborBudgetItem < ApplicationRecord
   def user_is_member_of_budget_project
     return if principal.nil? || budget&.project.nil?
 
-    unless principal.member_of?(budget.project)
+    unless Principal.possible_assignee(budget.project).exists?(id: principal.id)
       errors.add(:principal, :not_a_member_of_budget_project)
     end
   end

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
         subject: "Subject"
         type: "Cost type"
         labor_budget: "Planned labor costs"
+        labor_budget_items: "Planned labor costs"
         material_budget: "Planned unit costs"
         base_amount: "Base amount"
       work_package:
@@ -56,6 +57,7 @@ en:
               not_a_member_of_budget_project: "is not a member of the budget's project"
     models:
       budget: "Budget"
+      labor_budget_item: "Planned labor cost"
       material_budget_item: "Unit"
 
   activity:

--- a/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
+++ b/modules/budgets/spec/components/budgets/widgets/budget_by_cost_type_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Budgets::Widgets::BudgetByCostType, type: :component do
 
   let(:project) { create(:project_with_types) }
   let(:current_user) do
-    create(:user, member_with_permissions: { project => %i[view_budgets view_cost_rates view_hourly_rates] })
+    create(:user, member_with_permissions: { project => %i[view_budgets view_cost_rates
+                                                           view_hourly_rates work_package_assigned] })
   end
 
   subject(:rendered_component) { render_component(project, current_user:) }

--- a/modules/budgets/spec/factories/labor_budget_item_factory.rb
+++ b/modules/budgets/spec/factories/labor_budget_item_factory.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       next unless project&.persisted? && principal&.persisted?
       next if Member.exists?(principal:, project:)
 
-      role = create(:project_role, permissions: [])
+      role = create(:project_role, permissions: %i[work_package_assigned])
       create(:member, principal:, project:, roles: [role])
     end
   end

--- a/modules/budgets/spec/features/budgets/update_budget_spec.rb
+++ b/modules/budgets/spec/features/budgets/update_budget_spec.rb
@@ -330,4 +330,23 @@ RSpec.describe "updating a budget", :js, with_settings: { costs_currency: "EUR" 
       expect(budget_page.labor_costs_at(1)).to have_no_content "125.00 EUR"
     end
   end
+
+  describe "with a group as planned labor cost" do
+    let(:group) { create(:group, member_with_permissions: { project => %i[work_package_assigned] }) }
+    let(:budget_page) { Pages::EditBudget.new budget.id }
+
+    before { group }
+
+    it "saves the budget without error and displays the group on the show page" do
+      budget_page.visit!
+      click_on "Update"
+
+      budget_page.add_labor_costs! 5, user_name: group.name, comment: "team work"
+
+      click_on "Submit"
+      expect(budget_page).to have_content("Successful update")
+
+      expect(page).to have_css(".labor_budget_items tbody td", text: group.name)
+    end
+  end
 end

--- a/modules/budgets/spec/models/budgets/aggregated_budgets_spec.rb
+++ b/modules/budgets/spec/models/budgets/aggregated_budgets_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Budgets::AggregatedBudgets do
     context "with all components" do
       let(:user_with_rates) do
         create(:user,
-               member_with_permissions: { project => %i[view_budgets view_cost_rates view_hourly_rates] })
+               member_with_permissions: { project => %i[view_budgets view_cost_rates view_hourly_rates work_package_assigned] })
       end
       let(:aggregated) { described_class.new(project:, current_user: user_with_rates) }
       let!(:cost_type) { create(:cost_type) }

--- a/modules/budgets/spec/models/budgets/aggregated_budgets_with_spend_spec.rb
+++ b/modules/budgets/spec/models/budgets/aggregated_budgets_with_spend_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Budgets::AggregatedBudgetsWithSpend do
                                                     view_cost_entries
                                                     view_cost_rates
                                                     view_time_entries
-                                                    view_hourly_rates] })
+                                                    view_hourly_rates
+                                                    work_package_assigned] })
   end
   shared_let(:work_package) { create(:work_package, project: project) }
 

--- a/modules/budgets/spec/models/labor_budget_item_spec.rb
+++ b/modules/budgets/spec/models/labor_budget_item_spec.rb
@@ -29,8 +29,9 @@
 require_relative "../spec_helper"
 
 RSpec.describe LaborBudgetItem do
-  let(:item) { build(:labor_budget_item, budget:, user:) }
+  let(:item) { build(:labor_budget_item, budget:, principal:) }
   let(:budget) { build(:budget, project:) }
+  let(:principal) { user }
   let(:user) { create(:user) }
   let(:user2) { create(:user) }
   let(:rate) do
@@ -101,7 +102,7 @@ RSpec.describe LaborBudgetItem do
       before do
         item.save!
         item.reload
-        item.update_attribute(:user_id, user.id)
+        item.update(user_id: user.id)
         item.reload
       end
 
@@ -109,12 +110,13 @@ RSpec.describe LaborBudgetItem do
     end
 
     describe "WHEN a group is provided" do
+      let(:principal) { group }
       let(:group) { create(:group) }
 
       before do
         item.save!
         item.reload
-        item.update_attribute(:user_id, group.id)
+        item.update(user_id: group.id)
         item.reload
       end
 
@@ -125,7 +127,7 @@ RSpec.describe LaborBudgetItem do
       before do
         item.save!
         item.reload
-        item.update_attribute(:user_id, user.id)
+        item.update(user_id: user.id)
         user.destroy
         item.reload
       end
@@ -206,6 +208,30 @@ RSpec.describe LaborBudgetItem do
       it "skips the membership check and does not add a membership error" do
         item.valid?
         expect(item.errors.where(:principal, :not_a_member_of_budget_project)).to be_empty
+      end
+    end
+
+    describe "WHEN a group is provided as principal" do
+      let(:group) { create(:group) }
+
+      before do
+        create(:member, principal: group, project:, roles: [create(:project_role, permissions: %i[work_package_assigned])])
+        item.principal = group
+      end
+
+      it "is valid when the group is a member of the budget project" do
+        expect(item).to be_valid
+      end
+
+      context "when the group is not a member of the budget project" do
+        before do
+          Member.where(principal: group, project:).destroy_all
+        end
+
+        it "is not valid" do
+          expect(item).not_to be_valid
+          expect(item.errors.where(:principal, :not_a_member_of_budget_project)).not_to be_empty
+        end
       end
     end
   end

--- a/modules/budgets/spec/models/labor_budget_items/scopes/visible_spec.rb
+++ b/modules/budgets/spec/models/labor_budget_items/scopes/visible_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe LaborBudgetItems::Scopes::Visible do
   shared_let(:other_user) { create(:user) }
   shared_let(:user) do
     create(:user,
-           member_with_permissions: { view_project => %i[view_hourly_rates],
-                                      view_own_project => %i[view_own_hourly_rate] })
+           member_with_permissions: { view_project => %i[view_hourly_rates work_package_assigned],
+                                      view_own_project => %i[view_own_hourly_rate work_package_assigned] })
   end
   shared_let(:view_budget) { create(:budget, project: view_project) }
   shared_let(:view_own_budget) { create(:budget, project: view_own_project) }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/74197

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Fix the validation raising an undefined method `member_of?` when a group was assigned to a labor cost item.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

The validation now matches the principal against the same principals list as the one populating the select in the UI: if it’s in the select, it passes the validation.

I had to update some specs to add the relevant permissions.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
