### PR TITLE
Allow setting external link on redirect page without blank target

### DIFF
--- a/app/views/external_link_warning/show.html.erb
+++ b/app/views/external_link_warning/show.html.erb
@@ -39,6 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
        scheme: :danger,
        data: {
          turbo: false,
+         skip_external_link_blank: true,
          allow_external_link: true
        }
      ) { I18n.t("external_link_warning.continue_button") } %>

--- a/frontend/src/stimulus/controllers/external-links.controller.ts
+++ b/frontend/src/stimulus/controllers/external-links.controller.ts
@@ -112,7 +112,9 @@ export default class ExternalLinksController extends ApplicationController {
   }
 
   private updateExternalLink(link:HTMLAnchorElement) {
-    link.target = '_blank';
+    if (!link.dataset.skipExternalLinkBlank) {
+      link.target = '_blank';
+    }
     attributeTokenList(link, 'rel').add('noopener', 'noreferrer');
 
     // Capture external links through redirect page


### PR DESCRIPTION
The target=_blank is forced by a stimulus controller, so we need it to opt out of that behavior.

https://community.openproject.org/projects/openproject/work_packages/73914/activity