### PR TITLE
fix: Correctly handle semantic ID counter on project copy

### DIFF
--- a/app/services/projects/copy_service.rb
+++ b/app/services/projects/copy_service.rb
@@ -126,7 +126,7 @@ module Projects
     end
 
     def skipped_attributes
-      %w[id created_at updated_at name identifier active templated lft rgt]
+      %w[id created_at updated_at name identifier active templated lft rgt wp_sequence_counter]
     end
 
     def source_attributes

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -381,6 +381,18 @@ RSpec.describe(
       end
     end
 
+    context "when source project has a non-zero wp_sequence_counter",
+            with_settings: { work_packages_identifier: "semantic" } do
+      before do
+        source.update_column(:wp_sequence_counter, 5)
+      end
+
+      it "succeeds and resets wp_sequence_counter to 0 on the copy" do
+        expect(subject).to be_success
+        expect(project_copy.wp_sequence_counter).to eq(0)
+      end
+    end
+
     context "with all modules selected" do
       let(:only_args) { all_modules }
       let(:storage1) { source_automatic_project_storage.storage }

--- a/spec/services/projects/copy_service_integration_spec.rb
+++ b/spec/services/projects/copy_service_integration_spec.rb
@@ -383,6 +383,8 @@ RSpec.describe(
 
     context "when source project has a non-zero wp_sequence_counter",
             with_settings: { work_packages_identifier: "semantic" } do
+      let(:target_project_params) { { name: "Target Project Name", identifier: "COPY1" } }
+
       before do
         source.update_column(:wp_sequence_counter, 5)
       end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74750

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Fix the issue described in the ticket. 

The root cause is that when `wp_sequence_counter` had non-zero value (= the project has had semantic IDs enabled and there is at least one WP), the copy mechanism attempted to copy it over to the new project, because it detected a difference from the default value (zero).

However, since `wp_sequence_counter` isn't declared as writable (since it's not specified in `Projects::BaseContract`), it trips up our own validation and the error propagates into the UI as the message visible in the parent ticket.

# What approach did you choose and why?
Let's just completely ignore that column during the copy process. The new project will get it initialized to 0, and then the counter gets organically gradually increased by the (optional) copying of all WPs from the old project.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
