### PR TITLE
[#73831] Re-fix Sprints column scroll content overlap [FOLLOW UP]

### DIFF
--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -66,9 +66,11 @@
 
 //------------------ Sprint planning divider (side-by-side only) ----
 @container backlogsListsContainer (min-width: 655px)
-  .op-sprint-planning-lists:not(:last-child)
-    border-right: 1px solid var(--borderColor-default)
+  .op-sprint-planning-lists
     padding-right: var(--stack-gap-normal)
+
+    &:not(:last-child)
+      border-right: 1px solid var(--borderColor-default)
 
 //------------------ Mobile responsive styling -----------------------
 @container backlogsListsContainer (max-width: 654px)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/73831 (follow up)

# What are you trying to accomplish?

Restores the sprint planning list padding lost while resolving the Backlogs Sass conflict in:
f8e3ea3019e36b46f36f2aa16d3f924591fc207

## Screenshots

See #23119

# What approach did you choose and why?

See #23119

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
