### PR TITLE
Remove Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -384,8 +384,6 @@ group :development, :test do
   gem "active_record_doctor", "~> 2.0.1"
 end
 
-gem "bootsnap", "~> 1.24.0", require: false
-
 # API gems
 gem "grape", "~> 3.2.0"
 gem "grape_logging", "~> 3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,8 +402,6 @@ GEM
       smart_properties
     bigdecimal (4.1.2)
     bindata (2.5.1)
-    bootsnap (1.24.3)
-      msgpack (~> 1.2)
     brakeman (8.0.4)
       racc
     browser (6.2.0)
@@ -1586,7 +1584,6 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1.217)
   axe-core-rspec
   bcrypt (~> 3.1.22)
-  bootsnap (~> 1.24.0)
   brakeman (~> 8.0.1)
   browser (~> 6.2.0)
   budgets!
@@ -1843,7 +1840,6 @@ CHECKSUMS
   better_html (2.2.0) sha256=e68ab66ab09696b708333bbf35e8aa3c107500ba7892f528e2111624bdd8cf76
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
-  bootsnap (1.24.3) sha256=f7fa3d20597e2f0aa52b0a1aba83fb54d4f79e9c2e210ec4fa1e8895514dcad8
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   budgets (1.0.0)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -48,8 +48,3 @@ if env == "production" && ENV["OPENPROJECT_PROD_DEPRECATIONS"] != "true"
   StructuredWarnings::BuiltInWarning.disable
   StructuredWarnings::DeprecationWarning.disable
 end
-
-if env == "development"
-  warn "Starting with bootsnap."
-  require "bootsnap/setup" # Speed up boot time by caching expensive operations.
-end

--- a/nix/gemset.nix
+++ b/nix/gemset.nix
@@ -440,17 +440,6 @@
     };
     version = "1.0.0";
   };
-  bootsnap = {
-    dependencies = ["msgpack"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1qnh58f5n3yppmpqj555pp9qbppmgrjay17y9pvg5dfhvmix08kl";
-      type = "gem";
-    };
-    version = "1.7.2";
-  };
   brakeman = {
     groups = ["development" "test"];
     platforms = [];


### PR DESCRIPTION
It's a gem that is intimately coupled with the
implementation of Ruby, which adds chances to
introduce errors in random pieces of code that
would not exist otherwise.

Capturing the room temperature among core contributors to OpenProject showed that no one was there to defend the presence of Bootsnap and some people (including myself) had an opinion on removing it.