### PR TITLE
Use formatted_id in user-facing WP identifier rendering

### DIFF
--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -47,7 +47,7 @@ module WorkPackagesHelper
                    class: link_to_work_package_css_classes(work_package)) do
       link_parts = []
       link_parts << work_package.type.to_s if work_package.type_id
-      link_parts << "##{work_package.id}:"
+      link_parts << "#{work_package.formatted_id}:"
       link_parts << content_tag(:span, I18n.t(:label_closed_work_packages), class: "sr-only") if work_package.closed?
       link_parts << work_package.subject if link_subject
 

--- a/app/helpers/work_packages_helper.rb
+++ b/app/helpers/work_packages_helper.rb
@@ -35,9 +35,9 @@ module WorkPackagesHelper
   # Displays a link to +work_package+ with its subject.
   # Examples:
   #
-  #   link_to_work_package(package)                            # => Defect #6: This is the subject
-  #   link_to_work_package(package, link_subject: true)        # => Defect #6: This is the subject (everything within the link)
-  #   link_to_work_package(package, display_project: true)     # => Foo - Defect #6: This is the subject
+  #   link_to_work_package(package)                            # => Defect <id>: This is the subject
+  #   link_to_work_package(package, link_subject: true)        # => Defect <id>: This is the subject (everything within the link)
+  #   link_to_work_package(package, display_project: true)     # => Foo - Defect <id>: This is the subject
   def link_to_work_package(work_package, display_project: false, link_subject: false) # rubocop:disable Metrics/AbcSize
     output = ActiveSupport::SafeBuffer.new
     output << "#{work_package.project} - " if display_project && work_package.project_id

--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -276,7 +276,7 @@ class WorkPackage < ApplicationRecord
   end
 
   def to_s
-    "#{type.name unless type.is_standard} ##{id}: #{subject}"
+    "#{type.name unless type.is_standard} #{formatted_id}: #{subject}"
   end
 
   def infoline(show_standard_type: true)

--- a/lib/open_project/journal_formatter/cause.rb
+++ b/lib/open_project/journal_formatter/cause.rb
@@ -243,7 +243,7 @@ class OpenProject::JournalFormatter::Cause < JournalFormatter::Base
     if related_work_package
       I18n.t(
         "journals.cause_descriptions.#{cause['type']}",
-        link: html? ? link_to_work_package(related_work_package, link_subject: true) : "##{related_work_package.id}"
+        link: html? ? link_to_work_package(related_work_package, link_subject: true) : related_work_package.formatted_id
       )
 
     else

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -90,6 +90,25 @@ RSpec.describe WorkPackagesHelper do
         expect(helper.link_to_work_package(stub_work_package)).to have_no_text(text)
       end
     end
+
+    describe "in semantic mode",
+             with_flag: { semantic_work_package_ids: true },
+             with_settings: { work_packages_identifier: "semantic" } do
+      let(:stub_work_package) { build_stubbed(:work_package, type: stub_type, identifier: "MACROPROJ-42") }
+
+      it "uses the semantic identifier in the visible link label" do
+        link_text = Regexp.new("^#{stub_type.name} #{stub_work_package.formatted_id}:$")
+        expect(helper.link_to_work_package(stub_work_package))
+          .to have_css("a[href='#{work_package_path(stub_work_package)}']", text: link_text)
+      end
+
+      it "does not embed the bare numeric `#N` form in the link label" do
+        # The href independently uses display_id (via to_param) and is fine;
+        # the visible label is what this assertion guards.
+        result = helper.link_to_work_package(stub_work_package)
+        expect(result).to have_no_css("a", text: /##{stub_work_package.id}:/)
+      end
+    end
   end
 
   describe "#work_packages_columns_options" do

--- a/spec/helpers/work_packages_helper_spec.rb
+++ b/spec/helpers/work_packages_helper_spec.rb
@@ -97,14 +97,12 @@ RSpec.describe WorkPackagesHelper do
       let(:stub_work_package) { build_stubbed(:work_package, type: stub_type, identifier: "MACROPROJ-42") }
 
       it "uses the semantic identifier in the visible link label" do
-        link_text = Regexp.new("^#{stub_type.name} #{stub_work_package.formatted_id}:$")
+        link_text = Regexp.new("^#{stub_type.name} MACROPROJ-42:$")
         expect(helper.link_to_work_package(stub_work_package))
           .to have_css("a[href='#{work_package_path(stub_work_package)}']", text: link_text)
       end
 
       it "does not embed the bare numeric `#N` form in the link label" do
-        # The href independently uses display_id (via to_param) and is fine;
-        # the visible label is what this assertion guards.
         result = helper.link_to_work_package(stub_work_package)
         expect(result).to have_no_css("a", text: /##{stub_work_package.id}:/)
       end

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -154,6 +154,33 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
         )
       end
     end
+
+    context "in semantic mode",
+            with_flag: { semantic_work_package_ids: true },
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:semantic_project) { create(:project, identifier: "MACROPROJ") }
+      let(:work_package) { create(:work_package, project: semantic_project) }
+
+      before do
+        work_package.allocate_and_register_semantic_id
+        allow(WorkPackage).to receive(:visible).with(User.current).and_return(WorkPackage.where(id: work_package.id))
+      end
+
+      it "renders the related work package's formatted_id in raw text mode" do
+        wp = work_package.reload
+        expect(cause).to render_raw_variant(a_string_including(wp.formatted_id))
+        expect(cause).not_to render_raw_variant(a_string_including("##{wp.id}"))
+      end
+
+      it "renders the related work package's formatted_id in the link label in HTML mode" do
+        wp = work_package.reload
+        # The visible link label should be `… formatted_id: subject`, not
+        # `… #1234: subject`. The href is mode-agnostic and uses display_id
+        # via `to_param` regardless.
+        expect(cause).to render_html_variant(a_string_including("#{wp.formatted_id}:"))
+        expect(cause).not_to render_html_variant(a_string_including(" ##{wp.id}:"))
+      end
+    end
   end
 
   context "when the change was caused by a change to a predecessor" do

--- a/spec/lib/open_project/journal_formatter/cause_spec.rb
+++ b/spec/lib/open_project/journal_formatter/cause_spec.rb
@@ -174,9 +174,6 @@ RSpec.describe OpenProject::JournalFormatter::Cause do
 
       it "renders the related work package's formatted_id in the link label in HTML mode" do
         wp = work_package.reload
-        # The visible link label should be `… formatted_id: subject`, not
-        # `… #1234: subject`. The href is mode-agnostic and uses display_id
-        # via `to_param` regardless.
         expect(cause).to render_html_variant(a_string_including("#{wp.formatted_id}:"))
         expect(cause).not_to render_html_variant(a_string_including(" ##{wp.id}:"))
       end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -943,4 +943,31 @@ RSpec.describe WorkPackage do
       end
     end
   end
+
+  describe "#to_s" do
+    let(:task_type) { create(:type_task) }
+
+    context "in classic mode",
+            with_flag: { semantic_work_package_ids: false },
+            with_settings: { work_packages_identifier: "classic" } do
+      let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
+
+      it "renders the numeric id with a `#` prefix" do
+        expect(work_package.to_s).to eq("Task ##{work_package.id}: Hello world")
+      end
+    end
+
+    context "in semantic mode",
+            with_flag: { semantic_work_package_ids: true },
+            with_settings: { work_packages_identifier: "semantic" } do
+      let(:project) { create(:project, identifier: "MACROPROJ", types: [task_type]) }
+      let(:work_package) { create(:work_package, project:, type: task_type, subject: "Hello world") }
+
+      it "renders the semantic identifier without a `#` prefix" do
+        wp = work_package.reload
+        expect(wp.to_s).to eq("Task #{wp.display_id}: Hello world")
+        expect(wp.to_s).not_to include("##{wp.id}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74945

Split out of #22976; ships independently.

# What are you trying to accomplish?

Three WP render paths spoke numeric ids — `WorkPackage#to_s` (autocomplete dropdown rows and the delete-confirmation dialog), `link_to_work_package` (the visible link label in activity-feed entries), and `JournalFormatter::Cause` (the automatic entry emitted when a parent / child / predecessor date cascade fires).

All three switch to `formatted_id`, which produces `PROJ-7` in semantic mode and `#42` in classic. The href uses `to_param` and is mode-correct without changes; this updates only the visible label.

## Screenshots

<img width="1389" height="962" alt="pr22976-activity-cause-formatter-semantic" src="https://github.com/user-attachments/assets/c3c5e463-3d44-4df4-90a7-95ccd51c84a6" />

<img width="1389" height="962" alt="pr22976-autocomplete-dropdown-semantic-annotated" src="https://github.com/user-attachments/assets/a76f30ed-1f56-41db-9135-75f2f9147a2a" />

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)