### PR TITLE
Adapt skeleton loader for wikis tab

### DIFF
--- a/modules/wikis/frontend/module/wikis-tab/wikis-tab.template.html
+++ b/modules/wikis/frontend/module/wikis-tab/wikis-tab.template.html
@@ -1,11 +1,8 @@
 <turbo-frame [src]="turboFrameSrc" id="work-package-wikis-tab-content">
   <op-content-loader viewBox="0 0 100 100">
-    <svg:rect x="0" y="0" width="70" height="5" rx="1" />
+    <svg:rect x="0" y="0" width="100" height="25" rx="1" />
 
-    <svg:rect x="75" y="0" width="25" height="5" rx="1" />
-
-    <svg:rect x="0" y="10" width="100" height="8" rx="1" />
-
-    <svg:rect x="0" y="25" width="100" height="12" rx="1" />
+    <svg:rect x="0" y="28" width="100" height="8" rx="1" />
+    <svg:rect x="0" y="39" width="100" height="8" rx="1" />
   </op-content-loader>
 </turbo-frame>


### PR DESCRIPTION
Trying to get it slightly more aligned with expectable content:

* one large box with a blank slate
* two small boxes that are collapsed

This is essentially a default assumption. It might be wrong in some setups, but it's better than the previous skeleton that didn't match the eventual layout slightly.

# Screenshots

<img width="547" height="453" alt="image" src="https://github.com/user-attachments/assets/62ce810e-c77c-41a2-b61d-44ae64a909ec" />

