### PR TITLE
Add 'message' key to English locale file

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2614,6 +2614,7 @@ en:
         other: "Priorities"
       meeting_participant: "Meeting participant"
       member: "Member"
+      message: "Message"
       news: "News"
       notification:
         one: "Notification"


### PR DESCRIPTION
# What are you trying to accomplish?
Translate Message model name

## Screenshots
<img width="1097" height="213" alt="Screenshot_20260519_125436" src="https://github.com/user-attachments/assets/4114bef6-103e-4a81-bfa4-19b27fa5b0f7" />

# What approach did you choose and why?
Add locale key to I18n to allow translate it via Crowdin.