### PR TITLE
[#74516] Sprints API defaults to maximum page size

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/api/work_package_schema_representer.rb
@@ -59,7 +59,7 @@ module OpenProject::Backlogs
                                          backlogs_constraint_passed?(:sprint)
                                      },
                                      href_callback: ->(*) {
-                                       api_v3_paths.project_sprints(represented.project_id)
+                                       "#{api_v3_paths.project_sprints(represented.project_id)}?pageSize=-1"
                                      }
 
             define_method :backlogs_constraint_passed? do |attribute|

--- a/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     it_behaves_like "links to allowed values via collection link" do
-      let(:href) { api_v3_paths.project_sprints(project.id) }
+      let(:href) { "#{api_v3_paths.project_sprints(project.id)}?pageSize=-1" }
     end
 
     context "when lacking permission to set the sprint" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74516

# What are you trying to accomplish?
The work package detail page should allow users to search within all (valid) sprints within the sprint inline edit field.

# Screenshots
https://github.com/user-attachments/assets/22ed0a99-46aa-4894-8af2-7ff4572fbbe7

# What approach did you choose and why?
There where 2 options that I considered when implementing this:

1. Create another API endpoint that offers an unpaginated collection representer and add a custom sprint edit field component that uses the new endpoint to fetch all sprints, effectively bypassing all pagination for sprints.
2. Set a pageSize of `-1` within the href_callback so that the existing edit field component uses the configured max page size when fetching sprints.

I went with option 2 since it's a minimal change and should be good enough for the vast majority of installations. Most setups probably do not have more eligible sprints than the default page size.

Introducing a new API endpoint would have added more, arguably unneeded complexity. Additionally, introducing a custom `SelectEditFieldComponent` for sprints would have required us to add that one to the frontend directory, polluting the core with module specifics. Also, if there really _are_ a lot of sprints, having _some_ kind of maximum page size is a safe guard that is worth keeping.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
