### PR TITLE
Fix in text handling to allow UTF-8 characters in frontend

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -687,8 +687,13 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
         `;
   }
 
-  private sanitizedValue(value:string):string {
-    return this.sanitizer.sanitize(SecurityContext.HTML, value) ?? '';
+  private sanitizedValue(value: string): string {
+    if (!value) return '';
+
+    const sanitized = this.sanitizer.sanitize(SecurityContext.HTML, value) ?? '';
+
+    const parser = new DOMParser();
+    return parser.parseFromString(sanitized, 'text/html').body.textContent || sanitized;
   }
 
   protected formatNumber(value:number):string {

--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -688,7 +688,9 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
   }
 
   private sanitizedValue(value: string): string {
-    if (!value) return '';
+    if (!value) {
+      return '';
+    }
 
     const sanitized = this.sanitizer.sanitize(SecurityContext.HTML, value) ?? '';
 


### PR DESCRIPTION

# What are you trying to accomplish?
Currently latin characters such as ó or í are not being properly handled. With this fix they are shown properly in the frontend.

## Screenshots
Before:
<img width="142" height="46" alt="image" src="https://github.com/user-attachments/assets/5dcf8472-d188-4111-8922-18bb4b046bbf" />
After:
<img width="191" height="33" alt="image" src="https://github.com/user-attachments/assets/2cc34c34-232c-48e7-b175-21ce8cd90701" />


# What approach did you choose and why?
I modified the component's internal sanitizedValue() helper method to sequentially handle both security and character decoding:

Sanitize First: Utilize Angular's DomSanitizer.sanitize(SecurityContext.HTML, value) to remove potential XSS vectors.

Decode Second: Pass the sanitized string into a browser-native DOMParser().parseFromString() execution to safely parse out the decimal entities into normal Spanish UTF-8 text before it hits the lit-html template.

This approach was chosen because it cleanly centralizes the logic in a pre-existing utility function without complicating the layout template.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
