### PR TITLE
Fix current_schedule_end time using the new start_time

### DIFF
--- a/modules/meeting/app/models/recurring_meeting.rb
+++ b/modules/meeting/app/models/recurring_meeting.rb
@@ -154,7 +154,7 @@ class RecurringMeeting < ApplicationRecord
   end
 
   def current_schedule_end
-    start_time + template.duration.hours
+    current_schedule_start + template.duration.hours
   end
 
   def time_zone_differs?

--- a/modules/meeting/spec/factories/recurring_meeting_factory.rb
+++ b/modules/meeting/spec/factories/recurring_meeting_factory.rb
@@ -52,7 +52,11 @@ FactoryBot.define do
       # create template
       template = create(:meeting_template,
                         :author_participates,
+                        start_time: recurring_meeting.start_time,
+                        title: recurring_meeting.title,
+                        location: recurring_meeting.location,
                         author: recurring_meeting.author,
+                        duration: recurring_meeting.duration,
                         recurring_meeting:,
                         project:)
 

--- a/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
@@ -50,24 +50,15 @@ RSpec.describe "Onetime templates CRUD", :js do
       before { visit templates_meetings_path }
 
       it "shows all onetime templates" do
-        expect(page).to have_text("Template 1")
-        expect(page).to have_text("Template 2")
-      end
+        page.within("#content") do
+          expect(page).to have_text("Template 1")
+          expect(page).to have_text("Template 2")
+          expect(page).to have_no_text(series_template.title)
+          expect(page).to have_no_text("Regular meeting")
+          expect(page).to have_text(project.name)
+          expect(page).to have_text(other_project.name)
+        end
 
-      it "excludes series templates" do
-        expect(page).to have_no_text(series_template.title)
-      end
-
-      it "excludes regular meetings" do
-        expect(page).to have_no_text("Regular meeting")
-      end
-
-      it "shows project names" do
-        expect(page).to have_text(project.name)
-        expect(page).to have_text(other_project.name)
-      end
-
-      it "shows action menu for each template" do
         within_row("Template 1") do
           expect(page).to have_css('[data-test-selector="more-button"]')
         end

--- a/modules/meeting/spec/models/recurring_meeting_spec.rb
+++ b/modules/meeting/spec/models/recurring_meeting_spec.rb
@@ -311,6 +311,22 @@ RSpec.describe RecurringMeeting,
     end
   end
 
+  describe "#current_schedule_end" do
+    let(:recurring_meeting) do
+      create(
+        :recurring_meeting,
+        start_time: DateTime.parse("2026-02-24T13:45:00+01:00"),
+        current_schedule_start: DateTime.parse("2026-05-05T13:45:00+02:00"),
+        duration: 0.25,
+        time_zone: "Europe/Berlin"
+      )
+    end
+
+    it "uses current_schedule_start plus duration" do
+      expect(recurring_meeting.current_schedule_end).to eq(DateTime.parse("2026-05-05T14:00:00+02:00"))
+    end
+  end
+
   describe "#uid" do
     it "assigns a uid on create" do
       series = build(:recurring_meeting)


### PR DESCRIPTION
we use current_schedule_start and current_schedule_end to output the "current occurrence rule" which may be later than the original start date.

However, current_schedule_end did use the original start_time, this caused this bug:

DTSTART;TZID=Europe/Berlin:20260505T134500
DTEND;TZID=Europe/Berlin:20260224T140000

DTEND < DTSTART should not be possible, ever.

https://community.openproject.org/work_packages/74729