### PR TITLE
Show only 10 most recent recurrences from the previous schedule

### DIFF
--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -32,6 +32,11 @@ require "icalendar/tzinfo"
 
 module Meetings
   class IcalendarBuilder
+    # Emit at most this many meetings from a previous schedule as RECURRENCE-ID
+    # overrides. Older instantiated meetings (before `current_schedule_start`) are
+    # silently dropped from the feed to keep it bounded.
+    PAST_OCCURRENCES_LIMIT = 10
+
     attr_reader :builder_internal_timezone, :calendar, :all_times, :calendar_generated_for_user
 
     delegate :publish, to: :calendar
@@ -301,9 +306,20 @@ module Meetings
 
     # Methods for recurring meetings
     def add_instantiated_occurrences(recurring_meeting:)
-      upcoming_instantiated_schedules(recurring_meeting).each do |meeting|
+      previous, upcoming = instantiated_schedules(recurring_meeting)
+                             .partition { |meeting| in_previous_schedule?(meeting, recurring_meeting) }
+
+      recent_previous = previous
+                          .sort_by(&:recurrence_start_time)
+                          .last(PAST_OCCURRENCES_LIMIT)
+
+      (recent_previous + upcoming).each do |meeting|
         add_single_recurring_occurrence(meeting:)
       end
+    end
+
+    def in_previous_schedule?(meeting, recurring_meeting)
+      meeting.recurrence_start_time < recurring_meeting.current_schedule_start
     end
 
     def add_virtual_occurences_for_interim_responses(recurring_meeting:) # rubocop:disable Metrics/AbcSize
@@ -342,20 +358,29 @@ module Meetings
       end
     end
 
+    # Only emit EXDATE for cancelled meetings: their dates are still in the RRULE
+    # expansion (if at or after current_schedule_start) and need to be suppressed.
+    # Meetings from a previous schedule are already outside the RRULE expansion
+    # because DTSTART = current_schedule_start, so EXDATE'ing them would be a no-op.
     def set_excluded_recurrence_dates(event:, recurring_meeting:)
-      event.exdate = if series_cache_loaded?
-                       @excluded_dates_cache[recurring_meeting.id] || []
-                     else
-                       recurring_meeting
-                         .meetings
-                         .not_templated
-                         .cancelled
-                         .where.not(recurrence_start_time: nil)
-                         .pluck(:recurrence_start_time)
-                     end.map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
+      event.exdate = cancelled_recurrence_dates(recurring_meeting)
+                       .map { ical_datetime(it, timezone: recurring_meeting.time_zone) }
     end
 
-    def upcoming_instantiated_schedules(recurring_meeting)
+    def cancelled_recurrence_dates(recurring_meeting)
+      if series_cache_loaded?
+        @excluded_dates_cache[recurring_meeting.id] || []
+      else
+        recurring_meeting
+          .meetings
+          .not_templated
+          .cancelled
+          .where.not(recurrence_start_time: nil)
+          .pluck(:recurrence_start_time)
+      end
+    end
+
+    def instantiated_schedules(recurring_meeting)
       if series_cache_loaded?
         @instantiated_occurrences_cache[recurring_meeting.id] || []
       else

--- a/modules/meeting/app/services/meetings/icalendar_builder.rb
+++ b/modules/meeting/app/services/meetings/icalendar_builder.rb
@@ -369,13 +369,14 @@ module Meetings
 
     def cancelled_recurrence_dates(recurring_meeting)
       if series_cache_loaded?
-        @excluded_dates_cache[recurring_meeting.id] || []
+        (@excluded_dates_cache[recurring_meeting.id] || [])
+          .select { it >= recurring_meeting.current_schedule_start }
       else
         recurring_meeting
           .meetings
           .not_templated
           .cancelled
-          .where.not(recurrence_start_time: nil)
+          .where(recurrence_start_time: recurring_meeting.current_schedule_start...)
           .pluck(:recurrence_start_time)
       end
     end

--- a/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
+++ b/modules/meeting/spec/services/meetings/icalendar_builder_recurring_meeting_with_updated_schedule_spec.rb
@@ -215,4 +215,48 @@ RSpec.describe Meetings::IcalendarBuilder, "recurring meeting with updated sched
       expect(second_occurrence_event.rrule).to be_empty
     end
   end
+
+  context "when the current schedule start is moved after many instantiated occurrences" do
+    let(:past_occurrence_count) { 12 }
+
+    let!(:past_occurrence_start_times) do
+      recurring_meeting.schedule
+                       .next_occurrences(past_occurrence_count, start_time - 1.second)
+                       .each do |occurrence_start|
+        create(
+          :recurring_meeting_occurrence,
+          recurring_meeting: recurring_meeting,
+          start_time: occurrence_start,
+          recurrence_start_time: occurrence_start,
+          duration: recurring_meeting.template.duration
+        )
+      end
+    end
+
+    let!(:new_schedule_start) do
+      recurring_meeting.next_occurrence(from_time: past_occurrence_start_times.last)
+    end
+
+    before do
+      recurring_meeting.update!(current_schedule_start: new_schedule_start)
+    end
+
+    it "emits only the 10 most recent previous-schedule occurrences as overrides without polluting EXDATE" do
+      builder.add_series_event(recurring_meeting: recurring_meeting)
+
+      master_event = parsed_calendar.events.find { |event| event.recurrence_id.nil? }
+      override_events = parsed_calendar.events.select { |event| event.recurrence_id.present? }
+
+      expect(master_event.dtstart).to eq(new_schedule_start)
+      expect(master_event.dtend).to eq(new_schedule_start + recurring_meeting.template.duration.hours)
+
+      # EXDATE is reserved for cancelled meetings still in the RRULE expansion.
+      # Previous-schedule occurrences are already outside it, so EXDATE'ing them would be a no-op.
+      expect(Array(master_event.exdate)).to be_empty
+
+      expect(override_events.count).to eq(10)
+      expect(override_events.map { |evt| evt.recurrence_id.to_time })
+        .to match_array(past_occurrence_start_times.last(10).map(&:to_time))
+    end
+  end
 end


### PR DESCRIPTION
When the schedule of a series changes (and with it, current_schedule_start), past meetings that are BEFORE this 'new' start date should be listed as EXDATE, as they no longer match the schedule.

This PR also limits these occurrences to at max 10, so we don't output too many past events and bloat the ICS feed with it.
