### PR TITLE
Improve error handling around duplicate project folders

### DIFF
--- a/modules/storages/app/contracts/storages/project_storages/base_contract.rb
+++ b/modules/storages/app/contracts/storages/project_storages/base_contract.rb
@@ -48,6 +48,11 @@ module Storages::ProjectStorages
     attribute :project_folder_id
     validates :project_folder_id, presence: true, if: :project_folder_mode_manual?
 
+    # For automatically managed folders, the project_folder_id should not even be choosable by the user, but in any case
+    # we have to make sure to not introduce duplicates, because this could lead to one project taking ownership of a folder
+    # that already belongs to another project
+    validate :project_folder_id_unique, if: :project_folder_mode_automatic?
+
     attribute :project_folder_mode do
       if Storages::ProjectStorage.project_folder_modes.keys.exclude?(@model.project_folder_mode)
         errors.add :project_folder_mode, :invalid
@@ -62,10 +67,26 @@ module Storages::ProjectStorages
       @model.project_folder_manual?
     end
 
+    def project_folder_mode_automatic?
+      @model.project_folder_automatic?
+    end
+
     def project_folder_mode_available_for_storage
       if storage&.available_project_folder_modes&.exclude?(@model.project_folder_mode)
         errors.add :project_folder_mode, :mode_unavailable
       end
+    end
+
+    def project_folder_id_unique
+      return if @model.project_folder_id.blank?
+      return if @model.storage.blank?
+
+      collision = ::Storages::ProjectStorage
+                    .where(storage_id: @model.storage_id, project_folder_id: @model.project_folder_id)
+                    .where.not(id: @model.id)
+                    .exists?
+
+      errors.add(:project_folder_id, :taken) if collision
     end
   end
 end

--- a/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
+++ b/modules/storages/app/controllers/storages/admin/project_storages_controller.rb
@@ -141,7 +141,7 @@ class Storages::Admin::ProjectStoragesController < Projects::SettingsController
       .require(:storages_project_storage)
       .permit("storage_id", "project_folder_mode", "project_folder_id")
       .to_h
-      .reverse_merge(project_id: @project.id)
+      .merge(project_id: @project.id)
   end
 
   def project_folder_mode_from_params

--- a/modules/storages/app/services/storages/nextcloud_managed_folder_permissions_service.rb
+++ b/modules/storages/app/services/storages/nextcloud_managed_folder_permissions_service.rb
@@ -108,6 +108,12 @@ module Storages
 
     # rubocop:disable Metrics/AbcSize
     def set_folder_permissions(remote_admins, project_storage)
+      project_folder_id = project_storage.project_folder_id
+
+      if project_folder_id_collision?(project_storage)
+        return add_error(:set_folder_permission, collision_error, options: { folder: project_folder_id })
+      end
+
       admin_permissions = remote_admins.to_set.map { |username| { user_id: username, permissions: FILE_PERMISSIONS } }
       base_permissions = base_remote_permissions(admin_permissions)
 
@@ -117,7 +123,6 @@ module Storages
       end
 
       permissions = base_permissions + users_permissions
-      project_folder_id = project_storage.project_folder_id
 
       input_data = build_set_permissions_input_data(project_folder_id, permissions).value_or do |failure|
         log_validation_error(failure, project_folder_id:, permissions:)
@@ -157,6 +162,19 @@ module Storages
       @commands[:group_users].call(auth_strategy:, input_data:).or do |error|
         Failure(add_error(:group_users, error, options: { group: group }))
       end
+    end
+
+    # We refuse to overwrite an ACL when another project_storage on the same storage holds the same folder id
+    # (defense in depth in case the contract check is bypassed or a folder id collision is written directly to the DB)
+    def project_folder_id_collision?(project_storage)
+      ::Storages::ProjectStorage
+        .where(storage_id: project_storage.storage_id, project_folder_id: project_storage.project_folder_id)
+        .where.not(id: project_storage.id)
+        .exists?
+    end
+
+    def collision_error
+      ::Storages::Adapters::Results::Error.new(source: self.class, code: :folder_id_collision)
     end
 
     ### Model Scopes

--- a/modules/storages/app/services/storages/one_drive_managed_folder_permissions_service.rb
+++ b/modules/storages/app/services/storages/one_drive_managed_folder_permissions_service.rb
@@ -62,6 +62,12 @@ module Storages
     def apply_permission_to_folders
       info "Setting permissions to project folders"
       @project_storages.includes(:project).with_project_folder.find_each do |project_storage|
+        project_folder_id = project_storage.project_folder_id
+
+        if project_folder_id_collision?(project_storage)
+          next add_error(:set_folder_permission, collision_error, options: { folder: project_folder_id })
+        end
+
         permissions = admin_remote_identities_scope.pluck(:origin_user_id).map do |origin_user_id|
           { user_id: origin_user_id, permissions: [:write_files] }
         end
@@ -72,7 +78,6 @@ module Storages
 
         info "Setting permissions for #{project_storage.managed_project_folder_name}: #{permissions}"
 
-        project_folder_id = project_storage.project_folder_id
         build_permissions_input_data(project_folder_id, permissions)
           .either(
             ->(input_data) { set_permissions.call(storage: @storage, auth_strategy:, input_data:) },
@@ -101,6 +106,19 @@ module Storages
       else
         project_remote_identities.where(user: project_storage.project.users)
       end
+    end
+
+    # We refuse to overwrite an ACL when another project_storage on the same storage holds the same folder id
+    # (defense in depth in case the contract check is bypassed or a folder id collision is written directly to the DB)
+    def project_folder_id_collision?(project_storage)
+      ::Storages::ProjectStorage
+        .where(storage_id: project_storage.storage_id, project_folder_id: project_storage.project_folder_id)
+        .where.not(id: project_storage.id)
+        .exists?
+    end
+
+    def collision_error
+      ::Storages::Adapters::Results::Error.new(source: self.class, code: :folder_id_collision)
     end
 
     def client_remote_identities_scope

--- a/modules/storages/config/locales/en.yml
+++ b/modules/storages/config/locales/en.yml
@@ -108,21 +108,25 @@ en:
         remote_folders: 'Read contents of the team folder:'
         remove_user_from_group: 'Remove User from Group:'
         rename_project_folder: 'Rename managed project Folder:'
+        set_folder_permission: 'Set managed project Folder permissions:'
       one_drive_sync_service:
         create_folder: 'Managed Project Folder Creation:'
         ensure_root_folder_permissions: 'Set Base Folder Permissions:'
         hide_inactive_folders: 'Hide Inactive Folders Step:'
         remote_folders: 'Read contents of the drive root folder:'
         rename_project_folder: 'Rename managed project Folder:'
+        set_folder_permission: 'Set managed project Folder permissions:'
       sharepoint_sync_service:
         create_folder: 'Managed Project Folder Creation:'
         ensure_root_folder_permissions: 'Set Base Folder Permissions:'
         hide_inactive_folders: 'Hide Inactive Folders Step:'
         remote_folders: 'Read contents of the drive root folder:'
         rename_project_folder: 'Rename managed project Folder:'
+        set_folder_permission: 'Set managed project Folder permissions:'
     errors:
       messages:
         error: An unexpected error occurred. Please check OpenProject logs for more information or contact an administrator
+        folder_id_collision: Multiple project storages try to manage the project folder %{folder}. Its synchronization was skipped.
         forbidden: OpenProject could not access the requested resource. Please check your permissions configuration on the Storage Provider.
         unauthorized: OpenProject could not authenticate with the Storage Provider. Please ensure that you have access to it.
       models:

--- a/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
+++ b/modules/storages/spec/contracts/storages/project_storages/base_contract_spec.rb
@@ -52,15 +52,32 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
       end
 
       it_behaves_like "contract is valid"
-    end
 
-    context "when the project folder mode is `automatic` but the storage is not automatically managed" do
-      before do
-        project_storage.project_folder_mode = "automatic"
-        project_storage.storage.automatic_management_enabled = false
+      context "and when the storage is not automatically managed" do
+        before do
+          project_storage.storage.automatic_management_enabled = false
+        end
+
+        it_behaves_like "contract is invalid", project_folder_mode: :mode_unavailable
       end
 
-      it_behaves_like "contract is invalid", project_folder_mode: :mode_unavailable
+      context "and when setting project storage to an existing project_folder_id" do
+        before do
+          create(:project_storage, storage:, project_folder_id: "existing-project-folder")
+          project_storage.project_folder_id = "existing-project-folder"
+        end
+
+        it_behaves_like "contract is invalid", project_folder_id: :taken
+      end
+
+      context "and when setting project storage to project_folder_id existing on other storage" do
+        before do
+          create(:project_storage, project_folder_id: "existing-project-folder")
+          project_storage.project_folder_id = "existing-project-folder"
+        end
+
+        it_behaves_like "contract is valid"
+      end
     end
 
     context "if the project folder mode is `manual`" do
@@ -79,6 +96,15 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
 
         it_behaves_like "contract is valid"
       end
+
+      context "and when setting project storage to an existing project_folder_id" do
+        before do
+          create(:project_storage, storage:, project_folder_id: "existing-project-folder")
+          project_storage.project_folder_id = "existing-project-folder"
+        end
+
+        it_behaves_like "contract is valid"
+      end
     end
 
     include_examples "contract reuses the model errors"
@@ -86,7 +112,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
 
   describe "For a nextcloud storage" do
     let(:contract) { described_class.new(project_storage, build_stubbed(:admin)) }
-    let(:storage) { build_stubbed(:nextcloud_storage) }
+    let(:storage) { create(:nextcloud_storage) }
     let(:project_storage) { build(:project_storage, storage:) }
 
     it_behaves_like "a ProjectStorage BaseContract"
@@ -104,7 +130,7 @@ RSpec.describe Storages::ProjectStorages::BaseContract do
 
   describe "For a one drive storage" do
     let(:contract) { described_class.new(project_storage, build_stubbed(:admin)) }
-    let(:storage) { build_stubbed(:one_drive_storage) }
+    let(:storage) { create(:one_drive_storage) }
     let(:project_storage) { build(:project_storage, storage:) }
 
     it_behaves_like "a ProjectStorage BaseContract"

--- a/modules/storages/spec/services/storages/nextcloud_managed_folder_permissions_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_managed_folder_permissions_service_spec.rb
@@ -160,7 +160,7 @@ module Storages
         end
       end
 
-      it "adds and remove users from the remote group", vcr: "nextcloud/managed_folder_set_permissions_group_users" do
+      it "adds and removes users from the remote group", vcr: "nextcloud/managed_folder_set_permissions_group_users" do
         service.call
 
         users = Adapters::Input::GroupUsers.build(group: storage.group).bind do |input_data|
@@ -173,6 +173,24 @@ module Storages
           Adapters::Input::RemoveUserFromGroup.build(group: storage.group, user:).bind do |input_data|
             Adapters::Registry["nextcloud.commands.remove_user_from_group"].call(storage:, auth_strategy:, input_data:)
           end
+        end
+      end
+
+      context "when two project storages have the same project_folder_id (regression #75022)" do
+        before do
+          create(:project_storage, storage:, project_folder_id: project_storage.project_folder_id)
+        end
+
+        it "fails with an appropriate error", vcr: "nextcloud/managed_folder_set_permissions" do
+          result = service.call
+          expect(result).to be_failure
+          expect(result.errors.details[:set_folder_permission]).to contain_exactly(
+            error: :folder_id_collision,
+            folder: project_storage.project_folder_id
+          )
+
+          # Ensure presence of a translation
+          expect(result.errors.full_messages).to all(be_a(String))
         end
       end
     end

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_permissions_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_permissions_service_spec.rb
@@ -278,6 +278,24 @@ module Storages
 
           expect(remote_permissions_for(inactive_project_storage)).to be_empty
         end
+
+        context "and when two project storages have the same project_folder_id (regression #75022)" do
+          before do
+            create(:project_storage, storage:, project_folder_id: project_storage.project_folder_id)
+          end
+
+          it "fails with an appropriate error", vcr: "one_drive/sync_service_set_permissions" do
+            result = service.call
+            expect(result).to be_failure
+            expect(result.errors.details[:set_folder_permission]).to contain_exactly(
+              error: :folder_id_collision,
+              folder: project_storage.project_folder_id
+            )
+
+            # Ensure presence of a translation
+            expect(result.errors.full_messages).to all(be_a(String))
+          end
+        end
       end
 
       context "when the project is public", vcr: "one_drive/sync_service_public_project" do


### PR DESCRIPTION
Don't allow to point two project storages to the same project_folder_id if one of them is automatically managed. This ensures that ownership is always consistently applied according to one project only.

# Ticket
https://community.openproject.org/wp/75022