### PR TITLE
Fix delete confirmation text

### DIFF
--- a/app/components/my/access_token/oauth_application/row_component.rb
+++ b/app/components/my/access_token/oauth_application/row_component.rb
@@ -46,9 +46,13 @@ module My
           end
         end
 
+        def active_token_count
+          oauth_application_tokens.count { |t| !t.expired? && !t.revoked? }
+        end
+
         def active_tokens
           render(Primer::Beta::Text.new(test_selector: "oauth-application-#{oauth_application.id}-active-tokens")) do
-            oauth_application_tokens.count { |t| !t.expired? && !t.revoked? }.to_s
+            active_token_count.to_s
           end
         end
 
@@ -74,11 +78,8 @@ module My
                    data: {
                      turbo_method: :post,
                      turbo_confirm: t(
-                       "oauth.revoke_my_application_confirmation",
-                       token_count: t(
-                         "oauth.x_active_tokens",
-                         count: oauth_application_tokens.count
-                       )
+                       "oauth.confirm_revoke_my_application",
+                       count: active_token_count
                      )
                    }
                  ))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6279,9 +6279,6 @@ en:
       scopes: "Permissions"
       successful_application_revocation: "Revocation of application %{application_name} successful."
       none_given: "No OAuth applications have been granted access to your user account."
-    x_active_tokens:
-      one: "one active token"
-      other: "%{count} active token"
     flows:
       authorization_code: "Authorization code flow"
       client_credentials: "Client credentials flow"
@@ -6291,8 +6288,10 @@ en:
     client_credentials_impersonation_html: >
       By default, OpenProject provides OAuth 2.0 authorization via %{authorization_code_flow_link}.
       You can optionally enable %{client_credentials_flow_link}, but you must provide a user on whose behalf requests will be performed.
+    confirm_revoke_my_application:
+      one: "Do you really want to remove this application? This will revoke one token active for it."
+      other: "Do you really want to remove this application? This will revoke %{count} tokens active for it."
     authorization_error: "An authorization error has occurred."
-    revoke_my_application_confirmation: "Do you really want to remove this application? This will revoke %{token_count} active for it."
     my_registered_applications: "Registered OAuth applications"
 
   oauth_client:


### PR DESCRIPTION
The terms "token" and "active" were duplicated in the translation. It has now been simplified to only translate on a single level, not used two nested translations.

# Ticket
https://community.openproject.org/wp/72958