### PR TITLE
Consistently use secrets definition instead of inherit and fix templates

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -51,7 +51,11 @@ jobs:
     with:
       branch: ${{ needs.compute-inputs.outputs.branch }}
       tag: ${{ needs.compute-inputs.outputs.tag }}
-    secrets: inherit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_APP_PRIVATE_KEY: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+      OPS_MAIL_SMTP_TOKEN: ${{ secrets.OPS_MAIL_SMTP_TOKEN }}
 
   trigger_helm_release:
     if: ${{ github.repository == 'opf/openproject' }}

--- a/.github/workflows/docker-scheduled.yml
+++ b/.github/workflows/docker-scheduled.yml
@@ -13,7 +13,11 @@ jobs:
     with:
       branch: dev
       tag: dev
-    secrets: inherit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_APP_PRIVATE_KEY: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+      OPS_MAIL_SMTP_TOKEN: ${{ secrets.OPS_MAIL_SMTP_TOKEN }}
   build-release-candidate:
     if: github.repository == 'opf/openproject'
     # References to release/X.Y and X.Y-rc are being
@@ -22,4 +26,8 @@ jobs:
     with:
       branch: release/17.4
       tag: 17.4-rc
-    secrets: inherit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_APP_PRIVATE_KEY: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+      OPS_MAIL_SMTP_TOKEN: ${{ secrets.OPS_MAIL_SMTP_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,15 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      DEPLOY_APP_PRIVATE_KEY:
+        required: true
+      OPS_MAIL_SMTP_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       branch:
@@ -44,7 +53,10 @@ jobs:
       use_test_registry: ${{ inputs.use_test_registry }}
       branch: ${{ inputs.branch }}
       tag: ${{ inputs.tag }}
-    secrets: inherit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_APP_PRIVATE_KEY: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
   setup:
     needs: [build-hocuspocus]
     runs-on: ubuntu-latest
@@ -55,17 +67,21 @@ jobs:
           ref: ${{ inputs.branch }}
       - name: Set version outputs and convert tags
         id: extract_version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_USE_TEST_REGISTRY: ${{ inputs.use_test_registry }}
+          REGISTRY_IMAGE: ${{ vars.REGISTRY_IMAGE }}
         run: |
           set -e
-          echo "Processing tag: ${{ inputs.tag }}"
-          ./script/gh/docker-tags.rb "${{ inputs.tag }}" --version
-          ./script/gh/docker-tags.rb "${{ inputs.tag }}" --format-for-docker
+          echo "Processing tag: $INPUT_TAG"
+          ./script/gh/docker-tags.rb "$INPUT_TAG" --version
+          ./script/gh/docker-tags.rb "$INPUT_TAG" --format-for-docker
 
           # Determine registry image based on workflow_dispatch input
-          if [ "${{ inputs.use_test_registry }}" = "true" ]; then
+          if [ "$INPUT_USE_TEST_REGISTRY" = "true" ]; then
             echo "registry_image=openproject/openproject-test" >> "$GITHUB_OUTPUT"
           else
-            echo "registry_image=${{ vars.REGISTRY_IMAGE }}" >> "$GITHUB_OUTPUT"
+            echo "registry_image=$REGISTRY_IMAGE" >> "$GITHUB_OUTPUT"
           fi
       - name: Verify outputs
         run: |
@@ -351,7 +367,8 @@ jobs:
     needs: [setup, build, merge]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/email-notification.yml
-    secrets: inherit
+    secrets:
+      OPS_MAIL_SMTP_TOKEN: ${{ secrets.OPS_MAIL_SMTP_TOKEN }}
     with:
       subject: "Docker build failed"
       body: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/hocuspocus-docker.yml
+++ b/.github/workflows/hocuspocus-docker.yml
@@ -42,6 +42,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      DEPLOY_APP_PRIVATE_KEY:
+        required: true
 
 jobs:
   build:
@@ -62,19 +69,25 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
       - name: Determine tags
         id: tags
+        env:
+          INPUT_USE_TEST_REGISTRY: ${{ inputs.use_test_registry }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          FALLBACK_BRANCH: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          SHORT_SHA: ${{ steps.short-sha.outputs.short_sha }}
         run: |
           REGISTRY=openproject/hocuspocus
 
-          if [ "${{ inputs.use_test_registry }}" = "true" ]; then
+          if [ "$INPUT_USE_TEST_REGISTRY" = "true" ]; then
             REGISTRY=openproject/hocuspocus-test
           fi
 
-          BRANCH=$(echo '${{ inputs.branch || github.ref_name }}' | tr / -)
-          SPECIFIC_TAG=$BRANCH-${{ steps.short-sha.outputs.short_sha }}
+          BRANCH=$(echo "${INPUT_BRANCH:-$FALLBACK_BRANCH}" | tr / -)
+          SPECIFIC_TAG=$BRANCH-$SHORT_SHA
           LATEST_TAG=$BRANCH-latest
 
-          if [ -n "${{ inputs.tag }}" ]; then
-            SPECIFIC_TAG=$(echo '${{ inputs.tag }}' | tr -d v)
+          if [ -n "$INPUT_TAG" ]; then
+            SPECIFIC_TAG=$(echo "$INPUT_TAG" | tr -d v)
             LATEST_TAG=latest
           fi
 

--- a/.github/workflows/seed-all-locales.yml
+++ b/.github/workflows/seed-all-locales.yml
@@ -115,7 +115,8 @@ jobs:
     needs: [prepare, seed]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/email-notification.yml
-    secrets: inherit
+    secrets:
+      OPS_MAIL_SMTP_TOKEN: ${{ secrets.OPS_MAIL_SMTP_TOKEN }}
     with:
       to: operations@openproject.com
       subject: "Seeding with some locales failed on ${{ needs.prepare.outputs.ref }}"


### PR DESCRIPTION
Replaced secrets: inherit with explicit secret mapping in docker related workflow and seed-all-locales.yml.

Avoid github template expansions for inputs