### PR TITLE
Use formatted_id in WorkPackage#infoline

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -281,7 +281,7 @@ class WorkPackage < ApplicationRecord
 
   def infoline(show_standard_type: true)
     type_name = show_standard_type || !type.is_standard ? type.name : ""
-    "#{type_name}: #{subject} (##{id})"
+    "#{type_name}: #{subject} (#{formatted_id})"
   end
 
   # Return true if the work_package is closed, otherwise false

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -915,4 +915,32 @@ RSpec.describe WorkPackage do
       end
     end
   end
+
+  describe "#infoline" do
+    let(:infoline_type) { create(:type, name: "Task") }
+    let(:infoline_work_package) do
+      create(:work_package, subject: "Hello world", project: infoline_project, type: infoline_type)
+    end
+
+    context "when semantic mode is active",
+            with_flag: { semantic_work_package_ids: true },
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:infoline_project) { create(:project, identifier: "MYPROJ") }
+
+      before { infoline_work_package }
+
+      it "renders the semantic identifier without a hash prefix" do
+        expect(infoline_work_package.reload.infoline).to eq("Task: Hello world (MYPROJ-1)")
+      end
+    end
+
+    context "when semantic mode is not active",
+            with_flag: { semantic_work_package_ids: false } do
+      let(:infoline_project) { create(:project) }
+
+      it "renders the hash-prefixed numeric id" do
+        expect(infoline_work_package.infoline).to eq("Task: Hello world (##{infoline_work_package.id})")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

Follow-up from manual verification of #22976.

## Screenshots

**Before** — `infoline` interpolated `##{id}`, so `<title>` showed the numeric id in semantic mode:

<!-- drop pr23098-before-semantic.png here -->
<img width="1548" height="1043" alt="pr23098-before-semantic" src="https://github.com/user-attachments/assets/f2e6b809-116a-413f-a8bc-f28d2e4e7952" />

**After** — `infoline` interpolates `#{formatted_id}`, so `<title>` matches the URL in semantic mode:

<!-- drop pr23098-after-semantic.png here -->
<img width="1548" height="1043" alt="pr23098-after-semantic" src="https://github.com/user-attachments/assets/071fe930-dcb6-4f4c-a042-87a87347f9df" />


## Fix

The work package show page's `<title>` keeps producing a numeric id in semantic mode (e.g. `Epic: Subject (#9575)` rather than `D1-1`). The title is built from `WorkPackage#infoline`, which hardcodes the `#` prefix; switching it to `formatted_id` yields `#42` in classic mode and `PROJ-1` in semantic. Spec coverage added in both modes.