### PR TITLE
[73502] Update Wiki provider icon

### DIFF
--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -94,7 +94,7 @@ module OpenProject::Wikis
            { controller: "/wikis/admin/wiki_providers", action: :index },
            if: ->(_) { OpenProject::FeatureDecisions.wiki_enhancements_active? },
            caption: :project_module_wiki_platforms,
-           icon: "browser"
+           icon: "book"
     end
 
     patch_with_namespace :WikiPages, :CreateService


### PR DESCRIPTION
# Ticket
[73502](https://community.openproject.org/projects/stream-xwiki-integration/work_packages/73502/)

# What are you trying to accomplish?
Update the icon for the wiki providers menu and for the admin page menu. 

## Screenshots
<img width="511" height="226" alt="Screenshot 2026-05-18 at 12 11 22" src="https://github.com/user-attachments/assets/f5e0f9b5-aea1-44a2-97a5-72de637083dc" />

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
