### PR TITLE
improve visiblity of notice on why attachments cannot be backed up

### DIFF
--- a/frontend/src/app/core/setup/globals/components/admin/backup.component.html
+++ b/frontend/src/app/core/setup/globals/components/admin/backup.component.html
@@ -34,25 +34,31 @@
         <span class="icon icon-error"></span>
         <span>{{ text.note }}</span>
       </p>
-      <div>
-        <fieldset class="form--fieldset">
-          <legend class="form--fieldset-legend">
-            {{ text.options }}
-          </legend>
-          <label class="form--label-with-check-box" [title]="includeAttachmentsTitle()">
-            <div class="form--check-box-container">
-              <input
-                type="checkbox"
-                class="form--check-box"
-                [checked]="includeAttachments"
-                (change)="includeAttachments = !includeAttachments"
-                [disabled]="!mayIncludeAttachments"
-              >
-            </div>
-            {{ text.includeAttachments }}
-          </label>
-        </fieldset>
-      </div>
+      @if (mayIncludeAttachments) {
+        <div>
+          <fieldset class="form--fieldset">
+            <legend class="form--fieldset-legend">
+              {{ text.options }}
+            </legend>
+            <label class="form--label-with-check-box">
+              <div class="form--check-box-container">
+                <input
+                  type="checkbox"
+                  class="form--check-box"
+                  [checked]="includeAttachments"
+                  (change)="includeAttachments = !includeAttachments"
+                >
+              </div>
+              {{ text.includeAttachments }}
+            </label>
+          </fieldset>
+        </div>
+      } @else {
+        <p class="danger-zone--warning">
+          <span class="icon icon-error"></span>
+          <span>{{ text.attachmentsDisabled }}</span>
+        </p>
+      }
       <div class="danger-zone--verification">
         <input
           type="password"

--- a/frontend/src/app/core/setup/globals/components/admin/backup.component.ts
+++ b/frontend/src/app/core/setup/globals/components/admin/backup.component.ts
@@ -96,10 +96,6 @@ export class BackupComponent implements AfterViewInit {
     return this.pathHelper.attachmentDownloadPath(this.lastBackupAttachmentId, undefined);
   }
 
-  public includeAttachmentsTitle():string {
-    return this.mayIncludeAttachments ? '' : this.text.attachmentsDisabled;
-  }
-
   public triggerBackup(event?:Event) {
     if (event) {
       event.stopPropagation();


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/71237

# What are you trying to accomplish?

Quick adaptation on the backup danger zone to explain why attachments cannot be downloaded. The only change is that the text previously only displayed as a title attribute is now rendered as a warning if the size is exceeded.