### PR TITLE
Fix timezone service spec in local timezones

### DIFF
--- a/frontend/src/app/core/datetime/timezone.service.spec.ts
+++ b/frontend/src/app/core/datetime/timezone.service.spec.ts
@@ -32,6 +32,7 @@ import { PathHelperService } from 'core-app/core/path-helper/path-helper.service
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
+import moment from 'moment-timezone';
 
 describe('TimezoneService', () => {
   const TIME = '2013-02-08T09:30:26';
@@ -44,19 +45,27 @@ describe('TimezoneService', () => {
       timezone: () => timezone,
     };
 
+    if (!timezone) {
+      vi.spyOn(moment.tz, 'guess').mockReturnValue('Etc/UTC');
+    }
+
     TestBed.configureTestingModule({
-    imports: [],
-    providers: [
+      imports: [],
+      providers: [
         { provide: I18nService, useValue: {} },
         { provide: ConfigurationService, useValue: ConfigurationServiceStub },
         PathHelperService,
         TimezoneService,
         provideHttpClient(withInterceptorsFromDi()),
-    ]
-});
+      ],
+    });
 
     timezoneService = TestBed.inject(TimezoneService);
   };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   describe('without time zone set', () => {
     beforeEach(() => {


### PR DESCRIPTION
# Ticket
No work package.

# What are you trying to accomplish?

Fix a timezone service spec that fails in non-UTC local browser timezones (this is a big annoyance when not working from GMT!)

When no explicit timezone is configured, `TimezoneService` falls back to `moment.tz.guess()`, so the spec must not depend on the developer machine timezone.

# What approach did you choose and why?
Mock `moment.tz.guess()` to return `Etc/UTC` for the no-config case and restore mocks after each test. This keeps production behavior unchanged while making the UTC expectation deterministic. The existing configured-timezone test still covers the non-UTC conversion path.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (not applicable)
- [x] Tested major browsers (Chromium, Firefox, WebKit via `npm test`)
