### PR TITLE
fix: Do not trigger bg jobs for supressed `JOURNAL_UPDATED` notifications

### DIFF
--- a/config/initializers/subscribe_listeners.rb
+++ b/config/initializers/subscribe_listeners.rb
@@ -56,6 +56,7 @@ Rails.application.config.after_initialize do
 
   OpenProject::Notifications.subscribe(OpenProject::Events::JOURNAL_UPDATED) do |payload|
     next unless payload[:trigger_callbacks]
+    next unless payload[:send_notification]
 
     # A job is scheduled immediately that creates notifications (in-app if
     # supported) right away and schedules jobs to be run for mail and digest


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
When triggering a conversion from classic project identifier mode to semantic project identifier mode, the process generates a flood of noop `Notifications::WorkflowJobs`.

Let's make sure to skip enqueueing background jobs if there are no notifications to cover.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
