### PR TITLE
Harmonize look and feel of new wiki forms

### DIFF
--- a/modules/wikis/app/components/wikis/admin/forms/general_info_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/general_info_form_component.html.erb
@@ -1,35 +1,30 @@
 <%=
   component_wrapper do
-    primer_form_with(
-      model: wiki_provider,
-      url: form_url,
-      method: form_method
-    ) do |form|
-      flex_layout do |general_info_row|
-        general_info_row.with_row(mb: 3) do
-          render(Primer::Beta::Text.new(font_weight: :bold)) { t("wikis.admin.wiki_providers.xwiki_instance") }
-        end
+    flex_layout(mb: 3) do |general_info_row|
+      general_info_row.with_row do
+        render(Primer::Beta::Text.new(font_weight: :bold)) { t("wikis.admin.wiki_providers.xwiki_instance") }
+      end
 
-        general_info_row.with_row(mb: 3) do
-          render(Primer::Beta::Text.new(test_selector: "wiki-provider-configuration-instructions")) do
-            t(".xwiki_instance_description")
-          end
+      general_info_row.with_row do
+        render(Primer::Beta::Text.new(color: :subtle, test_selector: "wiki-provider-configuration-instructions")) do
+          t(".xwiki_instance_description")
         end
+      end
 
-        general_info_row.with_row(mb: 3) do
-          render(Wikis::Admin::NameInputForm.new(form))
-        end
-
-        general_info_row.with_row(mb: 3) do
-          render(Wikis::Admin::UrlInputForm.new(form))
-        end
-
-        general_info_row.with_row(mb: 3) do
-          render(Wikis::Admin::XWikiAuthenticationMethodSelectForm.new(form))
-        end
-
-        general_info_row.with_row do
-          render(Wikis::Admin::SubmitOrCancelForm.new(form, wiki_provider:))
+      general_info_row.with_row(mt: 3) do
+        primer_form_with(
+          model: wiki_provider,
+          url: form_url,
+          method: form_method
+        ) do |form|
+          render(
+            Primer::Forms::FormList.new(
+              Wikis::Admin::NameInputForm.new(form),
+              Wikis::Admin::UrlInputForm.new(form),
+              Wikis::Admin::XWikiAuthenticationMethodSelectForm.new(form),
+              Wikis::Admin::SubmitOrCancelForm.new(form, wiki_provider:)
+            )
+          )
         end
       end
     end

--- a/modules/wikis/app/components/wikis/admin/forms/oauth_application_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/oauth_application_form_component.html.erb
@@ -1,12 +1,12 @@
 <%=
   component_wrapper do
     flex_layout(flex_items: :center) do |credentials_row|
-      credentials_row.with_row(mb: 3) do
+      credentials_row.with_row do
         render(Primer::Beta::Text.new(font_weight: :bold)) { t("wikis.admin.wiki_providers.oauth.openproject_oauth") }
       end
 
       credentials_row.with_row(mb: 3) do
-        render(Primer::Beta::Text.new) { t("wikis.admin.wiki_providers.#{wiki_provider}.oauth.openproject_oauth_description") }
+        render(Primer::Beta::Text.new(color: :subtle)) { t("wikis.admin.wiki_providers.#{wiki_provider}.oauth.openproject_oauth_description") }
       end
 
       credentials_row.with_row(mb: 3) do
@@ -42,11 +42,13 @@
       end
 
       credentials_row.with_row do
-        render(Primer::Beta::Button.new(
-          scheme: :primary,
-          tag: :a,
-          href: done_button_path
-        )) { t("wikis.buttons.done_continue") }
+        render(
+          Primer::Beta::Button.new(
+            scheme: :primary,
+            tag: :a,
+            href: done_button_path
+          )
+        ) { t("wikis.buttons.done_continue") }
       end
     end
   end

--- a/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/forms/oauth_client_form_component.html.erb
@@ -6,12 +6,12 @@
       method: form_method
     ) do |form|
       flex_layout do |oauth_client_row|
-        oauth_client_row.with_row(mb: 3) do
+        oauth_client_row.with_row do
           render(Primer::Beta::Text.new(font_weight: :bold)) { t("wikis.admin.wiki_providers.#{wiki_provider}.oauth.provider_oauth") }
         end
 
         oauth_client_row.with_row(mb: 3) do
-          render(Primer::Beta::Text.new) { t("wikis.admin.wiki_providers.#{wiki_provider}.oauth.provider_oauth_description") }
+          render(Primer::Beta::Text.new(color: :subtle)) { t("wikis.admin.wiki_providers.#{wiki_provider}.oauth.provider_oauth_description") }
         end
 
         oauth_client_row.with_row(mb: 3) do
@@ -31,8 +31,12 @@
         end
 
         oauth_client_row.with_row do
-          concat(render(Wikis::Admin::SubmitOrCancelForm.new(form, wiki_provider:,
-                                                             cancel_button_options: { href: cancel_button_path })))
+          render(
+            Wikis::Admin::SubmitOrCancelForm.new(
+              form, wiki_provider:,
+                    cancel_button_options: { href: cancel_button_path }
+            )
+          )
         end
       end
     end

--- a/modules/wikis/app/forms/wikis/admin/xwiki_authentication_method_select_form.rb
+++ b/modules/wikis/app/forms/wikis/admin/xwiki_authentication_method_select_form.rb
@@ -34,7 +34,8 @@ module Wikis::Admin
       f.select_list(
         name: :authentication_method,
         label: I18n.t("activerecord.attributes.wikis/xwiki_provider.authentication_method"),
-        required: true
+        required: true,
+        input_width: :large
       ) do |select|
         Wikis::XWikiProvider::AUTHENTICATION_METHODS.each do |method|
           select.option(


### PR DESCRIPTION
# Ticket
none

# What are you trying to accomplish?
Harmonize look and feel of new wiki forms:
* Reduce spacing between heading and description
* Change color of the description to `subtle`
* Reduce width of select box for authentication method
* Remove unnecessary flex and concat calls

## Screenshots

<img width="748" height="589" alt="Bildschirmfoto 2026-05-12 um 09 28 43" src="https://github.com/user-attachments/assets/0a3dd1a0-462c-440d-9e37-1ad57bf48817" />
