### PR TITLE
[#74977] Modify friendly_id_slugs constraints.

### DIFF
--- a/db/migrate/20260515101148_modify_friendly_id_slugs_constraints.rb
+++ b/db/migrate/20260515101148_modify_friendly_id_slugs_constraints.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class ModifyFriendlyIdSlugsConstraints < ActiveRecord::Migration[8.1]
+  def up
+    # Remove duplicate NULL scope rows, keeping the most recent one per (slug, sluggable_type)
+    say_with_time "Cleaning up duplicate NULL scope rows" do
+      execute <<~SQL.squish
+        DELETE FROM friendly_id_slugs
+        WHERE scope IS NULL
+          AND id NOT IN (
+            SELECT DISTINCT ON (slug, sluggable_type) id
+            FROM friendly_id_slugs
+            WHERE scope IS NULL
+            ORDER BY slug, sluggable_type, created_at DESC NULLS LAST, id DESC
+          );
+      SQL
+    end
+
+    say_with_time "Cleaning up NULL sluggable_type rows" do
+      execute <<~SQL.squish
+        DELETE FROM friendly_id_slugs
+        WHERE sluggable_type IS NULL;
+      SQL
+    end
+
+    change_column_null :friendly_id_slugs, :sluggable_type, false
+
+    remove_index :friendly_id_slugs,
+                 name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope"
+
+    # create index that treats every null value as unique
+    execute <<~SQL.squish
+      CREATE UNIQUE INDEX index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope
+      ON friendly_id_slugs (slug, sluggable_type, scope)
+      NULLS NOT DISTINCT;
+    SQL
+  end
+
+  def down
+    remove_index :friendly_id_slugs,
+                 name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope"
+
+    change_column_null :friendly_id_slugs, :sluggable_type, true
+
+    add_index :friendly_id_slugs,
+              %i[slug sluggable_type scope],
+              unique: true,
+              name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope"
+  end
+end

--- a/modules/backlogs/spec/models/friendly_id/slug_spec.rb
+++ b/modules/backlogs/spec/models/friendly_id/slug_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe FriendlyId::Slug do
+  describe "friendly_id_slugs(slug, sluggable_type, scope) unique constraints" do
+    it "ensures uniqueness with null scope" do
+      p = create(:project)
+      expect do
+        described_class.create!(sluggable: p, slug: "my-app", scope: nil)
+        described_class.create!(sluggable: p, slug: "my-app", scope: nil)
+      end.to raise_error(
+        ActiveRecord::RecordNotUnique,
+        /PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope"\n/ # rubocop:disable Layout/LineLength
+      )
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -606,4 +606,16 @@ RSpec.describe Project do
       end
     end
   end
+
+  describe "projects.identifier unique database constraint" do
+    let!(:other_project) { create(:project, identifier: "my-app") }
+    let(:project) { build(:project, identifier: "my-app") }
+
+    it "ensures uniqueness with disabled validation" do
+      expect { project.save!(validate: false) }.to raise_error(
+        ActiveRecord::RecordNotUnique,
+        /PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_projects_on_lower_identifier"\n/
+      )
+    end
+  end
 end

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -109,41 +109,5 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
         expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
     end
-
-    context "when the classic identifier from history is taken by another project" do
-      let!(:other_project) { create(:project, identifier: "my-app") }
-      let!(:project) do
-        create(:project).tap do |p|
-          p.update_columns(identifier: "MYAPP", wp_sequence_counter: 0)
-          FriendlyId::Slug.create!(sluggable: p, slug: "my-app")
-        end
-      end
-
-      before { allow(Setting::WorkPackageIdentifier).to receive_messages(classic?: true, semantic?: false) }
-
-      it "raises ActiveRecord::RecordInvalid" do
-        expect { described_class.new(project).call }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
-
-    context "when the classic identifier from history is historically reserved by another project" do
-      let!(:other_project) do
-        create(:project).tap do |p|
-          FriendlyId::Slug.create!(sluggable: p, slug: "my-app")
-        end
-      end
-      let!(:project) do
-        create(:project).tap do |p|
-          p.update_columns(identifier: "MYAPP", wp_sequence_counter: 0)
-          FriendlyId::Slug.create!(sluggable: p, slug: "my-app")
-        end
-      end
-
-      before { allow(Setting::WorkPackageIdentifier).to receive_messages(classic?: true, semantic?: false) }
-
-      it "raises ActiveRecord::RecordInvalid" do
-        expect { described_class.new(project).call }.to raise_error(ActiveRecord::RecordInvalid)
-      end
-    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/74977

Add NOT NULL to *sluggable_type* and fix NULL *scope* uniqueness in *friendly_id_slugs*

- Delete duplicate NULL *scope* rows, keeping the most recent per (slug, sluggable_type)
- Delete NULL *sluggable_type* rows before adding NOT NULL constraint
- Replace unique index on (slug, sluggable_type, scope) with NULLS NOT DISTINCT variant (requires Postgres 15+)

Why?

1. *sluggable_type* NOT NULL
    Every slug must belong to a model (e.g. Post, User). A slug with no *sluggable_type* is orphaned and meaningless.
2. NULLS NOT DISTINCT 
   In the unique constraint not treating every NULL *scope* as unique leads to duplicate records if *scope* is NULL which does not make sense and pollutes the table with unnecessary data