### PR TITLE
feat: Release reserved project identifiers via admin

### DIFF
--- a/app/components/admin/settings/project_reserved_identifiers/index_component.html.erb
+++ b/app/components/admin/settings/project_reserved_identifiers/index_component.html.erb
@@ -1,0 +1,34 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= component_wrapper do %>
+  <%= render(Admin::Settings::ProjectReservedIdentifiers::TableComponent.new(rows:)) %>
+<% end %>

--- a/app/components/admin/settings/project_reserved_identifiers/index_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/index_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings::ProjectReservedIdentifiers
+  class IndexComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    alias_method :rows, :model
+  end
+end

--- a/app/components/admin/settings/project_reserved_identifiers/release_dialog_component.html.erb
+++ b/app/components/admin/settings/project_reserved_identifiers/release_dialog_component.html.erb
@@ -1,0 +1,59 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%=
+  render(
+    Primer::OpenProject::DangerDialog.new(
+      id: "release-identifier-dialog",
+      title: I18n.t("admin.reserved_identifiers.dialog.title"),
+      confirm_button_text: I18n.t("admin.reserved_identifiers.dialog.confirm_button"),
+      cancel_button_text: I18n.t("button_cancel"),
+      form_arguments: {
+        action: admin_settings_project_reserved_identifier_path(@slug.id),
+        method: :delete
+      }
+    )
+  ) do |dialog|
+    dialog.with_confirmation_message do |message|
+      message.with_heading(tag: :h2) do
+        I18n.t("admin.reserved_identifiers.dialog.heading", identifier: @slug.slug)
+      end
+
+      message.with_description_content(
+        I18n.t("admin.reserved_identifiers.dialog.description")
+      )
+    end
+
+    dialog.with_confirmation_check_box_content(
+      I18n.t("admin.reserved_identifiers.dialog.checkbox_label")
+    )
+  end
+%>

--- a/app/components/admin/settings/project_reserved_identifiers/release_dialog_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/release_dialog_component.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin
+  module Settings
+    module ProjectReservedIdentifiers
+      class ReleaseDialogComponent < ApplicationComponent
+        include OpPrimer::ComponentHelpers
+        include OpTurbo::Streamable
+
+        def initialize(slug:)
+          super
+          @slug = slug
+        end
+      end
+    end
+  end
+end

--- a/app/components/admin/settings/project_reserved_identifiers/row_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/row_component.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings::ProjectReservedIdentifiers
+  class RowComponent < OpPrimer::BorderBoxRowComponent
+    def project
+      link_to(row.sluggable.name, project_overview_path(row.sluggable))
+    end
+
+    def identifier
+      row.slug
+    end
+
+    def reserved_at
+      t("admin.reserved_identifiers.reserved_ago",
+        time: helpers.time_ago_in_words(row.created_at))
+    end
+
+    def button_links
+      [release_button]
+    end
+
+    private
+
+    def release_button
+      render(
+        Primer::Beta::Button.new(
+          tag: :a,
+          href: confirm_dialog_admin_settings_project_reserved_identifier_path(row.id),
+          scheme: :link,
+          size: :small,
+          data: { turbo_stream: true }
+        )
+      ) { t("admin.reserved_identifiers.btn_release") }
+    end
+  end
+end

--- a/app/components/admin/settings/project_reserved_identifiers/sub_header_component.html.erb
+++ b/app/components/admin/settings/project_reserved_identifiers/sub_header_component.html.erb
@@ -1,0 +1,44 @@
+<%#
+  -- copyright
+  OpenProject is an open source project management software.
+  Copyright (C) the OpenProject GmbH
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License version 3.
+
+  OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+  Copyright (C) 2006-2013 Jean-Philippe Lang
+  Copyright (C) 2010-2013 the ChiliProject Team
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+  See COPYRIGHT and LICENSE files for more details.
+
+  ++#
+%>
+
+<%= render(Primer::OpenProject::SubHeader.new(data: sub_header_data_attributes)) do |subheader| %>
+  <% subheader.with_filter_input(
+       name: "name",
+       label: t("admin.reserved_identifiers.filter_label"),
+       visually_hide_label: true,
+       value: filter_input_value,
+       placeholder: t("admin.reserved_identifiers.filter_label"),
+       leading_visual: { icon: :search, size: :small },
+       show_clear_button: true,
+       clear_button_id: clear_button_id,
+       data: filter_input_data_attributes
+     ) %>
+<% end %>

--- a/app/components/admin/settings/project_reserved_identifiers/sub_header_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/sub_header_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings::ProjectReservedIdentifiers
+  class SubHeaderComponent < ApplicationComponent
+    def initialize(query:)
+      super()
+      @query = query
+    end
+
+    def filter_input_value
+      @query.find_active_filter(:name)&.values&.first
+    end
+
+    def clear_button_id = "reserved-identifiers-filter-clear"
+
+    def sub_header_data_attributes
+      {
+        controller: "filter--filters-form",
+        "filter--filters-form-perform-turbo-requests-value": true,
+        "filter--filters-form-output-format-value": "json",
+        "filter--filters-form-url-path-name-value": helpers.search_admin_settings_project_reserved_identifiers_path,
+        "filter--filters-form-clear-button-id-value": clear_button_id
+      }
+    end
+
+    def filter_input_data_attributes
+      {
+        "filter-name": "name",
+        "filter-type": "string",
+        "filter-operator": "~",
+        "filter--filters-form-target": "simpleFilter filterValueContainer simpleValue"
+      }
+    end
+  end
+end

--- a/app/components/admin/settings/project_reserved_identifiers/table_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/table_component.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings::ProjectReservedIdentifiers
+  class TableComponent < OpPrimer::BorderBoxTableComponent
+    columns :project, :identifier, :reserved_at
+    mobile_columns :identifier, :reserved_at
+
+    def mobile_title = I18n.t("admin.reserved_identifiers.title")
+    def has_actions? = true
+
+    def headers
+      [
+        [:project,     { caption: t("admin.reserved_identifiers.col_project") }],
+        [:identifier,  { caption: t("admin.reserved_identifiers.col_identifier") }],
+        [:reserved_at, { caption: t("admin.reserved_identifiers.col_reserved") }]
+      ]
+    end
+
+    def blank_title       = t("admin.reserved_identifiers.empty_heading")
+    def blank_description = t("admin.reserved_identifiers.empty_body")
+    def blank_icon        = :"check-circle"
+  end
+end

--- a/app/controllers/admin/settings/project_reserved_identifiers_controller.rb
+++ b/app/controllers/admin/settings/project_reserved_identifiers_controller.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Admin::Settings
+  class ProjectReservedIdentifiersController < ::ApplicationController
+    include OpTurbo::ComponentStream
+    include PaginationHelper
+
+    before_action :require_admin
+    before_action :require_classic_mode
+    before_action :find_slug, only: %i[confirm_dialog destroy]
+
+    menu_item :project_reserved_identifiers_settings
+
+    layout "admin"
+
+    def index
+      @query = build_query
+      @slugs = @query.results
+        .includes(:sluggable)
+        .paginate(page: page_param, per_page: per_page_param)
+    end
+
+    def search
+      index
+      replace_via_turbo_stream(
+        component: Admin::Settings::ProjectReservedIdentifiers::IndexComponent.new(@slugs)
+      )
+      current_url = admin_settings_project_reserved_identifiers_path(params.permit(:filters))
+      turbo_streams << turbo_stream.push_state(current_url)
+      respond_with_turbo_streams
+    end
+
+    def confirm_dialog
+      respond_with_dialog Admin::Settings::ProjectReservedIdentifiers::ReleaseDialogComponent.new(slug: @slug)
+    end
+
+    def destroy
+      @slug.destroy!
+      redirect_to admin_settings_project_reserved_identifiers_path,
+                  flash: { notice: t("admin.reserved_identifiers.released_notice", identifier: @slug.slug) }
+    end
+
+    private
+
+    def find_slug
+      @slug = Project.identifier_slugs.historically_reserved.find(params.expect(:id))
+    rescue ActiveRecord::RecordNotFound
+      render_404
+    end
+
+    def build_query
+      ParamsToQueryService
+        .new(FriendlyId::Slug, current_user,
+             query_class: Queries::ProjectReservedIdentifiers::ProjectReservedIdentifierQuery)
+        .call(params)
+    end
+
+    def require_classic_mode
+      return unless Setting::WorkPackageIdentifier.semantic?
+
+      redirect_to admin_settings_work_packages_identifier_path,
+                  flash: { warning: t("admin.reserved_identifiers.not_available_in_semantic_mode") }
+    end
+  end
+end

--- a/app/models/queries/project_reserved_identifiers.rb
+++ b/app/models/queries/project_reserved_identifiers.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries::ProjectReservedIdentifiers
+  ::Queries::Register.register(ProjectReservedIdentifierQuery) do
+    filter Filters::NameFilter
+  end
+end

--- a/app/models/queries/project_reserved_identifiers/filters/name_filter.rb
+++ b/app/models/queries/project_reserved_identifiers/filters/name_filter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::ProjectReservedIdentifiers::Filters::NameFilter <
+  Queries::ProjectReservedIdentifiers::Filters::ProjectReservedIdentifierFilter
+  def self.key
+    :name
+  end
+
+  def type
+    :string
+  end
+
+  def human_name
+    I18n.t("admin.reserved_identifiers.filter_label")
+  end
+
+  def where
+    escaped = ActiveRecord::Base.sanitize_sql_like(values.first)
+    case operator
+    when "~", "**"
+      ["friendly_id_slugs.slug ILIKE :q OR projects.name ILIKE :q", { q: "%#{escaped}%" }]
+    when "!~"
+      ["friendly_id_slugs.slug NOT ILIKE :q AND projects.name NOT ILIKE :q", { q: "%#{escaped}%" }]
+    else
+      raise "Unsupported operator #{operator}"
+    end
+  end
+end

--- a/app/models/queries/project_reserved_identifiers/filters/project_reserved_identifier_filter.rb
+++ b/app/models/queries/project_reserved_identifiers/filters/project_reserved_identifier_filter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::ProjectReservedIdentifiers::Filters::ProjectReservedIdentifierFilter < Queries::Filters::Base
+  self.model = FriendlyId::Slug
+end

--- a/app/models/queries/project_reserved_identifiers/project_reserved_identifier_query.rb
+++ b/app/models/queries/project_reserved_identifiers/project_reserved_identifier_query.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class Queries::ProjectReservedIdentifiers::ProjectReservedIdentifierQuery
+  include Queries::BaseQuery
+  include Queries::UnpersistedQuery
+
+  def self.model
+    FriendlyId::Slug
+  end
+
+  def default_scope
+    Project.identifier_slugs
+      .historically_reserved
+      .where("slug ~ ? AND slug !~ ?", "^[a-z0-9_-]+$", "^[0-9]+$")
+      .joins("JOIN projects ON projects.id = friendly_id_slugs.sluggable_id")
+      .order("projects.name ASC, friendly_id_slugs.created_at DESC")
+  end
+end

--- a/app/views/admin/settings/project_reserved_identifiers/index.html.erb
+++ b/app/views/admin/settings/project_reserved_identifiers/index.html.erb
@@ -1,0 +1,45 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+<% html_title t(:label_administration), t(:label_project_plural), t("admin.reserved_identifiers.title") %>
+
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t("admin.reserved_identifiers.title") }
+    header.with_description { t("admin.reserved_identifiers.lede_html") }
+    header.with_breadcrumbs(
+      [{ href: admin_index_path, text: t(:label_administration) },
+       { href: admin_settings_project_custom_fields_path, text: t(:label_project_plural) },
+       t("admin.reserved_identifiers.title")]
+    )
+  end
+%>
+
+<%= render(Admin::Settings::ProjectReservedIdentifiers::SubHeaderComponent.new(query: @query)) %>
+
+<%= render(Admin::Settings::ProjectReservedIdentifiers::IndexComponent.new(@slugs)) %>

--- a/config/initializers/menus.rb
+++ b/config/initializers/menus.rb
@@ -464,6 +464,12 @@ Redmine::MenuManager.map :admin_menu do |menu|
             caption: :label_project_list_plural,
             parent: :admin_projects_settings
 
+  menu.push :project_reserved_identifiers_settings,
+            { controller: "/admin/settings/project_reserved_identifiers", action: :index },
+            if: ->(_) { User.current.admin? && Setting::WorkPackageIdentifier.classic? },
+            caption: :label_reserved_identifiers,
+            parent: :admin_projects_settings
+
   menu.push :custom_fields,
             { controller: "/custom_fields" },
             if: ->(_) { User.current.admin? },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,6 +59,25 @@ en:
           confirm_button_text: "Make public"
 
   admin:
+    reserved_identifiers:
+      title: "Reserved project identifiers"
+      lede_html: "When a project's identifier is renamed, the previous identifier is kept reserved so that existing links and integrations keep working.<br>Here you can release reserved identifiers so that they may be used by other projects."
+      col_identifier: "Identifier"
+      col_project: "Project"
+      col_reserved: "Reserved"
+      not_available_in_semantic_mode: "Reserved identifiers are only available in classic identifier mode."
+      filter_label: "Filter identifiers"
+      btn_release: "Release"
+      released_notice: "Identifier \"%{identifier}\" has been released."
+      dialog:
+        title: "Release identifier"
+        heading: "Release \"%{identifier}\"?"
+        description: "Releasing this identifier cannot be undone. External links and integrations using it will stop resolving, and the name becomes available for any new project to claim."
+        checkbox_label: "I understand that this cannot be undone."
+        confirm_button: "Release identifier"
+      empty_heading: "No reserved identifiers"
+      reserved_ago: "%{time} ago"
+      empty_body: "When a project's identifier changes, the previous one will appear here so you can release it once it's safe to do so."
     plugins:
       no_results_title_text: There are currently no plugins installed.
       no_results_content_text: See our integrations and plugins page for more information.
@@ -4397,6 +4416,7 @@ en:
   label_project_new: "New project"
   label_project_plural: "Projects"
   label_project_list_plural: "Project lists"
+  label_reserved_identifiers: "Reserved identifiers"
   label_project_life_cycle: "Project life cycle"
   label_project_attributes_plural: "Project attributes"
   label_project_custom_field_plural: "Project attributes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -755,6 +755,15 @@ Rails.application.routes.draw do
       resource :date_format, controller: "/admin/settings/date_format_settings", only: %i[show update]
       resource :icalendar, controller: "/admin/settings/icalendar_settings", only: %i[show update]
 
+      resources :project_reserved_identifiers, only: %i[index destroy] do
+        collection do
+          get :search, defaults: { format: :turbo_stream }
+        end
+        member do
+          get :confirm_dialog, defaults: { format: :turbo_stream }
+        end
+      end
+
       # Redirect /settings to general settings
       get "/", to: redirect("/admin/settings/general")
 

--- a/spec/components/admin/settings/project_reserved_identifiers/index_component_spec.rb
+++ b/spec/components/admin/settings/project_reserved_identifiers/index_component_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Settings::ProjectReservedIdentifiers::IndexComponent, type: :component do
+  let!(:project) { create(:project, identifier: "cur-id") }
+  let!(:slug) { FriendlyId::Slug.create!(sluggable: project, slug: "prev-id") }
+
+  subject(:rendered_component) { render_inline(described_class.new([slug])) }
+
+  it "renders a component_wrapper div with a stable DOM id" do
+    wrapper_id = described_class.new([]).wrapper_key
+    expect(rendered_component).to have_css "##{wrapper_id}"
+  end
+
+  it "renders the table inside the wrapper" do
+    expect(rendered_component).to have_css ".Box"
+  end
+
+  it "renders the identifier slug" do
+    expect(rendered_component).to have_text("prev-id")
+  end
+end

--- a/spec/components/admin/settings/project_reserved_identifiers/row_component_spec.rb
+++ b/spec/components/admin/settings/project_reserved_identifiers/row_component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Settings::ProjectReservedIdentifiers::RowComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let!(:project) { create(:project, identifier: "current-id", name: "My Project") }
+  let!(:slug) { FriendlyId::Slug.create!(sluggable: project, slug: "old-id") }
+
+  subject(:rendered_component) do
+    render_inline(
+      Admin::Settings::ProjectReservedIdentifiers::TableComponent.new(rows: [slug])
+    )
+  end
+
+  it "renders a link to the project overview" do
+    expect(rendered_component).to have_link("My Project",
+                                            href: project_overview_path(project))
+  end
+
+  it "renders the identifier slug" do
+    expect(rendered_component).to have_text("old-id")
+  end
+
+  it "renders a Release action link pointing to the confirm dialog" do
+    expect(rendered_component).to have_link(
+      I18n.t("admin.reserved_identifiers.btn_release"),
+      href: confirm_dialog_admin_settings_project_reserved_identifier_path(slug.id)
+    )
+  end
+end

--- a/spec/components/admin/settings/project_reserved_identifiers/sub_header_component_spec.rb
+++ b/spec/components/admin/settings/project_reserved_identifiers/sub_header_component_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Settings::ProjectReservedIdentifiers::SubHeaderComponent, type: :component do
+  let(:query) { Queries::ProjectReservedIdentifiers::ProjectReservedIdentifierQuery.new(user: build(:admin)) }
+
+  subject(:rendered_component) { render_inline(described_class.new(query:)) }
+
+  context "with no active filter" do
+    it "renders a filter input" do
+      expect(rendered_component).to have_field(type: :text)
+    end
+
+    it "wires the filters-form Stimulus controller" do
+      expect(rendered_component).to have_css "[data-controller='filter--filters-form']"
+    end
+  end
+
+  context "with a name filter active" do
+    before { query.where(:name, "~", ["my-search-term"]) }
+
+    it "pre-populates the filter input value" do
+      expect(rendered_component).to have_css "input[value='my-search-term']"
+    end
+  end
+end

--- a/spec/components/admin/settings/project_reserved_identifiers/table_component_spec.rb
+++ b/spec/components/admin/settings/project_reserved_identifiers/table_component_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Admin::Settings::ProjectReservedIdentifiers::TableComponent, type: :component do
+  subject(:rendered_component) { render_inline(described_class.new(rows:)) }
+
+  shared_examples_for "rendering column headings" do
+    it_behaves_like "rendering Border Box Grid heading", text: "Project"
+    it_behaves_like "rendering Border Box Grid heading", text: "Identifier"
+    it_behaves_like "rendering Border Box Grid heading", text: "Reserved"
+    it_behaves_like "rendering Border Box Grid mobile heading", text: "Reserved project identifiers"
+  end
+
+  context "with no slugs" do
+    let(:rows) { [] }
+
+    it_behaves_like "rendering Box", row_count: 1
+    it_behaves_like "rendering column headings"
+    it_behaves_like "rendering Blank Slate",
+                    heading: I18n.t("admin.reserved_identifiers.empty_heading"),
+                    icon: :"check-circle"
+  end
+
+  context "with slugs" do
+    let!(:project) { create(:project, identifier: "current-id") }
+    let!(:slug) { FriendlyId::Slug.create!(sluggable: project, slug: "old-id") }
+    let(:rows) { [slug] }
+
+    it_behaves_like "rendering Box", row_count: 1
+    it_behaves_like "rendering column headings"
+    it_behaves_like "rendering Border Box Grid rows", row_count: 1, col_count: 3
+
+    it "renders the identifier" do
+      expect(rendered_component).to have_text("old-id")
+    end
+
+    it "renders a Release button" do
+      expect(rendered_component).to have_text(I18n.t("admin.reserved_identifiers.btn_release"))
+    end
+  end
+end

--- a/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
+++ b/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Admin::Settings::ProjectReservedIdentifiersController do
+  shared_let(:admin) { create(:admin) }
+
+  current_user { admin }
+
+  describe "GET #index" do
+    context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+      it "redirects to the identifier settings page" do
+        get :index
+        expect(response).to redirect_to(admin_settings_work_packages_identifier_path)
+      end
+    end
+
+    context "in classic mode", with_settings: { work_packages_identifier: "classic" } do
+      it "responds 200" do
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+
+      context "with a classic reserved slug" do
+        let!(:project) { create(:project, identifier: "current-id") }
+
+        before { FriendlyId::Slug.create!(sluggable: project, slug: "old-classic") }
+
+        it "includes the slug in @slugs" do
+          get :index
+          expect(assigns(:slugs).map(&:slug)).to include("old-classic")
+        end
+      end
+
+      context "with a pure-numeric reserved slug" do
+        let!(:project) { create(:project, identifier: "current-id") }
+
+        before { FriendlyId::Slug.create!(sluggable: project, slug: "12345") }
+
+        it "excludes pure-numeric slugs" do
+          get :index
+          expect(assigns(:slugs).map(&:slug)).not_to include("12345")
+        end
+      end
+    end
+  end
+
+  describe "GET #search", with_settings: { work_packages_identifier: "classic" } do
+    it "responds with turbo stream" do
+      get :search, format: :turbo_stream
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    end
+
+    context "with a reserved slug" do
+      let!(:project) { create(:project, identifier: "current-id") }
+
+      before { FriendlyId::Slug.create!(sluggable: project, slug: "old-search") }
+
+      it "includes the slug in @slugs when no filter is set" do
+        get :search, format: :turbo_stream
+        expect(assigns(:slugs).map(&:slug)).to include("old-search")
+      end
+
+      it "filters @slugs by the name filter" do
+        filters = JSON.generate([{ "name" => { "operator" => "~", "values" => ["old-search"] } }])
+        get :search, params: { filters: }, format: :turbo_stream
+        expect(assigns(:slugs).map(&:slug)).to include("old-search")
+      end
+
+      it "returns no slugs when the filter matches nothing" do
+        filters = JSON.generate([{ "name" => { "operator" => "~", "values" => ["zzz-no-match"] } }])
+        get :search, params: { filters: }, format: :turbo_stream
+        expect(assigns(:slugs)).to be_empty
+      end
+    end
+  end
+
+  describe "GET #confirm_dialog", with_settings: { work_packages_identifier: "classic" } do
+    let!(:project) { create(:project, identifier: "current-id") }
+
+    context "with a historically reserved slug" do
+      let!(:slug) { FriendlyId::Slug.create!(sluggable: project, slug: "old-id") }
+
+      it "responds with a turbo stream" do
+        get :confirm_dialog, params: { id: slug.id }, format: :turbo_stream
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
+
+      context "with an unknown id" do
+        it "renders 404" do
+          get :confirm_dialog, params: { id: 0 }, format: :turbo_stream
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "when the slug is the project's own current active identifier" do
+      let!(:slug) { project.slugs.find_by!(slug: "current-id") }
+
+      it "renders 404 because the slug is not historically reserved" do
+        get :confirm_dialog, params: { id: slug.id }, format: :turbo_stream
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "DELETE #destroy", with_settings: { work_packages_identifier: "classic" } do
+    let!(:project) { create(:project, identifier: "current-id") }
+    let!(:slug) { FriendlyId::Slug.create!(sluggable: project, slug: "old-id") }
+
+    it "destroys the slug and redirects with a flash notice" do
+      expect { delete :destroy, params: { id: slug.id } }
+        .to change(FriendlyId::Slug, :count).by(-1)
+
+      expect(response).to redirect_to(admin_settings_project_reserved_identifiers_path)
+      expect(flash[:notice]).to include("old-id")
+    end
+
+    context "with an unknown id" do
+      it "renders 404" do
+        delete :destroy, params: { id: 0 }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74992/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add a simple admin page that shows reserved identifiers, i.e. those blocked by `FriendlyId` history feature. Releasing an identifier allows users to reuse it for some other project.

The feature is only available for classic mode and only lists classic identifiers.

## Screenshots
<img width="1066" height="462" alt="Screenshot 2026-05-20 at 20 50 44" src="https://github.com/user-attachments/assets/7b0338ba-feff-48b2-8ec0-b51a98e47cc9" />
<img width="1063" height="327" alt="Screenshot 2026-05-20 at 20 50 24" src="https://github.com/user-attachments/assets/5e2031ce-e3a7-4693-a6a8-d6d362055557" />
<img width="492" height="317" alt="Screenshot 2026-05-20 at 20 50 30" src="https://github.com/user-attachments/assets/dbf2bd8c-76f3-4633-817f-a99bdaf12cd7" />



# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
