### PR TITLE
[#74950] Angular: Migration to the inject function

### DIFF
--- a/frontend/src/app/core/active-window/active-window.service.ts
+++ b/frontend/src/app/core/active-window/active-window.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, DOCUMENT } from '@angular/core';
+import { Injectable, DOCUMENT, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
 
@@ -6,7 +6,9 @@ import { debugLog } from 'core-app/shared/helpers/debug_output';
 export class ActiveWindowService {
   private activeState$ = new BehaviorSubject<boolean>(true);
 
-  constructor(@Inject(DOCUMENT) document:Document) {
+  constructor() {
+    const document = inject<Document>(DOCUMENT);
+
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState) {
         debugLog(`Browser window has visibility state changed to ${document.visibilityState}`);

--- a/frontend/src/app/core/apiv3/api-v3.service.ts
+++ b/frontend/src/app/core/apiv3/api-v3.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { ApiV3GettableResource, ApiV3ResourceCollection } from 'core-app/core/apiv3/paths/apiv3-resource';
 import { Constructor } from 'core-app/core/util-types';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -65,6 +65,9 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class ApiV3Service {
+  readonly injector = inject(Injector);
+  readonly pathHelper = inject(PathHelperService);
+
   // /api/v3/attachments
   public readonly attachments = this.apiV3CollectionEndpoint('attachments');
 
@@ -172,11 +175,6 @@ export class ApiV3Service {
 
   // VIRTUAL boards are /api/v3/grids + a scope filter
   public readonly boards = this.apiV3CustomEndpoint(ApiV3BoardsPaths);
-
-  constructor(
-    readonly injector:Injector,
-    readonly pathHelper:PathHelperService,
-  ) { }
 
   /**
    * Returns the part of the API that exists both

--- a/frontend/src/app/core/apiv3/endpoints/projects/project.cache.ts
+++ b/frontend/src/app/core/apiv3/endpoints/projects/project.cache.ts
@@ -37,8 +37,8 @@ import { ProjectResource } from 'core-app/features/hal/resources/project-resourc
 export class ProjectCache extends StateCacheService<ProjectResource> {
   @InjectField() private schemaCacheService:SchemaCacheService;
 
-  constructor(readonly injector:Injector,
-    state:MultiInputState<ProjectResource>) {
+  // eslint-disable-next-line @angular-eslint/prefer-inject -- manually instantiated, not DI-resolved
+  constructor(readonly injector:Injector, state:MultiInputState<ProjectResource>) {
     super(state);
   }
 

--- a/frontend/src/app/core/augmenting/openproject-augmenting.module.ts
+++ b/frontend/src/app/core/augmenting/openproject-augmenting.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { NgModule } from '@angular/core';
+import { NgModule, inject } from '@angular/core';
 import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.module';
 import { OpModalWrapperAugmentService } from 'core-app/shared/components/modal/modal-wrapper-augment.service';
 
@@ -34,7 +34,9 @@ import { OpModalWrapperAugmentService } from 'core-app/shared/components/modal/m
   imports: [OpenprojectModalModule],
 })
 export class OpenprojectAugmentingModule {
-  constructor(modalWrapper:OpModalWrapperAugmentService) {
+  constructor() {
+    const modalWrapper = inject(OpModalWrapperAugmentService);
+
     // Setup augmenting services
     modalWrapper.setupListener();
 

--- a/frontend/src/app/core/backup/op-backup.service.ts
+++ b/frontend/src/app/core/backup/op-backup.service.ts
@@ -26,17 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { Observable } from 'rxjs';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 
 @Injectable({ providedIn: 'root' })
 export class OpenProjectBackupService {
-  constructor(
-    protected apiV3Service:ApiV3Service,
-  ) {
-  }
+  protected apiV3Service = inject(ApiV3Service);
+
 
   public triggerBackup(backupToken:string, includeAttachments = true):Observable<HalResource> {
     return this

--- a/frontend/src/app/core/browser/browser-detector.service.ts
+++ b/frontend/src/app/core/browser/browser-detector.service.ts
@@ -1,9 +1,9 @@
-import { Inject, Injectable, DOCUMENT } from '@angular/core';
+import { Injectable, DOCUMENT, inject } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class BrowserDetector {
-  constructor(@Inject(DOCUMENT) private documentElement:Document) {
-  }
+  private documentElement = inject<Document>(DOCUMENT);
+
 
   /**
    * Detect mobile browser based on the Rails determined UA

--- a/frontend/src/app/core/config/configuration.service.ts
+++ b/frontend/src/app/core/config/configuration.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import moment from 'moment';
 
 import { ConfigurationResource } from 'core-app/features/hal/resources/configuration-resource';
@@ -35,14 +35,12 @@ import { type DurationFormat } from 'core-app/shared/helpers/chronic_duration';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigurationService {
+  private readonly apiV3Service = inject(ApiV3Service);
+
   // fetches configuration from the ApiV3 endpoint
   // TODO: this currently saves the request between page reloads,
   // but could easily be stored in localStorage
   private configuration:ConfigurationResource;
-
-  public constructor(
-    private readonly apiV3Service:ApiV3Service,
-  ) { }
 
   public initialize():Promise<void> {
     return this.loadConfiguration();

--- a/frontend/src/app/core/current-project/current-project.service.spec.ts
+++ b/frontend/src/app/core/current-project/current-project.service.spec.ts
@@ -26,7 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { TestBed } from '@angular/core/testing';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { CurrentProjectService } from './current-project.service';
 
 describe('currentProject service', () => {
@@ -40,7 +42,15 @@ describe('currentProject service', () => {
   };
 
   beforeEach(() => {
-    currentProject = new CurrentProjectService(new PathHelperService(), apiV3Stub);
+    TestBed.configureTestingModule({
+      providers: [
+        CurrentProjectService,
+        PathHelperService,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        { provide: ApiV3Service, useValue: apiV3Stub },
+      ],
+    });
+    currentProject = TestBed.inject(CurrentProjectService);
   });
 
   describe('with no meta present', () => {

--- a/frontend/src/app/core/current-project/current-project.service.ts
+++ b/frontend/src/app/core/current-project/current-project.service.ts
@@ -26,21 +26,21 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { getMetaElement } from '../setup/globals/global-helpers';
 
 @Injectable({ providedIn: 'root' })
 export class CurrentProjectService {
+  private PathHelper = inject(PathHelperService);
+  private apiV3Service = inject(ApiV3Service);
+
   private currentId:string|null = null;
   private currentName:string|null = null;
   private currentIdentifier:string|null = null;
 
-  constructor(
-    private PathHelper:PathHelperService,
-    private apiV3Service:ApiV3Service,
-  ) {
+  constructor() {
     this.detect();
   }
 

--- a/frontend/src/app/core/current-user/current-user.module.ts
+++ b/frontend/src/app/core/current-user/current-user.module.ts
@@ -1,4 +1,4 @@
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 
 import { CurrentUserService } from './current-user.service';
 import { CurrentUserStore } from './current-user.store';
@@ -35,7 +35,9 @@ export function bootstrapModule(injector:Injector):void {
   ],
 })
 export class CurrentUserModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     bootstrapModule(injector);
   }
 }

--- a/frontend/src/app/core/current-user/current-user.query.ts
+++ b/frontend/src/app/core/current-user/current-user.query.ts
@@ -1,11 +1,17 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Query } from '@datorama/akita';
 import { CurrentUserState, CurrentUserStore } from './current-user.store';
 
 @Injectable()
 export class CurrentUserQuery extends Query<CurrentUserState> {
-  constructor(protected store:CurrentUserStore) {
+  protected store:CurrentUserStore;
+
+  constructor() {
+    const store = inject(CurrentUserStore);
+
     super(store);
+
+    this.store = store;
   }
 
   isLoggedIn$ = this.select((state) => !!state.loggedIn);

--- a/frontend/src/app/core/current-user/current-user.service.ts
+++ b/frontend/src/app/core/current-user/current-user.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ApiV3ListFilter } from 'core-app/core/apiv3/paths/apiv3-list-resource.interface';
 import { CapabilitiesResourceService } from 'core-app/core/state/capabilities/capabilities.service';
@@ -38,12 +38,12 @@ import { CurrentUser, CurrentUserStore } from './current-user.store';
 
 @Injectable({ providedIn: 'root' })
 export class CurrentUserService {
-  constructor(
-    private apiV3Service:ApiV3Service,
-    private currentUserStore:CurrentUserStore,
-    private currentUserQuery:CurrentUserQuery,
-    private capabilitiesService:CapabilitiesResourceService,
-  ) {
+  private apiV3Service = inject(ApiV3Service);
+  private currentUserStore = inject(CurrentUserStore);
+  private currentUserQuery = inject(CurrentUserQuery);
+  private capabilitiesService = inject(CapabilitiesResourceService);
+
+  constructor() {
     this.setupLegacyDataListeners();
   }
 

--- a/frontend/src/app/core/datetime/timezone.service.ts
+++ b/frontend/src/app/core/datetime/timezone.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import moment, { Moment } from 'moment-timezone';
@@ -34,10 +34,9 @@ import { outputChronicDuration } from '../../shared/helpers/chronic_duration';
 
 @Injectable({ providedIn: 'root' })
 export class TimezoneService {
-  constructor(
-    readonly configurationService:ConfigurationService,
-    readonly I18n:I18nService,
-  ) { }
+  readonly configurationService = inject(ConfigurationService);
+  readonly I18n = inject(I18nService);
+
 
   /**
    * Returns the user's configured timezone or guesses it through moment

--- a/frontend/src/app/core/days/weekday.service.ts
+++ b/frontend/src/app/core/days/weekday.service.ts
@@ -26,10 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Injectable,
-  Injector,
-} from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import moment, { Moment } from 'moment';
 import {
   take,
@@ -45,13 +42,11 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class WeekdayService {
+  readonly injector = inject(Injector);
+
   @InjectField() weekdaysService:WeekdayResourceService;
 
   private weekdays:IWeekday[];
-
-  constructor(
-    readonly injector:Injector,
-  ) {}
 
   /**
    * @param date The iso day number (1-7) or a date instance

--- a/frontend/src/app/core/enterprise/banners.service.ts
+++ b/frontend/src/app/core/enterprise/banners.service.ts
@@ -26,18 +26,20 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Inject, Injectable, DOCUMENT } from '@angular/core';
+import { Injectable, DOCUMENT, inject } from '@angular/core';
 import { enterpriseEditionUrl } from 'core-app/core/setup/globals/constants.const';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 @Injectable({ providedIn: 'root' })
 export class BannersService {
+  protected documentElement = inject<Document>(DOCUMENT);
+  protected configuration = inject(ConfigurationService);
+
   private readonly _bannersHidden:boolean = true;
 
-  constructor(
-    @Inject(DOCUMENT) protected documentElement:Document,
-    protected configuration:ConfigurationService,
-  ) {
+  constructor() {
+    const documentElement = this.documentElement;
+
     this._bannersHidden = documentElement.body.classList.contains('ee-banners-hidden');
   }
 

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -1,16 +1,5 @@
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostListener,
-  Input,
-  OnDestroy,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, Input, OnDestroy, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { first, map, switchMap, tap } from 'rxjs/operators';
 import { GlobalSearchService } from 'core-app/core/global_search/services/global-search.service';
@@ -74,6 +63,18 @@ interface SearchResultItems {
   standalone: false,
 })
 export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
+  readonly elementRef = inject(ElementRef);
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly pathHelperService = inject(PathHelperService);
+  readonly halResourceService = inject(HalResourceService);
+  readonly globalSearchService = inject(GlobalSearchService);
+  readonly currentProjectService = inject(CurrentProjectService);
+  readonly deviceService = inject(DeviceService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly recentItemsService = inject(RecentItemsService);
+
   @Input() public placeholder:string;
 
   @ViewChild('btn', { static: true }) btn:ElementRef;
@@ -131,19 +132,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
     search: this.I18n.t('js.autocompleter.search'),
   };
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly pathHelperService:PathHelperService,
-    readonly halResourceService:HalResourceService,
-    readonly globalSearchService:GlobalSearchService,
-    readonly currentProjectService:CurrentProjectService,
-    readonly deviceService:DeviceService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly halNotification:HalResourceNotificationService,
-    readonly recentItemsService:RecentItemsService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/core/global_search/openproject-global-search.module.ts
+++ b/frontend/src/app/core/global_search/openproject-global-search.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { OpenprojectWorkPackagesModule } from 'core-app/features/work-packages/openproject-work-packages.module';
 import { GlobalSearchInputComponent } from 'core-app/core/global_search/input/global-search-input.component';
 import { GlobalSearchWorkPackagesComponent } from 'core-app/core/global_search/global-search-work-packages.component';
@@ -53,6 +53,5 @@ import { RecentItemsService } from 'core-app/core/recent-items.service';
   ],
 })
 export class OpenprojectGlobalSearchModule {
-  constructor(readonly injector:Injector) {
-  }
+  readonly injector = inject(Injector);
 }

--- a/frontend/src/app/core/global_search/services/global-search.service.ts
+++ b/frontend/src/app/core/global_search/services/global-search.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
@@ -34,13 +34,11 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 
 @Injectable()
 export class GlobalSearchService {
-  constructor(
-    protected I18n:I18nService,
-    protected injector:Injector,
-    protected PathHelper:PathHelperService,
-    protected currentProjectService:CurrentProjectService,
-  ) {
-  }
+  protected I18n = inject(I18nService);
+  protected injector = inject(Injector);
+  protected PathHelper = inject(PathHelperService);
+  protected currentProjectService = inject(CurrentProjectService);
+
 
   public submitSearch(query:string, scope:string):void {
     const path = this.searchPath(scope);

--- a/frontend/src/app/core/global_search/tabs/global-search-tabs.component.ts
+++ b/frontend/src/app/core/global_search/tabs/global-search-tabs.component.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit } from '@angular/core';
-import { StateService } from '@uirouter/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { GlobalSearchService } from 'core-app/core/global_search/services/global-search.service';
 import { ScrollableTabsComponent } from 'core-app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component';
@@ -40,20 +39,13 @@ import { TabDefinition } from 'core-app/shared/components/tabs/tab.interface';
   standalone: false,
 })
 export class GlobalSearchTabsComponent extends ScrollableTabsComponent implements OnInit, OnDestroy {
+  readonly globalSearchService = inject(GlobalSearchService);
+
   private currentTabSub:Subscription;
 
   private tabsSub:Subscription;
 
-  public classes:string[] = ['global-search--tabs', 'scrollable-tabs'];
-
-  constructor(
-    readonly globalSearchService:GlobalSearchService,
-    protected readonly $state:StateService,
-    public injector:Injector,
-    cdRef:ChangeDetectorRef,
-  ) {
-    super($state, cdRef, injector);
-  }
+  public override classes:string[] = ['global-search--tabs', 'scrollable-tabs'];
 
   ngOnInit():void {
     this.currentTabSub = this.globalSearchService

--- a/frontend/src/app/core/html-sanitize/html-sanitize.service.ts
+++ b/frontend/src/app/core/html-sanitize/html-sanitize.service.ts
@@ -26,12 +26,13 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, SecurityContext } from '@angular/core';
+import { Injectable, SecurityContext, inject } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Injectable({ providedIn: 'root' })
 export class HTMLSanitizeService {
-  public constructor(readonly sanitizer:DomSanitizer) { }
+  readonly sanitizer = inject(DomSanitizer);
+
 
   public sanitize(string:string):SafeHtml {
     return this.sanitizer.sanitize(SecurityContext.HTML, string) || '';

--- a/frontend/src/app/core/html/op-title.service.ts
+++ b/frontend/src/app/core/html/op-title.service.ts
@@ -1,13 +1,13 @@
 import { Title } from '@angular/platform-browser';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { getMetaContent } from '../setup/globals/global-helpers';
 
 const titlePartsSeparator = ' | ';
 
 @Injectable({ providedIn: 'root' })
 export class OpTitleService {
-  constructor(private titleService:Title) {
-  }
+  private titleService = inject(Title);
+
 
   public get current():string {
     return this.titleService.getTitle();

--- a/frontend/src/app/core/i18n/i18n.service.ts
+++ b/frontend/src/app/core/i18n/i18n.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { NgSelectConfig } from '@ng-select/ng-select';
 import { I18n } from 'i18n-js';
 import { FormatNumberOptions, TranslateOptions } from 'i18n-js/src/typing';
@@ -6,12 +6,12 @@ import { getMetaValue } from '../setup/globals/global-helpers';
 
 @Injectable({ providedIn: 'root' })
 export class I18nService {
+  private config = inject(NgSelectConfig);
+
   private i18n:I18n = window.I18n;
   private instanceLocale:string;
 
-  constructor(
-    private config:NgSelectConfig,
-  ) {
+  constructor() {
     this.instanceLocale = getMetaValue('openproject_initializer', 'instanceLocale', 'en');
 
     this.config.addTagText = this.t('js.autocomplete_ng_select.add_tag');

--- a/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
+++ b/frontend/src/app/core/main-menu/main-menu-toggle.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { DeviceService } from 'core-app/core/browser/device.service';
@@ -35,6 +35,9 @@ import { queryVisible } from 'core-app/shared/helpers/dom-helpers';
 
 @Injectable({ providedIn: 'root' })
 export class MainMenuToggleService {
+  injector = inject(Injector);
+  readonly deviceService = inject(DeviceService);
+
   private elementWidth:number;
 
   private elementMinWidth = 11;
@@ -61,10 +64,7 @@ export class MainMenuToggleService {
 
   private wasCollapsedByUser = false;
 
-  constructor(
-    public injector:Injector,
-    readonly deviceService:DeviceService,
-  ) {
+  constructor() {
     this.initializeMenu();
     // Add resize event listener
     window.addEventListener('resize', this.onWindowResize.bind(this));

--- a/frontend/src/app/core/main-menu/submenu.service.ts
+++ b/frontend/src/app/core/main-menu/submenu.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { type FrameElement } from '@hotwired/turbo';
 import { StateService } from '@uirouter/core';
 
 @Injectable({ providedIn: 'root' })
 export class SubmenuService {
-  constructor(protected $state:StateService) {}
+  protected $state = inject(StateService);
+
 
   reloadSubmenu(selectedQueryId:string|null, sidemenuId?:string):void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment

--- a/frontend/src/app/core/routing/openproject-router.module.ts
+++ b/frontend/src/app/core/routing/openproject-router.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { FirstRouteService } from 'core-app/core/routing/first-route-service';
 import { UIRouterModule } from '@uirouter/angular';
 import { ApplicationBaseComponent } from 'core-app/core/routing/base/application-base.component';
@@ -52,7 +52,9 @@ import {
   ],
 })
 export class OpenprojectRouterModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeUiRouterListeners(injector);
   }
 }

--- a/frontend/src/app/core/schemas/schema-cache.service.ts
+++ b/frontend/src/app/core/schemas/schema-cache.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 import { State } from '@openproject/reactivestates';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { StateCacheService } from 'core-app/core/apiv3/cache/state-cache.service';
 import { firstValueFrom, Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
@@ -41,13 +41,17 @@ export const fallbackSchemaId = '__fallback';
 
 @Injectable()
 export class SchemaCacheService extends StateCacheService<SchemaResource> {
+  readonly states:States;
+  readonly halResourceService = inject(HalResourceService);
+
   fallbackSchema = this.halResourceService.createHalResourceOfClass<SchemaResource>(SchemaResource, {}, true);
 
-  constructor(
-    readonly states:States,
-    readonly halResourceService:HalResourceService,
-  ) {
+  constructor() {
+    const states = inject(States);
+
     super(states.schemas);
+    this.states = states;
+
     this.putValue(fallbackSchemaId, this.fallbackSchema);
   }
 

--- a/frontend/src/app/core/setup/globals/components/admin/backup.component.ts
+++ b/frontend/src/app/core/setup/globals/components/admin/backup.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Injector, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Injector, ViewChild, inject } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
@@ -43,6 +43,13 @@ import { JobStatusModalService } from 'core-app/features/job-status/job-status-m
   standalone: false,
 })
 export class BackupComponent implements AfterViewInit {
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  injector = inject(Injector);
+  protected i18n = inject(I18nService);
+  protected toastService = inject(ToastService);
+  protected pathHelper = inject(PathHelperService);
+  protected jobStatusModalService = inject(JobStatusModalService);
+
   public text = {
     info: this.i18n.t('js.backup.info'),
     note: this.i18n.t('js.backup.note'),
@@ -72,14 +79,7 @@ export class BackupComponent implements AfterViewInit {
 
   @ViewChild('backupTokenInput') backupTokenInput:ElementRef<HTMLInputElement>;
 
-  constructor(
-    readonly elementRef:ElementRef<HTMLElement>,
-    public injector:Injector,
-    protected i18n:I18nService,
-    protected toastService:ToastService,
-    protected pathHelper:PathHelperService,
-    protected jobStatusModalService:JobStatusModalService,
-  ) {
+  constructor() {
     this.includeAttachments = this.mayIncludeAttachments;
   }
 

--- a/frontend/src/app/core/state/resource-store.service.ts
+++ b/frontend/src/app/core/state/resource-store.service.ts
@@ -58,10 +58,7 @@ import {
   HttpClient,
   HttpErrorResponse,
 } from '@angular/common/http';
-import {
-  Injectable,
-  Injector,
-} from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
@@ -76,17 +73,14 @@ export type ResourceKeyInput = ApiV3ListParameters|string;
 
 @Injectable()
 export abstract class ResourceStoreService<T extends { id:ID }> {
+  readonly injector = inject(Injector);
+  readonly http = inject(HttpClient);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly toastService = inject(ToastService);
+
   protected store:ResourceStore<T> = this.createStore();
 
   protected query = new QueryEntity(this.store);
-
-  constructor(
-    readonly injector:Injector,
-    readonly http:HttpClient,
-    readonly apiV3Service:ApiV3Service,
-    readonly toastService:ToastService,
-  ) {
-  }
 
   /**
    * Require the results for the given filter params

--- a/frontend/src/app/core/state/storage-files/storage-files.service.ts
+++ b/frontend/src/app/core/state/storage-files/storage-files.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { combineLatest, Observable } from 'rxjs';
 import {
   filter, map, take, tap,
@@ -44,14 +44,12 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 
 @Injectable()
 export class StorageFilesResourceService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly apiV3Service = inject(ApiV3Service);
+
   private readonly store:StorageFilesStore = new StorageFilesStore();
 
   private readonly query = new QueryEntity(this.store);
-
-  constructor(
-    private readonly httpClient:HttpClient,
-    private readonly apiV3Service:ApiV3Service,
-  ) {}
 
   files(link:IHalResourceLink):Observable<IStorageFiles> {
     const value = this.store.getValue().files[link.href];

--- a/frontend/src/app/core/top-menu/top-menu.service.ts
+++ b/frontend/src/app/core/top-menu/top-menu.service.ts
@@ -26,10 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Inject,
-  Injectable,
-} from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { isVisible } from 'core-app/shared/helpers/dom-helpers';
 
@@ -37,8 +34,8 @@ export const ANIMATION_RATE_MS = 100;
 
 @Injectable({ providedIn: 'root' })
 export class TopMenuService {
-  constructor(@Inject(DOCUMENT) private document:Document) {
-  }
+  private document = inject<Document>(DOCUMENT);
+
 
   register():void {
     this.skipContentClickListener();

--- a/frontend/src/app/core/turbo/turbo-requests.service.ts
+++ b/frontend/src/app/core/turbo/turbo-requests.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { renderStreamMessage } from '@hotwired/turbo';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
@@ -7,13 +7,9 @@ import { getMetaContent } from '../setup/globals/global-helpers';
 
 @Injectable({ providedIn: 'root' })
 export class TurboRequestsService {
+  private toast = inject(ToastService);
+
   #controllers = new Map<string, AbortController>();
-
-  constructor(
-    private toast:ToastService,
-  ) {
-
-  }
 
   public request(
     url:string,

--- a/frontend/src/app/features/admin/editable-query-props/editable-query-props.component.ts
+++ b/frontend/src/app/features/admin/editable-query-props/editable-query-props.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   ExternalQueryConfigurationService,
@@ -11,6 +11,11 @@ import {
   standalone: false,
 })
 export class EditableQueryPropsComponent implements OnInit {
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private I18n = inject(I18nService);
+  private cdRef = inject(ChangeDetectorRef);
+  private externalQuery = inject(ExternalQueryConfigurationService);
+
   id:string|null;
 
   name:string|null;
@@ -22,14 +27,6 @@ export class EditableQueryPropsComponent implements OnInit {
   text = {
     edit_query: this.I18n.t('js.admin.type_form.edit_query'),
   };
-
-  constructor(
-    private elementRef:ElementRef<HTMLElement>,
-    private I18n:I18nService,
-    private cdRef:ChangeDetectorRef,
-    private externalQuery:ExternalQueryConfigurationService,
-  ) {
-  }
 
   ngOnInit() {
     const element = this.elementRef.nativeElement;

--- a/frontend/src/app/features/bim/bcf/api/bcf-api.service.ts
+++ b/frontend/src/app/features/bim/bcf/api/bcf-api.service.ts
@@ -26,12 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { BcfResourceCollectionPath } from 'core-app/features/bim/bcf/api/bcf-path-resources';
 import { BcfProjectPaths } from 'core-app/features/bim/bcf/api/projects/bcf-project.paths';
 
 @Injectable({ providedIn: 'root' })
 export class BcfApiService {
+  readonly injector = inject(Injector);
+
   public readonly bcfApiVersion = '2.1';
 
   public readonly appBasePath = window.appBasePath || '';
@@ -40,9 +42,6 @@ export class BcfApiService {
 
   // /api/bcf/:version/projects
   public readonly projects = new BcfResourceCollectionPath(this.injector, this.bcfApiBase, 'projects', BcfProjectPaths);
-
-  constructor(readonly injector:Injector) {
-  }
 
   /**
    * Parse the given string into a BCF resource path

--- a/frontend/src/app/features/bim/bcf/api/bcf-authorization.service.ts
+++ b/frontend/src/app/features/bim/bcf/api/bcf-authorization.service.ts
@@ -6,17 +6,16 @@ import {
   Observable,
 } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 export type AllowedExtensionKey = keyof BcfExtensionResource;
 
 @Injectable({ providedIn: 'root' })
 export class BcfAuthorizationService {
+  readonly bcfApi = inject(BcfApiService);
+
   // Poor mans caching to avoid repeatedly fetching from the backend.
   protected authorizationMap = multiInput<BcfExtensionResource>();
-
-  constructor(readonly bcfApi:BcfApiService) {
-  }
 
   /**
    * Returns an observable boolean whether the given action

--- a/frontend/src/app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
+++ b/frontend/src/app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
@@ -7,14 +7,14 @@ import { CreateBcfViewpointData } from 'core-app/features/bim/bcf/api/bcf-api.mo
 
 @Injectable()
 export abstract class ViewerBridgeService {
+  readonly injector = inject(Injector);
+
   @InjectField() state:StateService;
 
   /**
    * Determine whether a viewer should be shown
    */
   abstract shouldShowViewer:boolean;
-
-  protected constructor(readonly injector:Injector) {}
 
   /**
    * Get a viewpoint from the viewer

--- a/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
+++ b/frontend/src/app/features/bim/bcf/bcf-wp-attribute-group/bcf-wp-attribute-group.component.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnDestroy,
-  OnInit,
-  Optional,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { NgxGalleryComponent, NgxGalleryOptions } from '@kolkov/ngx-gallery';
@@ -62,6 +52,17 @@ import { filter, take } from 'rxjs/operators';
   standalone: false,
 })
 export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements AfterViewInit, OnDestroy, OnInit {
+  readonly state = inject(StateService);
+  readonly bcfAuthorization = inject(BcfAuthorizationService);
+  readonly viewerBridge = inject(ViewerBridgeService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly wpCreate = inject(WorkPackageCreateService);
+  readonly toastService = inject(ToastService);
+  readonly bcfViewer = inject(BcfViewService, { optional: true });
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
+  readonly viewpointsService = inject(ViewpointsService);
+
   @Input() workPackage:WorkPackageResource;
 
   @ViewChild(NgxGalleryComponent) gallery:NgxGalleryComponent;
@@ -145,19 +146,6 @@ export class BcfWpAttributeGroupComponent extends UntilDestroyedMixin implements
   viewerVisible = false;
 
   projectId:string;
-
-  constructor(readonly state:StateService,
-    readonly bcfAuthorization:BcfAuthorizationService,
-    readonly viewerBridge:ViewerBridgeService,
-    readonly apiV3Service:ApiV3Service,
-    readonly wpCreate:WorkPackageCreateService,
-    readonly toastService:ToastService,
-    @Optional() readonly bcfViewer:BcfViewService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-    readonly viewpointsService:ViewpointsService) {
-    super();
-  }
 
   ngAfterViewInit():void {
     // Observe changes on the work package to update the viewpoints

--- a/frontend/src/app/features/bim/bcf/helper/bcf-detector.service.ts
+++ b/frontend/src/app/features/bim/bcf/helper/bcf-detector.service.ts
@@ -1,9 +1,9 @@
-import { Inject, Injectable, DOCUMENT } from '@angular/core';
+import { Injectable, DOCUMENT, inject } from '@angular/core';
 
 @Injectable()
 export class BcfDetectorService {
-  constructor(@Inject(DOCUMENT) private documentElement:Document) {
-  }
+  private documentElement = inject<Document>(DOCUMENT);
+
 
   /**
    * Detect whether the BCF module was activated,

--- a/frontend/src/app/features/bim/bcf/helper/bcf-path-helper.service.ts
+++ b/frontend/src/app/features/bim/bcf/helper/bcf-path-helper.service.ts
@@ -26,14 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
 
 @Injectable()
 export class BcfPathHelperService {
-  constructor(readonly pathHelper:PathHelperService) {
-  }
+  readonly pathHelper = inject(PathHelperService);
+
 
   public projectImportIssuePath(projectIdentifier:string) {
     return `${this.pathHelper.projectPath(projectIdentifier)}/issues/upload`;

--- a/frontend/src/app/features/bim/bcf/helper/viewpoints.service.ts
+++ b/frontend/src/app/features/bim/bcf/helper/viewpoints.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { BcfApiService } from 'core-app/features/bim/bcf/api/bcf-api.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -42,6 +42,8 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 @Injectable()
 export class ViewpointsService {
+  readonly injector = inject(Injector);
+
   topicUUID:string|number|null = null;
 
   @InjectField() bcfApi:BcfApiService;
@@ -49,8 +51,6 @@ export class ViewpointsService {
   @InjectField() viewerBridge:ViewerBridgeService;
 
   @InjectField() apiV3Service:ApiV3Service;
-
-  constructor(readonly injector:Injector) { }
 
   public getViewPointResource(workPackage:WorkPackageResource, index:number):BcfViewpointPaths {
     const viewpointHref = (workPackage.bcfViewpoints as HalResource[])[index].href!;

--- a/frontend/src/app/features/bim/bcf/openproject-bcf.module.spec.ts
+++ b/frontend/src/app/features/bim/bcf/openproject-bcf.module.spec.ts
@@ -26,40 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map, shareReplay, startWith } from 'rxjs/operators';
-import { NavigationService } from 'core-app/core/navigation/navigation.service';
+import { Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { IFCViewerService } from 'core-app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service';
+import { viewerBridgeServiceFactory } from 'core-app/features/bim/bcf/openproject-bcf.module';
 
-@Injectable({ providedIn: 'root' })
-export class UrlParamsService {
-  private navigation = inject(NavigationService);
+describe('viewerBridgeServiceFactory', () => {
+  it('falls back to an IFC viewer service when none is registered', () => {
+    const injector = TestBed.inject(Injector);
 
-
-  public get(key:string):string|null {
-    return this.searchParams.get(key);
-  }
-
-  public pathMatching(key:RegExp, url = window.location.pathname):string|null {
-    return url.match(key)?.[1] || null;
-  }
-
-  public pathMatching$(key:RegExp):Observable<string|null> {
-    return this
-      .navigation
-      .urlChanged$
-      .pipe(
-        startWith(document.location.href),
-        map((url) => this.pathMatching(key, url)),
-        shareReplay(1),
-      );
-  }
-
-  public has(key:string):boolean {
-    return this.searchParams.has(key);
-  }
-
-  private get searchParams():URLSearchParams {
-    return new URLSearchParams(window.location.search);
-  }
-}
+    expect(viewerBridgeServiceFactory(injector)).toBeInstanceOf(IFCViewerService);
+  });
+});

--- a/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
+++ b/frontend/src/app/features/bim/bcf/openproject-bcf.module.ts
@@ -29,6 +29,8 @@
 import {
   Injector,
   NgModule,
+  inject,
+  runInInjectionContext,
 } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { NgxGalleryModule } from '@kolkov/ngx-gallery';
@@ -57,9 +59,12 @@ import { RefreshButtonComponent } from 'core-app/features/bim/ifc_models/toolbar
  */
 export const viewerBridgeServiceFactory = (injector:Injector) => {
   if (window.navigator.userAgent.search('Revit') > -1) {
-    return new RevitBridgeService(injector);
+    return runInInjectionContext(injector, () => new RevitBridgeService());
   }
-  return injector.get(IFCViewerService, new IFCViewerService(injector));
+
+  const ifcViewerService = injector.get(IFCViewerService, null);
+
+  return ifcViewerService ?? runInInjectionContext(injector, () => new IFCViewerService());
 };
 
 @NgModule({
@@ -93,7 +98,9 @@ export const viewerBridgeServiceFactory = (injector:Injector) => {
 export class OpenprojectBcfModule {
   static bootstrapCalled = false;
 
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     OpenprojectBcfModule.bootstrap(injector);
   }
 

--- a/frontend/src/app/features/bim/ifc_models/bcf/split/left/bcf-split-left.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/bcf/split/left/bcf-split-left.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bcf-view.service';
@@ -42,9 +38,9 @@ import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bc
   standalone: false,
 })
 export class BcfSplitLeftComponent implements OnInit {
-  showViewer$:Observable<boolean>;
+  private readonly bcfView = inject(BcfViewService);
 
-  constructor(private readonly bcfView:BcfViewService) {}
+  showViewer$:Observable<boolean>;
 
   ngOnInit():void {
     this.showViewer$ = this.bcfView.live$()

--- a/frontend/src/app/features/bim/ifc_models/bcf/split/right/bcf-split-right.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/bcf/split/right/bcf-split-right.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bcf-view.service';
 import { map } from 'rxjs/operators';
@@ -42,9 +38,9 @@ import { map } from 'rxjs/operators';
   standalone: false,
 })
 export class BcfSplitRightComponent implements OnInit {
-  showWorkPackages$:Observable<boolean>;
+  private readonly bcfView = inject(BcfViewService);
 
-  constructor(private readonly bcfView:BcfViewService) {}
+  showWorkPackages$:Observable<boolean>;
 
   ngOnInit():void {
     this.showWorkPackages$ = this.bcfView.live$()

--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  HostListener,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { IFCViewerService } from 'core-app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service';
 import { IfcModelsDataService } from 'core-app/features/bim/ifc_models/pages/viewer/ifc-models-data.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -56,6 +47,12 @@ import { filter, take } from 'rxjs/operators';
   standalone: false,
 })
 export class IFCViewerComponent implements OnInit, OnDestroy, AfterViewInit {
+  ifcData = inject(IfcModelsDataService);
+  private I18n = inject(I18nService);
+  private ifcViewerService = inject(IFCViewerService);
+  private currentUserService = inject(CurrentUserService);
+  private currentProjectService = inject(CurrentProjectService);
+
   private viewInitialized$ = new Subject<void>();
 
   modelCount:number = this.ifcData.models.length;
@@ -85,14 +82,6 @@ export class IFCViewerComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('inspectorPane') inspectorElement:ElementRef;
 
   @ViewChild('xeokitToolbarIcons') xeokitToolbarIcons:ElementRef;
-
-  constructor(
-    public ifcData:IfcModelsDataService,
-    private I18n:I18nService,
-    private ifcViewerService:IFCViewerService,
-    private currentUserService:CurrentUserService,
-    private currentProjectService:CurrentProjectService,
-  ) { }
 
   ngOnInit():void {
     if (this.modelCount === 0) {

--- a/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
+++ b/frontend/src/app/features/bim/ifc_models/ifc-viewer/ifc-viewer.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { XeokitServer } from 'core-app/features/bim/ifc_models/xeokit/xeokit-server';
 import { ViewerBridgeService } from 'core-app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service';
 import { BehaviorSubject, Observable, of } from 'rxjs';
@@ -122,10 +122,6 @@ export class IFCViewerService extends ViewerBridgeService {
   @InjectField() currentProjectService:CurrentProjectService;
 
   @InjectField() httpClient:HttpClient;
-
-  constructor(readonly injector:Injector) {
-    super(injector);
-  }
 
   public newViewer(elements:XeokitElements, projects:IfcProjectDefinition[]):void {
     const server = new XeokitServer(this.pathHelper, this.ifcModelsDataService);

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/bcf-view.service.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/bcf-view.service.ts
@@ -26,10 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageQueryStateService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-base.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { ViewerBridgeService } from 'core-app/features/bim/bcf/bcf-viewer-bridge/viewer-bridge.service';
 
@@ -43,6 +42,9 @@ export type BcfViewState = 'cards'|'viewer'|'splitTable'|'splitCards'|'table';
 
 @Injectable()
 export class BcfViewService extends WorkPackageQueryStateService<BcfViewState> {
+  private readonly I18n = inject(I18nService);
+  private readonly viewerBridgeService = inject(ViewerBridgeService);
+
   public text:Record<string, string> = {
     cards: this.I18n.t('js.views.card'),
     viewer: this.I18n.t('js.ifc_models.views.viewer'),
@@ -58,14 +60,6 @@ export class BcfViewService extends WorkPackageQueryStateService<BcfViewState> {
     splitCards: 'icon-view-split2',
     table: 'icon-view-list',
   };
-
-  constructor(
-    private readonly I18n:I18nService,
-    private readonly viewerBridgeService:ViewerBridgeService,
-    protected readonly querySpace:IsolatedQuerySpace,
-  ) {
-    super(querySpace);
-  }
 
   hasChanged(query:QueryResource):boolean {
     return this.current !== query.displayRepresentation;

--- a/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/pages/viewer/ifc-viewer-page.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Injector, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewEncapsulation, inject } from '@angular/core';
 
 import {
   PartitionedQuerySpacePageComponent,
@@ -94,6 +94,10 @@ import {
 export class IFCViewerPageComponent
   extends PartitionedQuerySpacePageComponent
   implements UntilDestroyedMixin, OnInit, OnDestroy {
+  readonly ifcData = inject(IfcModelsDataService);
+  readonly bcfView = inject(BcfViewService);
+  readonly viewerBridgeService = inject(ViewerBridgeService);
+
   text = {
     title: this.I18n.t('js.bcf.management'),
     delete: this.I18n.t('js.button_delete'),
@@ -156,15 +160,6 @@ export class IFCViewerPageComponent
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   private removeSubscription:Function;
-
-  constructor(
-    readonly ifcData:IfcModelsDataService,
-    readonly bcfView:BcfViewService,
-    readonly injector:Injector,
-    readonly viewerBridgeService:ViewerBridgeService,
-  ) {
-    super(injector);
-  }
 
   ngOnInit():void {
     super.ngOnInit();

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-export-button.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-helper.service';
@@ -59,6 +57,18 @@ import { JobStatusModalService } from 'core-app/features/job-status/job-status-m
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BcfExportButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly bcfPathHelper = inject(BcfPathHelperService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly queryUrlParamsHelper = inject(UrlParamsHelperService);
+  readonly jobStatusModalService = inject(JobStatusModalService);
+  readonly httpClient = inject(HttpClient);
+  readonly injector = inject(Injector);
+  readonly toastService = inject(ToastService);
+  readonly state = inject(StateService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public text = {
     export: this.I18n.t('js.bcf.export'),
     export_hover: this.I18n.t('js.bcf.export_bcf_xml_file'),
@@ -67,20 +77,6 @@ export class BcfExportButtonComponent extends UntilDestroyedMixin implements OnI
   public query:QueryResource;
 
   public exportLink:string;
-
-  constructor(readonly I18n:I18nService,
-    readonly currentProject:CurrentProjectService,
-    readonly bcfPathHelper:BcfPathHelperService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly queryUrlParamsHelper:UrlParamsHelperService,
-    readonly jobStatusModalService:JobStatusModalService,
-    readonly httpClient:HttpClient,
-    readonly injector:Injector,
-    readonly toastService:ToastService,
-    readonly state:StateService,
-    readonly cdRef:ChangeDetectorRef) {
-    super();
-  }
 
   ngOnInit() {
     this.querySpace.query

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/bcf-import-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-helper.service';
@@ -48,15 +48,14 @@ import { BcfPathHelperService } from 'core-app/features/bim/bcf/helper/bcf-path-
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BcfImportButtonComponent {
+  readonly I18n = inject(I18nService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly bcfPathHelper = inject(BcfPathHelperService);
+
   public text = {
     import: this.I18n.t('js.bcf.import'),
     import_hover: this.I18n.t('js.bcf.import_bcf_xml_file'),
   };
-
-  constructor(readonly I18n:I18nService,
-    readonly currentProject:CurrentProjectService,
-    readonly bcfPathHelper:BcfPathHelperService) {
-  }
 
   public handleClick() {
     const projectIdentifier = this.currentProject.identifier;

--- a/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/import-export-bcf/refresh-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { StateService } from '@uirouter/core';
 
@@ -43,14 +43,13 @@ import { StateService } from '@uirouter/core';
   standalone: false,
 })
 export class RefreshButtonComponent {
+  readonly I18n = inject(I18nService);
+  readonly state = inject(StateService);
+
   public text = {
     refresh: this.I18n.t('js.bcf.refresh'),
     refresh_hover: this.I18n.t('js.bcf.refresh_work_package'),
   };
-
-  constructor(readonly I18n:I18nService,
-    readonly state:StateService) {
-  }
 
   refresh() {
     void this.state.go('.', {}, { reload: true });

--- a/frontend/src/app/features/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/manage-ifc-models-button/bim-manage-ifc-models-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IfcModelsDataService } from 'core-app/features/bim/ifc_models/pages/viewer/ifc-models-data.service';
 
@@ -49,6 +49,9 @@ import { IfcModelsDataService } from 'core-app/features/bim/ifc_models/pages/vie
   standalone: false,
 })
 export class BimManageIfcModelsButtonComponent {
+  readonly I18n = inject(I18nService);
+  readonly ifcData = inject(IfcModelsDataService);
+
   text = {
     manage: this.I18n.t('js.ifc_models.models.ifc_models'),
   };
@@ -56,8 +59,4 @@ export class BimManageIfcModelsButtonComponent {
   manageAllowed = this.ifcData.allowed('manage_ifc_models');
 
   manageIFCPath = this.ifcData.manageIFCPath;
-
-  constructor(readonly I18n:I18nService,
-    readonly ifcData:IfcModelsDataService) {
-  }
 }

--- a/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-button.component.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bcf-view.service';
 
@@ -50,7 +50,8 @@ import { BcfViewService } from 'core-app/features/bim/ifc_models/pages/viewer/bc
   standalone: false,
 })
 export class BcfViewToggleButtonComponent {
-  view$ = this.bcfView.live$();
+  readonly I18n = inject(I18nService);
+  readonly bcfView = inject(BcfViewService);
 
-  constructor(readonly I18n:I18nService, readonly bcfView:BcfViewService) { }
+  view$ = this.bcfView.live$();
 }

--- a/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-dropdown.directive.ts
+++ b/frontend/src/app/features/bim/ifc_models/toolbar/view-toggle/bcf-view-toggle-dropdown.directive.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { StateService } from '@uirouter/core';
@@ -48,15 +47,11 @@ import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op
   standalone: false,
 })
 export class BcfViewToggleDropdownDirective extends OpContextMenuTrigger {
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly bcfView:BcfViewService,
-    readonly I18n:I18nService,
-    readonly state:StateService,
-    readonly wpFiltersService:WorkPackageFiltersService,
-    readonly viewerBridgeService:ViewerBridgeService) {
-    super(elementRef, opContextMenu);
-  }
+  readonly bcfView = inject(BcfViewService);
+  readonly I18n = inject(I18nService);
+  readonly state = inject(StateService);
+  readonly wpFiltersService = inject(WorkPackageFiltersService);
+  readonly viewerBridgeService = inject(ViewerBridgeService);
 
   protected open(evt:Event):void {
     this.buildItems();

--- a/frontend/src/app/features/bim/revit_add_in/revit-add-in-settings-button.service.ts
+++ b/frontend/src/app/features/bim/revit_add_in/revit-add-in-settings-button.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -36,13 +36,15 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
  */
 @Injectable()
 export class RevitAddInSettingsButtonService {
+  private readonly i18n = inject(I18nService);
+
   private readonly labelText:string;
 
   private readonly groupLabelText:string;
 
-  constructor(
-    private readonly i18n:I18nService,
-  ) {
+  constructor() {
+    const i18n = this.i18n;
+
     const onRevitAddInEnvironment = window.navigator.userAgent.search('Revit') > -1;
 
     if (onRevitAddInEnvironment) {

--- a/frontend/src/app/features/bim/revit_add_in/revit-bridge.service.ts
+++ b/frontend/src/app/features/bim/revit_add_in/revit-bridge.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import {
   distinctUntilChanged, filter, first, map,
@@ -66,8 +66,8 @@ export class RevitBridgeService extends ViewerBridgeService {
 
   revitMessageReceived$ = this.revitMessageReceivedSource.asObservable();
 
-  constructor(readonly injector:Injector) {
-    super(injector);
+  constructor() {
+    super();
 
     if (window.RevitBridge) {
       this.hookUpRevitListener();

--- a/frontend/src/app/features/boards/board/add-card-dropdown/add-card-dropdown-menu.directive.ts
+++ b/frontend/src/app/features/boards/board/add-card-dropdown/add-card-dropdown-menu.directive.ts
@@ -26,13 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectorRef, Directive, ElementRef, Injector,
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, Injector, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
@@ -43,18 +40,14 @@ import { BoardListComponent } from 'core-app/features/boards/board/board-list/bo
   standalone: false,
 })
 export class AddCardDropdownMenuDirective extends OpContextMenuTrigger {
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly opModalService:OpModalService,
-    readonly authorisationService:AuthorisationService,
-    readonly wpInlineCreate:WorkPackageInlineCreateService,
-    readonly boardList:BoardListComponent,
-    readonly injector:Injector,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService) {
-    super(elementRef, opContextMenu);
-  }
+  readonly opModalService = inject(OpModalService);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly wpInlineCreate = inject(WorkPackageInlineCreateService);
+  readonly boardList = inject(BoardListComponent);
+  readonly injector = inject(Injector);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
 
   protected open(evt:Event) {
     this.items = this.buildItems();

--- a/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
+++ b/frontend/src/app/features/boards/board/add-list-modal/add-list-modal.component.ts
@@ -26,12 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit, ViewChild,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Board } from 'core-app/features/boards/board/board';
 import { BoardService } from 'core-app/features/boards/board/board.service';
@@ -58,6 +54,14 @@ import { HalResource } from 'core-app/features/hal/resources/hal-resource';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class AddListModalComponent extends OpModalComponent implements OnInit {
+  readonly boardActions = inject(BoardActionsRegistryService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly boardService = inject(BoardService);
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly pathHelper = inject(PathHelperService);
+
   @ViewChild(OpAutocompleterComponent, { static: true }) public ngSelectComponent:OpAutocompleterComponent;
 
   getAutocompleterData = (searchTerm:string):Observable<HalResource[]> => {
@@ -111,19 +115,6 @@ export class AddListModalComponent extends OpModalComponent implements OnInit {
 
   /** Whether the no results warning is displayed */
   showWarning = false;
-
-  constructor(readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly boardActions:BoardActionsRegistryService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly boardService:BoardService,
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentProject:CurrentProjectService,
-    readonly pathHelper:PathHelperService) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/features/boards/board/board-actions/assignee/assignee-board-header.component.ts
+++ b/frontend/src/app/features/boards/board/board-actions/assignee/assignee-board-header.component.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UserResource } from 'core-app/features/hal/resources/user-resource';
@@ -41,13 +41,12 @@ import { UserResource } from 'core-app/features/hal/resources/user-resource';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class AssigneeBoardHeaderComponent {
+  readonly pathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input('resource') public user:UserResource;
 
   text = {
     assignee: this.I18n.t('js.work_packages.properties.assignee'),
   };
-
-  constructor(readonly pathHelper:PathHelperService,
-    readonly I18n:I18nService) {
-  }
 }

--- a/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/board-action.service.ts
@@ -7,7 +7,7 @@ import { BoardListsService } from 'core-app/features/boards/board/board-list/boa
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { map } from 'rxjs/operators';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { WorkPackageChangeset } from 'core-app/features/work-packages/components/wp-edit/work-package-changeset';
@@ -25,15 +25,15 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
 @Injectable()
 export abstract class BoardActionService {
-  constructor(readonly injector:Injector,
-    protected boardListsService:BoardListsService,
-    protected I18n:I18nService,
-    protected halResourceService:HalResourceService,
-    protected pathHelper:PathHelperService,
-    protected currentProject:CurrentProjectService,
-    protected apiV3Service:ApiV3Service,
-    protected schemaCache:SchemaCacheService) {
-  }
+  readonly injector = inject(Injector);
+  protected boardListsService = inject(BoardListsService);
+  protected I18n = inject(I18nService);
+  protected halResourceService = inject(HalResourceService);
+  protected pathHelper = inject(PathHelperService);
+  protected currentProject = inject(CurrentProjectService);
+  protected apiV3Service = inject(ApiV3Service);
+  protected schemaCache = inject(SchemaCacheService);
+
 
   /**
    * Get the attribute name

--- a/frontend/src/app/features/boards/board/board-actions/status/status-board-header.component.ts
+++ b/frontend/src/app/features/boards/board/board-actions/status/status-board-header.component.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { StatusResource } from 'core-app/features/hal/resources/status-resource';
 
@@ -40,12 +40,11 @@ import { StatusResource } from 'core-app/features/hal/resources/status-resource'
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class StatusBoardHeaderComponent {
+  readonly I18n = inject(I18nService);
+
   @Input('resource') public status:StatusResource;
 
   text = {
     status: this.I18n.t('js.work_packages.properties.status'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/frontend/src/app/features/boards/board/board-actions/subproject/subproject-board-header.component.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subproject/subproject-board-header.component.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -42,6 +42,9 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SubprojectBoardHeaderComponent {
+  readonly pathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public resource:HalResource;
 
   idFromLink = idFromLink;
@@ -49,8 +52,4 @@ export class SubprojectBoardHeaderComponent {
   text = {
     project: this.I18n.t('js.label_project'),
   };
-
-  constructor(readonly pathHelper:PathHelperService,
-    readonly I18n:I18nService) {
-  }
 }

--- a/frontend/src/app/features/boards/board/board-actions/subtasks/subtasks-board-header.component.ts
+++ b/frontend/src/app/features/boards/board/board-actions/subtasks/subtasks-board-header.component.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -43,6 +43,9 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SubtasksBoardHeaderComponent implements OnInit {
+  readonly pathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public resource:WorkPackageResource;
 
   idFromLink = idFromLink;
@@ -52,10 +55,6 @@ export class SubtasksBoardHeaderComponent implements OnInit {
   };
 
   typeHighlightingClass:string;
-
-  constructor(readonly pathHelper:PathHelperService,
-    readonly I18n:I18nService) {
-  }
 
   ngOnInit() {
     this.typeHighlightingClass = Highlighting.inlineClass('type', this.resource.type.id!);

--- a/frontend/src/app/features/boards/board/board-actions/version/version-board-header.component.ts
+++ b/frontend/src/app/features/boards/board/board-actions/version/version-board-header.component.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { VersionResource } from 'core-app/features/hal/resources/version-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -41,11 +41,11 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class VersionBoardHeaderComponent {
-  @Input('resource') public version:VersionResource;
+  readonly I18n = inject(I18nService);
+  readonly pathHelper = inject(PathHelperService);
 
-  constructor(readonly I18n:I18nService,
-    readonly pathHelper:PathHelperService) {
-  }
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input('resource') public version:VersionResource;
 
   public text = {
     isLocked: this.I18n.t('js.boards.version.is_locked'),

--- a/frontend/src/app/features/boards/board/board-filter/board-filter.component.ts
+++ b/frontend/src/app/features/boards/board/board-filter/board-filter.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { Board } from 'core-app/features/boards/board/board';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
@@ -23,21 +23,19 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardFilterComponent extends UntilDestroyedMixin implements AfterViewInit {
+  private readonly currentProjectService = inject(CurrentProjectService);
+  private readonly querySpace = inject(IsolatedQuerySpace);
+  private readonly apiV3Service = inject(ApiV3Service);
+  private readonly halResourceService = inject(HalResourceService);
+  private readonly wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+  private readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  private readonly urlParamsHelper = inject(UrlParamsHelperService);
+  private readonly boardFilters = inject(BoardFiltersService);
+
   /** Current active */
   @Input() public board$:Observable<Board>;
 
   initialized = false;
-
-  constructor(private readonly currentProjectService:CurrentProjectService,
-    private readonly querySpace:IsolatedQuerySpace,
-    private readonly apiV3Service:ApiV3Service,
-    private readonly halResourceService:HalResourceService,
-    private readonly wpStatesInitialization:WorkPackageStatesInitializationService,
-    private readonly wpTableFilters:WorkPackageViewFiltersService,
-    private readonly urlParamsHelper:UrlParamsHelperService,
-    private readonly boardFilters:BoardFiltersService) {
-    super();
-  }
 
   ngAfterViewInit():void {
     if (!this.board$) {

--- a/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-inline-create.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import {
   WorkPackageInlineCreateService,
@@ -40,13 +40,8 @@ import { Observable } from 'rxjs';
 
 @Injectable()
 export class BoardInlineCreateService extends WorkPackageInlineCreateService {
-  constructor(
-    readonly injector:Injector,
-    protected readonly querySpace:IsolatedQuerySpace,
-    protected readonly halResourceService:HalResourceService,
-  ) {
-    super(injector);
-  }
+  protected readonly querySpace = inject(IsolatedQuerySpace);
+  protected readonly halResourceService = inject(HalResourceService);
 
   /**
    * A separate reference pane for the inline create component

--- a/frontend/src/app/features/boards/board/board-list/board-list-menu.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list-menu.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
@@ -49,17 +47,16 @@ import { BoardActionService } from 'core-app/features/boards/board/board-actions
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardListMenuComponent {
+  readonly opModalService = inject(OpModalService);
+  readonly authorisationService = inject(AuthorisationService);
+  private readonly querySpace = inject(IsolatedQuerySpace);
+  private readonly boardService = inject(BoardService);
+  private readonly boardActionRegistry = inject(BoardActionsRegistryService);
+  readonly I18n = inject(I18nService);
+
   @Input() board:Board;
 
   @Output() onRemove = new EventEmitter<void>();
-
-  constructor(readonly opModalService:OpModalService,
-    readonly authorisationService:AuthorisationService,
-    private readonly querySpace:IsolatedQuerySpace,
-    private readonly boardService:BoardService,
-    private readonly boardActionRegistry:BoardActionsRegistryService,
-    readonly I18n:I18nService) {
-  }
 
   public get menuItems() {
     return async () => {

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -5,7 +5,6 @@ import {
   ElementRef,
   EventEmitter,
   inject,
-  Injector,
   Input,
   OnDestroy,
   OnInit,
@@ -19,7 +18,6 @@ import {
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
 import { BoardInlineCreateService } from 'core-app/features/boards/board/board-list/board-inline-create.service';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { Board } from 'core-app/features/boards/board/board';
@@ -89,6 +87,31 @@ export interface DisabledButtonPlaceholder {
   standalone: false,
 })
 export class BoardListComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
+  readonly apiv3Service = inject(ApiV3Service);
+  readonly state = inject(StateService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly transitions = inject(TransitionService);
+  readonly boardFilters = inject(BoardFiltersService);
+  readonly toastService = inject(ToastService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly halEvents = inject(HalEventsService);
+  readonly wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+  readonly wpViewFocusService = inject(WorkPackageViewFocusService);
+  readonly wpViewSelectionService = inject(WorkPackageViewSelectionService);
+  readonly boardListCrossSelectionService = inject(BoardListCrossSelectionService);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly wpInlineCreate = inject(WorkPackageInlineCreateService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly boardService = inject(BoardService);
+  readonly boardActionRegistry = inject(BoardActionsRegistryService);
+  readonly causedUpdates = inject(CausedUpdatesService);
+  readonly keepTab = inject(KeepTabService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly pathHelper = inject(PathHelperService);
+
   /** Output fired upon query removal */
   @Output() onRemove = new EventEmitter<void>();
 
@@ -127,13 +150,15 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public columnsQueryProps:any;
 
-  public text = {
-    addCard: this.I18n.t('js.boards.add_card'),
-    updateSuccessful: this.I18n.t('js.notice_successful_update'),
-    areYouSure: this.I18n.t('js.text_are_you_sure'),
-    unnamed_list: this.I18n.t('js.boards.label_unnamed_list'),
-    click_to_remove: this.I18n.t('js.boards.click_to_remove_list'),
-  };
+  public get text() {
+    return {
+      addCard: this.i18n.t('js.boards.add_card'),
+      updateSuccessful: this.i18n.t('js.notice_successful_update'),
+      areYouSure: this.i18n.t('js.text_are_you_sure'),
+      unnamed_list: this.i18n.t('js.boards.label_unnamed_list'),
+      click_to_remove: this.i18n.t('js.boards.click_to_remove_list'),
+    };
+  }
 
   /** Are we allowed to remove and drag & drop elements ? */
   public canDragInto = false;
@@ -152,37 +177,6 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   public buttonPlaceholder:DisabledButtonPlaceholder|undefined;
 
   private readonly states = inject(States);
-
-  constructor(
-    readonly apiv3Service:ApiV3Service,
-    readonly I18n:I18nService,
-    readonly state:StateService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly transitions:TransitionService,
-    readonly boardFilters:BoardFiltersService,
-    readonly toastService:ToastService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly halNotification:HalResourceNotificationService,
-    readonly halEvents:HalEventsService,
-    readonly wpStatesInitialization:WorkPackageStatesInitializationService,
-    readonly wpViewFocusService:WorkPackageViewFocusService,
-    readonly wpViewSelectionService:WorkPackageViewSelectionService,
-    readonly boardListCrossSelectionService:BoardListCrossSelectionService,
-    readonly authorisationService:AuthorisationService,
-    readonly wpInlineCreate:WorkPackageInlineCreateService,
-    readonly injector:Injector,
-    readonly halEditing:HalResourceEditingService,
-    readonly loadingIndicator:LoadingIndicatorService,
-    readonly schemaCache:SchemaCacheService,
-    readonly boardService:BoardService,
-    readonly boardActionRegistry:BoardActionsRegistryService,
-    readonly causedUpdates:CausedUpdatesService,
-    readonly keepTab:KeepTabService,
-    readonly currentProject:CurrentProjectService,
-    readonly pathHelper:PathHelperService,
-  ) {
-    super(I18n, injector);
-  }
 
   ngOnInit():void {
     // Unset the isNew flag
@@ -257,7 +251,7 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
   }
 
   public get errorMessage() {
-    return this.I18n.t('js.boards.error_loading_the_list', { error_message: this.loadingError });
+    return this.i18n.t('js.boards.error_loading_the_list', { error_message: this.loadingError });
   }
 
   public canMove(workPackage:WorkPackageResource) {

--- a/frontend/src/app/features/boards/board/board-list/board-lists.service.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-lists.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
@@ -19,17 +19,14 @@ import { IOPFieldSchema } from 'core-app/features/hal/interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class BoardListsService {
+  private readonly CurrentProject = inject(CurrentProjectService);
+  private readonly pathHelper = inject(PathHelperService);
+  private readonly apiV3Service = inject(ApiV3Service);
+  private readonly halResourceService = inject(HalResourceService);
+  private readonly toastService = inject(ToastService);
+  private readonly I18n = inject(I18nService);
+
   private v3 = this.pathHelper.api.v3;
-
-  constructor(
-    private readonly CurrentProject:CurrentProjectService,
-    private readonly pathHelper:PathHelperService,
-    private readonly apiV3Service:ApiV3Service,
-    private readonly halResourceService:HalResourceService,
-    private readonly toastService:ToastService,
-    private readonly I18n:I18nService) {
-
-  }
 
   private create(params:object, filters:ApiV3Filter[]):Observable<QueryResource> {
     const filterJson = JSON.stringify(filters);

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-entry.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-entry.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Injector,
-  Input,
-  OnDestroy,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnDestroy, inject } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
@@ -64,12 +57,14 @@ import { QueryUpdatedService } from 'core-app/features/boards/board/query-update
   standalone: false,
 })
 export class BoardEntryComponent implements OnDestroy {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+
   @Input() boardId:string;
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly injector:Injector,
-  ) {
+  constructor() {
+    const injector = this.injector;
+
     populateInputsFromDataset(this);
 
     document.body.classList.add('router--boards-full-view');

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -54,6 +54,24 @@ import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-p
   standalone: false,
 })
 export class BoardListContainerComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly state = inject(StateService);
+  readonly toastService = inject(ToastService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly boardComponent = inject(BoardPartitionedPageComponent);
+  readonly BoardList = inject(BoardListsService);
+  readonly boardActionRegistry = inject(BoardActionsRegistryService);
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly Boards = inject(BoardService);
+  readonly boardListCrossSelectionService = inject(BoardListCrossSelectionService);
+  readonly Drag = inject(DragAndDropService);
+  readonly apiv3Service = inject(ApiV3Service);
+  readonly QueryUpdated = inject(QueryUpdatedService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly currentProject = inject(CurrentProjectService);
+
   @Input() boardId:string;
   text = {
     delete: this.I18n.t('js.button_delete'),
@@ -95,28 +113,6 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   private currentQueryUpdatedMonitoring:Subscription;
 
   private readonly wpStates = inject(States);
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly state:StateService,
-    readonly toastService:ToastService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly boardComponent:BoardPartitionedPageComponent,
-    readonly BoardList:BoardListsService,
-    readonly boardActionRegistry:BoardActionsRegistryService,
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly Boards:BoardService,
-    readonly boardListCrossSelectionService:BoardListCrossSelectionService,
-    readonly Drag:DragAndDropService,
-    readonly apiv3Service:ApiV3Service,
-    readonly QueryUpdated:QueryUpdatedService,
-    readonly pathHelper:PathHelperService,
-    readonly currentProject:CurrentProjectService,
-) {
-    super();
-  }
 
   ngOnInit():void {
     const id:string = this.boardId || this.state.params.board_id?.toString();

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-partitioned-page.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Injector,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, Input, OnInit, inject } from '@angular/core';
 import {
   DynamicComponentDefinition,
   ToolbarButtonComponentDefinition,
@@ -60,6 +53,20 @@ export function boardCardViewHandlerFactory(injector:Injector) {
   standalone: false,
 })
 export class BoardPartitionedPageComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly state = inject(StateService);
+  readonly toastService = inject(ToastService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly injector = inject(Injector);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly boardFilters = inject(BoardFiltersService);
+  readonly Boards = inject(BoardService);
+  readonly titleService = inject(OpTitleService);
+  readonly submenuService = inject(SubmenuService);
+  readonly pathHelperService = inject(PathHelperService);
+  readonly currentProject = inject(CurrentProjectService);
+
   @Input() boardId:string;
   text = {
     button_more: this.I18n.t('js.button_more'),
@@ -128,24 +135,6 @@ export class BoardPartitionedPageComponent extends UntilDestroyedMixin implement
       },
     },
   ];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly state:StateService,
-    readonly toastService:ToastService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly boardFilters:BoardFiltersService,
-    readonly Boards:BoardService,
-    readonly titleService:OpTitleService,
-    readonly submenuService:SubmenuService,
-    readonly pathHelperService:PathHelperService,
-    readonly currentProject:CurrentProjectService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     // Ensure board is being loaded

--- a/frontend/src/app/features/boards/board/board.service.ts
+++ b/frontend/src/app/features/boards/board/board.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -10,6 +10,12 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 
 @Injectable({ providedIn: 'root' })
 export class BoardService {
+  protected apiV3Service = inject(ApiV3Service);
+  protected PathHelper = inject(PathHelperService);
+  protected CurrentProject = inject(CurrentProjectService);
+  protected halResourceService = inject(HalResourceService);
+  protected I18n = inject(I18nService);
+
   public currentBoard$:BehaviorSubject<string|null> = new BehaviorSubject<string|null>(null);
 
   private loadAllPromise:Promise<Board[]>|undefined;
@@ -20,15 +26,6 @@ export class BoardService {
       { attribute: this.I18n.t(`js.boards.board_type.action_type.${attr}`) }),
     unnamed_list: this.I18n.t('js.boards.label_unnamed_list'),
   };
-
-  constructor(
-    protected apiV3Service:ApiV3Service,
-    protected PathHelper:PathHelperService,
-    protected CurrentProject:CurrentProjectService,
-    protected halResourceService:HalResourceService,
-    protected I18n:I18nService,
-  ) {
-  }
 
   /**
    * Return all boards in the current scope of the project

--- a/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.ts
+++ b/frontend/src/app/features/boards/board/configuration-modal/board-configuration.modal.ts
@@ -1,19 +1,5 @@
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ComponentFactoryResolver,
-  ElementRef,
-  Inject,
-  Injector,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ApplicationRef, ChangeDetectionStrategy, Component, ComponentFactoryResolver, ElementRef, Injector, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import {
   ActiveTabInterface,
   TabComponent,
@@ -34,6 +20,13 @@ import { Board } from 'core-app/features/boards/board/board';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardConfigurationModalComponent extends OpModalComponent implements OnInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly boardService = inject(BoardService);
+  readonly boardConfigurationService = inject(BoardConfigurationService);
+  readonly injector = inject(Injector);
+  readonly appRef = inject(ApplicationRef);
+  readonly componentFactoryResolver = inject(ComponentFactoryResolver);
+
   public text = {
     title: this.I18n.t('js.boards.configuration_modal.title'),
     closePopup: this.I18n.t('js.close_popup_title'),
@@ -47,18 +40,6 @@ export class BoardConfigurationModalComponent extends OpModalComponent implement
 
   // And a reference to the actual portal host interface
   public tabPortalHost:TabPortalOutlet;
-
-  constructor(@Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly boardService:BoardService,
-    readonly boardConfigurationService:BoardConfigurationService,
-    readonly injector:Injector,
-    readonly appRef:ApplicationRef,
-    readonly componentFactoryResolver:ComponentFactoryResolver,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     this.element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/features/boards/board/configuration-modal/board-configuration.service.ts
+++ b/frontend/src/app/features/boards/board/configuration-modal/board-configuration.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TabInterface } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { BoardHighlightingTabComponent } from 'core-app/features/boards/board/configuration-modal/tabs/highlighting-tab.component';
 
 @Injectable()
 export class BoardConfigurationService {
+  readonly I18n = inject(I18nService);
+
   protected _tabs:TabInterface[] = [
     {
       id: 'highlighting',
@@ -12,9 +14,6 @@ export class BoardConfigurationService {
       componentClass: BoardHighlightingTabComponent,
     },
   ];
-
-  constructor(readonly I18n:I18nService) {
-  }
 
   public get tabs() {
     return this._tabs;

--- a/frontend/src/app/features/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/features/boards/board/configuration-modal/tabs/highlighting-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, Injector, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
@@ -15,6 +15,10 @@ import { CardHighlightingMode } from 'core-app/features/work-packages/components
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardHighlightingTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  locals = inject<OpModalLocalsMap>(OpModalLocalsToken);
+  readonly I18n = inject(I18nService);
+
   // Highlighting mode
   public highlightingMode:CardHighlightingMode = 'none';
 
@@ -34,11 +38,6 @@ export class BoardHighlightingTabComponent implements TabComponent, OnInit {
       entire_card_by: this.I18n.t('js.card.highlighting.entire_card_by'),
     },
   };
-
-  constructor(readonly injector:Injector,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService) {
-  }
 
   public onSave() {
     this.updateMode(this.highlightingMode);

--- a/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
+++ b/frontend/src/app/features/boards/board/inline-add/board-inline-add-autocompleter.component.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
@@ -66,6 +56,18 @@ import { HalResourceService } from 'core-app/features/hal/services/hal-resource.
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
+  private readonly querySpace = inject(IsolatedQuerySpace);
+  private readonly pathHelper = inject(PathHelperService);
+  private readonly apiV3Service = inject(ApiV3Service);
+  private readonly urlParamsHelper = inject(UrlParamsHelperService);
+  private readonly notificationService = inject(WorkPackageNotificationService);
+  private readonly CurrentProject = inject(CurrentProjectService);
+  private readonly halResourceService = inject(HalResourceService);
+  private readonly schemaCacheService = inject(SchemaCacheService);
+  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly I18n = inject(I18nService);
+  private readonly wpCardDragDrop = inject(WorkPackageCardDragAndDropService);
+
   readonly text = {
     placeholder: this.I18n.t('js.relations_autocomplete.placeholder'),
   };
@@ -118,19 +120,6 @@ export class BoardInlineAddAutocompleterComponent implements AfterViewInit {
   @Output() onCancel = new EventEmitter<undefined>();
 
   @Output() onReferenced = new EventEmitter<WorkPackageResource>();
-
-  constructor(private readonly querySpace:IsolatedQuerySpace,
-    private readonly pathHelper:PathHelperService,
-    private readonly apiV3Service:ApiV3Service,
-    private readonly urlParamsHelper:UrlParamsHelperService,
-    private readonly notificationService:WorkPackageNotificationService,
-    private readonly CurrentProject:CurrentProjectService,
-    private readonly halResourceService:HalResourceService,
-    private readonly schemaCacheService:SchemaCacheService,
-    private readonly cdRef:ChangeDetectorRef,
-    private readonly I18n:I18nService,
-    private readonly wpCardDragDrop:WorkPackageCardDragAndDropService) {
-  }
 
   ngAfterViewInit():void {
     if (!this.ngSelectComponent.ngSelectInstance) {

--- a/frontend/src/app/features/boards/board/query-updated/query-updated.service.ts
+++ b/frontend/src/app/features/boards/board/query-updated/query-updated.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { interval } from 'rxjs';
 import { filter, startWith, switchMap } from 'rxjs/operators';
 import { ActiveWindowService } from 'core-app/core/active-window/active-window.service';
@@ -8,9 +8,9 @@ const POLLING_INTERVAL = 2000;
 
 @Injectable()
 export class QueryUpdatedService {
-  constructor(readonly activeWindow:ActiveWindowService,
-    readonly apiV3Service:ApiV3Service) {
-  }
+  readonly activeWindow = inject(ActiveWindowService);
+  readonly apiV3Service = inject(ApiV3Service);
+
 
   public monitor(ids:string[]) {
     let time = new Date();

--- a/frontend/src/app/features/boards/board/toolbar-menu/boards-menu-button.component.ts
+++ b/frontend/src/app/features/boards/board/toolbar-menu/boards-menu-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Board } from 'core-app/features/boards/board/board';
 import { Observable } from 'rxjs';
@@ -19,12 +19,11 @@ import { Observable } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class BoardsMenuButtonComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() board$:Observable<Board>;
 
   text = {
     button_more: this.I18n.t('js.button_more'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/frontend/src/app/features/boards/board/toolbar-menu/boards-toolbar-menu.directive.ts
+++ b/frontend/src/app/features/boards/board/toolbar-menu/boards-toolbar-menu.directive.ts
@@ -26,13 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Directive, ElementRef, Injector, Input,
-} from '@angular/core';
+import { Directive, Injector, Input, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { Board } from 'core-app/features/boards/board/board';
 import { BoardConfigurationModalComponent } from 'core-app/features/boards/board/configuration-modal/board-configuration.modal';
@@ -46,21 +43,16 @@ import { selectableTitleIdentifier, triggerEditingEvent } from 'core-app/shared/
   standalone: false,
 })
 export class BoardsToolbarMenuDirective extends OpContextMenuTrigger {
-  @Input('boardsToolbarMenu-resource') public board:Board;
+  readonly opModalService = inject(OpModalService);
+  readonly boardService = inject(BoardService);
+  readonly Notifications = inject(ToastService);
+  readonly State = inject(StateService);
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly http = inject(HttpClient);
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly opModalService:OpModalService,
-    readonly boardService:BoardService,
-    readonly Notifications:ToastService,
-    readonly State:StateService,
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly http:HttpClient,
-  ) {
-    super(elementRef, opContextMenu);
-  }
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input('boardsToolbarMenu-resource') public board:Board;
 
   public get locals() {
     return {

--- a/frontend/src/app/features/calendar/calendar-entry.component.ts
+++ b/frontend/src/app/features/calendar/calendar-entry.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Input,
-  OnDestroy,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnDestroy, inject } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
@@ -45,9 +39,11 @@ import {
   standalone: false,
 })
 export class CalendarEntryComponent implements OnDestroy {
+  readonly elementRef = inject(ElementRef);
+
   @Input() queryId:string;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
     document.body.classList.add('router--calendar');
   }

--- a/frontend/src/app/features/calendar/op-calendar.service.spec.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.spec.ts
@@ -26,16 +26,25 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { TestBed } from '@angular/core/testing';
 import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
+import { WeekdayService } from 'core-app/core/days/weekday.service';
+import { DayResourceService } from 'core-app/core/state/days/day.service';
+import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 describe('OP calendar service', () => {
   let service:OpCalendarService;
 
   beforeEach(() => {
-    // This is not a valid constructor call, but since we only want to test a helper method that does not
-    // depend on injected services, we can pass null values here.
-    // @ts-expect-error ignore invalid constructor call since we don't need a completely valid instance
-    service = new OpCalendarService(null, null, null);
+    TestBed.configureTestingModule({
+      providers: [
+        OpCalendarService,
+        { provide: WeekdayService, useValue: {} },
+        { provide: DayResourceService, useValue: {} },
+        { provide: ConfigurationService, useValue: {} },
+      ],
+    });
+    service = TestBed.inject(OpCalendarService);
   });
 
   describe('stripYearFromDateFormat', () => {

--- a/frontend/src/app/features/calendar/op-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-calendar.service.ts
@@ -1,7 +1,4 @@
-import {
-  ElementRef,
-  Injectable,
-} from '@angular/core';
+import { ElementRef, Injectable, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { WeekdayService } from 'core-app/core/days/weekday.service';
@@ -13,17 +10,13 @@ import { DayHeaderContentArg } from '@fullcalendar/core';
 
 @Injectable()
 export class OpCalendarService extends UntilDestroyedMixin {
+  readonly weekdayService = inject(WeekdayService);
+  readonly dayService = inject(DayResourceService);
+  readonly configurationService = inject(ConfigurationService);
+
   resize$ = new Subject<void>();
 
   resizeObs:ResizeObserver;
-
-  constructor(
-    readonly weekdayService:WeekdayService,
-    readonly dayService:DayResourceService,
-    readonly configurationService:ConfigurationService,
-  ) {
-    super();
-  }
 
   resizeObserver(v:ElementRef|undefined):void {
     if (!v) {

--- a/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
+++ b/frontend/src/app/features/calendar/op-work-packages-calendar.service.ts
@@ -75,6 +75,28 @@ interface CalendarOptionsWithDayGrid extends CalendarOptions {
 
 @Injectable()
 export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
+  private I18n = inject(I18nService);
+  private configuration = inject(ConfigurationService);
+  private sanitizer = inject(DomSanitizer);
+  readonly injector = inject(Injector);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly toastService = inject(ToastService);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly wpListChecksumService = inject(WorkPackagesListChecksumService);
+  readonly urlParamsHelper = inject(UrlParamsHelperService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly halResourceService = inject(HalResourceService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly wpTableSelection = inject(WorkPackageViewSelectionService);
+  readonly contextMenuService = inject(OPContextMenuService);
+  readonly calendarService = inject(OpCalendarService);
+  readonly weekdayService = inject(WeekdayService);
+  readonly dayService = inject(DayResourceService);
+
   static MAX_DISPLAYED = 500;
 
   tooManyResultsText:string|null;
@@ -90,32 +112,6 @@ export class OpWorkPackagesCalendarService extends UntilDestroyedMixin {
     );
 
   private readonly states = inject(States);
-
-  constructor(
-    private I18n:I18nService,
-    private configuration:ConfigurationService,
-    private sanitizer:DomSanitizer,
-    readonly injector:Injector,
-    readonly schemaCache:SchemaCacheService,
-    readonly toastService:ToastService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpListService:WorkPackagesListService,
-    readonly wpListChecksumService:WorkPackagesListChecksumService,
-    readonly urlParamsHelper:UrlParamsHelperService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly apiV3Service:ApiV3Service,
-    readonly halResourceService:HalResourceService,
-    readonly timezoneService:TimezoneService,
-    readonly pathHelper:PathHelperService,
-    readonly halEditing:HalResourceEditingService,
-    readonly wpTableSelection:WorkPackageViewSelectionService,
-    readonly contextMenuService:OPContextMenuService,
-    readonly calendarService:OpCalendarService,
-    readonly weekdayService:WeekdayService,
-    readonly dayService:DayResourceService,
-  ) {
-    super();
-  }
 
   calendarOptions(additionalOptions:CalendarOptions):CalendarOptions {
     return { ...this.defaultOptions(), ...additionalOptions };

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -1,17 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnDestroy,
-  Output,
-  SecurityContext,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, Output, SecurityContext, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { FullCalendarComponent } from '@fullcalendar/angular';
 import { States } from 'core-app/core/states/states.service';
 import moment, { Moment } from 'moment';
@@ -115,6 +102,25 @@ const ADD_ENTRY_PROHIBITED_CLASS_NAME = '-prohibited';
   standalone: false,
 })
 export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
+  readonly states = inject(States);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly $state = inject(StateService);
+  private element = inject(ElementRef);
+  readonly i18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly notifications = inject(HalResourceNotificationService);
+  private sanitizer = inject(DomSanitizer);
+  private configuration = inject(ConfigurationService);
+  private timezone = inject(TimezoneService);
+  private schemaCache = inject(SchemaCacheService);
+  private colors = inject(ColorsService);
+  private browserDetector = inject(BrowserDetector);
+  private calendar = inject(OpCalendarService);
+  readonly weekdayService = inject(WeekdayService);
+  readonly dayService = inject(DayResourceService);
+  readonly turboRequests = inject(TurboRequestsService);
+  readonly pathHelper = inject(PathHelperService);
+
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
 
   @Input() projectIdentifier:string;
@@ -201,27 +207,6 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
         this.calendarOptions$.next(this.additionalOptions);
       });
   }
-
-  constructor(
-    readonly states:States,
-    readonly apiV3Service:ApiV3Service,
-    readonly $state:StateService,
-    private element:ElementRef,
-    readonly i18n:I18nService,
-    readonly injector:Injector,
-    readonly notifications:HalResourceNotificationService,
-    private sanitizer:DomSanitizer,
-    private configuration:ConfigurationService,
-    private timezone:TimezoneService,
-    private schemaCache:SchemaCacheService,
-    private colors:ColorsService,
-    private browserDetector:BrowserDetector,
-    private calendar:OpCalendarService,
-    readonly weekdayService:WeekdayService,
-    readonly dayService:DayResourceService,
-    readonly turboRequests:TurboRequestsService,
-    readonly pathHelper:PathHelperService,
-  ) { }
 
   ngAfterViewInit():void {
     document.addEventListener('dialog:close', this.closeDialogHandler);

--- a/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/features/calendar/wp-calendar/wp-calendar.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Input,
-  OnInit,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import {
   CalendarOptions,
   DateSelectArg,
@@ -103,6 +95,29 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
   standalone: false,
 })
 export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implements OnInit {
+  readonly actions$ = inject(ActionsService);
+  readonly states = inject(States);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly schemaCache = inject(SchemaCacheService);
+  private element = inject(ElementRef);
+  readonly i18n = inject(I18nService);
+  readonly toastService = inject(ToastService);
+  private sanitizer = inject(DomSanitizer);
+  private I18n = inject(I18nService);
+  private configuration = inject(ConfigurationService);
+  readonly calendar = inject(OpCalendarService);
+  readonly workPackagesCalendar = inject(OpWorkPackagesCalendarService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly weekdayService = inject(WeekdayService);
+  readonly dayService = inject(DayResourceService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly pathHelper = inject(PathHelperService);
+  readonly timezoneService = inject(TimezoneService);
+
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
 
   @ViewChild('ucCalendar', { read: ElementRef })
@@ -122,33 +137,6 @@ export class WorkPackagesCalendarComponent extends UntilDestroyedMixin implement
     cannot_drag_to_non_working_day: this.I18n.t('js.team_planner.cannot_drag_to_non_working_day'),
     today: this.I18n.t('js.team_planner.today'),
   };
-
-  constructor(
-    readonly actions$:ActionsService,
-    readonly states:States,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpListService:WorkPackagesListService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly schemaCache:SchemaCacheService,
-    private element:ElementRef,
-    readonly i18n:I18nService,
-    readonly toastService:ToastService,
-    private sanitizer:DomSanitizer,
-    private I18n:I18nService,
-    private configuration:ConfigurationService,
-    readonly calendar:OpCalendarService,
-    readonly workPackagesCalendar:OpWorkPackagesCalendarService,
-    readonly currentProject:CurrentProjectService,
-    readonly halEditing:HalResourceEditingService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly weekdayService:WeekdayService,
-    readonly dayService:DayResourceService,
-    readonly apiV3Service:ApiV3Service,
-    readonly pathHelper:PathHelperService,
-    readonly timezoneService:TimezoneService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     registerEffectCallbacks(this, this.untilDestroyed());

--- a/frontend/src/app/features/enterprise/enterprise-banner-frame.component.ts
+++ b/frontend/src/app/features/enterprise/enterprise-banner-frame.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
 
@@ -37,6 +37,9 @@ import { BannersService } from 'core-app/core/enterprise/banners.service';
   standalone: false,
 })
 export class EnterpriseBannerFrameComponent implements OnInit {
+  protected pathHelper = inject(PathHelperService);
+  protected banners = inject(BannersService);
+
   @Input() public feature:string;
 
   @Input() public dismissable = false;
@@ -44,12 +47,6 @@ export class EnterpriseBannerFrameComponent implements OnInit {
   visible:boolean;
   frameURL:string;
   frameID:string;
-
-  constructor(
-    protected pathHelper:PathHelperService,
-    protected banners:BannersService,
-  ) {
-  }
 
   ngOnInit() {
     this.visible = this.banners.showBannerFor(this.feature);

--- a/frontend/src/app/features/hal/services/hal-aware-error-handler.ts
+++ b/frontend/src/app/features/hal/services/hal-aware-error-handler.ts
@@ -1,7 +1,4 @@
-import {
-  ErrorHandler,
-  Injectable,
-} from '@angular/core';
+import { ErrorHandler, Injectable, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { ErrorResource } from 'core-app/features/hal/resources/error-resource';
@@ -14,13 +11,11 @@ interface RejectedPromise {
 
 @Injectable()
 export class HalAwareErrorHandler extends ErrorHandler {
+  private readonly I18n = inject(I18nService);
+
   private text = {
     internal_error: this.I18n.t('js.error.internal'),
   };
-
-  constructor(private readonly I18n:I18nService) {
-    super();
-  }
 
   public handleError(error:unknown):void {
     let message:string = this.text.internal_error;

--- a/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource-notification.service.ts
@@ -28,7 +28,7 @@
 
 import { StateService } from '@uirouter/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { LoadingIndicatorService } from 'core-app/core/loading-indicator/loading-indicator.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -41,6 +41,8 @@ import { HalError } from 'core-app/features/hal/services/hal-error';
 
 @Injectable()
 export class HalResourceNotificationService {
+  injector = inject(Injector);
+
   @InjectField() protected I18n:I18nService;
 
   @InjectField() protected $state:StateService;
@@ -52,9 +54,6 @@ export class HalResourceNotificationService {
   @InjectField() protected loadingIndicator:LoadingIndicatorService;
 
   @InjectField() protected schemaCache:SchemaCacheService;
-
-  constructor(public injector:Injector) {
-  }
 
   public showSave(resource:HalResource, isCreate = false) {
     const message:any = {

--- a/frontend/src/app/features/hal/services/hal-resource.service.ts
+++ b/frontend/src/app/features/hal/services/hal-resource.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { catchError, map } from 'rxjs/operators';
 import { Observable, throwError } from 'rxjs';
@@ -59,16 +59,13 @@ interface ErrorWithType {
 
 @Injectable({ providedIn: 'root' })
 export class HalResourceService {
+  readonly injector = inject(Injector);
+  readonly http = inject(HttpClient);
+
   /**
    * List of all known hal resources, extendable.
    */
   private config:Record<string, HalResourceFactoryConfigInterface> = {};
-
-  constructor(
-    readonly injector:Injector,
-    readonly http:HttpClient,
-  ) {
-  }
 
   /**
    * Perform a HTTP request and return a HalResource promise.

--- a/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/in-app-notification-bell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, HostListener } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, HostListener, inject } from '@angular/core';
 import { combineLatest, merge, Observable, timer } from 'rxjs';
 import { filter, map, shareReplay, switchMap, throttleTime } from 'rxjs/operators';
 import { ActiveWindowService } from 'core-app/core/active-window/active-window.service';
@@ -15,6 +15,12 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   standalone: false,
 })
 export class InAppNotificationBellComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly storeService = inject(IanBellService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly activeWindow = inject(ActiveWindowService);
+  readonly pathHelper = inject(PathHelperService);
+
   @Input() interval = 50000;
 
   polling$:Observable<number>;
@@ -25,13 +31,7 @@ export class InAppNotificationBellComponent implements OnInit {
 
   public bellDisplayLimit = 99;
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly storeService:IanBellService,
-    readonly apiV3Service:ApiV3Service,
-    readonly activeWindow:ActiveWindowService,
-    readonly pathHelper:PathHelperService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
+++ b/frontend/src/app/features/in-app-notifications/bell/state/ian-bell.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   catchError,
   map,
@@ -57,6 +57,9 @@ import { IanBellStore } from 'core-app/features/in-app-notifications/bell/state/
 @Injectable({ providedIn: 'root' })
 @EffectHandler
 export class IanBellService {
+  readonly actions$ = inject(ActionsService);
+  readonly resourceService = inject(InAppNotificationsResourceService);
+
   readonly id = 'ian-bell';
 
   readonly store = new IanBellStore();
@@ -65,10 +68,7 @@ export class IanBellService {
 
   unread$ = this.query.unread$;
 
-  constructor(
-    readonly actions$:ActionsService,
-    readonly resourceService:InAppNotificationsResourceService,
-  ) {
+  constructor() {
     this.query.unreadCountChanged$.subscribe((count) => {
       this.actions$.dispatch(notificationCountChanged({ origin: this.id, count }));
     });

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { filter, map } from 'rxjs/operators';
 import { StateService } from '@uirouter/angular';
@@ -52,6 +52,17 @@ import {
   standalone: false,
 })
 export class InAppNotificationCenterComponent implements OnInit {
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+  readonly I18n = inject(I18nService);
+  readonly storeService = inject(IanCenterService);
+  readonly bellService = inject(IanBellService);
+  readonly urlParams = inject(UrlParamsService);
+  readonly state = inject(StateService);
+  readonly apiV3 = inject(ApiV3Service);
+  readonly pathService = inject(PathHelperService);
+  readonly colorsService = inject(ColorsService);
+
   maxSize = NOTIFICATIONS_MAX_SIZE;
 
   hasMoreThanPageSize$ = this.storeService.hasMoreThanPageSize$;
@@ -140,20 +151,6 @@ export class InAppNotificationCenterComponent implements OnInit {
   };
 
   protected readonly idFromLink = idFromLink;
-
-  constructor(
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    readonly I18n:I18nService,
-    readonly storeService:IanCenterService,
-    readonly bellService:IanBellService,
-    readonly urlParams:UrlParamsService,
-    readonly state:StateService,
-    readonly apiV3:ApiV3Service,
-    readonly pathService:PathHelperService,
-    readonly colorsService:ColorsService,
-  ) {
-  }
 
   ngOnInit():void {
     const facet = this.urlParams.get('facet') || 'unread';

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { debounceTime, defaultIfEmpty, distinctUntilChanged, map, mapTo, switchMap, take, tap } from 'rxjs/operators';
 import { forkJoin, from, Observable, Subject } from 'rxjs';
 import { ID, Query } from '@datorama/akita';
@@ -71,6 +71,18 @@ export interface INotificationPageQueryParameters {
 @Injectable({ providedIn: 'root' })
 @EffectHandler
 export class IanCenterService extends UntilDestroyedMixin {
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly resourceService = inject(InAppNotificationsResourceService);
+  readonly actions$ = inject(ActionsService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly toastService = inject(ToastService);
+  readonly urlParams = inject(UrlParamsService);
+  readonly state = inject(StateService);
+  readonly deviceService = inject(DeviceService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly ianBellService = inject(IanBellService);
+
   readonly id = 'ian-center';
 
   readonly store = new IanCenterStore();
@@ -182,19 +194,7 @@ export class IanCenterService extends UntilDestroyedMixin {
 
   selectedWorkPackage$ = this.urlParams.pathMatching$(/\/details\/(\d+)/);
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly resourceService:InAppNotificationsResourceService,
-    readonly actions$:ActionsService,
-    readonly apiV3Service:ApiV3Service,
-    readonly toastService:ToastService,
-    readonly urlParams:UrlParamsService,
-    readonly state:StateService,
-    readonly deviceService:DeviceService,
-    readonly pathHelper:PathHelperService,
-    readonly ianBellService:IanBellService,
-  ) {
+  constructor() {
     super();
     this.reload.subscribe();
 

--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
@@ -13,6 +13,9 @@ import { PrincipalLike } from 'core-app/shared/components/principal/principal-ty
   standalone: false,
 })
 export class InAppNotificationActorsLineComponent implements OnInit {
+  readonly deviceService = inject(DeviceService);
+  private I18n = inject(I18nService);
+
   @HostBinding('class.op-ian-actors') className = true;
 
   @Input() aggregatedNotifications:INotification[];
@@ -33,11 +36,6 @@ export class InAppNotificationActorsLineComponent implements OnInit {
     placeholder: this.I18n.t('js.placeholders.default'),
     mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
   };
-
-  constructor(
-    readonly deviceService:DeviceService,
-    private I18n:I18nService,
-  ) { }
 
   ngOnInit():void {
     // Don't show the actor if the first item is actor-less (date alert)

--- a/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/date-alert/in-app-notification-date-alert.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IInAppNotificationDetailsAttribute, INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
@@ -20,6 +13,9 @@ import moment, { Moment } from 'moment';
   standalone: false,
 })
 export class InAppNotificationDateAlertComponent implements OnInit {
+  private I18n = inject(I18nService);
+  private timezoneService = inject(TimezoneService);
+
   @Input() aggregatedNotifications:INotification[];
 
   @HostBinding('class.op-ian-date-alert') className = true;
@@ -48,11 +44,6 @@ export class InAppNotificationDateAlertComponent implements OnInit {
     due_today: this.I18n.t('js.notifications.date_alerts.property_today'),
     note: '', // date alerts do not have notes
   };
-
-  constructor(
-    private I18n:I18nService,
-    private timezoneService:TimezoneService,
-  ) { }
 
   ngOnInit():void {
     // Find the most important date alert

--- a/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/in-app-notification-entry.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -23,6 +23,14 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
   standalone: false,
 })
 export class InAppNotificationEntryComponent extends UntilDestroyedMixin implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly I18n = inject(I18nService);
+  readonly storeService = inject(IanCenterService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly deviceService = inject(DeviceService);
+  readonly urlParams = inject(UrlParamsService);
+
   @HostBinding('class.op-ian-item') className = true;
 
   @Input() notification:INotification;
@@ -54,18 +62,6 @@ export class InAppNotificationEntryComponent extends UntilDestroyedMixin impleme
   private clickTimer:ReturnType<typeof setTimeout>;
 
   workPackageId:string|null;
-
-  constructor(
-    readonly apiV3Service:ApiV3Service,
-    readonly I18n:I18nService,
-    readonly storeService:IanCenterService,
-    readonly timezoneService:TimezoneService,
-    readonly pathHelper:PathHelperService,
-    readonly deviceService:DeviceService,
-    readonly urlParams:UrlParamsService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     const href = this.notification._links.resource?.href;

--- a/frontend/src/app/features/in-app-notifications/entry/relative-time/in-app-notification-relative-time.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/relative-time/in-app-notification-relative-time.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
@@ -20,6 +14,9 @@ import { distinctUntilChanged, map } from 'rxjs/operators';
   standalone: false,
 })
 export class InAppNotificationRelativeTimeComponent implements OnInit {
+  private I18n = inject(I18nService);
+  private timezoneService = inject(TimezoneService);
+
   @Input() notification:INotification;
   @Input() hasActorByLine = true;
 
@@ -36,11 +33,6 @@ export class InAppNotificationRelativeTimeComponent implements OnInit {
       { date: age },
     ),
   };
-
-  constructor(
-    private I18n:I18nService,
-    private timezoneService:TimezoneService,
-  ) { }
 
   ngOnInit():void {
     this.buildTime();

--- a/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
+++ b/frontend/src/app/features/in-app-notifications/entry/reminder-alert/in-app-notification-reminder-alert.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IInAppNotificationDetailsResource, INotification } from 'core-app/core/state/in-app-notifications/in-app-notification.model';
 
@@ -18,6 +11,8 @@ import { IInAppNotificationDetailsResource, INotification } from 'core-app/core/
   standalone: false,
 })
 export class InAppNotificationReminderAlertComponent implements OnInit {
+  private I18n = inject(I18nService);
+
   @Input() aggregatedNotifications:INotification[];
 
   @HostBinding('class.op-ian-reminder-alert') className = true;
@@ -26,10 +21,6 @@ export class InAppNotificationReminderAlertComponent implements OnInit {
   reminderAlert:INotification;
   hasDateAlert = false;
   dateAlerts:INotification[] = [];
-
-  constructor(
-    private I18n:I18nService,
-  ) { }
 
   ngOnInit():void {
     this.reminderAlert = this.deriveMostRecentReminder(this.aggregatedNotifications);

--- a/frontend/src/app/features/job-status/job-status-modal.service.ts
+++ b/frontend/src/app/features/job-status/job-status-modal.service.ts
@@ -1,13 +1,12 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Injectable({ providedIn: 'root' })
 export class JobStatusModalService {
-  constructor(
-    protected pathHelper:PathHelperService,
-    protected turboRequests:TurboRequestsService,
-  ) {}
+  protected pathHelper = inject(PathHelperService);
+  protected turboRequests = inject(TurboRequestsService);
+
 
   public show(jobId:string):void {
     void this.turboRequests.requestStream(this.jobModalUrl(jobId));

--- a/frontend/src/app/features/plugins/openproject-plugins.module.ts
+++ b/frontend/src/app/features/plugins/openproject-plugins.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { HookService } from 'core-app/features/plugins/hook-service';
 import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import { debugLog } from 'core-app/shared/helpers/debug_output';
@@ -37,7 +37,9 @@ import { debugLog } from 'core-app/shared/helpers/debug_output';
   ],
 })
 export class OpenprojectPluginsModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     debugLog('Registering OpenProject plugin context');
     const pluginContext = new OpenProjectPluginContext(injector);
     window.OpenProject.pluginContext.putValue(pluginContext);

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  HostBinding,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { imagePath } from 'core-app/shared/helpers/images/path-helper';
 import {
@@ -45,6 +37,17 @@ import { OpWorkPackagesCalendarService } from 'core-app/features/calendar/op-wor
   standalone: false,
 })
 export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  private readonly querySpace = inject(IsolatedQuerySpace);
+  private I18n = inject(I18nService);
+  private readonly apiV3Service = inject(ApiV3Service);
+  private readonly notificationService = inject(WorkPackageNotificationService);
+  private readonly currentProject = inject(CurrentProjectService);
+  private readonly urlParamsHelper = inject(UrlParamsHelperService);
+  private readonly workPackagesCalendar = inject(OpWorkPackagesCalendarService);
+  private readonly calendarDrag = inject(CalendarDragDropService);
+  private readonly actions$ = inject(ActionsService);
+  private readonly wpFilters = inject(WorkPackageViewFiltersService);
+
   @HostBinding('class.op-add-existing-pane') className = true;
 
   @ViewChild('container') container:ElementRef;
@@ -108,21 +111,6 @@ export class AddExistingPaneComponent extends UntilDestroyedMixin implements OnI
   image = {
     empty_state: imagePath('team-planner/add-existing-pane--empty-state.gif'),
   };
-
-  constructor(
-    private readonly querySpace:IsolatedQuerySpace,
-    private I18n:I18nService,
-    private readonly apiV3Service:ApiV3Service,
-    private readonly notificationService:WorkPackageNotificationService,
-    private readonly currentProject:CurrentProjectService,
-    private readonly urlParamsHelper:UrlParamsHelperService,
-    private readonly workPackagesCalendar:OpWorkPackagesCalendarService,
-    private readonly calendarDrag:CalendarDragDropService,
-    private readonly actions$:ActionsService,
-    private readonly wpFilters:WorkPackageViewFiltersService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     combineLatest([

--- a/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/assignee/add-assignee.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Injector, Input, Output, inject } from '@angular/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -54,23 +46,21 @@ import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/r
   standalone: false,
 })
 export class AddAssigneeComponent {
+  protected elementRef = inject(ElementRef);
+  protected halResourceService = inject(HalResourceService);
+  protected I18n = inject(I18nService);
+  protected halNotification = inject(HalResourceNotificationService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly injector = inject(Injector);
+  readonly currentProjectService = inject(CurrentProjectService);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+
   @Output() public selectAssignee = new EventEmitter<HalResource>();
 
   @Input() alreadySelected:string[] = [];
 
   public getOptionsFn = (query:string):Observable<unknown[]> => this.autocomplete(query);
-
-  constructor(
-    protected elementRef:ElementRef,
-    protected halResourceService:HalResourceService,
-    protected I18n:I18nService,
-    protected halNotification:HalResourceNotificationService,
-    readonly pathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly injector:Injector,
-    readonly currentProjectService:CurrentProjectService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-  ) { }
 
   public autocomplete(term:string|null):Observable<HalResource[]> {
     const filters = new ApiV3FilterBuilder();

--- a/frontend/src/app/features/team-planner/team-planner/calendar-drag-drop.service.ts
+++ b/frontend/src/app/features/team-planner/team-planner/calendar-drag-drop.service.ts
@@ -1,7 +1,4 @@
-import {
-  ElementRef,
-  Injectable,
-} from '@angular/core';
+import { ElementRef, Injectable, inject } from '@angular/core';
 import { ThirdPartyDraggable } from '@fullcalendar/interaction';
 import { DragMetaInput } from '@fullcalendar/common';
 import dragula, { Drake } from 'dragula';
@@ -15,6 +12,11 @@ import moment from 'moment-timezone';
 
 @Injectable()
 export class CalendarDragDropService {
+  readonly authorisation = inject(AuthorisationService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly workPackagesCalendarService = inject(OpWorkPackagesCalendarService);
+  readonly I18n = inject(I18nService);
+
   drake:Drake;
 
   draggableWorkPackages$ = new BehaviorSubject<WorkPackageResource[]>([]);
@@ -27,14 +29,6 @@ export class CalendarDragDropService {
       fallback: this.I18n.t('js.team_planner.modify.errors.fallback'),
     },
   };
-
-  constructor(
-    readonly authorisation:AuthorisationService,
-    readonly schemaCache:SchemaCacheService,
-    readonly workPackagesCalendarService:OpWorkPackagesCalendarService,
-    readonly I18n:I18nService,
-  ) {
-  }
 
   destroyDrake():void {
     if (this.drake) {

--- a/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/planner/team-planner.component.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  HostListener,
-  Injector,
-  OnDestroy,
-  OnInit,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostListener, Injector, OnDestroy, OnInit, TemplateRef, ViewChild, inject } from '@angular/core';
 import {
   CalendarOptions,
   DateSelectArg,
@@ -143,6 +133,27 @@ export type TeamPlannerViewOptions = Record<TeamPlannerViewOptionKey, RawOptions
   standalone: false,
 })
 export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  private configuration = inject(ConfigurationService);
+  private principalsResourceService = inject(PrincipalsResourceService);
+  private capabilitiesResourceService = inject(CapabilitiesResourceService);
+  private wpTableFilters = inject(WorkPackageViewFiltersService);
+  private querySpace = inject(IsolatedQuerySpace);
+  private currentProject = inject(CurrentProjectService);
+  private I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly calendar = inject(OpCalendarService);
+  readonly workPackagesCalendar = inject(OpWorkPackagesCalendarService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly calendarDrag = inject(CalendarDragDropService);
+  readonly actions$ = inject(ActionsService);
+  readonly toastService = inject(ToastService);
+  readonly loadingIndicatorService = inject(LoadingIndicatorService);
+  readonly weekdayService = inject(WeekdayService);
+  readonly deviceService = inject(DeviceService);
+
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
 
   @ViewChild('ucCalendar', { read: ElementRef })
@@ -402,31 +413,6 @@ export class TeamPlannerComponent extends UntilDestroyedMixin implements OnInit,
       },
     },
   };
-
-  constructor(
-    private configuration:ConfigurationService,
-    private principalsResourceService:PrincipalsResourceService,
-    private capabilitiesResourceService:CapabilitiesResourceService,
-    private wpTableFilters:WorkPackageViewFiltersService,
-    private querySpace:IsolatedQuerySpace,
-    private currentProject:CurrentProjectService,
-    private I18n:I18nService,
-    readonly injector:Injector,
-    readonly calendar:OpCalendarService,
-    readonly workPackagesCalendar:OpWorkPackagesCalendarService,
-    readonly halEditing:HalResourceEditingService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly schemaCache:SchemaCacheService,
-    readonly apiV3Service:ApiV3Service,
-    readonly calendarDrag:CalendarDragDropService,
-    readonly actions$:ActionsService,
-    readonly toastService:ToastService,
-    readonly loadingIndicatorService:LoadingIndicatorService,
-    readonly weekdayService:WeekdayService,
-    readonly deviceService:DeviceService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     registerEffectCallbacks(this, this.untilDestroyed());

--- a/frontend/src/app/features/team-planner/team-planner/team-planner-entry.component.ts
+++ b/frontend/src/app/features/team-planner/team-planner/team-planner-entry.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  OnDestroy,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnDestroy, inject } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
@@ -16,7 +11,9 @@ import {
   standalone: false,
 })
 export class TeamPlannerEntryComponent implements OnDestroy {
-  constructor(readonly elementRef:ElementRef) {
+  readonly elementRef = inject(ElementRef);
+
+  constructor() {
     populateInputsFromDataset(this);
     document.body.classList.add('router--team-planner');
   }

--- a/frontend/src/app/features/user-preferences/state/user-preferences.service.ts
+++ b/frontend/src/app/features/user-preferences/state/user-preferences.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { ApiV3UserPreferencesPaths } from 'core-app/core/apiv3/endpoints/users/apiv3-user-preferences-paths';
@@ -9,16 +9,13 @@ import { UserPreferencesQuery } from 'core-app/features/user-preferences/state/u
 
 @Injectable({ providedIn: 'root' })
 export class UserPreferencesService {
+  private apiV3Service = inject(ApiV3Service);
+  private toastService = inject(ToastService);
+  private I18n = inject(I18nService);
+
   readonly store = new UserPreferencesStore();
 
   readonly query = new UserPreferencesQuery(this.store);
-
-  constructor(
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-    private I18n:I18nService,
-  ) {
-  }
 
   get(user:string):void {
     this.store.setLoading(true);

--- a/frontend/src/app/features/work-packages/components/back-routing/back-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { BackRoutingService } from 'core-app/features/work-packages/components/back-routing/back-routing.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -38,17 +38,14 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   standalone: false,
 })
 export class BackButtonComponent {
+  readonly backRoutingService = inject(BackRoutingService);
+  readonly I18n = inject(I18nService);
+
   @Input() public linkClass:string;
 
   public text = {
     goBack: this.I18n.t('js.button_back'),
   };
-
-  constructor(
-    readonly backRoutingService:BackRoutingService,
-    readonly I18n:I18nService,
-  ) {
-  }
 
   public goBack():void {
     this.backRoutingService.goBack();

--- a/frontend/src/app/features/work-packages/components/back-routing/back-routing.service.ts
+++ b/frontend/src/app/features/work-packages/components/back-routing/back-routing.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { StateService, Transition } from '@uirouter/core';
 import { KeepTabService } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
@@ -40,14 +40,13 @@ export interface BackRouteOptions {
 
 @Injectable({ providedIn: 'root' })
 export class BackRoutingService {
+  readonly injector = inject(Injector);
+
   @InjectField() private $state:StateService;
 
   @InjectField() private keepTab:KeepTabService;
 
   private _backRoute:BackRouteOptions;
-
-  constructor(readonly injector:Injector) {
-  }
 
   private goToOtherState(route:string, params:Record<string, unknown>):Promise<unknown> {
     return this.$state.go(route, params);

--- a/frontend/src/app/features/work-packages/components/edit-actions-bar/wp-edit-actions-bar.component.ts
+++ b/frontend/src/app/features/work-packages/components/edit-actions-bar/wp-edit-actions-bar.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
 
@@ -39,6 +37,10 @@ import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-f
   standalone: false,
 })
 export class WorkPackageEditActionsBarComponent {
+  private I18n = inject(I18nService);
+  private editForm = inject(EditFormComponent);
+  private cdRef = inject(ChangeDetectorRef);
+
   @Output() public onSave = new EventEmitter<void>();
 
   @Output() public onCancel = new EventEmitter<void>();
@@ -49,11 +51,6 @@ export class WorkPackageEditActionsBarComponent {
     save: this.I18n.t('js.button_save'),
     cancel: this.I18n.t('js.button_cancel'),
   };
-
-  constructor(private I18n:I18nService,
-    private editForm:EditFormComponent,
-    private cdRef:ChangeDetectorRef) {
-  }
 
   public set saving(active:boolean) {
     this._saving = active;

--- a/frontend/src/app/features/work-packages/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
+++ b/frontend/src/app/features/work-packages/components/filters/abstract-filter-date-time-value/abstract-filter-date-time-value.controller.ts
@@ -28,21 +28,17 @@
 
 import { Moment } from 'moment';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { OnInit, Directive } from '@angular/core';
+import { OnInit, Directive, inject } from '@angular/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 
 @Directive()
 export abstract class AbstractDateTimeValueController extends UntilDestroyedMixin implements OnInit {
-  public filter:QueryFilterInstanceResource;
+  protected I18n = inject(I18nService);
+  protected timezoneService = inject(TimezoneService);
 
-  constructor(
-    protected I18n:I18nService,
-    protected timezoneService:TimezoneService,
-  ) {
-    super();
-  }
+  public filter:QueryFilterInstanceResource;
 
   ngOnInit() {
     this.filter.values = (this.filter.values as string[]).filter((value) => (value === '' || this.timezoneService.isValidISODateTime(value)));

--- a/frontend/src/app/features/work-packages/components/filters/filter-boolean-value/filter-boolean-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-boolean-value/filter-boolean-value.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
@@ -38,14 +38,13 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
   standalone: false,
 })
 export class FilterBooleanValueComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() public shouldFocus = false;
 
   @Input() public filter:QueryFilterInstanceResource;
 
   @Output() public filterChanged = new EventEmitter<QueryFilterInstanceResource>();
-
-  constructor(readonly I18n:I18nService) {
-  }
 
   public get value():HalResource | string {
     // Boolean fields should be initialized as true by default

--- a/frontend/src/app/features/work-packages/components/filters/filter-container/filter-container.directive.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-container/filter-container.directive.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, Output, inject } from '@angular/core';
 import {
   WorkPackageViewFiltersService,
 } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
@@ -55,6 +47,11 @@ import { WorkPackagesListService } from 'core-app/features/work-packages/compone
   standalone: false,
 })
 export class WorkPackageFilterContainerComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly wpFiltersService = inject(WorkPackageFiltersService);
+  readonly wpListService = inject(WorkPackagesListService);
+
   @Input() showFilterButton = false;
 
   @Input() filterButtonText:string = I18n.t('js.button_filter');
@@ -67,12 +64,7 @@ export class WorkPackageFilterContainerComponent extends UntilDestroyedMixin imp
 
   public loaded = false;
 
-  constructor(
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly wpFiltersService:WorkPackageFiltersService,
-    readonly wpListService:WorkPackagesListService,
-  ) {
+  constructor() {
     super();
     this.visible$ = this.wpFiltersService.observeUntil(componentDestroyed(this));
   }

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-time-value/filter-date-time-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-time-value/filter-date-time-value.component.ts
@@ -26,20 +26,11 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  HostBinding,
-  OnInit,
-  Output,
-} from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ChangeDetectionStrategy, Component, Input, HostBinding, OnInit, Output } from '@angular/core';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { Moment } from 'moment';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { AbstractDateTimeValueController } from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller';
 
@@ -64,11 +55,6 @@ export class FilterDateTimeValueComponent extends AbstractDateTimeValueControlle
   @Input() public filter:QueryFilterInstanceResource;
 
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
-
-  constructor(readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService) {
-    super(I18n, timezoneService);
-  }
 
   public get value():HalResource|string {
     return this.filter.values[0];

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-times-value/filter-date-times-value.component.ts
@@ -27,18 +27,9 @@
 //++
 
 import { Moment } from 'moment';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, Output } from '@angular/core';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { AbstractDateTimeValueController } from '../abstract-filter-date-time-value/abstract-filter-date-time-value.controller';
 import { validDate } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
@@ -68,13 +59,6 @@ export class FilterDateTimesValueComponent extends AbstractDateTimeValueControll
   readonly text = {
     spacer: this.I18n.t('js.filter.value_spacer'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-  ) {
-    super(I18n, timezoneService);
-  }
 
   public get begin():string {
     return (this.filter.values[0] || '') as string;

--- a/frontend/src/app/features/work-packages/components/filters/filter-date-value/filter-date-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-date-value/filter-date-value.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -51,6 +45,9 @@ import moment from 'moment-timezone';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FilterDateValueComponent extends UntilDestroyedMixin {
+  readonly timezoneService = inject(TimezoneService);
+  readonly I18n = inject(I18nService);
+
   @HostBinding('id') get id() {
     return `div-values-${this.filter.id}`;
   }
@@ -60,11 +57,6 @@ export class FilterDateValueComponent extends UntilDestroyedMixin {
   @Input() public filter:QueryFilterInstanceResource;
 
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
-
-  constructor(readonly timezoneService:TimezoneService,
-    readonly I18n:I18nService) {
-    super();
-  }
 
   public get value():string {
     return this.filter.values[0] as string;

--- a/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-dates-value/filter-dates-value.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import moment from 'moment';
@@ -51,6 +45,9 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FilterDatesValueComponent extends UntilDestroyedMixin {
+  readonly timezoneService = inject(TimezoneService);
+  readonly I18n = inject(I18nService);
+
   @HostBinding('id') get id() {
     return `div-values-${this.filter.id}`;
   }
@@ -66,13 +63,6 @@ export class FilterDatesValueComponent extends UntilDestroyedMixin {
   readonly text = {
     spacer: this.I18n.t('js.filter.value_spacer'),
   };
-
-  constructor(
-    readonly timezoneService:TimezoneService,
-    readonly I18n:I18nService,
-  ) {
-    super();
-  }
 
   public get value():string[] {
     return (this.filter.values || []) as string[];

--- a/frontend/src/app/features/work-packages/components/filters/filter-integer-value/filter-integer-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-integer-value/filter-integer-value.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -45,16 +45,14 @@ import { QueryFilterResource } from 'core-app/features/hal/resources/query-filte
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FilterIntegerValueComponent extends UntilDestroyedMixin {
+  readonly I18n = inject(I18nService);
+  readonly schemaCache = inject(SchemaCacheService);
+
   @Input() public shouldFocus = false;
 
   @Input() public filter:QueryFilterInstanceResource;
 
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this));
-
-  constructor(readonly I18n:I18nService,
-    readonly schemaCache:SchemaCacheService) {
-    super();
-  }
 
   public get value() {
     return parseInt(this.filter.values[0] as string);

--- a/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-project/filter-project.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
@@ -48,6 +48,10 @@ import { IAPIFilter } from 'core-app/shared/components/autocompleter/op-autocomp
   standalone: false,
 })
 export class FilterProjectComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentProjectService = inject(CurrentProjectService);
+
   @Input() public shouldFocus = false;
 
   @Input() public filter:QueryFilterInstanceResource;
@@ -55,14 +59,6 @@ export class FilterProjectComponent extends UntilDestroyedMixin implements OnIni
   @Output() public filterChanged = new DebouncedEventEmitter<QueryFilterInstanceResource>(componentDestroyed(this), 0);
 
   additionalProjectApiFilters:IAPIFilter[] = [];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentProjectService:CurrentProjectService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     const projectID = this.currentProjectService.id;

--- a/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-searchable-multiselect-value/filter-searchable-multiselect-value.component.ts
@@ -10,16 +10,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { take } from 'rxjs/internal/operators/take';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, ViewChild, inject } from '@angular/core';
 
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
@@ -44,6 +35,14 @@ import { MAGIC_FILTER_AUTOCOMPLETE_PAGE_SIZE } from 'core-app/core/apiv3/helpers
   standalone: false,
 })
 export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMixin implements OnInit {
+  readonly halResourceService = inject(HalResourceService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
+  protected currentProject = inject(CurrentProjectService);
+  protected currentUser = inject(CurrentUserService);
+  readonly halNotification = inject(HalResourceNotificationService);
+
   @Input() public filter:QueryFilterInstanceResource;
 
   @Input() public shouldFocus = false;
@@ -84,18 +83,6 @@ export class FilterSearchableMultiselectValueComponent extends UntilDestroyedMix
   }
 
   @ViewChild('ngSelectInstance', { static: true }) ngSelectInstance:NgSelectComponent;
-
-  constructor(
-    readonly halResourceService:HalResourceService,
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-    protected currentProject:CurrentProjectService,
-    protected currentUser:CurrentUserService,
-    readonly halNotification:HalResourceNotificationService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     if (this.filter.id === 'id') {

--- a/frontend/src/app/features/work-packages/components/filters/filter-string-value/filter-string-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-string-value/filter-string-value.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
@@ -44,6 +44,8 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class FilterStringValueComponent extends UntilDestroyedMixin {
+  readonly I18n = inject(I18nService);
+
   @Input() public shouldFocus = false;
 
   @Input() public filter:QueryFilterInstanceResource;
@@ -53,10 +55,6 @@ export class FilterStringValueComponent extends UntilDestroyedMixin {
   readonly text = {
     enter_text: this.I18n.t('js.work_packages.description_enter_text'),
   };
-
-  constructor(readonly I18n:I18nService) {
-    super();
-  }
 
   public get value():HalResource|string {
     return this.filter.values[0];

--- a/frontend/src/app/features/work-packages/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/filter-toggled-multiselect-value/filter-toggled-multiselect-value.component.ts
@@ -27,17 +27,7 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResourceSortingService } from 'core-app/features/hal/services/hal-resource-sorting.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -55,6 +45,14 @@ import { compareByHref } from 'core-app/shared/helpers/angular/tracking-function
   standalone: false,
 })
 export class FilterToggledMultiselectValueComponent implements OnInit, AfterViewInit {
+  readonly halResourceService = inject(HalResourceService);
+  readonly halSorting = inject(HalResourceSortingService);
+  readonly PathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentUser = inject(CurrentUserService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
+
   @Input() public shouldFocus = false;
 
   @Input() public filter:QueryFilterInstanceResource;
@@ -72,17 +70,6 @@ export class FilterToggledMultiselectValueComponent implements OnInit, AfterView
   readonly text = {
     placeholder: this.I18n.t('js.placeholders.selection'),
   };
-
-  constructor(
-    readonly halResourceService:HalResourceService,
-    readonly halSorting:HalResourceSortingService,
-    readonly PathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentUser:CurrentUserService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-  ) {
-  }
 
   ngOnInit():void {
     const values = (this.filter.currentSchema!.values!.allowedValues as HalResource[]);

--- a/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  HostBinding,
-  Input,
-  OnInit,
-  Output,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, OnInit, Output, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   compareByHref,
@@ -61,6 +52,12 @@ import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class QueryFilterComponent implements OnInit {
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly I18n = inject(I18nService);
+  readonly currentProject = inject(CurrentProjectService);
+
   @HostBinding('class.op-query-filter') className = true;
 
   @Input() public shouldFocus = false;
@@ -90,15 +87,6 @@ export class QueryFilterComponent implements OnInit {
     button_delete: this.I18n.t('js.button_delete'),
     incompatible_filter: this.I18n.t('js.work_packages.filters.baseline_incompatible'),
   };
-
-  constructor(
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpTableBaseline:WorkPackageViewBaselineService,
-    readonly schemaCache:SchemaCacheService,
-    readonly I18n:I18nService,
-    readonly currentProject:CurrentProjectService,
-  ) {
-  }
 
   public onFilterUpdated(filter:QueryFilterInstanceResource) {
     this.filter = filter;

--- a/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filters/query-filters.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { DebouncedEventEmitter } from 'core-app/shared/helpers/rxjs/debounced-event-emitter';
 import { NgSelectComponent } from '@ng-select/ng-select';
@@ -59,6 +50,13 @@ const ADD_FILTER_SELECT_INDEX = -1;
   standalone: false,
 })
 export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit, OnChanges {
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
+  readonly wpFiltersService = inject(WorkPackageFiltersService);
+  readonly I18n = inject(I18nService);
+  readonly alternativeSearchService = inject(AlternativeSearchService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @ViewChild(NgSelectComponent) public ngSelectComponent:NgSelectComponent;
 
   @Input() public filters:QueryFilterInstanceResource[];
@@ -87,17 +85,6 @@ export class QueryFiltersComponent extends UntilDestroyedMixin implements OnInit
     filter_by_text: this.I18n.t('js.work_packages.label_filter_by_text'),
     baseline_warning: this.I18n.t('js.work_packages.filters.baseline_warning'),
   };
-
-  constructor(
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpTableBaseline:WorkPackageViewBaselineService,
-    readonly wpFiltersService:WorkPackageFiltersService,
-    readonly I18n:I18nService,
-    readonly alternativeSearchService:AlternativeSearchService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     this.wpTableFilters.live$()

--- a/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/quick-filter-by-text-input/quick-filter-by-text-input.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
 import { Subject } from 'rxjs';
@@ -48,6 +48,10 @@ import { QueryFilterResource } from 'core-app/features/hal/resources/query-filte
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageFilterByTextInputComponent extends UntilDestroyedMixin {
+  readonly I18n = inject(I18nService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+
   @Output() public deactivateFilter = new EventEmitter<QueryFilterResource>();
 
   public text = {
@@ -63,9 +67,7 @@ export class WorkPackageFilterByTextInputComponent extends UntilDestroyedMixin {
   /** Input for search requests */
   public searchTermChanged:Subject<string> = new Subject<string>();
 
-  constructor(readonly I18n:I18nService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpTableFilters:WorkPackageViewFiltersService) {
+  constructor() {
     super();
 
     this.wpTableFilters

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-legends/baseline-legends.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  HostBinding,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostBinding, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -61,6 +54,14 @@ import { filter } from 'rxjs/operators';
   standalone: false,
 })
 export class OpBaselineLegendsComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly configuration = inject(ConfigurationService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @HostBinding('class.op-baseline-legends') className = true;
 
   public numAdded = 0;
@@ -85,18 +86,6 @@ export class OpBaselineLegendsComponent extends UntilDestroyedMixin implements O
     maintained_with_changes: this.I18n.t('js.baseline.legends.maintained_with_changes'),
     in_your_timezone: this.I18n.t('js.baseline.legends.in_your_timezone'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly wpTableBaseline:WorkPackageViewBaselineService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly schemaCache:SchemaCacheService,
-    readonly timezoneService:TimezoneService,
-    readonly configuration:ConfigurationService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline-modal/baseline-modal.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -40,6 +36,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   standalone: false,
 })
 export class OpBaselineModalComponent {
+  readonly I18n = inject(I18nService);
+
   @HostBinding('class.op-baseline-modal') className = true;
 
   public opened = false;
@@ -51,10 +49,6 @@ export class OpBaselineModalComponent {
     apply: this.I18n.t('js.baseline.apply'),
 
   };
-
-  constructor(
-    readonly I18n:I18nService,
-  ) {}
 
   public toggleOpen():void {
     this.opened = !this.opened;

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  HostBinding,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, OnInit, Output, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -71,6 +63,15 @@ const DEFAULT_SELECTED_TIME = '08:00';
   standalone: false,
 })
 export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
+  readonly halResourceService = inject(HalResourceService);
+  readonly weekdaysService = inject(WeekdayService);
+  readonly daysService = inject(DayResourceService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly configuration = inject(ConfigurationService);
+  readonly Banner = inject(BannersService);
+
   @HostBinding('class.op-baseline') className = true;
 
   @Output() submitted = new EventEmitter<void>();
@@ -161,19 +162,6 @@ export class OpBaselineComponent extends UntilDestroyedMixin implements OnInit {
       title: this.I18n.t('js.baseline.drop_down.between_two_specific_dates'),
     },
   ];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly wpTableBaseline:WorkPackageViewBaselineService,
-    readonly halResourceService:HalResourceService,
-    readonly weekdaysService:WeekdayService,
-    readonly daysService:DayResourceService,
-    readonly timezoneService:TimezoneService,
-    readonly configuration:ConfigurationService,
-    readonly Banner:BannersService,
-  ) {
-    super();
-  }
 
   public ngOnInit():void {
     this.userTimezone = this.timezoneService.userTimezone();

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb-parent.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -49,6 +43,11 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageBreadcrumbParentComponent {
+  protected readonly I18n = inject(I18nService);
+  protected readonly wpRelationsHierarchy = inject(WorkPackageRelationsHierarchyService);
+  protected readonly notificationService = inject(WorkPackageNotificationService);
+  protected readonly pathHelper = inject(PathHelperService);
+
   @Input() workPackage:WorkPackageResource;
 
   @Output() onSwitch = new EventEmitter<boolean>();
@@ -63,14 +62,6 @@ export class WorkPackageBreadcrumbParentComponent {
   };
 
   private editing:boolean;
-
-  public constructor(
-    protected readonly I18n:I18nService,
-    protected readonly wpRelationsHierarchy:WorkPackageRelationsHierarchyService,
-    protected readonly notificationService:WorkPackageNotificationService,
-    protected readonly pathHelper:PathHelperService,
-  ) {
-  }
 
   public canModifyParent():boolean {
     return !!this.workPackage.changeParent;

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -42,17 +42,15 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageBreadcrumbComponent {
+  private I18n = inject(I18nService);
+  private pathHelper = inject(PathHelperService);
+
   @Input() workPackage:WorkPackageResource;
 
   public text = {
     parent: this.I18n.t('js.relations_hierarchy.parent_headline'),
     hierarchy: this.I18n.t('js.relations_hierarchy.hierarchy_headline'),
   };
-
-  constructor(
-    private I18n:I18nService,
-    private pathHelper:PathHelperService,
-  ) {}
 
   public inputActive = false;
 

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-create-button/wp-create-button.component.ts
@@ -27,7 +27,7 @@
 //++
 
 import { StateService, TransitionService } from '@uirouter/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { Observable } from 'rxjs';
@@ -43,6 +43,14 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
   standalone: false,
 })
 export class WorkPackageCreateButtonComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  readonly $state = inject(StateService);
+  readonly currentUser = inject(CurrentUserService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly transition = inject(TransitionService);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() stateName$:Observable<string>;
 
   @Input() routedFromAngular = true;
@@ -63,18 +71,6 @@ export class WorkPackageCreateButtonComponent extends UntilDestroyedMixin implem
     createButton: this.I18n.t('js.label_work_package'),
     explanation: this.I18n.t('js.label_create_work_package'),
   };
-
-  constructor(
-    readonly $state:StateService,
-    readonly currentUser:CurrentUserService,
-    readonly currentProject:CurrentProjectService,
-    readonly authorisationService:AuthorisationService,
-    readonly transition:TransitionService,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this.projectIdentifier = this.currentProject.identifier;

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-details-view-button/wp-details-view-button.component.ts
@@ -28,9 +28,7 @@
 
 import { WorkPackageViewFocusService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service';
 import { StateService, TransitionService } from '@uirouter/core';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, inject } from '@angular/core';
 import { AbstractWorkPackageButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-buttons.module';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { States } from 'core-app/core/states/states.service';
@@ -44,6 +42,14 @@ import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-p
   standalone: false,
 })
 export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageButtonComponent implements OnDestroy {
+  readonly $state = inject(StateService);
+  readonly I18n:I18nService;
+  readonly transitions = inject(TransitionService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  states = inject(States);
+  wpTableFocus = inject(WorkPackageViewFocusService);
+  keepTab = inject(KeepTabService);
+
   public projectIdentifier:string;
 
   public accessKey = 8;
@@ -64,16 +70,12 @@ export class WorkPackageDetailsViewButtonComponent extends AbstractWorkPackageBu
 
   private transitionListener:Function;
 
-  constructor(
-    readonly $state:StateService,
-    readonly I18n:I18nService,
-    readonly transitions:TransitionService,
-    readonly cdRef:ChangeDetectorRef,
-    public states:States,
-    public wpTableFocus:WorkPackageViewFocusService,
-    public keepTab:KeepTabService,
-  ) {
+  constructor() {
+    const I18n = inject(I18nService);
+
     super(I18n);
+    this.I18n = I18n;
+
 
     this.activateLabel = I18n.t('js.button_open_details');
     this.deactivateLabel = I18n.t('js.button_close_details');

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-filter-button/wp-filter-button.component.ts
@@ -28,9 +28,7 @@
 
 import { AbstractWorkPackageButtonComponent } from 'core-app/features/work-packages/components/wp-buttons/wp-buttons.module';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
 import { componentDestroyed } from '@w11k/ngx-componentdestroyed';
 import { WorkPackageFiltersService } from 'core-app/features/work-packages/components/filters/wp-filters/wp-filters.service';
@@ -42,6 +40,11 @@ import { WorkPackageFiltersService } from 'core-app/features/work-packages/compo
   standalone: false,
 })
 export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit {
+  readonly I18n:I18nService;
+  protected cdRef = inject(ChangeDetectorRef);
+  protected wpFiltersService = inject(WorkPackageFiltersService);
+  protected wpTableFilters = inject(WorkPackageViewFiltersService);
+
   public count:number;
 
   public initialized = false;
@@ -52,13 +55,12 @@ export class WorkPackageFilterButtonComponent extends AbstractWorkPackageButtonC
 
   public title = this.I18n.t('js.work_packages.filters.title');
 
-  constructor(
-    readonly I18n:I18nService,
-    protected cdRef:ChangeDetectorRef,
-    protected wpFiltersService:WorkPackageFiltersService,
-    protected wpTableFilters:WorkPackageViewFiltersService,
-  ) {
+  constructor() {
+    const I18n = inject(I18nService);
+
     super(I18n);
+
+    this.I18n = I18n;
   }
 
   ngOnInit():void {

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-mark-notification-button/work-package-mark-notification-button.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-view-base/state/wp-single-view.service';
@@ -10,17 +10,14 @@ import { WpSingleViewService } from 'core-app/features/work-packages/routing/wp-
   standalone: false,
 })
 export class WorkPackageMarkNotificationButtonComponent {
+  private I18n = inject(I18nService);
+  private storeService = inject(WpSingleViewService);
+
   @Input() public workPackage:WorkPackageResource;
 
   text = {
     mark_as_read: this.I18n.t('js.notifications.center.mark_as_read'),
   };
-
-  constructor(
-    private I18n:I18nService,
-    private storeService:WpSingleViewService,
-  ) {
-  }
 
   markAllBelongingNotificationsAsRead():void {
     this.storeService.markAllAsRead();

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ActionsService } from 'core-app/core/state/actions/actions.service';
@@ -51,22 +51,18 @@ import { filter, map, startWith, switchMap } from 'rxjs/operators';
   standalone: false,
 })
 export class WorkPackageReminderButtonComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly opModalService = inject(OpModalService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly actions$ = inject(ActionsService);
+  readonly storeService = inject(IanBellService);
+
   @Input() public workPackage:WorkPackageResource;
 
   hasReminder$:Observable<boolean>;
 
   public buttonTitle = this.I18n.t('js.work_packages.reminders.button_label');
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly opModalService:OpModalService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly apiV3Service:ApiV3Service,
-    readonly actions$:ActionsService,
-    readonly storeService:IanBellService,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     const reminderModalUpdated$ = this

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-reminder-button/wp-reminder-context-menu.directive.ts
@@ -1,5 +1,4 @@
-import { Directive, ElementRef, Input, OnInit } from '@angular/core';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
+import { Directive, Input, OnInit, inject } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -14,19 +13,13 @@ import { ReminderPreset, REMINDER_PRESET_OPTIONS } from 'core-app/features/work-
   standalone: false,
 })
 export class WorkPackageReminderContextMenuDirective extends OpContextMenuTrigger implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly opModalService = inject(OpModalService);
+
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('wpReminderContextMenu-workPackage') workPackage:WorkPackageResource;
 
   protected items:OpContextMenuItem[] = [];
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly I18n:I18nService,
-    readonly opModalService:OpModalService,
-  ) {
-    super(elementRef, opContextMenu);
-  }
 
   ngOnInit() {
     this.buildItems();

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-settings-button/wp-settings-button.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -39,6 +35,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   standalone: false,
 })
 export class WorkPackageSettingsButtonComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() hideTableOptions = false;
 
   @Input() showCalendarSharingOption = false;
@@ -46,7 +44,4 @@ export class WorkPackageSettingsButtonComponent {
   public text = {
     more_actions: this.I18n.t('js.button_more_actions'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-share-button/wp-share-button.component.ts
@@ -27,7 +27,7 @@
 //++
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
@@ -51,6 +51,13 @@ import { CollectionResource } from 'core-app/features/hal/resources/collection-r
   standalone: false,
 })
 export class WorkPackageShareButtonComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly opModalService = inject(OpModalService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly bannersService = inject(BannersService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly actions$ = inject(ActionsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   showEnterpriseIcon = !this.bannersService.allowsTo('work_package_sharing');
@@ -60,17 +67,6 @@ export class WorkPackageShareButtonComponent extends UntilDestroyedMixin impleme
   public text = {
     share: this.I18n.t('js.sharing.share'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly opModalService:OpModalService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly bannersService:BannersService,
-    readonly apiV3Service:ApiV3Service,
-    readonly actions$:ActionsService,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this.shareCount$ = this

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-status-button/wp-status-button.component.ts
@@ -28,9 +28,7 @@
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Highlighting } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -48,6 +46,11 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageStatusButtonComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly halEditing = inject(HalResourceEditingService);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public small = false;
@@ -57,13 +60,6 @@ export class WorkPackageStatusButtonComponent extends UntilDestroyedMixin implem
     workPackageReadOnly: this.I18n.t('js.work_packages.message_work_package_read_only'),
     workPackageStatusBlocked: this.I18n.t('js.work_packages.message_work_package_status_blocked'),
   };
-
-  constructor(readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly schemaCache:SchemaCacheService,
-    readonly halEditing:HalResourceEditingService) {
-    super();
-  }
 
   ngOnInit() {
     this.halEditing

--- a/frontend/src/app/features/work-packages/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/wp-timeline-toggle-button/wp-timeline-toggle-button.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewTimelineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service';
 import { TimelineZoomLevel } from 'core-app/features/hal/resources/query-resource';
@@ -48,6 +46,10 @@ export interface TimelineButtonText extends ButtonControllerText {
   standalone: false,
 })
 export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButtonComponent implements OnInit {
+  readonly I18n:I18nService;
+  readonly cdRef = inject(ChangeDetectorRef);
+  wpTableTimeline = inject(WorkPackageViewTimelineService);
+
   public buttonId = 'work-packages-timeline-toggle-button';
 
   public iconClass = 'icon-view-timeline';
@@ -68,10 +70,12 @@ export class WorkPackageTimelineButtonComponent extends AbstractWorkPackageButto
 
   public isMinLevel = false;
 
-  constructor(readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    public wpTableTimeline:WorkPackageViewTimelineService) {
+  constructor() {
+    const I18n = inject(I18nService);
+
     super(I18n);
+    this.I18n = I18n;
+
 
     this.activateLabel = I18n.t('js.gantt_chart.button_activate');
     this.deactivateLabel = I18n.t('js.gantt_chart.button_deactivate');

--- a/frontend/src/app/features/work-packages/components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-buttons/zen-mode-toggle-button/zen-mode-toggle-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 import { AbstractWorkPackageButtonComponent } from '../wp-buttons.module';
@@ -39,6 +39,9 @@ import screenfull from 'screenfull';
   standalone: false,
 })
 export class ZenModeButtonComponent extends AbstractWorkPackageButtonComponent {
+  readonly I18n:I18nService;
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public buttonId = 'work-packages-zen-mode-toggle-button';
 
   public buttonClass = 'toolbar-icon';
@@ -51,13 +54,12 @@ export class ZenModeButtonComponent extends AbstractWorkPackageButtonComponent {
 
   private deactivateLabel:string;
 
-  constructor(
-    // eslint-disable-next-line @angular-eslint/prefer-inject
-    readonly I18n:I18nService,
-    // eslint-disable-next-line @angular-eslint/prefer-inject
-    readonly cdRef:ChangeDetectorRef
-  ) {
+  constructor() {
+    const I18n = inject(I18nService);
+
     super(I18n);
+    this.I18n = I18n;
+
 
     this.activateLabel = I18n.t('js.zen_mode.button_activate');
     this.deactivateLabel = I18n.t('js.zen_mode.button_deactivate');

--- a/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-drag-and-drop.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, Optional } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageViewOrderService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service';
 import { States } from 'core-app/core/states/states.service';
@@ -16,6 +16,16 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class WorkPackageCardDragAndDropService {
+  readonly states = inject(States);
+  readonly injector = inject(Injector);
+  readonly reorderService = inject(WorkPackageViewOrderService);
+  readonly wpCreate = inject(WorkPackageCreateService);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly dragService = inject(DragAndDropService, { optional: true });
+  readonly wpInlineCreate = inject(WorkPackageInlineCreateService);
+
   private _workPackages:WorkPackageResource[];
 
   /** Whether the card view has an active inline created wp */
@@ -23,18 +33,6 @@ export class WorkPackageCardDragAndDropService {
 
   /** A reference to the component in use, to have access to the current input variables */
   public cardView:WorkPackageCardViewComponent;
-
-  public constructor(readonly states:States,
-    readonly injector:Injector,
-    readonly reorderService:WorkPackageViewOrderService,
-    readonly wpCreate:WorkPackageCreateService,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentProject:CurrentProjectService,
-    @Optional() readonly dragService:DragAndDropService,
-    readonly wpInlineCreate:WorkPackageInlineCreateService) {
-
-  }
 
   public init(componentRef:WorkPackageCardViewComponent) {
     this.cardView = componentRef;

--- a/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-view.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/services/wp-card-view.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 
 @Injectable()
 export class WorkPackageCardViewService {
-  public constructor(readonly querySpace:IsolatedQuerySpace) {
-  }
+  readonly querySpace = inject(IsolatedQuerySpace);
+
 
   public classIdentifier(wp:WorkPackageResource) {
     // The same class names are used for the proximity to the table representation.

--- a/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-card-view/wp-card-view.component.ts
@@ -1,16 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnInit,
-  Output,
-  ViewChild, OnDestroy,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Injector, Input, OnInit, Output, ViewChild, OnDestroy, inject } from '@angular/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
@@ -55,6 +43,25 @@ export type CardViewOrientation = 'horizontal'|'vertical';
   standalone: false,
 })
 export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, WorkPackageViewOutputs, OnDestroy {
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly states = inject(States);
+  readonly injector = inject(Injector);
+  readonly $state = inject(StateService);
+  readonly I18n = inject(I18nService);
+  readonly wpCreate = inject(WorkPackageCreateService);
+  readonly wpInlineCreate = inject(WorkPackageInlineCreateService);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly halEvents = inject(HalEventsService);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly causedUpdates = inject(CausedUpdatesService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly pathHelper = inject(PathHelperService);
+  readonly wpTableSelection = inject(WorkPackageViewSelectionService);
+  readonly wpViewOrder = inject(WorkPackageViewOrderService);
+  readonly cardView = inject(WorkPackageCardViewService);
+  readonly cardDragDrop = inject(WorkPackageCardDragAndDropService);
+  readonly deviceService = inject(DeviceService);
+
   @Input('dragOutOfHandler') public canDragOutOf:(wp:WorkPackageResource) => boolean;
 
   @Input() public dragInto:boolean;
@@ -118,27 +125,6 @@ export class WorkPackageCardViewComponent extends UntilDestroyedMixin implements
   };
 
   isNewResource = isNewResource;
-
-  constructor(readonly querySpace:IsolatedQuerySpace,
-    readonly states:States,
-    readonly injector:Injector,
-    readonly $state:StateService,
-    readonly I18n:I18nService,
-    readonly wpCreate:WorkPackageCreateService,
-    readonly wpInlineCreate:WorkPackageInlineCreateService,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly halEvents:HalEventsService,
-    readonly authorisationService:AuthorisationService,
-    readonly causedUpdates:CausedUpdatesService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly pathHelper:PathHelperService,
-    readonly wpTableSelection:WorkPackageViewSelectionService,
-    readonly wpViewOrder:WorkPackageViewOrderService,
-    readonly cardView:WorkPackageCardViewService,
-    readonly cardDragDrop:WorkPackageCardDragAndDropService,
-    readonly deviceService:DeviceService) {
-    super();
-  }
 
   ngOnInit() {
     this.registerCreationCallback();

--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { CustomActionResource } from 'core-app/features/hal/resources/custom-action-resource';
@@ -42,19 +40,15 @@ import { BannersService } from 'core-app/core/enterprise/banners.service';
   standalone: false,
 })
 export class WpCustomActionsComponent extends UntilDestroyedMixin implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly bannersService = inject(BannersService);
+
   @Input() workPackage:WorkPackageResource;
 
   actions:CustomActionResource[] = [];
 
   available = this.bannersService.allowsTo('custom_actions');
-
-  constructor(
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-    readonly bannersService:BannersService,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this

--- a/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-custom-actions/wp-custom-actions/wp-custom-action.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, OnInit, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { CustomActionResource } from 'core-app/features/hal/resources/custom-action-resource';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
@@ -51,21 +51,17 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
   standalone: false,
 })
 export class WpCustomActionComponent extends UntilDestroyedMixin implements OnInit {
+  private halResourceService = inject(HalResourceService);
+  private apiV3Service = inject(ApiV3Service);
+  private wpActivity = inject(WorkPackagesActivityService);
+  private notificationService = inject(WorkPackageNotificationService);
+  private halEditing = inject(HalResourceEditingService);
+  private halEvents = inject(HalEventsService);
+  private cdRef = inject(ChangeDetectorRef);
+
   @Input() workPackage:WorkPackageResource;
 
   @Input() action:CustomActionResource;
-
-  constructor(
-    private halResourceService:HalResourceService,
-    private apiV3Service:ApiV3Service,
-    private wpActivity:WorkPackagesActivityService,
-    private notificationService:WorkPackageNotificationService,
-    private halEditing:HalResourceEditingService,
-    private halEvents:HalEventsService,
-    private cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this

--- a/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-details/wp-details-toolbar.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -44,6 +44,11 @@ import { Observable, of } from 'rxjs';
   standalone: false,
 })
 export class WorkPackageSplitViewToolbarComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly configurationService = inject(ConfigurationService);
+  readonly currentUserService = inject(CurrentUserService);
+
   @Input() workPackage:WorkPackageResource;
 
   @Input() displayNotificationsButton:boolean;
@@ -54,14 +59,6 @@ export class WorkPackageSplitViewToolbarComponent implements OnInit {
   public text = {
     button_more: this.I18n.t('js.button_more'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly halEditing:HalResourceEditingService,
-    readonly configurationService:ConfigurationService,
-    readonly currentUserService:CurrentUserService,
-  ) {
-  }
 
   ngOnInit() {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access

--- a/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-edit/wp-edit-field/wp-replacement-label.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, Component, ElementRef, Input, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, inject } from '@angular/core';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
 
 @Component({
@@ -41,13 +39,12 @@ import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-f
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageReplacementLabelComponent implements OnInit {
+  protected wpeditForm = inject(EditFormComponent);
+  protected elementRef = inject(ElementRef);
+
   @Input() public fieldName:string;
 
   private element:HTMLElement;
-
-  constructor(protected wpeditForm:EditFormComponent,
-    protected elementRef:ElementRef) {
-  }
 
   ngOnInit() {
     this.element = this.elementRef.nativeElement;

--- a/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-form-group/wp-attribute-group.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, HostBinding, Injector, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Injector, Input, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
@@ -48,20 +48,16 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageFormAttributeGroupComponent extends UntilDestroyedMixin {
+  readonly I18n = inject(I18nService);
+  wpEditForm = inject(EditFormComponent);
+  protected injector = inject(Injector);
+
   @HostBinding('class.wp-attribute-group') className = true;
   @HostBinding('class.attributes-group--attributes') parentClassName = true;
 
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public group:GroupDescriptor;
-
-  constructor(
-    readonly I18n:I18nService,
-    public wpEditForm:EditFormComponent,
-    protected injector:Injector,
-  ) {
-    super();
-  }
 
   /**
    * Hide read-only fields, but only when in the create mode

--- a/frontend/src/app/features/work-packages/components/wp-grid/wp-grid.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-grid/wp-grid.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output, OnInit, inject } from '@angular/core';
 import { WorkPackageViewHighlightingService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service';
 import { CardViewOrientation } from 'core-app/features/work-packages/components/wp-card-view/wp-card-view.component';
 import { WorkPackageViewSortByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service';
@@ -74,6 +72,12 @@ import { WorkPackageViewOutputs } from 'core-app/features/work-packages/routing/
   standalone: false,
 })
 export class WorkPackagesGridComponent implements WorkPackageViewOutputs, OnInit {
+  readonly wpTableHighlight = inject(WorkPackageViewHighlightingService);
+  readonly wpTableSortBy = inject(WorkPackageViewSortByService);
+  readonly wpList = inject(WorkPackagesListService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public configuration:WorkPackageTableConfiguration;
 
   @Input() public showResizer = false;
@@ -95,13 +99,6 @@ export class WorkPackagesGridComponent implements WorkPackageViewOutputs, OnInit
   public gridOrientation:CardViewOrientation = 'horizontal';
 
   public highlightingMode:HighlightingMode = 'none';
-
-  constructor(readonly wpTableHighlight:WorkPackageViewHighlightingService,
-    readonly wpTableSortBy:WorkPackageViewSortByService,
-    readonly wpList:WorkPackagesListService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly cdRef:ChangeDetectorRef) {
-  }
 
   ngOnInit() {
     this.dragInto = this.configuration.dragAndDropEnabled;

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.component.ts
@@ -26,19 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostListener,
-  Injector,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostListener, Injector, Input, OnInit, Output, inject } from '@angular/core';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import {
   WorkPackageViewFocusService,
@@ -81,6 +69,19 @@ import { delegate, DelegateEvent } from '@knowledgecode/delegate';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
+  readonly injector = inject(Injector);
+  protected readonly elementRef = inject(ElementRef);
+  protected readonly schemaCache = inject(SchemaCacheService);
+  protected readonly I18n = inject(I18nService);
+  protected readonly querySpace = inject(IsolatedQuerySpace);
+  protected readonly cdRef = inject(ChangeDetectorRef);
+  protected readonly wpCreate = inject(WorkPackageCreateService);
+  protected readonly wpInlineCreate = inject(WorkPackageInlineCreateService);
+  protected readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  protected readonly wpTableFocus = inject(WorkPackageViewFocusService);
+  protected readonly halEditing = inject(HalResourceEditingService);
+  protected readonly authorisationService = inject(AuthorisationService);
+
   @Input() colspan:number;
 
   @Input() table:WorkPackageTable;
@@ -111,21 +112,6 @@ export class WorkPackageInlineCreateComponent extends UntilDestroyedMixin implem
 
   get isActive():boolean {
     return this.mode !== 'inactive';
-  }
-
-  constructor(public readonly injector:Injector,
-    protected readonly elementRef:ElementRef,
-    protected readonly schemaCache:SchemaCacheService,
-    protected readonly I18n:I18nService,
-    protected readonly querySpace:IsolatedQuerySpace,
-    protected readonly cdRef:ChangeDetectorRef,
-    protected readonly wpCreate:WorkPackageCreateService,
-    protected readonly wpInlineCreate:WorkPackageInlineCreateService,
-    protected readonly wpTableColumns:WorkPackageViewColumnsService,
-    protected readonly wpTableFocus:WorkPackageViewFocusService,
-    protected readonly halEditing:HalResourceEditingService,
-    protected readonly authorisationService:AuthorisationService) {
-    super();
   }
 
   ngOnInit() {

--- a/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-inline-create/wp-inline-create.service.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Injectable,
-  Injector,
-  OnDestroy,
-} from '@angular/core';
+import { Injectable, Injector, OnDestroy, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import {
   Observable,
@@ -45,14 +41,13 @@ import { CurrentProjectService } from 'core-app/core/current-project/current-pro
 
 @Injectable()
 export class WorkPackageInlineCreateService implements OnDestroy {
+  readonly injector = inject(Injector);
+
   @InjectField() I18n!:I18nService;
 
   @InjectField() protected readonly currentUser:CurrentUserService;
 
   @InjectField() protected readonly currentProject:CurrentProjectService;
-
-  constructor(readonly injector:Injector) {
-  }
 
   /**
    * A separate reference pane for the inline create component

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list-checksum.service.ts
@@ -28,16 +28,16 @@
 
 import { StateService, TransitionPromise } from '@uirouter/core';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageViewPagination } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-table-pagination';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { Subject } from 'rxjs';
 
 @Injectable()
 export class WorkPackagesListChecksumService {
-  constructor(protected UrlParamsHelper:UrlParamsHelperService,
-    protected $state:StateService) {
-  }
+  protected UrlParamsHelper = inject(UrlParamsHelperService);
+  protected $state = inject(StateService);
+
 
   public id:string|null;
 

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list-invalid-query.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list-invalid-query.service.ts
@@ -27,7 +27,7 @@
 //++
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { QueryFilterInstanceSchemaResource } from 'core-app/features/hal/resources/query-filter-instance-schema-resource';
 import { QueryFormResource } from 'core-app/features/hal/resources/query-form-resource';
@@ -39,8 +39,8 @@ import { QueryColumn } from '../wp-query/query-column';
 
 @Injectable()
 export class WorkPackagesListInvalidQueryService {
-  constructor(protected halResourceService:HalResourceService) {
-  }
+  protected halResourceService = inject(HalResourceService);
+
 
   public restoreQuery(query:QueryResource, form:QueryFormResource) {
     this.restoreFilters(query, form.payload, form.schema);

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-list.service.ts
@@ -31,7 +31,7 @@ import { States } from 'core-app/core/states/states.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { StateService } from '@uirouter/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import isPersistedResource from 'core-app/features/hal/helpers/is-persisted-resource';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
@@ -63,6 +63,23 @@ export interface QueryDefinition {
 
 @Injectable()
 export class WorkPackagesListService {
+  readonly injector = inject(Injector);
+  protected toastService = inject(ToastService);
+  readonly I18n = inject(I18nService);
+  protected UrlParamsHelper = inject(UrlParamsHelperService);
+  protected authorisationService = inject(AuthorisationService);
+  protected $state = inject(StateService);
+  protected apiV3Service = inject(ApiV3Service);
+  protected states = inject(States);
+  protected querySpace = inject(IsolatedQuerySpace);
+  protected pagination = inject(PaginationService);
+  protected configuration = inject(ConfigurationService);
+  protected wpTablePagination = inject(WorkPackageViewPaginationService);
+  protected wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+  protected wpListInvalidQueryService = inject(WorkPackagesListInvalidQueryService);
+  protected wpQueryView = inject(WorkPackagesQueryViewService);
+  protected submenuService = inject(SubmenuService);
+
   @InjectField() protected readonly currentUser:CurrentUserService;
 
   // We remember the query requests coming in so we can ensure only the latest request is being tended to
@@ -87,25 +104,6 @@ export class WorkPackagesListService {
       // diverting observables to the LATEST emitted.
       share(),
     );
-
-  constructor(
-    readonly injector:Injector,
-    protected toastService:ToastService,
-    readonly I18n:I18nService,
-    protected UrlParamsHelper:UrlParamsHelperService,
-    protected authorisationService:AuthorisationService,
-    protected $state:StateService,
-    protected apiV3Service:ApiV3Service,
-    protected states:States,
-    protected querySpace:IsolatedQuerySpace,
-    protected pagination:PaginationService,
-    protected configuration:ConfigurationService,
-    protected wpTablePagination:WorkPackageViewPaginationService,
-    protected wpStatesInitialization:WorkPackageStatesInitializationService,
-    protected wpListInvalidQueryService:WorkPackagesListInvalidQueryService,
-    protected wpQueryView:WorkPackagesQueryViewService,
-    protected submenuService:SubmenuService,
-  ) { }
 
   /**
    * Stream a query request as a HTTP observable. Each request to this method will

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-query-view.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { Observable } from 'rxjs';
@@ -8,10 +8,9 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
 
 @Injectable()
 export class WorkPackagesQueryViewService {
-  constructor(
-    protected $state:StateService,
-    protected apiV3Service:ApiV3Service,
-  ) { }
+  protected $state = inject(StateService);
+  protected apiV3Service = inject(ApiV3Service);
+
 
   create(query:QueryResource):Observable<IView> {
     if (!query.href) {

--- a/frontend/src/app/features/work-packages/components/wp-list/wp-states-initialization.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-list/wp-states-initialization.service.ts
@@ -2,7 +2,7 @@ import { States } from 'core-app/core/states/states.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageViewHighlightingService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service';
 import { take } from 'rxjs/operators';
 import { WorkPackageViewOrderService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service';
@@ -29,29 +29,28 @@ import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/
 
 @Injectable()
 export class WorkPackageStatesInitializationService {
-  constructor(
-    protected states:States,
-    protected querySpace:IsolatedQuerySpace,
-    protected wpTableColumns:WorkPackageViewColumnsService,
-    protected wpTableGroupBy:WorkPackageViewGroupByService,
-    protected wpTableGroupFold:WorkPackageViewCollapsedGroupsService,
-    protected wpTableSortBy:WorkPackageViewSortByService,
-    protected wpTableFilters:WorkPackageViewFiltersService,
-    protected wpTableSum:WorkPackageViewSumService,
-    protected wpTableTimeline:WorkPackageViewTimelineService,
-    protected wpTableHierarchies:WorkPackageViewHierarchiesService,
-    protected wpTableHighlighting:WorkPackageViewHighlightingService,
-    protected wpTableRelationColumns:WorkPackageViewRelationColumnsService,
-    protected wpTablePagination:WorkPackageViewPaginationService,
-    protected wpTableOrder:WorkPackageViewOrderService,
-    protected wpTableAdditionalElements:WorkPackageViewAdditionalElementsService,
-    protected apiV3Service:ApiV3Service,
-    protected wpListChecksumService:WorkPackagesListChecksumService,
-    protected authorisationService:AuthorisationService,
-    protected wpDisplayRepresentation:WorkPackageViewDisplayRepresentationService,
-    protected wpIncludeSubprojects:WorkPackageViewIncludeSubprojectsService,
-    protected wpTimestamps:WorkPackageViewBaselineService,
-  ) { }
+  protected states = inject(States);
+  protected querySpace = inject(IsolatedQuerySpace);
+  protected wpTableColumns = inject(WorkPackageViewColumnsService);
+  protected wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  protected wpTableGroupFold = inject(WorkPackageViewCollapsedGroupsService);
+  protected wpTableSortBy = inject(WorkPackageViewSortByService);
+  protected wpTableFilters = inject(WorkPackageViewFiltersService);
+  protected wpTableSum = inject(WorkPackageViewSumService);
+  protected wpTableTimeline = inject(WorkPackageViewTimelineService);
+  protected wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  protected wpTableHighlighting = inject(WorkPackageViewHighlightingService);
+  protected wpTableRelationColumns = inject(WorkPackageViewRelationColumnsService);
+  protected wpTablePagination = inject(WorkPackageViewPaginationService);
+  protected wpTableOrder = inject(WorkPackageViewOrderService);
+  protected wpTableAdditionalElements = inject(WorkPackageViewAdditionalElementsService);
+  protected apiV3Service = inject(ApiV3Service);
+  protected wpListChecksumService = inject(WorkPackagesListChecksumService);
+  protected authorisationService = inject(AuthorisationService);
+  protected wpDisplayRepresentation = inject(WorkPackageViewDisplayRepresentationService);
+  protected wpIncludeSubprojects = inject(WorkPackageViewIncludeSubprojectsService);
+  protected wpTimestamps = inject(WorkPackageViewBaselineService);
+
 
   /**
    * Initialize the query and table states from the given query and results.

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  Injector,
-  Input,
-  OnInit,
-  ViewChild, OnDestroy,
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, Injector, Input, OnInit, ViewChild, OnDestroy, inject } from '@angular/core';
 import {
   StateService,
   Transition,
@@ -63,6 +56,20 @@ import { HalSource } from 'core-app/features/hal/interfaces';
 
 @Directive()
 export class WorkPackageCreateComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  readonly injector = inject(Injector);
+  protected readonly $state = inject(StateService);
+  protected readonly I18n = inject(I18nService);
+  protected readonly titleService = inject(OpTitleService);
+  protected readonly notificationService = inject(WorkPackageNotificationService);
+  protected readonly states = inject(States);
+  protected readonly wpCreate = inject(WorkPackageCreateService);
+  protected readonly wpViewFocus = inject(WorkPackageViewFocusService);
+  protected readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  protected readonly pathHelper = inject(PathHelperService);
+  protected readonly apiV3Service = inject(ApiV3Service);
+  protected readonly currentProjectService = inject(CurrentProjectService);
+  protected readonly cdRef = inject(ChangeDetectorRef);
+
   public successState:string = splitViewRoute(this.$state);
 
   public cancelState:string = this.$state?.current?.data?.baseRoute;
@@ -88,24 +95,6 @@ export class WorkPackageCreateComponent extends UntilDestroyedMixin implements O
 
   /** Explicitly remember destroy state in this abstract base */
   protected destroyed = false;
-
-  constructor(
-    public readonly injector:Injector,
-    protected readonly $state:StateService,
-    protected readonly I18n:I18nService,
-    protected readonly titleService:OpTitleService,
-    protected readonly notificationService:WorkPackageNotificationService,
-    protected readonly states:States,
-    protected readonly wpCreate:WorkPackageCreateService,
-    protected readonly wpViewFocus:WorkPackageViewFocusService,
-    protected readonly wpTableFilters:WorkPackageViewFiltersService,
-    protected readonly pathHelper:PathHelperService,
-    protected readonly apiV3Service:ApiV3Service,
-    protected readonly currentProjectService:CurrentProjectService,
-    protected readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   public ngOnInit() {
     // In case the create form is still routed via Angular, the stateParams are empty. We then read the params from the Transition

--- a/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-new/wp-create.service.ts
@@ -26,10 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Injectable,
-  Injector,
-} from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import {
   firstValueFrom,
   Observable,
@@ -68,23 +65,23 @@ export const newWorkPackageHref = '/api/v3/work_packages/new';
 
 @Injectable()
 export class WorkPackageCreateService extends UntilDestroyedMixin {
+  protected injector = inject(Injector);
+  protected hooks = inject(HookService);
+  protected apiV3Service = inject(ApiV3Service);
+  protected halResourceService = inject(HalResourceService);
+  protected querySpace = inject(IsolatedQuerySpace);
+  protected authorisationService = inject(AuthorisationService);
+  protected halEditing = inject(HalResourceEditingService);
+  protected schemaCache = inject(SchemaCacheService);
+  protected halEvents = inject(HalEventsService);
+  protected attachmentsService = inject(AttachmentsResourceService);
+
   protected form:Promise<FormResource>|undefined;
 
   // Allow callbacks to happen on newly created work packages
   protected newWorkPackageCreatedSubject = new Subject<WorkPackageResource>();
 
-  constructor(
-    protected injector:Injector,
-    protected hooks:HookService,
-    protected apiV3Service:ApiV3Service,
-    protected halResourceService:HalResourceService,
-    protected querySpace:IsolatedQuerySpace,
-    protected authorisationService:AuthorisationService,
-    protected halEditing:HalResourceEditingService,
-    protected schemaCache:SchemaCacheService,
-    protected halEvents:HalEventsService,
-    protected attachmentsService:AttachmentsResourceService,
-  ) {
+  constructor() {
     super();
 
     this.halEditing

--- a/frontend/src/app/features/work-packages/components/wp-query/query-filters.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/query-filters.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryFormResource } from 'core-app/features/hal/resources/query-form-resource';
 import {
   QueryFilterInstanceSchemaResource,
@@ -11,8 +11,8 @@ import { CollectionResource } from 'core-app/features/hal/resources/collection-r
 
 @Injectable()
 export class QueryFiltersService {
-  constructor(protected schemaCache:SchemaCacheService) {
-  }
+  protected schemaCache = inject(SchemaCacheService);
+
 
   /**
    * Get the matching schema of the filter resource

--- a/frontend/src/app/features/work-packages/components/wp-query/query-param-listener.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/query-param-listener.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { WorkPackagesListChecksumService } from 'core-app/features/work-packages/components/wp-list/wp-list-checksum.service';
 import { WorkPackagesListService } from 'core-app/features/work-packages/components/wp-list/wp-list.service';
 import { TransitionService } from '@uirouter/core';
@@ -34,6 +34,8 @@ import { Subject } from 'rxjs';
 
 @Injectable()
 export class QueryParamListenerService {
+  readonly injector = inject(Injector);
+
   readonly wpListChecksumService:WorkPackagesListChecksumService = this.injector.get(WorkPackagesListChecksumService);
 
   readonly wpListService:WorkPackagesListService = this.injector.get(WorkPackagesListService);
@@ -44,7 +46,7 @@ export class QueryParamListenerService {
 
   public queryChangeListener:Function;
 
-  constructor(readonly injector:Injector) {
+  constructor() {
     this.listenForQueryParamsChanged();
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.spec.ts
@@ -26,15 +26,28 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { TestBed } from '@angular/core/testing';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
+import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
 
 describe('UrlParamsHelper', () => {
   const paginationStub = {
     getPerPage: () => 20,
   } as any;
 
-  const UrlParamsHelper = new UrlParamsHelperService(paginationStub);
+  let UrlParamsHelper:UrlParamsHelperService;
   let queryString;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        UrlParamsHelperService,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        { provide: PaginationService, useValue: paginationStub },
+      ],
+    });
+    UrlParamsHelper = TestBed.inject(UrlParamsHelperService);
+  });
 
   describe('buildQueryString', () => {
     const params = {

--- a/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
+++ b/frontend/src/app/features/work-packages/components/wp-query/url-params-helper.ts
@@ -31,7 +31,7 @@ import { QuerySortByResource } from 'core-app/features/hal/resources/query-sort-
 import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import isPersistedResource from 'core-app/features/hal/helpers/is-persisted-resource';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { ApiV3Filter, ApiV3FilterBuilder, FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
@@ -102,8 +102,8 @@ export interface QueryRequestParams {
 
 @Injectable({ providedIn: 'root' })
 export class UrlParamsHelperService {
-  public constructor(public paginationService:PaginationService) {
-  }
+  paginationService = inject(PaginationService);
+
 
   // copied more or less from angular buildUrl
   public buildQueryString(params:any) {

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-inline-create.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
@@ -41,11 +41,8 @@ import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 
 @Injectable()
 export class WpChildrenInlineCreateService extends WorkPackageInlineCreateService implements WpRelationInlineCreateServiceInterface {
-  constructor(readonly injector:Injector,
-    protected readonly wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
-    protected readonly schemaCache:SchemaCacheService) {
-    super(injector);
-  }
+  protected readonly wpRelationsHierarchyService = inject(WorkPackageRelationsHierarchyService);
+  protected readonly schemaCache = inject(SchemaCacheService);
 
   /**
    * A separate reference pane for the inline create component

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-query.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/children/wp-children-query.component.ts
@@ -26,11 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
 import { WorkPackageRelationsHierarchyService } from 'core-app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service';
 import { OpUnlinkTableAction } from 'core-app/features/work-packages/components/wp-table/table-actions/actions/unlink-table-action';
 import { OpTableActionFactory } from 'core-app/features/work-packages/components/wp-table/table-actions/table-action';
@@ -58,6 +57,14 @@ import { WorkPackageRelationsService } from 'core-app/features/work-packages/com
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryBase implements OnInit {
+  protected wpRelationsHierarchyService = inject(WorkPackageRelationsHierarchyService);
+  protected PathHelper = inject(PathHelperService);
+  protected wpInlineCreate = inject(WorkPackageInlineCreateService);
+  protected halEvents = inject(HalEventsService);
+  protected apiV3Service = inject(ApiV3Service);
+  readonly I18n = inject(I18nService);
+  readonly wpRelations = inject(WorkPackageRelationsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public query:QueryResource;
@@ -81,19 +88,6 @@ export class WorkPackageChildrenQueryComponent extends WorkPackageRelationQueryB
       (child:WorkPackageResource) => !!child.changeParent,
     ),
   ];
-
-  constructor(
-    protected wpRelationsHierarchyService:WorkPackageRelationsHierarchyService,
-    protected PathHelper:PathHelperService,
-    protected wpInlineCreate:WorkPackageInlineCreateService,
-    protected halEvents:HalEventsService,
-    protected apiV3Service:ApiV3Service,
-    protected queryUrlParamsHelper:UrlParamsHelperService,
-    readonly I18n:I18nService,
-    readonly wpRelations:WorkPackageRelationsService,
-    ) {
-    super(queryUrlParamsHelper);
-  }
 
   ngOnInit() {
     // Set reference target and reference class

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   WorkPackageInlineCreateService,
@@ -61,6 +61,16 @@ import { FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-bui
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpRelationInlineAddExistingComponent {
+  protected readonly parent = inject(WorkPackageInlineCreateComponent);
+  protected readonly wpInlineCreate = inject(WorkPackageInlineCreateService) as WpRelationInlineCreateServiceInterface;
+  protected apiV3Service = inject(ApiV3Service);
+  protected wpRelations = inject(WorkPackageRelationsService);
+  protected notificationService = inject(WorkPackageNotificationService);
+  protected halEvents = inject(HalEventsService);
+  protected urlParamsHelper = inject(UrlParamsHelperService);
+  protected querySpace = inject(IsolatedQuerySpace);
+  protected readonly I18n = inject(I18nService);
+
   public selectedWpId:string;
 
   public isDisabled = false;
@@ -70,18 +80,6 @@ export class WpRelationInlineAddExistingComponent {
   public text = {
     abort: this.I18n.t('js.relation_buttons.abort'),
   };
-
-  constructor(
-    protected readonly parent:WorkPackageInlineCreateComponent,
-    @Inject(WorkPackageInlineCreateService) protected readonly wpInlineCreate:WpRelationInlineCreateServiceInterface,
-    protected apiV3Service:ApiV3Service,
-    protected wpRelations:WorkPackageRelationsService,
-    protected notificationService:WorkPackageNotificationService,
-    protected halEvents:HalEventsService,
-    protected urlParamsHelper:UrlParamsHelperService,
-    protected querySpace:IsolatedQuerySpace,
-    protected readonly I18n:I18nService,
-  ) {}
 
   public addExisting() {
     if (_.isNil(this.selectedWpId)) {

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-inline-create.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
 import { WpRelationInlineAddExistingComponent } from 'core-app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component';
@@ -45,10 +45,6 @@ export class WpRelationInlineCreateService extends WorkPackageInlineCreateServic
   @InjectField() wpRelations:WorkPackageRelationsService;
 
   @InjectField() halEvents:HalEventsService;
-
-  constructor(public injector:Injector) {
-    super(injector);
-  }
 
   /**
    * A separate reference pane for the inline create component

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-query.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/relations/wp-relation-query.component.ts
@@ -26,17 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Inject,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
 import { OpUnlinkTableAction } from 'core-app/features/work-packages/components/wp-table/table-actions/actions/unlink-table-action';
 import { OpTableActionFactory } from 'core-app/features/work-packages/components/wp-table/table-actions/table-action';
 import { WorkPackageInlineCreateService } from 'core-app/features/work-packages/components/wp-inline-create/wp-inline-create.service';
@@ -63,6 +56,13 @@ import { GroupDescriptor } from 'core-app/features/work-packages/components/wp-s
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryBase implements OnInit {
+  protected readonly PathHelper = inject(PathHelperService);
+  protected readonly wpInlineCreate = inject(WorkPackageInlineCreateService) as WpRelationInlineCreateService;
+  protected readonly wpRelations = inject(WorkPackageRelationsService);
+  protected readonly halEvents = inject(HalEventsService);
+  protected readonly notificationService = inject(WorkPackageNotificationService);
+  protected readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public query:QueryResource;
@@ -88,16 +88,6 @@ export class WorkPackageRelationQueryComponent extends WorkPackageRelationQueryB
   ];
 
   public idFromLink = idFromLink;
-
-  constructor(protected readonly PathHelper:PathHelperService,
-              @Inject(WorkPackageInlineCreateService) protected readonly wpInlineCreate:WpRelationInlineCreateService,
-              protected readonly wpRelations:WorkPackageRelationsService,
-              protected readonly halEvents:HalEventsService,
-              protected readonly queryUrlParamsHelper:UrlParamsHelperService,
-              protected readonly notificationService:WorkPackageNotificationService,
-              protected readonly I18n:I18nService) {
-    super(queryUrlParamsHelper);
-  }
 
   ngOnInit() {
     const relationType = this.getRelationTypeFromQuery();

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/wp-relation-query.base.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/wp-relation-query.base.ts
@@ -27,7 +27,7 @@
 //++
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { Directive, ViewChild } from '@angular/core';
+import { Directive, ViewChild, inject } from '@angular/core';
 import { WorkPackageEmbeddedTableComponent } from 'core-app/features/work-packages/components/wp-table/embedded/wp-embedded-table.component';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
@@ -35,6 +35,8 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
 
 @Directive()
 export abstract class WorkPackageRelationQueryBase extends UntilDestroyedMixin {
+  protected queryUrlParamsHelper = inject(UrlParamsHelperService);
+
   public workPackage:WorkPackageResource;
 
   /** Input is either a query resource, or directly query props */
@@ -48,10 +50,6 @@ export abstract class WorkPackageRelationQueryBase extends UntilDestroyedMixin {
 
   /** Reference to the embedded table instance */
   @ViewChild('embeddedTable') protected embeddedTable?:WorkPackageEmbeddedTableComponent;
-
-  constructor(protected queryUrlParamsHelper:UrlParamsHelperService) {
-    super();
-  }
 
   /**
    * Request to refresh the results of the embedded table

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.component.ts
@@ -1,8 +1,6 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
@@ -23,6 +21,14 @@ import { Highlighting } from 'core-app/features/work-packages/components/wp-fast
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationRowComponent extends UntilDestroyedMixin implements OnInit {
+  protected apiV3Service = inject(ApiV3Service);
+  protected notificationService = inject(WorkPackageNotificationService);
+  protected wpRelations = inject(WorkPackageRelationsService);
+  protected halEvents = inject(HalEventsService);
+  protected I18n = inject(I18nService);
+  protected cdRef = inject(ChangeDetectorRef);
+  protected PathHelper = inject(PathHelperService);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public relatedWorkPackage:WorkPackageResource;
@@ -69,16 +75,6 @@ export class WorkPackageRelationRowComponent extends UntilDestroyedMixin impleme
       description: this.I18n.t('js.placeholders.relation_description'),
     },
   };
-
-  constructor(protected apiV3Service:ApiV3Service,
-    protected notificationService:WorkPackageNotificationService,
-    protected wpRelations:WorkPackageRelationsService,
-    protected halEvents:HalEventsService,
-    protected I18n:I18nService,
-    protected cdRef:ChangeDetectorRef,
-    protected PathHelper:PathHelperService) {
-    super();
-  }
 
   ngOnInit() {
     this.relation = this.relatedWorkPackage.relatedBy!;

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -1,10 +1,5 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
@@ -21,6 +16,12 @@ import { WorkPackageRelationsService } from '../wp-relations.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationsCreateComponent {
+  readonly I18n = inject(I18nService);
+  protected wpRelations = inject(WorkPackageRelationsService);
+  protected notificationService = inject(WorkPackageNotificationService);
+  protected halEvents = inject(HalEventsService);
+  protected cdRef = inject(ChangeDetectorRef);
+
   @Input() readonly workPackage:WorkPackageResource;
 
   public showRelationsCreateForm = false;
@@ -38,15 +39,6 @@ export class WorkPackageRelationsCreateComponent {
     relationType: this.I18n.t('js.relation_buttons.relation_type'),
     addNewRelation: this.I18n.t('js.relation_buttons.add_new_relation'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    protected wpRelations:WorkPackageRelationsService,
-    protected notificationService:WorkPackageNotificationService,
-    protected halEvents:HalEventsService,
-    protected cdRef:ChangeDetectorRef,
-  ) {
-  }
 
   public onSelected(workPackage?:WorkPackageResource) {
     if (workPackage) {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.component.ts
@@ -27,9 +27,7 @@
 //++
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import {
-  ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBinding, Input, Output, ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBinding, Input, Output, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -42,6 +40,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationsGroupComponent {
+  readonly I18n = inject(I18nService);
+
   @HostBinding('class.attributes-group') className = true;
 
   @Input() public relatedWorkPackages:WorkPackageResource[];
@@ -62,11 +62,6 @@ export class WorkPackageRelationsGroupComponent {
     groupByType: this.I18n.t('js.relation_buttons.group_by_wp_type'),
     groupByRelation: this.I18n.t('js.relation_buttons.group_by_relation_type'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-  ) {
-  }
 
   public get togglerText() {
     if (this.groupByWorkPackageType) {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.directive.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -49,6 +49,12 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationsHierarchyComponent extends UntilDestroyedMixin implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public relationType:string;
@@ -64,16 +70,6 @@ export class WorkPackageRelationsHierarchyComponent extends UntilDestroyedMixin 
   public canAddRelation:boolean;
 
   public childrenQueryProps:any;
-
-  constructor(
-    readonly apiV3Service:ApiV3Service,
-    readonly PathHelper:PathHelperService,
-    readonly I18n:I18nService,
-    readonly schemaCache:SchemaCacheService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   public text = {
     parentHeadline: this.I18n.t('js.relations_hierarchy.parent_headline'),

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-hierarchy/wp-relations-hierarchy.service.ts
@@ -29,7 +29,7 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { States } from 'core-app/core/states/states.service';
 import { StateService } from '@uirouter/core';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -37,14 +37,13 @@ import { HalEventsService } from 'core-app/features/hal/services/hal-events.serv
 
 @Injectable()
 export class WorkPackageRelationsHierarchyService {
-  constructor(protected $state:StateService,
-    protected states:States,
-    protected halEvents:HalEventsService,
-    protected notificationService:WorkPackageNotificationService,
-    protected pathHelper:PathHelperService,
-    protected apiV3Service:ApiV3Service) {
+  protected $state = inject(StateService);
+  protected states = inject(States);
+  protected halEvents = inject(HalEventsService);
+  protected notificationService = inject(WorkPackageNotificationService);
+  protected pathHelper = inject(PathHelperService);
+  protected apiV3Service = inject(ApiV3Service);
 
-  }
 
   public changeParent(workPackage:WorkPackageResource, parentId:string|null) {
     const payload:any = {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Input,
-  OnDestroy,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { filter, throttleTime } from 'rxjs/operators';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -53,6 +44,12 @@ import { HalEventsService } from 'core-app/features/hal/services/hal-events.serv
   standalone: false,
 })
 export class WorkPackageRelationsComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
+  private wpRelations = inject(WorkPackageRelationsService);
+  private apiV3Service = inject(ApiV3Service);
+  private halEvents = inject(HalEventsService);
+  private PathHelper = inject(PathHelperService);
+  private turboRequests = inject(TurboRequestsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   @ViewChild('frameElement') readonly relationTurboFrame:ElementRef<HTMLIFrameElement>;
@@ -60,16 +57,6 @@ export class WorkPackageRelationsComponent extends UntilDestroyedMixin implement
   turboFrameSrc:string;
 
   private turboFrameListener:EventListener = this.updateFrontendData.bind(this);
-
-  constructor(
-    private wpRelations:WorkPackageRelationsService,
-    private apiV3Service:ApiV3Service,
-    private halEvents:HalEventsService,
-    private PathHelper:PathHelperService,
-    private turboRequests:TurboRequestsService,
-) {
-    super();
-  }
 
   ngOnInit() {
     this.turboFrameSrc = `${this.PathHelper.staticBase}/work_packages/${this.workPackage.id}/relations_tab`;

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations.service.ts
@@ -1,7 +1,7 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { multiInput, MultiInputState, StatesGroup } from '@openproject/reactivestates';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { StateCacheService } from 'core-app/core/apiv3/cache/state-cache.service';
@@ -26,12 +26,12 @@ export class RelationStateGroup extends StatesGroup {
 
 @Injectable()
 export class WorkPackageRelationsService extends StateCacheService<RelationsStateValue> {
-  constructor(
-    private PathHelper:PathHelperService,
-    private apiV3Service:ApiV3Service,
-    private halResource:HalResourceService,
-    readonly turboRequests:TurboRequestsService,
-  ) {
+  private PathHelper = inject(PathHelperService);
+  private apiV3Service = inject(ApiV3Service);
+  private halResource = inject(HalResourceService);
+  readonly turboRequests = inject(TurboRequestsService);
+
+  constructor() {
     super(new RelationStateGroup().relations);
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
+++ b/frontend/src/app/features/work-packages/components/wp-reminder-modal/wp-reminder.modal.ts
@@ -1,15 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  OnInit,
-  ViewChild, AfterViewInit, OnDestroy,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild, AfterViewInit, OnDestroy, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -28,6 +18,11 @@ import { CollectionResource } from 'core-app/features/hal/resources/collection-r
   standalone: false,
 })
 export class WorkPackageReminderModalComponent extends OpModalComponent implements OnInit, AfterViewInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly actions$ = inject(ActionsService);
+  readonly apiV3Service = inject(ApiV3Service);
+
   @ViewChild('frameElement') frameElement:ElementRef<HTMLIFrameElement>;
 
   // Hide close button so it's not duplicated in primer (WP#51699)
@@ -48,16 +43,8 @@ export class WorkPackageReminderModalComponent extends OpModalComponent implemen
 
   private boundListener = this.turboSubmitEndListener.bind(this);
 
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef<HTMLElement>,
-    readonly pathHelper:PathHelperService,
-    readonly actions$:ActionsService,
-    readonly apiV3Service:ApiV3Service,
-  ) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    super();
 
     this.workPackage = this.locals.workPackage as WorkPackageResource;
     this.preset = this.locals.preset as ReminderPreset | undefined;

--- a/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.ts
+++ b/frontend/src/app/features/work-packages/components/wp-share-modal/wp-share.modal.ts
@@ -1,15 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -23,6 +13,10 @@ import { shareModalUpdated } from 'core-app/features/work-packages/components/wp
   standalone: false,
 })
 export class WorkPackageShareModalComponent extends OpModalComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly actions$ = inject(ActionsService);
+
   @ViewChild('frameElement') frameElement:ElementRef<HTMLIFrameElement>|undefined;
 
   // Hide close button so it's not duplicated in primer (WP#51699)
@@ -36,15 +30,8 @@ export class WorkPackageShareModalComponent extends OpModalComponent implements 
     button_close: this.I18n.t('js.button_close'),
   };
 
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef<HTMLElement>,
-    readonly pathHelper:PathHelperService,
-    readonly actions$:ActionsService,
-  ) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    super();
 
     this.workPackage = this.locals.workPackage as WorkPackageResource;
     this.frameSrc = this.pathHelper.workPackageSharePath(this.workPackage.id!);

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/activity-base.controller.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectorRef, Directive, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, OnInit, inject } from '@angular/core';
 import { UIRouterGlobals } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -40,24 +40,20 @@ import { UrlHelpers } from 'core-stimulus/controllers/dynamic/work-packages/acti
 
 @Directive()
 export class ActivityPanelBaseController extends UntilDestroyedMixin implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly storeService = inject(WpSingleViewService);
+  readonly browserDetector = inject(BrowserDetector);
+  readonly deviceService = inject(DeviceService);
+  readonly pathHelper = inject(PathHelperService);
+
   public workPackage:WorkPackageResource;
 
   public workPackageId:string;
 
   public turboFrameSrc:string;
-
-  constructor(
-    readonly apiV3Service:ApiV3Service,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly uiRouterGlobals:UIRouterGlobals,
-    readonly storeService:WpSingleViewService,
-    readonly browserDetector:BrowserDetector,
-    readonly deviceService:DeviceService,
-    readonly pathHelper:PathHelperService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     this.turboFrameSrc = this.buildTurboFrameSrc();

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/activity-panel/wp-activity.service.ts
@@ -28,17 +28,16 @@
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { WorkPackageLinkedResourceCache } from 'core-app/features/work-packages/components/wp-single-view-tabs/wp-linked-resource-cache.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 @Injectable()
 export class WorkPackagesActivityService extends WorkPackageLinkedResourceCache<HalResource[]> {
-  constructor(public ConfigurationService:ConfigurationService,
-    readonly timezoneService:TimezoneService) {
-    super();
-  }
+  ConfigurationService = inject(ConfigurationService);
+  readonly timezoneService = inject(TimezoneService);
+
 
   public get order() {
     return this.isReversed ? 'desc' : 'asc';

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -51,6 +46,12 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class WorkPackageFilesTabComponent implements OnInit {
+  private readonly i18n = inject(I18nService);
+  private readonly currentUserService = inject(CurrentUserService);
+  private readonly projectStoragesResourceService = inject(ProjectStoragesResourceService);
+  private readonly pathHelper = inject(PathHelperService);
+  private readonly turboRequests = inject(TurboRequestsService);
+
   @Input() workPackage:WorkPackageResource;
 
   text = {
@@ -66,14 +67,6 @@ export class WorkPackageFilesTabComponent implements OnInit {
   allowManageFileLinks$:Observable<boolean>;
 
   showAttachments:boolean;
-
-  constructor(
-    private readonly i18n:I18nService,
-    private readonly currentUserService:CurrentUserService,
-    private readonly projectStoragesResourceService:ProjectStoragesResourceService,
-    private readonly pathHelper:PathHelperService,
-    private readonly turboRequests:TurboRequestsService,
-  ) { }
 
   ngOnInit():void {
     const project = this.workPackage.project as HalResource;

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service.spec.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service.spec.ts
@@ -26,6 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
+import { TestBed } from '@angular/core/testing';
+import {
+  StateService,
+  TransitionService,
+  UIRouterGlobals,
+} from '@uirouter/core';
 import { KeepTabService } from './keep-tab.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -57,7 +63,20 @@ describe('keepTab service', () => {
       params: { tabIdentifier: 'activity' },
     };
 
-    keepTab = new KeepTabService($state, uiRouterGlobals, $transitions, pathHelper, currentProject);
+    TestBed.configureTestingModule({
+      providers: [
+        KeepTabService,
+        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+        { provide: StateService, useValue: $state },
+        { provide: UIRouterGlobals, useValue: uiRouterGlobals },
+        { provide: TransitionService, useValue: $transitions },
+        { provide: PathHelperService, useValue: pathHelper },
+        { provide: CurrentProjectService, useValue: currentProject },
+        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      ],
+    });
+
+    keepTab = TestBed.inject(KeepTabService);
 
     defaults = {
       showTab: 'work-packages.show.tabs',

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service.ts
@@ -33,24 +33,26 @@ import {
   UIRouterGlobals,
 } from '@uirouter/core';
 import { ReplaySubject } from 'rxjs';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { splitViewRoute } from 'core-app/features/work-packages/routing/split-view-routes.helper';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 
 @Injectable({ providedIn: 'root' })
 export class KeepTabService {
+  protected $state = inject(StateService);
+  protected uiRouterGlobals = inject(UIRouterGlobals);
+  protected $transitions = inject(TransitionService);
+  protected pathHelper = inject(PathHelperService);
+  protected currentProject = inject(CurrentProjectService);
+
   protected currentTab = 'overview';
 
   protected subject = new ReplaySubject<Record<string, string>>(1);
 
-  constructor(
-    protected $state:StateService,
-    protected uiRouterGlobals:UIRouterGlobals,
-    protected $transitions:TransitionService,
-    protected pathHelper:PathHelperService,
-    protected currentProject:CurrentProjectService,
-    ) {
+  constructor() {
+    const $transitions = this.$transitions;
+
     this.updateTabs();
     $transitions.onSuccess({}, (transition:Transition) => {
       this.updateTabs(transition.params('to').tabIdentifier);

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/overview-tab/overview-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -43,20 +43,16 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageOverviewTabComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly $state = inject(StateService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
 
   public workPackageId:string;
 
   public tabName = this.I18n.t('js.label_latest_activity');
-
-  public constructor(
-    readonly I18n:I18nService,
-    readonly $state:StateService,
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this.workPackageId = this.workPackage?.id || this.$state.params.workPackageId as string;

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/relations-tab/relations-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/relations-tab/relations-tab.component.ts
@@ -27,7 +27,7 @@
 //++
 
 import { UIRouterGlobals } from '@uirouter/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -43,18 +43,14 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageRelationsTabComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public workPackageId?:string;
 
   @Input() public workPackage:WorkPackageResource;
-
-  public constructor(
-    readonly I18n:I18nService,
-    readonly uiRouterGlobals:UIRouterGlobals,
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     const { workPackageId } = this.uiRouterGlobals.params as unknown as { workPackageId:string };

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/watchers-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, inject } from '@angular/core';
 import { UIRouterGlobals } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -50,6 +50,17 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
   standalone: false,
 })
 export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly elementRef = inject(ElementRef);
+  readonly wpWatchersService = inject(WorkPackageWatchersService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly pathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly turboRequests = inject(TurboRequestsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public workPackageId:string;
@@ -77,21 +88,6 @@ export class WorkPackageWatchersTabComponent extends UntilDestroyedMixin impleme
       placeholder: this.I18n.t('js.watchers.typeahead_placeholder'),
     },
   };
-
-  public constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    readonly wpWatchersService:WorkPackageWatchersService,
-    readonly uiRouterGlobals:UIRouterGlobals,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly loadingIndicator:LoadingIndicatorService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly pathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly turboRequests:TurboRequestsService,
-  ) {
-    super();
-  }
 
   public ngOnInit() {
     this.element = this.elementRef.nativeElement;

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watcher-entry.component.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UserResource } from 'core-app/features/hal/resources/user-resource';
 import { WorkPackageWatchersTabComponent } from './watchers-tab.component';
@@ -44,13 +39,12 @@ import { WorkPackageWatchersTabComponent } from './watchers-tab.component';
   standalone: false,
 })
 export class WorkPackageWatcherEntryComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly panelCtrl = inject(WorkPackageWatchersTabComponent);
+
   @Input() public watcher:UserResource;
 
   public text:{ remove:string };
-
-  constructor(readonly I18n:I18nService,
-    readonly panelCtrl:WorkPackageWatchersTabComponent) {
-  }
 
   ngOnInit():void {
     this.text = {

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Injector,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, OnInit, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { distinctUntilChanged, first, map } from 'rxjs/operators';
@@ -99,6 +91,23 @@ export const overflowingContainerAttribute = 'overflowingIdentifier';
   standalone: false,
 })
 export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implements OnInit {
+  protected readonly injector = inject(Injector);
+  private readonly states = inject(States);
+  private readonly I18n = inject(I18nService);
+  private readonly hook = inject(HookService);
+  private readonly $state = inject(StateService);
+  private readonly elementRef = inject(ElementRef);
+  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly PathHelper = inject(PathHelperService);
+  private readonly schemaCache = inject(SchemaCacheService);
+  private readonly currentProject = inject(CurrentProjectService);
+  private readonly halEditing = inject(HalResourceEditingService);
+  private readonly halResourceService = inject(HalResourceService);
+  private readonly currentUserService = inject(CurrentUserService);
+  private readonly displayFieldService = inject(DisplayFieldService);
+  private readonly projectsResourceService = inject(ProjectsResourceService);
+  private readonly projectStoragesService = inject(ProjectStoragesResourceService);
+
   @Input() public workPackage:WorkPackageResource;
 
   /** Should we show the project field */
@@ -144,27 +153,6 @@ export class WorkPackageSingleViewComponent extends UntilDestroyedMixin implemen
   element:HTMLElement;
 
   projectStorages = new BehaviorSubject<IProjectStorage[]>([]);
-
-  constructor(
-    protected readonly injector:Injector,
-    private readonly states:States,
-    private readonly I18n:I18nService,
-    private readonly hook:HookService,
-    private readonly $state:StateService,
-    private readonly elementRef:ElementRef,
-    private readonly cdRef:ChangeDetectorRef,
-    private readonly PathHelper:PathHelperService,
-    private readonly schemaCache:SchemaCacheService,
-    private readonly currentProject:CurrentProjectService,
-    private readonly halEditing:HalResourceEditingService,
-    private readonly halResourceService:HalResourceService,
-    private readonly currentUserService:CurrentUserService,
-    private readonly displayFieldService:DisplayFieldService,
-    private readonly projectsResourceService:ProjectsResourceService,
-    private readonly projectStoragesService:ProjectStoragesResourceService,
-  ) {
-    super();
-  }
 
   public ngOnInit():void {
     this.element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/features/work-packages/components/wp-subject/wp-subject.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-subject/wp-subject.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { UIRouterGlobals } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { randomString } from 'core-app/shared/helpers/random-string';
@@ -47,14 +43,10 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageSubjectComponent extends UntilDestroyedMixin {
+  protected uiRouterGlobals = inject(UIRouterGlobals);
+  protected apiV3Service = inject(ApiV3Service);
+
   @Input() workPackage:WorkPackageResource;
 
   public readonly uniqueElementIdentifier = `work-packages--subject-type-row-${randomString(16)}`;
-
-  constructor(
-    protected uiRouterGlobals:UIRouterGlobals,
-    protected apiV3Service:ApiV3Service,
-  ) {
-    super();
-  }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/config-menu/config-menu.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/config-menu/config-menu.component.ts
@@ -1,5 +1,5 @@
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { ChangeDetectionStrategy, Component, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, inject } from '@angular/core';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { WpTableConfigurationModalComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal';
@@ -14,16 +14,14 @@ import { WpTableConfigurationModalComponent } from 'core-app/features/work-packa
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackagesTableConfigMenuComponent {
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly opModalService = inject(OpModalService);
+  readonly opContextMenu = inject(OPContextMenuService);
+
   public text = {
     configureTable: this.I18n.t('js.toolbar.settings.configure_view'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly opModalService:OpModalService,
-    readonly opContextMenu:OPContextMenuService,
-  ) { }
 
   public openTableConfigurationModal() {
     this.opContextMenu.close();

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/columns-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/columns-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Injector, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { QueryColumn } from 'core-app/features/work-packages/components/wp-query/query-column';
 import {
@@ -20,6 +20,10 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationColumnsTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+
   public availableColumnsOptions = this.wpTableColumns.all.map((c) => this.column2Like(c));
 
   public availableColumns = this.wpTableColumns.all;
@@ -39,13 +43,6 @@ export class WpTableConfigurationColumnsTabComponent implements TabComponent, On
     inputLabel: this.I18n.t('js.label_add_columns'),
     inputDragLabel: this.I18n.t('js.label_manage_columns'),
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-) {
-  }
 
   public onSave() {
     this.wpTableColumns.setColumnsById(this.selectedColumns.map((c) => c.id));

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.ts
@@ -3,7 +3,7 @@ import { TabComponent } from 'core-app/features/work-packages/components/wp-tabl
 import { WorkPackageViewGroupByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
 import { WorkPackageViewHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
 import { WorkPackageViewSumService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sum.service';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit, inject } from '@angular/core';
 import { QueryGroupByResource } from 'core-app/features/hal/resources/query-group-by-resource';
 
 @Component({
@@ -16,6 +16,13 @@ import { QueryGroupByResource } from 'core-app/features/hal/resources/query-grou
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationDisplaySettingsTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  readonly wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  readonly wpTableSums = inject(WorkPackageViewSumService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   // Display mode
   public displayMode:'hierarchy'|'grouped'|'default' = 'default';
 
@@ -43,15 +50,6 @@ export class WpTableConfigurationDisplaySettingsTabComponent implements TabCompo
       hierarchy_hint: `— ${this.I18n.t('js.work_packages.table_configuration.hierarchy_hint')}`,
     },
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableGroupBy:WorkPackageViewGroupByService,
-    readonly wpTableHierarchies:WorkPackageViewHierarchiesService,
-    readonly wpTableSums:WorkPackageViewSumService,
-    readonly cdRef:ChangeDetectorRef,
-  ) { }
 
   public onSave() {
     // Update hierarchy state

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/filters-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/filters-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Injector, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   TabComponent,
@@ -19,6 +19,11 @@ import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/que
   standalone: false,
 })
 export class WpTableConfigurationFiltersTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpFiltersService = inject(WorkPackageFiltersService);
+
   public filters:QueryFilterInstanceResource[] = [];
 
   public eeShowBanners = false;
@@ -31,14 +36,6 @@ export class WpTableConfigurationFiltersTabComponent implements TabComponent, On
     upsellRelationColumns: this.I18n.t('js.modals.upsell_relation_columns'),
     upsellRelationColumnsLink: this.I18n.t('js.modals.upsell_relation_columns_link'),
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpFiltersService:WorkPackageFiltersService,
-  ) {
-  }
 
   ngOnInit() {
     this.wpTableFilters

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/highlighting-tab.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Injector,
-  ViewChild, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, ViewChild, OnInit, inject } from '@angular/core';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { WorkPackageViewHighlightingService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -22,6 +17,13 @@ import { repositionDropdownBugfix } from 'core-app/shared/components/autocomplet
   standalone: false,
 })
 export class WpTableConfigurationHighlightingTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly Banners = inject(BannersService);
+  readonly wpTableHighlight = inject(WorkPackageViewHighlightingService);
+
   // Display mode
   public highlightingMode:HighlightingMode = 'inline';
 
@@ -53,14 +55,6 @@ export class WpTableConfigurationHighlightingTabComponent implements TabComponen
     },
     more_info_link: enterpriseDocsUrl.tableHighlighting,
   };
-
-  constructor(readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly Banners:BannersService,
-    readonly wpTableHighlight:WorkPackageViewHighlightingService) {
-  }
 
   ngOnInit() {
     this.availableInlineHighlightedAttributes = this.availableHighlightedAttributes;

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewSortByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
@@ -30,6 +30,11 @@ export type SortingMode = 'automatic'|'manual';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationSortByTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableSortBy = inject(WorkPackageViewSortByService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public text = {
     title: this.I18n.t('js.label_sort_by'),
     placeholder: this.I18n.t('js.placeholders.default'),
@@ -60,13 +65,6 @@ export class WpTableConfigurationSortByTabComponent implements TabComponent, OnI
   public sortingMode:SortingMode = 'automatic';
 
   public manualSortColumn:SortColumn;
-
-  constructor(readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableSortBy:WorkPackageViewSortByService,
-    readonly cdRef:ChangeDetectorRef) {
-
-  }
 
   public onSave() {
     let sortElements;

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.ts
@@ -1,9 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Injector,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { WorkPackageViewTimelineService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service';
@@ -22,6 +17,12 @@ import { StateService } from '@uirouter/angular';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationTimelinesTabComponent implements TabComponent, OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableTimeline = inject(WorkPackageViewTimelineService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly $state = inject(StateService);
+
   public timelineVisible = false;
 
   public availableAttributes:{ id:string, name:string }[];
@@ -60,15 +61,6 @@ export class WpTableConfigurationTimelinesTabComponent implements TabComponent, 
       farRight: this.I18n.t('js.gantt_chart.labels.farRight'),
     },
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableTimeline:WorkPackageViewTimelineService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly $state:StateService,
-  ) {
-  }
 
   public onSave() {
     this.wpTableTimeline.update({

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Injector,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
@@ -24,6 +18,13 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationRelationSelectorComponent implements OnInit {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly ConfigurationService = inject(ConfigurationService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   private relationFilterIds:string[] = [
     'parent',
     'precedes',
@@ -61,14 +62,6 @@ export class WpTableConfigurationRelationSelectorComponent implements OnInit {
     partof: this.I18n.t('js.relation_labels.includes'),
     includes: this.I18n.t('js.relation_labels.partof'),
   };
-
-  constructor(readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly ConfigurationService:ConfigurationService,
-    readonly schemaCache:SchemaCacheService,
-    readonly cdRef:ChangeDetectorRef) {
-  }
 
   ngOnInit() {
     void this.initializeRelationFilters();

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.modal.ts
@@ -1,19 +1,4 @@
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ComponentFactoryResolver,
-  ElementRef,
-  EventEmitter,
-  Inject,
-  InjectionToken,
-  Injector,
-  OnDestroy,
-  OnInit,
-  Optional,
-  ViewChild,
-} from '@angular/core';
+import { ApplicationRef, ChangeDetectionStrategy, Component, ComponentFactoryResolver, ElementRef, EventEmitter, InjectionToken, Injector, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { WorkPackageViewColumnsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service';
 import { WpTableConfigurationService } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.service';
@@ -27,9 +12,7 @@ import { WorkPackageStatesInitializationService } from 'core-app/features/work-p
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { LoadingIndicatorService } from 'core-app/core/loading-indicator/loading-indicator.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { ComponentType } from '@angular/cdk/portal';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -48,6 +31,20 @@ export const WpTableConfigurationModalPrependToken = new InjectionToken<Componen
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTableConfigurationModalComponent extends OpModalComponent implements OnInit, OnDestroy {
+  prependModalComponent = inject<ComponentType<unknown> | null>(WpTableConfigurationModalPrependToken, { optional: true });
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly appRef = inject(ApplicationRef);
+  readonly componentFactoryResolver = inject(ComponentFactoryResolver);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly ConfigurationService = inject(ConfigurationService);
+  readonly $state = inject(StateService);
+
   public text = {
     title: this.I18n.t('js.work_packages.table_configuration.modal_title'),
     closePopup: this.I18n.t('js.close_popup_title'),
@@ -74,28 +71,7 @@ export class WpTableConfigurationModalComponent extends OpModalComponent impleme
 
   // Try to load an optional provided configuration service, and fall back to the default one
   private wpTableConfigurationService:WpTableConfigurationService =
-  this.injector.get(WpTableConfigurationService, new WpTableConfigurationService(this.I18n, this.$state));
-
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    @Optional() @Inject(WpTableConfigurationModalPrependToken) public prependModalComponent:ComponentType<any>|null,
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly appRef:ApplicationRef,
-    readonly componentFactoryResolver:ComponentFactoryResolver,
-    readonly loadingIndicator:LoadingIndicatorService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpStatesInitialization:WorkPackageStatesInitializationService,
-    readonly apiV3Service:ApiV3Service,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly ConfigurationService:ConfigurationService,
-    readonly elementRef:ElementRef,
-    readonly $state:StateService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
+  this.injector.get(WpTableConfigurationService);
 
   ngOnInit() {
     this.element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WpTableConfigurationDisplaySettingsTabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component';
 import { TabInterface } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
@@ -10,8 +10,11 @@ import { WpTableConfigurationHighlightingTabComponent } from 'core-app/features/
 import { OpBaselineComponent } from 'core-app/features/work-packages/components/wp-baseline/baseline/baseline.component';
 import { StateService } from '@uirouter/angular';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class WpTableConfigurationService {
+  readonly I18n = inject(I18nService);
+  readonly $state = inject(StateService);
+
   protected _tabs:TabInterface[] = [
     {
       id: 'columns',
@@ -44,12 +47,6 @@ export class WpTableConfigurationService {
       componentClass: WpTableConfigurationHighlightingTabComponent,
     },
   ];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly $state:StateService,
-  ) {
-  }
 
   public get tabs() {
     if (this.$state.current.name?.includes('work-packages') || this.$state.current.name?.includes('bim')) {

--- a/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service.ts
@@ -27,7 +27,7 @@
 //++
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalLink } from 'core-app/features/hal/hal-link/hal-link';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { UrlParamsHelperService } from 'core-app/features/work-packages/components/wp-query/url-params-helper';
 import { HookService } from 'core-app/features/plugins/hook-service';
@@ -47,6 +47,13 @@ export interface WorkPackageAction {
 
 @Injectable()
 export class WorkPackageContextMenuHelperService {
+  private HookService = inject(HookService);
+  private UrlParamsHelper = inject(UrlParamsHelperService);
+  private wpViewRepresentation = inject(WorkPackageViewDisplayRepresentationService);
+  private wpViewTimeline = inject(WorkPackageViewTimelineService);
+  private wpViewIndent = inject(WorkPackageViewHierarchyIdentationService);
+  private PathHelper = inject(PathHelperService);
+
   private BULK_ACTIONS = [
     {
       text: I18n.t('js.work_packages.bulk_actions.edit'),
@@ -73,14 +80,6 @@ export class WorkPackageContextMenuHelperService {
       href: this.PathHelper.workPackagesBulkDeletePath(),
     },
   ];
-
-  constructor(private HookService:HookService,
-    private UrlParamsHelper:UrlParamsHelperService,
-    private wpViewRepresentation:WorkPackageViewDisplayRepresentationService,
-    private wpViewTimeline:WorkPackageViewTimelineService,
-    private wpViewIndent:WorkPackageViewHierarchyIdentationService,
-    private PathHelper:PathHelperService) {
-  }
 
   public getPermittedActionLinks(workPackage:WorkPackageResource, permittedActionConstants:any, allowSplitScreenActions:boolean):WorkPackageAction[] {
     const singularPermittedActions:any[] = [];

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/embedded-tables-macro.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/embedded-tables-macro.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import {
   WorkPackageTableConfigurationObject,
 } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
@@ -44,6 +44,8 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class EmbeddedTablesMacroComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() public queryProps:object;
 
   public configuration:WorkPackageTableConfigurationObject = {
@@ -52,9 +54,7 @@ export class EmbeddedTablesMacroComponent {
     contextMenuEnabled: false,
   };
 
-  constructor(
-    readonly elementRef:ElementRef,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table-entry.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/embedded/wp-embedded-table-entry.component.ts
@@ -1,6 +1,4 @@
-import {
-  ChangeDetectionStrategy, Component, ElementRef, Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
@@ -23,13 +21,15 @@ export const wpTableEntrySelector = 'wp-embedded-table-entry';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageEmbeddedTableEntryComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() public queryProps:unknown;
 
   @Input() public configuration:unknown;
 
   @Input() public initialLoadingIndicator = true;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 }

--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.service.ts
@@ -1,6 +1,4 @@
-import {
-  ApplicationRef, ComponentFactoryResolver, Injectable, Injector,
-} from '@angular/core';
+import { ApplicationRef, Injectable, Injector, inject } from '@angular/core';
 import { ComponentPortal, DomPortalOutlet } from '@angular/cdk/portal';
 import { TransitionService } from '@uirouter/core';
 import { FocusHelperService } from 'core-app/shared/directives/focus/focus-helper';
@@ -14,18 +12,16 @@ export type Class = new(...args:any[]) => any;
 
 @Injectable()
 export class ExternalQueryConfigurationService {
+  readonly FocusHelper = inject(FocusHelperService);
+  private appRef = inject(ApplicationRef);
+  private $transitions = inject(TransitionService);
+  private injector = inject(Injector);
+
   // Hold a reference to the DOM node we're using as a host
   private _portalHostElement:HTMLElement;
 
   // And a reference to the actual portal host interface on top of the element
   private _bodyPortalHost:DomPortalOutlet;
-
-  constructor(
-    readonly FocusHelper:FocusHelperService,
-    private appRef:ApplicationRef,
-    private $transitions:TransitionService,
-    private injector:Injector) {
-  }
 
   /**
    * Create a portal host element to contain the table configuration components.

--- a/frontend/src/app/features/work-packages/components/wp-table/external-configuration/restricted-wp-table-configuration.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/external-configuration/restricted-wp-table-configuration.service.ts
@@ -1,20 +1,12 @@
-import { Inject, Injectable } from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { Injectable, inject } from '@angular/core';
 import { TabInterface } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { WpTableConfigurationService } from 'core-app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration.service';
 import { QueryConfigurationLocals } from 'core-app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.component';
 import { OpQueryConfigurationLocalsToken } from 'core-app/features/work-packages/components/wp-table/external-configuration/external-query-configuration.constants';
-import { StateService } from '@uirouter/angular';
 
 @Injectable()
 export class RestrictedWpTableConfigurationService extends WpTableConfigurationService {
-  constructor(
-    @Inject(OpQueryConfigurationLocalsToken) readonly locals:QueryConfigurationLocals,
-    readonly I18n:I18nService,
-    readonly $state:StateService,
-  ) {
-    super(I18n, $state);
-  }
+  readonly locals = inject<QueryConfigurationLocals>(OpQueryConfigurationLocalsToken);
 
   public get tabs():TabInterface[] {
     const disabledTabs = this.locals.disabledTabs || {};

--- a/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/sort-header/sort-header.directive.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit, ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Input,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   QueryColumn, queryColumnTypes,
@@ -61,6 +55,15 @@ import { WorkPackageViewBaselineService } from 'core-app/features/work-packages/
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix
 export class SortHeaderDirective extends UntilDestroyedMixin implements AfterViewInit {
+  private wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  private wpTableSortBy = inject(WorkPackageViewSortByService);
+  private wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  private wpTableBaseline = inject(WorkPackageViewBaselineService);
+  private wpTableRelationColumns = inject(WorkPackageViewRelationColumnsService);
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private cdRef = inject(ChangeDetectorRef);
+  private I18n = inject(I18nService);
+
   @Input() headerColumn:QueryColumn;
 
   @Input() locale:string;
@@ -90,19 +93,6 @@ export class SortHeaderDirective extends UntilDestroyedMixin implements AfterVie
   baselineIncompatible = false;
 
   private currentSortDirection:QuerySortByDirection|null;
-
-  constructor(
-    private wpTableHierarchies:WorkPackageViewHierarchiesService,
-    private wpTableSortBy:WorkPackageViewSortByService,
-    private wpTableGroupBy:WorkPackageViewGroupByService,
-    private wpTableBaseline:WorkPackageViewBaselineService,
-    private wpTableRelationColumns:WorkPackageViewRelationColumnsService,
-    private elementRef:ElementRef<HTMLElement>,
-    private cdRef:ChangeDetectorRef,
-    private I18n:I18nService,
-  ) {
-    super();
-  }
 
   ngAfterViewInit() {
     setTimeout(() => this.initialize());

--- a/frontend/src/app/features/work-packages/components/wp-table/table-actions/table-actions.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/table-actions/table-actions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import {
   OpTableActionFactory,
 } from 'core-app/features/work-packages/components/wp-table/table-actions/table-action';
@@ -8,8 +8,8 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
 
 @Injectable()
 export class OpTableActionsService {
-  constructor(private readonly injector:Injector) {
-  }
+  private readonly injector = inject(Injector);
+
 
   /**
    * Actions currently registered

--- a/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/table-pagination/wp-table-pagination.component.ts
@@ -26,16 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { combineLatest } from 'rxjs';
 
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   WorkPackageViewPaginationService,
 } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service';
@@ -48,7 +41,6 @@ import {
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/wp-collection-resource';
 import { TablePaginationComponent } from 'core-app/shared/components/table-pagination/table-pagination.component';
-import { PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
 
 @Component({
   templateUrl: '../../../../../shared/components/table-pagination/table-pagination.component.html',
@@ -57,16 +49,9 @@ import { PaginationService } from 'core-app/shared/components/table-pagination/p
   standalone: false,
 })
 export class WorkPackageTablePaginationComponent extends TablePaginationComponent implements OnInit, OnDestroy {
-  constructor(
-    protected paginationService:PaginationService,
-    protected cdRef:ChangeDetectorRef,
-    protected wpTablePagination:WorkPackageViewPaginationService,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpTableSortBy:WorkPackageViewSortByService,
-    readonly I18n:I18nService,
-  ) {
-    super(paginationService, cdRef, I18n);
-  }
+  protected wpTablePagination = inject(WorkPackageViewPaginationService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpTableSortBy = inject(WorkPackageViewSortByService);
 
   ngOnInit() {
     super.ngOnInit();
@@ -110,7 +95,7 @@ export class WorkPackageTablePaginationComponent extends TablePaginationComponen
 
   public paginationInfoText(work_packages:WorkPackageCollectionResource) {
     if (this.isManualSortingMode && (work_packages.count < work_packages.total)) {
-      return I18n.t('js.work_packages.limited_results',
+      return this.I18n.t('js.work_packages.limited_results',
         { count: work_packages.count });
     }
     return undefined;

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Injector,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Injector, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   IToast,
@@ -101,6 +95,22 @@ import { IDay } from 'core-app/core/state/days/day.model';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageTimelineTableController extends UntilDestroyedMixin implements AfterViewInit {
+  readonly injector = inject(Injector);
+  private elementRef = inject(ElementRef);
+  private states = inject(States);
+  wpTableComponent = inject(WorkPackagesTableComponent);
+  private toastService = inject(ToastService);
+  private wpTableTimeline = inject(WorkPackageViewTimelineService);
+  private notificationService = inject(WorkPackageNotificationService);
+  private wpRelations = inject(WorkPackageRelationsService);
+  private wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  private halEvents = inject(HalEventsService);
+  private querySpace = inject(IsolatedQuerySpace);
+  readonly I18n = inject(I18nService);
+  private workPackageViewCollapsedGroupsService = inject(WorkPackageViewCollapsedGroupsService);
+  private weekdaysService = inject(WeekdayService);
+  private daysService = inject(DayResourceService);
+
   private element:HTMLElement;
 
   public workPackageTable:WorkPackageTable;
@@ -147,26 +157,6 @@ export class WorkPackageTimelineTableController extends UntilDestroyedMixin impl
     const workPackagesWithGroupHeaderCell = this.orderedRows.filter((row) => wpsWithGroupHeaderCell.includes(row.workPackageId) && !this.workPackageIdOrder.includes(row));
 
     return workPackagesWithGroupHeaderCell;
-  }
-
-  constructor(
-    public readonly injector:Injector,
-    private elementRef:ElementRef,
-    private states:States,
-    public wpTableComponent:WorkPackagesTableComponent,
-    private toastService:ToastService,
-    private wpTableTimeline:WorkPackageViewTimelineService,
-    private notificationService:WorkPackageNotificationService,
-    private wpRelations:WorkPackageRelationsService,
-    private wpTableHierarchies:WorkPackageViewHierarchiesService,
-    private halEvents:HalEventsService,
-    private querySpace:IsolatedQuerySpace,
-    readonly I18n:I18nService,
-    private workPackageViewCollapsedGroupsService:WorkPackageViewCollapsedGroupsService,
-    private weekdaysService:WeekdayService,
-    private daysService:DayResourceService,
-  ) {
-    super();
   }
 
   ngAfterViewInit() {

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-relations.directive.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, Component, ElementRef, Injector, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Injector, OnInit, inject } from '@angular/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { State } from '@openproject/reactivestates';
 import { combineLatest } from 'rxjs';
@@ -87,20 +85,18 @@ function newSegment(vp:TimelineViewParameters,
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageTableTimelineRelations extends UntilDestroyedMixin implements OnInit {
+  readonly injector = inject(Injector);
+  elementRef = inject(ElementRef);
+  states = inject(States);
+  workPackageTimelineTableController = inject(WorkPackageTimelineTableController);
+  wpTableTimeline = inject(WorkPackageViewTimelineService);
+  wpRelations = inject(WorkPackageRelationsService);
+
   @InjectField() querySpace:IsolatedQuerySpace;
 
   private container:HTMLElement;
 
   private workPackagesWithRelations:Record<string, RelationsStateValue> = {};
-
-  constructor(public readonly injector:Injector,
-              public elementRef:ElementRef,
-              public states:States,
-              public workPackageTimelineTableController:WorkPackageTimelineTableController,
-              public wpTableTimeline:WorkPackageViewTimelineService,
-              public wpRelations:WorkPackageRelationsService) {
-    super();
-  }
 
   ngOnInit() {
     const element = this.elementRef.nativeElement;

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-static-elements.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/global-elements/wp-timeline-static-elements.directive.ts
@@ -25,12 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { States } from 'core-app/core/states/states.service';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
 import { calculatePositionValueForDayCountingPx, TimelineViewParameters } from '../wp-timeline';
@@ -50,15 +45,18 @@ import { TodayLineElement } from './wp-timeline.today-line';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageTableTimelineStaticElements implements OnInit {
+  states = inject(States);
+  workPackageTimelineTableController = inject(WorkPackageTimelineTableController);
+
   public element:HTMLElement;
 
   private container:HTMLElement;
 
   private elements:TimelineStaticElement[];
 
-  constructor(elementRef:ElementRef,
-    public states:States,
-    public workPackageTimelineTableController:WorkPackageTimelineTableController) {
+  constructor() {
+    const elementRef = inject(ElementRef);
+
     this.element = elementRef.nativeElement;
 
     this.elements = [

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/grid/wp-timeline-grid.directive.ts
@@ -25,12 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, inject } from '@angular/core';
 import moment, { Moment } from 'moment';
 import { TimelineZoomLevel } from 'core-app/features/hal/resources/query-resource';
 import { WorkPackageTimelineTableController } from '../container/wp-timeline-container.directive';
@@ -53,15 +48,13 @@ import { WeekdayService } from 'core-app/core/days/weekday.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageTableTimelineGrid implements AfterViewInit {
+  private elementRef = inject(ElementRef);
+  wpTimeline = inject(WorkPackageTimelineTableController);
+  private weekdaysService = inject(WeekdayService);
+
   private activeZoomLevel:TimelineZoomLevel;
 
   private gridContainer:HTMLElement;
-
-  constructor(
-    private elementRef:ElementRef,
-    public wpTimeline:WorkPackageTimelineTableController,
-    private weekdaysService:WeekdayService,
-  ) {}
 
   ngAfterViewInit():void {
     const element = this.elementRef.nativeElement;

--- a/frontend/src/app/features/work-packages/components/wp-table/timeline/header/wp-timeline-header.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/timeline/header/wp-timeline-header.directive.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { WorkPackageTimelineTableController } from 'core-app/features/work-packages/components/wp-table/timeline/container/wp-timeline-container.directive';
 import moment, { Moment } from 'moment';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -50,16 +50,19 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageTimelineHeaderController implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly wpTimelineService = inject(WorkPackageViewTimelineService);
+  readonly workPackageTimelineTableController = inject(WorkPackageTimelineTableController);
+
   public element:HTMLElement;
 
   private activeZoomLevel:TimelineZoomLevel;
 
   private innerHeader:HTMLElement;
 
-  constructor(elementRef:ElementRef,
-    readonly I18n:I18nService,
-    readonly wpTimelineService:WorkPackageViewTimelineService,
-    readonly workPackageTimelineTableController:WorkPackageTimelineTableController) {
+  constructor() {
+    const elementRef = inject(ElementRef);
+
     this.element = elementRef.nativeElement;
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table-sums-row/wp-table-sums-row.directive.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table-sums-row/wp-table-sums-row.directive.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit, Directive, ElementRef, Injector, Input,
-} from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Injector, Input, inject } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { States } from 'core-app/core/states/states.service';
@@ -51,6 +49,15 @@ import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/w
   standalone: false,
 })
 export class WorkPackageTableSumsRowController implements AfterViewInit {
+  readonly injector = inject(Injector);
+  readonly elementRef = inject(ElementRef);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly states = inject(States);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly wpTableSums = inject(WorkPackageViewSumService);
+  readonly I18n = inject(I18nService);
+
   @Input('wpTableSumsRow-table') workPackageTable:WorkPackageTable;
 
   public isHidden = true;
@@ -61,14 +68,9 @@ export class WorkPackageTableSumsRowController implements AfterViewInit {
 
   private groupSumsBuilder:GroupSumsBuilder;
 
-  constructor(readonly injector:Injector,
-    readonly elementRef:ElementRef,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly states:States,
-    readonly schemaCache:SchemaCacheService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly wpTableSums:WorkPackageViewSumService,
-    readonly I18n:I18nService) {
+  constructor() {
+    const I18n = this.I18n;
+
     this.text = {
       sum: I18n.t('js.label_total_sum'),
     };

--- a/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-table/wp-table.component.ts
@@ -26,18 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnInit,
-  Output,
-  ViewEncapsulation, OnDestroy,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Injector, Input, OnInit, Output, ViewEncapsulation, OnDestroy, inject } from '@angular/core';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
@@ -82,6 +71,19 @@ export interface WorkPackageFocusContext {
   standalone: false,
 })
 export class WorkPackagesTableComponent extends UntilDestroyedMixin implements OnInit, TableEventComponent, OnDestroy {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  readonly wpTableTimeline = inject(WorkPackageViewTimelineService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly wpTableSortBy = inject(WorkPackageViewSortByService);
+  readonly wpTableSums = inject(WorkPackageViewSumService);
+  readonly wpTableBaseline = inject(WorkPackageViewBaselineService);
+
   @Input() projectIdentifier:string;
 
   @Input('configuration') configurationObject:WorkPackageTableConfigurationObject;
@@ -135,23 +137,6 @@ export class WorkPackagesTableComponent extends UntilDestroyedMixin implements O
   public inlineCreateVisible = false;
 
   public sumVisible = false;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly injector:Injector,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly wpTableGroupBy:WorkPackageViewGroupByService,
-    readonly wpTableTimeline:WorkPackageViewTimelineService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly wpTableSortBy:WorkPackageViewSortByService,
-    readonly wpTableSums:WorkPackageViewSumService,
-    readonly wpTableBaseline:WorkPackageViewBaselineService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     this.configuration = new WorkPackageTableConfiguration(this.configurationObject);

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/wp-tab-wrapper.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/wp-tab-wrapper.component.ts
@@ -27,12 +27,7 @@
 //++
 
 import { UIRouterGlobals } from '@uirouter/core';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { Observable } from 'rxjs';
@@ -51,6 +46,11 @@ import { WorkPackageResource } from 'core-app/features/hal/resources/work-packag
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpTabWrapperComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly wpTabsService = inject(WorkPackageTabsService);
+
   @Input() public workPackageId:string;
   @Input() public tabIdentifier:string;
 
@@ -60,13 +60,6 @@ export class WpTabWrapperComponent implements OnInit {
     workPackage:WorkPackageResource;
     tab:WpTabDefinition | undefined;
   }>;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly uiRouterGlobals:UIRouterGlobals,
-    readonly apiV3Service:ApiV3Service,
-    readonly wpTabsService:WorkPackageTabsService
-  ) {}
 
   ngOnInit() {
     if (this.workPackageId === undefined) {

--- a/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/components/wp-tabs/wp-tabs.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Injector, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Injector, Input, OnInit, Output, inject } from '@angular/core';
 import {
   KeepTabService,
 } from 'core-app/features/work-packages/components/wp-single-view-tabs/keep-tab/keep-tab.service';
@@ -21,6 +21,15 @@ import { WpTabDefinition } from 'core-app/features/work-packages/components/wp-t
   standalone: false,
 })
 export class WpTabsComponent implements OnInit {
+  readonly wpTabsService = inject(WorkPackageTabsService);
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly $state = inject(StateService);
+  readonly uiRouterGlobals = inject(UIRouterGlobals);
+  readonly keepTab = inject(KeepTabService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly currentProject = inject(CurrentProjectService);
+
   @Input() workPackage:WorkPackageResource;
 
   @Input() view:'full'|'split';
@@ -41,18 +50,6 @@ export class WpTabsComponent implements OnInit {
       goToFullScreen: this.I18n.t('js.button_show_fullscreen'),
     },
   };
-
-  constructor(
-    readonly wpTabsService:WorkPackageTabsService,
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly $state:StateService,
-    readonly uiRouterGlobals:UIRouterGlobals,
-    readonly keepTab:KeepTabService,
-    readonly pathHelper:PathHelperService,
-    readonly currentProject:CurrentProjectService,
-  ) {
-  }
 
   ngOnInit():void {
     this.canViewWatchers = !!(this.workPackage && this.workPackage.watchers);

--- a/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
+++ b/frontend/src/app/features/work-packages/components/wp-tabs/services/wp-tabs/wp-tabs.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { from } from 'rxjs';
 import { StateService } from '@uirouter/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -64,13 +64,13 @@ import {
   providedIn: 'root',
 })
 export class WorkPackageTabsService {
+  private $state = inject(StateService);
+  private I18n = inject(I18nService);
+  private injector = inject(Injector);
+
   private registeredTabs:WpTabDefinition[];
 
-  constructor(
-    private $state:StateService,
-    private I18n:I18nService,
-    private injector:Injector,
-  ) {
+  constructor() {
     this.registeredTabs = this.buildDefaultTabs();
   }
 

--- a/frontend/src/app/features/work-packages/components/wp-timer-button/wp-timer-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-timer-button/wp-timer-button.component.ts
@@ -27,7 +27,7 @@
 //++
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -54,6 +54,16 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
   standalone: false,
 })
 export class WorkPackageTimerButtonComponent extends UntilDestroyedMixin {
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly timeEntryService = inject(TimeEntryTimerService);
+  readonly halEditing = inject(HalResourceEditingService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly toastService = inject(ToastService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
   @InjectField() PathHelper:PathHelperService;
   @InjectField() TurboRequests:TurboRequestsService;
@@ -73,21 +83,6 @@ export class WorkPackageTimerButtonComponent extends UntilDestroyedMixin {
     stop_timer: this.I18n.t('js.timer.button_stop'),
     timer_already_stopped: this.I18n.t('js.timer.timer_already_stopped'),
   };
-
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly timeEntryService:TimeEntryTimerService,
-    readonly halEditing:HalResourceEditingService,
-    readonly schemaCache:SchemaCacheService,
-    readonly timezoneService:TimezoneService,
-    readonly toastService:ToastService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
 
   activeForWorkPackage(entry:TimeEntryResource | null):boolean {

--- a/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-watcher-button/wp-watcher-button.component.ts
@@ -27,9 +27,7 @@
 //++
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageWatchersService } from 'core-app/features/work-packages/components/wp-single-view-tabs/watchers-tab/wp-watchers.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -42,6 +40,11 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
   standalone: false,
 })
 export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly wpWatchersService = inject(WorkPackageWatchersService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
 
   @Input() public disabled = false;
@@ -53,15 +56,6 @@ export class WorkPackageWatcherButtonComponent extends UntilDestroyedMixin imple
   public buttonId:string;
 
   public watched:boolean;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly wpWatchersService:WorkPackageWatchersService,
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this

--- a/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
+++ b/frontend/src/app/features/work-packages/directives/query-space/wp-isolated-query-space.directive.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, inject } from '@angular/core';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import {
   OpTableActionsService,
@@ -196,10 +196,11 @@ import {
   ],
 })
 export class WorkPackageIsolatedQuerySpaceDirective {
-  constructor(
-    public querySpace:IsolatedQuerySpace,
-    elementRef:ElementRef,
-  ) {
+  querySpace = inject(IsolatedQuerySpace);
+
+  constructor() {
+    const elementRef = inject(ElementRef);
+
     debugLog('Opening isolated query space in %O', elementRef.nativeElement);
   }
 }

--- a/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
+++ b/frontend/src/app/features/work-packages/openproject-work-packages.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule, inject } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectFieldsModule } from 'core-app/shared/components/fields/openproject-fields.module';
 import { OpenprojectModalModule } from 'core-app/shared/components/modal/modal.module';
@@ -683,9 +683,13 @@ import {
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class OpenprojectWorkPackagesModule {
+  private injector = inject(Injector);
+
   static bootstrapAttributeGroupsCalled = false;
 
-  constructor(private injector:Injector) {
+  constructor() {
+    const injector = this.injector;
+
     OpenprojectWorkPackagesModule.bootstrapAttributeGroups(injector);
   }
 

--- a/frontend/src/app/features/work-packages/routing/wp-full-copy/wp-full-copy-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-copy/wp-full-copy-entry.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
@@ -48,13 +48,15 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageFullCopyEntryComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() type:string;
   @Input() copiedFromWorkPackageId:string;
   @Input() parentId?:string;
   @Input() projectIdentifier?:string;
   @Input() routedFromAngular:boolean;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
 
     document.body.classList.add('router--work-packages-full-create');

--- a/frontend/src/app/features/work-packages/routing/wp-full-create/wp-full-create-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-create/wp-full-create-entry.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
@@ -48,12 +48,14 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageFullCreateEntryComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() type:string;
   @Input() parentId?:string;
   @Input() projectIdentifier?:string;
   @Input() routedFromAngular:boolean;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
 
     document.body.classList.add('router--work-packages-full-create');

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view-entry.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
@@ -49,11 +49,13 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageFullViewEntryComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() workPackageId:string;
   @Input() activeTab:string;
   @Input() routedFromAngular:boolean;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
 
     document.body.classList.add('router--work-packages-full-view', 'router--work-packages-base');

--- a/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-full-view/wp-full-view.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  HostListener,
-  Injector,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, OnInit, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 import { TabDefinition } from 'core-app/shared/components/tabs/tab.interface';
@@ -61,6 +53,12 @@ import { Observable, of } from 'rxjs';
   standalone: false,
 })
 export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase implements OnInit {
+  wpTableSelection = inject(WorkPackageViewSelectionService);
+  recentItemsService = inject(RecentItemsService);
+  readonly $state = inject(StateService);
+  readonly currentUserService = inject(CurrentUserService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   // Watcher properties
   public isWatched:boolean;
 
@@ -79,17 +77,6 @@ export class WorkPackagesFullViewComponent extends WorkPackageSingleViewBase imp
       buttonMore: this.i18n.t('js.button_more'),
     },
   };
-
-  constructor(
-    public injector:Injector,
-    public wpTableSelection:WorkPackageViewSelectionService,
-    public recentItemsService:RecentItemsService,
-    readonly $state:StateService,
-    readonly currentUserService:CurrentUserService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super(injector);
-  }
 
   public onTabSelected(tab:TabDefinition):void {
     if (!this.routedFromAngular) {

--- a/frontend/src/app/features/work-packages/routing/wp-split-create/wp-split-create-entry.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-create/wp-split-create-entry.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  Input,
-  OnDestroy,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnDestroy, inject } from '@angular/core';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
 } from 'core-app/features/work-packages/directives/query-space/wp-isolated-query-space.directive';
@@ -57,10 +50,12 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkPackageSplitCreateEntryComponent implements AfterViewInit, OnDestroy {
+  readonly elementRef = inject(ElementRef);
+
   @Input() projectIdentifier?:string;
   @Input() type?:string;
 
-  constructor(readonly elementRef:ElementRef) {
+  constructor() {
     populateInputsFromDataset(this);
     document.body.classList.add('router--work-packages-partitioned-split-view-new');
   }

--- a/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-split-view/wp-split-view.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, HostListener, Injector, Input, OnInit, Type } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, Input, OnInit, Type, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import {
   WorkPackageViewFocusService,
@@ -67,6 +67,17 @@ import { resolveRoutingId } from 'core-app/features/work-packages/helpers/work-p
   standalone: false,
 })
 export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase implements OnInit {
+  states = inject(States);
+  firstRoute = inject(FirstRouteService);
+  keepTab = inject(KeepTabService);
+  wpTableSelection = inject(WorkPackageViewSelectionService);
+  wpTableFocus = inject(WorkPackageViewFocusService);
+  recentItemsService = inject(RecentItemsService);
+  readonly $state = inject(StateService);
+  readonly urlParams = inject(UrlParamsService);
+  readonly backRouting = inject(BackRoutingService);
+  readonly wpTabs = inject(WorkPackageTabsService);
+
   hasState = !!this.$state.current;
   /** Reference to the base route e.g., work-packages.partitioned.list or bim.partitioned.split */
   private baseRoute:string = this.$state.current?.data?.baseRoute as string;
@@ -74,22 +85,6 @@ export class WorkPackageSplitViewComponent extends WorkPackageSingleViewBase imp
   @Input() showTabs = true;
 
   @Input() resizerClass = 'work-packages-partitioned-page--content-right';
-
-  constructor(
-    public injector:Injector,
-    public states:States,
-    public firstRoute:FirstRouteService,
-    public keepTab:KeepTabService,
-    public wpTableSelection:WorkPackageViewSelectionService,
-    public wpTableFocus:WorkPackageViewFocusService,
-    public recentItemsService:RecentItemsService,
-    readonly $state:StateService,
-    readonly urlParams:UrlParamsService,
-    readonly backRouting:BackRoutingService,
-    readonly wpTabs:WorkPackageTabsService,
-  ) {
-    super(injector);
-  }
 
     // enable other parts of the application to trigger an immediate update
   // e.g. a stimulus controller

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/state/wp-single-view.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WpSingleViewStore } from './wp-single-view.store';
 import {
   filter,
@@ -27,6 +27,10 @@ import { Query } from '@datorama/akita';
 @EffectHandler
 @Injectable()
 export class WpSingleViewService {
+  readonly actions$ = inject(ActionsService);
+  readonly currentUser$ = inject(CurrentUserService);
+  private resourceService = inject(InAppNotificationsResourceService);
+
   id = 'WorkPackage Activity Store';
 
   protected store = new WpSingleViewStore();
@@ -62,13 +66,6 @@ export class WpSingleViewService {
 
   get params():ApiV3ListParameters {
     return { filters: this.query.getValue().notifications.filters };
-  }
-
-  constructor(
-    readonly actions$:ActionsService,
-    readonly currentUser$:CurrentUserService,
-    private resourceService:InAppNotificationsResourceService,
-  ) {
   }
 
   setFilters(workPackageId:string):void {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-additional-elements.service.ts
@@ -28,7 +28,7 @@
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   RelationsStateValue,
   WorkPackageRelationsService,
@@ -51,17 +51,15 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class WorkPackageViewAdditionalElementsService {
-  constructor(
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpTableHierarchies:WorkPackageViewHierarchiesService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly halResourceService:HalResourceService,
-    readonly apiV3Service:ApiV3Service,
-    readonly schemaCache:SchemaCacheService,
-    readonly wpRelations:WorkPackageRelationsService,
-  ) {
-  }
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly halResourceService = inject(HalResourceService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly wpRelations = inject(WorkPackageRelationsService);
+
 
   public initialize(query:QueryResource, results:WorkPackageCollectionResource):void {
     const rows = results.elements;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-base.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-base.service.ts
@@ -33,21 +33,19 @@ import {
 import { map, mapTo, take } from 'rxjs/operators';
 import { merge, Observable } from 'rxjs';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QuerySchemaResource } from 'core-app/features/hal/resources/query-schema-resource';
 import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/wp-collection-resource';
 
 @Injectable()
 export abstract class WorkPackageViewBaseService<T> {
+  protected readonly querySpace = inject(IsolatedQuerySpace);
+
   /** Internal state to push non-persisted updates */
   protected updatesState = input<T>();
 
   /** Internal pristine state filled during +initialize+ only */
   protected pristineState = input<T>();
-
-  constructor(
-    protected readonly querySpace:IsolatedQuerySpace,
-  ) { }
 
   /**
    * Get the state value from the current query.

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-baseline.service.ts
@@ -26,9 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { States } from 'core-app/core/states/states.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { WorkPackageQueryStateService } from './wp-view-base.service';
@@ -66,17 +65,12 @@ export const BASELINE_INCOMPATIBLE_COLUMNS = [
 
 @Injectable()
 export class WorkPackageViewBaselineService extends WorkPackageQueryStateService<string[]> {
-  constructor(
-    protected readonly states:States,
-    protected readonly querySpace:IsolatedQuerySpace,
-    protected readonly pathHelper:PathHelperService,
-    protected readonly configurationService:ConfigurationService,
-    protected readonly timezoneService:TimezoneService,
-    protected readonly weekdaysService:WeekdayService,
-    protected readonly daysService:DayResourceService,
-  ) {
-    super(querySpace);
-  }
+  protected readonly states = inject(States);
+  protected readonly pathHelper = inject(PathHelperService);
+  protected readonly configurationService = inject(ConfigurationService);
+  protected readonly timezoneService = inject(TimezoneService);
+  protected readonly weekdaysService = inject(WeekdayService);
+  protected readonly daysService = inject(DayResourceService);
 
   public nonWorkingDays:IDay[] = [];
 

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service.ts
@@ -27,9 +27,8 @@
 //++
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageViewGroupByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { take } from 'rxjs/operators';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
@@ -40,7 +39,12 @@ import { WorkPackageViewBaseService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewCollapsedGroupsService extends WorkPackageViewBaseService<IGroupsCollapseEvent> {
-  readonly wpTypesToShowInCollapsedGroupHeaders:((wp:WorkPackageResource) => boolean)[];
+  readonly workPackageViewGroupByService = inject(WorkPackageViewGroupByService);
+  private schemaCacheService = inject(SchemaCacheService);
+
+  isMilestone = (workPackage:WorkPackageResource):boolean => this.schemaCacheService.of(workPackage)?.isMilestone as boolean;
+
+  readonly wpTypesToShowInCollapsedGroupHeaders:((wp:WorkPackageResource) => boolean)[] = [this.isMilestone];
 
   readonly groupTypesWithHeaderCellsWhenCollapsed = ['project'];
 
@@ -64,15 +68,6 @@ export class WorkPackageViewCollapsedGroupsService extends WorkPackageViewBaseSe
     return this.workPackageViewGroupByService.current;
   }
 
-  constructor(
-    protected readonly querySpace:IsolatedQuerySpace,
-    readonly workPackageViewGroupByService:WorkPackageViewGroupByService,
-    private schemaCacheService:SchemaCacheService,
-  ) {
-    super(querySpace);
-    this.wpTypesToShowInCollapsedGroupHeaders = [this.isMilestone];
-  }
-
   // Every time the groupedBy changes, this services is initialized
   private getDefaultState():IGroupsCollapseEvent {
     return {
@@ -83,8 +78,6 @@ export class WorkPackageViewCollapsedGroupsService extends WorkPackageViewBaseSe
       ...this.getAllGroupsCollapsedState(this.currentGroups, this.querySpace.collapsedGroups.value!),
     };
   }
-
-  isMilestone = (workPackage:WorkPackageResource):boolean => this.schemaCacheService.of(workPackage)?.isMilestone;
 
   toggleGroupCollapseState(groupIdentifier:string):void {
     const newCollapsedState = !this.config.state[groupIdentifier];

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service.ts
@@ -27,9 +27,8 @@
 //++
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { States } from 'core-app/core/states/states.service';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryColumn, queryColumnTypes } from 'core-app/features/work-packages/components/wp-query/query-column';
 import { combine } from '@openproject/reactivestates';
 import { mapTo, take } from 'rxjs/operators';
@@ -39,9 +38,7 @@ import { sharedUserColumn } from 'core-app/features/work-packages/components/wp-
 
 @Injectable()
 export class WorkPackageViewColumnsService extends WorkPackageQueryStateService<QueryColumn[]> {
-  public constructor(readonly states:States, readonly querySpace:IsolatedQuerySpace) {
-    super(querySpace);
-  }
+  readonly states = inject(States);
 
   public valueFromQuery(query:QueryResource):QueryColumn[] {
     return [...query.columns];

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-display-representation.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-display-representation.service.ts
@@ -28,8 +28,7 @@
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 export const wpDisplayListRepresentation = 'list';
@@ -38,12 +37,7 @@ export type WorkPackageDisplayRepresentationValue = 'list'|'card';
 
 @Injectable()
 export class WorkPackageViewDisplayRepresentationService extends WorkPackageQueryStateService<string|null> {
-  public constructor(
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-  ) {
-    super(querySpace);
-  }
+  readonly states = inject(States);
 
   public hasChanged(query:QueryResource) {
     return this.current !== query.displayRepresentation;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
+import { Injectable, inject } from '@angular/core';
 import { combine, input, InputState } from '@openproject/reactivestates';
 import { States } from 'core-app/core/states/states.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -43,6 +42,8 @@ import { map } from 'rxjs/operators';
 
 @Injectable()
 export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<QueryFilterInstanceResource[]> {
+  protected readonly states = inject(States);
+
   public hidden:string[] = [
     'datesInterval',
     'precedes',
@@ -67,13 +68,6 @@ export class WorkPackageViewFiltersService extends WorkPackageQueryStateService<
 
   /** Flag state to determine whether the filters are incomplete */
   private incomplete = input<boolean>(false);
-
-  constructor(
-    protected readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-  ) {
-    super(querySpace);
-  }
 
   /**
    * Load all schemas for the current filters and fill respective states

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-focus.service.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
+import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { WorkPackageViewSelectionService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service';
@@ -42,10 +41,7 @@ export interface WPFocusState {
 
 @Injectable()
 export class WorkPackageViewFocusService extends WorkPackageViewBaseService<WPFocusState> {
-  constructor(public querySpace:IsolatedQuerySpace,
-    public wpTableSelection:WorkPackageViewSelectionService) {
-    super(querySpace);
-  }
+  wpTableSelection = inject(WorkPackageViewSelectionService);
 
   public isFocused(workPackageId:string) {
     return this.focusedWorkPackage === workPackageId;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service.ts
@@ -28,8 +28,7 @@
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryColumn } from 'core-app/features/work-packages/components/wp-query/query-column';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { QueryGroupByResource } from 'core-app/features/hal/resources/query-group-by-resource';
@@ -37,10 +36,7 @@ import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewGroupByService extends WorkPackageQueryStateService<QueryGroupByResource|null> {
-  public constructor(readonly states:States,
-    readonly querySpace:IsolatedQuerySpace) {
-    super(querySpace);
-  }
+  readonly states = inject(States);
 
   valueFromQuery(query:QueryResource) {
     return query.groupBy || null;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy-indentation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { WorkPackageViewHierarchiesService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-hierarchy.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -10,13 +10,13 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class WorkPackageViewHierarchyIdentationService {
-  constructor(private wpViewHierarchies:WorkPackageViewHierarchiesService,
-    private wpDisplayRepresentation:WorkPackageViewDisplayRepresentationService,
-    private states:States,
-    private wpRelationHierarchy:WorkPackageRelationsHierarchyService,
-    private apiV3Service:ApiV3Service,
-    private querySpace:IsolatedQuerySpace) {
-  }
+  private wpViewHierarchies = inject(WorkPackageViewHierarchiesService);
+  private wpDisplayRepresentation = inject(WorkPackageViewDisplayRepresentationService);
+  private states = inject(States);
+  private wpRelationHierarchy = inject(WorkPackageRelationsHierarchyService);
+  private apiV3Service = inject(ApiV3Service);
+  private querySpace = inject(IsolatedQuerySpace);
+
 
   /**
    * Return whether the current hierarchy mode is active

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-highlighting.service.ts
@@ -1,6 +1,5 @@
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { States } from 'core-app/core/states/states.service';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -13,13 +12,8 @@ import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewHighlightingService extends WorkPackageQueryStateService<WorkPackageViewHighlight> {
-  public constructor(
-    readonly states:States,
-    readonly Banners:BannersService,
-    readonly querySpace:IsolatedQuerySpace,
-  ) {
-    super(querySpace);
-  }
+  readonly states = inject(States);
+  readonly Banners = inject(BannersService);
 
   initialize(query:QueryResource, results:WorkPackageCollectionResource, schema?:QuerySchemaResource) {
     super.initialize(query, results, schema);

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-include-subprojects.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-include-subprojects.service.ts
@@ -28,18 +28,12 @@
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { States } from 'core-app/core/states/states.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewIncludeSubprojectsService extends WorkPackageQueryStateService<boolean> {
-  public constructor(
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-  ) {
-    super(querySpace);
-  }
+  readonly states = inject(States);
 
   public hasChanged(query:QueryResource):boolean {
     return this.current !== query.includeSubprojects;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-order.service.ts
@@ -26,11 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { take } from 'rxjs/operators';
 import { InputState } from '@openproject/reactivestates';
 import { States } from 'core-app/core/states/states.service';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
@@ -47,16 +46,11 @@ import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class WorkPackageViewOrderService extends WorkPackageQueryStateService<QueryOrder> {
-  constructor(
-    protected readonly querySpace:IsolatedQuerySpace,
-    protected readonly apiV3Service:ApiV3Service,
-    protected readonly states:States,
-    protected readonly causedUpdates:CausedUpdatesService,
-    protected readonly wpTableSortBy:WorkPackageViewSortByService,
-    protected readonly pathHelper:PathHelperService,
-) {
-    super(querySpace);
-  }
+  protected readonly apiV3Service = inject(ApiV3Service);
+  protected readonly states = inject(States);
+  protected readonly causedUpdates = inject(CausedUpdatesService);
+  protected readonly wpTableSortBy = inject(WorkPackageViewSortByService);
+  protected readonly pathHelper = inject(PathHelperService);
 
   public initialize(query:QueryResource, results:WorkPackageCollectionResource, schema?:QuerySchemaResource):Promise<unknown> {
     // Take over our current value if the query is not saved

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-pagination.service.ts
@@ -26,10 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { WorkPackageCollectionResource } from 'core-app/features/hal/resources/wp-collection-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { WorkPackageViewPagination } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-table-pagination';
 import { WorkPackageViewBaseService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-base.service';
 import { PaginationObject, PaginationService } from 'core-app/shared/components/table-pagination/pagination-service';
@@ -43,10 +42,7 @@ export interface PaginationUpdateObject {
 
 @Injectable()
 export class WorkPackageViewPaginationService extends WorkPackageViewBaseService<WorkPackageViewPagination> {
-  public constructor(querySpace:IsolatedQuerySpace,
-    readonly paginationService:PaginationService) {
-    super(querySpace);
-  }
+  readonly paginationService = inject(PaginationService);
 
   public get paginationObject():PaginationObject {
     if (this.current) {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-relation-columns.service.ts
@@ -29,9 +29,8 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { WorkPackageViewRelationColumns } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-table-relation-columns';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { RelationsStateValue, WorkPackageRelationsService } from 'core-app/features/work-packages/components/wp-relations/wp-relations.service';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   QueryColumn,
   queryColumnTypes,
@@ -48,15 +47,10 @@ export type RelationColumnType = 'toType'|'ofType'|'children';
 
 @Injectable()
 export class WorkPackageViewRelationColumnsService extends WorkPackageViewBaseService<WorkPackageViewRelationColumns> {
-  constructor(
-public querySpace:IsolatedQuerySpace,
-    public wpTableColumns:WorkPackageViewColumnsService,
-    public halResourceService:HalResourceService,
-    public apiV3Service:ApiV3Service,
-    public wpRelations:WorkPackageRelationsService,
-) {
-    super(querySpace);
-  }
+  wpTableColumns = inject(WorkPackageViewColumnsService);
+  halResourceService = inject(HalResourceService);
+  apiV3Service = inject(ApiV3Service);
+  wpRelations = inject(WorkPackageRelationsService);
 
   public valueFromQuery(_query:QueryResource):WorkPackageViewRelationColumns {
     // Take over current expanded values

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-selection.service.ts
@@ -1,5 +1,4 @@
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { States } from 'core-app/core/states/states.service';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
@@ -18,10 +17,12 @@ export interface WorkPackageViewSelectionState {
 
 @Injectable()
 export class WorkPackageViewSelectionService extends WorkPackageViewBaseService<WorkPackageViewSelectionState> implements OnDestroy {
-  public constructor(readonly querySpace:IsolatedQuerySpace,
-    readonly states:States,
-    readonly opContextMenu:OPContextMenuService) {
-    super(querySpace);
+  readonly states = inject(States);
+  readonly opContextMenu = inject(OPContextMenuService);
+
+  public constructor() {
+    super();
+
     this.reset();
   }
 

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sort-by.service.ts
@@ -28,10 +28,9 @@
 
 import { combine } from '@openproject/reactivestates';
 import { mapTo } from 'rxjs/operators';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { States } from 'core-app/core/states/states.service';
 import { QuerySortByResource } from 'core-app/features/hal/resources/query-sort-by-resource';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -40,11 +39,8 @@ import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewSortByService extends WorkPackageQueryStateService<QuerySortByResource[]> {
-  constructor(protected readonly states:States,
-    protected readonly querySpace:IsolatedQuerySpace,
-    protected readonly pathHelper:PathHelperService) {
-    super(querySpace);
-  }
+  protected readonly states = inject(States);
+  protected readonly pathHelper = inject(PathHelperService);
 
   public valueFromQuery(query:QueryResource) {
     return [...query.sortBy];

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sum.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-sum.service.ts
@@ -27,15 +27,11 @@
 //++
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { Injectable } from '@angular/core';
 import { WorkPackageQueryStateService } from './wp-view-base.service';
 
 @Injectable()
 export class WorkPackageViewSumService extends WorkPackageQueryStateService<boolean> {
-  public constructor(querySpace:IsolatedQuerySpace) {
-    super(querySpace);
-  }
 
   public valueFromQuery(query:QueryResource) {
     return !!query.sums;

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/view-services/wp-view-timeline.service.ts
@@ -28,7 +28,6 @@
 
 import { Injectable } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { input } from '@openproject/reactivestates';
 import { WorkPackageTimelineState } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-table-timeline';
 import { zoomLevelOrder } from 'core-app/features/work-packages/components/wp-table/timeline/wp-timeline';
@@ -39,10 +38,6 @@ import { WorkPackageQueryStateService } from './wp-view-base.service';
 export class WorkPackageViewTimelineService extends WorkPackageQueryStateService<WorkPackageTimelineState> {
   /** Remember the computed zoom level to correct zooming after leaving autozoom */
   public appliedZoomLevel$ = input<TimelineZoomLevel>('auto');
-
-  public constructor(protected readonly querySpace:IsolatedQuerySpace) {
-    super(querySpace);
-  }
 
   public valueFromQuery(query:QueryResource) {
     return {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-package-single-view.base.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  Injector,
-  Input,
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import {
@@ -71,6 +66,8 @@ import { StateService } from '@uirouter/angular';
 
 @Directive()
 export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
+  injector = inject(Injector);
+
   @Input() routedFromAngular = true;
 
   @Input() workPackageId:string;
@@ -128,9 +125,7 @@ export abstract class WorkPackageSingleViewBase extends UntilDestroyedMixin {
 
   public displayNotificationsButton$:Observable<boolean>;
 
-  constructor(
-    public injector:Injector,
-  ) {
+  constructor() {
     super();
 
     if (this.routedFromAngular && this.workPackageId === undefined) {

--- a/frontend/src/app/features/work-packages/routing/wp-view-base/work-packages-view.base.ts
+++ b/frontend/src/app/features/work-packages/routing/wp-view-base/work-packages-view.base.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectorRef, Directive, Injector, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, Injector, OnDestroy, OnInit, inject } from '@angular/core';
 import { StateService, TransitionService } from '@uirouter/core';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -94,6 +94,8 @@ import { tableRefreshRequest } from 'core-app/features/work-packages/routing/wp-
 
 @Directive()
 export abstract class WorkPackagesViewBase extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  injector = inject(Injector);
+
   @InjectField() $state:StateService;
 
   @InjectField() states:States;
@@ -157,10 +159,6 @@ export abstract class WorkPackagesViewBase extends UntilDestroyedMixin implement
 
   /** Remember explicitly when this component was destroyed */
   destroyed = false;
-
-  constructor(public injector:Injector) {
-    super();
-  }
 
   ngOnInit() {
     // Listen to changes on the query state objects

--- a/frontend/src/app/features/work-packages/services/notifications/work-package-notification.service.ts
+++ b/frontend/src/app/features/work-packages/services/notifications/work-package-notification.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { IToast } from 'core-app/shared/components/toaster/toast.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
@@ -36,13 +36,8 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
 
 @Injectable()
 export class WorkPackageNotificationService extends HalResourceNotificationService {
-  constructor(
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly turboRequests:TurboRequestsService,
-  ) {
-    super(injector);
-  }
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly turboRequests = inject(TurboRequestsService);
 
   public showSave(resource:HalResource, isCreate = false) {
     const message:IToast = {

--- a/frontend/src/app/features/work-packages/services/work-package.service.ts
+++ b/frontend/src/app/features/work-packages/services/work-package.service.ts
@@ -39,20 +39,19 @@ import { resolveNumericId } from 'core-app/features/work-packages/helpers/work-p
 
 @Injectable()
 export class WorkPackageService {
+  private readonly http = inject(HttpClient);
+  private readonly $state = inject(StateService);
+  private readonly PathHelper = inject(PathHelperService);
+  private readonly UrlParamsHelper = inject(UrlParamsHelperService);
+  private readonly toastService = inject(ToastService);
+  private readonly I18n = inject(I18nService);
+  private readonly halEvents = inject(HalEventsService);
+
   private text = {
     successful_delete: this.I18n.t('js.work_packages.message_successful_bulk_delete'),
   };
 
   private readonly states = inject(States);
-
-  constructor(private readonly http:HttpClient,
-    private readonly $state:StateService,
-    private readonly PathHelper:PathHelperService,
-    private readonly UrlParamsHelper:UrlParamsHelperService,
-    private readonly toastService:ToastService,
-    private readonly I18n:I18nService,
-    private readonly halEvents:HalEventsService) {
-  }
 
   public performBulkDelete(ids:string[], defaultHandling:boolean) {
     const params = {

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list-item.component.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -60,6 +50,13 @@ import { IFileIcon } from 'core-app/shared/components/storages/icons.mapping';
   standalone: false,
 })
 export class OpAttachmentListItemComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit {
+  private readonly I18n = inject(I18nService);
+  private readonly pathHelper = inject(PathHelperService);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly confirmDialogService = inject(ConfirmDialogService);
+  private readonly principalsResourceService = inject(PrincipalsResourceService);
+  private readonly principalRendererService = inject(PrincipalRendererService);
+
   @Input() public attachment:IAttachment;
 
   @Input() public index:number;
@@ -93,17 +90,6 @@ export class OpAttachmentListItemComponent extends UntilDestroyedMixin implement
   public fileIcon:IFileIcon;
 
   private viewInitialized$ = new BehaviorSubject<boolean>(false);
-
-  constructor(
-    private readonly I18n:I18nService,
-    private readonly pathHelper:PathHelperService,
-    private readonly timezoneService:TimezoneService,
-    private readonly confirmDialogService:ConfirmDialogService,
-    private readonly principalsResourceService:PrincipalsResourceService,
-    private readonly principalRendererService:PrincipalRendererService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     this.fileIcon = getIconForMimeType(this.attachment.contentType);

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { IAttachment } from 'core-app/core/state/attachments/attachment.model';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { AttachmentsResourceService } from 'core-app/core/state/attachments/attachments.service';
@@ -44,6 +38,8 @@ import { AttachmentsResourceService } from 'core-app/core/state/attachments/atta
   standalone: false,
 })
 export class OpAttachmentListComponent extends UntilDestroyedMixin {
+  private readonly attachmentsResourceService = inject(AttachmentsResourceService);
+
   @Input() public attachments:IAttachment[] = [];
 
   @Input() public collectionKey:string;
@@ -53,12 +49,6 @@ export class OpAttachmentListComponent extends UntilDestroyedMixin {
   @Input() public showDelete = true;
 
   @Output() public attachmentRemoved = new EventEmitter<void>();
-
-  constructor(
-    private readonly attachmentsResourceService:AttachmentsResourceService,
-  ) {
-    super();
-  }
 
   public removeAttachment(attachment:IAttachment):void {
     this.attachmentsResourceService.removeAttachment(this.collectionKey, attachment).subscribe(() => {

--- a/frontend/src/app/shared/components/attachments/attachments.component.ts
+++ b/frontend/src/app/shared/components/attachments/attachments.component.ts
@@ -26,20 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { fromEvent, Observable } from 'rxjs';
 import { filter, map, tap } from 'rxjs/operators';
 
@@ -69,6 +56,16 @@ function containsFiles(dataTransfer:DataTransfer):boolean {
   standalone: false,
 })
 export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  elementRef = inject(ElementRef);
+  protected readonly I18n = inject(I18nService);
+  protected readonly states = inject(States);
+  protected readonly toastService = inject(ToastService);
+  private readonly uploadService = inject(OpUploadService);
+  protected readonly halResourceService = inject(HalResourceService);
+  protected readonly attachmentsResourceService = inject(AttachmentsResourceService);
+  protected readonly timezoneService = inject(TimezoneService);
+  protected readonly cdRef = inject(ChangeDetectorRef);
+
   @HostBinding('attr.data-test-selector') public testSelector = 'op-attachments';
 
   @HostBinding('class.op-file-section') public className = true;
@@ -135,17 +132,7 @@ export class OpAttachmentsComponent extends UntilDestroyedMixin implements OnIni
     this.cdRef.detectChanges();
   };
 
-  constructor(
-    public elementRef:ElementRef,
-    protected readonly I18n:I18nService,
-    protected readonly states:States,
-    protected readonly toastService:ToastService,
-    private readonly uploadService:OpUploadService,
-    protected readonly halResourceService:HalResourceService,
-    protected readonly attachmentsResourceService:AttachmentsResourceService,
-    protected readonly timezoneService:TimezoneService,
-    protected readonly cdRef:ChangeDetectorRef,
-  ) {
+  constructor() {
     super();
 
     populateInputsFromDataset(this);

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text-modal.service.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text-modal.service.ts
@@ -26,18 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Injectable({ providedIn: 'root' })
 export class AttributeHelpTextModalService {
-  constructor(
-    protected pathHelper:PathHelperService,
-    protected turboRequests:TurboRequestsService,
-  ) {
+  protected pathHelper = inject(PathHelperService);
+  protected turboRequests = inject(TurboRequestsService);
 
-  }
 
   public show(helpTextId:string):Promise<unknown> {
     return this.turboRequests.requestStream(this.helpTextModalUrl(helpTextId));

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Injector,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { AttributeHelpTextsService } from './attribute-help-text.service';
@@ -50,6 +42,13 @@ export const attributeHelpTextSelector = 'attribute-help-text';
   standalone: false,
 })
 export class AttributeHelpTextComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  protected attributeHelpTexts = inject(AttributeHelpTextsService);
+  protected attributeHelpTextModalService = inject(AttributeHelpTextModalService);
+  protected cdRef = inject(ChangeDetectorRef);
+  protected injector = inject(Injector);
+  protected I18n = inject(I18nService);
+
   // Attribute to show help text for
   @Input() public attribute:string;
 
@@ -69,14 +68,7 @@ export class AttributeHelpTextComponent implements OnInit {
     open_dialog: this.I18n.t('js.help_texts.show_modal'),
   };
 
-  constructor(
-    readonly elementRef:ElementRef,
-    protected attributeHelpTexts:AttributeHelpTextsService,
-    protected attributeHelpTextModalService:AttributeHelpTextModalService,
-    protected cdRef:ChangeDetectorRef,
-    protected injector:Injector,
-    protected I18n:I18nService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.service.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/attribute-help-text.service.ts
@@ -27,17 +27,16 @@
 //++
 
 import { input } from '@openproject/reactivestates';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { HelpTextResource } from 'core-app/features/hal/resources/help-text-resource';
 import { firstValueFrom, map } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class AttributeHelpTextsService {
-  private helpTexts = input<HelpTextResource[]>();
+  private apiV3Service = inject(ApiV3Service);
 
-  constructor(private apiV3Service:ApiV3Service) {
-  }
+  private helpTexts = input<HelpTextResource[]>();
 
   /**
    * Search for a given attribute help text

--- a/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.component.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
@@ -48,6 +40,12 @@ import { StaticAttributeHelpTextModalComponent } from './static-attribute-help-t
   standalone: false,
 })
 export class StaticAttributeHelpTextComponent {
+  readonly elementRef = inject(ElementRef);
+  protected opModalService = inject(OpModalService);
+  protected cdRef = inject(ChangeDetectorRef);
+  protected injector = inject(Injector);
+  protected I18n = inject(I18nService);
+
   // Attribute pass the modal title and content
   @Input() public title:string;
 
@@ -59,13 +57,7 @@ export class StaticAttributeHelpTextComponent {
     open_dialog: this.I18n.t('js.help_texts.show_modal'),
   };
 
-  constructor(
-    readonly elementRef:ElementRef,
-    protected opModalService:OpModalService,
-    protected cdRef:ChangeDetectorRef,
-    protected injector:Injector,
-    protected I18n:I18nService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.ts
+++ b/frontend/src/app/shared/components/attribute-help-texts/static-attribute-help-text.modal.ts
@@ -26,13 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 
 @Component({
   templateUrl: './static-attribute-help-text.modal.html',
@@ -40,6 +36,8 @@ import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
   standalone: false,
 })
 export class StaticAttributeHelpTextModalComponent extends OpModalComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+
   readonly text = {
     close: this.I18n.t('js.button_close'),
   };
@@ -47,17 +45,4 @@ export class StaticAttributeHelpTextModalComponent extends OpModalComponent impl
   public title:string = this.locals.title as string;
 
   public content:string = this.locals.content as string;
-
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
-
-  ngOnInit() {
-    super.ngOnInit();
-  }
 }

--- a/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Injector,
-  Input,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Injector, Input, Output, ViewChild, inject } from '@angular/core';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -64,6 +54,8 @@ export interface CreateAutocompleterValueOption {
   standalone: false,
 })
 export class CreateAutocompleterComponent extends UntilDestroyedMixin implements AfterViewInit {
+  readonly injector = inject(Injector);
+
   @Input() public availableValues:CreateAutocompleterValueOption[];
 
   @Input() public appendTo:string;
@@ -118,7 +110,7 @@ export class CreateAutocompleterComponent extends UntilDestroyedMixin implements
 
   private _openDirectly = false;
 
-  constructor(readonly injector:Injector) {
+  constructor() {
     super();
 
     this.text.add_new_action = this.I18n.t('js.label_create');

--- a/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/draggable-autocomplete/draggable-autocomplete.component.ts
@@ -1,15 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  OnDestroy,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, OnDestroy, Output, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { NgSelectComponent } from '@ng-select/ng-select';
 import { DragulaService, Group } from 'ng2-dragula';
@@ -40,6 +29,11 @@ export interface DraggableOption {
   standalone: false,
 })
 export class DraggableAutocompleteComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly elementRef = inject(ElementRef);
+  readonly dragula = inject(DragulaService);
+  readonly alternativeSearchService = inject(AlternativeSearchService);
+
   /** Options to show in the autocompleter */
   @Input() options:DraggableOption[];
 
@@ -97,15 +91,6 @@ export class DraggableAutocompleteComponent extends UntilDestroyedMixin implemen
   @ViewChild('input') inputElement:ElementRef;
 
   public appendTo = 'body';
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    readonly dragula:DragulaService,
-    readonly alternativeSearchService:AlternativeSearchService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     populateInputsFromDataset(this);

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component.ts
@@ -1,27 +1,6 @@
 /* We just forward the ng-select outputs without renaming */
 /* eslint-disable @angular-eslint/no-output-native */
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ContentChild,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Injector,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-  TemplateRef,
-  Type,
-  ViewChild,
-  ViewContainerRef,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, ElementRef, EventEmitter, forwardRef, HostBinding, Injector, Input, OnChanges, OnInit, Output, SimpleChanges, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, inject } from '@angular/core';
 import { DropdownPosition, NgSelectComponent } from '@ng-select/ng-select';
 import { BehaviorSubject, merge, NEVER, Observable, of, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs/operators';
@@ -96,6 +75,16 @@ type GroupValueFn = (key:string | any, children:any[]) => string | any;
 export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocompleteItem>
   extends UntilDestroyedMixin
   implements OnInit, AfterViewInit, OnChanges, ControlValueAccessor {
+  readonly injector = inject(Injector);
+  readonly elementRef = inject<ElementRef<HTMLElement & { ngSelectComponentInstance?:NgSelectComponent }>>(ElementRef);
+  readonly http = inject(HttpClient);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly vcRef = inject(ViewContainerRef);
+  readonly I18n = inject(I18nService);
+  readonly halResourceService = inject(HalResourceService);
+  readonly pathHelperService = inject(PathHelperService);
+
   @HostBinding('class.op-autocompleter') className = true;
 
   @Input() public filters?:IAPIFilter[] = [];
@@ -297,21 +286,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   footerTemplate:TemplateRef<Element>;
 
-  readonly opAutocompleterService = new OpAutocompleterService(this.apiV3Service, this.halResourceService);
-
-  constructor(
-    readonly injector:Injector,
-    readonly elementRef:ElementRef,
-    readonly http:HttpClient,
-    readonly apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-    readonly vcRef:ViewContainerRef,
-    readonly I18n:I18nService,
-    readonly halResourceService:HalResourceService,
-    readonly pathHelperService:PathHelperService,
-  ) {
-    super();
-  }
+  readonly opAutocompleterService = inject(OpAutocompleterService);
 
   ngOnInit() {
     populateInputsFromDataset(this);
@@ -333,8 +308,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
 
   ngAfterViewInit():void {
     // Store ng-select instance on the host element for access from Stimulus controllers
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
-    (this.elementRef.nativeElement as any).ngSelectComponentInstance = this.ngSelectInstance;
+    this.elementRef.nativeElement.ngSelectComponentInstance = this.ngSelectInstance;
 
     if (this.inputName && this.model) {
       this.syncHiddenField(this.mappedInputValue);
@@ -484,7 +458,7 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     }
 
     return this.typeahead.pipe(
-      filter(() => !!(this.defaultData || this.url || this.getOptionsFn)),
+      filter(() => [this.defaultData, this.url, this.getOptionsFn].some(Boolean)),
       distinctUntilChanged(),
       tap(() => this.loading$.next(true)),
       debounceTime(this.debounceTimeForCurrentEnvironment),
@@ -518,11 +492,9 @@ export class OpAutocompleterComponent<T extends IAutocompleteItem = IAutocomplet
     this.model = value;
   }
 
-  onChange = (_:T|T[]|null):void => {
-  };
+  onChange = (_:T|T[]|null):void => undefined;
 
-  onTouched = (_:T|T[]|null):void => {
-  };
+  onTouched = (_:T|T[]|null):void => undefined;
 
   registerOnChange(fn:(_:T|T[]|null) => void):void {
     this.onChange = fn;

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/op-autocompleter.spec.ts
@@ -2,7 +2,7 @@ import type { Mock } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { States } from 'core-app/core/states/states.service';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ChangeDetectionStrategy, Component, NO_ERRORS_SCHEMA } from '@angular/core';
 import { of, map } from 'rxjs';
 import { NgSelectModule } from '@ng-select/ng-select';
 
@@ -10,6 +10,15 @@ import { OpAutocompleterComponent } from './op-autocompleter.component';
 import { TOpAutocompleterResource } from './typings';
 import { By } from '@angular/platform-browser';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+@Component({
+  selector: 'op-test-autocompleter',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+class TestAutocompleterComponent extends OpAutocompleterComponent {
+}
 
 describe('autocompleter', () => {
   let fixture:ComponentFixture<OpAutocompleterComponent>;
@@ -86,7 +95,7 @@ describe('autocompleter', () => {
     fixture = TestBed.createComponent(OpAutocompleterComponent);
     getOptionsFnSpy = vi.fn().mockImplementation((searchTerm:string) => {
       return of(workPackagesStub).pipe(map((wps) => wps.filter((wp) => searchTerm !== '' && wp.subject.includes(searchTerm))));
-    });
+    }) as unknown as Mock;
 
     fixture.componentInstance.resource = 'work_packages' as TOpAutocompleterResource;
     fixture.componentInstance.filters = [];
@@ -328,5 +337,20 @@ describe('autocompleter', () => {
 
       expect(getOptionsFnSpy).toHaveBeenCalledWith('Wor');
     });
+  });
+});
+
+describe('derived autocompleter', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestAutocompleterComponent],
+      providers: [States, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    }).compileComponents();
+  });
+
+  it('provides shared autocompleter dependencies to subclasses', () => {
+    const fixture = TestBed.createComponent(TestAutocompleterComponent);
+
+    expect(fixture.componentInstance.opAutocompleterService).toBeDefined();
   });
 });

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3FilterBuilder } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { map } from 'rxjs/operators';
 import { ApiV3ResourceCollection } from 'core-app/core/apiv3/paths/apiv3-resource';
@@ -20,15 +20,11 @@ import { addFiltersToPath } from 'core-app/core/apiv3/helpers/add-filters-to-pat
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 
-@Injectable()
-
+@Injectable({ providedIn: 'root' })
 export class OpAutocompleterService extends UntilDestroyedMixin {
-  constructor(
-    private apiV3Service:ApiV3Service,
-    private halResourceService:HalResourceService,
-  ) {
-    super();
-  }
+  private apiV3Service = inject(ApiV3Service);
+  private halResourceService = inject(HalResourceService);
+
 
   // A method for fetching data with different resource type and different filter
   public loadAvailable(matching:string, resource:TOpAutocompleterResource, filters?:IAPIFilter[], searchKey?:string):Observable<HalResource[]> {
@@ -98,7 +94,7 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
     switch (resource) {
       // in this case we can add more functions for fetching usual resources
       default: {
-        return this.loadAvailable(matching || '', resource, filters, searchKey);
+        return this.loadAvailable(matching ?? '', resource, filters, searchKey);
       }
     }
   }
@@ -111,7 +107,7 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
       return of([]);
     }
 
-    const finalFilters:ApiV3FilterBuilder = this.createFilters(filters ?? [], matching || '', searchKey);
+    const finalFilters:ApiV3FilterBuilder = this.createFilters(filters ?? [], matching ?? '', searchKey);
     const params = this.createParams(resource);
 
     const stringifiedBuiltOutUrl = addFiltersToPath(url, finalFilters, params).toString();

--- a/frontend/src/app/shared/components/autocompleter/project-phase-autocompleter/project-phase-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/project-phase-autocompleter/project-phase-autocompleter.component.ts
@@ -28,7 +28,7 @@
  * ++
  */
 
-import { ChangeDetectionStrategy, Component, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CreateAutocompleterComponent } from '../create-autocompleter/create-autocompleter.component';
 import { opPhaseIconData, toDOMString } from '@openproject/octicons-angular';
 import { ProjectPhaseResource } from 'core-app/features/hal/resources/project-phase-resource';
@@ -49,8 +49,8 @@ export class ProjectPhaseAutocompleterComponent extends CreateAutocompleterCompo
 
   public phaseIcon:SafeHtml;
 
-  constructor(readonly injector:Injector) {
-    super(injector);
+  constructor() {
+    super();
 
     this.phaseIcon = this.sanitizer.bypassSecurityTrustHtml(toDOMString(opPhaseIconData, 'small', { 'aria-hidden': 'true', class: 'octicon' }));
   }

--- a/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/time-entries-work-package-autocompleter/time-entries-work-package-autocompleter-template.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Injector, Input, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Injector, Input, TemplateRef, ViewChild, inject } from '@angular/core';
 import {
   IAutocompleterTemplateComponent,
   OpAutocompleterComponent,
@@ -41,6 +41,8 @@ import {
   standalone: false,
 })
 export class TimeEntriesWorkPackageAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {
+  readonly injector = inject(Injector);
+
   @Input() public mode:string|undefined;
   @Input() public isOpenedInModal = false;
   @Input() public hoverCards = true;
@@ -48,9 +50,4 @@ export class TimeEntriesWorkPackageAutocompleterTemplateComponent implements IAu
   @ViewChild('headerTemplate') headerTemplate:TemplateRef<Element>;
 
   autocompleter:TimeEntriesWorkPackageAutocompleterComponent = this.injector.get(OpAutocompleterComponent) as TimeEntriesWorkPackageAutocompleterComponent;
-
-  constructor(
-    readonly injector:Injector,
-  ) {
-  }
 }

--- a/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/user-autocompleter/user-autocompleter-template.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, TemplateRef, ViewChild, inject } from '@angular/core';
 import {
   IAutocompleterTemplateComponent,
 } from 'core-app/shared/components/autocompleter/op-autocompleter/op-autocompleter.component';
@@ -41,11 +41,11 @@ import { hrefFromPrincipal, typeFromHref } from 'core-app/shared/components/prin
   standalone: false,
 })
 export class UserAutocompleterTemplateComponent implements IAutocompleterTemplateComponent {
+  private readonly pathHelperService = inject(PathHelperService);
+
   @Input() public inviteUserToProject:string|undefined;
   @Input() public isOpenedInModal = false;
   @Input() public hoverCards = true;
-
-  constructor(private readonly pathHelperService:PathHelperService) {}
 
   @ViewChild('optionTemplate') optionTemplate:TemplateRef<Element>;
   @ViewChild('footerTemplate') footerTemplate?:TemplateRef<Element>;

--- a/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/autocompleter/version-autocompleter/version-autocompleter.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Injector,
-  Output,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Output, inject } from '@angular/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { CreateAutocompleterComponent } from 'core-app/shared/components/autocompleter/create-autocompleter/create-autocompleter.component';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -52,6 +44,13 @@ import { firstValueFrom } from 'rxjs';
   standalone: false,
 })
 export class VersionAutocompleterComponent extends CreateAutocompleterComponent implements AfterViewInit {
+  readonly I18n = inject(I18nService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly pathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly halNotification = inject(HalResourceNotificationService);
+
   @Output() public onCreate = new EventEmitter<VersionResource>();
 
   groupByFn = (item:HalResource):string|null => {
@@ -59,18 +58,6 @@ export class VersionAutocompleterComponent extends CreateAutocompleterComponent 
     const project = item.definingProject as HalResource | undefined;
     return project?.name || this.I18n.t('js.project.not_available');
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly currentProject:CurrentProjectService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly pathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly halNotification:HalResourceNotificationService,
-  ) {
-    super(injector);
-  }
 
   ngAfterViewInit() {
     super.ngAfterViewInit();

--- a/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.ts
+++ b/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.ts
@@ -26,11 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 export type BreadcrumbItem =
@@ -45,12 +41,10 @@ export type BreadcrumbItem =
   standalone: false,
 })
 export class OpBreadcrumbsComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() items:BreadcrumbItem[] = [];
   @Input() lastItemSection?:string | null = null;
-
-  constructor(
-    readonly I18n:I18nService,
-  ) { }
 
   text = {
     breadcrumb: this.I18n.t('js.breadcrumb'),

--- a/frontend/src/app/shared/components/colors/colors-autocompleter.component.ts
+++ b/frontend/src/app/shared/components/colors/colors-autocompleter.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, inject } from '@angular/core';
 import {
   Highlighting,
 } from 'core-app/features/work-packages/components/wp-fast-table/builders/highlighting/highlighting.functions';
@@ -62,6 +62,9 @@ interface ColorItem {
   standalone: false,
 })
 export class ColorsAutocompleterComponent implements OnInit {
+  protected elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  protected readonly I18n = inject(I18nService);
+
   public options:ColorItem[];
 
   public selectedOption?:ColorItem|string;
@@ -73,12 +76,6 @@ export class ColorsAutocompleterComponent implements OnInit {
   private updateInputField:HTMLInputElement|undefined;
 
   private selectedColorId:string;
-
-  constructor(
-    protected elementRef:ElementRef<HTMLElement>,
-    protected readonly I18n:I18nService,
-  ) {
-  }
 
   ngOnInit() {
     this.setColorOptions();

--- a/frontend/src/app/shared/components/copy-to-clipboard/copy-to-clipboard.service.ts
+++ b/frontend/src/app/shared/components/copy-to-clipboard/copy-to-clipboard.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -34,10 +34,9 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   providedIn: 'root',
 })
 export class CopyToClipboardService {
-  constructor(
-    readonly toastService:ToastService,
-    readonly I18n:I18nService,
-  ) { }
+  readonly toastService = inject(ToastService);
+  readonly I18n = inject(I18nService);
+
 
   copy(content:string, successMessage?:string) {
     if (!navigator.clipboard) {

--- a/frontend/src/app/shared/components/date/op-date-time.component.ts
+++ b/frontend/src/app/shared/components/date/op-date-time.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 
 @Component({
@@ -45,14 +45,13 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class OpDateTimeComponent implements OnInit {
+  readonly timezoneService = inject(TimezoneService);
+
   @Input() dateTimeValue:any;
 
   public date:any;
 
   public time:any;
-
-  constructor(readonly timezoneService:TimezoneService) {
-  }
 
   ngOnInit() {
     const c = this.timezoneService.formattedDatetimeComponents(this.dateTimeValue);

--- a/frontend/src/app/shared/components/datepicker/basic-datepicker.module.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-datepicker.module.ts
@@ -1,4 +1,4 @@
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
@@ -28,6 +28,5 @@ import { OpBasicSingleDatePickerComponent } from './basic-single-date-picker/bas
   ],
 })
 export class OpBasicDatePickerModule {
-  constructor(readonly injector:Injector) {
-  }
+  readonly injector = inject(Injector);
 }

--- a/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-range-date-picker/basic-range-date-picker.component.ts
@@ -26,22 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Injector,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, HostBinding, Injector, Input, OnInit, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   ControlValueAccessor,
@@ -81,6 +66,13 @@ export const opBasicRangeDatePickerSelector = 'op-basic-range-date-picker';
   standalone: false,
 })
 export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAccessor, AfterViewInit {
+  readonly I18n = inject(I18nService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+  readonly deviceService = inject(DeviceService);
+
   @HostBinding('class.op-basic-range-datepicker') className = true;
 
   @HostBinding('class.op-basic-range-datepicker_mobile') mobile = false;
@@ -133,14 +125,7 @@ export class OpBasicRangeDatePickerComponent implements OnInit, ControlValueAcce
     spacer: this.I18n.t('js.filter.value_spacer'),
   };
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    readonly deviceService:DeviceService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/basic-single-date-picker/basic-single-date-picker.component.ts
@@ -26,22 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Injector, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { onDayCreate, validDate } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
@@ -67,6 +52,13 @@ import { DeviceService } from 'core-app/core/browser/device.service';
   standalone: false,
 })
 export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, OnInit, AfterViewInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+  readonly deviceService = inject(DeviceService);
+
   @Output() valueChange = new EventEmitter();
 
   @Output() picked = new EventEmitter();
@@ -112,14 +104,7 @@ export class OpBasicSingleDatePickerComponent implements ControlValueAccessor, O
 
   public datePickerInstance:DatePicker;
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    readonly deviceService:DeviceService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
+++ b/frontend/src/app/shared/components/datepicker/modal-single-date-picker/modal-single-date-picker.component.ts
@@ -26,21 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterContentInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  Injector,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Injector, Input, OnInit, Output, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { onDayCreate, parseDate, setDates } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
@@ -73,6 +59,13 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class OpModalSingleDatePickerComponent implements ControlValueAccessor, OnInit, AfterContentInit {
+  readonly I18n = inject(I18nService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+  readonly spotDropModalTeleportationService = inject(SpotDropModalTeleportationService);
+
   @Output() closed = new EventEmitter();
 
   @Output() valueChange = new EventEmitter();
@@ -145,14 +138,7 @@ export class OpModalSingleDatePickerComponent implements ControlValueAccessor, O
     },
   };
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    readonly spotDropModalTeleportationService:SpotDropModalTeleportationService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/datepicker/sheet/date-picker-sheet.component.ts
+++ b/frontend/src/app/shared/components/datepicker/sheet/date-picker-sheet.component.ts
@@ -26,22 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Injector,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, Injector, Input, OnChanges, Output, SimpleChanges, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { onDayCreate } from 'core-app/shared/components/datepicker/helpers/date-modal.helpers';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
@@ -61,6 +46,13 @@ import { DeviceService } from 'core-app/core/browser/device.service';
   standalone: false,
 })
 export class OpDatePickerSheetComponent implements AfterViewInit, OnChanges {
+  readonly I18n = inject(I18nService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+  readonly deviceService = inject(DeviceService);
+
   @HostBinding('class.op-datepicker-sheet') className = true;
 
   @Input() dates:string[];
@@ -76,16 +68,6 @@ export class OpDatePickerSheetComponent implements AfterViewInit, OnChanges {
   @ViewChild('flatpickrTarget') flatpickrTarget:ElementRef<HTMLElement>;
 
   datePickerInstance:DatePicker;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    readonly deviceService:DeviceService,
-  ) {
-  }
 
   ngAfterViewInit():void {
     this.initializeDatepicker();

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker-instance.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Injector,
-  Input,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { DayElement } from 'flatpickr/dist/types/instance';
@@ -65,6 +56,15 @@ export type DateMode = 'single'|'range';
   standalone: false,
 })
 export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin implements AfterViewInit {
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly I18n = inject(I18nService);
+  readonly timezoneService = inject(TimezoneService);
+  readonly deviceService = inject(DeviceService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly elementRef = inject(ElementRef);
+
   @Input() public ignoreNonWorkingDays:boolean;
   @Input() public scheduleManually:boolean;
 
@@ -89,16 +89,7 @@ export class OpWpDatePickerInstanceComponent extends UntilDestroyedMixin impleme
   private minimalSchedulingDate:Date|null;
   private onFlatpickrSetValuesBound = this.onFlatpickrSetValues.bind(this);
 
-  constructor(
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly apiV3Service:ApiV3Service,
-    readonly I18n:I18nService,
-    readonly timezoneService:TimezoneService,
-    readonly deviceService:DeviceService,
-    readonly pathHelper:PathHelperService,
-    readonly elementRef:ElementRef,
-  ) {
+  constructor() {
     super();
     populateInputsFromDataset(this);
     this.startDateValue = this.toDate(this.startDate);

--- a/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.ts
+++ b/frontend/src/app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal.ts
@@ -26,18 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 
 @Component({
@@ -46,18 +37,11 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class OpWpDatePickerModalComponent extends OpModalComponent implements OnInit {
+  readonly pathHelper = inject(PathHelperService);
+
   turboFrameSrc:string;
 
   showCloseButton = false;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly pathHelper:PathHelperService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
+++ b/frontend/src/app/shared/components/editable-toolbar-title/editable-toolbar-title.component.ts
@@ -25,21 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Injector,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, Injector, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { whenOutside } from 'core-app/shared/directives/focus/contain-helpers';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
@@ -58,6 +44,9 @@ export const selectableTitleIdentifier = 'editable-toolbar-title';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class EditableToolbarTitleComponent implements OnInit, OnChanges {
+  readonly injector = inject(Injector);
+  private cdRef = inject(ChangeDetectorRef);
+
   @Input('title') public inputTitle:string;
 
   @Input() public editable = true;
@@ -100,9 +89,6 @@ export class EditableToolbarTitleComponent implements OnInit, OnChanges {
     confirm_edit_cancel: this.I18n.t('js.work_packages.query.confirm_edit_cancel'),
     duplicate_query_title: this.I18n.t('js.work_packages.query.errors.duplicate_query_title'),
   };
-
-  constructor(readonly injector:Injector, private cdRef:ChangeDetectorRef) {
-  }
 
   ngOnInit():void {
     this.text.input_title = `${this.text.click_to_edit} ${this.text.press_enter_to_save}`;

--- a/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor-augmented-textarea/ckeditor-augmented-textarea.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
@@ -66,6 +57,13 @@ import { attributeTokenList, ensureId } from 'core-app/shared/helpers/dom-helper
   standalone: false,
 })
 export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin implements OnInit {
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  protected pathHelper = inject(PathHelperService);
+  protected halResourceService = inject(HalResourceService);
+  protected Notifications = inject(ToastService);
+  protected I18n = inject(I18nService);
+  protected states = inject(States);
+
   // Track form submission "in-flight" state per form, to prevent multiple
   // submissions from multiple CKEditor instances on the same form.
   private static inFlight = new WeakMap<HTMLFormElement, boolean>();
@@ -135,14 +133,7 @@ export class CkeditorAugmentedTextareaComponent extends UntilDestroyedMixin impl
 
   private labelClickSubscription:Subscription;
 
-  constructor(
-    readonly elementRef:ElementRef<HTMLElement>,
-    protected pathHelper:PathHelperService,
-    protected halResourceService:HalResourceService,
-    protected Notifications:ToastService,
-    protected I18n:I18nService,
-    protected states:States,
-  ) {
+  constructor() {
     super();
     populateInputsFromDataset(this);
   }

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-preview.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-preview.service.ts
@@ -26,16 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Injector } from '@angular/core';
+import { ApplicationRef, ComponentFactoryResolver, ComponentRef, Injectable, Injector, inject } from '@angular/core';
 
 @Injectable()
 export class CKEditorPreviewService {
-  constructor(
-    private readonly componentFactoryResolver:ComponentFactoryResolver,
-    private readonly appRef:ApplicationRef,
-    private readonly injector:Injector,
-  ) {
-  }
+  private readonly componentFactoryResolver = inject(ComponentFactoryResolver);
+  private readonly appRef = inject(ApplicationRef);
+  private readonly injector = inject(Injector);
+
 
   /**
    * Render preview into the given element, return a remover function to disconnect all

--- a/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
+++ b/frontend/src/app/shared/components/editor/components/ckeditor/ckeditor-setup.service.ts
@@ -1,5 +1,5 @@
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ICKEditorContext,
   ICKEditorStatic,
@@ -21,17 +21,14 @@ declare global {
 
 @Injectable()
 export class CKEditorSetupService {
+  readonly PathHelper = inject(PathHelperService);
+  readonly configurationService = inject(ConfigurationService);
+
   /** The language CKEditor was able to load, falls back to 'en' */
   private loadedLocale = 'en';
 
   /** Prefetch ckeditor when browser is idle */
   private prefetch:Promise<unknown>;
-
-  constructor(
-    readonly PathHelper:PathHelperService,
-    readonly configurationService:ConfigurationService,
-    ) {
-  }
 
   public initialize() {
     this.prefetch = this.load();

--- a/frontend/src/app/shared/components/editor/openproject-editor.module.ts
+++ b/frontend/src/app/shared/components/editor/openproject-editor.module.ts
@@ -86,6 +86,4 @@ export function initializeServices(injector:Injector) {
   ],
 })
 export class OpenprojectEditorModule {
-  constructor(injector:Injector) {
-  }
 }

--- a/frontend/src/app/shared/components/fields/display/display-field.component.ts
+++ b/frontend/src/app/shared/components/fields/display/display-field.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnInit, ViewChild, inject } from '@angular/core';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { DisplayFieldService } from 'core-app/shared/components/fields/display/display-field.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
@@ -14,6 +14,10 @@ import { SchemaResource } from 'core-app/features/hal/resources/schema-resource'
   standalone: false,
 })
 export class DisplayFieldComponent implements OnInit {
+  private injector = inject(Injector);
+  private displayFieldService = inject(DisplayFieldService);
+  private schemaCache = inject(SchemaCacheService);
+
   @Input() resource:HalResource;
 
   @Input() fieldName:string;
@@ -25,13 +29,6 @@ export class DisplayFieldComponent implements OnInit {
   @Input() displayFieldOptions:Record<string, unknown> = {};
 
   @ViewChild('displayFieldContainer') container:ElementRef<HTMLSpanElement>;
-
-  constructor(
-    private injector:Injector,
-    private displayFieldService:DisplayFieldService,
-    private schemaCache:SchemaCacheService,
-  ) {
-  }
 
   ngOnInit():void {
     void this.schemaCache

--- a/frontend/src/app/shared/components/fields/display/field-types/excluded-icon-helper.service.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/excluded-icon-helper.service.ts
@@ -26,16 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { StatusResource } from 'core-app/features/hal/resources/status-resource';
 
 @Injectable({ providedIn: 'root' })
 export class ExcludedIconHelperService {
-  constructor(
-    private apiV3Service:ApiV3Service,
-  ) {}
+  private apiV3Service = inject(ApiV3Service);
+
 
   public addIconIfExcludedFromTotals(element:HTMLElement, resource:WorkPackageResource):void {
     if (resource?.status) {

--- a/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/hierarchy-query-link-helper.service.ts
@@ -26,16 +26,15 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import URI from 'urijs';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 
 @Injectable({ providedIn: 'root' })
 export class HierarchyQueryLinkHelperService {
-  constructor(
-    private pathHelper:PathHelperService,
-  ) {}
+  private pathHelper = inject(PathHelperService);
+
 
   public addHref(link:HTMLAnchorElement, resource:HalResource):void {
     if (resource && resource.id) {

--- a/frontend/src/app/shared/components/fields/display/info/op-exclusion-info.component.ts
+++ b/frontend/src/app/shared/components/fields/display/info/op-exclusion-info.component.ts
@@ -28,13 +28,7 @@
  * ++
  */
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -45,6 +39,9 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   standalone: false,
 })
 export class OpExclusionInfoComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public opened = false;
 
   @Input() public statusName:string;
@@ -54,11 +51,6 @@ export class OpExclusionInfoComponent implements OnInit {
     modalContent: '',
     buttonClose: this.I18n.t('js.button_close'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {}
 
   ngOnInit() {
     this.text.modalContent = this.I18n.t('js.exclusion_info.modal.content', { status_name: this.statusName || '' });

--- a/frontend/src/app/shared/components/fields/edit/edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-field.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  Inject,
-  InjectionToken,
-  Injector,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, InjectionToken, Injector, OnDestroy, OnInit, inject } from '@angular/core';
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { Field, IFieldSchema } from 'core-app/shared/components/fields/field.base';
@@ -53,21 +44,23 @@ export const editModeClassName = '-editing';
 
 @Directive()
 export abstract class EditFieldComponent extends Field implements OnInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly elementRef = inject(ElementRef);
+  protected change = inject<ResourceChangeset<HalResource>>(OpEditingPortalChangesetToken);
+  schema = inject<IFieldSchema>(OpEditingPortalSchemaToken);
+  readonly handler = inject<EditFieldHandler>(OpEditingPortalHandlerToken);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly injector = inject(Injector);
+
   /** Self reference */
   public self = this;
 
   protected element:HTMLElement;
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-    @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-    @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-    readonly cdRef:ChangeDetectorRef,
-    readonly injector:Injector,
-  ) {
+  constructor() {
     super();
+    const change = this.change;
+
 
     this.updateFromChangeset(change);
   }

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.component.ts
@@ -26,20 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Optional,
-  Output,
-} from '@angular/core';
+import { ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, inject } from '@angular/core';
 import { StateService, Transition, TransitionService } from '@uirouter/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { EditableAttributeFieldComponent } from 'core-app/shared/components/fields/edit/field/editable-attribute-field.component';
@@ -70,6 +57,18 @@ import { firstValueFrom } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class EditFormComponent extends EditForm<HalResource> implements OnInit, OnDestroy {
+  readonly injector:Injector;
+  protected readonly elementRef = inject(ElementRef);
+  private appRef = inject(ApplicationRef);
+  private readonly cdRef = inject(ChangeDetectorRef);
+  protected readonly $transitions = inject(TransitionService);
+  protected readonly configurationService = inject(ConfigurationService);
+  protected readonly editingPortalService = inject(EditingPortalService);
+  protected readonly $state = inject(StateService);
+  protected readonly I18n = inject(I18nService);
+  protected readonly editFormRouting = inject(EditFormRoutingService, { optional: true });
+  private globalEditFormChangesTrackerService = inject(GlobalEditFormChangesTrackerService);
+
   @Input() resource:HalResource;
 
   @Input('inEditMode') initializeEditMode = false;
@@ -84,20 +83,16 @@ export class EditFormComponent extends EditForm<HalResource> implements OnInit, 
 
   private unregisterListener:Function;
 
-  constructor(public readonly injector:Injector,
-    protected readonly elementRef:ElementRef,
-    private appRef:ApplicationRef,
-    private readonly cdRef:ChangeDetectorRef,
-    protected readonly $transitions:TransitionService,
-    protected readonly ConfigurationService:ConfigurationService,
-    protected readonly editingPortalService:EditingPortalService,
-    protected readonly $state:StateService,
-    protected readonly I18n:I18nService,
-    @Optional() protected readonly editFormRouting:EditFormRoutingService,
-    private globalEditFormChangesTrackerService:GlobalEditFormChangesTrackerService) {
+  constructor() {
+    const injector = inject(Injector);
+
     super(injector);
+    this.injector = injector;
+    const $transitions = this.$transitions;
+    const I18n = this.I18n;
+
     const confirmText = I18n.t('js.work_packages.confirm_edit_cancel');
-    const requiresConfirmation = ConfigurationService.warnOnLeavingUnsaved();
+    const requiresConfirmation = this.configurationService.warnOnLeavingUnsaved();
 
     this.unregisterListener = $transitions.onBefore({}, (transition:Transition) => {
       if (!this.editing) {

--- a/frontend/src/app/shared/components/fields/edit/editing-portal/edit-form-portal.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/editing-portal/edit-form-portal.component.ts
@@ -1,16 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Injector, Input, OnDestroy, OnInit, Output, inject } from '@angular/core';
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
 import { HalResourceEditFieldHandler } from 'core-app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler';
 import { takeUntil } from 'rxjs/operators';
@@ -34,6 +22,11 @@ import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/r
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class EditFormPortalComponent implements OnInit, OnDestroy, AfterViewInit {
+  readonly injector = inject(Injector);
+  readonly editField = inject(EditFieldService);
+  readonly elementRef = inject(ElementRef);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() schemaInput:IFieldSchema;
 
   @Input() changeInput:ResourceChangeset;
@@ -55,13 +48,6 @@ export class EditFormPortalComponent implements OnInit, OnDestroy, AfterViewInit
   public htmlId:string;
 
   public label:string;
-
-  constructor(
-    readonly injector:Injector,
-    readonly editField:EditFieldService,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-  ) { }
 
   ngOnInit() {
     if (this.editFieldHandler && this.schemaInput) {

--- a/frontend/src/app/shared/components/fields/edit/editing-portal/editing-portal-service.ts
+++ b/frontend/src/app/shared/components/fields/edit/editing-portal/editing-portal-service.ts
@@ -1,9 +1,7 @@
 /**
  * A CDK portal implementation to wrap edit-fields in non-angular contexts.
  */
-import {
-  ApplicationRef, Injectable, Injector,
-} from '@angular/core';
+import { ApplicationRef, Injectable, Injector, inject } from '@angular/core';
 import { ComponentPortal, DomPortalOutlet } from '@angular/cdk/portal';
 import { EditFormPortalComponent } from 'core-app/shared/components/fields/edit/editing-portal/edit-form-portal.component';
 import { createLocalInjector } from 'core-app/shared/components/fields/edit/editing-portal/edit-form-portal.injector';
@@ -16,10 +14,9 @@ import { HalResourceEditFieldHandler } from 'core-app/shared/components/fields/e
 
 @Injectable({ providedIn: 'root' })
 export class EditingPortalService {
-  constructor(private readonly appRef:ApplicationRef,
-    private readonly pathHelper:PathHelperService) {
+  private readonly appRef = inject(ApplicationRef);
+  private readonly pathHelper = inject(PathHelperService);
 
-  }
 
   public create(container:HTMLElement,
     injector:Injector,

--- a/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/date-picker-edit-field.component.ts
@@ -26,35 +26,22 @@
  *  See COPYRIGHT and LICENSE files for more details.
  */
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  Inject,
-  Injector,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { Directive, OnDestroy, OnInit, inject } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import {
   EditFieldComponent,
-  OpEditingPortalChangesetToken,
-  OpEditingPortalHandlerToken,
-  OpEditingPortalSchemaToken,
 } from 'core-app/shared/components/fields/edit/edit-field.component';
 import { DeviceService } from 'core-app/core/browser/device.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
-import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { OpWpDatePickerModalComponent } from 'core-app/shared/components/datepicker/wp-date-picker-modal/wp-date-picker.modal';
 
 @Directive()
 export abstract class DatePickerEditFieldComponent extends EditFieldComponent implements OnInit, OnDestroy {
+  readonly pathHelper = inject(PathHelperService);
+  readonly opModalService = inject(OpModalService);
+
   @InjectField() readonly timezoneService:TimezoneService;
 
   @InjectField() deviceService:DeviceService;
@@ -64,20 +51,6 @@ export abstract class DatePickerEditFieldComponent extends EditFieldComponent im
   private createHandler:EventListener = this.handleSuccessfulCreate.bind(this);
   private updateHandler:EventListener = this.handleSuccessfulUpdate.bind(this);
   private cancelHandler:EventListener = this.cancel.bind(this);
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-    @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-    @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-    readonly cdRef:ChangeDetectorRef,
-    readonly injector:Injector,
-    readonly pathHelper:PathHelperService,
-    readonly opModalService:OpModalService,
-  ) {
-    super(I18n, elementRef, change, schema, handler, cdRef, injector);
-  }
 
   ngOnInit():void {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/progress-popover-edit-field.component.ts
@@ -28,27 +28,9 @@
  * ++
  */
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  Injector,
-  OnInit,
-} from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ProgressEditFieldComponent } from 'core-app/shared/components/fields/edit/field-types/progress-edit-field.component';
-import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/resource-changeset';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
-import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
-import {
-  OpEditingPortalChangesetToken,
-  OpEditingPortalHandlerToken,
-  OpEditingPortalSchemaToken,
-} from 'core-app/shared/components/fields/edit/edit-field.component';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -61,6 +43,12 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
   standalone: false,
 })
 export class ProgressPopoverEditFieldComponent extends ProgressEditFieldComponent implements OnInit {
+  readonly pathHelper = inject(PathHelperService);
+  private halEvents = inject(HalEventsService);
+  private toastService = inject(ToastService);
+  private apiV3Service = inject(ApiV3Service);
+  private timezoneService = inject(TimezoneService);
+
   text = {
     title: this.I18n.t('js.work_packages.progress.title'),
     button_close: this.I18n.t('js.button_close'),
@@ -71,23 +59,6 @@ export class ProgressPopoverEditFieldComponent extends ProgressEditFieldComponen
   public frameId:string;
 
   opened = false;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-    @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-    @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-    readonly cdRef:ChangeDetectorRef,
-    readonly injector:Injector,
-    readonly pathHelper:PathHelperService,
-    private halEvents:HalEventsService,
-    private toastService:ToastService,
-    private apiV3Service:ApiV3Service,
-    private timezoneService:TimezoneService,
-  ) {
-    super(I18n, elementRef, change, schema, handler, cdRef, injector);
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/fields/edit/field-types/project-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/project-edit-field.component.ts
@@ -26,31 +26,14 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  Injector,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { from } from 'rxjs';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   EditFieldComponent,
-  OpEditingPortalChangesetToken,
-  OpEditingPortalHandlerToken,
-  OpEditingPortalSchemaToken,
 } from 'core-app/shared/components/fields/edit/edit-field.component';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { IProject } from 'core-app/core/state/projects/project.model';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { ResourceChangeset } from '../../changeset/resource-changeset';
-import { IFieldSchema } from '../../field.base';
-import { EditFieldHandler } from '../editing-portal/edit-field-handler';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { take, tap } from 'rxjs/operators';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
@@ -66,32 +49,13 @@ import { FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-bui
   standalone: false,
 })
 export class ProjectEditFieldComponent extends EditFieldComponent implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly http = inject(HttpClient);
+  readonly halResourceService = inject(HalResourceService);
+
   isNew = isNewResource(this.resource);
 
   url:string;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-    @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-    @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-    readonly cdRef:ChangeDetectorRef,
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly http:HttpClient,
-    readonly halResourceService:HalResourceService,
-  ) {
-    super(
-      I18n,
-      elementRef,
-      change,
-      schema,
-      handler,
-      cdRef,
-      injector,
-    );
-  }
 
   initialize():void {
     if (this.schema.allowedValues) {

--- a/frontend/src/app/shared/components/fields/edit/field-types/user-edit-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field-types/user-edit-field.component.ts
@@ -26,29 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  Injector,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   EditFieldComponent,
-  OpEditingPortalChangesetToken,
-  OpEditingPortalHandlerToken,
-  OpEditingPortalSchemaToken,
 } from 'core-app/shared/components/fields/edit/edit-field.component';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
-// import { IProject } from 'core-app/core/state/projects/project.model';
-import { HalResource } from 'core-app/features/hal/resources/hal-resource';
-import { ResourceChangeset } from '../../changeset/resource-changeset';
-import { IFieldSchema } from '../../field.base';
-import { EditFieldHandler } from '../editing-portal/edit-field-handler';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { IUserAutocompleteItem } from 'core-app/shared/components/autocompleter/user-autocompleter/user-autocompleter.component';
@@ -60,32 +43,13 @@ import { CallableHalLink } from 'core-app/features/hal/hal-link/hal-link';
   standalone: false,
 })
 export class UserEditFieldComponent extends EditFieldComponent implements OnInit {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly http = inject(HttpClient);
+  readonly halResourceService = inject(HalResourceService);
+
   isNew = isNewResource(this.resource);
 
   url:string;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly elementRef:ElementRef,
-    @Inject(OpEditingPortalChangesetToken) protected change:ResourceChangeset<HalResource>,
-    @Inject(OpEditingPortalSchemaToken) public schema:IFieldSchema,
-    @Inject(OpEditingPortalHandlerToken) readonly handler:EditFieldHandler,
-    readonly cdRef:ChangeDetectorRef,
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly http:HttpClient,
-    readonly halResourceService:HalResourceService,
-  ) {
-    super(
-      I18n,
-      elementRef,
-      change,
-      schema,
-      handler,
-      cdRef,
-      injector,
-    );
-  }
 
   initialize():void {
     const link = this.schema.allowedValues as CallableHalLink|undefined;

--- a/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
+++ b/frontend/src/app/shared/components/fields/edit/field/editable-attribute-field.component.ts
@@ -29,18 +29,7 @@
 import {
   HalResourceEditingService,
 } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Injector,
-  Input,
-  OnDestroy,
-  OnInit,
-  Optional,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { getPosition } from 'core-app/shared/helpers/set-click-position/set-click-position';
@@ -66,6 +55,16 @@ import { SchemaResource } from 'core-app/features/hal/resources/schema-resource'
   standalone: false,
 })
 export class EditableAttributeFieldComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  protected states = inject(States);
+  protected injector = inject(Injector);
+  protected elementRef = inject(ElementRef);
+  protected opContextMenu = inject(OPContextMenuService);
+  protected halEditing = inject(HalResourceEditingService);
+  protected schemaCache = inject(SchemaCacheService);
+  protected editForm = inject(EditFormComponent, { optional: true });
+  protected cdRef = inject(ChangeDetectorRef);
+  protected I18n = inject(I18nService);
+
   @Input() public fieldName:string;
 
   @Input() public resource:HalResource;
@@ -89,21 +88,6 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
   private element:HTMLElement;
 
   public destroyed = false;
-
-  constructor(
-    protected states:States,
-    protected injector:Injector,
-    protected elementRef:ElementRef,
-    protected opContextMenu:OPContextMenuService,
-    protected halEditing:HalResourceEditingService,
-    protected schemaCache:SchemaCacheService,
-    // Get parent field group from injector if we're in a form
-    @Optional() protected editForm:EditFormComponent,
-    protected cdRef:ChangeDetectorRef,
-    protected I18n:I18nService,
-  ) {
-    super();
-  }
 
   public setActive(active = true):void {
     this.active = active;
@@ -197,7 +181,7 @@ export class EditableAttributeFieldComponent extends UntilDestroyedMixin impleme
     // Activate the field
     this.setActive(true);
 
-    return this.editForm
+    return this.editForm!
       .activate(this.fieldName, noWarnings)
       .catch(() => this.deactivate(true));
   }

--- a/frontend/src/app/shared/components/fields/edit/modal-with-turbo-content/modal-with-turbo-content.directive.ts
+++ b/frontend/src/app/shared/components/fields/edit/modal-with-turbo-content/modal-with-turbo-content.directive.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  Output,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, EventEmitter, Input, OnDestroy, Output, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
@@ -49,6 +40,13 @@ import { ResourceChangeset } from 'core-app/shared/components/fields/changeset/r
   standalone: false,
 })
 export class ModalWithTurboContentDirective implements AfterViewInit, OnDestroy {
+  readonly elementRef = inject(ElementRef);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly halEvents = inject(HalEventsService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly toastService = inject(ToastService);
+  readonly I18n = inject(I18nService);
+
   @Input() resource:HalResource;
   @Input() change:ResourceChangeset<HalResource>;
 
@@ -59,17 +57,6 @@ export class ModalWithTurboContentDirective implements AfterViewInit, OnDestroy 
   private contextBasedListenerBound = this.contextBasedListener.bind(this);
   private preserveSegmentAttributesBound = this.preserveSegmentAttributes.bind(this);
   private cancelListenerBound = this.cancelListener.bind(this);
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    readonly halEvents:HalEventsService,
-    readonly apiV3Service:ApiV3Service,
-    readonly toastService:ToastService,
-    readonly I18n:I18nService,
-  ) {
-
-  }
 
   ngAfterViewInit() {
     (this.elementRef.nativeElement as HTMLElement)

--- a/frontend/src/app/shared/components/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
+++ b/frontend/src/app/shared/components/fields/edit/services/global-edit-form-changes-tracker/global-edit-form-changes-tracker.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { EditFormComponent } from 'core-app/shared/components/fields/edit/edit-form/edit-form.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -6,15 +6,15 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   providedIn: 'root',
 })
 export class GlobalEditFormChangesTrackerService {
+  private i18nService = inject(I18nService);
+
   private activeForms = new Map<EditFormComponent, boolean>();
 
   get thereAreFormsWithUnsavedChanges() {
     return Array.from(this.activeForms.keys()).some((form) => !form.change.isEmpty());
   }
 
-  constructor(
-    private i18nService:I18nService,
-  ) {
+  constructor() {
     // Global beforeunload hook to show a data loss warn
     // when the user clicks on a link out of the Angular app
     window.addEventListener('beforeunload', (event) => {

--- a/frontend/src/app/shared/components/fields/edit/services/hal-resource-editing.service.ts
+++ b/frontend/src/app/shared/components/fields/edit/services/hal-resource-editing.service.ts
@@ -30,7 +30,7 @@ import {
   combine, deriveRaw, InputState, multiInput, State, StatesGroup,
 } from '@openproject/reactivestates';
 import { filter, map } from 'rxjs/operators';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import { Subject } from 'rxjs';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
 import { ChangeMap } from 'core-app/shared/components/fields/changeset/changeset';
@@ -92,12 +92,14 @@ export type ResourceChangesetClass = new(...args:any[]) => ResourceChangeset;
 
 @Injectable()
 export class HalResourceEditingService extends StateCacheService<ResourceChangeset> {
+  protected readonly injector = inject(Injector);
+  protected readonly halEvents = inject(HalEventsService);
+  protected readonly hook = inject(HookService);
+
   /** Committed / saved changes to work packages observable */
   public committedChanges = new Subject<ResourceChangesetCommit>();
 
-  constructor(protected readonly injector:Injector,
-    protected readonly halEvents:HalEventsService,
-    protected readonly hook:HookService) {
+  constructor() {
     super(new ChangesetStates().changesets);
   }
 

--- a/frontend/src/app/shared/components/fields/macros/attribute-label-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-label-macro.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, OnInit, inject } from '@angular/core';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import {
@@ -60,6 +52,14 @@ import { IOPFieldSchema } from 'core-app/features/hal/interfaces';
   standalone: false,
 })
 export class AttributeLabelMacroComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+  readonly resourceLoader = inject(AttributeModelLoaderService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly displayField = inject(DisplayFieldService);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   // Whether the value could not be loaded
   error:string|null = null;
 
@@ -82,17 +82,6 @@ export class AttributeLabelMacroComponent implements OnInit {
 
   // The label to render
   label:string|undefined;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly injector:Injector,
-    readonly resourceLoader:AttributeModelLoaderService,
-    readonly schemaCache:SchemaCacheService,
-    readonly displayField:DisplayFieldService,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-  }
 
   ngOnInit():void {
     const element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import {
   firstValueFrom,
@@ -51,6 +51,11 @@ export type SupportedAttributeModels = 'project'|'workPackage';
 
 @Injectable({ providedIn: 'root' })
 export class AttributeModelLoaderService {
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly transitions = inject(TransitionService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly I18n = inject(I18nService);
+
   text = {
     not_found: this.I18n.t('js.editor.macro.attribute_reference.not_found'),
   };
@@ -59,10 +64,9 @@ export class AttributeModelLoaderService {
   // we may need to expensively filter for them
   private cache$ = multiInput<HalResource>();
 
-  constructor(readonly apiV3Service:ApiV3Service,
-    readonly transitions:TransitionService,
-    readonly currentProject:CurrentProjectService,
-    readonly I18n:I18nService) {
+  constructor() {
+    const transitions = this.transitions;
+
     // Clear cached values whenever leaving the page
     transitions.onStart({}, () => {
       this.cache$.clear();

--- a/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-value-macro.component.ts
@@ -26,16 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, OnInit, ViewChild, inject } from '@angular/core';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import {
@@ -63,6 +54,14 @@ export const ATTRIBUTE_MACRO_CLASS = 'op-attribute-value-macro';
   standalone: false,
 })
 export class AttributeValueMacroComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+  readonly resourceLoader = inject(AttributeModelLoaderService);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly displayField = inject(DisplayFieldService);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @ViewChild('displayContainer') private displayContainer:ElementRef<HTMLSpanElement>;
 
   // Whether the value could not be loaded
@@ -80,17 +79,6 @@ export class AttributeValueMacroComponent implements OnInit {
   resource:HalResource;
 
   fieldName:string;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly injector:Injector,
-    readonly resourceLoader:AttributeModelLoaderService,
-    readonly schemaCache:SchemaCacheService,
-    readonly displayField:DisplayFieldService,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-  }
 
   ngOnInit():void {
     const element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/fields/macros/work-package-quickinfo-macro.component.ts
+++ b/frontend/src/app/shared/components/fields/macros/work-package-quickinfo-macro.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, OnInit, inject } from '@angular/core';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -59,6 +52,15 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class WorkPackageQuickinfoMacroComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly schemaCache = inject(SchemaCacheService);
+  readonly displayField = inject(DisplayFieldService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   // Whether the value could not be loaded
   error:string|null = null;
 
@@ -77,17 +79,6 @@ export class WorkPackageQuickinfoMacroComponent implements OnInit {
   workPackageHoverCardUrl:string;
 
   detailed = false;
-
-  constructor(readonly elementRef:ElementRef,
-    readonly injector:Injector,
-    readonly apiV3Service:ApiV3Service,
-    readonly schemaCache:SchemaCacheService,
-    readonly displayField:DisplayFieldService,
-    readonly pathHelper:PathHelperService,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-  }
 
   ngOnInit() {
     const element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/fields/openproject-fields.module.ts
+++ b/frontend/src/app/shared/components/fields/openproject-fields.module.ts
@@ -131,6 +131,4 @@ import { FormsModule } from '@angular/forms';
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class OpenprojectFieldsModule {
-  constructor(injector:Injector) {
-  }
 }

--- a/frontend/src/app/shared/components/grids/grid/area.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/area.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { GridWidgetArea } from 'core-app/shared/components/grids/areas/grid-widget-area';
 import { GridArea } from 'core-app/shared/components/grids/areas/grid-area';
 import { GridGap } from 'core-app/shared/components/grids/areas/grid-gap';
@@ -26,6 +26,10 @@ interface GridPatchPayload {
 
 @Injectable()
 export class GridAreaService {
+  private apiV3Service = inject(ApiV3Service);
+  private toastService = inject(ToastService);
+  private i18n = inject(I18nService);
+
   private resource:GridResource;
 
   public schema:SchemaResource;
@@ -49,13 +53,6 @@ export class GridAreaService {
   public $mousedOverArea = new BehaviorSubject(this.mousedOverArea);
 
   public helpMode = false;
-
-  constructor(
-    private apiV3Service:ApiV3Service,
-    private toastService:ToastService,
-    private i18n:I18nService,
-  ) {
-  }
 
   public set gridResource(value:GridResource) {
     this.resource = value;

--- a/frontend/src/app/shared/components/grids/grid/drag-and-drop.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/drag-and-drop.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { Injectable, OnDestroy, inject } from '@angular/core';
 import { GridWidgetArea } from 'core-app/shared/components/grids/areas/grid-widget-area';
 import { GridArea } from 'core-app/shared/components/grids/areas/grid-area';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
@@ -8,6 +8,9 @@ import { distinctUntilChanged, filter, throttleTime } from 'rxjs/operators';
 
 @Injectable()
 export class GridDragAndDropService implements OnDestroy {
+  readonly layout = inject(GridAreaService);
+  readonly move = inject(GridMoveService);
+
   public draggedArea:GridWidgetArea|null;
 
   public placeholderArea:GridWidgetArea|null;
@@ -16,8 +19,7 @@ export class GridDragAndDropService implements OnDestroy {
 
   private mousedOverAreaObserver:Subscription;
 
-  constructor(readonly layout:GridAreaService,
-    readonly move:GridMoveService) {
+  constructor() {
     // ngOnInit is not called on services
     this.setupMousedOverAreaSubscription();
   }

--- a/frontend/src/app/shared/components/grids/grid/grid.component.ts
+++ b/frontend/src/app/shared/components/grids/grid/grid.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentRef, HostListener, Input, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentRef, HostListener, Input, OnDestroy, OnInit, inject } from '@angular/core';
 import { GridResource } from 'core-app/features/hal/resources/grid-resource';
 import { DomSanitizer } from '@angular/platform-browser';
 import { GridWidgetsService } from 'core-app/shared/components/grids/widgets/widgets.service';
@@ -41,6 +41,16 @@ export const GRID_PROVIDERS = [
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class GridComponent implements OnDestroy, OnInit {
+  private sanitization = inject(DomSanitizer);
+  private widgetsService = inject(GridWidgetsService);
+  drag = inject(GridDragAndDropService);
+  resize = inject(GridResizeService);
+  layout = inject(GridAreaService);
+  add = inject(GridAddWidgetService);
+  remove = inject(GridRemoveWidgetService);
+  readonly browserDetector = inject(BrowserDetector);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public uiWidgets:ComponentRef<any>[] = [];
 
   public GRID_AREA_HEIGHT = 'auto';
@@ -50,18 +60,6 @@ export class GridComponent implements OnDestroy, OnInit {
   public component = WidgetWpGraphComponent;
 
   @Input() grid:GridResource;
-
-  constructor(private sanitization:DomSanitizer,
-    private widgetsService:GridWidgetsService,
-    public drag:GridDragAndDropService,
-    public resize:GridResizeService,
-    public layout:GridAreaService,
-    public add:GridAddWidgetService,
-    public remove:GridRemoveWidgetService,
-    readonly browserDetector:BrowserDetector,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-  }
 
   ngOnInit() {
     this.layout.gridResource = this.grid;

--- a/frontend/src/app/shared/components/grids/grid/initialization.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/initialization.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { GridResource } from 'core-app/features/hal/resources/grid-resource';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -10,10 +10,9 @@ import {
 
 @Injectable()
 export class GridInitializationService {
-  constructor(
-    readonly apiV3Service:ApiV3Service,
-    readonly halResourceService:HalResourceService) {
-  }
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly halResourceService = inject(HalResourceService);
+
 
   // If a page with the current page exists (scoped to the current user by the backend)
   // that page will be used to initialized the grid.

--- a/frontend/src/app/shared/components/grids/grid/move.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/move.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { GridWidgetArea } from 'core-app/shared/components/grids/areas/grid-widget-area';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
 
 @Injectable()
 export class GridMoveService {
-  constructor(private layout:GridAreaService) {}
+  private layout = inject(GridAreaService);
+
 
   public down(movedArea:GridWidgetArea|null, ignoreArea:GridWidgetArea) {
     const movedAreas:GridWidgetArea[] = [];

--- a/frontend/src/app/shared/components/grids/grid/resize.service.ts
+++ b/frontend/src/app/shared/components/grids/grid/resize.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { GridWidgetArea } from 'core-app/shared/components/grids/areas/grid-widget-area';
 import { GridArea } from 'core-app/shared/components/grids/areas/grid-area';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
@@ -8,13 +8,13 @@ import { GridDragAndDropService } from 'core-app/shared/components/grids/grid/dr
 
 @Injectable()
 export class GridResizeService {
+  readonly layout = inject(GridAreaService);
+  readonly move = inject(GridMoveService);
+  readonly drag = inject(GridDragAndDropService);
+
   private resizedArea:GridWidgetArea|null;
 
   private targetIds:string[];
-
-  constructor(readonly layout:GridAreaService,
-    readonly move:GridMoveService,
-    readonly drag:GridDragAndDropService) { }
 
   public end(area:GridWidgetArea):Promise<GridResource>|undefined {
     if (!this.resizedArea) {

--- a/frontend/src/app/shared/components/grids/widgets/abstract-widget.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/abstract-widget.component.ts
@@ -49,9 +49,6 @@ export abstract class AbstractWidgetComponent extends UntilDestroyedMixin {
     return true;
   }
 
-  /** Inserted by Angular inject() migration for backwards compatibility */
-  constructor(...args:unknown[]);
-
   constructor() {
     super();
   }

--- a/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
+++ b/frontend/src/app/shared/components/grids/widgets/add/add.modal.ts
@@ -1,9 +1,5 @@
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { WidgetRegistration } from 'core-app/shared/components/grids/grid/grid.component';
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { GridWidgetResource } from 'core-app/features/hal/resources/grid-widget-resource';
@@ -21,6 +17,11 @@ import { filter, take } from 'rxjs/operators';
   standalone: false,
 })
 export class AddGridWidgetModalComponent extends OpModalComponent implements OnInit {
+  readonly widgetsService = inject(GridWidgetsService);
+  readonly i18n = inject(I18nService);
+  readonly bannerService = inject(BannersService);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+
   text = {
     title: this.i18n.t('js.grid.add_widget'),
     close_popup: this.i18n.t('js.button_close'),
@@ -32,18 +33,6 @@ export class AddGridWidgetModalComponent extends OpModalComponent implements OnI
   public eeShowBanners = false;
 
   private schema:SchemaResource;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) readonly locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly widgetsService:GridWidgetsService,
-    readonly i18n:I18nService,
-    readonly bannerService:BannersService,
-    readonly loadingIndicator:LoadingIndicatorService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service.ts
@@ -1,5 +1,5 @@
 import { EditFieldHandler } from 'core-app/shared/components/fields/edit/editing-portal/edit-field-handler';
-import { ElementRef, Injectable, Injector } from '@angular/core';
+import { ElementRef, Injectable, Injector, inject } from '@angular/core';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { GridWidgetResource } from 'core-app/features/hal/resources/grid-widget-resource';
@@ -13,6 +13,11 @@ import { HalSource } from 'core-app/features/hal/interfaces';
 
 @Injectable()
 export class CustomTextEditFieldService extends EditFieldHandler {
+  protected elementRef = inject(ElementRef);
+  protected injector = inject(Injector);
+  protected halResource = inject(HalResourceService);
+  protected schemaCache = inject(SchemaCacheService);
+
   public fieldName = 'text';
 
   public valueChanged$:BehaviorSubject<string>;
@@ -22,15 +27,6 @@ export class CustomTextEditFieldService extends EditFieldHandler {
   public changeset:ResourceChangeset;
 
   public active:boolean;
-
-  constructor(
-    protected elementRef:ElementRef,
-    protected injector:Injector,
-    protected halResource:HalResourceService,
-    protected schemaCache:SchemaCacheService,
-  ) {
-    super();
-  }
 
   public initialize(value:GridWidgetResource) {
     this.initializeChangeset(value);

--- a/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/custom-text/custom-text.component.ts
@@ -1,21 +1,8 @@
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Injector,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject } from '@angular/core';
 import {
   CustomTextEditFieldService,
 } from 'core-app/shared/components/grids/widgets/custom-text/custom-text-edit-field.service';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
 import { filter } from 'rxjs/operators';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
@@ -30,29 +17,23 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
   standalone: false,
 })
 export class WidgetCustomTextComponent extends AbstractWidgetComponent implements OnInit, OnChanges, OnDestroy {
+  handler = inject(CustomTextEditFieldService);
+  protected cdr = inject(ChangeDetectorRef);
+  protected sanitization = inject(DomSanitizer);
+  protected appRef = inject(ApplicationRef);
+  protected layout = inject(GridAreaService);
+
   protected currentRawText:string;
 
   public customText:SafeHtml;
 
-  public text = {
-    attachments: this.I18n.t('js.label_attachments'),
-  };
+  public text!:{ attachments:string };
 
   @ViewChild('displayContainer') readonly displayContainer:ElementRef<HTMLElement>;
 
-  constructor(
-    protected I18n:I18nService,
-    protected injector:Injector,
-    public handler:CustomTextEditFieldService,
-    protected cdr:ChangeDetectorRef,
-    protected sanitization:DomSanitizer,
-    protected appRef:ApplicationRef,
-    protected layout:GridAreaService,
-  ) {
-    super(I18n, injector);
-  }
-
   ngOnInit():void {
+    this.text = { attachments: this.i18n.t('js.label_attachments') };
+
     this.setupVariables(true);
 
     this
@@ -96,7 +77,7 @@ export class WidgetCustomTextComponent extends AbstractWidgetComponent implement
   }
 
   public get placeholderText() {
-    return this.I18n.t('js.grid.widgets.work_packages_overview.placeholder');
+    return this.i18n.t('js.grid.widgets.work_packages_overview.placeholder');
   }
 
   public get inplaceEditClasses() {

--- a/frontend/src/app/shared/components/grids/widgets/documents/documents.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/documents/documents.component.ts
@@ -1,13 +1,5 @@
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Injector,
-  OnInit,
-  SecurityContext,
-} from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, SecurityContext, inject } from '@angular/core';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -24,6 +16,14 @@ import { DocumentResource } from '../../../../../../../../modules/documents/fron
   standalone: false,
 })
 export class WidgetDocumentsComponent extends AbstractWidgetComponent implements OnInit {
+  readonly halResource = inject(HalResourceService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly timezone = inject(TimezoneService);
+  readonly domSanitizer = inject(DomSanitizer);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly cdr = inject(ChangeDetectorRef);
+
   public text = {
     noResults: this.i18n.t('js.grid.widgets.documents.no_results'),
     project: this.i18n.t('js.label_project'),
@@ -32,18 +32,6 @@ export class WidgetDocumentsComponent extends AbstractWidgetComponent implements
   public entries:DocumentResource[] = [];
 
   private entriesLoaded = false;
-
-  constructor(readonly halResource:HalResourceService,
-    readonly pathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly i18n:I18nService,
-    readonly timezone:TimezoneService,
-    readonly domSanitizer:DomSanitizer,
-    protected readonly injector:Injector,
-    readonly currentProject:CurrentProjectService,
-    readonly cdr:ChangeDetectorRef) {
-    super(i18n, injector);
-  }
 
   ngOnInit() {
     this.halResource

--- a/frontend/src/app/shared/components/grids/widgets/header/header.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/header/header.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { GridAreaService } from 'core-app/shared/components/grids/grid/area.service';
 import { GridDragAndDropService } from 'core-app/shared/components/grids/grid/drag-and-drop.service';
 
@@ -40,18 +38,14 @@ import { GridDragAndDropService } from 'core-app/shared/components/grids/grid/dr
   standalone: false,
 })
 export class WidgetHeaderComponent {
+  readonly layout = inject(GridAreaService);
+  readonly drag = inject(GridDragAndDropService);
+
   @Input() name:string;
 
   @Input() editable = true;
 
   @Output() onRenamed = new EventEmitter<string>();
-
-  constructor(
-    readonly layout:GridAreaService,
-    readonly drag:GridDragAndDropService,
-  ) {
-
-  }
 
   public renamed(name:string) {
     this.onRenamed.emit(name);

--- a/frontend/src/app/shared/components/grids/widgets/members/members.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/members/members.component.ts
@@ -1,10 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Injector,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AbstractTurboWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-turbo-widget.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { CurrentUserService } from 'core-app/core/current-user/current-user.service';
 
@@ -15,19 +10,14 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
   standalone: false
 })
 export class WidgetMembersComponent extends AbstractTurboWidgetComponent {
-  text = {
-    missing_permission: this.I18n.t('js.grid.widgets.missing_permission'),
-  };
+  protected readonly currentProject = inject(CurrentProjectService);
+  protected readonly currentUser = inject(CurrentUserService);
+
+  get text() {
+    return { missing_permission: this.i18n.t('js.grid.widgets.missing_permission') };
+  }
 
   hasCapability$ = this.currentUser.hasCapabilities$('memberships/read', this.currentProject.id);
-  constructor(
-    protected readonly I18n:I18nService,
-    protected readonly injector:Injector,
-    protected readonly currentProject:CurrentProjectService,
-    protected readonly currentUser:CurrentUserService,
-  ) {
-    super(I18n, injector);
-  }
 
   public get projectIdentifier() {
     return this.currentProject.identifier;

--- a/frontend/src/app/shared/components/grids/widgets/menu/widget-abstract-menu.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/menu/widget-abstract-menu.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Directive, Injector, Input } from '@angular/core';
+import { Directive, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
 import { GridWidgetResource } from 'core-app/features/hal/resources/grid-widget-resource';
@@ -35,13 +35,12 @@ import { GridAreaService } from 'core-app/shared/components/grids/grid/area.serv
 
 @Directive()
 export abstract class WidgetAbstractMenuComponent {
-  @Input() resource:GridWidgetResource;
+  readonly injector = inject(Injector);
+  readonly i18n = inject(I18nService);
+  protected readonly remove = inject(GridRemoveWidgetService);
+  protected readonly layout = inject(GridAreaService);
 
-  constructor(readonly injector:Injector,
-    readonly i18n:I18nService,
-    protected readonly remove:GridRemoveWidgetService,
-    protected readonly layout:GridAreaService) {
-  }
+  @Input() resource:GridWidgetResource;
 
   public get menuItemsFactory():() => Promise<OpContextMenuItem[]> {
     return this.buildItems.bind(this);

--- a/frontend/src/app/shared/components/grids/widgets/project-favorites/widget-project-favorites.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/project-favorites/widget-project-favorites.component.ts
@@ -1,14 +1,5 @@
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  HostBinding,
-  Injector,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostBinding, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -26,6 +17,13 @@ import { Observable } from 'rxjs';
   standalone: false,
 })
 export class WidgetProjectFavoritesComponent extends AbstractWidgetComponent implements OnInit {
+  readonly halResource = inject(HalResourceService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly timezone = inject(TimezoneService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly cdr = inject(ChangeDetectorRef);
+
   @HostBinding('class.op-widget-project-favorites') className = true;
 
   public text = {
@@ -34,19 +32,6 @@ export class WidgetProjectFavoritesComponent extends AbstractWidgetComponent imp
   };
 
   public projects$:Observable<ProjectResource[]>;
-
-  constructor(
-    readonly halResource:HalResourceService,
-    readonly pathHelper:PathHelperService,
-    readonly i18n:I18nService,
-    protected readonly injector:Injector,
-    readonly timezone:TimezoneService,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentProject:CurrentProjectService,
-    readonly cdr:ChangeDetectorRef,
-  ) {
-    super(i18n, injector);
-  }
 
   ngOnInit() {
     const filters = new ApiV3FilterBuilder();

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/configuration-modal/configuration.modal.ts
@@ -1,9 +1,5 @@
-import {
-  ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, Injector, OnInit,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ApplicationRef, ChangeDetectionStrategy, Component, Injector, OnInit, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { LoadingIndicatorService } from 'core-app/core/loading-indicator/loading-indicator.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -20,6 +16,14 @@ import { TimeEntriesCurrentUserConfigurationModalService } from 'core-app/shared
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class TimeEntriesCurrentUserConfigurationModalComponent extends OpModalComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly appRef = inject(ApplicationRef);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly configuration = inject(ConfigurationService);
+  readonly timeEntriesCurrentUserConfigurationModalService = inject(TimeEntriesCurrentUserConfigurationModalService);
+
   public text = {
     displayedDays: this.I18n.t('js.grid.widgets.time_entries_current_user.displayed_days'),
     closePopup: this.I18n.t('js.close_popup_title'),
@@ -35,19 +39,6 @@ export class TimeEntriesCurrentUserConfigurationModalComponent extends OpModalCo
   public daysOriginalCheckedValues:boolean[];
 
   public days:IDayData[];
-
-  constructor(@Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly appRef:ApplicationRef,
-    readonly loadingIndicator:LoadingIndicatorService,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly configuration:ConfigurationService,
-    readonly elementRef:ElementRef,
-    readonly timeEntriesCurrentUserConfigurationModalService:TimeEntriesCurrentUserConfigurationModalService) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     const localDayOptions = this.locals.options.days;

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/current-user/time-entries-current-user.component.ts
@@ -1,9 +1,6 @@
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 import { DisplayedDays } from 'core-app/features/calendar/te-calendar/te-calendar.component';
@@ -16,17 +13,13 @@ import { TimezoneService } from 'core-app/core/datetime/timezone.service';
   standalone: false,
 })
 export class WidgetTimeEntriesCurrentUserComponent extends AbstractWidgetComponent implements OnInit {
+  readonly timezone = inject(TimezoneService);
+  readonly pathHelper = inject(PathHelperService);
+  protected readonly cdr = inject(ChangeDetectorRef);
+
   public entries:TimeEntryResource[] = [];
 
   public displayedDays:DisplayedDays;
-
-  constructor(protected readonly injector:Injector,
-    readonly timezone:TimezoneService,
-    readonly i18n:I18nService,
-    readonly pathHelper:PathHelperService,
-    protected readonly cdr:ChangeDetectorRef) {
-    super(i18n, injector);
-  }
 
   public ngOnInit() {
     this.displayedDays = this.resource.options.days as DisplayedDays;

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -1,11 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Directive,
-  Injector,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, Injector, OnDestroy, OnInit, inject } from '@angular/core';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -27,6 +20,13 @@ import { MeetingResource } from 'core-app/features/hal/resources/meeting-resourc
 
 @Directive()
 export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetComponent implements OnInit, AfterViewInit, OnDestroy {
+  readonly injector = inject(Injector);
+  readonly timezone = inject(TimezoneService);
+  readonly i18n = inject(I18nService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly confirmDialog = inject(ConfirmDialogService);
+  protected readonly cdr = inject(ChangeDetectorRef);
+
   public text = {
     edit: this.i18n.t('js.button_edit'),
     delete: this.i18n.t('js.button_delete'),
@@ -50,17 +50,6 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
 
   @InjectField() public readonly apiV3Service:ApiV3Service;
   @InjectField() public readonly turboRequests:TurboRequestsService;
-
-  constructor(
-    readonly injector:Injector,
-    readonly timezone:TimezoneService,
-    readonly i18n:I18nService,
-    readonly pathHelper:PathHelperService,
-    readonly confirmDialog:ConfirmDialogService,
-    protected readonly cdr:ChangeDetectorRef,
-  ) {
-    super(i18n, injector);
-  }
 
   ngOnInit():void {
     this.loadTimeEntries();

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/project/time-entries-project.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/project/time-entries-project.component.ts
@@ -1,17 +1,7 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  Injector,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { WidgetTimeEntriesListComponent } from 'core-app/shared/components/grids/widgets/time-entries/list/time-entries-list.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
-import { TimezoneService } from 'core-app/core/datetime/timezone.service';
-import { ConfirmDialogService } from 'core-app/shared/components/modals/confirm-dialog/confirm-dialog.service';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 
 @Component({
@@ -26,15 +16,7 @@ import { HalResourceEditingService } from 'core-app/shared/components/fields/edi
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WidgetTimeEntriesProjectComponent extends WidgetTimeEntriesListComponent implements OnInit {
-  constructor(readonly injector:Injector,
-    readonly timezone:TimezoneService,
-    readonly i18n:I18nService,
-    readonly pathHelper:PathHelperService,
-    readonly confirmDialog:ConfirmDialogService,
-    protected readonly cdr:ChangeDetectorRef,
-    protected readonly currentProject:CurrentProjectService) {
-    super(injector, timezone, i18n, pathHelper, confirmDialog, cdr);
-  }
+  protected readonly currentProject = inject(CurrentProjectService);
 
   protected dmFilters():[string, FilterOperator, [string]][] {
     return [['spentOn', '>t-', ['7']] as [string, FilterOperator, [string]],

--- a/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-calendar/wp-calendar.component.ts
@@ -26,9 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import {
   WorkPackageIsolatedQuerySpaceDirective,
@@ -42,20 +41,14 @@ import { CurrentUserService } from 'core-app/core/current-user/current-user.serv
   standalone: false,
 })
 export class WidgetWpCalendarComponent extends AbstractWidgetComponent {
-  text = {
-    missing_permission: this.I18n.t('js.grid.widgets.missing_permission'),
-  };
+  protected readonly currentProject = inject(CurrentProjectService);
+  protected readonly currentUser = inject(CurrentUserService);
+
+  get text() {
+    return { missing_permission: this.i18n.t('js.grid.widgets.missing_permission') };
+  }
 
   hasCapability$ = this.currentUser.hasCapabilities$('work_packages/read', this.currentProject.id);
-
-  constructor(
-    protected readonly I18n:I18nService,
-    protected readonly injector:Injector,
-    protected readonly currentProject:CurrentProjectService,
-    protected readonly currentUser:CurrentUserService,
-  ) {
-    super(I18n, injector);
-  }
 
   public get projectIdentifier() {
     return this.currentProject.identifier;

--- a/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/wp-graph/wp-graph.component.ts
@@ -1,8 +1,5 @@
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, OnDestroy, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { WorkPackageEmbeddedGraphDataset } from 'core-app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component';
-import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { AbstractWidgetComponent } from 'core-app/shared/components/grids/widgets/abstract-widget.component';
 import { ChartOptions } from 'chart.js';
 import { WpGraphConfigurationService } from 'core-app/shared/components/work-package-graphs/configuration/wp-graph-configuration.service';
@@ -17,14 +14,10 @@ import { WpGraphConfiguration } from 'core-app/shared/components/work-package-gr
   standalone: false,
 })
 export class WidgetWpGraphComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
-  public datasets:WorkPackageEmbeddedGraphDataset[] = [];
+  protected cdr = inject(ChangeDetectorRef);
+  protected readonly graphConfiguration = inject(WpGraphConfigurationService);
 
-  constructor(protected i18n:I18nService,
-    protected injector:Injector,
-    protected cdr:ChangeDetectorRef,
-    protected readonly graphConfiguration:WpGraphConfigurationService) {
-    super(i18n, injector);
-  }
+  public datasets:WorkPackageEmbeddedGraphDataset[] = [];
 
   ngOnInit() {
     this.initializeConfiguration();

--- a/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/header-project-select.component.ts
@@ -28,7 +28,7 @@
 
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { ChangeDetectionStrategy, Component, HostBinding, OnDestroy, OnInit, ViewEncapsulation, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, OnDestroy, OnInit, ViewEncapsulation, ElementRef, ViewChild, AfterViewInit, inject } from '@angular/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { BehaviorSubject, Observable, ReplaySubject, Subscription } from 'rxjs';
 import { map, shareReplay, take, tap } from 'rxjs/operators';
@@ -56,6 +56,14 @@ import { ConfigurationService } from 'core-app/core/config/configuration.service
   standalone: false,
 })
 export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implements OnInit, OnDestroy, AfterViewInit {
+  readonly pathHelper = inject(PathHelperService);
+  readonly configuration = inject(ConfigurationService);
+  readonly I18n = inject(I18nService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly searchableProjectListService = inject(SearchableProjectListService);
+  readonly currentUserService = inject(CurrentUserService);
+  readonly apiV3Service = inject(ApiV3Service);
+
   @HostBinding('class.op-project-select') className = true;
 
   @ViewChild('projectSearchField', { read: ElementRef })
@@ -161,15 +169,7 @@ export class OpHeaderProjectSelectComponent extends UntilDestroyedMixin implemen
 
   private displayModeLocalStorageKey = 'openProject-project-select-display-mode';
 
-  constructor(
-    readonly pathHelper:PathHelperService,
-    readonly configuration:ConfigurationService,
-    readonly I18n:I18nService,
-    readonly currentProject:CurrentProjectService,
-    readonly searchableProjectListService:SearchableProjectListService,
-    readonly currentUserService:CurrentUserService,
-    readonly apiV3Service:ApiV3Service,
-  ) {
+  constructor() {
     super();
 
     if(this.currentProject.id) {

--- a/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
+++ b/frontend/src/app/shared/components/header-project-select/list/header-project-select-list.component.ts
@@ -1,17 +1,5 @@
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, Input, OnChanges, OnInit, Output, SimpleChanges, inject } from '@angular/core';
 import {
   SearchableProjectListService,
 } from 'core-app/shared/components/searchable-project-list/searchable-project-list.service';
@@ -29,6 +17,14 @@ import { getMetaContent } from 'core-app/core/setup/globals/global-helpers';
   standalone: false,
 })
 export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
+  readonly I18n = inject(I18nService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly configuration = inject(ConfigurationService);
+  readonly searchableProjectListService = inject(SearchableProjectListService);
+  readonly elementRef = inject(ElementRef);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly currentProjectService = inject(CurrentProjectService);
+
   @HostBinding('class.spot-list') classNameList = true;
 
   @HostBinding('class.op-header-project-select-list') className = true;
@@ -63,16 +59,6 @@ export class OpHeaderProjectSelectListComponent implements OnInit, OnChanges {
   };
 
   public portfolioModelsEnabled = this.configuration.activeFeatureFlags.includes('portfolioModels');
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly pathHelper:PathHelperService,
-    readonly configuration:ConfigurationService,
-    readonly searchableProjectListService:SearchableProjectListService,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    readonly currentProjectService:CurrentProjectService,
-  ) { }
 
   ngOnInit():void {
     if (this.root) {

--- a/frontend/src/app/shared/components/modal/modal-overlay.component.ts
+++ b/frontend/src/app/shared/components/modal/modal-overlay.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ComponentRef,
-  ElementRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentRef, ElementRef, ViewChild, inject } from '@angular/core';
 import { CdkPortalOutlet, ComponentPortal } from '@angular/cdk/portal';
 import { combineLatest } from 'rxjs';
 import { distinctUntilChanged, filter } from 'rxjs/operators';
@@ -52,6 +45,10 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
   standalone: false,
 })
 export class OpModalOverlayComponent extends UntilDestroyedMixin {
+  readonly modalService = inject(OpModalService);
+  readonly I18n = inject(I18nService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   public notFullscreen = false;
 
   mobileTopPosition = false;
@@ -72,14 +69,6 @@ export class OpModalOverlayComponent extends UntilDestroyedMixin {
   activeModalData$ = this.modalService.activeModalData$;
 
   activeModalInstance$ = this.modalService.activeModalInstance$;
-
-  constructor(
-    readonly modalService:OpModalService,
-    readonly I18n:I18nService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
 
   setupListener():void {
     combineLatest([

--- a/frontend/src/app/shared/components/modal/modal-wrapper-augment.service.ts
+++ b/frontend/src/app/shared/components/modal/modal-wrapper-augment.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Inject, Injectable, Injector, DOCUMENT } from '@angular/core';
+import { Injectable, Injector, DOCUMENT, inject } from '@angular/core';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { DynamicContentModalComponent } from 'core-app/shared/components/modals/modal-wrapper/dynamic-content.modal';
 
@@ -36,11 +36,14 @@ import { DynamicContentModalComponent } from 'core-app/shared/components/modals/
  */
 @Injectable({ providedIn: 'root' })
 export class OpModalWrapperAugmentService {
-  constructor(
-    @Inject(DOCUMENT) protected documentElement:Document,
-    protected injector:Injector,
-    protected opModalService:OpModalService,
-  ) {
+  protected documentElement = inject<Document>(DOCUMENT);
+  protected injector = inject(Injector);
+  protected opModalService = inject(OpModalService);
+
+  constructor() {
+    const documentElement = this.documentElement;
+    const opModalService = this.opModalService;
+
     documentElement.addEventListener('turbo:before-render', () => opModalService.close());
   }
 

--- a/frontend/src/app/shared/components/modal/modal.component.ts
+++ b/frontend/src/app/shared/components/modal/modal.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Inject, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -35,6 +35,10 @@ import { debounce } from 'lodash';
 
 @Directive()
 export abstract class OpModalComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  locals = inject<OpModalLocalsMap>(OpModalLocalsToken);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly elementRef = inject(ElementRef);
+
   /* Reference to service */
   protected service:OpModalService = this.locals.service;
 
@@ -50,14 +54,6 @@ export abstract class OpModalComponent extends UntilDestroyedMixin implements On
 
   /* Data to be return from this modal instance */
   public data:unknown;
-
-  protected constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     this.element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/modal/modal.service.ts
+++ b/frontend/src/app/shared/components/modal/modal.service.ts
@@ -27,11 +27,7 @@
 //++
 
 import { ComponentType } from '@angular/cdk/portal';
-import {
-  Injectable,
-  InjectionToken,
-  Injector,
-} from '@angular/core';
+import { Injectable, InjectionToken, Injector, inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 
@@ -50,13 +46,13 @@ export interface ModalData {
 
 @Injectable({ providedIn: 'root' })
 export class OpModalService {
+  private readonly injector = inject(Injector);
+
   public activeModalInstance$ = new BehaviorSubject<OpModalComponent|null>(null);
 
   public activeModalData$ = new BehaviorSubject<ModalData|null>(null);
 
-  constructor(
-    private readonly injector:Injector,
-  ) {
+  constructor() {
     // Listen to keystrokes on window to close context menus
     window.addEventListener('keydown', (evt:KeyboardEvent) => {
       if (evt.key !== 'Escape' || evt.defaultPrevented) {

--- a/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.ts
+++ b/frontend/src/app/shared/components/modals/confirm-dialog/confirm-dialog.modal.ts
@@ -26,17 +26,9 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 export interface ConfirmDialogOptions {
@@ -69,6 +61,8 @@ export interface ConfirmDialogOptions {
   standalone: false,
 })
 export class ConfirmDialogModalComponent extends OpModalComponent {
+  readonly I18n = inject(I18nService);
+
   public showClose:boolean;
 
   public showListData:boolean;
@@ -101,14 +95,10 @@ export class ConfirmDialogModalComponent extends OpModalComponent {
 
   public dangerHighlighting:boolean;
 
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-  ) {
-    super(locals, cdRef, elementRef);
-    this.options = (locals.options || {}) as ConfirmDialogOptions;
+  constructor() {
+    super();
+
+    this.options = (this.locals.options ?? {}) as ConfirmDialogOptions;
 
     this.dangerHighlighting = _.defaultTo(this.options.dangerHighlighting, false);
     this.showListData = _.defaultTo(this.options.showListData, false);

--- a/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
+++ b/frontend/src/app/shared/components/modals/editor/editor-macros.service.ts
@@ -27,7 +27,7 @@
 //++
 
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
-import { Injectable, Injector } from '@angular/core';
+import { Injectable, Injector, inject } from '@angular/core';
 import {
   WpButtonMacroModalComponent,
 } from 'core-app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal';
@@ -44,11 +44,9 @@ import { PortalOutletTarget } from 'core-app/shared/components/modal/portal-outl
 
 @Injectable()
 export class EditorMacrosService {
-  constructor(
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-  ) {
-  }
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+
 
   /**
    * Show a modal to edit the work package button macro settings.

--- a/frontend/src/app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal.ts
+++ b/frontend/src/app/shared/components/modals/editor/macro-child-pages-modal/child-pages-macro.modal.ts
@@ -26,12 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -43,6 +39,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ChildPagesMacroModalComponent extends OpModalComponent implements AfterViewInit {
+  readonly I18n = inject(I18nService);
+
   public changed = false;
 
   public showClose = true;
@@ -67,11 +65,9 @@ export class ChildPagesMacroModalComponent extends OpModalComponent implements A
     close_popup: this.I18n.t('js.close_popup_title'),
   };
 
-  constructor(readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    super();
+
     this.selectedPage = this.page = this.locals.page;
     this.selectedIncludeParent = this.includeParent = this.locals.includeParent;
 

--- a/frontend/src/app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal.ts
+++ b/frontend/src/app/shared/components/modals/editor/macro-code-block-modal/code-block-macro.modal.ts
@@ -27,11 +27,9 @@
 //++
 
 import {
-  AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, ViewChild, inject,
+  AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject,
 } from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CodeMirrorLoaderService } from 'core-app/shared/components/editor/components/ckeditor/codemirror-loader.service';
 import type { Editor as CodeMirrorEditor } from 'codemirror';
@@ -66,9 +64,6 @@ export class CodeBlockMacroModalComponent extends OpModalComponent implements Af
 
   @ViewChild('codeMirrorPane', { static: true }) codeMirrorPane:ElementRef;
 
-  readonly elementRef = inject(ElementRef);
-  public locals = inject(OpModalLocalsToken) as OpModalLocalsMap;
-  readonly cdRef = inject(ChangeDetectorRef);
   readonly I18n = inject(I18nService);
   readonly codeMirrorLoader = inject(CodeMirrorLoaderService);
 
@@ -82,11 +77,7 @@ export class CodeBlockMacroModalComponent extends OpModalComponent implements Af
   };
 
   constructor() {
-    super(
-      inject(OpModalLocalsToken) as OpModalLocalsMap,
-      inject(ChangeDetectorRef),
-      inject(ElementRef),
-    );
+    super();
     this.languageClass = (this.locals.languageClass as string | undefined) ?? 'language-text';
     this.content = this.locals.content as string;
 

--- a/frontend/src/app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal.ts
+++ b/frontend/src/app/shared/components/modals/editor/macro-wiki-include-page-modal/wiki-include-page-macro.modal.ts
@@ -26,12 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 @Component({
@@ -43,6 +39,8 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WikiIncludePageMacroModalComponent extends OpModalComponent implements AfterViewInit {
+  readonly I18n = inject(I18nService);
+
   public changed = false;
 
   public showClose = true;
@@ -62,11 +60,9 @@ export class WikiIncludePageMacroModalComponent extends OpModalComponent impleme
     close_popup: this.I18n.t('js.close_popup_title'),
   };
 
-  constructor(readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    super();
+
     this.selectedPage = this.page = this.locals.page;
 
     // We could provide an autocompleter here to get correct page names

--- a/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.ts
+++ b/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.ts
@@ -26,18 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  ViewChild,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TypeResource } from 'core-app/features/hal/resources/type-resource';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -50,6 +40,10 @@ import { FormResource } from 'core-app/features/hal/resources/form-resource';
   standalone: false,
 })
 export class WpButtonMacroModalComponent extends OpModalComponent implements AfterViewInit {
+  protected currentProject = inject(CurrentProjectService);
+  protected apiV3Service = inject(ApiV3Service);
+  readonly I18n = inject(I18nService);
+
   public changed = false;
 
   public showClose = true;
@@ -77,13 +71,9 @@ export class WpButtonMacroModalComponent extends OpModalComponent implements Aft
     close_popup: this.I18n.t('js.close_popup_title'),
   };
 
-  constructor(readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    protected currentProject:CurrentProjectService,
-    protected apiV3Service:ApiV3Service,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService) {
-    super(locals, cdRef, elementRef);
+  constructor() {
+    super();
+
     this.selectedType = this.type = this.locals.type;
     this.classes = this.locals.classes;
     this.buttonStyle = this.classes === 'button';

--- a/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
+++ b/frontend/src/app/shared/components/modals/get-ical-url-modal/query-get-ical-url.modal.ts
@@ -31,10 +31,8 @@ import { States } from 'core-app/core/states/states.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, inject,
+  ChangeDetectionStrategy, Component, OnInit, inject,
 } from '@angular/core';
 import {
   UntypedFormGroup,
@@ -59,12 +57,9 @@ interface TokenNameFormValue {
   standalone: false,
 })
 export class QueryGetIcalUrlModalComponent extends OpModalComponent implements OnInit {
-  public readonly elementRef = inject(ElementRef);
-  public locals:OpModalLocalsMap = inject(OpModalLocalsToken);
   public readonly I18n = inject(I18nService);
   public readonly states = inject(States);
   public readonly querySpace = inject(IsolatedQuerySpace);
-  public readonly cdRef = inject(ChangeDetectorRef);
   public readonly wpListService = inject(WorkPackagesListService);
   public readonly halNotification = inject(HalResourceNotificationService);
   public readonly toastService = inject(ToastService);
@@ -101,15 +96,6 @@ export class QueryGetIcalUrlModalComponent extends OpModalComponent implements O
 
   get nameControl():AbstractControl|null {
     return this.tokenNameForm.get('name');
-  }
-
-  constructor() {
-    // Pass required deps to the base class using inject()
-    super(
-      inject(OpModalLocalsToken),
-      inject(ChangeDetectorRef),
-      inject(ElementRef),
-    );
   }
 
   ngOnInit():void {

--- a/frontend/src/app/shared/components/modals/modal-wrapper/dynamic-content.modal.ts
+++ b/frontend/src/app/shared/components/modals/modal-wrapper/dynamic-content.modal.ts
@@ -26,17 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -46,14 +36,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   standalone: false,
 })
 export class DynamicContentModalComponent extends OpModalComponent implements OnInit, OnDestroy {
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
+  readonly I18n = inject(I18nService);
 
   ngOnInit():void {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/modals/save-modal/save-query.modal.ts
+++ b/frontend/src/app/shared/components/modals/save-modal/save-query.modal.ts
@@ -26,15 +26,11 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { QuerySharingChange } from 'core-app/shared/components/modals/share-modal/query-sharing-form.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -50,6 +46,13 @@ import { States } from 'core-app/core/states/states.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SaveQueryModalComponent extends OpModalComponent {
+  readonly I18n = inject(I18nService);
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly toastService = inject(ToastService);
+
   public queryName = '';
 
   public isStarred = false;
@@ -70,20 +73,6 @@ export class SaveQueryModalComponent extends OpModalComponent {
     button_cancel: this.I18n.t('js.button_cancel'),
     close_popup: this.I18n.t('js.close_popup_title'),
   };
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpListService:WorkPackagesListService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly toastService:ToastService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   public setValues(change:QuerySharingChange):void {
     this.isStarred = change.isStarred;

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.component.ts
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing-form.component.ts
@@ -1,8 +1,6 @@
 import { States } from 'core-app/core/states/states.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
-import {
-  ChangeDetectionStrategy, Component, EventEmitter, Input, Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 
@@ -21,6 +19,11 @@ export interface QuerySharingChange {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class QuerySharingFormComponent {
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly I18n = inject(I18nService);
+
   @Input() public isSave:boolean;
 
   @Input() public isStarred:boolean;
@@ -36,12 +39,6 @@ export class QuerySharingFormComponent {
     showInMenuText: this.I18n.t('js.work_packages.query.star_text'),
     visibleForOthersText: this.I18n.t('js.work_packages.query.public_text'),
   };
-
-  constructor(readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly authorisationService:AuthorisationService,
-    readonly I18n:I18nService) {
-  }
 
   public get canStar() {
     return this.isSave

--- a/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.ts
+++ b/frontend/src/app/shared/components/modals/share-modal/query-sharing.modal.ts
@@ -32,11 +32,7 @@ import { HalResourceNotificationService } from 'core-app/features/hal/services/h
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { QuerySharingChange } from 'core-app/shared/components/modals/share-modal/query-sharing-form.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -50,6 +46,13 @@ import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/q
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class QuerySharingModalComponent extends OpModalComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly toastService = inject(ToastService);
+
   public query:QueryResource;
 
   public isStarred = false;
@@ -68,20 +71,6 @@ export class QuerySharingModalComponent extends OpModalComponent implements OnIn
     button_cancel: this.I18n.t('js.button_cancel'),
     close_popup: this.I18n.t('js.close_popup_title'),
   };
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly cdRef:ChangeDetectorRef,
-    readonly wpListService:WorkPackagesListService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly toastService:ToastService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit():void {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
+++ b/frontend/src/app/shared/components/modals/view-settings-modal/view-settings.modal.ts
@@ -26,13 +26,11 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, inject } from '@angular/core';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { QuerySharingChange } from 'core-app/shared/components/modals/share-modal/query-sharing-form.component';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
@@ -48,6 +46,14 @@ import { WorkPackagesQueryViewService } from 'core-app/features/work-packages/co
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ViewSettingsModalComponent extends OpModalComponent {
+  readonly I18n = inject(I18nService);
+  readonly states = inject(States);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly wpView = inject(WorkPackagesQueryViewService);
+  readonly halNotification = inject(HalResourceNotificationService);
+  readonly toastService = inject(ToastService);
+
   public queryName = '';
 
   public isStarred = false;
@@ -68,21 +74,6 @@ export class ViewSettingsModalComponent extends OpModalComponent {
     button_cancel: this.I18n.t('js.button_cancel'),
     close_popup: this.I18n.t('js.close_popup_title'),
   };
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly I18n:I18nService,
-    readonly states:States,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpListService:WorkPackagesListService,
-    readonly wpView:WorkPackagesQueryViewService,
-    readonly halNotification:HalResourceNotificationService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly toastService:ToastService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   public setValues(change:QuerySharingChange):void {
     this.isStarred = change.isStarred;

--- a/frontend/src/app/shared/components/no-results/no-results.component.ts
+++ b/frontend/src/app/shared/components/no-results/no-results.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, inject } from '@angular/core';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 
 
@@ -37,6 +37,8 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   standalone: false,
 })
 export class NoResultsComponent {
+  readonly elementRef = inject(ElementRef);
+
   @Input() title:string;
 
   @Input() description:string;
@@ -45,9 +47,7 @@ export class NoResultsComponent {
 
   @HostBinding('class.generic-table--no-results-container') setHostClass = true;
 
-  constructor(
-    readonly elementRef:ElementRef,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 }

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-columns-context-menu.directive.ts
@@ -26,13 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  Directive, ElementRef, Injector, Input,
-} from '@angular/core';
+import { Directive, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { WorkPackageViewColumnsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-columns.service';
 import { WorkPackageViewGroupByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
@@ -50,6 +47,15 @@ import { computePosition, ComputePositionReturn, flip, shift } from '@floating-u
   standalone: false,
 })
 export class OpColumnsContextMenu extends OpContextMenuTrigger {
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly wpTableSortBy = inject(WorkPackageViewSortByService);
+  readonly wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  readonly wpTableHierarchies = inject(WorkPackageViewHierarchiesService);
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+  readonly I18n = inject(I18nService);
+  readonly confirmDialog = inject(ConfirmDialogService);
+
   @Input('opColumnsContextMenu-column') public column:QueryColumn;
 
   @Input('opColumnsContextMenu-table') public table:WorkPackageTable;
@@ -60,19 +66,6 @@ export class OpColumnsContextMenu extends OpContextMenuTrigger {
       title: this.I18n.t('js.modals.form_submit.title'),
     },
   };
-
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly wpTableSortBy:WorkPackageViewSortByService,
-    readonly wpTableGroupBy:WorkPackageViewGroupByService,
-    readonly wpTableHierarchies:WorkPackageViewHierarchiesService,
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-    readonly I18n:I18nService,
-    readonly confirmDialog:ConfirmDialogService) {
-    super(elementRef, opContextMenu);
-  }
 
   protected open(evt:Event) {
     if (!this.table.configuration.columnMenuEnabled) {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Directive, ElementRef } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, inject } from '@angular/core';
 import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpContextMenuHandler } from 'core-app/shared/components/op-context-menu/op-context-menu-handler';
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
@@ -10,15 +10,19 @@ import { computePosition, ComputePositionReturn, flip, shift } from '@floating-u
   standalone: false,
 })
 export class OpContextMenuTrigger extends OpContextMenuHandler implements AfterViewInit {
+  readonly elementRef = inject(ElementRef);
+  readonly opContextMenu:OPContextMenuService;
+
   protected element:HTMLElement;
 
   protected items:OpContextMenuItem[] = [];
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-  ) {
+  constructor() {
+    const opContextMenu = inject(OPContextMenuService);
+
     super(opContextMenu);
+
+    this.opContextMenu = opContextMenu;
   }
 
   ngAfterViewInit():void {

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-settings-dropdown-menu.directive.ts
@@ -26,13 +26,12 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Directive, ElementRef, Injector, Input, AfterViewInit } from '@angular/core';
+import { Directive, Injector, Input, AfterViewInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { AuthorisationService } from 'core-app/core/model-auth/model-auth.service';
 import {
   OpContextMenuTrigger,
 } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { States } from 'core-app/core/states/states.service';
 import { WorkPackagesListService } from 'core-app/features/work-packages/components/wp-list/wp-list.service';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
@@ -67,6 +66,18 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
   standalone: false,
 })
 export class OpSettingsMenuDirective extends OpContextMenuTrigger implements AfterViewInit {
+  readonly opModalService = inject(OpModalService);
+  readonly wpListService = inject(WorkPackagesListService);
+  readonly authorisationService = inject(AuthorisationService);
+  readonly states = inject(States);
+  readonly injector = inject(Injector);
+  readonly querySpace = inject(IsolatedQuerySpace);
+  readonly wpTableColumns = inject(WorkPackageViewColumnsService);
+  readonly urlParamsHelper = inject(UrlParamsHelperService);
+  readonly opStaticQueries = inject(StaticQueriesService);
+  readonly turboRequests = inject(TurboRequestsService);
+  readonly I18n = inject(I18nService);
+
   @Input('opSettingsContextMenu-query') public query:QueryResource;
 
   @Input() public hideTableOptions:boolean;
@@ -78,24 +89,6 @@ export class OpSettingsMenuDirective extends OpContextMenuTrigger implements Aft
   private loadingPromise:PromiseLike<any>;
 
   override readonly placement = 'bottom-end';
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly opModalService:OpModalService,
-    readonly wpListService:WorkPackagesListService,
-    readonly authorisationService:AuthorisationService,
-    readonly states:States,
-    readonly injector:Injector,
-    readonly querySpace:IsolatedQuerySpace,
-    readonly wpTableColumns:WorkPackageViewColumnsService,
-    readonly urlParamsHelper:UrlParamsHelperService,
-    readonly opStaticQueries:StaticQueriesService,
-    readonly turboRequests:TurboRequestsService,
-    readonly I18n:I18nService,
-  ) {
-    super(elementRef, opContextMenu);
-  }
 
   ngAfterViewInit():void {
     super.ngAfterViewInit();

--- a/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/op-types-context-menu.directive.ts
@@ -28,12 +28,7 @@
 
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
 import { StateService } from '@uirouter/core';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import {
-  Directive,
-  ElementRef,
-  Input, AfterViewInit,
-} from '@angular/core';
+import { Directive, Input, AfterViewInit, inject } from '@angular/core';
 import { isClickedWithModifier } from 'core-app/shared/helpers/link-handling/link-handling';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { WorkPackageCreateService } from 'core-app/features/work-packages/components/wp-new/wp-create.service';
@@ -49,6 +44,12 @@ import { BrowserDetector } from 'core-app/core/browser/browser-detector.service'
   standalone: false,
 })
 export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements AfterViewInit {
+  readonly wpCreate = inject(WorkPackageCreateService);
+  readonly $state = inject(StateService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly currentProject = inject(CurrentProjectService);
+  readonly browser = inject(BrowserDetector);
+
   @Input() public projectIdentifier:string|null|undefined;
 
   @Input() public stateName:string;
@@ -58,18 +59,6 @@ export class OpTypesContextMenuDirective extends OpContextMenuTrigger implements
   @Input() routedFromAngular = true;
 
   public isOpen = false;
-
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly wpCreate:WorkPackageCreateService,
-    readonly $state:StateService,
-    readonly pathHelper:PathHelperService,
-    readonly currentProject:CurrentProjectService,
-    readonly browser:BrowserDetector,
-  ) {
-    super(elementRef, opContextMenu);
-  }
 
   ngAfterViewInit():void {
     super.ngAfterViewInit();

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-create-settings-menu.directive.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
 import { States } from 'core-app/core/states/states.service';
@@ -38,15 +37,11 @@ import { FormResource } from 'core-app/features/hal/resources/form-resource';
   standalone: false,
 })
 export class WorkPackageCreateSettingsMenuDirective extends OpContextMenuTrigger {
+  readonly states = inject(States);
+  readonly halEditing = inject(HalResourceEditingService);
+
   override readonly placement = 'bottom-end';
   
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly states:States,
-    readonly halEditing:HalResourceEditingService) {
-    super(elementRef, opContextMenu);
-  }
-
   protected open(evt:Event) {
     const wp = this.states.workPackages.get('new').value;
 

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-group-toggle-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-group-toggle-dropdown-menu.directive.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewCollapsedGroupsService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-collapsed-groups.service';
@@ -37,12 +36,8 @@ import { WorkPackageViewCollapsedGroupsService } from 'core-app/features/work-pa
   standalone: false,
 })
 export class WorkPackageGroupToggleDropdownMenuDirective extends OpContextMenuTrigger {
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly I18n:I18nService,
-    readonly wpViewCollapsedGroups:WorkPackageViewCollapsedGroupsService) {
-    super(elementRef, opContextMenu);
-  }
+  readonly I18n = inject(I18nService);
+  readonly wpViewCollapsedGroups = inject(WorkPackageViewCollapsedGroupsService);
 
   protected open(evt:Event) {
     this.buildItems();

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-status-dropdown-menu.directive.ts
@@ -27,8 +27,7 @@
 //++
 
 import { StateService } from '@uirouter/core';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef, Input } from '@angular/core';
+import { Directive, Input, inject } from '@angular/core';
 import {
   OpContextMenuTrigger
 } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
@@ -56,18 +55,15 @@ import { HalError } from 'core-app/features/hal/services/hal-error';
   standalone: false,
 })
 export class WorkPackageStatusDropdownDirective extends OpContextMenuTrigger {
-  @Input('wpStatusDropdown-workPackage') public workPackage:WorkPackageResource;
+  readonly $state = inject(StateService);
+  protected workPackageNotificationService = inject(WorkPackageNotificationService);
+  protected halEditing = inject(HalResourceEditingService);
+  protected toastService = inject(ToastService);
+  protected I18n = inject(I18nService);
+  protected halEvents = inject(HalEventsService);
 
-  constructor(readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly $state:StateService,
-    protected workPackageNotificationService:WorkPackageNotificationService,
-    protected halEditing:HalResourceEditingService,
-    protected toastService:ToastService,
-    protected I18n:I18nService,
-    protected halEvents:HalEventsService) {
-    super(elementRef, opContextMenu);
-  }
+  // eslint-disable-next-line @angular-eslint/no-input-rename
+  @Input('wpStatusDropdown-workPackage') public workPackage:WorkPackageResource;
 
   protected open(evt:Event) {
     const change = this.halEditing.changeFor(this.workPackage);

--- a/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
+++ b/frontend/src/app/shared/components/op-context-menu/handlers/wp-view-dropdown-menu.directive.ts
@@ -26,8 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
@@ -42,15 +41,9 @@ import { WorkPackageViewTimelineService } from 'core-app/features/work-packages/
   standalone: false,
 })
 export class WorkPackageViewDropdownMenuDirective extends OpContextMenuTrigger {
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly I18n:I18nService,
-    readonly wpDisplayRepresentationService:WorkPackageViewDisplayRepresentationService,
-    readonly wpTableTimeline:WorkPackageViewTimelineService,
-  ) {
-    super(elementRef, opContextMenu);
-  }
+  readonly I18n = inject(I18nService);
+  readonly wpDisplayRepresentationService = inject(WorkPackageViewDisplayRepresentationService);
+  readonly wpTableTimeline = inject(WorkPackageViewTimelineService);
 
   public isOpen = false;
 

--- a/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.ts
+++ b/frontend/src/app/shared/components/op-context-menu/icon-triggered-context-menu/icon-triggered-context-menu.component.ts
@@ -26,12 +26,11 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Injector, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   OpContextMenuTrigger,
 } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
 import { OpModalService } from 'core-app/shared/components/modal/modal.service';
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
 
@@ -46,18 +45,12 @@ import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class IconTriggeredContextMenuComponent extends OpContextMenuTrigger {
-  override readonly placement = 'bottom-end';
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly opContextMenu:OPContextMenuService,
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-  ) {
-    super(elementRef, opContextMenu);
-  }
+  override readonly placement = 'bottom-end';
 
   @Input() menuItemsFactory:() => Promise<OpContextMenuItem[]>;
   @Input() customAriaLabel:string = this.I18n.t('js.label_open_menu');

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.component.ts
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
   OpContextMenuItem,
   OpContextMenuLocalsMap,
@@ -15,11 +15,13 @@ import { OPContextMenuService } from 'core-app/shared/components/op-context-menu
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class OPContextMenuComponent {
+  locals = inject<OpContextMenuLocalsMap>(OpContextMenuLocalsToken);
+
   public items:OpContextMenuItem[];
 
   public service:OPContextMenuService;
 
-  constructor(@Inject(OpContextMenuLocalsToken) public locals:OpContextMenuLocalsMap) {
+  constructor() {
     this.items = this.locals.items.filter((item) => !item?.hidden);
     this.service = this.locals.service;
   }

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.service.ts
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Injectable, Injector } from '@angular/core';
+import { ApplicationRef, Injectable, Injector, inject } from '@angular/core';
 import { ComponentPortal, ComponentType, DomPortalOutlet } from '@angular/cdk/portal';
 import { TransitionService } from '@uirouter/core';
 import { OpContextMenuHandler } from 'core-app/shared/components/op-context-menu/op-context-menu-handler';
@@ -11,6 +11,11 @@ import { FocusHelperService } from 'core-app/shared/directives/focus/focus-helpe
 
 @Injectable({ providedIn: 'root' })
 export class OPContextMenuService {
+  readonly FocusHelper = inject(FocusHelperService);
+  private appRef = inject(ApplicationRef);
+  private $transitions = inject(TransitionService);
+  private injector = inject(Injector);
+
   public active:OpContextMenuHandler|null = null;
 
   // Hold a reference to the DOM node we're using as a host
@@ -22,14 +27,6 @@ export class OPContextMenuService {
   // Allow temporarily disabling the close handler
   private isOpening = false;
   private openSeq = 0;
-
-  constructor(
-    readonly FocusHelper:FocusHelperService,
-    private appRef:ApplicationRef,
-    private $transitions:TransitionService,
-    private injector:Injector,
-  ) {
-  }
 
   public register() {
     const existing = document.querySelector('.op-context-menu--overlay');

--- a/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
+++ b/frontend/src/app/shared/components/op-non-working-days-list/op-non-working-days-list.component.ts
@@ -1,16 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector,
-  Input,
-  OnInit,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, Input, OnInit, ViewChild, ViewEncapsulation, inject } from '@angular/core';
 import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpModalService } from '../modal/modal.service';
@@ -47,6 +35,18 @@ export interface INonWorkingDay {
   standalone: false,
 })
 export class OpNonWorkingDaysListComponent implements OnInit, AfterViewInit {
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  protected I18n = inject(I18nService);
+  readonly bannersService = inject(BannersService);
+  readonly opModalService = inject(OpModalService);
+  readonly injector = inject(Injector);
+  readonly pathHelper = inject(PathHelperService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly dayService = inject(DayResourceService);
+  readonly confirmDialogService = inject(ConfirmDialogService);
+  readonly toast = inject(ToastService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @ViewChild(FullCalendarComponent) ucCalendar:FullCalendarComponent;
 
   @HostBinding('class.op-non-working-days-list') className = true;
@@ -119,19 +119,7 @@ export class OpNonWorkingDaysListComponent implements OnInit, AfterViewInit {
 
   };
 
-  constructor(
-    readonly elementRef:ElementRef<HTMLElement>,
-    protected I18n:I18nService,
-    readonly bannersService:BannersService,
-    readonly opModalService:OpModalService,
-    readonly injector:Injector,
-    readonly pathHelper:PathHelperService,
-    readonly apiV3Service:ApiV3Service,
-    readonly dayService:DayResourceService,
-    readonly confirmDialogService:ConfirmDialogService,
-    readonly toast:ToastService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
     this.listenToFormSubmit();
   }

--- a/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
+++ b/frontend/src/app/shared/components/op-view-select/op-static-queries.service.ts
@@ -28,16 +28,14 @@
 
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { StateService } from '@uirouter/core';
 
 @Injectable()
 export class StaticQueriesService {
-  constructor(
-    private readonly I18n:I18nService,
-    private readonly $state:StateService,
-  ) {
-  }
+  private readonly I18n = inject(I18nService);
+  private readonly $state = inject(StateService);
+
 
   public text = {
     work_packages: this.I18n.t('js.label_work_package_plural'),

--- a/frontend/src/app/shared/components/option-list/option-list.component.ts
+++ b/frontend/src/app/shared/components/option-list/option-list.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, HostBinding, Input, Output, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 export interface IOpOptionListOption<T> {
@@ -35,9 +26,9 @@ export type IOpOptionListValue<T> = T|null;
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class OpOptionListComponent<T> implements ControlValueAccessor {
-  @HostBinding('class.op-option-list') className = true;
+  private cdRef = inject(ChangeDetectorRef);
 
-  constructor(private cdRef:ChangeDetectorRef) {}
+  @HostBinding('class.op-option-list') className = true;
 
   @Input() options:IOpOptionListOption<T>[] = [];
 

--- a/frontend/src/app/shared/components/persistent-toggle/persistent-toggle.component.ts
+++ b/frontend/src/app/shared/components/persistent-toggle/persistent-toggle.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnInit, inject } from '@angular/core';
 import { slideDown, slideUp } from 'es6-slide-up-down';
 
 
@@ -40,6 +40,8 @@ import { slideDown, slideUp } from 'es6-slide-up-down';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class PersistentToggleComponent implements OnInit {
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
   /** Unique identifier of the toggle */
   private identifier:string;
 
@@ -50,9 +52,6 @@ export class PersistentToggleComponent implements OnInit {
   private element:HTMLElement;
 
   private targetNotification:HTMLElement|null;
-
-  constructor(private elementRef:ElementRef<HTMLElement>) {
-  }
 
   ngOnInit():void {
     this.element = this.elementRef.nativeElement;

--- a/frontend/src/app/shared/components/principal/principal-renderer.service.ts
+++ b/frontend/src/app/shared/components/principal/principal-renderer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { colorModes, ColorsService } from 'core-app/shared/components/colors/colors.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -28,12 +28,10 @@ export interface NameOptions {
 
 @Injectable({ providedIn: 'root' })
 export class PrincipalRendererService {
-  constructor(
-    private pathHelper:PathHelperService,
-    private apiV3Service:ApiV3Service,
-    private colors:ColorsService,
-  ) {
-  }
+  private pathHelper = inject(PathHelperService);
+  private apiV3Service = inject(ApiV3Service);
+  private colors = inject(ColorsService);
+
 
   renderAbbreviated(
     container:HTMLElement,

--- a/frontend/src/app/shared/components/principal/principal-rendering.module.ts
+++ b/frontend/src/app/shared/components/principal/principal-rendering.module.ts
@@ -1,4 +1,4 @@
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OpPrincipalComponent } from './principal.component';
 import { PrincipalRendererService } from './principal-renderer.service';
@@ -18,6 +18,5 @@ import { PrincipalRendererService } from './principal-renderer.service';
   ],
 })
 export class OpenprojectPrincipalRenderingModule {
-  constructor(readonly injector:Injector) {
-  }
+  readonly injector = inject(Injector);
 }

--- a/frontend/src/app/shared/components/principal/principal.component.ts
+++ b/frontend/src/app/shared/components/principal/principal.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Input,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
@@ -62,6 +54,15 @@ export interface PrincipalInput {
   standalone: false,
 })
 export class OpPrincipalComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly PathHelper = inject(PathHelperService);
+  readonly principalRenderer = inject(PrincipalRendererService);
+  readonly principalResourceService = inject(PrincipalsResourceService);
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly timezoneService = inject(TimezoneService);
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @Input() principal:PrincipalLike;
 
   @Input() hideAvatar = false;
@@ -83,16 +84,7 @@ export class OpPrincipalComponent implements OnInit {
 
   @Input() title = '';
 
-  public constructor(
-    readonly elementRef:ElementRef,
-    readonly PathHelper:PathHelperService,
-    readonly principalRenderer:PrincipalRendererService,
-    readonly principalResourceService:PrincipalsResourceService,
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly timezoneService:TimezoneService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
+  public constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/project-include/list/project-include-list.component.ts
+++ b/frontend/src/app/shared/components/project-include/list/project-include-list.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, Output, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -54,6 +47,11 @@ import { getMetaContent } from 'core-app/core/setup/globals/global-helpers';
   standalone: false,
 })
 export class OpProjectIncludeListComponent {
+  readonly I18n = inject(I18nService);
+  readonly currentProjectService = inject(CurrentProjectService);
+  readonly pathHelper = inject(PathHelperService);
+  readonly searchableProjectListService = inject(SearchableProjectListService);
+
   @HostBinding('class.spot-list') classNameList = true;
 
   @HostBinding('class.op-project-include-list') className = true;
@@ -79,13 +77,6 @@ export class OpProjectIncludeListComponent {
     include_all_selected: this.I18n.t('js.include_projects.tooltip.include_all_selected'),
     current_project: this.I18n.t('js.include_projects.tooltip.current_project'),
   };
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly currentProjectService:CurrentProjectService,
-    readonly pathHelper:PathHelperService,
-    readonly searchableProjectListService:SearchableProjectListService,
-  ) { }
 
   public updateList(selected:string[]):void {
     this.update.emit(selected);

--- a/frontend/src/app/shared/components/project-include/project-include.component.ts
+++ b/frontend/src/app/shared/components/project-include/project-include.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, OnDestroy, OnInit, inject } from '@angular/core';
 import { BehaviorSubject, combineLatest, Subscription } from 'rxjs';
 import {
   debounceTime,
@@ -56,6 +50,7 @@ import {
 import { QueryFilterInstanceResource } from 'core-app/features/hal/resources/query-filter-instance-resource';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
+import { IsolatedQuerySpace } from 'core-app/features/work-packages/directives/query-space/isolated-query-space';
 import { IProject } from 'core-app/core/state/projects/project.model';
 import {
   SearchableProjectListService,
@@ -77,6 +72,13 @@ import { calculatePositions } from 'core-app/shared/components/project-include/c
   standalone: false,
 })
 export class OpProjectIncludeComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  readonly I18n = inject(I18nService);
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpIncludeSubprojects = inject(WorkPackageViewIncludeSubprojectsService);
+  readonly halResourceService = inject(HalResourceService);
+  readonly searchableProjectListService = inject(SearchableProjectListService);
+  readonly querySpace = inject(IsolatedQuerySpace);
+
   @HostBinding('class.op-project-include') className = true;
 
   public text = {
@@ -95,7 +97,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
 
   public textFieldFocused = false;
 
-  public query$ = this.wpTableFilters.querySpace.query.values$();
+  public query$ = this.querySpace.query.values$();
 
   public displayModeOptions = [
     { value: 'all', title: this.text.filter_all },
@@ -258,13 +260,7 @@ export class OpProjectIncludeComponent extends UntilDestroyedMixin implements On
 
   public loading$ = new BehaviorSubject<boolean>(false);
 
-  constructor(
-    readonly I18n:I18nService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpIncludeSubprojects:WorkPackageViewIncludeSubprojectsService,
-    readonly halResourceService:HalResourceService,
-    readonly searchableProjectListService:SearchableProjectListService,
-  ) {
+  constructor() {
     super();
 
     this.projects$

--- a/frontend/src/app/shared/components/remote-field-updater/remote-field-updater.component.ts
+++ b/frontend/src/app/shared/components/remote-field-updater/remote-field-updater.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnDestroy, OnInit, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 export const remoteFieldUpdaterSelector = 'remote-field-updater';
@@ -38,11 +38,9 @@ export const remoteFieldUpdaterSelector = 'remote-field-updater';
   standalone: false,
 })
 export class RemoteFieldUpdaterComponent implements OnInit, OnDestroy {
-  constructor(
-    private elementRef:ElementRef,
-    private http:HttpClient,
-  ) {
-  }
+  private elementRef = inject(ElementRef);
+  private http = inject(HttpClient);
+
 
   private url:string;
 

--- a/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
+++ b/frontend/src/app/shared/components/resizer/resizer/wp-resizer.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, OnDestroy } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, OnDestroy, inject } from '@angular/core';
 import { debounceTime } from 'rxjs/operators';
 import { TransitionService } from '@uirouter/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
@@ -47,6 +47,9 @@ import { fromEvent } from 'rxjs';
   standalone: false,
 })
 export class WpResizerComponent extends UntilDestroyedMixin implements OnInit, AfterViewInit, OnDestroy {
+  private elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  readonly $transitions = inject(TransitionService);
+
   @Input() elementClass:string;
 
   @Input() resizeEvent:string;
@@ -69,13 +72,6 @@ export class WpResizerComponent extends UntilDestroyedMixin implements OnInit, A
   public moving = false;
 
   public resizerClass = 'work-packages--resizer icon-resizer-vertical-lines';
-
-  constructor(
-    private elementRef:ElementRef<HTMLElement>,
-    readonly $transitions:TransitionService,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     // Get element

--- a/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
+++ b/frontend/src/app/shared/components/searchable-project-list/searchable-project-list.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {
   ApiV3ListFilter,
   ApiV3ListParameters,
@@ -20,6 +20,11 @@ const UNDISCLOSED_ANCESTOR = 'urn:openproject-org:api:v3:undisclosed';
 
 @Injectable()
 export class SearchableProjectListService {
+  readonly http = inject(HttpClient);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly currentProjectService = inject(CurrentProjectService);
+  readonly configurationService = inject(ConfigurationService);
+
   private _searchText = '';
   private searchText$ = new BehaviorSubject<string>('');
   private loadingEnabled$ = new BehaviorSubject<boolean>(false);
@@ -122,13 +127,6 @@ export class SearchableProjectListService {
       return this.pipeConcatProjects(projects, this.extractAncestors(projects), extraFetches);
     })
   );
-
-  constructor(
-    readonly http:HttpClient,
-    readonly apiV3Service:ApiV3Service,
-    readonly currentProjectService:CurrentProjectService,
-    readonly configurationService:ConfigurationService,
-  ) { }
 
   /** Causes fetching of a new project list and enables reloads of the project list, when the searchText changes. */
   public enableLoading():void {

--- a/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.component.ts
+++ b/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.component.ts
@@ -26,19 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
@@ -64,6 +52,11 @@ import SpotDropAlignmentOption from 'core-app/spot/drop-alignment-options';
   standalone: false,
 })
 export class FileLinkListItemComponent implements OnInit, OnChanges, AfterViewInit {
+  private readonly i18n = inject(I18nService);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly confirmDialogService = inject(ConfirmDialogService);
+  private readonly principalRendererService = inject(PrincipalRendererService);
+
   @Input() public fileLink:IFileLink;
 
   @Input() public allowEditing = false;
@@ -98,13 +91,6 @@ export class FileLinkListItemComponent implements OnInit, OnChanges, AfterViewIn
     viewNotAllowedTooltipText: this.i18n.t('js.storages.file_links.tooltip.view_not_allowed'),
     notFoundTooltipText: this.i18n.t('js.storages.file_links.tooltip.not_found'),
   };
-
-  constructor(
-    private readonly i18n:I18nService,
-    private readonly timezoneService:TimezoneService,
-    private readonly confirmDialogService:ConfirmDialogService,
-    private readonly principalRendererService:PrincipalRendererService,
-  ) {}
 
   public get hasTooltip():boolean {
     return this.tooltip !== '';

--- a/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.spec.ts
+++ b/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.spec.ts
@@ -26,9 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectorRef, ElementRef } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { Observable, config, throwError } from 'rxjs';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { SortFilesPipe } from 'core-app/shared/components/storages/pipes/sort-files.pipe';
 import { StorageFilesResourceService } from 'core-app/core/state/storage-files/storage-files.service';
 import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
@@ -36,11 +37,9 @@ import { FilePickerBaseModalComponent, } from 'core-app/shared/components/storag
 import { StorageFileListItem } from 'core-app/shared/components/storages/storage-file-list-item/storage-file-list-item';
 import type { Mock } from 'vitest';
 
+// eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection,@angular-eslint/component-selector
+@Component({ selector: 'test-file-picker', template: '', standalone: false })
 class TestFilePickerBaseModalComponent extends FilePickerBaseModalComponent {
-  constructor(locals:OpModalLocalsMap, elementRef:ElementRef, cdRef:ChangeDetectorRef, sortFilesPipe:SortFilesPipe, storageFilesResourceService:StorageFilesResourceService) {
-    super(locals, elementRef, cdRef, sortFilesPipe, storageFilesResourceService);
-  }
-
   public loadDirectory(directory:IStorageFile):void {
     this.changeLevel(directory);
   }
@@ -59,8 +58,6 @@ describe('FilePickerBaseModalComponent', () => {
   }
 
   function buildComponent(spies:Spies) {
-    const cdRef = { detectChanges: spies.detectChanges } as unknown as ChangeDetectorRef;
-    const elementRef = { nativeElement: document.createElement('div') } as ElementRef;
     const locals = {
       service: { close: spies.close },
       storage: {
@@ -71,18 +68,26 @@ describe('FilePickerBaseModalComponent', () => {
         },
       },
       projectFolderMode: 'inactive',
-    } as unknown as OpModalLocalsMap;
-    const sortFilesPipe = { transform: (files:IStorageFile[]) => files } as SortFilesPipe;
-    const storageFilesResourceService = {
-      files: spies.files,
-      reset: spies.reset,
-    } as unknown as StorageFilesResourceService;
-    const component = new TestFilePickerBaseModalComponent(locals, elementRef, cdRef, sortFilesPipe, storageFilesResourceService);
+    };
 
+    TestBed.configureTestingModule({
+      declarations: [TestFilePickerBaseModalComponent],
+      providers: [
+        { provide: OpModalLocalsToken, useValue: locals },
+        { provide: ChangeDetectorRef, useValue: { detectChanges: spies.detectChanges } },
+        { provide: ElementRef, useValue: { nativeElement: document.createElement('div') } },
+        { provide: SortFilesPipe, useValue: { transform: (files:IStorageFile[]) => files } },
+        { provide: StorageFilesResourceService, useValue: { files: spies.files, reset: spies.reset } },
+      ],
+    });
+
+    const component = TestBed.runInInjectionContext(() => new TestFilePickerBaseModalComponent());
     component.ngOnInit();
 
-    return { component, cdRef, storageFilesResourceService };
+    return { component };
   }
+
+  afterEach(() => TestBed.resetTestingModule());
 
   it('cancels pending directory loading on destroy', () => {
     const teardown = vi.fn();

--- a/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/file-picker-base-modal/file-picker-base-modal.component.ts
@@ -26,14 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectorRef,
-  Directive,
-  ElementRef,
-  Inject,
-  OnDestroy,
-  OnInit,
-} from '@angular/core';
+import { Directive, OnDestroy, OnInit, inject } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   BehaviorSubject,
@@ -46,9 +39,7 @@ import { catchError, map } from 'rxjs/operators';
 
 import { IStorage } from 'core-app/core/state/storages/storage.model';
 import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { SortFilesPipe } from 'core-app/shared/components/storages/pipes/sort-files.pipe';
 import { StorageFilesResourceService } from 'core-app/core/state/storage-files/storage-files.service';
 import { Breadcrumb, BreadcrumbsContent } from 'core-app/spot/components/breadcrumbs/breadcrumbs-content';
@@ -69,6 +60,9 @@ type Alert = 'none'|'noAccess'|'managedFolderNoAccess'|'managedFolderNotFound'|'
 
 @Directive()
 export abstract class FilePickerBaseModalComponent extends OpModalComponent implements OnInit, OnDestroy {
+  protected readonly sortFilesPipe = inject(SortFilesPipe);
+  protected readonly storageFilesResourceService = inject(StorageFilesResourceService);
+
   private loadingSubscription:Subscription;
 
   protected readonly storageFiles$ = new BehaviorSubject<IStorageFile[]>([]);
@@ -95,16 +89,6 @@ export abstract class FilePickerBaseModalComponent extends OpModalComponent impl
     );
 
   public readonly loading$ = new BehaviorSubject<'loading'|'success'|'error'>('loading');
-
-  protected constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    protected readonly sortFilesPipe:SortFilesPipe,
-    protected readonly storageFilesResourceService:StorageFilesResourceService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit():void {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/file-picker-modal/file-picker-modal.component.ts
@@ -26,9 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -37,14 +35,10 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { IFileLink } from 'core-app/core/state/file-links/file-link.model';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { SortFilesPipe } from 'core-app/shared/components/storages/pipes/sort-files.pipe';
 import { FileLinksResourceService } from 'core-app/core/state/file-links/file-links.service';
 import { isDirectory, storageLocaleString } from 'core-app/shared/components/storages/functions/storages.functions';
-import { StorageFilesResourceService } from 'core-app/core/state/storage-files/storage-files.service';
 import {
   StorageFileListItem, StorageFileListItemCheckbox,
 } from 'core-app/shared/components/storages/storage-file-list-item/storage-file-list-item';
@@ -58,6 +52,12 @@ import {
   standalone: false,
 })
 export class FilePickerModalComponent extends FilePickerBaseModalComponent {
+  private readonly i18n = inject(I18nService);
+  private readonly toastService = inject(ToastService);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly configuration = inject(ConfigurationService);
+  private readonly fileLinksResourceService = inject(FileLinksResourceService);
+
   public readonly text = {
     header: this.i18n.t('js.storages.file_links.select'),
     alertNoAccess: this.i18n.t('js.storages.files.project_folder_no_access'),
@@ -117,25 +117,8 @@ export class FilePickerModalComponent extends FilePickerBaseModalComponent {
 
   private readonly fileMap:Record<string, IStorageFile> = {};
 
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    protected readonly sortFilesPipe:SortFilesPipe,
-    protected readonly storageFilesResourceService:StorageFilesResourceService,
-    private readonly i18n:I18nService,
-    private readonly toastService:ToastService,
-    private readonly timezoneService:TimezoneService,
-    private readonly configuration:ConfigurationService,
-    private readonly fileLinksResourceService:FileLinksResourceService,
-  ) {
-    super(
-      locals,
-      elementRef,
-      cdRef,
-      sortFilesPipe,
-      storageFilesResourceService,
-    );
+  constructor() {
+    super();
 
     this.showSelectAll = this.configuration.activeFeatureFlags.includes('storageFilePickingSelectAll');
   }

--- a/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/location-picker-modal/location-picker-modal.component.ts
@@ -26,26 +26,16 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { IStorageFile } from 'core-app/core/state/storage-files/storage-file.model';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
-import { SortFilesPipe } from 'core-app/shared/components/storages/pipes/sort-files.pipe';
 import {
   isDirectory,
   makeFilesCollectionLink,
   storageLocaleString,
 } from 'core-app/shared/components/storages/functions/storages.functions';
-import { StorageFilesResourceService } from 'core-app/core/state/storage-files/storage-files.service';
 import {
   StorageFileListItem,
 } from 'core-app/shared/components/storages/storage-file-list-item/storage-file-list-item';
@@ -61,6 +51,9 @@ import { map } from 'rxjs/operators';
   standalone: false,
 })
 export class LocationPickerModalComponent extends FilePickerBaseModalComponent {
+  private readonly i18n = inject(I18nService);
+  private readonly timezoneService = inject(TimezoneService);
+
   public submitted = false;
 
   public readonly text = {
@@ -136,24 +129,6 @@ export class LocationPickerModalComponent extends FilePickerBaseModalComponent {
           }
         }),
       );
-  }
-
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    protected sortFilesPipe:SortFilesPipe,
-    protected readonly storageFilesResourceService:StorageFilesResourceService,
-    private readonly i18n:I18nService,
-    private readonly timezoneService:TimezoneService,
-  ) {
-    super(
-      locals,
-      elementRef,
-      cdRef,
-      sortFilesPipe,
-      storageFilesResourceService,
-    );
   }
 
   public chooseLocation():void {

--- a/frontend/src/app/shared/components/storages/storage-information/storage-information.service.ts
+++ b/frontend/src/app/shared/components/storages/storage-information/storage-information.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -46,6 +46,9 @@ import {
 
 @Injectable()
 export class StorageInformationService {
+  private readonly i18n = inject(I18nService);
+  private readonly currentUserService = inject(CurrentUserService);
+
   private text = {
     fileLinkErrorHeader: this.i18n.t('js.storages.information.live_data_error'),
     fileLinkErrorContent: (storageType:string):string => this.i18n.t('js.storages.information.live_data_error_description', { storageType }),
@@ -59,11 +62,6 @@ export class StorageInformationService {
     suggestLogout: this.i18n.t('js.storages.information.suggest_logout'),
     suggestRelink: this.i18n.t('js.storages.information.suggest_relink'),
   };
-
-  constructor(
-    private readonly i18n:I18nService,
-    private readonly currentUserService:CurrentUserService,
-  ) {}
 
   public storageInformation(storage:IStorage, fileLinks:IFileLink[]):Observable<StorageInformationBox[]> {
     return this.currentUserService.isLoggedIn$

--- a/frontend/src/app/shared/components/storages/storage-login-button/storage-login-button.component.ts
+++ b/frontend/src/app/shared/components/storages/storage-login-button/storage-login-button.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, inject } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -43,15 +43,15 @@ import { populateInputsFromDataset } from 'core-app/shared/components/dataset-in
   standalone: false,
 })
 export class StorageLoginButtonComponent implements OnInit {
+  elementRef = inject(ElementRef);
+  private readonly i18n = inject(I18nService);
+  private readonly cookieService = inject(CookieService);
+
   @Input() input:IStorageLoginInput;
 
   label:string;
 
-  constructor(
-    public elementRef:ElementRef,
-    private readonly i18n:I18nService,
-    private readonly cookieService:CookieService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/shared/components/storages/storage/storage.component.ts
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.ts
@@ -26,18 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, inject } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   combineLatest,
@@ -113,6 +102,18 @@ import {
   standalone: false,
 })
 export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnDestroy {
+  private readonly i18n = inject(I18nService);
+  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly toastService = inject(ToastService);
+  private readonly uploadService = inject(OpUploadService);
+  private readonly opModalService = inject(OpModalService);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly pathHelperService = inject(PathHelperService);
+  private readonly storagesResourceService = inject(StoragesResourceService);
+  private readonly fileLinkResourceService = inject(FileLinksResourceService);
+  private readonly storageInformationService = inject(StorageInformationService);
+  private readonly storageFilesResourceService = inject(StorageFilesResourceService);
+
   @Input() public resource:HalResource;
 
   @Input() public projectStorage:IProjectStorage;
@@ -216,22 +217,6 @@ export class StorageComponent extends UntilDestroyedMixin implements OnInit, OnD
 
   public get openStorageLink() {
     return this.projectStorage._links.open?.href;
-  }
-
-  constructor(
-    private readonly i18n:I18nService,
-    private readonly cdRef:ChangeDetectorRef,
-    private readonly toastService:ToastService,
-    private readonly uploadService:OpUploadService,
-    private readonly opModalService:OpModalService,
-    private readonly timezoneService:TimezoneService,
-    private readonly pathHelperService:PathHelperService,
-    private readonly storagesResourceService:StoragesResourceService,
-    private readonly fileLinkResourceService:FileLinksResourceService,
-    private readonly storageInformationService:StorageInformationService,
-    private readonly storageFilesResourceService:StorageFilesResourceService,
-  ) {
-    super();
   }
 
   ngOnInit():void {

--- a/frontend/src/app/shared/components/storages/upload-conflict-modal/upload-conflict-modal.component.ts
+++ b/frontend/src/app/shared/components/storages/upload-conflict-modal/upload-conflict-modal.component.ts
@@ -26,18 +26,10 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 
 @Component({
   templateUrl: 'upload-conflict-modal.component.html',
@@ -45,6 +37,8 @@ import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.servi
   standalone: false,
 })
 export class UploadConflictModalComponent extends OpModalComponent {
+  private readonly i18n = inject(I18nService);
+
   public overwrite:boolean|null = null;
 
   public text = {
@@ -56,15 +50,6 @@ export class UploadConflictModalComponent extends OpModalComponent {
       cancel: this.i18n.t('js.button_cancel'),
     },
   };
-
-  public constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly elementRef:ElementRef,
-    private readonly i18n:I18nService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   public close(overwrite:boolean):void {
     this.overwrite = overwrite;

--- a/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
+++ b/frontend/src/app/shared/components/storages/upload/storage-upload.service.ts
@@ -28,7 +28,7 @@
 
 import { Observable } from 'rxjs';
 import { ID } from '@datorama/akita';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpEvent } from '@angular/common/http';
 
 import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
@@ -47,13 +47,9 @@ export interface IStorageFileUploadResponse {
 
 @Injectable()
 export class StorageUploadService extends OpUploadService {
-  private uploadStrategy:IUploadStrategy;
+  private readonly http = inject(HttpClient);
 
-  constructor(
-    private readonly http:HttpClient,
-  ) {
-    super();
-  }
+  private uploadStrategy:IUploadStrategy;
 
   public upload<T>(
     href:string,

--- a/frontend/src/app/shared/components/table-pagination/pagination-service.ts
+++ b/frontend/src/app/shared/components/table-pagination/pagination-service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 
 export const DEFAULT_PAGINATION_OPTIONS = {
@@ -48,9 +48,11 @@ export interface PaginationObject {
 
 @Injectable()
 export class PaginationService {
+  private configuration = inject(ConfigurationService);
+
   private paginationOptions:IPaginationOptions;
 
-  constructor(private configuration:ConfigurationService) {
+  constructor() {
     this.loadPaginationOptions();
   }
 

--- a/frontend/src/app/shared/components/table-pagination/table-pagination.component.ts
+++ b/frontend/src/app/shared/components/table-pagination/table-pagination.component.ts
@@ -26,15 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { PaginationInstance } from 'core-app/shared/components/table-pagination/pagination-instance';
@@ -47,6 +39,10 @@ import { PaginationService } from 'core-app/shared/components/table-pagination/p
   standalone: false,
 })
 export class TablePaginationComponent extends UntilDestroyedMixin implements OnInit {
+  protected paginationService = inject(PaginationService);
+  protected cdRef = inject(ChangeDetectorRef);
+  protected I18n = inject(I18nService);
+
   @Input() totalEntries:string;
 
   @Input() hideForSinglePageResults = false;
@@ -82,14 +78,6 @@ export class TablePaginationComponent extends UntilDestroyedMixin implements OnI
   public prePageNumbers:number[] = [];
 
   public perPageOptions:number[] = [];
-
-  constructor(
-    protected paginationService:PaginationService,
-    protected cdRef:ChangeDetectorRef,
-    protected I18n:I18nService,
-  ) {
-    super();
-  }
 
   ngOnInit():void {
     const paginationOptions = this.paginationService.getPaginationOptions();

--- a/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
+++ b/frontend/src/app/shared/components/tabs/scrollable-tabs/scrollable-tabs.component.ts
@@ -1,17 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  Input,
-  Injector,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  ViewChild,
-} from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Injector, OnChanges, Output, SimpleChanges, ViewChild, inject } from '@angular/core';
 import { TabDefinition } from 'core-app/shared/components/tabs/tab.interface';
 import {
   RawParams,
@@ -31,6 +18,10 @@ import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decora
   standalone: false,
 })
 export class ScrollableTabsComponent extends UntilDestroyedMixin implements AfterViewInit, OnChanges {
+  protected readonly $state = inject(StateService);
+  private cdRef = inject(ChangeDetectorRef);
+  injector = inject(Injector);
+
   @ViewChild('scrollContainer', { static: true }) scrollContainer:ElementRef;
 
   @ViewChild('scrollPane', { static: true }) scrollPane:ElementRef;
@@ -64,14 +55,6 @@ export class ScrollableTabsComponent extends UntilDestroyedMixin implements Afte
   private debouncedTabActivationTimeout:ReturnType<typeof setTimeout>|null;
 
   private dragTargetStack = 0;
-
-  constructor(
-    protected readonly $state:StateService,
-    private cdRef:ChangeDetectorRef,
-    public injector:Injector,
-  ) {
-    super();
-  }
 
   ngAfterViewInit():void {
     this.container = this.scrollContainer.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
+++ b/frontend/src/app/shared/components/time_entries/edit/trigger-actions-entry.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Injector, inject } from '@angular/core';
 import { InjectField } from 'core-app/shared/helpers/angular/inject-field.decorator';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ToastService } from 'core-app/shared/components/toaster/toast.service';
@@ -34,6 +34,8 @@ import { TurboRequestsService } from 'core-app/core/turbo/turbo-requests.service
   standalone: false,
 })
 export class TriggerActionsEntryComponent {
+  readonly injector = inject(Injector);
+
   @InjectField() readonly apiv3Service:ApiV3Service;
 
   @InjectField() readonly toastService:ToastService;
@@ -54,9 +56,6 @@ export class TriggerActionsEntryComponent {
     error: this.i18n.t('js.error.internal'),
     areYouSure: this.i18n.t('js.text_are_you_sure'),
   };
-
-  constructor(readonly injector:Injector) {
-  }
 
   editTimeEntry() {
     void this.loadEntry().subscribe((entry:TimeEntryResource) => {

--- a/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.ts
+++ b/frontend/src/app/shared/components/time_entries/timer/stop-existing-timer-modal.component.ts
@@ -26,19 +26,8 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Inject,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ChangeDetectionStrategy, Component, HostBinding, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
 import {
   Observable,
@@ -59,6 +48,9 @@ import { StateService } from '@uirouter/core';
   standalone: false,
 })
 export class StopExistingTimerModalComponent extends OpModalComponent implements OnInit {
+  readonly state = inject(StateService);
+  readonly I18n = inject(I18nService);
+
   @HostBinding('class.op-timer-stop-modal') className = true;
 
   public active:TimeEntryResource;
@@ -79,16 +71,6 @@ export class StopExistingTimerModalComponent extends OpModalComponent implements
     timer_already_running: this.I18n.t('js.timer.timer_already_running'),
     tracking_time: this.I18n.t('js.timer.tracking_time'),
   };
-
-  constructor(
-    readonly elementRef:ElementRef,
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    readonly cdRef:ChangeDetectorRef,
-    readonly state:StateService,
-    readonly I18n:I18nService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit() {
     super.ngOnInit();

--- a/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.ts
+++ b/frontend/src/app/shared/components/time_entries/timer/timer-account-menu.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  Injector,
-  OnInit,
-  ViewEncapsulation,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Injector, OnInit, ViewEncapsulation, inject } from '@angular/core';
 import { TimeEntryTimerService } from 'core-app/shared/components/time_entries/services/time-entry-timer.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
@@ -31,6 +22,13 @@ export const timerAccountSelector = 'op-timer-account-menu';
   standalone: false,
 })
 export class TimerAccountMenuComponent extends UntilDestroyedMixin implements OnInit {
+  readonly injector = inject(Injector);
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  readonly timeEntryService = inject(TimeEntryTimerService);
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly I18n = inject(I18nService);
+  readonly toastService = inject(ToastService);
+
   @HostBinding('class.op-timer-account-menu') className = true;
   @InjectField() PathHelper:PathHelperService;
   @InjectField() TurboRequests:TurboRequestsService;
@@ -49,17 +47,6 @@ export class TimerAccountMenuComponent extends UntilDestroyedMixin implements On
     stop: this.I18n.t('js.time_entry.stop'),
     timer_already_stopped: this.I18n.t('js.timer.timer_already_stopped'),
   };
-
-  constructor(
-    readonly injector:Injector,
-    readonly elementRef:ElementRef<HTMLElement>,
-    readonly timeEntryService:TimeEntryTimerService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly I18n:I18nService,
-    readonly toastService:ToastService,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     const parent = this.elementRef.nativeElement.parentElement!;

--- a/frontend/src/app/shared/components/toaster/toast.component.ts
+++ b/frontend/src/app/shared/components/toaster/toast.component.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import {
   BehaviorSubject,
   Observable,
@@ -52,6 +47,9 @@ import { IToast, ToastService, ToastType } from 'core-app/shared/components/toas
   standalone: false,
 })
 export class ToastComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly toastService = inject(ToastService);
+
   @Input() public toast:IToast;
 
   public text = {
@@ -71,12 +69,6 @@ export class ToastComponent implements OnInit {
   public removable = true;
 
   public loading$ = new BehaviorSubject<boolean>(false);
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly toastService:ToastService,
-  ) {
-  }
 
   ngOnInit():void {
     this.type = this.toast.type;

--- a/frontend/src/app/shared/components/toaster/toast.service.ts
+++ b/frontend/src/app/shared/components/toaster/toast.service.ts
@@ -29,7 +29,7 @@
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { input, State } from '@openproject/reactivestates';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpErrorResponse, HttpEvent } from '@angular/common/http';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -54,13 +54,13 @@ export interface IToast {
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {
+  readonly configurationService = inject(ConfigurationService);
+  readonly I18n = inject(I18nService);
+
   // The current stack of toasters
   private stack = input<IToast[]>([]);
 
-  constructor(
-    readonly configurationService:ConfigurationService,
-    readonly I18n:I18nService,
-  ) {
+  constructor() {
     window.addEventListener(OPToastEvent, ({ detail:toast }:CustomEvent<IToast>) => {
       this.add(toast);
     });

--- a/frontend/src/app/shared/components/toaster/toasts-container.component.ts
+++ b/frontend/src/app/shared/components/toaster/toasts-container.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 import { IToast, ToastService } from './toast.service';
 
@@ -46,14 +46,10 @@ import { IToast, ToastService } from './toast.service';
   standalone: false,
 })
 export class ToastsContainerComponent extends UntilDestroyedMixin implements OnInit {
-  public stack:IToast[] = [];
+  readonly toastService = inject(ToastService);
+  readonly cdRef = inject(ChangeDetectorRef);
 
-  constructor(
-    readonly toastService:ToastService,
-    readonly cdRef:ChangeDetectorRef,
-  ) {
-    super();
-  }
+  public stack:IToast[] = [];
 
   ngOnInit():void {
     this.toastService

--- a/frontend/src/app/shared/components/user-link/user-link.component.ts
+++ b/frontend/src/app/shared/components/user-link/user-link.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
 import { UserResource } from 'core-app/features/hal/resources/user-resource';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
@@ -51,10 +51,10 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class UserLinkComponent {
-  @Input() user:UserResource;
+  readonly I18n = inject(I18nService);
+  readonly pathHelperService = inject(PathHelperService);
 
-  constructor(readonly I18n:I18nService, readonly pathHelperService:PathHelperService) {
-  }
+  @Input() user:UserResource;
 
   public get href() {
     return this.user && this.user.showUserPath;

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab-inner.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab-inner.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
@@ -18,19 +18,29 @@ import { WorkPackageFiltersService } from 'core-app/features/work-packages/compo
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpGraphConfigurationFiltersTabInnerComponent extends QuerySpacedTabComponent implements TabComponent, OnInit {
+  readonly I18n:I18nService;
+  readonly wpTableFilters = inject(WorkPackageViewFiltersService);
+  readonly wpFiltersService = inject(WorkPackageFiltersService);
+  readonly wpStatesInitialization:WorkPackageStatesInitializationService;
+  readonly wpGraphConfiguration:WpGraphConfigurationService;
+  private cdRef = inject(ChangeDetectorRef);
+
   public filters:QueryFilterInstanceResource[] = [];
 
   public text = {
     multiSelectLabel: this.I18n.t('js.work_packages.label_column_multiselect'),
   };
 
-  constructor(readonly I18n:I18nService,
-    readonly wpTableFilters:WorkPackageViewFiltersService,
-    readonly wpFiltersService:WorkPackageFiltersService,
-    readonly wpStatesInitialization:WorkPackageStatesInitializationService,
-    readonly wpGraphConfiguration:WpGraphConfigurationService,
-    private cdRef:ChangeDetectorRef) {
+  constructor() {
+    const I18n = inject(I18nService);
+    const wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+    const wpGraphConfiguration = inject(WpGraphConfigurationService);
+
     super(I18n, wpStatesInitialization, wpGraphConfiguration);
+
+    this.I18n = I18n;
+    this.wpStatesInitialization = wpStatesInitialization;
+    this.wpGraphConfiguration = wpGraphConfiguration;
   }
 
   ngOnInit() {

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab-inner.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab-inner.component.ts
@@ -1,6 +1,6 @@
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WorkPackageViewGroupByService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-group-by.service';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { WpGraphConfigurationService } from 'core-app/shared/components/work-package-graphs/configuration/wp-graph-configuration.service';
 import { WorkPackageStatesInitializationService } from 'core-app/features/work-packages/components/wp-list/wp-states-initialization.service';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
@@ -23,6 +23,12 @@ interface OpChartType {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WpGraphConfigurationSettingsTabInnerComponent extends QuerySpacedTabComponent implements TabComponent, OnInit {
+  readonly I18n:I18nService;
+  readonly wpTableGroupBy = inject(WorkPackageViewGroupByService);
+  readonly wpStatesInitialization:WorkPackageStatesInitializationService;
+  readonly wpGraphConfiguration:WpGraphConfigurationService;
+  private cdRef = inject(ChangeDetectorRef);
+
   // Grouping
   public availableGroups:QueryGroupByResource[] = [];
 
@@ -35,12 +41,16 @@ export class WpGraphConfigurationSettingsTabInnerComponent extends QuerySpacedTa
     chart_type: this.I18n.t('js.chart.type'),
   };
 
-  constructor(readonly I18n:I18nService,
-    readonly wpTableGroupBy:WorkPackageViewGroupByService,
-    readonly wpStatesInitialization:WorkPackageStatesInitializationService,
-    readonly wpGraphConfiguration:WpGraphConfigurationService,
-    private cdRef:ChangeDetectorRef) {
+  constructor() {
+    const I18n = inject(I18nService);
+    const wpStatesInitialization = inject(WorkPackageStatesInitializationService);
+    const wpGraphConfiguration = inject(WpGraphConfigurationService);
+
     super(I18n, wpStatesInitialization, wpGraphConfiguration);
+
+    this.I18n = I18n;
+    this.wpStatesInitialization = wpStatesInitialization;
+    this.wpGraphConfiguration = wpGraphConfiguration;
   }
 
   public onSave() {

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/wp-graph-configuration.modal.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/wp-graph-configuration.modal.ts
@@ -1,21 +1,5 @@
-import {
-  ApplicationRef,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ComponentFactoryResolver,
-  ElementRef,
-  Inject,
-  InjectionToken,
-  Injector,
-  OnDestroy,
-  OnInit,
-  Optional,
-  ViewChild,
-} from '@angular/core';
-import { OpModalLocalsMap } from 'core-app/shared/components/modal/modal.types';
+import { ApplicationRef, ChangeDetectionStrategy, Component, ComponentFactoryResolver, ElementRef, InjectionToken, Injector, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
 import { OpModalComponent } from 'core-app/shared/components/modal/modal.component';
-import { OpModalLocalsToken } from 'core-app/shared/components/modal/modal.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import {
   ActiveTabInterface,
@@ -38,7 +22,15 @@ export const WpTableConfigurationModalPrependToken = new InjectionToken<Componen
   standalone: false,
 })
 export class WpGraphConfigurationModalComponent extends OpModalComponent implements OnInit, OnDestroy {
-  public element:HTMLElement;
+  prependModalComponent = inject<ComponentType<unknown> | null>(WpTableConfigurationModalPrependToken, { optional: true });
+  readonly I18n = inject(I18nService);
+  readonly injector = inject(Injector);
+  readonly appRef = inject(ApplicationRef);
+  readonly componentFactoryResolver = inject(ComponentFactoryResolver);
+  readonly loadingIndicator = inject(LoadingIndicatorService);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly configurationService = inject(ConfigurationService);
+  readonly graphConfiguration = inject(WpGraphConfigurationService);
 
   public text = {
     title: this.I18n.t('js.chart.modal_title'),
@@ -55,23 +47,6 @@ export class WpGraphConfigurationModalComponent extends OpModalComponent impleme
 
   // And a reference to the actual portal host interface
   public tabPortalHost:TabPortalOutlet;
-
-  constructor(
-    @Inject(OpModalLocalsToken) public locals:OpModalLocalsMap,
-    @Optional() @Inject(WpTableConfigurationModalPrependToken) public prependModalComponent:ComponentType<any>|null,
-    readonly I18n:I18nService,
-    readonly injector:Injector,
-    readonly appRef:ApplicationRef,
-    readonly componentFactoryResolver:ComponentFactoryResolver,
-    readonly loadingIndicator:LoadingIndicatorService,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly cdRef:ChangeDetectorRef,
-    readonly configurationService:ConfigurationService,
-    readonly elementRef:ElementRef,
-    readonly graphConfiguration:WpGraphConfigurationService,
-  ) {
-    super(locals, cdRef, elementRef);
-  }
 
   ngOnInit():void {
     this.element = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/components/work-package-graphs/configuration/wp-graph-configuration.service.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration/wp-graph-configuration.service.ts
@@ -2,7 +2,7 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { WpGraphConfigurationSettingsTabComponent } from 'core-app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab.component';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { TabInterface } from 'core-app/features/work-packages/components/wp-table/configuration-modal/tab-portal-outlet';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { WpGraphConfigurationFiltersTabComponent } from 'core-app/shared/components/work-package-graphs/configuration-modal/tabs/filters-tab.component';
 import { ChartOptions } from 'chart.js';
 import { QueryFormResource } from 'core-app/features/hal/resources/query-form-resource';
@@ -22,6 +22,11 @@ import {
 
 @Injectable()
 export class WpGraphConfigurationService {
+  readonly I18n = inject(I18nService);
+  readonly apiv3Service = inject(ApiV3Service);
+  readonly notificationService = inject(WorkPackageNotificationService);
+  readonly currentProject = inject(CurrentProjectService);
+
   private _configuration:WpGraphConfiguration;
 
   private _globalScope = false;
@@ -29,13 +34,6 @@ export class WpGraphConfigurationService {
   private _forms:Record<string, QueryFormResource> = {};
 
   private _formsPromise:Promise<unknown>|null;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly apiv3Service:ApiV3Service,
-    readonly notificationService:WorkPackageNotificationService,
-    readonly currentProject:CurrentProjectService,
-  ) { }
 
   public persistAndReload():Promise<unknown> {
     return this

--- a/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/embedded/wp-embedded-graph.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, SimpleChanges, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, SimpleChanges, OnChanges, inject } from '@angular/core';
 import { WorkPackageTableConfiguration } from 'core-app/features/work-packages/components/wp-table/wp-table-configuration';
 import { ChartOptions } from 'chart.js';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -35,6 +35,8 @@ interface ChartDataSet {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class WorkPackageEmbeddedGraphComponent implements OnChanges {
+  readonly i18n = inject(I18nService);
+
   @Input() public datasets:WorkPackageEmbeddedGraphDataset[];
 
   @Input() public chartOptions:ChartOptions;
@@ -58,8 +60,6 @@ export class WorkPackageEmbeddedGraphComponent implements OnChanges {
   public text = {
     noResults: this.i18n.t('js.work_packages.no_results.title'),
   };
-
-  constructor(readonly i18n:I18nService) {}
 
   ngOnChanges(changes:SimpleChanges) {
     if (changes.datasets) {

--- a/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
+++ b/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.component.ts
@@ -1,12 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  Input,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild, inject } from '@angular/core';
 import {
   WorkPackageEmbeddedGraphComponent,
   WorkPackageEmbeddedGraphDataset,
@@ -33,6 +25,11 @@ import {
   standalone: false,
 })
 export class WorkPackageOverviewGraphComponent implements OnInit {
+  readonly elementRef = inject<ElementRef<Element>>(ElementRef);
+  readonly I18n = inject(I18nService);
+  readonly graphConfigurationService = inject(WpGraphConfigurationService);
+  protected readonly cdr = inject(ChangeDetectorRef);
+
   @Input() initialFilters:any;
 
   @Input() globalScope:boolean;
@@ -53,12 +50,9 @@ export class WorkPackageOverviewGraphComponent implements OnInit {
 
   public error:string|null = null;
 
-  constructor(
-    readonly elementRef:ElementRef<Element>,
-    readonly I18n:I18nService,
-    readonly graphConfigurationService:WpGraphConfigurationService,
-    protected readonly cdr:ChangeDetectorRef,
-  ) {
+  constructor() {
+    const I18n = this.I18n;
+
     this.availableGroupBy = [{ label: I18n.t('js.work_packages.properties.category'), key: 'category' },
       { label: I18n.t('js.work_packages.properties.type'), key: 'type' },
       { label: I18n.t('js.work_packages.properties.status'), key: 'status' },

--- a/frontend/src/app/shared/components/work-packages/alternative-search.service.ts
+++ b/frontend/src/app/shared/components/work-packages/alternative-search.service.ts
@@ -1,12 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { QueryFilterResource } from 'core-app/features/hal/resources/query-filter-resource';
 
 @Injectable({ providedIn: 'root' })
 export class AlternativeSearchService {
-  constructor(
-    readonly I18n:I18nService,
-  ) { }
+  readonly I18n = inject(I18nService);
+
 
   private specialSearchStrings = {
     percentComplete: this.I18n.t('js.work_packages.properties.percentComplete'),

--- a/frontend/src/app/shared/directives/a11y/keyboard-shortcut.service.ts
+++ b/frontend/src/app/shared/directives/a11y/keyboard-shortcut.service.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { FocusHelperService } from 'core-app/shared/directives/focus/focus-helper';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
@@ -51,6 +51,11 @@ const accessibleListSelector = 'table.keyboard-accessible-list';
   providedIn: 'root',
 })
 export class KeyboardShortcutService {
+  private readonly PathHelper = inject(PathHelperService);
+  private readonly FocusHelper = inject(FocusHelperService);
+  private readonly currentProject = inject(CurrentProjectService);
+  private readonly configurationService = inject(ConfigurationService);
+
   // maybe move it to a .constant
   private shortcuts:Record<string, () => void> = {
     '?': () => this.showHelpModal(),
@@ -72,13 +77,6 @@ export class KeyboardShortcutService {
     'k': () => this.focusPrevItem(),
     'j': () => this.focusNextItem(),
   };
-
-  constructor(
-    private readonly PathHelper:PathHelperService,
-    private readonly FocusHelper:FocusHelperService,
-    private readonly currentProject:CurrentProjectService,
-    private readonly configurationService:ConfigurationService,
-  ) {}
 
   /**
    * Register the keyboard shortcuts.

--- a/frontend/src/app/shared/directives/focus/autofocus.directive.ts
+++ b/frontend/src/app/shared/directives/focus/autofocus.directive.ts
@@ -1,9 +1,4 @@
-import {
-  AfterViewInit,
-  Directive,
-  ElementRef,
-  Input,
-} from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input, inject } from '@angular/core';
 import { FocusHelperService } from './focus-helper';
 
 @Directive({
@@ -11,12 +6,10 @@ import { FocusHelperService } from './focus-helper';
   standalone: false,
 })
 export class AutofocusDirective implements AfterViewInit {
-  @Input('opAutofocus') public condition:string|boolean = true;
+  readonly FocusHelper = inject(FocusHelperService);
+  readonly elementRef = inject(ElementRef);
 
-  constructor(
-    readonly FocusHelper:FocusHelperService,
-    readonly elementRef:ElementRef,
-  ) { }
+  @Input('opAutofocus') public condition:string|boolean = true;
 
   ngAfterViewInit():void {
     this.updateFocus();

--- a/frontend/src/app/shared/directives/focus/focus-within.directive.ts
+++ b/frontend/src/app/shared/directives/focus/focus-within.directive.ts
@@ -28,9 +28,7 @@
 
 import { BehaviorSubject } from 'rxjs';
 import { auditTime } from 'rxjs/operators';
-import {
-  Directive, ElementRef, Input, OnInit,
-} from '@angular/core';
+import { Directive, ElementRef, Input, OnInit, inject } from '@angular/core';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 
 // with courtesy of http://stackoverflow.com/a/29722694/3206935
@@ -40,11 +38,9 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
   standalone: false,
 })
 export class FocusWithinDirective extends UntilDestroyedMixin implements OnInit {
-  @Input() public selector:string;
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  constructor(readonly elementRef:ElementRef<HTMLElement>) {
-    super();
-  }
+  @Input() public selector:string;
 
   ngOnInit() {
     const element = this.elementRef.nativeElement;

--- a/frontend/src/app/shared/directives/op-drag-scroll/op-drag-scroll.directive.ts
+++ b/frontend/src/app/shared/directives/op-drag-scroll/op-drag-scroll.directive.ts
@@ -25,7 +25,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 //++
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { Directive, ElementRef, OnInit, inject } from '@angular/core';
 
 declare global {
   interface GlobalEventHandlersEventMap {
@@ -38,8 +38,8 @@ declare global {
   standalone: false,
 })
 export class OpDragScrollDirective implements OnInit {
-  constructor(readonly elementRef:ElementRef<HTMLElement>) {
-  }
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
 
   ngOnInit() {
     const element = this.elementRef.nativeElement;

--- a/frontend/src/app/shared/directives/search-highlight.directive.ts
+++ b/frontend/src/app/shared/directives/search-highlight.directive.ts
@@ -1,18 +1,13 @@
-import {
-  AfterViewChecked,
-  Directive,
-  ElementRef,
-  Input,
-} from '@angular/core';
+import { AfterViewChecked, Directive, ElementRef, Input, inject } from '@angular/core';
 
 @Directive({
   selector: '[opSearchHighlight]',
   standalone: false,
 })
 export class OpSearchHighlightDirective implements AfterViewChecked {
-  @Input('opSearchHighlight') public query = '';
+  readonly elementRef = inject(ElementRef);
 
-  constructor(readonly elementRef:ElementRef) { }
+  @Input('opSearchHighlight') public query = '';
 
   ngAfterViewChecked():void {
     let el = this.elementRef.nativeElement as HTMLElement;

--- a/frontend/src/app/shared/helpers/drag-and-drop/drag-and-drop.service.ts
+++ b/frontend/src/app/shared/helpers/drag-and-drop/drag-and-drop.service.ts
@@ -1,6 +1,4 @@
-import {
-  Inject, Injectable, Injector, OnDestroy, DOCUMENT
-} from '@angular/core';
+import { Injectable, Injector, OnDestroy, DOCUMENT, inject } from '@angular/core';
 import { DomAutoscrollService } from 'core-app/shared/helpers/drag-and-drop/dom-autoscroll.service';
 import { findIndex, reinsert } from 'core-app/shared/helpers/drag-and-drop/drag-and-drop.helpers';
 import dragula, { Drake } from 'dragula';
@@ -32,6 +30,9 @@ export interface DragMember {
 
 @Injectable()
 export class DragAndDropService implements OnDestroy {
+  private document = inject<Document>(DOCUMENT);
+  readonly injector = inject(Injector);
+
   public drake:Drake|null = null;
 
   public members:DragMember[] = [];
@@ -44,8 +45,7 @@ export class DragAndDropService implements OnDestroy {
     }
   };
 
-  constructor(@Inject(DOCUMENT) private document:Document,
-    readonly injector:Injector) {
+  constructor() {
     this.document.documentElement.addEventListener('keydown', this.escapeListener);
   }
 

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 import { FormsModule } from '@angular/forms';
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { A11yModule } from '@angular/cdk/a11y';
 import { UIRouterGlobals } from '@uirouter/core';
 import { NgSelectModule } from '@ng-select/ng-select';
@@ -222,7 +222,9 @@ export function bootstrapModule(injector:Injector):void {
   ],
 })
 export class OpSharedModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     bootstrapModule(injector);
   }
 }

--- a/frontend/src/app/spot/components/checkbox/checkbox.component.ts
+++ b/frontend/src/app/spot/components/checkbox/checkbox.component.ts
@@ -1,15 +1,4 @@
-import {
-  Component,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Input,
-  Output,
-  ViewChild,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-} from '@angular/core';
+import { Component, ElementRef, EventEmitter, forwardRef, HostBinding, Input, Output, ViewChild, ChangeDetectionStrategy, ChangeDetectorRef, inject } from '@angular/core';
 import {
   ControlValueAccessor,
   NG_VALUE_ACCESSOR,
@@ -29,6 +18,8 @@ export type SpotCheckboxState = true|false|null;
   standalone: false,
 })
 export class SpotCheckboxComponent implements ControlValueAccessor {
+  readonly cdRef = inject(ChangeDetectorRef);
+
   @HostBinding('class.spot-checkbox') public className = true;
 
   @ViewChild('input') public input:ElementRef;
@@ -60,10 +51,6 @@ export class SpotCheckboxComponent implements ControlValueAccessor {
    * Emits when the checked state changes.
    */
   @Output() checkedChange = new EventEmitter<boolean>();
-
-  constructor(
-    readonly cdRef:ChangeDetectorRef,
-  ) {}
 
   onStateChange():void {
     const value = (this.input.nativeElement as HTMLInputElement).checked;

--- a/frontend/src/app/spot/components/drop-modal/drop-modal-portal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal-portal.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostBinding,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, OnInit, inject } from '@angular/core';
 import { SpotDropModalTeleportationService, TeleportInstance } from './drop-modal-teleportation.service';
 import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destroyed.mixin';
 
@@ -16,17 +9,13 @@ import { UntilDestroyedMixin } from 'core-app/shared/helpers/angular/until-destr
   standalone: false,
 })
 export class SpotDropModalPortalComponent extends UntilDestroyedMixin implements OnInit {
+  readonly cdRef = inject(ChangeDetectorRef);
+  readonly template$ = inject(SpotDropModalTeleportationService);
+  readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
   @HostBinding('class.spot-drop-modal-portal') className = true;
 
   template:TeleportInstance|null = null;
-
-  constructor(
-    readonly cdRef:ChangeDetectorRef,
-    readonly template$:SpotDropModalTeleportationService,
-    readonly elementRef:ElementRef<HTMLElement>,
-  ) {
-    super();
-  }
 
   ngOnInit() {
     this

--- a/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
+++ b/frontend/src/app/spot/components/drop-modal/drop-modal.component.ts
@@ -1,16 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  Input,
-  OnDestroy,
-  Output,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output, TemplateRef, ViewChild, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { findAllFocusableElementsWithin } from 'core-app/shared/helpers/focus-helpers';
 import { SpotDropModalTeleportationService } from './drop-modal-teleportation.service';
@@ -25,6 +13,11 @@ import { autoUpdate, computePosition, flip, limitShift, Placement, shift } from 
   standalone: false,
 })
 export class SpotDropModalComponent implements OnDestroy {
+  readonly i18n = inject(I18nService);
+  readonly elementRef = inject(ElementRef);
+  readonly cdRef = inject(ChangeDetectorRef);
+  private teleportationService = inject(SpotDropModalTeleportationService);
+
   @HostBinding('class.spot-drop-modal') public className = true;
 
   /**
@@ -98,13 +91,6 @@ export class SpotDropModalComponent implements OnDestroy {
   @ViewChild('body') body:TemplateRef<unknown>;
 
   @ViewChild('focusGrabber') focusGrabber:ElementRef;
-
-  constructor(
-    readonly i18n:I18nService,
-    readonly elementRef:ElementRef,
-    readonly cdRef:ChangeDetectorRef,
-    private teleportationService:SpotDropModalTeleportationService,
-  ) {}
 
   open() {
     this._opened = true;

--- a/frontend/src/app/spot/components/form-field/form-field.component.ts
+++ b/frontend/src/app/spot/components/form-field/form-field.component.ts
@@ -1,6 +1,4 @@
-import {
-  ChangeDetectionStrategy, Component, ContentChild, HostBinding, Input, Optional,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, HostBinding, Input, inject } from '@angular/core';
 import { AbstractControl, FormGroupDirective, NgControl } from '@angular/forms';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -14,6 +12,9 @@ import { I18nService } from 'core-app/core/i18n/i18n.service';
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SpotFormFieldComponent {
+  private _formGroupDirective = inject(FormGroupDirective, { optional: true });
+  readonly I18n = inject(I18nService);
+
   @HostBinding('class.spot-form-field') className = true;
 
   @HostBinding('class.spot-form-field_invalid') get errorClassName():boolean {
@@ -93,7 +94,7 @@ export class SpotFormFieldComponent {
     }
 
     if (this.showValidationErrorOn === 'submit') {
-      return this.formControl.invalid && this._formGroupDirective?.submitted;
+      return this.formControl.invalid && (this._formGroupDirective?.submitted ?? false);
     } if (this.showValidationErrorOn === 'blur') {
       return this.formControl.invalid && this.formControl.touched;
     } if (this.showValidationErrorOn === 'change') {
@@ -102,9 +103,4 @@ export class SpotFormFieldComponent {
 
     return false;
   }
-
-  constructor(
-    @Optional() private _formGroupDirective:FormGroupDirective,
-    readonly I18n:I18nService,
-  ) {}
 }

--- a/frontend/src/app/spot/components/selector-field/selector-field.component.ts
+++ b/frontend/src/app/spot/components/selector-field/selector-field.component.ts
@@ -1,11 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ContentChild,
-  HostBinding,
-  Input,
-  Optional,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, HostBinding, Input, inject } from '@angular/core';
 import {
   AbstractControl,
   FormGroupDirective,
@@ -22,6 +15,8 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SpotSelectorFieldComponent {
+  private formGroupDirective = inject(FormGroupDirective, { optional: true });
+
   @HostBinding('class.spot-form-field') className = true;
 
   @HostBinding('class.spot-selector-field') classNameCheckbox = true;
@@ -96,7 +91,7 @@ export class SpotSelectorFieldComponent {
     }
 
     if (this.showValidationErrorOn === 'submit') {
-      return this.formControl.invalid && this.formGroupDirective?.submitted;
+      return this.formControl.invalid && (this.formGroupDirective?.submitted ?? false);
     }
     if (this.showValidationErrorOn === 'blur') {
       return this.formControl.invalid && this.formControl.touched;
@@ -107,8 +102,4 @@ export class SpotSelectorFieldComponent {
 
     return false;
   }
-
-  constructor(
-    @Optional() private formGroupDirective:FormGroupDirective,
-  ) {}
 }

--- a/frontend/src/app/spot/components/switch/switch.component.ts
+++ b/frontend/src/app/spot/components/switch/switch.component.ts
@@ -1,15 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Input,
-  Output,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, HostBinding, Input, Output, ViewChild, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { populateInputsFromDataset } from 'core-app/shared/components/dataset-inputs';
 
@@ -28,6 +17,9 @@ export type SpotSwitchState = boolean;
   standalone: false,
 })
 export class SpotSwitchComponent implements ControlValueAccessor {
+  elementRef = inject(ElementRef);
+  cdRef = inject(ChangeDetectorRef);
+
   @HostBinding('class.spot-switch') public className = true;
 
   @ViewChild('input') public input:ElementRef;
@@ -60,10 +52,7 @@ export class SpotSwitchComponent implements ControlValueAccessor {
    */
   @Output() checkedChange = new EventEmitter<boolean>();
 
-  constructor(
-    public elementRef:ElementRef,
-    public cdRef:ChangeDetectorRef,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/frontend/src/app/spot/components/text-field/text-field.component.ts
+++ b/frontend/src/app/spot/components/text-field/text-field.component.ts
@@ -1,16 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  EventEmitter,
-  HostBinding,
-  HostListener,
-  Input,
-  Output,
-  ViewChild,
-  forwardRef,
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output, ViewChild, forwardRef, inject } from '@angular/core';
 import {
   ControlValueAccessor,
   NG_VALUE_ACCESSOR,
@@ -31,6 +19,8 @@ import {
   changeDetection: ChangeDetectionStrategy.Default,
 })
 export class SpotTextFieldComponent implements ControlValueAccessor {
+  private cdRef = inject(ChangeDetectorRef);
+
   @HostBinding('class.spot-text-field') public className = true;
 
   @HostBinding('class.spot-text-field_focused') public focused = false;
@@ -98,10 +88,6 @@ export class SpotTextFieldComponent implements ControlValueAccessor {
   @Output() public inputFocus = new EventEmitter<FocusEvent>();
 
   @Output() public inputBlur = new EventEmitter<FocusEvent>();
-
-  constructor(
-    private cdRef:ChangeDetectorRef,
-  ) {}
 
   onInputFocus(event:FocusEvent):void {
     this.focused = true;

--- a/frontend/src/app/spot/components/toggle/toggle.component.ts
+++ b/frontend/src/app/spot/components/toggle/toggle.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectorRef,
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  forwardRef,
-  HostBinding,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectorRef, ChangeDetectionStrategy, Component, EventEmitter, forwardRef, HostBinding, Input, Output, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 export interface SpotToggleOption<T> {
@@ -27,6 +18,8 @@ export interface SpotToggleOption<T> {
   standalone: false,
 })
 export class SpotToggleComponent<T> implements ControlValueAccessor {
+  private cdRef = inject(ChangeDetectorRef);
+
   // TODO: These old styles will need to be replaced
   @HostBinding('class.form--field-inline-buttons-container') public classNameOld = true;
 
@@ -69,10 +62,6 @@ export class SpotToggleComponent<T> implements ControlValueAccessor {
    * Emits when the selected value changes.
    */
   @Output() valueChange = new EventEmitter<T>();
-
-  constructor(
-    private cdRef:ChangeDetectorRef,
-  ) {}
 
   writeValue(value:T):void {
     this.value = value;

--- a/modules/avatars/frontend/module/avatar-upload-form/avatar-upload-form.component.ts
+++ b/modules/avatars/frontend/module/avatar-upload-form/avatar-upload-form.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, ViewChild, } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, OnInit, ViewChild, inject } from '@angular/core';
 
 import { resizeFile } from 'core-app/shared/helpers/images/resizer';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -44,6 +44,12 @@ import { HttpErrorResponse } from '@angular/common/http';
   standalone: false,
 })
 export class AvatarUploadFormComponent implements OnInit {
+  protected I18n = inject(I18nService);
+  protected elementRef = inject(ElementRef);
+  protected cdRef = inject(ChangeDetectorRef);
+  protected toastService = inject(ToastService);
+  protected uploadService = inject(OpUploadService);
+
   public form:any;
 
   public target:string;
@@ -70,14 +76,6 @@ export class AvatarUploadFormComponent implements OnInit {
     uploading: this.I18n.t('js.avatars.uploading_avatar'),
     preview: this.I18n.t('js.label_preview'),
   };
-
-  public constructor(
-    protected I18n:I18nService,
-    protected elementRef:ElementRef,
-    protected cdRef:ChangeDetectorRef,
-    protected toastService:ToastService,
-    protected uploadService:OpUploadService,
-  ) { }
 
   public ngOnInit() {
     const element = this.elementRef.nativeElement as HTMLElement;

--- a/modules/avatars/frontend/module/avatar-upload.service.ts
+++ b/modules/avatars/frontend/module/avatar-upload.service.ts
@@ -28,7 +28,7 @@
 
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpEvent } from '@angular/common/http';
 
 import { IUploadFile, OpUploadService } from 'core-app/core/upload/upload.service';
@@ -39,11 +39,8 @@ export interface AvatarUploadFile extends IUploadFile {
 
 @Injectable()
 export class AvatarUploadService extends OpUploadService {
-  constructor(
-    private readonly http:HttpClient,
-  ) {
-    super();
-  }
+  private readonly http = inject(HttpClient);
+
 
   public upload<T>(
     href:string,

--- a/modules/avatars/frontend/module/main.ts
+++ b/modules/avatars/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AvatarUploadFormComponent } from './avatar-upload-form/avatar-upload-form.component';
 import { registerCustomElement } from 'core-app/shared/helpers/angular/custom-elements.helper';
@@ -38,7 +38,9 @@ import { registerCustomElement } from 'core-app/shared/helpers/angular/custom-el
   ],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     registerCustomElement('opce-avatar-upload-form', AvatarUploadFormComponent, { injector });
   }
 }

--- a/modules/budgets/frontend/module/main.ts
+++ b/modules/budgets/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import { multiInput } from '@openproject/reactivestates';
 import { PlannedCostsFormAugment } from 'core-app/features/plugins/linked/budgets/augment/planned-costs-form';
@@ -49,7 +49,9 @@ export function initializeCostsPlugin(injector:Injector) {
 
 @NgModule({})
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeCostsPlugin(injector);
   }
 }

--- a/modules/costs/frontend/module/main.ts
+++ b/modules/costs/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { OpenProjectPluginContext } from 'core-app/features/plugins/plugin-context';
 import { CostsByTypeDisplayField } from './wp-display/costs-by-type-display-field.module';
 import { CurrencyDisplayField } from './wp-display/currency-display-field.module';
@@ -64,7 +64,9 @@ export function initializeCostsPlugin(injector:Injector) {
   ],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeCostsPlugin(injector);
   }
 }

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -27,18 +27,10 @@
 //++
 
 import copy from 'copy-text-to-clipboard';
-import {
-  Component,
-  Inject,
-  Input,
-} from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { GitActionsService } from '../git-actions/git-actions.service';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { OPContextMenuComponent } from "core-app/shared/components/op-context-menu/op-context-menu.component";
-import {
-  OpContextMenuLocalsMap,
-  OpContextMenuLocalsToken,
-} from "core-app/shared/components/op-context-menu/op-context-menu.types";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 import { ISnippet } from 'core-app/features/plugins/linked/openproject-github_integration/state/github-pull-request.model';
 
@@ -52,6 +44,9 @@ import { ISnippet } from 'core-app/features/plugins/linked/openproject-github_in
   standalone: false,
 })
 export class GitActionsMenuComponent extends OPContextMenuComponent {
+  readonly I18n = inject(I18nService);
+  readonly gitActions = inject(GitActionsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public text = {
@@ -90,13 +85,8 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     },
   ];
 
-  constructor(
-    @Inject(OpContextMenuLocalsToken)
-    public locals:OpContextMenuLocalsMap,
-    readonly I18n:I18nService,
-    readonly gitActions:GitActionsService,
-  ) {
-    super(locals);
+  constructor() {
+    super();
     this.workPackage = this.locals.workPackage as WorkPackageResource;
   }
 

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.directive.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.directive.ts
@@ -27,8 +27,7 @@
 //++
 
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef, Input } from '@angular/core';
+import { Directive, Input } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { GitActionsMenuComponent } from './git-actions-menu.component';
@@ -39,11 +38,6 @@ import { GitActionsMenuComponent } from './git-actions-menu.component';
 })
 export class GitActionsMenuDirective extends OpContextMenuTrigger {
   @Input('gitActionsCopyDropdown-workPackage') public workPackage:WorkPackageResource;
-
-  constructor(readonly elementRef:ElementRef,
-              readonly opContextMenu:OPContextMenuService) {
-    super(elementRef, opContextMenu);
-  }
 
   protected open(evt:Event) {
     this.opContextMenu.show(this, evt, GitActionsMenuComponent);

--- a/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
+++ b/modules/github_integration/frontend/module/github-tab/github-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { TabComponent } from "core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab";
 import { I18nService } from "core-app/core/i18n/i18n.service";
@@ -38,9 +38,8 @@ import { PathHelperService } from "core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class GitHubTabComponent implements TabComponent {
-  @Input() public workPackage:WorkPackageResource;
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
 
-  constructor(readonly PathHelper:PathHelperService,
-              readonly I18n:I18nService) {
-  }
+  @Input() public workPackage:WorkPackageResource;
 }

--- a/modules/github_integration/frontend/module/main.ts
+++ b/modules/github_integration/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import {
@@ -98,7 +98,9 @@ export function initializeGithubIntegrationPlugin(injector:Injector) {
   ],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeGithubIntegrationPlugin(injector);
     registerCustomElement('opce-github-pull-request', PullRequestMacroComponent, { injector });
   }

--- a/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-macro.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++    Ng1FieldControlsWrapper,
 
-import { ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnInit, } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Injector, Input, OnInit, inject } from '@angular/core';
 import {
   HalResourceEditingService
 } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
@@ -48,6 +48,11 @@ import { PullRequestState } from './pull-request-state.component';
   standalone: false,
 })
 export class PullRequestMacroComponent implements OnInit {
+  readonly elementRef = inject(ElementRef);
+  readonly injector = inject(Injector);
+  readonly pullRequests = inject(GithubPullRequestResourceService);
+  readonly I18n = inject(I18nService);
+
   @Input() pullRequestId:string;
 
   @Input() pullRequestState:PullRequestState;
@@ -56,12 +61,7 @@ export class PullRequestMacroComponent implements OnInit {
 
   displayText$:Observable<string|null>;
 
-  constructor(
-    readonly elementRef:ElementRef,
-    readonly injector:Injector,
-    readonly pullRequests:GithubPullRequestResourceService,
-    readonly I18n:I18nService,
-  ) {
+  constructor() {
     populateInputsFromDataset(this);
   }
 

--- a/modules/github_integration/frontend/module/pull-request/pull-request-state.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request-state.component.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 
@@ -47,17 +42,14 @@ export type PullRequestState = 'opened'|'closed'|'referenced'|'ready_for_review'
   standalone: false,
 })
 export class PullRequestStateComponent implements OnInit {
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() state:PullRequestState;
 
   @Input() small = false;
 
   displayText:string;
-
-  constructor(
-    readonly PathHelper:PathHelperService,
-    readonly I18n:I18nService,
-  ) {
-  }
 
   ngOnInit():void {
     this.displayText = this.I18n.t(

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.ts
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.ts
@@ -26,12 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
@@ -51,6 +46,9 @@ import {
 })
 
 export class PullRequestComponent {
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @HostBinding('class.op-pull-request') className = true;
 
   @Input() public pullRequest:IGithubPullRequest;
@@ -61,12 +59,6 @@ export class PullRequestComponent {
     label_details: this.I18n.t('js.label_details'),
     label_actions: this.I18n.t('js.github_integration.github_actions'),
   };
-
-  constructor(
-    readonly PathHelper:PathHelperService,
-    readonly I18n:I18nService,
-  ) {
-  }
 
   get state():string {
     if (this.pullRequest.state === 'open') {

--- a/modules/github_integration/frontend/module/tab-header/tab-header.component.ts
+++ b/modules/github_integration/frontend/module/tab-header/tab-header.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 
@@ -39,6 +39,8 @@ import { I18nService } from "core-app/core/i18n/i18n.service";
   standalone: false,
 })
 export class TabHeaderComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public text = {
@@ -48,7 +50,4 @@ export class TabHeaderComponent {
     gitMenuLabel: this.I18n.t('js.github_integration.tab_header.copy_menu.label'),
     gitMenuDescription: this.I18n.t('js.github_integration.tab_header.copy_menu.description'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/modules/github_integration/frontend/module/tab-prs/tab-prs.component.ts
+++ b/modules/github_integration/frontend/module/tab-prs/tab-prs.component.ts
@@ -26,13 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  HostBinding,
-  Input,
-  OnInit,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -51,6 +45,10 @@ import { Observable } from 'rxjs';
   standalone: false,
 })
 export class TabPrsComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly githubPullRequests = inject(GithubPullRequestResourceService);
+
   @HostBinding('class.op-github-prs') className = true;
 
   @Input() workPackage:WorkPackageResource;
@@ -58,12 +56,6 @@ export class TabPrsComponent implements OnInit {
   pullRequests$:Observable<IGithubPullRequest[]>;
 
   emptyText:string;
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly githubPullRequests:GithubPullRequestResourceService,
-  ) {}
 
   ngOnInit():void {
     this.emptyText = this.I18n.t('js.github_integration.tab_prs.empty', { wp_id: this.workPackage.id });

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -28,15 +28,11 @@
 //++
 
 import copy from 'copy-text-to-clipboard';
-import { Component, Inject, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { GitActionsService } from '../git-actions/git-actions.service';
 import { ISnippet } from "core-app/features/plugins/linked/openproject-gitlab_integration/typings";
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { OPContextMenuComponent } from "core-app/shared/components/op-context-menu/op-context-menu.component";
-import {
-  OpContextMenuLocalsMap,
-  OpContextMenuLocalsToken
-} from "core-app/shared/components/op-context-menu/op-context-menu.types";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 
 
@@ -49,6 +45,9 @@ import { I18nService } from "core-app/core/i18n/i18n.service";
   standalone: false,
 })
 export class GitActionsMenuComponent extends OPContextMenuComponent {
+  readonly I18n = inject(I18nService);
+  readonly gitActions = inject(GitActionsService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public text = {
@@ -85,12 +84,9 @@ export class GitActionsMenuComponent extends OPContextMenuComponent {
     },
   ];
 
-  constructor(@Inject(OpContextMenuLocalsToken)
-              public locals:OpContextMenuLocalsMap,
-              readonly I18n:I18nService,
-              readonly gitActions:GitActionsService) {
-    super(locals);
-    this.workPackage = this.locals.workPackage;
+  constructor() {
+    super();
+    this.workPackage = this.locals.workPackage as WorkPackageResource;
   }
 
   public onCopyButtonClick(snippet:ISnippet):void {

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.directive.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.directive.ts
@@ -28,8 +28,7 @@
 //++
 
 import { OpContextMenuItem } from 'core-app/shared/components/op-context-menu/op-context-menu.types';
-import { OPContextMenuService } from 'core-app/shared/components/op-context-menu/op-context-menu.service';
-import { Directive, ElementRef, Input } from '@angular/core';
+import { Directive, Input } from '@angular/core';
 import { OpContextMenuTrigger } from 'core-app/shared/components/op-context-menu/handlers/op-context-menu-trigger.directive';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { GitActionsMenuComponent } from './git-actions-menu.component';
@@ -41,11 +40,6 @@ import { GitActionsMenuComponent } from './git-actions-menu.component';
 })
 export class GitActionsMenuDirective extends OpContextMenuTrigger {
   @Input('gitActionsCopyDropdown-workPackage') public workPackage:WorkPackageResource;
-
-  constructor(readonly elementRef:ElementRef,
-              readonly opContextMenu:OPContextMenuService) {
-    super(elementRef, opContextMenu);
-  }
 
   protected open(evt:Event) {
     this.opContextMenu.show(this, evt, GitActionsMenuComponent);

--- a/modules/gitlab_integration/frontend/module/gitlab-tab/gitlab-tab.component.ts
+++ b/modules/gitlab_integration/frontend/module/gitlab-tab/gitlab-tab.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { TabComponent } from "core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab";
 import { I18nService } from "core-app/core/i18n/i18n.service";
@@ -42,9 +42,8 @@ import { PathHelperService } from "core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class GitlabTabComponent implements TabComponent {
-  @Input() public workPackage:WorkPackageResource;
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
 
-  constructor(readonly PathHelper:PathHelperService,
-              readonly I18n:I18nService) {
-  }
+  @Input() public workPackage:WorkPackageResource;
 }

--- a/modules/gitlab_integration/frontend/module/issue/issue.component.ts
+++ b/modules/gitlab_integration/frontend/module/issue/issue.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {IGitlabIssueResource} from 'core-app/features/plugins/linked/openproject-gitlab_integration/typings';
@@ -43,6 +43,9 @@ import {IGitlabIssueResource} from 'core-app/features/plugins/linked/openproject
 })
 
 export class IssueComponent {
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public gitlabIssue:IGitlabIssueResource;
 
   public text = {
@@ -50,10 +53,6 @@ export class IssueComponent {
     label_last_updated_on: this.I18n.t('js.gitlab_integration.updated_on'),
     label_details: this.I18n.t('js.label_details'),
   };
-
-  constructor(readonly PathHelper:PathHelperService,
-              readonly I18n:I18nService) {
-  }
 
   get state() {
 

--- a/modules/gitlab_integration/frontend/module/main.ts
+++ b/modules/gitlab_integration/frontend/module/main.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Injector, NgModule } from '@angular/core';
+import { Injector, NgModule, inject } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import {
@@ -116,7 +116,9 @@ export function initializeGitlabIntegrationPlugin(injector:Injector) {
   ],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeGitlabIntegrationPlugin(injector);
   }
 }

--- a/modules/gitlab_integration/frontend/module/merge-request/merge-request.component.ts
+++ b/modules/gitlab_integration/frontend/module/merge-request/merge-request.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {IGitlabMergeRequestResource} from 'core-app/features/plugins/linked/openproject-gitlab_integration/typings';
@@ -44,6 +44,9 @@ import {IGitlabMergeRequestResource} from 'core-app/features/plugins/linked/open
 })
 
 export class MergeRequestComponent {
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public mergeRequest:IGitlabMergeRequestResource;
 
   public text = {
@@ -52,10 +55,6 @@ export class MergeRequestComponent {
     label_details: this.I18n.t('js.label_details'),
     label_pipelines: this.I18n.t('js.gitlab_integration.gitlab_pipelines'),
   };
-
-  constructor(readonly PathHelper:PathHelperService,
-              readonly I18n:I18nService) {
-  }
 
   get state() {
 

--- a/modules/gitlab_integration/frontend/module/tab-header-issue/tab-header-issue.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-header-issue/tab-header-issue.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 
@@ -40,12 +40,11 @@ import { I18nService } from "core-app/core/i18n/i18n.service";
   standalone: false,
 })
 export class TabHeaderIssueComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public text = {
     title: this.I18n.t('js.gitlab_integration.tab_header_issue.title'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/modules/gitlab_integration/frontend/module/tab-header-mr/tab-header-mr.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-header-mr/tab-header-mr.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { I18nService } from "core-app/core/i18n/i18n.service";
 
@@ -40,6 +40,8 @@ import { I18nService } from "core-app/core/i18n/i18n.service";
   standalone: false,
 })
 export class TabHeaderMrsComponent {
+  readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
 
   public text = {
@@ -49,7 +51,4 @@ export class TabHeaderMrsComponent {
     gitMenuLabel: this.I18n.t('js.gitlab_integration.tab_header_mr.copy_menu.label'),
     gitMenuDescription: this.I18n.t('js.gitlab_integration.tab_header_mr.copy_menu.description'),
   };
-
-  constructor(readonly I18n:I18nService) {
-  }
 }

--- a/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { HalResourceService } from "core-app/features/hal/services/hal-resource.service";
 import { CollectionResource } from "core-app/features/hal/resources/collection-resource";
@@ -42,16 +42,14 @@ import {ApiV3Service} from "core-app/core/apiv3/api-v3.service";
   standalone: false,
 })
 export class TabIssueComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly halResourceService = inject(HalResourceService);
+  readonly changeDetector = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
 
   public gitlabIssues:IGitlabIssueResource[] = [];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly halResourceService:HalResourceService,
-    readonly changeDetector:ChangeDetectorRef,
-  ) {}
 
   ngOnInit(): void {
     const basePath = this.apiV3Service.work_packages.id(this.workPackage.id as string).path;

--- a/modules/gitlab_integration/frontend/module/tab-issue/wp-gitlab-issue.service.ts
+++ b/modules/gitlab_integration/frontend/module/tab-issue/wp-gitlab-issue.service.ts
@@ -29,16 +29,14 @@
 
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { HalResource } from "core-app/features/hal/resources/hal-resource";
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ConfigurationService } from "core-app/core/config/configuration.service";
 import { WorkPackageLinkedResourceCache } from 'core-app/features/work-packages/components/wp-single-view-tabs/wp-linked-resource-cache.service';
 
 @Injectable()
 export class WorkPackagesGitlabIssueService extends WorkPackageLinkedResourceCache<HalResource[]> {
+  ConfigurationService = inject(ConfigurationService);
 
-  constructor(public ConfigurationService:ConfigurationService) {
-    super();
-  }
 
   protected load(workPackage:WorkPackageResource):Promise<HalResource[]> {
     return workPackage.gitlab_issues.$update().then((data:any) => {

--- a/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.component.ts
@@ -27,7 +27,7 @@
 // See docs/COPYRIGHT.rdoc for more details.
 //++
 
-import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { HalResourceService } from "core-app/features/hal/services/hal-resource.service";
 import { CollectionResource } from "core-app/features/hal/resources/collection-resource";
@@ -42,16 +42,14 @@ import {ApiV3Service} from "core-app/core/apiv3/api-v3.service";
   standalone: false,
 })
 export class TabMrsComponent implements OnInit {
+  readonly I18n = inject(I18nService);
+  readonly apiV3Service = inject(ApiV3Service);
+  readonly halResourceService = inject(HalResourceService);
+  readonly changeDetector = inject(ChangeDetectorRef);
+
   @Input() public workPackage:WorkPackageResource;
 
   public mergeRequests:IGitlabMergeRequestResource[] = [];
-
-  constructor(
-    readonly I18n:I18nService,
-    readonly apiV3Service:ApiV3Service,
-    readonly halResourceService:HalResourceService,
-    readonly changeDetector:ChangeDetectorRef,
-  ) {}
 
   ngOnInit(): void {
     const basePath = this.apiV3Service.work_packages.id(this.workPackage.id as string).path;

--- a/modules/gitlab_integration/frontend/module/tab-mrs/wp-gitlab-mrs.service.ts
+++ b/modules/gitlab_integration/frontend/module/tab-mrs/wp-gitlab-mrs.service.ts
@@ -29,16 +29,14 @@
 
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 import { HalResource } from "core-app/features/hal/resources/hal-resource";
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ConfigurationService } from "core-app/core/config/configuration.service";
 import { WorkPackageLinkedResourceCache } from 'core-app/features/work-packages/components/wp-single-view-tabs/wp-linked-resource-cache.service';
 
 @Injectable()
 export class WorkPackagesGitlabMrsService extends WorkPackageLinkedResourceCache<HalResource[]> {
+  ConfigurationService = inject(ConfigurationService);
 
-  constructor(public ConfigurationService:ConfigurationService) {
-    super();
-  }
 
   protected load(workPackage:WorkPackageResource):Promise<HalResource[]> {
     return workPackage.gitlab_merge_requests.$update().then((data:any) => {

--- a/modules/meeting/frontend/module/main.ts
+++ b/modules/meeting/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule, inject } from '@angular/core';
 import { OpSharedModule } from 'core-app/shared/shared.module';
 import { OpenprojectTabsModule } from 'core-app/shared/components/tabs/openproject-tabs.module';
 import {
@@ -104,7 +104,9 @@ export function initializeMeetingPlugin(injector:Injector) {
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeMeetingPlugin(injector);
   }
 }

--- a/modules/meeting/frontend/module/meetings-tab/meetings-tab.component.ts
+++ b/modules/meeting/frontend/module/meetings-tab/meetings-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, inject } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
@@ -39,14 +39,12 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class MeetingsTabComponent implements OnInit, TabComponent {
+  private elementRef = inject(ElementRef);
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
   turboFrameSrc:string;
-
-  constructor(
-    private elementRef:ElementRef,
-    readonly PathHelper:PathHelperService,
-    readonly I18n:I18nService,
-  ) {}
 
   ngOnInit():void {
     this.turboFrameSrc = `${this.PathHelper.projectWorkPackagePath(this.workPackage.project.id as string, this.workPackage.id as string)}/meetings/tab`;

--- a/modules/wikis/frontend/module/main.ts
+++ b/modules/wikis/frontend/module/main.ts
@@ -24,7 +24,7 @@
 //
 // See COPYRIGHT and LICENSE files for more details.
 
-import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, Injector, NgModule, inject } from '@angular/core';
 
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { OpSharedModule } from 'core-app/shared/shared.module';
@@ -65,7 +65,9 @@ export function initializeWikiPlugin(injector:Injector) {
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class PluginModule {
-  constructor(injector:Injector) {
+  constructor() {
+    const injector = inject(Injector);
+
     initializeWikiPlugin(injector);
   }
 }

--- a/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
+++ b/modules/wikis/frontend/module/wikis-tab/wikis-tab.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, OnInit, inject } from '@angular/core';
 
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { TabComponent } from 'core-app/features/work-packages/components/wp-tabs/components/wp-tab-wrapper/tab';
@@ -40,14 +40,12 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
   standalone: false,
 })
 export class WikisTabComponent implements OnInit, TabComponent {
+  private elementRef = inject(ElementRef);
+  readonly PathHelper = inject(PathHelperService);
+  readonly I18n = inject(I18nService);
+
   @Input() public workPackage:WorkPackageResource;
   turboFrameSrc:string;
-
-  constructor(
-    private elementRef:ElementRef,
-    readonly PathHelper:PathHelperService,
-    readonly I18n:I18nService,
-  ) {}
 
   ngOnInit():void {
     this.turboFrameSrc = `${this.PathHelper.projectWorkPackagePath(this.workPackage.project.id as string, this.workPackage.id as string)}/wikis/tab`;


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74950

# What are you trying to accomplish?

Migrate Angular constructor-based dependency injection to the `inject()` function across the frontend codebase. This is a mechanical refactoring that removes ~2 200 lines of constructor boilerplate while aligning with the Angular team's recommended DI pattern.

# What approach did you choose and why?

Used the official Angular schematic as the initial pass:

```sh
cd frontend && npx ng generate @angular/core:inject-migration \
  --path ./ \
  --migrate-abstract-classes \
  --backwards-compatible-constructors=false \
  --non-nullable-optional=false
```

Manual follow-up was needed for:

- **Missed child classes** whose parents lost their constructor (e.g. `GlobalSearchTabsComponent`, `ViewSettingsModalComponent`)
- **Factory-instantiated services** (`ProjectCache`, `viewerBridgeServiceFactory`) that run outside an injection context — kept constructor params or wrapped in `runInInjectionContext()`
- **`OpAutocompleterService`** moved to `providedIn: 'root'` so subclasses can inherit it without a component-level provider
- **Eslint fixes** on changed lines (type-annotation spacing, unused imports, `any` → `unknown`, `||` → `??`)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)