### PR TITLE
reduce min/max threads to 3/5, update docs

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -1306,8 +1306,8 @@ module Settings
           "workers" => 2,
           "timeout" => Rails.env.production? ? 120 : 0,
           "wait_timeout" => 30,
-          "min_threads" => 4,
-          "max_threads" => 16,
+          "min_threads" => 3,
+          "max_threads" => 5,
           "term_on_timeout" => 1
         },
         writable: false

--- a/docs/installation-and-operations/configuration/environment/README.md
+++ b/docs/installation-and-operations/configuration/environment/README.md
@@ -394,7 +394,7 @@ OPENPROJECT_USER__DEFAULT__TIMEZONE (default=nil) Users default time zone
 OPENPROJECT_USER__FORMAT (default=:firstname_lastname) Users name format
 OPENPROJECT_USERS__DELETABLE__BY__ADMINS (default=false) User accounts deletable by admins
 OPENPROJECT_USERS__DELETABLE__BY__SELF (default=false) Users allowed to delete their accounts
-OPENPROJECT_WEB (default={"workers" => 2, "timeout" => 120, "wait_timeout" => 30, "min_threads" => 4, "max_threads" => 16, "term_on_timeout" => 1}) Web worker count and threads configuration
+OPENPROJECT_WEB (default={"workers" => 2, "timeout" => 120, "wait_timeout" => 30, "min_threads" => 3, "max_threads" => 5, "term_on_timeout" => 1}) Web worker count and threads configuration
 OPENPROJECT_WELCOME__ON__HOMESCREEN (default=false) Display welcome block on homescreen
 OPENPROJECT_WELCOME__TEXT (default=nil) Welcome block text
 OPENPROJECT_WELCOME__TITLE (default=nil) Welcome block title

--- a/docs/installation-and-operations/operation/scaling/README.md
+++ b/docs/installation-and-operations/operation/scaling/README.md
@@ -12,8 +12,12 @@ The following environment variables are relevant for performance.
 - `OPENPROJECT_WEB_WORKERS`: Number of web workers handling HTTP requests. Note that in Kubernetes deployments, this value is applied using replicas of the services.
 - `OPENPROJECT_WEB_TIMEOUT`: Maximum request processing time in seconds.
 - `OPENPROJECT_WEB_WAIT__TIMEOUT`: Timeout for waiting requests in seconds.
-- `OPENPROJECT_WEB_MIN__THREADS`: Minimum number of threads per web worker.
-- `OPENPROJECT_WEB_MAX__THREADS`: Maximum number of threads per web worker.
+- `OPENPROJECT_WEB_MIN__THREADS`: Minimum number of threads per web worker (default: 3).
+- `OPENPROJECT_WEB_MAX__THREADS`: Maximum number of threads per web worker (default: 5).
+
+> [!NOTE]
+>
+> Due to Ruby's Global VM Lock (GVL), MRI Ruby can only execute one thread at a time for CPU-bound work. More threads increase memory usage and context-switching overhead without proportional throughput gains. The defaults of 3–5 threads per worker reflect this constraint. See the [Rails performance guide](https://guides.rubyonrails.org/tuning_performance_for_deployment.html#understanding-ruby-s-concurrency-and-parallelism) for a detailed explanation. Scale horizontally by adding more workers rather than increasing thread counts.
 - `OPENPROJECT_GOOD__JOB__MAX_THREADS`: Maximum number of threads for background workers.
 
 ## Packaged installation

--- a/docs/installation-and-operations/system-requirements/README.md
+++ b/docs/installation-and-operations/system-requirements/README.md
@@ -105,9 +105,9 @@ These values are **guidelines** and should be adjusted based on actual monitorin
 
 - **CPU**: 2 CPU
 
-- **RAM**: 4 GB
+- **RAM**: 4 to 6 GB
 
-- **Web Workers**:  2 Workers, each with 4 threads
+- **Web Workers**:  2 Workers, each with 3–5 threads
 
 - **Background Workers**: 1 multithreaded worker with 4GiB RAM (more RAM possibly required for larger exports)
 
@@ -117,9 +117,9 @@ These values are **guidelines** and should be adjusted based on actual monitorin
 
 - **Database**: 2-4 CPU / 8 GiB RAM
 - **CPU**: 4 CPU
-- **RAM**: 8 GB
-- **Web Workers**: 4 Workers, each with 4-8 threads
-- **Background Workers**: 2 multithreaded workers with 4-6 GiB RAM
+- **RAM**: 8 to 12 GB
+- **Web Workers**: 4 Workers, each with 3–5 threads
+- **Background Workers**: 1 to 2 multithreaded workers with 4-6 GiB RAM, depending on workload [1]
 - **Disk Space**: 50 GB + additional disk space in case of internal attachment storage
 
 ### Large instance (~1500 users, medium to high concurrent activity)
@@ -127,8 +127,8 @@ These values are **guidelines** and should be adjusted based on actual monitorin
 - **Database**: 4-8 CPU / 16 GiB RAM
 - **CPU**: 8 CPU
 - **RAM**: 16-24 GB
-- **Web Workers**: 6-8 Workers, each with 8-32 threads
-- **Background Workers**: 4-8 multithreaded workers with 4-6GiB RAM, depending on workload
+- **Web Workers**: 6-8 Workers, each with 3–5 threads
+- **Background Workers**: 1 to 2 multithreaded workers with 4-6GiB RAM, depending on workload [1]
 - **Disk Space**: 100 GB + additional disk space in case of internal attachment storage
 
 ### Enterprise-scale multitenancy instance (~80K - 100K users, high concurrent activity)
@@ -138,9 +138,11 @@ These values are **guidelines** and should be adjusted based on actual monitorin
   - **CPU**: 8 CPU (e.g., AWS r7a.xlarge instances)
   - **RAM**: 32GB
 
-- **Web Workers**: 8 - 12 Workers, each with 8-32 threads and 6GiB available RAM
-- **Background Workers**: 8 multithreaded workers with 4-6GiB RAM, depending on workload
+- **Web Workers**: 8–12 Workers, each with 3–5 threads and 6GiB available RAM
+- **Background Workers**: 2 or more multithreaded workers with 4-6GiB RAM, depending on workload [1]
 - **Disk Space**: 250 GB + additional disk space in case of internal attachment storage
+
+[1] You can observe the `worker_backed_up` health check under `https://<your-openproject-instance>/health_checks/worker_backed_up`. If jobs are backing up, you will want to increase the number of background workers.
 
 ### Additional scaling recommendations
 


### PR DESCRIPTION
Our old default value for max_threads was much too high considering the nature of CRuby's threading implementation. This PR reduces the maximum to 5 and updates our docs accordingly.