### PR TITLE
perf: Reduce amount of advisory locking in ConvertProjectToSemanticService

### DIFF
--- a/app/services/project_identifiers/convert_project_to_semantic_service.rb
+++ b/app/services/project_identifiers/convert_project_to_semantic_service.rb
@@ -41,12 +41,10 @@ module ProjectIdentifiers
     end
 
     def call
-      ApplicationRecord.transaction do
-        fix_identifier_if_needed
-        reset_stale_identifiers
-        backfill_missing_ids
-        seed_alias_table
-      end
+      fix_identifier_if_needed
+      ApplicationRecord.transaction { reset_stale_identifiers }
+      ApplicationRecord.transaction { backfill_missing_ids }
+      ApplicationRecord.transaction { seed_alias_table }
     end
 
     private
@@ -57,15 +55,8 @@ module ProjectIdentifiers
       # Pure format check — no DB queries.
       return if ProjectIdentifiers::IdentifierAutofix::ProblematicIdentifiers.valid_format?(project.identifier)
 
-      # Serialize all concurrent identifier assignments with a transaction-level
-      # advisory lock. The lock is automatically released when the outer
-      # ApplicationRecord.transaction commits, so the next job waiting on it
-      # always reads a fully up-to-date exclusion set and can never generate a
-      # duplicate. Without this, parallel jobs can read the same exclusion set
-      # before any of them commits, then all pick the same candidate.
-      OpenProject::Mutex.with_advisory_lock(
-        Project, "semantic_identifier_generation", transaction: true
-      ) do
+      # Identifier assignments must run one at a time to avoid conflicts with concurrent renames or conversions.
+      OpenProject::Mutex.with_advisory_lock(Project, "semantic_identifier_generation") do
         assign_semantic_identifier
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/71645/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Follow-up to https://github.com/opf/openproject/pull/22765#issuecomment-4281237088 (thanks Kabiru!).

The advisory lock inside a job-wide transaction was effectively preventing a proper parallel run of this job. 

The 4 steps, which were originally wrapped in a single giant transaction, are actually all idempotent, so we might as well split them into separate transactions.