### PR TITLE
Fix Backlogs page scrolling caused by `.sr-only`

### DIFF
--- a/modules/backlogs/app/components/backlogs/story_points_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_points_component.html.erb
@@ -27,7 +27,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++%>
 
-<%= render(Primer::Beta::Text.new(color: :subtle)) do %>
+<%= render(Primer::Beta::Text.new(color: :subtle, position: :relative)) do %>
   <span aria-hidden="true"><%= story_points %></span>
   <span class="sr-only"><%= t(:"backlogs.story_points", count: story_points) %></span>
 <% end %>


### PR DESCRIPTION
# Ticket

n/a
original ticket: https://community.openproject.org/wp/74683

# What are you trying to accomplish?

d8d49fcbfa2 added `.sr-only` story-point labels. Those are absolutely positioned; without a positioned metric wrapper they contributed to `#content-body` overflow, making the whole Backlogs content area scroll. This patch scopes the `.sr-only` locally (via `position: relative`).

See d8d49fcbfa2cb7ea9702127fb0a75ce70269dbed
See #23061

## Screenshots


**Before**

https://github.com/user-attachments/assets/1daafa7e-567f-4fc1-b8d1-873cd0d78901

**After**

https://github.com/user-attachments/assets/e74a0712-fd4d-4fc0-8271-3fe4a6a598c1

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
