### PR TITLE
[#74885] changed admin icon for wikis

### DIFF
--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -94,7 +94,7 @@ module OpenProject::Wikis
            { controller: "/wikis/admin/wiki_providers", action: :index },
            if: ->(_) { OpenProject::FeatureDecisions.wiki_enhancements_active? },
            caption: :project_module_wiki_platforms,
-           icon: "browser"
+           icon: :book
     end
 
     patch_with_namespace :WikiPages, :CreateService


### PR DESCRIPTION
# Ticket
[#74885](https://community.openproject.org/work_packages/74885)

# What are you trying to accomplish?
- show the correct icon for wikis in the admin view
