### PR TITLE
[#74753] Make Backlog, Sprints columns full height

### DIFF
--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -29,7 +29,8 @@
 $op-backlogs-header--points-min-width: 5rem
 $op-backlogs-header--points-min-width-narrow: 2rem
 
-.controller-backlogs\/backlog.action-show
+.controller-backlogs\/backlog.action-show,
+.controller-backlogs\/backlog.action-details
   @include extended-content--bottom
 
 .op-backlogs-header,

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -29,7 +29,7 @@
 $op-backlogs-header--points-min-width: 5rem
 $op-backlogs-header--points-min-width-narrow: 2rem
 
-.action-sprint_planning
+.controller-backlogs\/backlog.action-show
   @include extended-content--bottom
 
 .op-backlogs-header,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74753

# What are you trying to accomplish?

> [!WARNING]
> #22936 (commit 2f53d61c) on `dev` also attempted to fix this issue, but renamed the CSS class incorrectly! _Bear this in mind when merging the release branch back into `dev`._

Fixes a regression resulting from the Controller action rename in #22791 (commit afcdcdcc).

See also #22534 (commit fc6a4fc) for the previous fix.


## Screenshots

| Before | After |
|--------|--------|
| <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 27 39" src="https://github.com/user-attachments/assets/4d2c7a41-f974-460d-ace6-a39097839f33" /> | <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 26 50" src="https://github.com/user-attachments/assets/41ca7d2a-7153-44b9-a125-fe86c3fbb627" /> |

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
