### PR TITLE
Resolve semantic identifiers in PDF text macro links

### DIFF
--- a/app/models/work_package/exports/macros/links.rb
+++ b/app/models/work_package/exports/macros/links.rb
@@ -61,12 +61,10 @@ module WorkPackage::Exports
       end
 
       def render_link(data_id, matcher)
-        # Defence-in-depth: the matcher regex constrains data_id today, but
-        # escaping survives a future widening or a caller that bypasses the
-        # matcher.
-        escaped_id = ERB::Util.html_escape(data_id)
-        link = "#{matcher.sep}#{escaped_id}"
-        %(<mention class="mention" data-id="#{escaped_id}" data-type="work_package" data-text="#{link}">#{link}</mention>)
+        link = "#{matcher.sep}#{data_id}"
+        content_tag(:mention, link,
+                    class: "mention",
+                    data: { id: data_id, type: "work_package", text: link })
       end
     end
 

--- a/app/models/work_package/exports/macros/links.rb
+++ b/app/models/work_package/exports/macros/links.rb
@@ -31,28 +31,44 @@
 module WorkPackage::Exports
   module Macros
     class WorkPackagesLinkHandler < OpenProject::TextFormatting::Matchers::LinkHandlers::WorkPackages
-      # PDF export only handles canonical numeric `#N` references. Semantic and
-      # leading-zero shapes fall through to literal text to avoid emitting a
-      # `<mention data-id="0">` (since `"PROJ-1".to_i == 0`). Semantic-id
-      # support in PDF export is tracked in https://community.openproject.org/wp/74766.
       def applicable?
-        hash_trigger? &&
-          matcher.prefix.blank? &&
-          WorkPackage::SemanticIdentifier.numeric_id?(matcher.identifier)
+        return false unless hash_trigger? && matcher.prefix.blank?
+
+        if WorkPackage::SemanticIdentifier.numeric_id?(matcher.identifier)
+          true
+        elsif WorkPackage::SemanticIdentifier.semantic_id?(matcher.identifier)
+          Setting::WorkPackageIdentifier.semantic_mode_active?
+        else
+          false
+        end
       end
 
-      # PDF rendering walks Markly nodes directly and bypasses the
-      # `PatternMatcherFilter` preload pipeline, so the parent's cache-driven
-      # `call` would miss every reference.
+      # PDF rendering walks Markly nodes via `app/models/exports/pdf/common/macro.rb`
+      # rather than the `PatternMatcherFilter` preload pipeline, so each semantic
+      # reference does its own `find_by_display_id` round-trip. A cache miss
+      # returns nil so the matcher emits literal text rather than a mention
+      # pointing at a non-existent identifier.
       def call
-        render_link(matcher.identifier.to_i, matcher)
+        if WorkPackage::SemanticIdentifier.semantic_id?(matcher.identifier)
+          wp = WorkPackage.find_by_display_id(matcher.identifier)
+          return nil unless wp
+
+          render_link(wp.display_id, matcher)
+        else
+          render_link(matcher.identifier.to_i.to_s, matcher)
+        end
       end
 
-      def render_link(wp_id, matcher)
-        link = "#{matcher.sep}#{wp_id}"
-        "<mention class=\"mention\" data-id=\"#{wp_id}\" data-type=\"work_package\" data-text=\"#{link}\">#{
-          link
-        }</mention>"
+      def render_link(data_id, matcher)
+        # `data_id` is regex-constrained at the matcher layer (numeric `\d+`
+        # or semantic `[A-Z][A-Z0-9_]*-\d+` per `ID_ROUTE_CONSTRAINT`) and
+        # for semantic input is sourced from `wp.display_id`. Escape both
+        # interpolated values so a future widening of the constraint, or a
+        # caller that bypasses the matcher, cannot regress into HTML
+        # attribute injection.
+        escaped_id = ERB::Util.html_escape(data_id)
+        link = "#{matcher.sep}#{escaped_id}"
+        %(<mention class="mention" data-id="#{escaped_id}" data-type="work_package" data-text="#{link}">#{link}</mention>)
       end
     end
 
@@ -61,9 +77,11 @@ module WorkPackage::Exports
         [WorkPackagesLinkHandler]
       end
 
-      # Faster inclusion check before the full regex is being applied
+      # Faster inclusion check before the full regex is being applied.
+      # Matches `#1`, `##42`, `#PROJ-7` openings — semantic-only bodies
+      # must reach the regex too.
       def self.applicable?(content)
-        /#\d/.match(content)
+        /#[A-Z\d]/.match(content)
       end
     end
   end

--- a/app/models/work_package/exports/macros/links.rb
+++ b/app/models/work_package/exports/macros/links.rb
@@ -43,29 +43,27 @@ module WorkPackage::Exports
         end
       end
 
-      # PDF rendering walks Markly nodes via `app/models/exports/pdf/common/macro.rb`
-      # rather than the `PatternMatcherFilter` preload pipeline, so each semantic
-      # reference does its own `find_by_display_id` round-trip. A cache miss
-      # returns nil so the matcher emits literal text rather than a mention
-      # pointing at a non-existent identifier.
+      # PDF rendering walks Markly nodes directly rather than the in-app
+      # preload pipeline, so each semantic reference does its own round-trip.
+      # Resolution is visibility-scoped: a reference to a work package the
+      # current user cannot see falls through to literal text, identical to
+      # an unknown identifier, so semantic ids cannot act as an existence
+      # oracle.
       def call
         if WorkPackage::SemanticIdentifier.semantic_id?(matcher.identifier)
-          wp = WorkPackage.find_by_display_id(matcher.identifier)
+          wp = WorkPackage.visible.find_by_display_id(matcher.identifier)
           return nil unless wp
 
           render_link(wp.display_id, matcher)
         else
-          render_link(matcher.identifier.to_i.to_s, matcher)
+          render_link(matcher.identifier, matcher)
         end
       end
 
       def render_link(data_id, matcher)
-        # `data_id` is regex-constrained at the matcher layer (numeric `\d+`
-        # or semantic `[A-Z][A-Z0-9_]*-\d+` per `ID_ROUTE_CONSTRAINT`) and
-        # for semantic input is sourced from `wp.display_id`. Escape both
-        # interpolated values so a future widening of the constraint, or a
-        # caller that bypasses the matcher, cannot regress into HTML
-        # attribute injection.
+        # Defence-in-depth: the matcher regex constrains data_id today, but
+        # escaping survives a future widening or a caller that bypasses the
+        # matcher.
         escaped_id = ERB::Util.html_escape(data_id)
         link = "#{matcher.sep}#{escaped_id}"
         %(<mention class="mention" data-id="#{escaped_id}" data-type="work_package" data-text="#{link}">#{link}</mention>)

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -201,28 +201,79 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
-    # Semantic-id support in PDF export is tracked separately in
-    # https://community.openproject.org/wp/74766. Until that ships, any
-    # `#PROJ-1`-shaped reference must fall through to literal text in PDF
-    # output rather than emitting `<mention data-id="0">` (since
-    # `"PROJ-1".to_i == 0`).
-    describe "with semantic identifier (out of scope per WP #74766)" do
-      describe "alone" do
+    describe "with semantic identifier" do
+      describe "in semantic mode",
+               with_flag: { semantic_work_package_ids: true },
+               with_settings: { work_packages_identifier: "semantic" } do
+        let(:semantic_project) { create(:project, identifier: "PROJ") }
+        let(:semantic_work_package) do
+          wp = create(:work_package, project: semantic_project, type: type_task, subject: "Semantic")
+          wp.allocate_and_register_semantic_id
+          wp.reload
+        end
+        let(:user) do
+          create(
+            :user,
+            member_with_permissions: {
+              project => %i[view_work_packages view_project_attributes view_project] + additional_permissions,
+              other_project => %i[view_work_packages view_project_attributes view_project] + additional_permissions,
+              semantic_project => %i[view_work_packages view_project_attributes view_project]
+            }
+          )
+        end
+
+        describe "alone" do
+          let(:markdown) { "see ##{semantic_work_package.identifier} here" }
+
+          it "renders the mention with the semantic identifier in data-id" do
+            expect(formatted).to include(%(data-id="#{semantic_work_package.identifier}"))
+            expect(formatted).to include(%(data-text="##{semantic_work_package.identifier}"))
+          end
+        end
+
+        describe "mixed with a numeric reference" do
+          let(:markdown) { "see ##{semantic_work_package.identifier} and ##{work_package.id}" }
+
+          it "renders both as mentions with their respective data-ids" do
+            expect(formatted).to include(%(data-id="#{semantic_work_package.identifier}"))
+            expect(formatted).to include(%(data-id="#{work_package.id}"))
+            expect(formatted).not_to include('data-id="0"')
+          end
+        end
+
+        describe "with an alias from a previous identifier" do
+          before do
+            create(:work_package_semantic_alias,
+                   work_package: semantic_work_package,
+                   identifier: "OLD-1")
+          end
+
+          let(:markdown) { "see #OLD-1 here" }
+
+          it "resolves the alias and renders the current identifier" do
+            expect(formatted).to include(%(data-id="#{semantic_work_package.identifier}"))
+            expect(formatted).not_to include(">#OLD-1<")
+          end
+        end
+
+        describe "for a missing work package" do
+          let(:markdown) { "see #GHOST-99 here" }
+
+          it "falls through to literal text without crashing" do
+            expect(formatted).to include("#GHOST-99")
+            expect(formatted).not_to include("<mention")
+            expect(formatted).not_to include('data-id="0"')
+          end
+        end
+      end
+
+      describe "in classic mode",
+               with_flag: { semantic_work_package_ids: false } do
         let(:markdown) { "see #PROJ-1 here" }
 
         it "falls through to literal text without emitting a mention" do
           expect(formatted).to include("#PROJ-1")
-          expect(formatted).not_to include('data-id="0"')
           expect(formatted).not_to include("<mention")
-        end
-      end
-
-      describe "mixed with a numeric reference" do
-        let(:markdown) { "see #PROJ-1 and ##{work_package.id}" }
-
-        it "renders the numeric reference as a mention but leaves the semantic literal" do
-          expect(formatted).to include("#PROJ-1")
-          expect(formatted).to include(%(data-id="#{work_package.id}"))
           expect(formatted).not_to include('data-id="0"')
         end
       end

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -252,6 +252,7 @@ RSpec.describe Exports::PDF::Common::Macro do
 
           it "resolves the alias and renders the current identifier" do
             expect(formatted).to include(%(data-id="#{semantic_work_package.identifier}"))
+            expect(formatted).to include(%(data-text="##{semantic_work_package.identifier}"))
             expect(formatted).not_to include(">#OLD-1<")
           end
         end
@@ -263,6 +264,21 @@ RSpec.describe Exports::PDF::Common::Macro do
             expect(formatted).to include("#GHOST-99")
             expect(formatted).not_to include("<mention")
             expect(formatted).not_to include('data-id="0"')
+          end
+        end
+
+        describe "for a work package the user cannot see" do
+          let(:hidden_project) { create(:project, identifier: "HIDDEN") }
+          let(:hidden_work_package) do
+            wp = create(:work_package, project: hidden_project, type: type_task, subject: "Hidden")
+            wp.allocate_and_register_semantic_id
+            wp.reload
+          end
+          let(:markdown) { "see ##{hidden_work_package.identifier} here" }
+
+          it "falls through to literal text and does not disclose the work package" do
+            expect(formatted).to include("##{hidden_work_package.identifier}")
+            expect(formatted).not_to include("<mention")
           end
         end
       end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74766

# What are you trying to accomplish?

Render `#PROJ-1`, `##PROJ-1`, and `###PROJ-1` references inside markdown descriptions as proper mentions in PDF exports. In semantic mode the macro handler resolves semantic input and emits a `<mention>` whose `data-id` carries the user-facing identifier. Level 1 produces a clickable `PROJ-1` link, level 2 expands inline to `Task PROJ-1: <subject>`, level 3 to `<status> Task PROJ-1: <subject>`.

Unknown identifiers and deleted work packages fall through to literal text. Historical aliases resolve to the current identifier — `#OLDPROJ-1` written in pre-rename content renders against the renamed project's identifier. Classic mode rejects semantic-shape input entirely; `#PROJ-1` in a classic export stays literal. Numeric input renders the mention straight from the matched id without a database lookup.

The fast-path filter widens to `/#[A-Z\d]/` so semantic-only bodies (no numeric refs) still reach the full regex.

## Screenshots

Before — semantic refs render as literal text:

<img width="595" height="842" alt="wp-pdf-demo-before" src="https://github.com/user-attachments/assets/c9e30a51-83ea-4468-8176-28b0cbf9f787" />

After — semantic refs resolve to mentions with type/subject expansion:

<img width="595" height="842" alt="wp-pdf-demo" src="https://github.com/user-attachments/assets/765035ec-f316-4587-8c97-e160a7485064" />

# What approach did you choose and why?

The handler uses the same mode gate and the same `data-id` shape as the in-app text formatter, so producers and consumers agree on what `data-id` means regardless of where the mention was authored. PDF rendering walks Markly nodes directly rather than going through the in-app preload pipeline, so each semantic reference does its own database round-trip on render. Acceptable for typical export bodies; preload optimisation can land separately if profiling flags an N+1 on large exports.

The interpolated id and link text are HTML-escaped on output. The matcher regex already constrains shape to `\d+|[A-Z][A-Z0-9_]*-\d+`, so the escape is defence-in-depth — a future caller bypassing the matcher still cannot inject HTML attributes.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
