### PR TITLE
Improve text on send emails meeting setting

### DIFF
--- a/modules/meeting/app/components/meetings/email_updates_banner_component.rb
+++ b/modules/meeting/app/components/meetings/email_updates_banner_component.rb
@@ -43,18 +43,6 @@ module Meetings
 
     private
 
-    def type
-      if @type == :participants
-        "participants"
-      elsif @meeting.is_a?(RecurringMeeting) || (@meeting.recurring? && @meeting.templated?)
-        "template"
-      elsif @meeting.recurring?
-        "occurrence"
-      else
-        "onetime"
-      end
-    end
-
     def status
       if @override.present?
         @override.to_s
@@ -66,21 +54,15 @@ module Meetings
     end
 
     def description
-      I18n.t("meeting.notifications.banner.#{type}.#{banner_status}")
+      I18n.t("meeting.notifications.#{status}")
     end
 
     def scheme
-      banner_status == "disabled" ? :warning : :default
+      status == "disabled" ? :warning : :default
     end
 
     def icon
-      banner_status == "disabled" ? nil : :info
-    end
-
-    def banner_status
-      return "draft_disabled" if type == "participants" && status == "disabled" && @meeting.draft?
-
-      status
+      status == "disabled" ? nil : :info
     end
   end
 end

--- a/modules/meeting/app/components/meetings/side_panel_component.rb
+++ b/modules/meeting/app/components/meetings/side_panel_component.rb
@@ -46,8 +46,8 @@ module Meetings
         enabled: @meeting.notify?,
         path: toggle_notifications_dialog_project_meeting_path(@meeting.project, @meeting),
         title: I18n.t("meeting.notifications.sidepanel.title"),
-        enabled_description: I18n.t("meeting.notifications.sidepanel.description.enabled"),
-        disabled_description: I18n.t("meeting.notifications.sidepanel.description.disabled"),
+        enabled_description: I18n.t("meeting.notifications.enabled"),
+        disabled_description: I18n.t("meeting.notifications.disabled"),
         alt_text: I18n.t("meeting.notifications.sidepanel.description.change_via_template"),
         show_button: !@meeting.recurring? || @meeting.templated?
       )

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -387,53 +387,22 @@ en:
         caption: This text will appear on every page at the center of the footer.
       submit_button: Download
     notifications:
+      disabled: "Participants will not receive email updates informing them of changes to the date, time or list of participants."
+      enabled: "All participants will receive updated calendar invites informing them of changes to date, time or list of participants."
       sidepanel:
         title: "Email calendar updates"
         description:
-          disabled: "Participants will not receive an email informing them of changes to the schedule or participants."
-          enabled: "All participants will receive updated calendar invites via email informing them of changes."
           change_via_template: "To change this, edit the series template."
       dialog:
         title:
           enable: "Enable email calendar updates?"
           disable: "Disable email calendar updates?"
         message:
-          enable: >
-            All participants will receive updated calendar invites via email every time there is a change to the meeting date, time, location or participants.
-            Once enabled, an email will be sent out immediately to all participants.
-          disable: >
-            Participants will no longer receive updated calendar invites via email when there are changes to the meeting date, time, location or participants.
-            If they already had an invite for this meeting, it might no longer be accurate.
+          enable: "Once enabled, an email will be sent out immediately to all participants."
+          disable: "If they already had an invite for this meeting, it might no longer be accurate."
         confirm_label:
           enable: "Enable email updates"
           disable: "Disable email updates"
-      banner:
-        participants:
-          enabled: >
-            All participants will receive emails informing them of changes to the meeting date, time or participants.
-          disabled: >
-            Email calendar updates are disabled. Participants will not receive an email informing them of changes to the meeting date, time or participants.
-          draft_disabled: >
-            Participants will not receive an email informing them of changes to the meeting date, time or participants.
-        onetime:
-          enabled: >
-            All participants will receive updated calendar invites informing them of changes to date, time or participants on this meeting.
-          disabled: >
-            Participants will not receive updated calendar invites informing them of changes to date, time or participants on this meeting.
-        occurrence:
-          enabled: >
-            Email calendar updates are enabled for the meeting series.
-            All participants will receive updated calendar invites for changes to meeting date, time or participants on this occurrence.
-          disabled: >
-            Email calendar updates are disabled for the meeting series.
-            Participants will not receive updated calendar invites for changes to the meeting date, time or participants on this occurrence.
-        template:
-          enabled: >
-            Email calendar updates are enabled for the meeting series.
-            Participants will receive updated calendar invites for changes to the meeting date, time or participants on this series.
-          disabled: >
-            Email calendar updates are disabled for the meeting series.
-            Participants will not receive updated calendar invites for changes to the meeting date, time or participants on this series.
     presentation_mode:
       title: "Presentation Mode"
       button_present: "Present"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -390,7 +390,7 @@ en:
       sidepanel:
         title: "Email calendar updates"
         description:
-          disabled: "Participants will not receive an email informing them of changes."
+          disabled: "Participants will not receive an email informing them of changes to the schedule or participants."
           enabled: "All participants will receive updated calendar invites via email informing them of changes."
           change_via_template: "To change this, edit the series template."
       dialog:
@@ -410,30 +410,30 @@ en:
       banner:
         participants:
           enabled: >
-            All participants will receive updated calendar invites via email when you add or remove participants.
+            All participants will receive emails informing them of changes to the meeting date, time or participants.
           disabled: >
-            Email calendar updates are disabled. Participants will not receive an email informing them when you add or remove participants.
+            Email calendar updates are disabled. Participants will not receive an email informing them of changes to the meeting date, time or participants.
           draft_disabled: >
-            Participants will not receive an email informing them when you add or remove participants.
+            Participants will not receive an email informing them of changes to the meeting date, time or participants.
         onetime:
           enabled: >
-            All participants will receive updated calendar invites via email when you add or remove participants.
+            All participants will receive updated calendar invites informing them of changes to date, time or participants on this meeting.
           disabled: >
-            Participants will not receive an email informing them of changes to meeting date, time or participants.
+            Participants will not receive updated calendar invites informing them of changes to date, time or participants on this meeting.
         occurrence:
           enabled: >
             Email calendar updates are enabled for the meeting series.
-            All participants will receive updated calendar invites informing them of your changes to this occurrence.
+            All participants will receive updated calendar invites for changes to meeting date, time or participants on this occurrence.
           disabled: >
             Email calendar updates are disabled for the meeting series.
-            Participants will not receive an email informing them of your changes to this occurrence.
+            Participants will not receive updated calendar invites for changes to the meeting date, time or participants on this occurrence.
         template:
           enabled: >
             Email calendar updates are enabled for the meeting series.
-            All participants will receive updated calendar invites informing them of your changes to this template or to individual occurrences.
+            Participants will receive updated calendar invites for changes to the meeting date, time or participants on this series.
           disabled: >
             Email calendar updates are disabled for the meeting series.
-            Participants will not receive an email informing them of your changes to this template or to individual occurrences.
+            Participants will not receive updated calendar invites for changes to the meeting date, time or participants on this series.
     presentation_mode:
       title: "Presentation Mode"
       button_present: "Present"

--- a/modules/meeting/spec/components/meetings/email_updates_banner_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/email_updates_banner_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
       let(:notify) { true }
 
       it "renders the onetime enabled banner" do
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.onetime.enabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.enabled")
         expect(subject).to have_css(".Banner")
         expect(subject).to have_no_selector(".Banner--warning")
       end
@@ -62,7 +62,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
       let(:notify) { false }
 
       it "renders the onetime disabled banner" do
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.onetime.disabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.disabled")
         expect(subject).to have_css(".Banner--warning")
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
       let(:notify) { true }
 
       it "renders the template enabled banner" do
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.template.enabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.enabled")
         expect(subject).to have_css(".Banner")
         expect(subject).to have_no_selector(".Banner--warning")
       end
@@ -94,7 +94,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
       let(:notify) { false }
 
       it "renders the template disabled banner" do
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.template.disabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.disabled")
         expect(subject).to have_css(".Banner--warning")
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
 
       it "renders the occurrence enabled banner" do
         template
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.occurrence.enabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.enabled")
         expect(subject).to have_css(".Banner")
         expect(subject).to have_no_selector(".Banner--warning")
       end
@@ -133,7 +133,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
 
       it "renders the occurrence disabled banner" do
         template
-        expect(subject).to have_text I18n.t("meeting.notifications.banner.occurrence.disabled")
+        expect(subject).to have_text I18n.t("meeting.notifications.disabled")
         expect(subject).to have_css(".Banner--warning")
       end
     end
@@ -150,7 +150,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
     let(:override) { "enabled" }
 
     it "renders the enabled banner regardless of notify" do
-      expect(subject).to have_text I18n.t("meeting.notifications.banner.onetime.enabled")
+      expect(subject).to have_text I18n.t("meeting.notifications.enabled")
       expect(subject).to have_css(".Banner")
       expect(subject).to have_no_selector(".Banner--warning")
     end
@@ -167,7 +167,7 @@ RSpec.describe Meetings::EmailUpdatesBannerComponent, type: :component do
     let(:override) { "disabled" }
 
     it "renders the disabled banner regardless of notify" do
-      expect(subject).to have_text I18n.t("meeting.notifications.banner.onetime.disabled")
+      expect(subject).to have_text I18n.t("meeting.notifications.disabled")
       expect(subject).to have_css(".Banner--warning")
     end
   end

--- a/modules/meeting/spec/features/meeting_notifications_spec.rb
+++ b/modules/meeting/spec/features/meeting_notifications_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe "Meeting notifications", :js do
     let(:show_page) { Pages::Meetings::Show.new(meeting) }
     let(:meetings_page) { Pages::Meetings::Index.new(project:) }
 
-    let(:enabled_text) { I18n.t("meeting.notifications.banner.onetime.enabled") }
-    let(:disabled_text) { I18n.t("meeting.notifications.banner.onetime.disabled") }
+    let(:enabled_text) { I18n.t("meeting.notifications.enabled") }
+    let(:disabled_text) { I18n.t("meeting.notifications.disabled") }
 
     before do
       meetings_page.visit!
@@ -112,7 +112,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")
         expect(page).to have_text("Enabled.")
-        expect(page).to have_text("All participants will receive updated calendar invites via email informing them of changes.")
+        expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
         expect(page).to have_selector(:link_or_button, "Disable")
       end
 
@@ -152,7 +152,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")
         expect(page).to have_text("Disabled.")
-        expect(page).to have_text("Participants will not receive an email informing them of changes.")
+        expect(page).to have_text(I18n.t("meeting.notifications.disabled"))
         expect(page).to have_selector(:link_or_button, "Enable")
       end
 
@@ -220,8 +220,8 @@ RSpec.describe "Meeting notifications", :js do
     let(:current_user) { user }
     let(:meetings_page) { Pages::Meetings::Index.new(project:) }
 
-    let(:enabled_text) { I18n.t("meeting.notifications.banner.template.enabled") }
-    let(:disabled_text) { I18n.t("meeting.notifications.banner.template.disabled") }
+    let(:enabled_text) { I18n.t("meeting.notifications.enabled") }
+    let(:disabled_text) { I18n.t("meeting.notifications.disabled") }
 
     before do
       meetings_page.visit!
@@ -273,7 +273,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")
         expect(page).to have_text("Enabled.")
-        expect(page).to have_text("All participants will receive updated calendar invites via email informing them of changes.")
+        expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
         expect(page).to have_selector(:link_or_button, "Disable")
       end
 
@@ -285,7 +285,7 @@ RSpec.describe "Meeting notifications", :js do
 
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
-        expect(page).to have_text(I18n.t("meeting.notifications.banner.template.enabled"))
+        expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
         template_page.set_start_time "12:00"
         wait_for_network_idle
         click_on "Save"
@@ -303,7 +303,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")
         expect(page).to have_text("Enabled.")
-        expect(page).to have_text("All participants will receive updated calendar invites via email informing them of changes.")
+        expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
         expect(page).to have_no_selector(:link_or_button, "Disable")
         expect(page).to have_text("To change this, edit the series template.")
       end
@@ -316,7 +316,7 @@ RSpec.describe "Meeting notifications", :js do
 
       page.within(".Overlay") do
         expect(page).to have_test_selector("notifications-banner")
-        expect(page).to have_text(I18n.t("meeting.notifications.banner.occurrence.enabled"))
+        expect(page).to have_text(I18n.t("meeting.notifications.enabled"))
         occurrence_page.set_start_time "13:00"
         wait_for_network_idle
         click_on "Save"
@@ -350,7 +350,7 @@ RSpec.describe "Meeting notifications", :js do
       page.within("[data-test-selector='email-updates-mode-selector']") do
         expect(page).to have_text("Email calendar updates")
         expect(page).to have_text("Disabled.")
-        expect(page).to have_text("Participants will not receive an email informing them of changes.")
+        expect(page).to have_text(I18n.t("meeting.notifications.disabled"))
         expect(page).to have_no_selector(:link_or_button, "Enable")
         expect(page).to have_text("To change this, edit the series template.")
       end


### PR DESCRIPTION
We received feedback that the text on when updates are being sent (or not sent) is not clear enough, and that they were assuming emails are being sent on content/agenda changes.

https://community.openproject.org/work_packages/75234