### PR TITLE
Add `allow_enabling` attribute to FeatureDecisions

### DIFF
--- a/app/forms/admin/settings/experimental_settings_form.rb
+++ b/app/forms/admin/settings/experimental_settings_form.rb
@@ -39,6 +39,8 @@ module Admin
           visually_hide_label: true
         ) do |group|
           available_feature_flags.each do |(label, name)|
+            next if !setting_value(name) && setting_disabled?(name)
+
             group.check_box(
               name:,
               label:,

--- a/lib_static/open_project/feature_decisions.rb
+++ b/lib_static/open_project/feature_decisions.rb
@@ -74,7 +74,8 @@ module OpenProject
     # Adding a new feature flag:
     #   OpenProject::FeatureDecisions.add :new_ui,
     #                                     description: "Enables the new user interface",
-    #                                     force_active: true
+    #                                     force_active: true,
+    #                                     allow_enabling: true
     #
     # Querying the state of the feature flag:
     #   OpenProject::FeatureDecisions.new_ui_active? # => true or false based on configuration
@@ -82,13 +83,15 @@ module OpenProject
     # @param [Symbol] flag_name The name of the feature flag to add.
     # @param [String, nil] description A description of the feature flag for documentation purposes.
     # @param [Boolean] force_active Whether to force the feature flag to be active in production or development environments.
+    # @param [Boolean] allow_enabling Whether to allow enabling the feature flag via ENV variable or administration.
     # @return [void]
     ##
-    def add(flag_name, description: nil, force_active: false)
+    def add(flag_name, description: nil, force_active: false, allow_enabling: true)
       all << flag_name
       define_flag_methods(flag_name)
       define_setting_definition(flag_name, description:,
-                                           force_active: force_active && (Rails.env.production? || Rails.env.development?))
+                                           force_active: force_active && (Rails.env.production? || Rails.env.development?),
+                                           allow_enabling: allow_enabling)
     end
 
     def active
@@ -105,12 +108,18 @@ module OpenProject
       end
     end
 
-    def define_setting_definition(flag_name, description: nil, force_active: false)
+    def define_setting_definition(flag_name, description: nil, force_active: false, allow_enabling: true)
+      writable = if force_active
+                   false
+                 else
+                   allow_enabling
+                 end
+
       Settings::Definition.add :"feature_#{flag_name}_active",
                                description:,
                                default: force_active || Rails.env.development?,
-                               writable: !force_active,
-                               disallow_override: force_active
+                               writable: writable,
+                               disallow_override: force_active || !allow_enabling
     end
   end
 end

--- a/spec/forms/admin/settings/experimental_settings_form_spec.rb
+++ b/spec/forms/admin/settings/experimental_settings_form_spec.rb
@@ -59,4 +59,17 @@ RSpec.describe Admin::Settings::ExperimentalSettingsForm, :settings_reset, type:
       expect(rendered_form).to have_field "Another example", type: :checkbox, fieldset: "Feature flags"
     end
   end
+
+  context "with a feature flag that has allow_enabling disabled" do
+    before do
+      OpenProject::FeatureDecisions.add :an_example, allow_enabling: false
+      OpenProject::FeatureDecisions.add :another_example
+    end
+
+    it "does not render the disabled flag with a false default", :aggregate_failures do
+      expect(rendered_form).to have_field count: 1, type: :checkbox, fieldset: "Feature flags"
+      expect(rendered_form).to have_no_field "An example", type: :checkbox, fieldset: "Feature flags"
+      expect(rendered_form).to have_field "Another example", type: :checkbox, fieldset: "Feature flags"
+    end
+  end
 end

--- a/spec/lib/open_project/feature_decisions_spec.rb
+++ b/spec/lib/open_project/feature_decisions_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
     end
   end
 
+  shared_context "when adding the feature flag with allow_enabling disabled" do
+    before do
+      described_class.add flag_name, allow_enabling: false
+    end
+  end
+
   describe "`flag_name`_active?" do
     context "without an ENV variable" do
       include_context "when adding the feature flag"
@@ -86,6 +92,25 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
       it "is true" do
         expect(described_class.send(:"#{flag_name}_active?"))
           .to be true
+      end
+    end
+
+    context "with allow_enabling disabled and no ENV variable" do
+      include_context "when adding the feature flag with allow_enabling disabled"
+
+      it "is false by default" do
+        expect(described_class.send(:"#{flag_name}_active?"))
+          .to be false
+      end
+    end
+
+    context "with allow_enabling disabled but ENV variable set to true",
+            with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "true" } do
+      include_context "when adding the feature flag with allow_enabling disabled"
+
+      it "is false (ENV variable is ignored)" do
+        expect(described_class.send(:"#{flag_name}_active?"))
+          .to be false
       end
     end
   end
@@ -133,6 +158,25 @@ RSpec.describe OpenProject::FeatureDecisions, :settings_reset do
       it "is an array with the flag included" do
         expect(described_class.active)
           .to eq [flag_name.to_s]
+      end
+    end
+
+    context "with allow_enabling disabled and no ENV variable" do
+      include_context "when adding the feature flag with allow_enabling disabled"
+
+      it "returns an empty array" do
+        expect(described_class.active)
+          .to eq []
+      end
+    end
+
+    context "with allow_enabling disabled but ENV variable set to true",
+            with_env: { "OPENPROJECT_FEATURE_EXAMPLE_FLAG_ACTIVE" => "true" } do
+      include_context "when adding the feature flag with allow_enabling disabled"
+
+      it "returns an empty array (ENV variable is ignored)" do
+        expect(described_class.active)
+          .to eq []
       end
     end
   end


### PR DESCRIPTION
extracted from #22968, as this might make sense for others.

```ruby
OpenProject::FeatureDecisions.add :some_feature, allow_enabling: Rails.env.local?
```