### PR TITLE
Resolve semantic identifiers in wiki reverse-link parser

### DIFF
--- a/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
@@ -38,13 +38,18 @@ module Wikis::Concerns
 
       Wikis::ReverseInlinePageLink.where(provider:, identifier: wiki_page.id).delete_all
 
-      identifiers = find_wp_links(wiki_page.text).uniq
+      # Bound the per-save lookup so a multi-megabyte pasted body can't push
+      # an unbounded IN-list into the alias-aware WP lookup. References past
+      # the cap simply don't get a reverse link recorded.
+      identifiers = find_wp_links(wiki_page.text).uniq.first(MAX_PRELOAD_IDENTIFIERS)
       return if identifiers.empty?
 
       WorkPackage.where_display_id_in(identifiers).find_each do |wp|
         Wikis::ReverseInlinePageLink.create!(linkable: wp, provider:, identifier: wiki_page.id)
       end
     end
+
+    MAX_PRELOAD_IDENTIFIERS = 500
 
     # Mirrors the prefix character class of the inline-text macro matcher
     # (lib/open_project/text_formatting/matchers/resource_links_matcher.rb).

--- a/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
@@ -51,13 +51,20 @@ module Wikis::Concerns
 
     MAX_PRELOAD_IDENTIFIERS = 500
 
-    # Mirrors the prefix character class of the inline-text macro matcher
-    # (lib/open_project/text_formatting/matchers/resource_links_matcher.rb).
-    # The trailing `(?!\w)` boundary on the semantic branch prevents
-    # `#PROJ-1abc` from incorrectly matching `#PROJ-1`; the numeric branch
-    # intentionally has no trailing boundary to preserve historic behaviour
-    # for inputs like `#13-blubb`.
-    WP_REF_RE = /(?:[[:space:],~>#\(\[\-]|^)#(?:(\d+)|([A-Z][A-Z0-9_]*-\d+)(?!\w))/ # rubocop:disable Style/RedundantRegexpEscape
+    # Mirrors the prefix character class of the inline-text macro matcher.
+    # The trailing `(?!\w)` on the semantic branch keeps `#PROJ-1abc` from
+    # matching `#PROJ-1`; the numeric branch deliberately has no trailing
+    # boundary to preserve historic behaviour for inputs like `#13-blubb`.
+    # rubocop:disable Style/RedundantRegexpEscape
+    WP_REF_RE = /
+      (?:[[:space:],~>\#\(\[\-]|^)\#
+      (?:
+        (\d+)
+        |
+        (#{WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN.source})(?!\w)
+      )
+    /x
+    # rubocop:enable Style/RedundantRegexpEscape
 
     private
 

--- a/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
@@ -32,25 +32,6 @@ module Wikis::Concerns
   module UpdateReverseInlineWikiPageLinks
     extend ActiveSupport::Concern
 
-    def update_reverse_inline_wiki_page_links(wiki_page)
-      provider = Wikis::InternalProvider.enabled.first
-      return if provider.nil?
-
-      Wikis::ReverseInlinePageLink.where(provider:, identifier: wiki_page.id).delete_all
-
-      # Bound the per-save lookup so a multi-megabyte pasted body can't push
-      # an unbounded IN-list into the alias-aware WP lookup. References past
-      # the cap simply don't get a reverse link recorded.
-      identifiers = find_wp_links(wiki_page.text).uniq.first(MAX_PRELOAD_IDENTIFIERS)
-      return if identifiers.empty?
-
-      WorkPackage.where_display_id_in(identifiers).find_each do |wp|
-        Wikis::ReverseInlinePageLink.create!(linkable: wp, provider:, identifier: wiki_page.id)
-      end
-    end
-
-    MAX_PRELOAD_IDENTIFIERS = 500
-
     # Mirrors the prefix character class of the inline-text macro matcher.
     # The trailing `(?!\w)` on the semantic branch keeps `#PROJ-1abc` from
     # matching `#PROJ-1`; the numeric branch deliberately has no trailing
@@ -65,6 +46,20 @@ module Wikis::Concerns
       )
     /x
     # rubocop:enable Style/RedundantRegexpEscape
+
+    def update_reverse_inline_wiki_page_links(wiki_page)
+      provider = Wikis::InternalProvider.enabled.first
+      return if provider.nil?
+
+      Wikis::ReverseInlinePageLink.where(provider:, identifier: wiki_page.id).delete_all
+
+      identifiers = find_wp_links(wiki_page.text).uniq
+      return if identifiers.empty?
+
+      WorkPackage.where_display_id_in(identifiers).find_each do |wp|
+        Wikis::ReverseInlinePageLink.create!(linkable: wp, provider:, identifier: wiki_page.id)
+      end
+    end
 
     private
 

--- a/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
+++ b/modules/wikis/app/services/wikis/concerns/update_reverse_inline_wiki_page_links.rb
@@ -38,22 +38,28 @@ module Wikis::Concerns
 
       Wikis::ReverseInlinePageLink.where(provider:, identifier: wiki_page.id).delete_all
 
-      find_wp_links(wiki_page.text).uniq.each do |wp_id|
-        wp = WorkPackage.find_by(id: wp_id)
-        next if wp.nil?
+      identifiers = find_wp_links(wiki_page.text).uniq
+      return if identifiers.empty?
 
+      WorkPackage.where_display_id_in(identifiers).find_each do |wp|
         Wikis::ReverseInlinePageLink.create!(linkable: wp, provider:, identifier: wiki_page.id)
       end
     end
+
+    # Mirrors the prefix character class of the inline-text macro matcher
+    # (lib/open_project/text_formatting/matchers/resource_links_matcher.rb).
+    # The trailing `(?!\w)` boundary on the semantic branch prevents
+    # `#PROJ-1abc` from incorrectly matching `#PROJ-1`; the numeric branch
+    # intentionally has no trailing boundary to preserve historic behaviour
+    # for inputs like `#13-blubb`.
+    WP_REF_RE = /(?:[[:space:],~>#\(\[\-]|^)#(?:(\d+)|([A-Z][A-Z0-9_]*-\d+)(?!\w))/ # rubocop:disable Style/RedundantRegexpEscape
 
     private
 
     def find_wp_links(text)
       return [] if text.blank?
 
-      # extracted prefix from lib/open_project/text_formatting/matchers/resource_links_matcher.rb
-      # adding # as additional prefix
-      text.scan(/(?:[[:space:],~>#\(\[\-]|^)#([0-9]+)/) # rubocop:disable Style/RedundantRegexpEscape
+      text.scan(WP_REF_RE).map { |numeric, semantic| numeric || semantic }
     end
   end
 end

--- a/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
@@ -179,6 +179,20 @@ RSpec.describe WikiPages::CreateService do
     end
   end
 
+  context "when a numeric reference is immediately followed by alphanumeric text" do
+    # The numeric branch of WP_REF_RE has no trailing `(?!\w)` boundary —
+    # historic behaviour matches `#13` inside `#13-blubb` and similar
+    # shapes. Locked here so a future tightening of the boundary can't
+    # silently strip reverse-links from existing wiki content.
+    let(:text) { "Trailing: ##{work_package.id}abc" }
+
+    it "still creates a reverse page link from the numeric prefix" do
+      subject
+
+      expect(reverse_link_finder.count).to eq(1)
+    end
+  end
+
   context "when the internal provider is disabled" do
     let(:internal_provider) { create(:internal_wiki_provider, enabled: false) }
 

--- a/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
@@ -202,4 +202,92 @@ RSpec.describe WikiPages::CreateService do
       expect(Wikis::ReverseInlinePageLink.count).to eq(0)
     end
   end
+
+  context "with a semantic-identifier reference",
+          with_flag: { semantic_work_package_ids: true },
+          with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, :semantic) }
+    let(:work_package) do
+      create(:work_package, project:).tap do |wp|
+        wp.allocate_and_register_semantic_id
+        wp.reload
+      end
+    end
+
+    context "when the reference uses the semantic identifier" do
+      let(:text) { "See ##{work_package.identifier} for context." }
+
+      it "creates a reverse page link" do
+        subject
+
+        expect(reverse_link_finder.count).to eq(1)
+      end
+    end
+
+    context "when the semantic reference uses the ## widget syntax" do
+      let(:text) { "Block: ###{work_package.identifier}." }
+
+      it "creates a reverse page link" do
+        subject
+
+        expect(reverse_link_finder.count).to eq(1)
+      end
+    end
+
+    context "when the semantic reference uses the ### widget syntax" do
+      let(:text) { "Detailed: ####{work_package.identifier}." }
+
+      it "creates a reverse page link" do
+        subject
+
+        expect(reverse_link_finder.count).to eq(1)
+      end
+    end
+
+    context "when the project has been renamed and a historical alias is referenced" do
+      let(:text) { "Historical: #OLD-#{work_package.sequence_number}." }
+
+      before do
+        WorkPackageSemanticAlias.create!(work_package:, identifier: "OLD-#{work_package.sequence_number}")
+      end
+
+      it "still creates a reverse page link" do
+        subject
+
+        expect(reverse_link_finder.count).to eq(1)
+      end
+    end
+
+    context "when no work package matches the semantic reference" do
+      let(:text) { "Missing: #GHOST-99." }
+
+      it "does not create a link" do
+        subject
+
+        expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+      end
+    end
+
+    context "when the semantic identifier is followed by an alphanumeric word character" do
+      let(:text) { "Boundary: ##{work_package.identifier}abc." }
+
+      it "does not create a link" do
+        subject
+
+        expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+      end
+    end
+  end
+
+  context "with a semantic-shape reference in classic mode",
+          with_flag: { semantic_work_package_ids: false },
+          with_settings: { work_packages_identifier: "classic" } do
+    let(:text) { "See #PROJ-1 for context." }
+
+    it "does not create a link" do
+      subject
+
+      expect(Wikis::ReverseInlinePageLink.count).to eq(0)
+    end
+  end
 end

--- a/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
@@ -306,6 +306,23 @@ RSpec.describe WikiPages::CreateService do
         expect(links.pluck(:linkable_id)).to contain_exactly(numeric_work_package.id, work_package.id)
       end
     end
+
+    context "when several reference shapes resolve to the same work package" do
+      let(:text) do
+        "Triple: ##{work_package.id}, ##{work_package.identifier}, #OLD-#{work_package.sequence_number}."
+      end
+
+      before do
+        WorkPackageSemanticAlias.create!(work_package:, identifier: "OLD-#{work_package.sequence_number}")
+      end
+
+      it "creates a single reverse page link" do
+        subject
+
+        expect(reverse_link_finder.count).to eq(1)
+        expect(reverse_link_finder.first.linkable).to eq(work_package)
+      end
+    end
   end
 
   context "with a semantic-shape reference in classic mode",

--- a/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
+++ b/modules/wikis/spec/services/wiki_pages/create_service_spec.rb
@@ -291,6 +291,21 @@ RSpec.describe WikiPages::CreateService do
         expect(Wikis::ReverseInlinePageLink.count).to eq(0)
       end
     end
+
+    context "when the body mixes a numeric and a semantic reference" do
+      let(:numeric_work_package) { create(:work_package) }
+      let(:text) do
+        "Mixed: ##{numeric_work_package.id} and ##{work_package.identifier}."
+      end
+
+      it "creates a reverse page link per referenced work package" do
+        subject
+
+        wiki_page = WikiPage.first
+        links = Wikis::ReverseInlinePageLink.where(provider: internal_provider, identifier: wiki_page.id)
+        expect(links.pluck(:linkable_id)).to contain_exactly(numeric_work_package.id, work_package.id)
+      end
+    end
   end
 
   context "with a semantic-shape reference in classic mode",


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74947 _Split out of #22976._

# What are you trying to accomplish?

The wiki module maintains a parser that scans saved wiki pages for work-package references and creates formal database links from each wiki page back to the referenced WPs (so the WP's "referenced from" tab populates). The parser was numeric-only — semantic-shape references like `#PROJ-1` were silently dropped, leaving reverse-link coverage uneven once a project is in semantic mode.

The matcher now accepts the same shape as the inline-text macro — `#NNN`, `#PROJ-1`, plus the `##` / `###` widget variants — and resolves each capture through `WorkPackage.where_display_id_in`, which mixes primary keys, current identifiers and historical aliases in one query. A rename history continues to produce a reverse link via the alias table.

## Screenshots

<img width="1400" height="900" alt="pr22976-wiki-autocomplete-annotated" src="https://github.com/user-attachments/assets/c0637902-ff27-4c4b-a498-b1fee72f7f6b" />
<img width="1400" height="900" alt="pr22976-wiki-rendered-annotated" src="https://github.com/user-attachments/assets/1ffbb3ba-cd03-4022-80f3-cd25ebf67789" />
<img width="1400" height="900" alt="pr22976-wiki-reverse-link-tab-annotated" src="https://github.com/user-attachments/assets/00876899-0672-485e-b77c-cd519eeb5491" />

# Merge checklist

- [x] Added/updated tests covering both modes plus the alias-rename case
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)