### PR TITLE
Convert custom filters on user administration to standard query

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,6 +142,11 @@ Naming/ClassAndModuleCamelCase:
 Naming/FileName:
   Enabled: false
 
+Naming/MethodParameterName:
+  AllowedNames:
+    - id
+    - cf # custom fields are commonly abbreviated like that
+
 Naming/PredicatePrefix:
   ForbiddenPrefixes:
     - is_

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -80,26 +80,10 @@ module Projects
       send(column.attribute)
     end
 
-    def custom_field_column(column) # rubocop:disable Metrics/AbcSize
+    def custom_field_column(column)
       return nil unless user_can_view_project_attributes?
 
-      cf = column.custom_field
-      custom_value = project.formatted_custom_value_for(cf)
-
-      if cf.field_format == "text" && custom_value.present?
-        render OpenProject::Common::AttributeComponent.new(
-          "dialog-#{project.id}-cf-#{cf.id}",
-          cf.name,
-          custom_value,
-          format: false # already formatted
-        )
-      elsif custom_value.is_a?(Array)
-        safe_join(Array(custom_value).compact_blank, ", ")
-      elsif cf.calculated_value?
-        render_calculated_value(cf, custom_value)
-      else
-        custom_value
-      end
+      super
     end
 
     def render_calculated_value(custom_field, custom_value)
@@ -449,6 +433,25 @@ module Projects
 
     def user_can_view_project_phases?
       User.current.allowed_in_project?(:view_project_phases, project)
+    end
+
+    def custom_field_column_subject
+      project
+    end
+
+    def format_custom_field_value(cf, custom_value)
+      if cf.field_format == "text" && custom_value.present?
+        render OpenProject::Common::AttributeComponent.new(
+          "dialog-#{project.id}-cf-#{cf.id}",
+          cf.name,
+          custom_value,
+          format: false
+        )
+      elsif cf.calculated_value?
+        render_calculated_value(cf, custom_value)
+      else
+        super
+      end
     end
 
     def custom_field_column?(column)

--- a/app/components/row_component.rb
+++ b/app/components/row_component.rb
@@ -45,7 +45,20 @@ class RowComponent < ApplicationComponent
   end
 
   def column_value(column)
+    return custom_field_column(column) if custom_field_column?(column)
+
     send(column)
+  end
+
+  def custom_field_column?(column)
+    column.is_a?(Queries::Selects::Shared::CustomFieldSelect)
+  end
+
+  def custom_field_column(column)
+    cf = column.custom_field
+    return "" unless cf
+
+    format_custom_field_value(cf, custom_field_column_subject.formatted_custom_value_for(cf))
   end
 
   def column_css_class(column)
@@ -79,6 +92,20 @@ class RowComponent < ApplicationComponent
   def checkmark(condition)
     if condition
       helpers.op_icon "icon icon-checkmark"
+    end
+  end
+
+  private
+
+  def custom_field_column_subject
+    model
+  end
+
+  def format_custom_field_value(_cf, custom_value)
+    if custom_value.is_a?(Array)
+      safe_join(Array(custom_value).compact_blank, ", ")
+    else
+      custom_value.to_s
     end
   end
 end

--- a/app/components/table_component.html.erb
+++ b/app/components/table_component.html.erb
@@ -26,55 +26,56 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
-
-<div class="generic-table--container <%= container_class %>" data-test-selector="<%= test_selector %>" id="<%= container_id %>">
-  <div class="generic-table--results-container">
-    <%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
-      <colgroup>
-        <% headers.each do |_name, _options| %>
-          <col>
-        <% end %>
-        <col data-highlight="false">
-      </colgroup>
-      <thead>
-        <tr>
-          <% headers.each do |name, options| %>
-            <% if sortable_column?(name) %>
-              <%= helpers.sort_header_tag(name, **options) %>
-            <% else %>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= options[:caption] %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-            <% end %>
+<%= component_wrapper do %>
+  <div class="generic-table--container <%= container_class %>" data-test-selector="<%= test_selector %>" id="<%= container_id %>">
+    <div class="generic-table--results-container">
+      <%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
+        <colgroup>
+          <% headers.each do |_name, _options| %>
+            <col>
           <% end %>
-          <th>
-            <%# last column for buttons %>
-            <div class="generic-table--empty-header"></div>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <% if rows.empty? %>
-        <tr class="generic-table--empty-row">
-          <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
-        </tr>
-        <% end %>
-        <%= render_collection rows %>
-      </tbody>
-    <% end %>
-    <% if inline_create_link %>
-      <div class="wp-inline-create-button">
-        <%= inline_create_link %>
-      </div>
-    <% end %>
+          <col data-highlight="false">
+        </colgroup>
+        <thead>
+          <tr>
+            <% headers.each do |name, options| %>
+              <% if sortable_column?(name) %>
+                <%= helpers.sort_header_tag(name, **options) %>
+              <% else %>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= options[:caption] %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+              <% end %>
+            <% end %>
+            <th>
+              <%# last column for buttons %>
+              <div class="generic-table--empty-header"></div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% if rows.empty? %>
+          <tr class="generic-table--empty-row">
+            <td colspan="<%= headers.length + 1 %>"><%= empty_row_message %></td>
+          </tr>
+          <% end %>
+          <%= render_collection rows %>
+        </tbody>
+      <% end %>
+      <% if inline_create_link %>
+        <div class="wp-inline-create-button">
+          <%= inline_create_link %>
+        </div>
+      <% end %>
+    </div>
   </div>
-</div>
-<% if paginated? %>
-  <%= helpers.pagination_links_full rows %>
+  <% if paginated? %>
+    <%= helpers.pagination_links_full rows %>
+  <% end %>
 <% end %>

--- a/app/components/table_component.rb
+++ b/app/components/table_component.rb
@@ -32,6 +32,7 @@
 # Abstract view component. Subclass this for a concrete table.
 class TableComponent < ApplicationComponent
   include Primer::AttributesHelper
+  include OpTurbo::Streamable
 
   def initialize(rows: [], table_arguments: {}, **)
     super(rows, **)

--- a/app/components/users/configure_view_modal_component.html.erb
+++ b/app/components/users/configure_view_modal_component.html.erb
@@ -1,0 +1,27 @@
+<%= render(Primer::Alpha::Dialog.new(title: t(:"queries.configure_view.heading"), size: :large, id: MODAL_ID, style: "min-height: 360px")) do |d| %>
+  <% d.with_header(variant: :large) %>
+  <%= render(Primer::Alpha::Dialog::Body.new) do %>
+    <%= primer_form_with(url: users_path, id: QUERY_FORM_ID, data: { "turbo-stream" => false }, method: :get) do %>
+      <% { filters: params[:filters], sortBy: params[:sortBy] }.each do |name, value| %>
+        <%= hidden_field_tag name, value if value.present? %>
+      <% end %>
+      <%= helpers.angular_component_tag "opce-draggable-autocompleter",
+                                        inputs: {
+                                          options: selectable_columns,
+                                          selected: selected_columns,
+                                          name: COLUMN_HTML_NAME,
+                                          id: COLUMN_HTML_ID,
+                                          dragAreaName: "#{COLUMN_HTML_ID}_dragarea",
+                                          formControlId: "#{COLUMN_HTML_ID}_autocompleter",
+                                          inputLabel: t(:"queries.configure_view.columns.input_label"),
+                                          inputPlaceholder: t(:"queries.configure_view.columns.input_placeholder"),
+                                          dragAreaLabel: t(:"queries.configure_view.columns.drag_area_label"),
+                                          appendToComponent: true
+                                        } %>
+    <% end %>
+  <% end %>
+  <%= render(Primer::Alpha::Dialog::Footer.new) do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": MODAL_ID })) { t(:button_cancel) } %>
+    <%= render(Primer::Beta::Button.new(scheme: :primary, type: :submit, data: { "test-selector": "#{MODAL_ID}-submit" }, form: QUERY_FORM_ID)) { t(:button_apply) } %>
+  <% end %>
+<% end %>

--- a/app/components/users/configure_view_modal_component.rb
+++ b/app/components/users/configure_view_modal_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,35 +26,38 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+module Users
+  class ConfigureViewModalComponent < ApplicationComponent
+    include OpTurbo::Streamable
 
-  def self.model
-    User
-  end
+    MODAL_ID = "op-user-list-configure-dialog"
+    QUERY_FORM_ID = "op-user-list-configure-query-form"
+    COLUMN_HTML_NAME = "columns"
+    COLUMN_HTML_ID = "columns-select"
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user
-  end
+    options :query
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
+    def selectable_columns
+      @selectable_columns ||= UserQuery.new
+                                       .available_selects
+                                       .reject { |c| text_format_custom_field?(c) }
+                                       .sort_by(&:caption)
+                                       .map { |c| { id: c.attribute, name: c.caption } }
+    end
 
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
+    def selected_columns
+      @selected_columns ||= query.selects
+                                 .reject { |c| text_format_custom_field?(c) }
+                                 .map { |c| { id: c.attribute, name: c.caption } }
+    end
 
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::CustomField
+    private
+
+    def text_format_custom_field?(select)
+      select.is_a?(Queries::Users::Selects::CustomField) &&
+        select.custom_field&.field_format == "text"
+    end
   end
 end

--- a/app/components/users/index_page_header_component.html.erb
+++ b/app/components/users/index_page_header_component.html.erb
@@ -1,17 +1,35 @@
-<%= render(Primer::OpenProject::PageHeader.new) do |header| %>
-  <% header.with_title { t(:label_user_plural) } %>
-  <% header.with_breadcrumbs(breadcrumb_items) %>
-  <% header.with_description do %>
-    <%= t(:label_enterprise_active_users, current: OpenProject::Enterprise.active_user_count, limit: user_limit) %>
-    &nbsp;
-    <%= render(
-          Primer::Beta::Button.new(
-            scheme: :primary,
-            size: :small,
-            tag: :a,
-            href: OpenProject::Enterprise.upgrade_path,
-            title: t(:title_enterprise_upgrade)
-          )
-        ) { t(:button_upgrade) } %>
-  <% end if user_limit %>
+<%= component_wrapper do %>
+  <%= render(Primer::OpenProject::PageHeader.new) do |header| %>
+    <% header.with_title { t(:label_user_plural) } %>
+    <% header.with_breadcrumbs(breadcrumb_items) %>
+    <% header.with_description do %>
+      <%= t(:label_enterprise_active_users, current: OpenProject::Enterprise.active_user_count, limit: user_limit) %>
+      &nbsp;
+      <%= render(
+            Primer::Beta::Button.new(
+              scheme: :primary,
+              size: :small,
+              tag: :a,
+              href: OpenProject::Enterprise.upgrade_path,
+              title: t(:title_enterprise_upgrade)
+            )
+          ) { t(:button_upgrade) } %>
+    <% end if user_limit %>
+    <% header.with_action_menu(
+         menu_arguments: { anchor_align: :end },
+         button_arguments: {
+           icon: "kebab-horizontal",
+           "aria-label": t(:label_more)
+         }
+       ) do |menu| %>
+      <% menu.with_item(
+           tag: :a,
+           label: t(:"queries.configure_view.heading"),
+           href: configure_view_modal_path,
+           content_arguments: { data: { controller: "async-dialog" }, rel: "nofollow" }
+         ) do |item| %>
+        <% item.with_leading_visual_icon(icon: :gear) %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/users/index_page_header_component.rb
+++ b/app/components/users/index_page_header_component.rb
@@ -29,8 +29,11 @@
 # ++
 
 class Users::IndexPageHeaderComponent < ApplicationComponent
+  include OpTurbo::Streamable
   include OpPrimer::ComponentHelpers
   include ApplicationHelper
+
+  options :query
 
   delegate :user_limit, to: :"OpenProject::Enterprise"
 
@@ -38,5 +41,24 @@ class Users::IndexPageHeaderComponent < ApplicationComponent
     [{ href: admin_index_path, text: t("label_administration") },
      { href: admin_settings_users_path, text: t(:label_user_and_permission) },
      t(:label_user_plural)]
+  end
+
+  def configure_view_modal_path
+    helpers.configure_view_modal_users_path(query_params)
+  end
+
+  private
+
+  def query_params
+    { filters: helpers.params[:filters],
+      sortBy: helpers.params[:sortBy],
+      columns: current_columns }.compact_blank
+  end
+
+  def current_columns
+    return if query.nil?
+
+    cols = query.selects.map { |s| s.attribute.to_s }.join(" ")
+    cols.presence
   end
 end

--- a/app/components/users/index_sub_header_component.html.erb
+++ b/app/components/users/index_sub_header_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  render(Primer::OpenProject::SubHeader.new) do |subheader|
+  render(Primer::OpenProject::SubHeader.new(data: sub_header_data_attributes)) do |subheader|
     subheader.with_action_button(
       scheme: :primary,
       leading_icon: :plus,
@@ -10,8 +10,21 @@
       t("activerecord.models.user")
     end
 
+    subheader.with_filter_input(
+      name: "any_name_attribute",
+      label: t(:label_search),
+      value: filter_input_value,
+      placeholder: t(:label_search),
+      clear_button_id: clear_button_id,
+      data: filter_input_data_attributes
+    )
+
+    subheader.with_filter_component do
+      render Users::UserFilterButtonComponent.new(query: @query)
+    end
+
     subheader.with_bottom_pane_component do
-      render Users::UserFilterComponent.new(@params, groups: @groups, status: @status)
+      render Users::UserFiltersComponent.new(query: @query, initially_expanded: filters_expanded?)
     end
   end
 %>

--- a/app/components/users/index_sub_header_component.rb
+++ b/app/components/users/index_sub_header_component.rb
@@ -32,11 +32,39 @@ module Users
   class IndexSubHeaderComponent < ApplicationComponent
     include ApplicationHelper
 
-    def initialize(groups:, status:, params:)
+    def initialize(query:)
       super
-      @groups = groups
-      @status = status
-      @params = params
+      @query = query
+    end
+
+    def filter_input_value
+      @query.find_active_filter(:any_name_attribute)&.values&.first
+    end
+
+    def sub_header_data_attributes
+      {
+        controller: "filter--filters-form",
+        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-clear-button-id-value": clear_button_id,
+        "filter--filters-form-display-filters-value": filters_expanded?
+      }
+    end
+
+    def filter_input_data_attributes
+      {
+        "filter-name": "any_name_attribute",
+        "filter-type": "string",
+        "filter-operator": "~",
+        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
+      }
+    end
+
+    def clear_button_id
+      "user-filters-form-clear-button"
+    end
+
+    def filters_expanded?
+      params[:filters].present?
     end
   end
 end

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -98,6 +98,24 @@ module Users
       user.admin? && !table.current_user.admin?
     end
 
+    private
+
+    def custom_field_id(column)
+      match = Queries::Users::Selects::CustomField::KEY.match(column.to_s)
+      return unless match
+
+      match.captures.first.to_i
+    end
+
+    def column_value(column)
+      if (cf_id = custom_field_id(column))
+        custom_field = UserCustomField.find_by(id: cf_id)
+        custom_field ? user.formatted_custom_value_for(custom_field).to_s : ""
+      else
+        send(column)
+      end
+    end
+
     def column_css_class(column)
       if column == :mail
         "email"

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -98,32 +98,25 @@ module Users
       user.admin? && !table.current_user.admin?
     end
 
-    private
-
-    def custom_field_id(column)
-      match = Queries::Users::Selects::CustomField::KEY.match(column.to_s)
-      return unless match
-
-      match.captures.first.to_i
-    end
-
     def column_value(column)
-      if (cf_id = custom_field_id(column))
-        custom_field = UserCustomField.find_by(id: cf_id)
-        custom_field ? user.formatted_custom_value_for(custom_field).to_s : ""
-      else
-        send(column)
-      end
+      return custom_field_column(column) if custom_field_column?(column)
+
+      send(column.respond_to?(:attribute) ? column.attribute : column)
     end
 
     def column_css_class(column)
-      if column == :mail
-        "email"
-      elsif column == :login
-        "username"
-      else
-        super
+      attr = column.respond_to?(:attribute) ? column.attribute : column
+      case attr
+      when :mail then "email"
+      when :login then "username"
+      else attr.to_s
       end
+    end
+
+    private
+
+    def custom_field_column_subject
+      user
     end
   end
 end

--- a/app/components/users/table_component.rb
+++ b/app/components/users/table_component.rb
@@ -33,6 +33,19 @@ module Users
     columns :login, :firstname, :lastname, :mail, :admin, :created_at, :last_login_on
     options :current_user
 
+    def before_render
+      @user_query = model if model.is_a?(Queries::BaseQuery)
+      super
+    end
+
+    def columns
+      @columns ||= if @user_query&.selects&.any?
+                     @user_query.selects.map(&:attribute)
+                   else
+                     super
+                   end
+    end
+
     def initial_sort
       %i[id asc]
     end
@@ -44,10 +57,14 @@ module Users
     end
 
     def header_options(name)
-      options = { caption: User.human_attribute_name(name) }
+      caption = if @user_query
+                  @user_query.selects.find { |s| s.attribute == name }&.caption || User.human_attribute_name(name)
+                else
+                  User.human_attribute_name(name)
+                end
 
-      options[:default_order] = "desc" if desc_by_default.include? name
-
+      options = { caption: }
+      options[:default_order] = "desc" if desc_by_default.include?(name)
       options
     end
 

--- a/app/components/users/table_component.rb
+++ b/app/components/users/table_component.rb
@@ -40,7 +40,7 @@ module Users
 
     def columns
       @columns ||= if @user_query&.selects&.any?
-                     @user_query.selects.map(&:attribute)
+                     @user_query.selects
                    else
                      super
                    end
@@ -51,20 +51,17 @@ module Users
     end
 
     def headers
-      columns.map do |name|
-        [name.to_s, header_options(name)]
+      columns.map do |column|
+        key = column.respond_to?(:attribute) ? column.attribute.to_s : column.to_s
+        [key, header_options(column)]
       end
     end
 
-    def header_options(name)
-      caption = if @user_query
-                  @user_query.selects.find { |s| s.attribute == name }&.caption || User.human_attribute_name(name)
-                else
-                  User.human_attribute_name(name)
-                end
-
+    def header_options(column)
+      attr = column.respond_to?(:attribute) ? column.attribute : column
+      caption = column.respond_to?(:caption) ? column.caption : User.human_attribute_name(attr)
       options = { caption: }
-      options[:default_order] = "desc" if desc_by_default.include?(name)
+      options[:default_order] = "desc" if desc_by_default.include?(attr)
       options
     end
 

--- a/app/components/users/user_filter_button_component.rb
+++ b/app/components/users/user_filter_button_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,12 +26,19 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class Queries::Users::Orders::DefaultOrder < Queries::Orders::Base
-  self.model = User
+module Users
+  class UserFilterButtonComponent < Filter::FilterButtonComponent
+    HIDDEN_FILTERS = [
+      Queries::Users::Filters::AnyNameAttributeFilter,
+      Queries::Users::Filters::BlockedFilter
+    ].freeze
 
-  def self.key
-    /\A(id|lastname|firstname|mail|login|admin|created_at|last_login_on)\z/
+    private
+
+    def filters_count
+      query.filters.count { |f| HIDDEN_FILTERS.none? { |klass| f.is_a?(klass) } }
+    end
   end
 end

--- a/app/components/users/user_filters_component.rb
+++ b/app/components/users/user_filters_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,12 +26,33 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class Queries::Users::Orders::DefaultOrder < Queries::Orders::Base
-  self.model = User
+module Users
+  class UserFiltersComponent < Filter::FilterComponent
+    def turbo_requests? = true
 
-  def self.key
-    /\A(id|lastname|firstname|mail|login|admin|created_at|last_login_on)\z/
+    def allowed_filters
+      super
+        .grep_v(Queries::Users::Filters::AnyNameAttributeFilter)
+        .grep_v(Queries::Users::Filters::BlockedFilter)
+        .sort_by(&:human_name)
+    end
+
+    protected
+
+    def additional_filter_attributes(filter)
+      case filter
+      when Queries::Users::Filters::GroupFilter
+        {
+          autocomplete_options: {
+            component: "opce-group-autocompleter",
+            resource: "groups"
+          }
+        }
+      else
+        super
+      end
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -427,10 +427,11 @@ class UsersController < ApplicationController
              status: User.statuses[:invited])
   end
 
-  def render_index_turbo_stream
+  def render_index_turbo_stream # rubocop:disable Metrics/AbcSize
     update_via_turbo_stream(component: Users::UserFilterButtonComponent.new(query: @query))
     replace_via_turbo_stream(component: Users::TableComponent.new(rows: @query, current_user:))
     turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page)))
+    turbo_streams << turbo_stream.replace("primerized-flash-messages", helpers.render_flash_messages)
     render turbo_stream: turbo_streams
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,11 +79,15 @@ class UsersController < ApplicationController
   include SortHelper
   include CustomFieldsHelper
   include PaginationHelper
+  include Queries::Loading
+
+  before_action :load_query_or_deny_access, only: :index
 
   def index
-    @groups = Group.visible.sort
-    @status = Users::UserFilterComponent.status_param params
-    @users = Users::UserFilterComponent.filter params
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render_index_turbo_stream }
+    end
   end
 
   def show
@@ -421,6 +425,13 @@ class UsersController < ApplicationController
       .merge(admin: params[:user][:admin] || false,
              login: params[:user][:login] || params[:user][:mail],
              status: User.statuses[:invited])
+  end
+
+  def render_index_turbo_stream
+    update_via_turbo_stream(component: Users::UserFilterButtonComponent.new(query: @query))
+    replace_via_turbo_stream(component: Users::TableComponent.new(rows: @query, current_user:))
+    turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page)))
+    render turbo_stream: turbo_streams
   end
 
   def prepare_views_for_tab # rubocop:disable Metrics/AbcSize

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -81,13 +81,17 @@ class UsersController < ApplicationController
   include PaginationHelper
   include Queries::Loading
 
-  before_action :load_query_or_deny_access, only: :index
+  before_action :load_query_or_deny_access, only: %i[index configure_view_modal]
 
   def index
     respond_to do |format|
       format.html
       format.turbo_stream { render_index_turbo_stream }
     end
+  end
+
+  def configure_view_modal
+    respond_with_dialog Users::ConfigureViewModalComponent.new(query: @query)
   end
 
   def show
@@ -428,9 +432,10 @@ class UsersController < ApplicationController
   end
 
   def render_index_turbo_stream # rubocop:disable Metrics/AbcSize
+    replace_via_turbo_stream(component: Users::IndexPageHeaderComponent.new(query: @query))
     update_via_turbo_stream(component: Users::UserFilterButtonComponent.new(query: @query))
     replace_via_turbo_stream(component: Users::TableComponent.new(rows: @query, current_user:))
-    turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page)))
+    turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page, :columns)))
     turbo_streams << turbo_stream.replace("primerized-flash-messages", helpers.render_flash_messages)
     render turbo_stream: turbo_streams
   end

--- a/app/models/queries/users/selects/default.rb
+++ b/app/models/queries/users/selects/default.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,35 +26,20 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class UserQuery < PersistedQuery
-  scope :visible, ->(user = User.current) { where(principal: user) }
+class Queries::Users::Selects::Default < Queries::Selects::Base
+  KEYS = %i[login firstname lastname mail admin created_at last_login_on].freeze
 
-  def self.model
-    User
+  def self.key
+    /\A(#{Regexp.union(KEYS.map(&:to_s))})\z/
   end
 
-  def default_scope
-    # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user
+  def self.all_available
+    KEYS.map { new(it) }
   end
 
-  register_query do
-    filter Queries::Users::Filters::NameFilter
-    filter Queries::Users::Filters::AnyNameAttributeFilter
-    filter Queries::Users::Filters::GroupFilter
-    filter Queries::Users::Filters::StatusFilter
-    filter Queries::Users::Filters::LoginFilter
-    filter Queries::Users::Filters::BlockedFilter
-    filter Queries::Users::Filters::CustomFieldFilter
-
-    order Queries::Users::Orders::DefaultOrder
-    order Queries::Users::Orders::NameOrder
-    order Queries::Users::Orders::GroupOrder
-    order Queries::Users::Orders::CustomFieldOrder
-
-    select Queries::Users::Selects::Default
-    select Queries::Users::Selects::CustomField
+  def caption
+    User.human_attribute_name(attribute)
   end
 end

--- a/app/models/user_queries/static.rb
+++ b/app/models/user_queries/static.rb
@@ -44,6 +44,7 @@ class UserQueries::Static
     def static_query_active
       UserQuery.new(name: I18n.t(:status_active)) do |query|
         query.where("status", "=", "active")
+        query.select(*Queries::Users::Selects::Default::KEYS, add_not_existing: false)
         query.clear_changes_information
       end
     end

--- a/app/models/user_queries/static.rb
+++ b/app/models/user_queries/static.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,16 +26,26 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module Users
-  class UserFilterComponent < ::UserFilterComponent
-    def filter_role(query, role_id)
-      super.uniq
+class UserQueries::Static
+  DEFAULT = "active"
+
+  class << self
+    def query(id)
+      case id
+      when DEFAULT, nil
+        static_query_active
+      end
     end
 
-    def clear_url
-      users_path
+    private
+
+    def static_query_active
+      UserQuery.new(name: I18n.t(:status_active)) do |query|
+        query.where("status", "=", "active")
+        query.clear_changes_information
+      end
     end
   end
 end

--- a/app/models/user_query.rb
+++ b/app/models/user_query.rb
@@ -29,6 +29,8 @@
 #++
 
 class UserQuery < PersistedQuery
+  scope :visible, ->(user = User.current) { where(principal: user) }
+
   def self.model
     User
   end

--- a/app/models/user_query.rb
+++ b/app/models/user_query.rb
@@ -37,7 +37,7 @@ class UserQuery < PersistedQuery
 
   def default_scope
     # Excludes the SystemUser, DeletedUser, AnonymousUser STI descendants of User.
-    User.user
+    User.user.visible
   end
 
   register_query do

--- a/app/services/user_queries/set_attributes_service.rb
+++ b/app/services/user_queries/set_attributes_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,12 +26,35 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-class Queries::Users::Orders::DefaultOrder < Queries::Orders::Base
-  self.model = User
+class UserQueries::SetAttributesService < BaseServices::SetAttributes
+  private
 
-  def self.key
-    /\A(id|lastname|firstname|mail|login|admin|created_at|last_login_on)\z/
+  def set_attributes(params)
+    set_filters(params.delete(:filters))
+    set_order(params.delete(:orders))
+
+    super
+  end
+
+  def set_default_attributes(_params)
+    # No user or project association needed for admin-scoped user queries
+  end
+
+  def set_filters(filters)
+    return unless filters
+
+    model.filters.clear
+    filters.each do |filter|
+      model.where(filter[:attribute], filter[:operator], filter[:values])
+    end
+  end
+
+  def set_order(orders)
+    return unless orders
+
+    model.orders.clear
+    model.order(orders.to_h { |o| [o[:attribute], o[:direction]] })
   end
 end

--- a/app/services/user_queries/set_attributes_service.rb
+++ b/app/services/user_queries/set_attributes_service.rb
@@ -34,12 +34,19 @@ class UserQueries::SetAttributesService < BaseServices::SetAttributes
   def set_attributes(params)
     set_filters(params.delete(:filters))
     set_order(params.delete(:orders))
+    set_select(params.delete(:selects))
 
     super
   end
 
   def set_default_attributes(_params)
-    # No user or project association needed for admin-scoped user queries
+    set_default_selects
+  end
+
+  def set_default_selects
+    return if model.selects.any?
+
+    model.select(*Queries::Users::Selects::Default::KEYS, add_not_existing: false)
   end
 
   def set_filters(filters)
@@ -49,6 +56,13 @@ class UserQueries::SetAttributesService < BaseServices::SetAttributes
     filters.each do |filter|
       model.where(filter[:attribute], filter[:operator], filter[:values])
     end
+  end
+
+  def set_select(selects)
+    return unless selects
+
+    model.selects.clear
+    model.select(*selects, add_not_existing: false)
   end
 
   def set_order(orders)

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++#%>
 <% html_title t(:label_administration), t(:label_user_plural) -%>
 
-<%= render Users::IndexPageHeaderComponent.new %>
+<%= render Users::IndexPageHeaderComponent.new(query: @query) %>
 
 <%= render Users::IndexSubHeaderComponent.new(query: @query) %>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,6 +30,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render Users::IndexPageHeaderComponent.new %>
 
-<%= render Users::IndexSubHeaderComponent.new(groups: @groups, status: @status, params: params) %>
+<%= render Users::IndexSubHeaderComponent.new(query: @query) %>
 
-<%= render Users::TableComponent.new(rows: @users, current_user:) %>
+<%= render Users::TableComponent.new(rows: @query, current_user:) %>

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -70,7 +70,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :create_user,
                      {
-                       users: %i[index show new create resend_invitation],
+                       users: %i[index show new create resend_invitation configure_view_modal],
                        "users/memberships": %i[create],
                        admin: %i[index]
                      },
@@ -85,7 +85,8 @@ Rails.application.reloader.to_prepare do
                                  update_reminders update_email_alerts update_workdays
                                  update_participating update_non_participating update_date_alerts
                                  new_project_settings create_project_settings
-                                 edit_project_settings update_project_settings destroy_project_settings],
+                                 edit_project_settings update_project_settings destroy_project_settings
+                                 configure_view_modal],
                        "users/memberships": %i[create update destroy],
                        admin: %i[index]
                      },
@@ -96,7 +97,7 @@ Rails.application.reloader.to_prepare do
 
       map.permission :view_all_principals,
                      {
-                       users: %i[index show]
+                       users: %i[index show configure_view_modal]
                      },
                      permissible_on: :global,
                      require: :loggedin,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -968,6 +968,9 @@ Rails.application.routes.draw do
   end
 
   resources :users, constraints: { id: /(\d+|me)/ }, except: :edit do
+    collection do
+      get :configure_view_modal
+    end
     resources :memberships, controller: "users/memberships", only: %i[update create destroy]
     resources :working_hours, controller: "users/working_hours", except: [:index]
     resources :non_working_times, controller: "users/non_working_times", except: [:index] do

--- a/frontend/src/global_styles/content/_table.sass
+++ b/frontend/src/global_styles/content/_table.sass
@@ -151,7 +151,7 @@ table.generic-table
 
     @media screen
       th[scope="row"]:not(.-no-ellipsis),
-      td:not(.-no-ellipsis)
+      td:not(.-no-ellipsis):not(.buttons)
         @include text-shortener
 
     .project td

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -736,15 +736,15 @@ RSpec.describe UsersController do
       expect(response).to have_rendered("index")
     end
 
-    it "assigns users" do
-      expect(assigns(:users)).to contain_exactly(user, admin, user_manager)
+    it "assigns a query" do
+      expect(assigns(:query).results).to contain_exactly(user, admin, user_manager)
     end
 
     context "with a name filter" do
-      let(:params) { { name: user.firstname } }
+      let(:params) { { filters: %(any_name_attribute ~ "#{user.firstname}") } }
 
-      it "assigns users" do
-        expect(assigns(:users)).to contain_exactly(user)
+      it "assigns a query filtered by name" do
+        expect(assigns(:query).results).to contain_exactly(user)
       end
     end
 
@@ -752,11 +752,11 @@ RSpec.describe UsersController do
       let(:group) { create(:group, members: [user]) }
 
       let(:params) do
-        { group_id: group.id }
+        { filters: %(group = "#{group.id}") }
       end
 
-      it "assigns users" do
-        expect(assigns(:users)).to contain_exactly(user)
+      it "assigns a query filtered by group" do
+        expect(assigns(:query).results).to contain_exactly(user)
       end
     end
 
@@ -764,7 +764,7 @@ RSpec.describe UsersController do
       let!(:deleted_user) { create(:user_marked_for_deletion) }
 
       it "does not include this user to the users list" do
-        expect(assigns(:users)).to contain_exactly(user, admin, user_manager)
+        expect(assigns(:query).results).to contain_exactly(user, admin, user_manager)
       end
     end
   end
@@ -806,14 +806,13 @@ RSpec.describe UsersController do
 
     context "enabled" do
       before do
-        allow(Setting).to receive(:session_ttl_enabled?).and_return(true)
-        allow(Setting).to receive(:session_ttl).and_return("120")
+        allow(Setting).to receive_messages(session_ttl_enabled?: true, session_ttl: "120")
         @controller.send(:logged_user=, admin)
       end
 
       context "before 120 min of inactivity" do
         before do
-          session[:updated_at] = Time.now - 1.hour
+          session[:updated_at] = 1.hour.ago
           get :index
         end
 
@@ -822,7 +821,7 @@ RSpec.describe UsersController do
 
       context "after 120 min of inactivity" do
         before do
-          session[:updated_at] = Time.now - 3.hours
+          session[:updated_at] = 3.hours.ago
           get :index
         end
 
@@ -842,7 +841,7 @@ RSpec.describe UsersController do
       context "with ttl = 0" do
         before do
           allow(Setting).to receive(:session_ttl).and_return("0")
-          session[:updated_at] = Time.now - 1.hour
+          session[:updated_at] = 1.hour.ago
           get :index
         end
 
@@ -852,7 +851,7 @@ RSpec.describe UsersController do
       context "with ttl < 0" do
         before do
           allow(Setting).to receive(:session_ttl).and_return("-60")
-          session[:updated_at] = Time.now - 1.hour
+          session[:updated_at] = 1.hour.ago
           get :index
         end
 
@@ -862,7 +861,7 @@ RSpec.describe UsersController do
       context "with ttl < 5 > 0" do
         before do
           allow(Setting).to receive(:session_ttl).and_return("4")
-          session[:updated_at] = Time.now - 1.hour
+          session[:updated_at] = 1.hour.ago
           get :index
         end
 

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -68,27 +68,18 @@ RSpec.describe "index users", :js do
     shared_let(:registered_user) { create(:user, status: User.statuses[:registered]) }
     shared_let(:invited_user) { create(:user, status: User.statuses[:invited]) }
 
-    it "shows the users by status and allows status manipulations",
+    it "shows active users by default and allows status filtering and manipulations",
        with_settings: { brute_force_block_after_failed_logins: 5,
                         brute_force_block_minutes: 10 } do
       index_page.visit!
 
-      # Order is by id, asc
-      # so first ones created are on top.
-      index_page.expect_listed(current_user, active_user, registered_user, invited_user)
-
-      index_page.order_by("Created on")
-      index_page.expect_order(invited_user, registered_user, active_user, current_user)
-
-      index_page.order_by("Created on")
-      index_page.expect_order(current_user, active_user, registered_user, invited_user)
+      # Default filter: active users only
+      index_page.expect_listed(current_user, active_user)
 
       index_page.lock_user(active_user)
-      index_page.expect_listed(current_user, active_user, registered_user, invited_user)
+      # active_user is now locked — still visible until filter changes
       index_page.expect_user_locked(active_user)
-
-      expect(active_user.reload)
-        .to be_locked
+      expect(active_user.reload).to be_locked
 
       index_page.filter_by_status("locked permanently")
       index_page.expect_listed(active_user)
@@ -106,30 +97,19 @@ RSpec.describe "index users", :js do
       index_page.filter_by_name(active_user.lastname[0..-3])
       index_page.expect_listed(active_user)
 
-      # temporarily block user
+      # temporarily block user — reset via action, no filter needed
       active_user.update(failed_login_count: 6,
                          last_failed_login_on: 9.minutes.ago)
       index_page.clear_filters
-      index_page.expect_listed(current_user, active_user, registered_user, invited_user)
-
-      index_page.filter_by_status("locked temporarily")
-      index_page.expect_listed(active_user)
+      # after clear, default active filter is restored
+      index_page.expect_listed(current_user, active_user)
 
       index_page.reset_failed_logins(active_user)
-      index_page.expect_non_listed
+      # still listed — reset doesn't change status
+      index_page.expect_listed(current_user, active_user)
 
-      # temporarily block user and lock permanently
-      active_user.reload
-      active_user.update(failed_login_count: 6,
-                         last_failed_login_on: 9.minutes.ago)
-      index_page.clear_filters
-
-      index_page.filter_by_status("locked temporarily")
-      index_page.expect_listed(active_user)
-
+      # lock permanently and unlock
       index_page.lock_user(active_user)
-      index_page.expect_listed(active_user)
-
       index_page.filter_by_status("locked permanently")
       index_page.expect_listed(active_user)
 
@@ -145,7 +125,6 @@ RSpec.describe "index users", :js do
 
       index_page.activate_user(registered_user)
       index_page.filter_by_status("active")
-
       index_page.expect_listed(current_user, active_user, registered_user)
     end
 
@@ -155,7 +134,7 @@ RSpec.describe "index users", :js do
 
       it "can too visit the page" do
         index_page.visit!
-        index_page.expect_listed(admin, current_user, active_user, registered_user, invited_user)
+        index_page.expect_listed(admin, current_user, active_user)
       end
     end
   end

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -39,6 +39,31 @@ RSpec.describe "index users", :js do
     login_as current_user
   end
 
+  describe "filtering", :js do
+    let!(:alice) { create(:user, login: "alice", firstname: "Alice", lastname: "Smith") }
+    let!(:bob)   { create(:user, login: "bob",   firstname: "Bob",   lastname: "Jones") }
+
+    it "filters by name via the search input and updates without a page reload" do
+      index_page.visit!
+      index_page.expect_listed(current_user, alice, bob)
+
+      index_page.filter_by_name("Alice")
+      index_page.expect_listed(alice)
+    end
+
+    it "allows changing the status filter away from the default active-only view" do
+      registered = create(:user, login: "charlie", status: User.statuses[:registered])
+
+      index_page.visit!
+      # Default: only active users
+      index_page.expect_listed(current_user, alice, bob)
+      expect(page).to have_no_css("td.username a", text: registered.login)
+
+      index_page.filter_by_status(I18n.t(:status_registered))
+      index_page.expect_listed(registered)
+    end
+  end
+
   describe "with some sortable users" do
     let!(:a_user) { create(:user, login: "aa_login", firstname: "aa_first", lastname: "xxx_a") }
     let!(:b_user) { create(:user, login: "bb_login", firstname: "bb_first", lastname: "nnn_b") }
@@ -77,21 +102,20 @@ RSpec.describe "index users", :js do
       index_page.expect_listed(current_user, active_user)
 
       index_page.lock_user(active_user)
-      # active_user is now locked — still visible until filter changes
-      index_page.expect_user_locked(active_user)
       expect(active_user.reload).to be_locked
 
-      index_page.filter_by_status("locked permanently")
+      index_page.filter_by_status(I18n.t(:status_locked))
       index_page.expect_listed(active_user)
+      index_page.expect_user_locked(active_user)
 
-      index_page.filter_by_status("active")
+      index_page.filter_by_status(I18n.t(:status_active))
       index_page.expect_listed(current_user)
 
-      index_page.filter_by_status("locked permanently")
+      index_page.filter_by_status(I18n.t(:status_locked))
       index_page.unlock_user(active_user)
       index_page.expect_non_listed
 
-      index_page.filter_by_status("active")
+      index_page.filter_by_status(I18n.t(:status_active))
       index_page.expect_listed(current_user, active_user)
 
       index_page.filter_by_name(active_user.lastname[0..-3])
@@ -108,28 +132,34 @@ RSpec.describe "index users", :js do
       # still listed — reset doesn't change status
       index_page.expect_listed(current_user, active_user)
 
-      # lock permanently and unlock
+      # Lock and unlock — failed logins were reset above, so the user is locked
+      # but not blocked, and the row exposes the plain "Unlock" action.
       index_page.lock_user(active_user)
-      index_page.filter_by_status("locked permanently")
+      index_page.filter_by_status(I18n.t(:status_locked))
       index_page.expect_listed(active_user)
 
-      index_page.unlock_and_reset_user(active_user)
+      index_page.unlock_user(active_user)
       index_page.expect_non_listed
 
-      index_page.filter_by_status("active")
+      index_page.filter_by_status(I18n.t(:status_active))
       index_page.expect_listed(current_user, active_user)
 
       # activate registered user
-      index_page.filter_by_status("registered")
+      index_page.filter_by_status(I18n.t(:status_registered))
       index_page.expect_listed(registered_user)
 
       index_page.activate_user(registered_user)
-      index_page.filter_by_status("active")
+      index_page.filter_by_status(I18n.t(:status_active))
       index_page.expect_listed(current_user, active_user, registered_user)
     end
 
     context "as global user" do
-      shared_let(:global_manage_user) { create(:user, global_permissions: [:manage_user]) }
+      # :manage_user declares :view_all_principals as a dependency in the
+      # access-control map; the factory does not auto-expand dependencies, so we
+      # add it explicitly to match real-world role configuration.
+      shared_let(:global_manage_user) do
+        create(:user, global_permissions: %i[manage_user view_all_principals])
+      end
       let(:current_user) { global_manage_user }
 
       it "can too visit the page" do

--- a/spec/features/users/unaccent_user_filter_spec.rb
+++ b/spec/features/users/unaccent_user_filter_spec.rb
@@ -51,14 +51,12 @@ RSpec.describe "Finding users with accents", :js do
   it "finds a user with accents in the name in the global administration" do
     visit users_path
 
-    fill_in "name", with: "Cecile"
-    click_on "Apply"
-    expect(page).to have_current_path /name=Cecile/
+    fill_in "Search", with: "Cecile"
+    wait_for_network_idle
     expect(page).to have_css("td.firstname", text: "Cécile")
 
-    fill_in "name", with: "Cécile"
-    click_on "Apply"
-    expect(page).to have_current_path /name=C%C3%A9cile/
+    fill_in "Search", with: "Cécile"
+    wait_for_network_idle
     expect(page).to have_css("td.firstname", text: "Cécile")
   end
 

--- a/spec/models/user_card_view_spec.rb
+++ b/spec/models/user_card_view_spec.rb
@@ -97,9 +97,14 @@ RSpec.describe UserCardView do
   end
 
   describe "#results" do
-    let!(:alice)  { create(:user, firstname: "Alice", lastname: "Anderson") }
+    # UserQuery scopes to users visible to the current user. Granting alice
+    # :view_all_principals lets her see every user without introducing an
+    # extra admin record that would pollute `contain_exactly` expectations.
+    let!(:alice)  { create(:user, firstname: "Alice", lastname: "Anderson", global_permissions: %i[view_all_principals]) }
     let!(:bob)    { create(:user, firstname: "Bob",   lastname: "Brown") }
     let!(:locked) { create(:locked_user, firstname: "Carol", lastname: "Clark") }
+
+    before { login_as(alice) }
 
     it "returns nil when there is no query" do
       expect(view.results).to be_nil

--- a/spec/models/user_query_integration_spec.rb
+++ b/spec/models/user_query_integration_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe UserQuery, "integration" do
   shared_let(:designer_option) { job_title_cf.custom_options.find_by(value: "Designer") }
   shared_let(:pm_option) { job_title_cf.custom_options.find_by(value: "Project Manager") }
 
-  shared_let(:alice) { create(:user, firstname: "Alice", lastname: "Anders") }
+  # Alice is the logged-in user across most examples; she needs view_all_principals
+  # so the existing filter/order expectations enumerate every seeded user.
+  # Visibility behaviour is exercised separately in the `describe "visibility"` block.
+  shared_let(:alice) { create(:user, firstname: "Alice", lastname: "Anders", global_permissions: %i[view_all_principals]) }
   shared_let(:bob) { create(:user, firstname: "Bob", lastname: "Bauer") }
   shared_let(:carol) { create(:user, firstname: "Carol", lastname: "Cohen") }
   shared_let(:dave) { create(:user, firstname: "Dave", lastname: "Doe") }
@@ -231,6 +234,57 @@ RSpec.describe UserQuery, "integration" do
       expect(select).to be_available
       expect(select.custom_field).to eq(job_title_cf)
       expect(select.caption).to eq(job_title_cf.name)
+    end
+  end
+
+  describe "visibility" do
+    # Override the outer admin login so each context can pin down its own viewer.
+    let(:viewer) { create(:user, firstname: "Viewer", lastname: "Visible") }
+
+    before { login_as(viewer) }
+
+    context "when the current user is an admin" do
+      let(:viewer) { create(:admin, firstname: "Viewer", lastname: "Admin") }
+
+      it "returns every active user" do
+        expect(query.results).to include(alice, bob, carol, dave, locked_eve, viewer)
+      end
+    end
+
+    context "when the current user has the :view_all_principals global permission" do
+      let(:viewer) do
+        create(:user, firstname: "Viewer", lastname: "Global",
+                      global_permissions: %i[view_all_principals])
+      end
+
+      it "returns every active user" do
+        expect(query.results).to include(alice, bob, carol, dave, locked_eve, viewer)
+      end
+    end
+
+    context "when the current user has no view permission and no shared membership" do
+      it "only sees themselves" do
+        expect(query.results).to contain_exactly(viewer)
+      end
+
+      it "sees other users that share a project membership" do
+        role = create(:project_role)
+        project = create(:project)
+        create(:member, principal: viewer, project: project, roles: [role])
+        create(:member, principal: alice, project: project, roles: [role])
+
+        expect(query.results).to contain_exactly(viewer, alice)
+      end
+
+      it "sees other users that share a group membership" do
+        create(:group, members: [viewer, alice])
+
+        expect(query.results).to contain_exactly(viewer, alice)
+      end
+
+      it "does not see users that share neither a project nor a group" do
+        expect(query.results).not_to include(bob, carol, dave, locked_eve)
+      end
     end
   end
 

--- a/spec/models/user_query_spec.rb
+++ b/spec/models/user_query_spec.rb
@@ -31,6 +31,11 @@
 require "spec_helper"
 
 RSpec.describe UserQuery do
+  # The query default scope filters to users visible to the current user.
+  # Admins satisfy `view_all_principals`, so `User.user.visible(admin)` is a no-op,
+  # keeping the SQL identical to the hand-written expectations.
+  current_user { create(:admin) }
+
   let(:instance) { described_class.new(name: "Users") }
   let(:base_scope) { User.user.order(id: :desc) }
 

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -62,23 +62,37 @@ module Pages
         end
 
         def filter_by_status(value)
-          select value, from: "Status:"
-          click_button "Apply"
+          open_filter_panel
+          select "Status", from: "Add filter"
+          within_filter("status") do
+            find("[data-filter-name='status'] select").select(value)
+          end
 
           wait_for_network_idle
         end
 
         def filter_by_name(value)
-          fill_in "Name", with: value
-          click_button "Apply"
+          fill_in "Search", with: value
 
           wait_for_network_idle
         end
 
         def clear_filters
-          click_link "Clear"
+          find_by_id("user-filters-form-clear-button").click
 
           wait_for_network_idle
+        end
+
+        def open_filter_panel
+          find("[data-test-selector='filter-component-toggle']").click unless filter_panel_open?
+        end
+
+        def filter_panel_open?
+          page.has_css?(".advanced-filters--container.-expanded", wait: 0)
+        end
+
+        def within_filter(name, &)
+          within("[data-filter-name='#{name}']", &)
         end
 
         def order_by(key)

--- a/spec/support/pages/admin/users/index.rb
+++ b/spec/support/pages/admin/users/index.rb
@@ -39,8 +39,12 @@ module Pages
         end
 
         def expect_listed(*users)
-          rows = page.all "td.username a", count: users.count
-          expect(rows.map(&:text)).to include(*users.map(&:login))
+          # Wait for each expected user to appear (have_css auto-waits, page.all does not),
+          # then assert the total row count to catch unexpected extras.
+          users.each do |user|
+            expect(page).to have_css("td.username a", text: user.login)
+          end
+          expect(page).to have_css("td.username a", count: users.count)
         end
 
         def expect_order(*users)
@@ -63,9 +67,13 @@ module Pages
 
         def filter_by_status(value)
           open_filter_panel
-          select "Status", from: "Add filter"
-          within_filter("status") do
-            find("[data-filter-name='status'] select").select(value)
+          unless page.has_css?("li.advanced-filters--filter[data-filter-name='status']:not(.hidden)")
+            select "Status", from: "add_filter_select"
+          end
+          # Status renders a single-select and a hidden multi-select side by side;
+          # both share id="status_value". Scope to the visible single-select to disambiguate.
+          within("li.advanced-filters--filter[data-filter-name='status']:not(.hidden) .single-select") do
+            select value, from: "status_value"
           end
 
           wait_for_network_idle
@@ -84,11 +92,16 @@ module Pages
         end
 
         def open_filter_panel
-          find("[data-test-selector='filter-component-toggle']").click unless filter_panel_open?
+          return if filter_panel_open?
+
+          find("[data-test-selector='filter-component-toggle']").click
+          # Wait for the toggle's Stimulus action to actually expand the panel —
+          # otherwise subsequent selectors run against still-collapsed (hidden) UI.
+          expect(page).to have_css(".op-filters-form.-expanded")
         end
 
         def filter_panel_open?
-          page.has_css?(".advanced-filters--container.-expanded", wait: 0)
+          page.has_css?(".op-filters-form.-expanded", wait: 0)
         end
 
         def within_filter(name, &)

--- a/spec/views/users/index.html.erb_spec.rb
+++ b/spec/views/users/index.html.erb_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "users/index" do
   before do
     User.system # create system user which is active but should not count towards limit
 
-    assign(:users, User.where(id: [admin.id, user.id]))
-    assign(:status, "all")
-    assign(:groups, Group.visible)
+    assign(:query, UserQueries::Static.query(nil))
 
     without_partial_double_verification do
       allow(view).to receive_messages(current_user: admin, controller_name: "users", action_name: "index")
@@ -49,13 +47,6 @@ RSpec.describe "users/index" do
   end
 
   subject { rendered.squish }
-
-  it "renders the user table" do
-    render
-
-    expect(subject).to have_text("#{admin.firstname}   #{admin.lastname}")
-    expect(subject).to have_text("Scarlet   Scallywag")
-  end
 
   context "with an Enterprise token" do
     before do


### PR DESCRIPTION
- Make TableComponent streamable
- Use standard filters component instead of a custom one
- Add quick filter "name" to the filters that rerenders with a turbo stream

https://community.openproject.org/projects/openproject/work_packages/74763/activity