### PR TITLE
[74321] Show default section more clearly when using the section selector for a meeting with no sections

### DIFF
--- a/modules/meeting/app/forms/meeting/add_to_section.rb
+++ b/modules/meeting/app/forms/meeting/add_to_section.rb
@@ -77,6 +77,7 @@ class Meeting::AddToSection < ApplicationForm
 
     items.concat(meeting.sections) if meeting.present? && @occurrence.nil?
     items.concat(@occurrence.sections) if @occurrence.present?
+    items.push(MeetingSection.new) if items.empty?
     items.push(meeting.backlog) if meeting.present? && !meeting.template? && meeting.backlog.present?
 
     items.reject! { |i| i == @selected_section } if @selected_section.present?

--- a/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
+++ b/modules/meeting/spec/features/structured_meetings/work_package_meetings_tab_spec.rb
@@ -666,24 +666,10 @@ RSpec.describe "Open the Meetings tab",
             expect(page).to have_css(".ng-option", text: "Series backlog")
           end
 
-          it "shows no preselection when no sections exist for recurring meeting occurrences" do
+          it "shows the automatically created untitled section when no sections exist for recurring meeting occurrences" do
             meeting = empty_recurring_meeting_occurrence
 
-            work_package_page.visit!
-            switch_to_meetings_tab
-
-            meetings_tab.open_add_to_meeting_dialog
-
-            fill_in("meeting_agenda_item_meeting_id", with: meeting.title)
-            page.find(".ng-option-marked", text: meeting.title)
-            page.find(".ng-option-marked").click
-
-            wait_for_network_idle
-
-            section_field = find_field("meeting_agenda_item_meeting_section_id")
-            expect(section_field).not_to be_disabled
-
-            expect(page).to have_no_css(".ng-value-label")
+            check_section_auto_selection(meeting, "Untitled section")
           end
 
           it "updates section selection when switching between meetings" do

--- a/modules/meeting/spec/forms/meeting/add_to_section_spec.rb
+++ b/modules/meeting/spec/forms/meeting/add_to_section_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Meeting::AddToSection, type: :forms do
+  include_context "with rendered form"
+
+  shared_let(:project) { create(:project, enabled_module_names: %w[meetings]) }
+  shared_let(:user) { create(:user) }
+
+  let(:params) { {} }
+
+  def section_option_names
+    expect(page).to have_css("opce-autocompleter")
+    JSON.parse(page.find("opce-autocompleter")["data-items"]).map { |o| o["name"] }
+  end
+
+  # Sections must be created inside `let(:model)` so they exist when the form is evaluated.
+  # The shared context renders the form in an outer `before` hook, which runs before any
+  # `let!` inner hooks — so data must be set up as part of the model itself.
+
+  context "when the meeting has named sections" do
+    let(:model) do
+      meeting = create(:meeting, project:, author: user)
+      create(:meeting_section, meeting:, title: "Section A")
+      create(:meeting_section, meeting:, title: "Section B")
+      meeting.sections.reload
+      create(:meeting_agenda_item, meeting:)
+    end
+
+    it "lists named sections and the backlog, without a placeholder" do
+      expect(section_option_names).to include("Section A", "Section B", "Agenda backlog")
+      expect(section_option_names).not_to include("Untitled section")
+    end
+  end
+
+  context "when the meeting has no named sections" do
+    let(:model) do
+      meeting = create(:meeting, project:, author: user)
+      create(:meeting_agenda_item, meeting:)
+    end
+
+    it "inserts an untitled placeholder before the backlog" do
+      expect(section_option_names).to eq(["Untitled section", "Agenda backlog"])
+    end
+  end
+
+  context "when an occurrence with no named sections is given" do
+    let(:model) do
+      recurring_meeting = create(:recurring_meeting, project:, author: user)
+      create(:recurring_meeting_occurrence, project:, recurring_meeting:)
+      create(:meeting_agenda_item, meeting: recurring_meeting.template)
+    end
+    let(:params) do
+      recurring_meeting = model.meeting.recurring_meeting
+      { occurrence: recurring_meeting.meetings.where(template: false).first }
+    end
+
+    it "inserts an untitled placeholder before the series backlog" do
+      expect(section_option_names).to include("Untitled section")
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/74321

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Eagerly display the `Untitled section` (which is automatically created on empty meetings) instead of a blank field.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<img width="980" height="558" alt="image" src="https://github.com/user-attachments/assets/69123881-0dd1-4a1e-8522-ec69ac6dee62" />

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

1. The first commit build an empty MeetingSection if no section exists on meeting or occurrence;
2. The second commit reverts that and mimics Rails [`select(include_blank:)`](https://api.rubyonrails.org/v5.1.7/classes/ActionView/Helpers/FormOptionsHelper.html) behaviour on the Autocompleter.

Pick your favourite.

# Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
