### PR TITLE
fix: Reduce flakiness of a budget spec

### DIFF
--- a/modules/budgets/spec/support/pages/budget_form.rb
+++ b/modules/budgets/spec/support/pages/budget_form.rb
@@ -64,6 +64,8 @@ module Pages
 
       if expected_costs.present?
         wait_for_network_idle
+        sleep(0.15)
+        wait_for_network_idle
         expect(page).to have_css("##{prefix}_costs", text: expected_costs)
       end
     end
@@ -107,6 +109,8 @@ module Pages
       fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
 
       if expected_costs.present?
+        wait_for_network_idle
+        sleep(0.15)
         wait_for_network_idle
         expect(page).to have_css("##{prefix}_costs", text: expected_costs)
       end


### PR DESCRIPTION
```
updating a budget with new cost items creates the cost items
       Failure/Error: example.run
         expected to find visible css "#budget_new_material_budget_item_attributes_0_costs" with text "150.00 EUR" but there were no matches. Also found "0.00
   EUR", which matched the selector but not all filters.
```

- The Stimulus controller's valueChanged uses a 100ms debounce before firing the fetch
- wait_for_network_idle in Ferrum polls for pending connections (pending_connections <= 0) — if called before the debounce fires, it sees no in-flight requests and returns immediately
- have_css then retries for 4s, but this appears inconsistent on CI under load

The fix: apply the two-phase wait pattern (wait_for_network_idle; sleep(0.15); wait_for_network_idle) — the first call handles any in-flight requests, the sleep ensures the 100ms debounce fires, and the second call waits for the resulting fetch. This matches the existing pattern for debounced requests in this codebase.