### PR TITLE
[#73831] Sprints column scroll bar overlaps content

### DIFF
--- a/app/components/open_project/common/main_menu_toggle_component.sass
+++ b/app/components/open_project/common/main_menu_toggle_component.sass
@@ -57,7 +57,7 @@
 
     @media only screen and (max-width: $breakpoint-lg)
       // Special logic for those pages that already use the new layout and have the content-bodyRight filled (so basically, the split screen opened full height on mobile)
-      #content:has(#content-bodyRight > *)
+      @include split-pane-active
         #menu-toggle--expand-button
           top: 60px
         .op-wp-breadcrumb

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -33,6 +33,15 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 .controller-backlogs\/backlog.action-details
   @include extended-content--bottom
 
+  #content-body
+    padding-right: 0
+
+  // Base layout restores padding-right: 1rem on #content-body when the
+  // split pane is open (specificity 0,3,0,0). Override it back to 0.
+  #content:has(#content-bodyRight > *)
+    #content-body
+      padding-right: 0
+
 .op-sprint-header
   display: grid
   grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
@@ -96,9 +105,11 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
 //------------------ Sprint planning divider (side-by-side only) ----
 @container backlogsListsContainer (min-width: 655px)
-  .op-sprint-planning-lists:not(:last-child)
-    border-right: 1px solid var(--borderColor-default)
+  .op-sprint-planning-lists
     padding-right: var(--stack-gap-normal)
+
+    &:not(:last-child)
+      border-right: 1px solid var(--borderColor-default)
 
 //------------------ Mobile responsive styling -----------------------
 @container backlogsListsContainer (max-width: 654px)

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -38,7 +38,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
   // Base layout restores padding-right: 1rem on #content-body when the
   // split pane is open (specificity 0,3,0,0). Override it back to 0.
-  #content:has(#content-bodyRight > *)
+  @include split-pane-active
     #content-body
       padding-right: 0
 

--- a/frontend/src/assets/sass/backlogs/_master_backlog.sass
+++ b/frontend/src/assets/sass/backlogs/_master_backlog.sass
@@ -33,27 +33,11 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 .controller-backlogs\/backlog.action-details
   @include extended-content--bottom
 
-.op-backlogs-header,
 .op-sprint-header
   display: grid
   grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width, max-content) auto
-  align-items: center
-
-  &--actions
-    margin-left: var(--stack-gap-normal)
-
-  &--menu
-    margin-left: var(--stack-gap-normal)
-
-.op-backlogs-header
-  grid-template-areas: "collapsible points menu"
-
-  &--points
-    margin-left: var(--stack-gap-normal)
-    font-variant-numeric: tabular-nums
-
-.op-sprint-header
   grid-template-areas: "collapsible actions menu"
+  align-items: center
 
   &--actions,
   &--menu
@@ -90,7 +74,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   container-name: backlogsListsContainer
   container-type: inline-size
 
-.op-backlogs-container, .op-sprint-planning-container
+.op-sprint-planning-container
   display: flex
   flex-direction: row
   gap: var(--stack-gap-normal)
@@ -99,7 +83,7 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   overflow: hidden
 
 
-.op-backlogs-lists, .op-sprint-planning-lists
+.op-sprint-planning-lists
   display: flex
   flex-direction: column
   gap: var(--stack-gap-normal)
@@ -107,46 +91,8 @@ $op-backlogs-header--points-min-width-narrow: 2rem
   min-height: 0
   overflow-y: auto
   overflow-x: hidden
-
-.op-sprint-planning-lists
   padding-top: var(--stack-padding-normal)
   padding-bottom: var(--stack-padding-normal)
-
-//------------------ Header form responsive styling -----------------------
-// Note: Using hardcoded values because Sass doesn't interpolate variables in
-// @container query conditions.
-// Note: 1102px is twice the small breakpoint plus the 16px gap. Since we show two boxes next to each other,
-// we thus assure that the form wraps at the small breakpoint.
-@container backlogsListsContainer (min-width: 1102px)
-  .op-backlogs-header-form
-    .FormControl-spacingWrapper
-      flex-direction: row
-      column-gap: 0.5rem
-      flex-wrap: wrap
-
-      & > :first-child
-        flex: 1 1 33%
-
-@container backlogsListsContainer (min-width: 1550px)
-  .op-backlogs-header-form
-    .FormControl-spacingWrapper
-      & > :first-child
-        flex-basis: 25%
-
-//------------------ Header responsive styling -----------------------
-// Note: 1143px is matching the the breakpoint we use within PVC for the container query.
-// Thus the layout switches at the exact same point.
-@container backlogsListsContainer (max-width: 1443px)
-  .op-backlogs-header
-    grid-template-rows: 1fr auto
-    grid-template-areas: "collapsible points menu" "collapsible . . "
-    align-items: baseline
-
-    &--menu
-      align-self: flex-start
-      // Unfortunately, the invisible button style bites us here again.
-      margin-top: -6px
-
 
 //------------------ Sprint planning divider (side-by-side only) ----
 @container backlogsListsContainer (min-width: 655px)
@@ -156,16 +102,13 @@ $op-backlogs-header--points-min-width-narrow: 2rem
 
 //------------------ Mobile responsive styling -----------------------
 @container backlogsListsContainer (max-width: 654px)
-  .op-backlogs-header
-    grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
-
   .op-backlogs-points-label
     display: none
 
   .op-backlogs-story
     grid-template-columns: 1fr minmax($op-backlogs-header--points-min-width-narrow, max-content) auto
 
-  .op-backlogs-container, .op-sprint-planning-container
+  .op-sprint-planning-container
     height: unset
     overflow: auto
     flex-direction: column

--- a/frontend/src/global_styles/layout/_base_mobile.sass
+++ b/frontend/src/global_styles/layout/_base_mobile.sass
@@ -80,7 +80,7 @@
 
   // Hide the header, when the content-bodyRight is shown, because it has it's own header.
   // Otherwise, the sticky header would lay on top of the split screen
-  #content:has(#content-bodyRight > *)
+  @include split-pane-active
     page-header,
     sub-header
       display: none
@@ -107,7 +107,7 @@
   #main
     grid-template-columns: auto
 
-  #content:has(#content-bodyRight > *)
+  @include split-pane-active
     grid-template-columns: 1fr auto
 
   // As soon as the split screen has content (so basically when its opened), it takes the available whole space

--- a/frontend/src/global_styles/openproject/_mixins.sass
+++ b/frontend/src/global_styles/openproject/_mixins.sass
@@ -263,6 +263,10 @@ $scrollbar-size: 10px
     .work-packages--filters-optional-container
       margin-right: 15px
 
+@mixin split-pane-active
+  #content:has(#content-bodyRight > *)
+    @content
+
 @mixin modifying--placeholder
   border: 1px dashed var(--accent-color)
   pointer-events: none


### PR DESCRIPTION
> [!NOTE]
> This PR is based on #23118. Please review/merge that PR first. 

# Ticket

https://community.openproject.org/wp/73831

# What are you trying to accomplish?

Fix padding so that scrollbars do not overlap content.

## Screenshots

| Browser | Before | After |
|--------|--------|--------|
| Firefox/Win | <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 18 34" src="https://github.com/user-attachments/assets/609345a3-6c37-4697-a528-242d3715e42c" /> | <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 20 29" src="https://github.com/user-attachments/assets/ff5c4346-f073-4035-886e-2bfd5c58f42c" /> |
| Chrome/Win | <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 18 09" src="https://github.com/user-attachments/assets/7d27f011-586b-44b5-9af3-8af9ac533475" /> | <img width="1507" height="970" alt="Screenshot 2026-05-07 at 23 19 35" src="https://github.com/user-attachments/assets/5733973e-9af3-4d7a-81b6-1484a20bd057" /> | 

# What approach did you choose and why?

> [!IMPORTANT]
> This PR also cherry-picks 9071b9b820848e2894b21e134b4971458755af14 from #22936 (now merged into `dev`)

Targets `#content-body` padding directly instead of using the broad `extended-content--right` mixin, which was also zeroing `#content-header` padding (causing the header spacing regression flagged in review). A follow-up commit extracts the `#content:has(#content-bodyRight > *)` selector into a `split-pane-active` Sass mixin to centralize it.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)