### PR TITLE
Deal with the move of Container into Dry::Core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,8 +201,8 @@ gem "nokogiri", "~> 1.19.2"
 
 gem "carrierwave", "~> 2.2.6"
 gem "carrierwave_direct", "~> 3.0.0"
-gem "ssrf_filter", "~> 1.3"
 gem "fog-aws"
+gem "ssrf_filter", "~> 1.3"
 
 gem "aws-sdk-core", "~> 3.244"
 # File upload via fog + screenshots on travis
@@ -219,7 +219,7 @@ gem "mini_magick", "~> 5.3.0", require: false
 gem "validate_url"
 
 # Storages support code
-gem "dry-container"
+gem "dry-core"
 gem "dry-monads"
 gem "dry-validation"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,8 +507,6 @@ GEM
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
-    dry-container (0.11.0)
-      concurrent-ruby (~> 1.0)
     dry-core (1.2.0)
       concurrent-ruby (~> 1.0)
       logger
@@ -1616,7 +1614,7 @@ DEPENDENCIES
   disposable (~> 0.6.2)
   doorkeeper (~> 5.9.0)
   dotenv-rails
-  dry-container
+  dry-core
   dry-monads
   dry-validation
   email_validator (~> 2.2.3)
@@ -1899,7 +1897,6 @@ CHECKSUMS
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dry-configurable (1.3.0) sha256=882d862858567fc1210d2549d4c090f34370fc1bb7c5c1933de3fe792e18afa8
-  dry-container (0.11.0) sha256=23be9381644d47343f3bf13b082b4255994ada0bfd88e0737eaaadc99d035229
   dry-core (1.2.0) sha256=0cc5a7da88df397f153947eeeae42e876e999c1e30900f3c536fb173854e96a1
   dry-inflector (1.3.1) sha256=7fb0c2bb04f67638f25c52e7ba39ab435d922a3a5c3cd196120f63accb682dcc
   dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3

--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/nextcloud_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/nextcloud_registry.rb
@@ -32,7 +32,7 @@ module Storages
   module Adapters
     module Providers
       module Nextcloud
-        NextcloudRegistry = Dry::Container::Namespace.new("nextcloud") do
+        NextcloudRegistry = Dry::Core::Container::Namespace.new("nextcloud") do
           namespace("authentication") do
             register(:userless, ->(*) { Input::Strategy.build(key: :basic_auth) })
             register(:user_bound, UserBoundAuthentication)

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/one_drive_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/one_drive_registry.rb
@@ -32,7 +32,7 @@ module Storages
   module Adapters
     module Providers
       module OneDrive
-        OneDriveRegistry = Dry::Container::Namespace.new("one_drive") do
+        OneDriveRegistry = Dry::Core::Container::Namespace.new("one_drive") do
           namespace("authentication") do
             register(:userless, ->(use_cache = true) { Input::Strategy.build(key: :oauth_client_credentials, use_cache:) })
             register(:user_bound, ->(user, storage = nil) { Input::Strategy.build(key: :oauth_user_token, user:, storage:) })

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/sharepoint_registry.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/sharepoint_registry.rb
@@ -32,7 +32,7 @@ module Storages
   module Adapters
     module Providers
       module Sharepoint
-        SharepointRegistry = Dry::Container::Namespace.new("sharepoint") do
+        SharepointRegistry = Dry::Core::Container::Namespace.new("sharepoint") do
           namespace("authentication") do
             register(:userless, ->(use_cache = true) { Input::Strategy.build(key: :oauth_client_credentials, use_cache:) })
             register(:user_bound, ->(user, storage = nil) { Input::Strategy.build(key: :oauth_user_token, user:, storage:) })

--- a/modules/storages/app/common/storages/adapters/registry.rb
+++ b/modules/storages/app/common/storages/adapters/registry.rb
@@ -28,12 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
+require "dry/core/container"
 
 module Storages
   module Adapters
     class Registry
-      extend Dry::Container::Mixin
+      extend Dry::Core::Container::Mixin
 
       # Extracts the known_providers from the registered keys
       # @return [Array<String>]
@@ -41,7 +41,7 @@ module Storages
         keys.map { it.split(".").first }.uniq
       end
 
-      class Resolver < Dry::Container::Resolver
+      class Resolver < Dry::Core::Container::Resolver
         include TaggedLogging
 
         def call(container, key)
@@ -49,7 +49,7 @@ module Storages
             info "Resolving #{key}"
             super
           end
-        rescue Dry::Container::KeyError
+        rescue Dry::Core::Container::KeyError
           error = Errors.registry_error_for(key)
 
           with_tagged_logger("Storages::Adapters::Registry") { error error.message }

--- a/modules/storages/spec/spec_helper.rb
+++ b/modules/storages/spec/spec_helper.rb
@@ -34,7 +34,7 @@
 # Loads spec_helper from OpenProject core
 # This will include any support file from OpenProject core
 require "spec_helper"
-require "dry/container/stub"
+require "dry/core/container/stub"
 
 STORAGES_CASSETTE_LIBRARY_DIR = "modules/storages/spec/support/fixtures/vcr_cassettes"
 

--- a/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/internal/registry.rb
@@ -32,7 +32,7 @@ module Wikis
   module Adapters
     module Providers
       module Internal
-        Registry = Dry::Container::Namespace.new("internal") do
+        Registry = Dry::Core::Container::Namespace.new("internal") do
           namespace("authentication") do
             register(:user_bound, Authentication::UserBound)
           end

--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/registry.rb
@@ -32,7 +32,7 @@ module Wikis
   module Adapters
     module Providers
       module XWiki
-        Registry = Dry::Container::Namespace.new("xwiki") do
+        Registry = Dry::Core::Container::Namespace.new("xwiki") do
           namespace("authentication") do
             register(:user_bound, Authentication::UserBound)
           end

--- a/modules/wikis/app/services/wikis/adapters/registry.rb
+++ b/modules/wikis/app/services/wikis/adapters/registry.rb
@@ -28,12 +28,12 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container"
+require "dry/core/container"
 
 module Wikis
   module Adapters
     class Registry
-      extend Dry::Container::Mixin
+      extend Dry::Core::Container::Mixin
 
       class Error < StandardError
       end
@@ -51,13 +51,13 @@ module Wikis
         keys.map { it.split(".").first }.uniq
       end
 
-      class Resolver < Dry::Container::Resolver
+      class Resolver < Dry::Core::Container::Resolver
         def call(container, key)
           Rails.logger.tagged("Wikis::Adapters::Registry") do
             Rails.logger.info "Resolving #{key}"
             super
           end
-        rescue Dry::Container::KeyError => e
+        rescue Dry::Core::Container::KeyError => e
           error = registry_error_for(key)
 
           Rails.logger.tagged("Wikis::Adapters::Registry") { Rails.logger.error (error || e).message }

--- a/modules/wikis/spec/spec_helper.rb
+++ b/modules/wikis/spec/spec_helper.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-require "dry/container/stub"
+require "dry/core/container/stub"
 require "dry/monads"
 
 RSpec.configure do |config|


### PR DESCRIPTION
`Dry::Container` as a standalone gem is being deprecated and was brought into `dry-core`. This PR addresses this.