### PR TITLE
Share semantic-id predicates and pin the route constraint

### DIFF
--- a/app/models/work_package/semantic_identifier.rb
+++ b/app/models/work_package/semantic_identifier.rb
@@ -84,19 +84,43 @@ module WorkPackage::SemanticIdentifier
     end
   end
 
-  # Returns true when value looks like a semantic work package identifier
-  # ("PROJ-42"). Non-strings (Integer, Hash, nil, Array) and numeric strings
-  # ("123", " 456 ") return false — these fall through to standard PK lookup.
+  # Routing predicate for WP finders: returns true when value is a String
+  # that needs string-based identifier/alias lookup. Three input kinds
+  # return true:
+  #   - true semantic identifiers ("PROJ-7")
+  #   - non-canonical numerics ("0123", "00")
+  #   - non-numeric strings ("abc")
+  # Only canonical numeric strings ("123") route to PK lookup and return
+  # false here. The predicate's name reflects routing intent, not strict
+  # shape validation — "0123" returns true even though it's clearly not
+  # a "semantic identifier" in the user-facing sense, because it still
+  # belongs on the string-lookup path.
   #
-  # The simple round-trip check (`value.strip.to_i.to_s != value.strip`) is
-  # intentional: it's faster than a regex and produces the same answer for
-  # every shape that can reach a work-package finder. Don't tighten it.
+  # Non-strings (Integer, Hash, nil) return false — already in PK-lookup
+  # shape.
   #
-  # Lives on this module rather than FinderMethods because the matcher /
-  # text-formatting layer needs the same predicate without pulling in finder
-  # internals.
+  # The round-trip check (rather than a regex) is intentional for
+  # performance: every value reaching a finder either parses as an
+  # integer or doesn't, and that's enough to dispatch. Don't tighten it.
   def self.semantic_id?(value)
     value.is_a?(String) && value.strip.to_i.to_s != value.strip
+  end
+
+  # Shape predicate: returns true when value is a canonical numeric ID —
+  # an Integer, or a String that round-trips through `to_i.to_s` ("0",
+  # "123"). Rejects leading-zero strings ("0123"), non-numeric strings,
+  # and nil.
+  #
+  # Pairs with `semantic_id?` at call sites that need to gate inputs to
+  # one of two lookup paths. They answer different questions (shape vs
+  # routing) and so are kept independent rather than expressing one as
+  # the negation of the other.
+  def self.numeric_id?(value)
+    case value
+    when Integer then true
+    when String  then value == value.to_i.to_s
+    else false
+    end
   end
 
   # Returns the user-facing identifier for this work package.

--- a/app/models/work_package/semantic_identifier.rb
+++ b/app/models/work_package/semantic_identifier.rb
@@ -84,32 +84,20 @@ module WorkPackage::SemanticIdentifier
     end
   end
 
-  # Routing predicate for WP finders: returns true when value is a String
-  # that needs string-based identifier/alias lookup. Three input kinds
-  # return true:
-  #   - true semantic identifiers ("PROJ-7")
-  #   - non-canonical numerics ("0123", "00")
-  #   - non-numeric strings ("abc")
-  # Only canonical numeric strings ("123") route to PK lookup and return
-  # false here. The predicate's name reflects routing intent, not strict
-  # shape validation — "0123" returns true even though it's clearly not
-  # a "semantic identifier" in the user-facing sense, because it still
-  # belongs on the string-lookup path.
+  # Returns true when value looks like a semantic work package identifier
+  # ("PROJ-42"). Non-strings (Integer, Hash, nil, Array) and numeric strings
+  # ("123", " 456 ") return false — these fall through to standard PK lookup.
   #
-  # Non-strings (Integer, Hash, nil) return false — already in PK-lookup
-  # shape.
-  #
-  # The round-trip check (rather than a regex) is intentional for
-  # performance: every value reaching a finder either parses as an
-  # integer or doesn't, and that's enough to dispatch. Don't tighten it.
+  # The round-trip check (rather than a regex) is intentional for performance.
+  # Every value that reaches a work-package finder either parses as an integer
+  # or doesn't, and that's enough to dispatch correctly. Don't tighten it.
   def self.semantic_id?(value)
     value.is_a?(String) && value.strip.to_i.to_s != value.strip
   end
 
-  # Shape predicate: returns true when value is a canonical numeric ID —
-  # an Integer, or a String that round-trips through `to_i.to_s` ("0",
-  # "123"). Rejects leading-zero strings ("0123"), non-numeric strings,
-  # and nil.
+  # Returns true when value is a canonical numeric ID —
+  # an Integer, or a String that round-trips through `to_i.to_s` ("0", "123").
+  # Rejects leading-zero strings ("0123"), non-numeric strings, and nil.
   #
   # For Strings the predicate is the exact complement of `semantic_id?`,
   # so the routing question (lookup by primary key vs by identifier/alias)

--- a/app/models/work_package/semantic_identifier.rb
+++ b/app/models/work_package/semantic_identifier.rb
@@ -84,6 +84,21 @@ module WorkPackage::SemanticIdentifier
     end
   end
 
+  # Returns true when value looks like a semantic work package identifier
+  # ("PROJ-42"). Non-strings (Integer, Hash, nil, Array) and numeric strings
+  # ("123", " 456 ") return false — these fall through to standard PK lookup.
+  #
+  # The simple round-trip check (`value.strip.to_i.to_s != value.strip`) is
+  # intentional: it's faster than a regex and produces the same answer for
+  # every shape that can reach a work-package finder. Don't tighten it.
+  #
+  # Lives on this module rather than FinderMethods because the matcher /
+  # text-formatting layer needs the same predicate without pulling in finder
+  # internals.
+  def self.semantic_id?(value)
+    value.is_a?(String) && value.strip.to_i.to_s != value.strip
+  end
+
   # Returns the user-facing identifier for this work package.
   # In semantic mode: the project-based identifier (e.g. "PROJ-42")
   # In classic mode: the numeric database ID

--- a/app/models/work_package/semantic_identifier.rb
+++ b/app/models/work_package/semantic_identifier.rb
@@ -111,14 +111,15 @@ module WorkPackage::SemanticIdentifier
   # "123"). Rejects leading-zero strings ("0123"), non-numeric strings,
   # and nil.
   #
-  # Pairs with `semantic_id?` at call sites that need to gate inputs to
-  # one of two lookup paths. They answer different questions (shape vs
-  # routing) and so are kept independent rather than expressing one as
-  # the negation of the other.
+  # For Strings the predicate is the exact complement of `semantic_id?`,
+  # so the routing question (lookup by primary key vs by identifier/alias)
+  # has a single source of truth. For non-String inputs the two diverge:
+  # Integers are numeric-only (no string-lookup routing applies); nil and
+  # other types are neither and both return false.
   def self.numeric_id?(value)
     case value
     when Integer then true
-    when String  then value == value.to_i.to_s
+    when String  then !semantic_id?(value)
     else false
     end
   end

--- a/app/models/work_package/semantic_identifier/finder_methods.rb
+++ b/app/models/work_package/semantic_identifier/finder_methods.rb
@@ -152,14 +152,8 @@ module WorkPackage::SemanticIdentifier::FinderMethods
     end
   end
 
-  # Returns true when value looks like a semantic work package identifier (e.g. "PROJ-42").
-  # Non-string values (Integer, Hash, nil, Array) and numeric strings ("123", " 456 ")
-  # return false — these fall through to standard ActiveRecord lookup.
   def semantic_id?(value)
-    return false unless value.is_a?(String)
-
-    stripped = value.strip
-    stripped.to_i.to_s != stripped
+    WorkPackage::SemanticIdentifier.semantic_id?(value)
   end
 
   def find_by_semantic_identifier(identifier)

--- a/app/models/work_package/semantic_identifier/finder_methods.rb
+++ b/app/models/work_package/semantic_identifier/finder_methods.rb
@@ -111,11 +111,12 @@ module WorkPackage::SemanticIdentifier::FinderMethods
   # semantic strings may be freely mixed; unknown values produce no match
   # rather than poisoning the rest of the set.
   #
-  # @param values [Array<String, Integer>, String, Integer] one or many
-  #   display ids. A bare String/Integer is wrapped via Array() so callers
-  #   can pass `where_display_id_in("PROJ-1")` and get a one-element relation.
-  def where_display_id_in(values)
-    values = Array(values).map(&:to_s)
+  # @param values [String, Integer, Array<String, Integer>] one or more
+  #   display ids. Pass scalars (`where_display_id_in("PROJ-1")`), varargs
+  #   (`where_display_id_in("PROJ-1", "PROJ-2")`), or a pre-built array
+  #   (`where_display_id_in(ids)`) interchangeably.
+  def where_display_id_in(*values)
+    values = values.flatten(1).compact.map(&:to_s)
     return none if values.empty?
 
     semantic, numeric = values.partition { semantic_id?(it) }

--- a/app/models/work_package/semantic_identifier/finder_methods.rb
+++ b/app/models/work_package/semantic_identifier/finder_methods.rb
@@ -110,6 +110,10 @@ module WorkPackage::SemanticIdentifier::FinderMethods
   # historical alias matches one of the supplied display ids. Numeric and
   # semantic strings may be freely mixed; unknown values produce no match
   # rather than poisoning the rest of the set.
+  #
+  # @param values [Array<String, Integer>, String, Integer] one or many
+  #   display ids. A bare String/Integer is wrapped via Array() so callers
+  #   can pass `where_display_id_in("PROJ-1")` and get a one-element relation.
   def where_display_id_in(values)
     values = Array(values).map(&:to_s)
     return none if values.empty?

--- a/modules/reporting/app/models/cost_query/filter/work_package_id.rb
+++ b/modules/reporting/app/models/cost_query/filter/work_package_id.rb
@@ -47,7 +47,7 @@ class CostQuery::Filter::WorkPackageId < Report::Filter::Base
   # Overwrites Report::Filter::Base self.label_for_value method
   # to achieve a more performant implementation
   def self.label_for_value(value)
-    return nil unless value.to_i.to_s == value.to_s # we expect an work_package-id
+    return nil unless WorkPackage::SemanticIdentifier.numeric_id?(value.to_s)
 
     work_package = WorkPackage.visible.find(value.to_i)
     [text_for_work_package(work_package), work_package.id] if work_package&.visible?(User.current)

--- a/spec/models/work_package/semantic_identifier_spec.rb
+++ b/spec/models/work_package/semantic_identifier_spec.rb
@@ -459,6 +459,40 @@ RSpec.describe WorkPackage::SemanticIdentifier do
     end
   end
 
+  describe ".numeric_id? and .semantic_id?" do
+    # `numeric_id?` answers a shape question (canonical numeric ID),
+    # `semantic_id?` answers a routing question (needs identifier/alias
+    # lookup). For Strings the two are mutually exclusive; Integers are
+    # numeric-only (no string-lookup routing applies).
+    [
+      ["123",     :numeric],
+      ["0",       :numeric],
+      [123,       :numeric],
+      [0,         :numeric],
+      ["0123",    :semantic],
+      ["00",      :semantic],
+      ["PROJ-1",  :semantic],
+      ["abc",     :semantic],
+      ["",        :semantic],
+      [nil,       :neither],
+      [{},        :neither]
+    ].each do |value, classification|
+      it "routes #{value.inspect} to #{classification}" do
+        case classification
+        when :numeric
+          expect(described_class.numeric_id?(value)).to be true
+          expect(described_class.semantic_id?(value)).to be false
+        when :semantic
+          expect(described_class.semantic_id?(value)).to be true
+          expect(described_class.numeric_id?(value)).to be false
+        when :neither
+          expect(described_class.numeric_id?(value)).to be false
+          expect(described_class.semantic_id?(value)).to be false
+        end
+      end
+    end
+  end
+
   describe "#display_id" do
     context "when semantic mode is active",
             with_flag: { semantic_work_package_ids: true },

--- a/spec/models/work_package/semantic_identifier_spec.rb
+++ b/spec/models/work_package/semantic_identifier_spec.rb
@@ -459,6 +459,27 @@ RSpec.describe WorkPackage::SemanticIdentifier do
     end
   end
 
+  describe "ID_ROUTE_CONSTRAINT" do
+    # Rails wraps route-constraint regexps with `\A…\z` when matching a path
+    # segment, so the spec uses an anchored regex to model the way the
+    # constant is actually used. This pins the composition with
+    # SEMANTIC_ID_PATTERN so a future change to the upstream prefix or
+    # sequence shape can't silently widen what the routes accept.
+    let(:anchored) { /\A(?:#{described_class::ID_ROUTE_CONSTRAINT.source})\z/ }
+
+    it "matches numeric work package ids" do
+      expect(anchored.match?("123")).to be true
+    end
+
+    it "matches semantic work package identifiers" do
+      expect(anchored.match?("PROJ-7")).to be true
+    end
+
+    it "rejects lowercased semantic shapes" do
+      expect(anchored.match?("proj-7")).to be false
+    end
+  end
+
   describe ".numeric_id? and .semantic_id?" do
     # `numeric_id?` answers a shape question (canonical numeric ID),
     # `semantic_id?` answers a routing question (needs identifier/alias

--- a/spec/models/work_package/semantic_identifier_spec.rb
+++ b/spec/models/work_package/semantic_identifier_spec.rb
@@ -394,6 +394,11 @@ RSpec.describe WorkPackage::SemanticIdentifier do
       expect(WorkPackage.where_display_id_in("MYPROJ-1")).to contain_exactly(work_package)
     end
 
+    it "accepts identifiers as varargs" do
+      expect(WorkPackage.where_display_id_in("MYPROJ-1", "MYPROJ-2"))
+        .to contain_exactly(work_package, work_package2)
+    end
+
     it "resolves a single numeric string" do
       expect(WorkPackage.where_display_id_in([work_package.id.to_s])).to contain_exactly(work_package)
     end

--- a/spec/models/work_package/semantic_identifier_spec.rb
+++ b/spec/models/work_package/semantic_identifier_spec.rb
@@ -467,6 +467,7 @@ RSpec.describe WorkPackage::SemanticIdentifier do
     [
       ["123",     :numeric],
       ["0",       :numeric],
+      [" 123 ",   :numeric],
       [123,       :numeric],
       [0,         :numeric],
       ["0123",    :semantic],


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74946 _(Split out of #22976)_

# What are you trying to accomplish?

Three call sites duplicated the `value == value.to_i.to_s` round-trip that filters leading-zero ID forms (`"0123"` and friends) — the text-formatting matcher, the PDF export macro, and the cost-query filter. Each spelled it out independently.

`WorkPackage::SemanticIdentifier` now exposes two predicates that capture the question once: `.numeric_id?` for the canonical-numeric guard, and `.semantic_id?` (promoted from `FinderMethods`) for the project-prefixed shape. They share a single whitespace-stripping path so `" 123 "` is consistently classified as numeric, not "neither".

The cost-query filter switches to `numeric_id?` here. Text-formatting and PDF callers convert in the follow-up slice.

Three anchored assertions on `ID_ROUTE_CONSTRAINT` lock the routing boundary in place — the constant composes from `SEMANTIC_ID_PATTERN`, which composes from `Projects::Identifier::SEMANTIC_FORMAT`, so a future change to either upstream pattern would silently widen what URLs Rails accepts without touching routes.rb. The assertions catch that.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)