### PR TITLE
Fix direct login for unauthenticated requests to OAuth authorize

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -356,7 +356,7 @@ class AccountController < ApplicationController
   end
 
   def direct_login(user)
-    if flash.empty?
+    if !flash_message_pending?
       ps = {}.tap do |p|
         p[:origin] = params[:back_url] if params[:back_url]
       end
@@ -445,6 +445,12 @@ class AccountController < ApplicationController
     flash[:error] = I18n.t(:notice_account_invalid_token)
 
     redirect_to signin_path
+  end
+
+  def flash_message_pending?
+    # confirm that the flash contains a message to be rendered, but ignore
+    # other flash content (such as _csp_appends)
+    flash.keys.map(&:to_s).intersect?(%w[notice warning error])
   end
 
   def apply_csp_appends

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -357,9 +357,8 @@ class AccountController < ApplicationController
 
   def direct_login(user)
     if !flash_message_pending?
-      ps = {}.tap do |p|
-        p[:origin] = params[:back_url] if params[:back_url]
-      end
+      ps = {}
+      ps[:origin] = params[:back_url] if params[:back_url]
 
       redirect_to direct_login_provider_url(ps)
     elsif Setting.login_required?

--- a/spec/features/auth/omniauth_spec.rb
+++ b/spec/features/auth/omniauth_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "Omniauth authentication" do
     end
 
     context "with direct login",
-            with_config: { omniauth_direct_login_provider: "developer" } do
+            with_settings: { omniauth_direct_login_provider: "developer" } do
       it "goes directly to the developer sign in and then redirect to the back url" do
         visit my_account_path
         # requires login, redirects to developer login which is why we see the login form now
@@ -110,7 +110,7 @@ RSpec.describe "Omniauth authentication" do
   end
 
   describe "sign out a user with direct login and login required",
-           with_config: { omniauth_direct_login_provider: "developer", login_required: true } do
+           with_settings: { omniauth_direct_login_provider: "developer", login_required: true } do
     it "shows a notice that the user has been logged out" do
       visit signout_path
 
@@ -217,13 +217,29 @@ RSpec.describe "Omniauth authentication" do
     end
 
     context "with direct login enabled and login required",
-            with_config: { omniauth_direct_login_provider: "developer" } do
-      before do
-        allow(Setting).to receive(:login_required?).and_return(true)
-      end
-
+            with_settings: { omniauth_direct_login_provider: "developer", login_required: true } do
       it_behaves_like "registration with registration by email" do
         let(:login_path) { "/auth/developer" }
+      end
+
+      context "when authorizing an external OAuth app" do
+        let(:oauth_client) { create(:oauth_application, redirect_uri: "https://rp.example.com/callback") }
+
+        it "logs in and registers successfully" do
+          visit oauth_authorization_path(
+            client_id: oauth_client.uid,
+            redirect_uri: oauth_client.redirect_uri,
+            response_type: "code",
+            prompt: "login"
+          )
+
+          SeleniumHubWaiter.wait
+          fill_in "email", with: user.mail # login form developer strategy
+
+          click_link_or_button "Sign In"
+
+          expect(page).to have_current_path(oauth_authorization_path, ignore_query: true)
+        end
       end
     end
   end
@@ -255,11 +271,7 @@ RSpec.describe "Omniauth authentication" do
     end
 
     context "with direct login and login required",
-            with_config: { omniauth_direct_login_provider: "developer" } do
-      before do
-        allow(Setting).to receive(:login_required?).and_return(true)
-      end
-
+            with_settings: { omniauth_direct_login_provider: "developer", login_required: true } do
       it_behaves_like "omniauth signin error" do
         let(:login_path) { signin_path }
         let(:instructions) { "You can try to sign in again by clicking" }


### PR DESCRIPTION
This was caused by a "cross reaction" of sorts.
    
bbd4cad40 tried to fix a redirect loop by checking for the presence of content in `flash` (assuming that this meant the presence of a text message to be shown to the user).
    
0fa8b4a77 used the flash storage to forward CSP extensions so they are usable for exactly one follow-up request. While this is an allowed usage of `flash`, it was sufficiently far away from what it's usually used for that it threw over expectations of the former change and consequently led to breaking the direct login workflow.


# Ticket
https://community.openproject.org/wp/74569