### PR TITLE
add major and minor floating tags for hocuspocus docker build

### DIFF
--- a/.github/workflows/hocuspocus-docker.yml
+++ b/.github/workflows/hocuspocus-docker.yml
@@ -72,15 +72,21 @@ jobs:
           BRANCH=$(echo '${{ inputs.branch || github.ref_name }}' | tr / -)
           SPECIFIC_TAG=$BRANCH-${{ steps.short-sha.outputs.short_sha }}
           LATEST_TAG=$BRANCH-latest
+          MINOR_TAG=
+          MAJOR_TAG=
 
           if [ -n "${{ inputs.tag }}" ]; then
             SPECIFIC_TAG=$(echo '${{ inputs.tag }}' | tr -d v)
             LATEST_TAG=latest
+            MINOR_TAG=$(echo $SPECIFIC_TAG | cut -d. -f1-2)
+            MAJOR_TAG=$(echo $SPECIFIC_TAG | cut -d. -f1)
           fi
 
           echo 'tags<<EOF' >> $GITHUB_OUTPUT
           echo $REGISTRY:$SPECIFIC_TAG >> $GITHUB_OUTPUT
           echo $REGISTRY:$LATEST_TAG >> $GITHUB_OUTPUT
+          [ -n "$MINOR_TAG" ] && echo $REGISTRY:$MINOR_TAG >> $GITHUB_OUTPUT
+          [ -n "$MAJOR_TAG" ] && echo $REGISTRY:$MAJOR_TAG >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         uses: docker/login-action@v4


### PR DESCRIPTION
Instead of only tagging say 17.4.0 and latest, this will also add 17.4 and 17 tags.