### PR TITLE
[72719] Avoid doubled flash messages when deleting versions

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -105,9 +105,10 @@ class VersionsController < ApplicationController
     unless call.success?
       flash[:error] = call.errors.full_messages
       flash[:error] << archived_project_mesage if archived_projects.any?
+    else
+      flash[:notice] = I18n.t :notice_successful_delete
     end
 
-    flash[:notice] = I18n.t :notice_successful_delete
     redirect_to project_settings_versions_path(@project), status: :see_other
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/openproject/work_packages/72719/activity#comment-1670261

# What are you trying to accomplish?
Only show success banner in the success case