### PR TITLE
fix issue where openprojects takes a long time to start due to chown

### DIFF
--- a/docker/prod/entrypoint.sh
+++ b/docker/prod/entrypoint.sh
@@ -49,17 +49,17 @@ if [ "$(id -u)" = '0' ]; then
 	echo "-----> Setting PGVERSION=$PGVERSION PGBIN=$PGBIN PGCONF_FILE=$PGCONF_FILE"
 	export PATH="$PGBIN:$PATH"
 
-	mkdir -p $APP_DATA_PATH/{files,git,svn}
+	mkdir -p "$APP_DATA_PATH"/{files,git,svn}
 	# The $APP_DATA_PATH may be hosted on a NAS that creates snapshots (or a btrfs filesystem). In such a case, the .snapshot folder cannot be touched.
-  find $APP_DATA_PATH | grep -v .snapshot | xargs -n 1 chown $APP_USER:$APP_USER
+	find "$APP_DATA_PATH" -path '*/.snapshot*' -prune -o -exec chown "$APP_USER:$APP_USER" {} +
 	if [ -d /etc/apache2/sites-enabled ]; then
-		chown -R $APP_USER:$APP_USER /etc/apache2/sites-enabled
+		chown -R "$APP_USER:$APP_USER" /etc/apache2/sites-enabled
 		echo "OpenProject currently expects to be reached on the following domain: ${SERVER_NAME:=localhost}, which does not seem to be how your installation is configured." > /var/www/html/index.html
 		echo "If you are an administrator, please ensure you have correctly set the SERVER_NAME variable when launching your container." >> /var/www/html/index.html
 	fi
 
 	# Clean up any dangling PID file
-	rm -f $APP_PATH/tmp/pids/*
+	rm -f "$APP_PATH"/tmp/pids/*
 
 	# Clean up a dangling PID file of apache
 	if [ -e "$APACHE_PIDFILE" ]; then


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
This chown causes our instance to take many minutes to restart. I want to improve upon that

## ~~Screenshots~~
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
chown allows for more than one file as argument so i use that to reduce the amount of fork and execve syscalls required. (find ... -exec ... + calls the command with all files combined once)

i created a test folder with some test files:
```bash
find . -type f | wc -l
576749
```

old variant `find . | grep -v .snapshot | xargs -n 1 chown 1000:1000` i aborted it after 5min 
my proposal `find . -not -path '*/.snapshot*' -exec chown 1000:1000 {} +` took 13s

# Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~
