### PR TITLE
[#74743] Add upcoming/past filter to meetings index page filters  

### DIFF
--- a/modules/meeting/app/components/meetings/meeting_filter_button_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filter_button_component.rb
@@ -36,7 +36,6 @@ module Meetings
       @filters_count ||= begin
         count = super
         count -= 1 if project.present?
-        count -= 1 if query.filters.find { |f| f.name == :time }
 
         count
       end

--- a/modules/meeting/app/components/meetings/meeting_filters_component.rb
+++ b/modules/meeting/app/components/meetings/meeting_filters_component.rb
@@ -64,7 +64,8 @@ module Meetings
         Queries::Meetings::Filters::AttendedUserFilter,
         Queries::Meetings::Filters::AuthorFilter,
         Queries::Meetings::Filters::InvitedUserFilter,
-        Queries::Meetings::Filters::RecurringFilter
+        Queries::Meetings::Filters::RecurringFilter,
+        Queries::Meetings::Filters::TimeFilter
       ]
 
       if project.nil?

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -193,10 +193,11 @@ RSpec.describe "Meetings", "Index", :js do
           wait_for_network_idle
 
           sort = [["start_time", "desc"]].to_json
+          time_filters = [{ "time" => { "operator" => "=", "values" => ["past"] } }].to_json
           if context == :global
-            expect(page).to have_current_path(meetings_path(filters: "[]", sortBy: sort))
+            expect(page).to have_current_path(meetings_path(filters: time_filters, sortBy: sort))
           else
-            expect(page).to have_current_path(project_meetings_path(project, filters: "[]", sortBy: sort))
+            expect(page).to have_current_path(project_meetings_path(project, filters: time_filters, sortBy: sort))
           end
         end
       end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/74743

Add `TimeFilter` to the list of allowed filters so that it shows up in the main filters section. Follows https://github.com/opf/openproject/pull/23105