### PR TITLE
Wait for page to be reloaded before testing custom element

### DIFF
--- a/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
+++ b/spec/features/wysiwyg/macros/quicklink_macros_spec.rb
@@ -171,7 +171,9 @@ RSpec.describe "Wysiwyg work package quicklink macros", :js do
       ####{wp_milestone_without_date.id}
     MD
 
-    click_on "Save"
+    wait_for_turbo { click_on "Save" }
+
+    expect_and_dismiss_flash(message: "Successful creation.")
 
     within("#content") do
       expect(page).to have_css("opce-macro-wp-quickinfo", text: /No dates$/)


### PR DESCRIPTION
The fact that the macro spec fails an expectation in the middle of the `#content` block hints at the fact that we tried to expect before the page load completed

```
 1) Wysiwyg work package quicklink macros displays dates with work package detailed link macro only if a date is present
     Failure/Error: expect(page).to have_css("opce-macro-wp-quickinfo", text: "End date only (no start date - 12/31/2020)")
       expected to find visible css "opce-macro-wp-quickinfo" with text "End date only (no start date - 12/31/2020)" within Obsolete #<Capybara::Node::Element> but there were no matches. Also found "<<ERROR>>", "<<ERROR>>", "<<ERROR>>", "<<ERROR>>", "status 24Milestone #23: Milestone with date (01/01/2020)", "status 25Milestone #24: Milestone without date", which matched the selector but not all filters. 
     # ./spec/features/wysiwyg/macros/quicklink_macros_spec.rb:179:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:366:in 'Capybara::Session#within'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in 'Method#call'
     # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in 'Capybara::DSL#within_element'
     # ./spec/support/within_check.rb:35:in 'WithinCheck#within'
     # ./spec/features/wysiwyg/macros/quicklink_macros_spec.rb:176:in 'block (2 levels) in <top (required)>'
     # ./spec/support/capybara.rb:22:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/without_env.rb:52:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_env.rb:60:in 'block (2 levels) in <top (required)>'
     # ./spec/support/shared/with_direct_uploads.rb:219:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # ./spec/support/rspec_retry.rb:26:in 'block (2 levels) in <top (required)>'
     # ./spec/support/cuprite_setup.rb:165:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in 'block in RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'Kernel#loop'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in 'RSpec::Retry#run'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in 'RSpec::Core::Example::Procsy#run_with_retry'
     # /usr/local/bundle/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in 'block (2 levels) in RSpec::Retry.setup'