### PR TITLE
Show "send password information" also for invited useres

### DIFF
--- a/app/views/users/form/authentication/_internal_password.html.erb
+++ b/app/views/users/form/authentication/_internal_password.html.erb
@@ -45,22 +45,20 @@
     </div>
   <% end %>
 
-  <% if @user.active? -%>
-    <div class="form--field send-information">
-      <%= styled_label_tag "send_information", t(:label_send_information) %>
-      <div class="form--field-container">
-        <%= styled_check_box_tag(
-              "send_information",
-              "1",
-              false,
-              data: { "password-force-change-target": "sendInformationCheckbox" }
-            ) %>
-      </div>
-      <div class="form--field-instructions">
-        <%= t("users.send_information_hint") %>
-      </div>
+  <div class="form--field send-information">
+    <%= styled_label_tag "send_information", t(:label_send_information) %>
+    <div class="form--field-container">
+      <%= styled_check_box_tag(
+            "send_information",
+            "1",
+            false,
+            data: { "password-force-change-target": "sendInformationCheckbox" }
+          ) %>
     </div>
-  <% end -%>
+    <div class="form--field-instructions">
+      <%= t("users.send_information_hint") %>
+    </div>
+  </div>
 
   <div class="form--field">
     <%= f.check_box :force_password_change,


### PR DESCRIPTION
When user invited, the auto-checking was not available as the field is not rendered. Let's render the field there as well to have consistent UX


https://community.openproject.org/projects/openproject/work_packages/73849/activity?query_id=7655