### PR TITLE
[#74906] Update UI text when deleting a wiki provider

### DIFF
--- a/modules/wikis/app/components/wikis/admin/destroy_confirmation_dialog_component.html.erb
+++ b/modules/wikis/app/components/wikis/admin/destroy_confirmation_dialog_component.html.erb
@@ -27,14 +27,12 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 
-<%= render(Primer::OpenProject::DangerDialog.new(title: t(".title"),
-                                                  form_arguments:,
-                                                  size: :large)) do |dialog| %>
-    <% dialog.with_confirmation_message do |message|
-        message.with_heading(tag: :h2) { t(".heading") }
-        message.with_description_content(
-          t(".warning_html", wiki_provider: content_tag(:strong, @wiki_provider.name))
-        )
-      end %>
-    <% dialog.with_confirmation_check_box_content(t(:text_permanent_delete_confirmation_checkbox_label)) %>
-<% end %>
+<%=
+  render(Primer::OpenProject::DangerDialog.new(title: t(".title"), form_arguments:, size: :large)) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) { t(".heading") }
+      message.with_description_content(t(".description_html", wiki_provider: content_tag(:strong, @wiki_provider.name)))
+    end
+    dialog.with_confirmation_check_box_content(t(:text_permanent_delete_confirmation_checkbox_label))
+  end
+%>

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -47,8 +47,10 @@ en:
     admin:
       destroy_confirmation_dialog_component:
         title: Delete wiki provider
-        heading: Delete wiki provider?
-        warning_html: "You are about to delete %{wiki_provider}. This action is irreversible."
+        heading: Permanently delete this wiki provider?
+        description_html: >-
+          The wiki provider %{wiki_provider} and all the related wiki page links will be deleted. In addition, every
+          inline wiki page link will no longer be accessible. This action is irreversible.
       forms:
         general_info_form_component:
           xwiki_instance_description: Please make sure you have administration privileges in your XWiki instance before doing the setup.


### PR DESCRIPTION
# Ticket
[#74906](https://community.openproject.org/work_packages/74906)

# What are you trying to accomplish?
- show the intended UI texts in the danger dialog when deleting wiki providers
