### PR TITLE
feat: Add progress bar for identifier conversion

### DIFF
--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.html.erb
@@ -45,10 +45,22 @@
 
         form.html_content do
           if change_in_progress?
-            render(Primer::Beta::Text.new(my: 3)) do
-              render(Primer::Beta::Spinner.new(size: :small, mr: 2)).to_s +
-                in_progress_banner_message
-            end
+            render(Primer::Box.new(my: 2)) {
+              render(Primer::Box.new(classes: "d-flex flex-justify-between flex-items-center f6", mb: 1)) {
+                render(Primer::Beta::Text.new(font_weight: :bold)) {
+                  in_progress_header
+                } +
+                render(Primer::Beta::Text.new) { "#{processed_projects_count} / #{total_projects_count}" }
+              } +
+              render(
+                Primer::Beta::ProgressBar.new(test_selector: "conversion-progress-bar").tap { |bar|
+                  bar.with_item(percentage: progress_percentage)
+                }
+              ) +
+              render(Primer::Box.new(mt: 1, color: :muted, classes: "f6")) {
+                I18n.t("admin.settings.work_packages_identifier.in_progress.footer_message")
+              }
+            }
           elsif completed?
             render(Primer::Alpha::Banner.new(scheme: :success, dismiss_scheme: :remove, mb: 3)) do
               I18n.t("admin.settings.work_packages_identifier.success_banner")

--- a/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
+++ b/app/components/work_packages/admin/settings/identifier_settings_form_component.rb
@@ -64,15 +64,12 @@ module WorkPackages
         def form_id = "wp-identifier-settings-form"
 
         def in_progress_banner_message
-          if ProjectIdentifiers::IdentifierAutofix.reversion_in_progress?
-            pending_count = Project.with_non_classic_identifier.count
-            I18n.t("admin.settings.work_packages_identifier.in_progress.classic_conversion_status_message",
-                   count: pending_count)
-          else
-            pending_count = ProjectIdentifiers::PendingProjectsFinder.count
-            I18n.t("admin.settings.work_packages_identifier.in_progress.semantic_conversion_status_message",
-                   count: pending_count)
-          end
+          key = if ProjectIdentifiers::IdentifierAutofix.reversion_in_progress?
+                  "admin.settings.work_packages_identifier.in_progress.reverting_banner_message"
+                else
+                  "admin.settings.work_packages_identifier.in_progress.converting_banner_message"
+                end
+          I18n.t(key)
         end
 
         def show_autofix_section?
@@ -81,6 +78,34 @@ module WorkPackages
 
         def change_in_progress? = state == :change_in_progress
         def completed?          = state == :completed
+
+        def total_projects_count
+          @total_projects_count ||= Project.count
+        end
+
+        def processed_projects_count
+          [total_projects_count - remaining_projects_count, 0].max
+        end
+
+        def progress_percentage
+          return 100 if total_projects_count.zero?
+
+          [(processed_projects_count.to_f / total_projects_count * 100), 100].min.round
+        end
+
+        def in_progress_header
+          key = ProjectIdentifiers::IdentifierAutofix.reversion_in_progress? ? :header_classic : :header_semantic
+          I18n.t("admin.settings.work_packages_identifier.in_progress.#{key}")
+        end
+
+        def remaining_projects_count
+          @remaining_projects_count ||=
+            if ProjectIdentifiers::IdentifierAutofix.reversion_in_progress?
+              Project.with_non_classic_identifier.count
+            else
+              ProjectIdentifiers::PendingProjectsFinder.count
+            end
+        end
 
         def wrapper_data_attrs
           if change_in_progress?
@@ -95,7 +120,7 @@ module WorkPackages
             data: {
               controller: "poll-for-changes",
               poll_for_changes_url_value: url_helpers.status_admin_settings_work_packages_identifier_path,
-              poll_for_changes_interval_value: 5000
+              poll_for_changes_interval_value: 3000
             }
           }
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -478,14 +478,9 @@ en:
           checkbox_label: I understand that this will permanently change all work package IDs
         success_banner: Successfully updated work package identifier format.
         in_progress:
-          semantic_conversion_status_message:
-            zero: Finalizing conversion to semantic format...
-            one: Project identifiers are being converted to semantic format. 1 project remaining.
-            other: Project identifiers are being converted to semantic format. %{count} projects remaining.
-          classic_conversion_status_message:
-            zero: Finalizing conversion to classic format...
-            one: Project identifiers are being converted to classic format. 1 project remaining.
-            other: Project identifiers are being converted to classic format. %{count} projects remaining.
+          header_semantic: "Converting to project-based identifiers"
+          header_classic: "Converting to numeric identifiers"
+          footer_message: "Background conversion is in progress. You can safely leave this page."
     workflows:
       tabs:
         default_transitions: "Default transitions"

--- a/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
+++ b/spec/components/work_packages/admin/settings/identifier_settings_form_component_spec.rb
@@ -56,41 +56,42 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
     before do
       allow(ProjectIdentifiers::IdentifierAutofix).to receive(:reversion_in_progress?).and_return(false)
       allow(ProjectIdentifiers::PendingProjectsFinder).to receive(:count).and_return(7)
+      allow(Project).to receive(:count).and_return(10)
     end
 
-    it "renders the converting banner with the pending project count" do
+    it "renders the semantic conversion header label" do
       render_component(component)
-      expect(page).to have_text("7 projects remaining")
+      expect(page).to have_text("Converting to project-based identifiers")
     end
 
-    context "with 1 project remaining" do
-      before { allow(ProjectIdentifiers::PendingProjectsFinder).to receive(:count).and_return(1) }
-
-      it "uses the singular form" do
-        render_component(component)
-        expect(page).to have_text("1 project remaining")
-      end
+    it "renders the processed / total counter" do
+      render_component(component)
+      expect(page).to have_text("3 / 10")
     end
 
-    context "with 0 projects remaining" do
-      before { allow(ProjectIdentifiers::PendingProjectsFinder).to receive(:count).and_return(0) }
+    it "renders a progress bar reflecting conversion progress" do
+      render_component(component)
+      expect(page).to have_test_selector("conversion-progress-bar")
+      expect(page).to have_css(".Progress-item[style*='width: 30%']")
+    end
 
-      it "renders the finalizing message" do
-        render_component(component)
-        expect(page).to have_text("Finalizing conversion to semantic format")
-        expect(page).to have_no_text("projects remaining")
-      end
+    it "renders the footer message" do
+      render_component(component)
+      expect(page).to have_text("Background conversion is in progress. You can safely leave this page.")
     end
 
     context "when reversion is in progress" do
       before do
         allow(ProjectIdentifiers::IdentifierAutofix).to receive(:reversion_in_progress?).and_return(true)
-        3.times { |i| create(:project).update_column(:identifier, "PROJ#{i}") }
+        allow(Project).to receive(:with_non_classic_identifier).and_return(
+          instance_double(ActiveRecord::Relation, count: 4)
+        )
       end
 
-      it "renders the converting-to-classic banner with the pending project count" do
+      it "shows the classic conversion header, correct counter, and does not call PendingProjectsFinder" do
         render_component(component)
-        expect(page).to have_text("3 projects remaining")
+        expect(page).to have_text("Converting to numeric identifiers")
+        expect(page).to have_text("6 / 10")
         expect(ProjectIdentifiers::PendingProjectsFinder).not_to have_received(:count)
       end
     end
@@ -126,9 +127,10 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
       expect(page).to have_text("Successfully updated work package identifier format.")
     end
 
-    it "does not render the in-progress spinner message" do
+    it "does not render the in-progress content" do
       render_component(component)
-      expect(page).to have_no_text("projects remaining")
+      expect(page).to have_no_text("Converting to")
+      expect(page).to have_no_test_selector("conversion-progress-bar")
     end
 
     it "renders the radio buttons as enabled" do
@@ -174,7 +176,8 @@ RSpec.describe WorkPackages::Admin::Settings::IdentifierSettingsFormComponent, t
 
     it "does not render in-progress or success content" do
       render_component(component)
-      expect(page).to have_no_text("projects remaining")
+      expect(page).to have_no_text("Converting to")
+      expect(page).to have_no_test_selector("conversion-progress-bar")
       expect(page).to have_no_text("Successfully updated work package identifier format.")
     end
 

--- a/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
+++ b/spec/controllers/admin/settings/work_packages_identifier_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Admin::Settings::WorkPackagesIdentifierController,
 
         expect(response).to have_http_status(:ok)
         expect(response).to have_turbo_stream(action: "replace", target: component_target)
-        expect(response.body).to include("projects remaining")
+        expect(response.body).to include("Background conversion is in progress")
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-jira-exit/work_packages/74903/activity

# What are you trying to accomplish?
* Add a nice progress bar!
* Reduce the status poll interval from 5s to 3s

## Screenshots
<img width="987" height="408" alt="Screenshot 2026-05-17 at 22 05 33" src="https://github.com/user-attachments/assets/bcaff0e8-e41b-4e27-8df0-3a43733536ab" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
