### PR TITLE
refactor: Improve naming of classic identifier conversion in the code

### DIFF
--- a/app/controllers/admin/settings/work_packages_identifier_controller.rb
+++ b/app/controllers/admin/settings/work_packages_identifier_controller.rb
@@ -76,7 +76,7 @@ module Admin::Settings
                                     .call(work_packages_identifier: Setting::WorkPackageIdentifier::CLASSIC)
       call.on_success do
         unless ProjectIdentifiers::IdentifierAutofix.job_in_progress?
-          ProjectIdentifiers::RevertInstanceToClassicIdsJob.perform_later
+          ProjectIdentifiers::ConvertInstanceToClassicIdsJob.perform_later
         end
         redirect_to action: "show"
       end

--- a/app/services/project_identifiers/convert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/convert_project_to_classic_service.rb
@@ -28,25 +28,35 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Reverts all projects to classic identifier mode. Triggered explicitly when the
-# admin switches the instance back to classic mode via the admin UI
-# (Admin::Settings::WorkPackagesIdentifierController#switch_to_classic).
-#
-# The global Setting.work_packages_identifier is expected to already be "classic"
-# before this job runs — it is set by the controller before enqueueing.
-class ProjectIdentifiers::RevertInstanceToClassicIdsJob < ApplicationJob
-  include GoodJob::ActiveJobExtensions::Concurrency
+module ProjectIdentifiers
+  # Reverts a single project back to classic identifier mode by restoring its
+  # project identifier to the most-recent classic-format slug from FriendlyId
+  # history. If no classic slug exists (e.g. the project was created in semantic
+  # mode), a new classic identifier is generated via Project.suggest_identifier.
+  #
+  # WP sequence_number/identifier, WorkPackageSemanticAlias rows, and
+  # wp_sequence_counter are intentionally left intact so that a back-switch to
+  # semantic mode can resume without data loss.
+  class ConvertProjectToClassicService
+    def initialize(project)
+      @project = project
+    end
 
-  good_job_control_concurrency_with(total_limit: 1)
-  retry_on StandardError, wait: :polynomially_longer, attempts: 8
+    def call
+      restore_classic_identifier
+    end
 
-  def perform
-    raise "expected Setting.work_packages_identifier to be classic" unless Setting::WorkPackageIdentifier.classic?
+    private
 
-    Project.find_each do |project|
-      next if Project.classic_identifier_format?(project.identifier)
+    attr_reader :project
 
-      ProjectIdentifiers::RevertProjectToClassicService.new(project).call
+    def restore_classic_identifier
+      generator = ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
+      classic = generator.restore_identifier(project) || generator.suggest_identifier(project.name)
+      # Suppress notifications: this is a background system operation, not a user edit.
+      Journal::NotificationConfiguration.with(false) do
+        project.update!(identifier: classic)
+      end
     end
   end
 end

--- a/app/services/project_identifiers/identifier_autofix.rb
+++ b/app/services/project_identifiers/identifier_autofix.rb
@@ -37,7 +37,7 @@ module ProjectIdentifiers
     ].freeze
 
     REVERSION_JOB_CLASSES = [
-      ProjectIdentifiers::RevertInstanceToClassicIdsJob.name
+      ProjectIdentifiers::ConvertInstanceToClassicIdsJob.name
     ].freeze
 
     def self.job_in_progress?

--- a/app/workers/project_identifiers/convert_instance_to_classic_ids_job.rb
+++ b/app/workers/project_identifiers/convert_instance_to_classic_ids_job.rb
@@ -28,35 +28,25 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module ProjectIdentifiers
-  # Reverts a single project back to classic identifier mode by restoring its
-  # project identifier to the most-recent classic-format slug from FriendlyId
-  # history. If no classic slug exists (e.g. the project was created in semantic
-  # mode), a new classic identifier is generated via Project.suggest_identifier.
-  #
-  # WP sequence_number/identifier, WorkPackageSemanticAlias rows, and
-  # wp_sequence_counter are intentionally left intact so that a back-switch to
-  # semantic mode can resume without data loss.
-  class RevertProjectToClassicService
-    def initialize(project)
-      @project = project
-    end
+# Reverts all projects to classic identifier mode. Triggered explicitly when the
+# admin switches the instance back to classic mode via the admin UI
+# (Admin::Settings::WorkPackagesIdentifierController#switch_to_classic).
+#
+# The global Setting.work_packages_identifier is expected to already be "classic"
+# before this job runs — it is set by the controller before enqueueing.
+class ProjectIdentifiers::ConvertInstanceToClassicIdsJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
 
-    def call
-      restore_classic_identifier
-    end
+  good_job_control_concurrency_with(total_limit: 1)
+  retry_on StandardError, wait: :polynomially_longer, attempts: 8
 
-    private
+  def perform
+    raise "expected Setting.work_packages_identifier to be classic" unless Setting::WorkPackageIdentifier.classic?
 
-    attr_reader :project
+    Project.find_each do |project|
+      next if Project.classic_identifier_format?(project.identifier)
 
-    def restore_classic_identifier
-      generator = ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
-      classic = generator.restore_identifier(project) || generator.suggest_identifier(project.name)
-      # Suppress notifications: this is a background system operation, not a user edit.
-      Journal::NotificationConfiguration.with(false) do
-        project.update!(identifier: classic)
-      end
+      ProjectIdentifiers::ConvertProjectToClassicService.new(project).call
     end
   end
 end

--- a/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
+++ b/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
     end
 
     context "when work_packages_identifier is 'classic'" do
-      it "updates the setting to classic, enqueues RevertInstanceToClassicIdsJob, and redirects" do
+      it "updates the setting to classic, enqueues ConvertInstanceToClassicIdsJob, and redirects" do
         expect do
           patch :update, params: { settings: { work_packages_identifier: "classic" } }
-        end.to have_enqueued_job(ProjectIdentifiers::RevertInstanceToClassicIdsJob)
+        end.to have_enqueued_job(ProjectIdentifiers::ConvertInstanceToClassicIdsJob)
 
         expect(Setting.work_packages_identifier).to eq("classic")
         expect(response).to redirect_to(action: "show")
@@ -112,7 +112,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
         it "does not enqueue another job but still updates the setting and redirects" do
           expect do
             patch :update, params: { settings: { work_packages_identifier: "classic" } }
-          end.not_to have_enqueued_job(ProjectIdentifiers::RevertInstanceToClassicIdsJob)
+          end.not_to have_enqueued_job(ProjectIdentifiers::ConvertInstanceToClassicIdsJob)
 
           expect(Setting.work_packages_identifier).to eq("classic")
           expect(response).to redirect_to(action: "show")
@@ -126,7 +126,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
 
         expect(response).to have_http_status(:bad_request)
         expect(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob).not_to have_been_enqueued
-        expect(ProjectIdentifiers::RevertInstanceToClassicIdsJob).not_to have_been_enqueued
+        expect(ProjectIdentifiers::ConvertInstanceToClassicIdsJob).not_to have_been_enqueued
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
 
         expect(response).to have_http_status(:bad_request)
         expect(ProjectIdentifiers::ConvertInstanceToSemanticIdsJob).not_to have_been_enqueued
-        expect(ProjectIdentifiers::RevertInstanceToClassicIdsJob).not_to have_been_enqueued
+        expect(ProjectIdentifiers::ConvertInstanceToClassicIdsJob).not_to have_been_enqueued
       end
     end
   end

--- a/spec/services/project_identifiers/convert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/convert_project_to_classic_service_spec.rb
@@ -30,7 +30,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
+RSpec.describe ProjectIdentifiers::ConvertProjectToClassicService do
   describe "#call" do
     context "when the project has a classic identifier in FriendlyId history" do
       let!(:project) do

--- a/spec/workers/project_identifiers/convert_instance_to_classic_ids_job_spec.rb
+++ b/spec/workers/project_identifiers/convert_instance_to_classic_ids_job_spec.rb
@@ -30,7 +30,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
+RSpec.describe ProjectIdentifiers::ConvertInstanceToClassicIdsJob do
   describe "#perform" do
     context "when the setting is not classic" do
       before { allow(Setting::WorkPackageIdentifier).to receive(:classic?).and_return(false) }
@@ -51,10 +51,10 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
           end
         end
 
-        it "calls RevertProjectToClassicService for each project" do
+        it "calls ConvertProjectToClassicService for each project" do
           services = projects.map do |project|
-            instance_double(ProjectIdentifiers::RevertProjectToClassicService, call: nil).tap do |service|
-              allow(ProjectIdentifiers::RevertProjectToClassicService).to receive(:new).with(project).and_return(service)
+            instance_double(ProjectIdentifiers::ConvertProjectToClassicService, call: nil).tap do |service|
+              allow(ProjectIdentifiers::ConvertProjectToClassicService).to receive(:new).with(project).and_return(service)
             end
           end
 
@@ -67,18 +67,18 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
       context "when a project already has a classic identifier" do
         let!(:project) { create(:project) }
 
-        it "skips it and does not call RevertProjectToClassicService" do
-          allow(ProjectIdentifiers::RevertProjectToClassicService).to receive(:new)
+        it "skips it and does not call ConvertProjectToClassicService" do
+          allow(ProjectIdentifiers::ConvertProjectToClassicService).to receive(:new)
           described_class.new.perform
-          expect(ProjectIdentifiers::RevertProjectToClassicService).not_to have_received(:new)
+          expect(ProjectIdentifiers::ConvertProjectToClassicService).not_to have_received(:new)
         end
       end
 
       context "when there are no projects" do
-        it "does not call RevertProjectToClassicService" do
-          allow(ProjectIdentifiers::RevertProjectToClassicService).to receive(:new)
+        it "does not call ConvertProjectToClassicService" do
+          allow(ProjectIdentifiers::ConvertProjectToClassicService).to receive(:new)
           described_class.new.perform
-          expect(ProjectIdentifiers::RevertProjectToClassicService).not_to have_received(:new)
+          expect(ProjectIdentifiers::ConvertProjectToClassicService).not_to have_received(:new)
         end
       end
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The current nomenclature in the code is off -- it describes conversion to semantic mode as "conversion" and conversion to classic mode as "reversion". 

This gives off a wrong impression; both modes are equally valid, and we may have users that start off in semantic mode and later convert to classic (= not a "reversion").

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
