### PR TITLE
add edit_work_packages as a dependency of manage_sprint_items

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -86,7 +86,7 @@ module OpenProject::Backlogs
                      "backlogs/inbox": %i[move reorder move_to_sprint_dialog] },
                    permissible_on: :project,
                    require: :member,
-                   dependencies: :view_sprints
+                   dependencies: %i[view_sprints edit_work_packages]
 
         permission :share_sprint,
                    { "projects/settings/backlog_sharings": %i[show update] },

--- a/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/permissions_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe OpenProject::AccessControl, "Backlogs module permissions" do # ru
   describe "manage_sprint_items" do
     subject { described_class.permission(:manage_sprint_items) }
 
-    it "depends on view_sprints, add_work_packages, and edit_work_packages" do
-      expect(subject.dependencies).to contain_exactly(:view_sprints)
+    it "depends on view_sprints and edit_work_packages" do
+      expect(subject.dependencies).to contain_exactly(:view_sprints, :edit_work_packages)
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74201

# What are you trying to accomplish?

The work package contract prevents editing any property of a work package unless the user has the `edit_work_packages` permission. This is also true for the sprint/backlog property. Therefore, `edit_work_package` is turned into a dependency of `mange_sprint_items`. 