### PR TITLE
fix: remove stuck placeholder block on failed attachment upload

### DIFF
--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1047,6 +1047,7 @@ en:
     error_could_not_resolve_user_name: "Couldn't resolve user name"
     error_attachment_upload: "File failed to upload: %{error}"
     error_attachment_upload_permission: "You don't have the permission to upload files on this resource."
+    error_attachment_type_not_allowed: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
 
     units:
       workPackage:

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -1045,9 +1045,9 @@ en:
 
     error_could_not_resolve_version_name: "Couldn't resolve version name"
     error_could_not_resolve_user_name: "Couldn't resolve user name"
+    error_attachment_type_not_allowed: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
     error_attachment_upload: "File failed to upload: %{error}"
     error_attachment_upload_permission: "You don't have the permission to upload files on this resource."
-    error_attachment_type_not_allowed: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
 
     units:
       workPackage:

--- a/docs/api/apiv3/components/schemas/configuration_model.yml
+++ b/docs/api/apiv3/components/schemas/configuration_model.yml
@@ -19,6 +19,12 @@ properties:
     type: string
     description: The format used to display Work, Remaining Work, and Spent time durations
     readOnly: true
+  attachmentWhitelist:
+    type: array
+    description: The list of allowed attachment MIME types or extension globs (e.g. "image/png", "*.pdf"). Empty means all types are allowed.
+    readOnly: true
+    items:
+      type: string
   activeFeatureFlags:
     type: array
     description: The list of all feature flags that are active

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -101,7 +101,7 @@ export class ConfigurationService {
   public get attachmentWhitelist():string[] {
     return this.systemPreference<string[]>('attachmentWhitelist') ?? [];
   }
-  
+
   public dateFormatPresent():boolean {
     return !!this.systemPreference('dateFormat');
   }

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -98,6 +98,10 @@ export class ConfigurationService {
     return this.systemPreference('allowedLinkProtocols') || null;
   }
 
+  public get attachmentWhitelist():string[] {
+    return this.systemPreference<string[]>('attachmentWhitelist') ?? [];
+  }
+  
   public dateFormatPresent():boolean {
     return !!this.systemPreference('dateFormat');
   }

--- a/frontend/src/app/features/hal/resources/configuration-resource.ts
+++ b/frontend/src/app/features/hal/resources/configuration-resource.ts
@@ -31,4 +31,5 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 export class ConfigurationResource extends HalResource {
   public perPageOptions:number[];
   public allowedLinkProtocols?:string[];
+  public attachmentWhitelist?:string[];
 }

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -46,7 +46,7 @@ import {
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as Y from 'yjs';
-import { useBlockNoteAttachments } from '../hooks/useBlockNoteAttachments';
+import { useBlockNoteAttachments, BlockNoteEditorRef } from '../hooks/useBlockNoteAttachments';
 import { useBlockNoteLocale } from '../hooks/useBlockNoteLocale';
 import { useOpTheme } from '../hooks/useOpTheme';
 
@@ -95,7 +95,7 @@ export function OpBlockNoteEditor({
   // placeholder block on failed uploads, but the editor is created later
   // in this function. We pass a lazy getter that reads from a ref assigned
   // after useCreateBlockNote, breaking the would-be circular dependency.
-  const editorRef = useRef<ReturnType<typeof useCreateBlockNote> | null>(null);
+  const editorRef = useRef<BlockNoteEditorRef | null>(null);
   const getEditor = useCallback(() => editorRef.current, []);
 
   const { enabled: attachmentsEnabled, uploadFile } = useBlockNoteAttachments(

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -44,7 +44,7 @@ import {
   useOpBlockNoteExtensions,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as Y from 'yjs';
 import { useBlockNoteAttachments } from '../hooks/useBlockNoteAttachments';
 import { useBlockNoteLocale } from '../hooks/useBlockNoteLocale';
@@ -90,7 +90,19 @@ export function OpBlockNoteEditor({
   doc,
 }:OpBlockNoteEditorProps) {
   const { localeString, localeDictionary } = useBlockNoteLocale(window.I18n.locale);
-  const { enabled: attachmentsEnabled, uploadFile } = useBlockNoteAttachments(attachmentsCollectionKey, attachmentsUploadUrl);
+
+  // useBlockNoteAttachments needs the editor instance to remove a stuck
+  // placeholder block on failed uploads, but the editor is created later
+  // in this function. We pass a lazy getter that reads from a ref assigned
+  // after useCreateBlockNote, breaking the would-be circular dependency.
+  const editorRef = useRef<ReturnType<typeof useCreateBlockNote> | null>(null);
+  const getEditor = useCallback(() => editorRef.current, []);
+
+  const { enabled: attachmentsEnabled, uploadFile } = useBlockNoteAttachments(
+    attachmentsCollectionKey,
+    attachmentsUploadUrl,
+    getEditor,
+  );
 
   useEffect(() => {
     initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
@@ -126,6 +138,7 @@ export function OpBlockNoteEditor({
 
   const editor = useCreateBlockNote(editorParams, [activeUser]);
   useOpBlockNoteExtensions(editor);
+  editorRef.current = editor;
   type EditorType = typeof editor;
   const theme = useOpTheme();
 

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -46,7 +46,7 @@ import {
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as Y from 'yjs';
-import { useBlockNoteAttachments, BlockNoteEditorRef } from '../hooks/useBlockNoteAttachments';
+import { useBlockNoteAttachments, EditorHandle } from '../hooks/useBlockNoteAttachments';
 import { useBlockNoteLocale } from '../hooks/useBlockNoteLocale';
 import { useOpTheme } from '../hooks/useOpTheme';
 
@@ -95,7 +95,7 @@ export function OpBlockNoteEditor({
   // placeholder block on failed uploads, but the editor is created later
   // in this function. We pass a lazy getter that reads from a ref assigned
   // after useCreateBlockNote, breaking the would-be circular dependency.
-  const editorRef = useRef<BlockNoteEditorRef | null>(null);
+  const editorRef = useRef<EditorHandle | null>(null);
   const getEditor = useCallback(() => editorRef.current, []);
 
   const { enabled: attachmentsEnabled, uploadFile } = useBlockNoteAttachments(
@@ -138,7 +138,8 @@ export function OpBlockNoteEditor({
 
   const editor = useCreateBlockNote(editorParams, [activeUser]);
   useOpBlockNoteExtensions(editor);
-  editorRef.current = editor;
+
+  useEffect(() => { editorRef.current = editor; }, [editor]);
   type EditorType = typeof editor;
   const theme = useOpTheme();
 

--- a/frontend/src/react/hooks/useAttachmentValidation.spec.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.spec.ts
@@ -32,7 +32,7 @@ import { renderHook } from '@testing-library/react';
 import { useAttachmentValidation } from './useAttachmentValidation';
 
 function mockPluginContext(whitelist:string[]) {
-  (window as any).OpenProject = {
+  (window as unknown as { OpenProject:unknown }).OpenProject = {
     getPluginContext: () => Promise.resolve({
       services: {
         configurationService: { attachmentWhitelist: whitelist },
@@ -46,7 +46,7 @@ function mockFile(name:string, type:string):File {
 }
 
 beforeEach(() => {
-  (window as any).I18n = { t: (_key:string, opts?:{ value?:string }) => `not allowed: ${opts?.value ?? ''}` };
+  (window as unknown as { I18n:unknown }).I18n = { t: (_key:string, opts?:{ value?:string }) => `not allowed: ${opts?.value ?? ''}` };
 });
 
 describe('useAttachmentValidation', () => {
@@ -120,9 +120,7 @@ describe('useAttachmentValidation', () => {
       const { result } = renderHook(() => useAttachmentValidation());
       const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
       expect(validation.valid).toBe(false);
-      if (!validation.valid) {
-        expect(validation.reason).toBe('not allowed: image/png');
-      }
+      expect((validation as { valid:false; reason:string }).reason).toBe('not allowed: image/png');
     });
   });
 });

--- a/frontend/src/react/hooks/useAttachmentValidation.spec.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.spec.ts
@@ -1,0 +1,128 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useAttachmentValidation } from './useAttachmentValidation';
+
+function mockPluginContext(whitelist:string[]) {
+  (window as any).OpenProject = {
+    getPluginContext: () => Promise.resolve({
+      services: {
+        configurationService: { attachmentWhitelist: whitelist },
+      },
+    }),
+  };
+}
+
+function mockFile(name:string, type:string):File {
+  return new File([''], name, { type });
+}
+
+beforeEach(() => {
+  (window as any).I18n = { t: (_key:string, opts?:{ value?:string }) => `not allowed: ${opts?.value ?? ''}` };
+});
+
+describe('useAttachmentValidation', () => {
+  describe('when whitelist is empty', () => {
+    it('allows any file', async () => {
+      mockPluginContext([]);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(true);
+    });
+  });
+
+  describe('when file.type is empty', () => {
+    it('defers to the backend (allows the file)', async () => {
+      mockPluginContext(['image/png']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('file.xyz', ''));
+      expect(validation.valid).toBe(true);
+    });
+  });
+
+  describe('bare MIME type entries', () => {
+    it('allows a file whose MIME type is in the whitelist', async () => {
+      mockPluginContext(['image/png', 'image/jpeg']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(true);
+    });
+
+    it('rejects a file whose MIME type is not in the whitelist', async () => {
+      mockPluginContext(['image/jpeg']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(false);
+    });
+  });
+
+  describe('extension glob entries (*.ext format)', () => {
+    it('allows a file matching a *.ext glob', async () => {
+      mockPluginContext(['*.png']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(true);
+    });
+
+    it('allows a file matching a *ext glob (no dot)', async () => {
+      mockPluginContext(['*png']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(true);
+    });
+
+    it('is case-insensitive for the extension', async () => {
+      mockPluginContext(['*.PNG']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(true);
+    });
+
+    it('rejects a file whose extension is not in the whitelist', async () => {
+      mockPluginContext(['*.jpg']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(false);
+    });
+  });
+
+  describe('rejected files', () => {
+    it('returns a translated reason', async () => {
+      mockPluginContext(['image/jpeg']);
+      const { result } = renderHook(() => useAttachmentValidation());
+      const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
+      expect(validation.valid).toBe(false);
+      if (!validation.valid) {
+        expect(validation.reason).toBe('not allowed: image/png');
+      }
+    });
+  });
+});

--- a/frontend/src/react/hooks/useAttachmentValidation.spec.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.spec.ts
@@ -45,8 +45,20 @@ function mockFile(name:string, type:string):File {
   return new File([''], name, { type });
 }
 
+let originalOpenProject:unknown;
+let originalI18n:unknown;
+
 beforeEach(() => {
-  (window as unknown as { I18n:unknown }).I18n = { t: (_key:string, opts?:{ value?:string }) => `not allowed: ${opts?.value ?? ''}` };
+  const win = window as unknown as { OpenProject:unknown; I18n:unknown };
+  originalOpenProject = win.OpenProject;
+  originalI18n = win.I18n;
+  win.I18n = { t: (_key:string, opts?:{ value?:string }) => `not allowed: ${opts?.value ?? ''}` };
+});
+
+afterEach(() => {
+  const win = window as unknown as { OpenProject:unknown; I18n:unknown };
+  win.OpenProject = originalOpenProject;
+  win.I18n = originalI18n;
 });
 
 describe('useAttachmentValidation', () => {
@@ -92,11 +104,11 @@ describe('useAttachmentValidation', () => {
       expect(validation.valid).toBe(true);
     });
 
-    it('allows a file matching a *ext glob (no dot)', async () => {
+    it('does not match a *ext glob without a dot (backend also rejects this format)', async () => {
       mockPluginContext(['*png']);
       const { result } = renderHook(() => useAttachmentValidation());
       const validation = await result.current.validateFile(mockFile('photo.png', 'image/png'));
-      expect(validation.valid).toBe(true);
+      expect(validation.valid).toBe(false);
     });
 
     it('is case-insensitive for the extension', async () => {

--- a/frontend/src/react/hooks/useAttachmentValidation.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.ts
@@ -1,0 +1,70 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { useCallback } from 'react';
+
+export interface AttachmentValidationResult {
+  valid:boolean;
+  reason?:string;
+}
+
+export function useAttachmentValidation() {
+  const validateFile = useCallback(async (file:File):Promise<AttachmentValidationResult> => {
+    const pluginContext = await window.OpenProject.getPluginContext();
+    const whitelist = pluginContext.services.configurationService.attachmentWhitelist;
+
+    if (!whitelist || whitelist.length === 0) {
+      return { valid: true };
+    }
+
+    // Empty file.type means the browser couldn't infer the MIME from the
+    // extension (e.g. .xyz). Defer to the backend in that case - it does
+    // real magic-byte detection that we can't replicate cheaply on the client.
+    if (!file.type) {
+      return { valid: true };
+    }
+
+    if (whitelist.includes(file.type)) {
+      return { valid: true };
+    }
+
+    return {
+      valid: false,
+      reason: window.I18n.t(
+        'js.activerecord.errors.models.attachment.attributes.content_type.not_allowlisted',
+        { value: file.type },
+      ),
+    };
+  }, []);
+
+  return { validateFile };
+}
+
+export default useAttachmentValidation;

--- a/frontend/src/react/hooks/useAttachmentValidation.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.ts
@@ -52,8 +52,8 @@ export function useAttachmentValidation() {
 
     const ext = file.name.split('.').pop()?.toLowerCase();
     const allowed = whitelist.some((entry) =>
-      entry.startsWith('*')
-        ? entry.slice(1).replace(/^\./, '').toLowerCase() === ext
+      entry.startsWith('*.')
+        ? entry.slice(2).toLowerCase() === ext
         : entry === file.type,
     );
 

--- a/frontend/src/react/hooks/useAttachmentValidation.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.ts
@@ -58,7 +58,7 @@ export function useAttachmentValidation() {
     return {
       valid: false,
       reason: window.I18n.t(
-        'js.activerecord.errors.models.attachment.attributes.content_type.not_allowlisted',
+        'js.error_attachment_type_not_allowed',
         { value: file.type },
       ),
     };

--- a/frontend/src/react/hooks/useAttachmentValidation.ts
+++ b/frontend/src/react/hooks/useAttachmentValidation.ts
@@ -30,10 +30,9 @@
 
 import { useCallback } from 'react';
 
-export interface AttachmentValidationResult {
-  valid:boolean;
-  reason?:string;
-}
+export type AttachmentValidationResult =
+  | { valid:true }
+  | { valid:false; reason:string };
 
 export function useAttachmentValidation() {
   const validateFile = useCallback(async (file:File):Promise<AttachmentValidationResult> => {
@@ -51,7 +50,14 @@ export function useAttachmentValidation() {
       return { valid: true };
     }
 
-    if (whitelist.includes(file.type)) {
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    const allowed = whitelist.some((entry) =>
+      entry.startsWith('*')
+        ? entry.slice(1).replace(/^\./, '').toLowerCase() === ext
+        : entry === file.type,
+    );
+
+    if (allowed) {
       return { valid: true };
     }
 

--- a/frontend/src/react/hooks/useBlockNoteAttachments.ts
+++ b/frontend/src/react/hooks/useBlockNoteAttachments.ts
@@ -71,16 +71,16 @@ export function useBlockNoteAttachments(
   }, [getEditor]);
 
   const uploadFile = useCallback(async (file:File, blockId?:string):Promise<string> => {
-    const pluginContext = await window.OpenProject.getPluginContext();
-
-    const validation = await validateFile(file);
-    if (!validation.valid) {
-      pluginContext.services.notifications.addError(validation.reason);
-      removePlaceholder(blockId);
-      return '';
-    }
-
     try {
+      const pluginContext = await window.OpenProject.getPluginContext();
+
+      const validation = await validateFile(file);
+      if (!validation.valid) {
+        pluginContext.services.notifications.addError(validation.reason);
+        removePlaceholder(blockId);
+        return '';
+      }
+
       const service = pluginContext.services.attachmentsResourceService;
       const uploadFiles:IUploadFile[] = [{ file }];
       const result = await firstValueFrom(
@@ -93,9 +93,8 @@ export function useBlockNoteAttachments(
       }
       return href;
     } catch (error) {
-      pluginContext.services.notifications.addError(
-        error instanceof Error ? error.message : String(error),
-      );
+      const pluginContext = await window.OpenProject.getPluginContext().catch(() => null);
+      pluginContext?.services.notifications.addError(error as never);
       removePlaceholder(blockId);
 
       // Return '' instead of rethrowing: BlockNote 0.44.x doesn't catch

--- a/frontend/src/react/hooks/useBlockNoteAttachments.ts
+++ b/frontend/src/react/hooks/useBlockNoteAttachments.ts
@@ -38,14 +38,14 @@ export interface BlockNoteAttachmentsResult {
   uploadFile?:(file:File, blockId?:string) => Promise<string>;
 }
 
-export interface BlockNoteEditorRef {
+export interface EditorHandle {
   removeBlocks:(ids:string[]) => void;
 }
 
 export function useBlockNoteAttachments(
   attachmentsCollectionKey:string,
   attachmentsUploadUrl:string,
-  getEditor?:() => BlockNoteEditorRef | null,
+  getEditor?:() => EditorHandle | null,
 ):BlockNoteAttachmentsResult {
   const enabled = (
     attachmentsCollectionKey !== undefined &&
@@ -75,7 +75,7 @@ export function useBlockNoteAttachments(
 
     const validation = await validateFile(file);
     if (!validation.valid) {
-      pluginContext.services.notifications.addError(validation.reason ?? 'File not allowed');
+      pluginContext.services.notifications.addError(validation.reason);
       removePlaceholder(blockId);
       return '';
     }
@@ -92,10 +92,10 @@ export function useBlockNoteAttachments(
         throw new Error('Upload returned no download location');
       }
       return href;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error:any) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      pluginContext.services.notifications.addError(error);
+    } catch (error) {
+      pluginContext.services.notifications.addError(
+        error instanceof Error ? error.message : String(error),
+      );
       removePlaceholder(blockId);
 
       // Return '' instead of rethrowing: BlockNote 0.44.x doesn't catch

--- a/frontend/src/react/hooks/useBlockNoteAttachments.ts
+++ b/frontend/src/react/hooks/useBlockNoteAttachments.ts
@@ -31,7 +31,6 @@
 import { IUploadFile } from 'core-app/core/upload/upload.service';
 import { useCallback } from 'react';
 import { firstValueFrom } from 'rxjs';
-import type { BlockNoteEditor } from '@blocknote/core';
 import { useAttachmentValidation } from './useAttachmentValidation';
 
 export interface BlockNoteAttachmentsResult {
@@ -39,10 +38,14 @@ export interface BlockNoteAttachmentsResult {
   uploadFile?:(file:File, blockId?:string) => Promise<string>;
 }
 
+export interface BlockNoteEditorRef {
+  removeBlocks:(ids:string[]) => void;
+}
+
 export function useBlockNoteAttachments(
   attachmentsCollectionKey:string,
   attachmentsUploadUrl:string,
-  getEditor?:() => BlockNoteEditor<any, any, any> | null,
+  getEditor?:() => BlockNoteEditorRef | null,
 ):BlockNoteAttachmentsResult {
   const enabled = (
     attachmentsCollectionKey !== undefined &&

--- a/frontend/src/react/hooks/useBlockNoteAttachments.ts
+++ b/frontend/src/react/hooks/useBlockNoteAttachments.ts
@@ -31,15 +31,18 @@
 import { IUploadFile } from 'core-app/core/upload/upload.service';
 import { useCallback } from 'react';
 import { firstValueFrom } from 'rxjs';
+import type { BlockNoteEditor } from '@blocknote/core';
+import { useAttachmentValidation } from './useAttachmentValidation';
 
 export interface BlockNoteAttachmentsResult {
   enabled:boolean;
-  uploadFile?:(file:File) => Promise<string>;
+  uploadFile?:(file:File, blockId?:string) => Promise<string>;
 }
 
 export function useBlockNoteAttachments(
   attachmentsCollectionKey:string,
   attachmentsUploadUrl:string,
+  getEditor?:() => BlockNoteEditor<any, any, any> | null,
 ):BlockNoteAttachmentsResult {
   const enabled = (
     attachmentsCollectionKey !== undefined &&
@@ -48,25 +51,57 @@ export function useBlockNoteAttachments(
     attachmentsUploadUrl !== ''
   );
 
-  const uploadFile = useCallback(async (file:File):Promise<string> => {
+  const { validateFile } = useAttachmentValidation();
+
+  // BlockNote 0.44.x creates a "Loading..." placeholder block before awaiting
+  // uploadFile (blocknote.js Ie(), ~line 1130) and only calls updateBlock on
+  // the success path - it has no try/catch around the await. On rejection,
+  // the placeholder is left in the document forever. We remove it ourselves
+  // here. removeBlocks is synchronous and safe because BlockNote never
+  // touches the block again after the rejected await.
+  const removePlaceholder = useCallback((blockId?:string) => {
+    const editor = getEditor?.();
+    if (!editor || !blockId) return;
+    try {
+      editor.removeBlocks([blockId]);
+    } catch { /* already removed by a collaborator via Yjs */ }
+  }, [getEditor]);
+
+  const uploadFile = useCallback(async (file:File, blockId?:string):Promise<string> => {
     const pluginContext = await window.OpenProject.getPluginContext();
+
+    const validation = await validateFile(file);
+    if (!validation.valid) {
+      pluginContext.services.notifications.addError(validation.reason ?? 'File not allowed');
+      removePlaceholder(blockId);
+      return '';
+    }
+
     try {
       const service = pluginContext.services.attachmentsResourceService;
       const uploadFiles:IUploadFile[] = [{ file }];
       const result = await firstValueFrom(
-        service.addAttachments(attachmentsCollectionKey, attachmentsUploadUrl, uploadFiles)
+        service.addAttachments(attachmentsCollectionKey, attachmentsUploadUrl, uploadFiles),
       );
 
-      return result?.[0]._links.staticDownloadLocation.href ?? '';
+      const href = result?.[0]?._links?.staticDownloadLocation?.href;
+      if (!href) {
+        throw new Error('Upload returned no download location');
+      }
+      return href;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error:any) {
-      const toastService = pluginContext.services.notifications;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      toastService.addError(error);
+      pluginContext.services.notifications.addError(error);
+      removePlaceholder(blockId);
 
+      // Return '' instead of rethrowing: BlockNote 0.44.x doesn't catch
+      // uploadFile rejections, so throwing would surface as Uncaught (in
+      // promise). The placeholder is already gone, so the success-path
+      // updateBlock that follows our return won't fire anyway.
       return '';
     }
-  }, [attachmentsCollectionKey, attachmentsUploadUrl]);
+  }, [attachmentsCollectionKey, attachmentsUploadUrl, validateFile, removePlaceholder]);
 
   if (!enabled) {
     return { enabled };

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -118,11 +118,12 @@ module API
 
         property :attachment_whitelist,
                  getter: ->(*) {
-                    raw = Setting.attachment_whitelist
-                    Array(raw).flat_map { |entry| entry.to_s.split(/\r?\n/) }
-                              .map(&:strip)
-                              .reject(&:blank?)
+                   raw = Setting.attachment_whitelist
+                   Array(raw).flat_map { |entry| entry.to_s.split(/\r?\n/) }
+                             .map(&:strip)
+                             .compact_blank
                  }
+
         property :user_preferences,
                  embedded: true,
                  exec_context: :decorator,

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -118,10 +118,7 @@ module API
 
         property :attachment_whitelist,
                  getter: ->(*) {
-                   raw = Setting.attachment_whitelist
-                   Array(raw).flat_map { |entry| entry.to_s.split(/\r?\n/) }
-                             .map(&:strip)
-                             .compact_blank
+                   Array(Setting.attachment_whitelist).map(&:strip).compact_blank
                  }
 
         property :user_preferences,

--- a/lib/api/v3/configuration/configuration_representer.rb
+++ b/lib/api/v3/configuration/configuration_representer.rb
@@ -116,6 +116,13 @@ module API
         property :allowed_link_protocols,
                  getter: ->(*) { Setting::AllowedLinkProtocols.all }
 
+        property :attachment_whitelist,
+                 getter: ->(*) {
+                    raw = Setting.attachment_whitelist
+                    Array(raw).flat_map { |entry| entry.to_s.split(/\r?\n/) }
+                              .map(&:strip)
+                              .reject(&:blank?)
+                 }
         property :user_preferences,
                  embedded: true,
                  exec_context: :decorator,

--- a/spec/lib/api/v3/configuration/configuration_representer_spec.rb
+++ b/spec/lib/api/v3/configuration/configuration_representer_spec.rb
@@ -248,6 +248,38 @@ RSpec.describe API::V3::Configuration::ConfigurationRepresenter do
       end
     end
 
+    describe "attachmentWhitelist" do
+      context "with a configured whitelist" do
+        before { allow(Setting).to receive(:attachment_whitelist).and_return(["*.png", "image/jpeg"]) }
+
+        it "returns the entries as an array" do
+          expect(subject)
+            .to be_json_eql(["*.png", "image/jpeg"].to_json)
+                  .at_path("attachmentWhitelist")
+        end
+      end
+
+      context "with blank entries in the whitelist" do
+        before { allow(Setting).to receive(:attachment_whitelist).and_return(["  *.png  ", "", "image/jpeg"]) }
+
+        it "strips whitespace and removes blank entries" do
+          expect(subject)
+            .to be_json_eql(["*.png", "image/jpeg"].to_json)
+                  .at_path("attachmentWhitelist")
+        end
+      end
+
+      context "with an empty whitelist" do
+        before { allow(Setting).to receive(:attachment_whitelist).and_return([]) }
+
+        it "returns an empty array" do
+          expect(subject)
+            .to be_json_eql([].to_json)
+                  .at_path("attachmentWhitelist")
+        end
+      end
+    end
+
     describe "availableFeatures" do
       context "without any features" do
         it "is an empty array" do

--- a/spec/requests/api/v3/configuration_resource_spec.rb
+++ b/spec/requests/api/v3/configuration_resource_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe "API v3 Configuration resource" do
               .at_path("perPageOptions")
     end
 
+    it "returns the attachment whitelist", with_settings: { attachment_whitelist: ["*.png", "image/jpeg"] } do
+      expect(subject.body)
+        .to be_json_eql(["*.png", "image/jpeg"].to_json)
+              .at_path("attachmentWhitelist")
+    end
+
+    it "returns an empty attachment whitelist when none is configured", with_settings: { attachment_whitelist: [] } do
+      expect(subject.body)
+        .to be_json_eql([].to_json)
+              .at_path("attachmentWhitelist")
+    end
+
     it "embedds the current user preferences" do
       expect(subject.body)
         .to be_json_eql("UserPreferences".to_json)


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/68792

# What are you trying to accomplish?
Closes the bug where dragging a file with an unsupported extension into a BlockNote editor leaves a "Loading..." placeholder block stuck in the document. The backend rejects the upload and shows the error toast, but BlockNote never cleans up the placeholder, forcing the user to click and delete it manually.
In addition to fixing the visible bug, this PR adds client-side pre-validation of the file's MIME type so that obviously disallowed files (e.g. dropping .txt when the whitelist is [image/png]) are rejected instantly without an upload round-trip.

# What approach did you choose and why?
The bug lives in BlockNote 0.44.2, not in our code. Its drop handler (Ie() around blocknote.js:1130) creates a placeholder block, then does await editor.uploadFile(file, blockId) with no try/catch, and calls updateBlock only on the success path. On rejection, the placeholder is orphaned and there is no hook to clean it up upstream.
Three options were on the table:

Patch BlockNote (upstream PR or local patch-package). Cleanest semantically, but slow and adds maintenance burden until merged.
Workaround in our uploadFile. Catch rejections inside the function we already pass to BlockNote and remove the placeholder ourselves.
Pre-validate before the file ever reaches uploadFile. Through a ProseMirror plugin that intercepts drop/paste earlier than BlockNote.

I went with option 2 as the primary fix (it fully closes the ticket) and layered a lightweight version of option 3 on top of it (MIME pre-validation inside uploadFile, before the upload starts). The pure ProseMirror-plugin variant was rejected because making sure our handler runs before BlockNote's would be brittle and the UX win over "placeholder appears for ~50ms then disappears" is marginal.
Implementation details:

useBlockNoteAttachments accepts a lazy getEditor getter so it can call editor.removeBlocks([blockId]) from its rejection path without creating a circular dependency with useCreateBlockNote. The ref is read only inside the catch (always after the editor is assigned), so there is no race.
removeBlocks is called synchronously in the catch - verified by reading blocknote.js: the updateBlock call sits after the awaited uploadFile, so on rejection BlockNote never touches the block again. No queueMicrotask or other deferral hack is needed.
uploadFile returns '' instead of rethrowing on failure. Rethrowing would surface as Uncaught (in promise) because BlockNote 0.44.2 does not catch its own await uploadFile. Since the placeholder has already been removed by the time we return, the success-path updateBlock that follows our return is harmless on rejection (it doesn't run) and a no-op concern on the validation path either.
Pre-validation lives in a separate useAttachmentValidation hook. It reads attachment_whitelist from ConfigurationService, which I extended along with ConfigurationResource and ConfigurationRepresenter to expose Setting.attachment_whitelist through the existing /api/v3/configuration endpoint - the same channel already used for attachment_max_size, allowed_link_protocols, etc. No new endpoint, no new config mechanism.
Validation deliberately skips files with an empty file.type (e.g. .xyz). Browsers can't infer a MIME for unknown extensions, and blocking them client-side would also block legitimate cases. The backend does proper magic-byte detection via marcel, so we defer to it. These files still produce the cleanest possible UX because the placeholder cleanup from option 2 handles them.
The user-facing error string reuses the existing activerecord.errors.models.attachment.attributes.content_type.not_allowlisted translation so the message is identical whether the rejection comes from the client or the server.

Known limitations (documented in code comments):

The placeholder cleanup is tied to BlockNote 0.44.2 internals. If a future version starts catching uploadFile rejections itself, our removeBlocks will become a redundant call on an already-removed block - caught by the inner try/catch, but worth re-evaluating on upgrade. The version is named in the comment for that reason.
file.type from the browser is extension-based, not magic-byte based. A renamed evil.exe -> cute.png would pass our check and fail server-side. This is expected: client-side validation is for UX, server-side is for security.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
