### PR TITLE
[#74570] Fetch data refresh button is still actionable 

### DIFF
--- a/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_fetch_data_component.html.erb
@@ -40,20 +40,6 @@ See COPYRIGHT and LICENSE files for more details.
           })
         end
       end
-      if model.in_state?(:instance_meta_done, :configuring)
-        row.with_column do
-          render(
-            Primer::Beta::IconButton.new(
-              icon: :"op-reload",
-              tag: :a,
-              scheme: :invisible,
-              href: continue_admin_import_jira_run_path(jira_id: model.jira.id, id: model.id, step: 'fetch_instance_meta'),
-              aria: { label: "Back to fetch data" },
-              data: { turbo_stream: true }
-            )
-          )
-        end
-      end
     end
   end
   if model.in_state?(:initial)


### PR DESCRIPTION
…after user moved on to import configuration step

# Ticket
https://community.openproject.org/wp/74570

# What approach did you choose and why?

We remove the button
