### PR TITLE
fix flickering budget update form spec

### DIFF
--- a/modules/budgets/spec/support/pages/budget_form.rb
+++ b/modules/budgets/spec/support/pages/budget_form.rb
@@ -59,12 +59,13 @@ module Pages
       prefix = "#{unit_cost_attr_id(type)}_#{id}"
       options = { fill_options: { clear: :backspace } }
 
-      fill_in("#{prefix}_units", with: units, **options) if units.present?
-      fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
+      retry_block do
+        fill_in("#{prefix}_units", with: units, **options) if units.present?
+        fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
 
-      if expected_costs.present?
-        wait_for_network_idle
-        expect(page).to have_css("##{prefix}_costs", text: expected_costs)
+        if expected_costs.present?
+          expect(page).to have_css("##{prefix}_costs", text: expected_costs)
+        end
       end
     end
 
@@ -102,13 +103,14 @@ module Pages
       prefix = "#{labor_cost_attr_id(type)}_#{id}"
       options = { fill_options: { clear: :backspace } }
 
-      fill_in("#{prefix}_hours", with: hours, **options) if hours.present?
-      select user_name, from: "#{prefix}_user_id" if user_name.present?
-      fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
+      retry_block do
+        fill_in("#{prefix}_hours", with: hours, **options) if hours.present?
+        select user_name, from: "#{prefix}_user_id" if user_name.present?
+        fill_in("#{prefix}_comments", with: comment, **options) if comment.present?
 
-      if expected_costs.present?
-        wait_for_network_idle
-        expect(page).to have_css("##{prefix}_costs", text: expected_costs)
+        if expected_costs.present?
+          expect(page).to have_css("##{prefix}_costs", text: expected_costs)
+        end
       end
     end
 


### PR DESCRIPTION
rspec ./modules/budgets/spec/features/budgets/update_budget_spec.rb:54

The assumption is that the update form is rendered and filled before the JS that is tested is instantiated. The fix is to fill in the fields again if the spec fails

