### PR TITLE
perf: Remove concurrency cap from ConvertProjectToSemanticIdsJob

### DIFF
--- a/app/workers/project_identifiers/convert_project_to_semantic_ids_job.rb
+++ b/app/workers/project_identifiers/convert_project_to_semantic_ids_job.rb
@@ -29,9 +29,6 @@
 #++
 
 class ProjectIdentifiers::ConvertProjectToSemanticIdsJob < ApplicationJob
-  include GoodJob::ActiveJobExtensions::Concurrency
-
-  good_job_control_concurrency_with(perform_limit: 5)
   queue_with_priority :above_normal
   retry_on StandardError, wait: :polynomially_longer, attempts: 8
   discard_on ActiveRecord::RecordNotFound


### PR DESCRIPTION
`ConvertProjectToSemanticIdsJob` is a job that gets scheduled via a parallel batch to convert all project identifiers from classic to semantic mode. 

For instances with large number of projects (10k+?), this also means the equivalent number of `ConvertProjectToSemanticIdsJobs`. As far as I'm aware, this is a fairly unprecedented thing in the codebase, and we need to figure out how we want to treat this.

We have two options here: 
* A) **Cap the number of concurrent executions for this job** (= the prior state). This way, we keep the batch execution safe and steady, but the limit is very vague and retry queue gets temporarily littered with lots of jobs in `ConcurrencyExceededError`.
* B) **Remove the concurrency cap** (= this PR). This ensures that the execution will run in parallel up to the system limit. However, we _may_ run into DB pool exhaustion issues or performance problems on large or misconfigured instances

I'd like to propose option **B)** via this PR. Reasoning:
* This batch is fairly critical and if any user messes around with projects in the system _while it is running_, it may cause DB inconsistencies. This is why we want to have it run as quickly as possible and off-hours. 
* If we introduce a random limit for this batch, the issue is kind of solved here, but we're likely to deal with this issue again the next time we heavily parallelize an operation. I'd rather give this a try, and if any issues arise, fix them at the _systemic_ level so that we don't have to deal with this again.
* Even if we run into DB pool exhaustion issues, the retry policy will cover this.
* Retry queue will become clean.

