### PR TITLE
Chip/block blue border is clipped on the left side at the beginning of a line

### DIFF
--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -18,7 +18,6 @@ $blocknote-max-width: 800px
     height: 100%
     max-width: $blocknote-max-width
     min-height: 80vh
-    overflow: auto
     width: 100%
     background-color: transparent
     padding-top: 10px // Small padding to display cursor label when at the very top


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/communicator-stream/work_packages/74979

# What are you trying to accomplish?
Remove `overflow: auto` from `.bn-editor` that was causing the left border of work package cards to be clipped inside the editor container.

## Screenshots
<img width="531" height="319" alt="image" src="https://github.com/user-attachments/assets/fe6a28ae-d208-4b46-9d85-d5325f079518" />
<img width="808" height="550" alt="image" src="https://github.com/user-attachments/assets/35934929-18a4-467d-acef-643b3b307a8f" />

# What approach did you choose and why?
Removed the `overflow: auto` property from `.bn-editor`. The property was creating a new block formatting context which clipped child elements (WP cards) that rendered outside the editor bounds. No scroll functionality was lost since the overflow was not needed.


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
