### PR TITLE
[#74636] The all parameter is lost when using the finish sprint dialog

### DIFF
--- a/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
 
     d.with_body do
       primer_form_with(
-        url: finish_project_backlogs_sprint_path(project, sprint),
+        url: finish_project_backlogs_sprint_path(project, sprint, all_backlogs_params),
         method: :post,
         id: FORM_ID,
         data: { controller: "show-when-value-selected" }

--- a/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/finish_sprint_dialog_component.rb
@@ -32,6 +32,7 @@ module Backlogs
   class FinishSprintDialogComponent < ApplicationComponent
     include OpTurbo::Streamable
     include OpPrimer::ComponentHelpers
+    include CommonHelper
 
     DIALOG_ID = "finish-sprint-dialog"
     FORM_ID = "finish-sprint-dialog-form"

--- a/modules/backlogs/spec/components/backlogs/finish_sprint_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/finish_sprint_dialog_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::FinishSprintDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:admin) { create(:admin) }
+  current_user { admin }
+
+  let(:project) { create(:project) }
+  let(:sprint) { create(:agile_sprint, project:, name: "Sprint 1", status: "active") }
+  let(:available_sprints) { [] }
+
+  def render_component
+    render_inline(described_class.new(sprint:, project:, available_sprints:))
+  end
+
+  it "renders the finish sprint dialog title" do
+    render_component
+
+    expect(page).to have_text(I18n.t("backlogs.finish_sprint_dialog_component.title"))
+  end
+
+  it "renders the form targeting the finish sprint path" do
+    render_component
+
+    expect(page).to have_element(:form, action: finish_project_backlogs_sprint_path(project, sprint))
+  end
+
+  it "does not include the all parameter in the form action by default" do
+    render_component
+
+    expect(page).to have_no_css("form[action*='all=']", visible: :all)
+  end
+
+  context "when params[:all] is true" do
+    before { vc_test_controller.params[:all] = "1" }
+
+    it "propagates the all parameter in the form action" do
+      render_component
+
+      expect(page).to have_css(
+        "form[action='#{finish_project_backlogs_sprint_path(project, sprint, all: 1)}']",
+        visible: :all
+      )
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74636

# What are you trying to accomplish?
Maintain the backlog expanded state after submitting the finish sprint dialog.

# What approach did you choose and why?
- Pass the `all` param to the finish sprint dialog form.
# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
