### PR TITLE
Retry CKEditor setData event in case it's not initialized yet

### DIFF
--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
@@ -69,6 +69,14 @@ export class CKEditorSetupService {
       .createWatchdog(editorClass, contentWrapper, config)
       .then((watchdog:ICKEditorWatchdog) => {
         const { editor } = watchdog;
+        const updateLastUpdated = () => {
+          const editable = wrapper.querySelector<HTMLElement>('.ck-editor__editable_inline');
+          if (!editable) {
+            return;
+          }
+
+          editable.dataset.lastUpdated = String(new Date().getTime());
+        };
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         toolbarWrapper.appendChild(editor.ui.view.toolbar.element);
 
@@ -78,9 +86,11 @@ export class CKEditorSetupService {
         });
         wrapper.addEventListener('op:ckeditor:setData', (event:CustomEvent<string>) => {
           editor.setData(event.detail);
+          updateLastUpdated();
         });
         wrapper.addEventListener('op:ckeditor:clear', () => {
           editor.setData(' ');
+          updateLastUpdated();
         });
         wrapper.addEventListener('op:ckeditor:getData', (event:CustomEvent<(data:string) => void>) => {
           event.detail(editor.getData({ trim: false }));

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -34,9 +34,11 @@ module Components
       wait_until_loaded
 
       textarea = container.find(".op-ckeditor-source-element", visible: :all)
+      last_updated_before = last_updated_for(textarea)
 
       # we set the content using a op:ckeditor:setData custom event.
-      # We need to make sure that CKEditor receives this event by actively calling getData on it again.
+      # We need to make sure that CKEditor receives this event.
+      # We do this by asserting the editable data-last-updated timestamp increases.
       retry_block do
         page.execute_script(
           'arguments[0].dispatchEvent(new CustomEvent("op:ckeditor:setData", { detail: arguments[1] }))',
@@ -44,16 +46,20 @@ module Components
           text
         )
 
-        sleep 0.5
+        last_updated_after = last_updated_for(textarea)
+        expect(last_updated_after).to be >= last_updated_before
+      end
+    end
 
-        data = page.execute_script(<<~JS, textarea.native)
+    def last_updated_for(textarea)
+      page.evaluate_script(<<~JS, textarea.native)
+        (() => {
           const editable = arguments[0].closest('.op-ckeditor--wrapper')
             ?.querySelector('.ck-editor__editable_inline');
-          return editable?.ckeditorInstance?.getData({ trim: false }) ?? null;
-        JS
-
-        expect(data).to be_present
-      end
+          const parsed = Number.parseInt(editable?.dataset?.lastUpdated ?? '0', 10);
+          return Number.isFinite(parsed) ? parsed : 0;
+        })()
+      JS
     end
 
     def clear

--- a/spec/support/components/wysiwyg/wysiwyg_editor.rb
+++ b/spec/support/components/wysiwyg/wysiwyg_editor.rb
@@ -34,11 +34,26 @@ module Components
       wait_until_loaded
 
       textarea = container.find(".op-ckeditor-source-element", visible: :all)
-      page.execute_script(
-        'arguments[0].dispatchEvent(new CustomEvent("op:ckeditor:setData", { detail: arguments[1] }))',
-        textarea.native,
-        text
-      )
+
+      # we set the content using a op:ckeditor:setData custom event.
+      # We need to make sure that CKEditor receives this event by actively calling getData on it again.
+      retry_block do
+        page.execute_script(
+          'arguments[0].dispatchEvent(new CustomEvent("op:ckeditor:setData", { detail: arguments[1] }))',
+          textarea.native,
+          text
+        )
+
+        sleep 0.5
+
+        data = page.execute_script(<<~JS, textarea.native)
+          const editable = arguments[0].closest('.op-ckeditor--wrapper')
+            ?.querySelector('.ck-editor__editable_inline');
+          return editable?.ckeditorInstance?.getData({ trim: false }) ?? null;
+        JS
+
+        expect(data).to be_present
+      end
     end
 
     def clear


### PR DESCRIPTION
Another stab at trying to fix 

```
  1) Work package activity filtering when the work package has comments and changesets resets an only_changes filter if a comment is added by the user
     Failure/Error: expect(page).to have_test_selector("op-journal-notes-body", text:, wait: 10)
       expected page to have test selector op-journal-notes-body with text "Third comment by admin". Also found: "First comment by admin", "Second comment by admin", which matched the selector but not all filters.
     # ./spec/support/components/work_packages/activities.rb:296:in 'Components::WorkPackages::Activities#add_comment'
     # ./spec/features/activities/work_package/activities_spec.rb:686:in 'block (4 levels) in <top (required)>'
```


set_markdown dispatches a op:ckeditor:setData custom event immediately after .ck-content appeared in the DOM.
But the eventlistener for this event is registered inside an async .then() callback in ckeditor-setup.service.ts.

The event listener may not yet be registered at that point, causing inserted text to "vanish" and not be saved at all