### PR TITLE
Use link_translate for LDAP group sync documentation

### DIFF
--- a/config/static_links.yml
+++ b/config/static_links.yml
@@ -184,10 +184,12 @@ sysadmin_docs:
     href: https://www.openproject.org/docs/system-admin-guide/users-permissions/roles-permissions/#roles-and-permissions
   ldap:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/ldap-connections/
+  ldap_group_sync:
+    href: https://www.openproject.org/docs/system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/
   mcp_resources:
-   href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#resources
+    href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#resources
   mcp_tools:
-   href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#tools
+    href: https://www.openproject.org/docs/system-admin-guide/integrations/mcp-server/#tools
   oidc:
     href: https://www.openproject.org/docs/system-admin-guide/authentication/openid-providers/
   oidc_acr_values:

--- a/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
+++ b/modules/ldap_groups/app/views/ldap_groups/synchronized_groups/index.html.erb
@@ -42,7 +42,14 @@
 <div class="op-toast -info">
   <div class="op-toast--content">
     <strong><%= t("note") %></strong>
-    <%= t("ldap_groups.synchronized_groups.help_text_html") %>
+    <%=
+      link_translate(
+        "ldap_groups.synchronized_groups.help_text_html",
+        links: {
+          docs_url: %i[sysadmin_docs ldap_group_sync]
+        }
+      )
+    %>
   </div>
 </div>
 

--- a/modules/ldap_groups/config/locales/en.yml
+++ b/modules/ldap_groups/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
         It depends on LDAP groups need to use the <em>groupOfNames / memberOf</em> attribute set to be working with OpenProject.
         <br/>
         Groups are synchronized hourly through a cron job.
-        <a href="https://www.openproject.org/help/administration/manage-ldap-authentication/">Please see our documentation on this topic</a>.
+        [Please see our documentation on this topic](docs_url).
 
       no_results: 'No synchronized groups found.'
       no_members: 'This group has no synchronized members yet.'


### PR DESCRIPTION
This avoids hardcoding the documentation URL in the translation file (easier to update) and makes the link localized.

Also fix the url from https://www.openproject.org/help/administration/manage-ldap-authentication/ (which was redirecting to https://www.openproject.org/docs/system-admin-guide/authentication/ldap-connections/) to https://www.openproject.org/docs/system-admin-guide/authentication/ldap-connections/ldap-group-synchronization/