### PR TITLE
[#74552] Wrong pane (Backlog/Buckets, not Sprints) autoscrolls

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.spec.ts
@@ -70,14 +70,6 @@ describe('GenericDragAndDropController', () => {
     return ariaPressedTarget.call(controller, el);
   }
 
-  function callResolveMirrorContainer():Element {
-    const resolveMirrorContainer = Reflect.get(controller, 'resolveMirrorContainer') as (
-      this:GenericDragAndDropController
-    ) => Element;
-
-    return resolveMirrorContainer.call(controller);
-  }
-
   describe('canStartDrag', () => {
     it('allows dragging a draggable row in handle-less mode', () => {
       const row = draggableRow();
@@ -153,23 +145,6 @@ describe('GenericDragAndDropController', () => {
       setValue('handleSelectorValue', '.DragHandle');
 
       expect(callAriaPressedTarget(row)).toBe(handle);
-    });
-  });
-
-  describe('resolveMirrorContainer', () => {
-    it('returns the configured mirror container target when present', () => {
-      const mirrorContainer = document.createElement('div');
-
-      Object.defineProperty(controller, 'hasMirrorContainerTarget', { value: true, configurable: true });
-      Object.defineProperty(controller, 'mirrorContainerTarget', { value: mirrorContainer, configurable: true });
-
-      expect(callResolveMirrorContainer()).toBe(mirrorContainer);
-    });
-
-    it('falls back to document.body when no mirror container target exists', () => {
-      Object.defineProperty(controller, 'hasMirrorContainerTarget', { value: false, configurable: true });
-
-      expect(callResolveMirrorContainer()).toBe(document.body);
     });
   });
 });

--- a/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/generic-drag-and-drop.controller.ts
@@ -43,12 +43,10 @@ interface TargetConfig {
 }
 
 export default class GenericDragAndDropController extends Controller {
-  static targets = ['container', 'scrollContainer', 'mirrorContainer'];
+  static targets = ['container', 'scrollContainer'];
 
   containerTargets:HTMLElement[];
   scrollContainerTargets:HTMLElement[];
-  declare readonly hasMirrorContainerTarget:boolean;
-  declare readonly mirrorContainerTarget:HTMLElement;
 
   static values = {
     handle: { type: Boolean, default: true },
@@ -129,7 +127,6 @@ export default class GenericDragAndDropController extends Controller {
         moves: (el, _source, handle, _sibling) => this.canStartDrag(el, handle),
         accepts: (el:Element, target:Element, source:Element, sibling:Element) => this.accepts(el, target, source, sibling),
         revertOnSpill: true, // enable reverting of elements if they are dropped outside of a valid target
-        mirrorContainer: this.resolveMirrorContainer(),
       },
     )
       .on('cloned', (clone, _original, type) => {
@@ -258,10 +255,6 @@ export default class GenericDragAndDropController extends Controller {
     const container = target.querySelector<HTMLElement>(accessor);
     invariant(container, `Expected container element matching "${accessor}"`);
     return container;
-  }
-
-  private resolveMirrorContainer():Element {
-    return this.hasMirrorContainerTarget ? this.mirrorContainerTarget : document.body;
   }
 
   // Returns the data-draggable-id of the element preceding el in its container,

--- a/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_bucket_component.rb
@@ -67,7 +67,7 @@ module Backlogs
 
     def drop_target_config
       {
-        generic_drag_and_drop_target: "container mirrorContainer",
+        generic_drag_and_drop_target: "container",
         target_container_accessor: ":scope > ul",
         target_id: backlog_bucket.persisted? ? "backlog_bucket:#{backlog_bucket.id}" : "inbox",
         target_allowed_drag_type: "story"

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -97,7 +97,7 @@ module Backlogs
 
     def drop_target_config
       {
-        generic_drag_and_drop_target: "container mirrorContainer",
+        generic_drag_and_drop_target: "container",
         target_container_accessor: ":scope > ul",
         target_id: "inbox",
         target_allowed_drag_type: "story"

--- a/modules/backlogs/spec/requests/backlogs/backlog_spec.rb
+++ b/modules/backlogs/spec/requests/backlogs/backlog_spec.rb
@@ -106,26 +106,6 @@ RSpec.describe "Backlogs::Backlog", :skip_csrf, type: :rails_request do
           expect(response.body).to include('id="sprint_backlogs_container"')
         end
       end
-
-      it "uses the inbox border box as the drag mirror container" do
-        get "/projects/#{project.identifier}/backlogs/backlog", headers: { "Turbo-Frame" => "backlogs_container" }
-
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include(%(id="inbox_#{project.id}"))
-        expect(response.body).to include('data-generic-drag-and-drop-target="container mirrorContainer"')
-      end
-
-      context "with backlog buckets enabled", with_flag: { backlog_buckets: true } do
-        shared_let(:backlog_bucket) { create(:backlog_bucket, project:) }
-
-        it "uses each backlog bucket border box as the drag mirror container" do
-          get "/projects/#{project.identifier}/backlogs/backlog", headers: { "Turbo-Frame" => "backlogs_container" }
-
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to include(%(data-test-selector="backlog-bucket-#{backlog_bucket.id}"))
-          expect(response.body).to include('data-generic-drag-and-drop-target="container mirrorContainer"')
-        end
-      end
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74552

# What are you trying to accomplish?

Fix a Backlogs drag-and-drop regression where dragging a work package from the backlog/bucket pane into a sprint can autoscroll the backlog side instead of the sprint side (seen in Firefox and Crome).

This effectively reverts the drag-preview/mirror-container behavior introduced or expanded in:

- https://github.com/opf/openproject/pull/22838
- https://github.com/opf/openproject/pull/22883

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Remove the optional `mirrorContainer` target from the generic drag-and-drop Stimulus controller and stop marking the Backlogs inbox/buckets as mirror containers. This lets Dragula append the drag mirror to its default container again, which avoids the wrong pane being selected for autoscroll while dragging backlog items into sprint lists.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
