### PR TITLE
Use .to_hash on the schema representer before caching

### DIFF
--- a/lib/api/v3/projects/schemas/project_schema_representer.rb
+++ b/lib/api/v3/projects/schemas/project_schema_representer.rb
@@ -145,6 +145,7 @@ module API
             OpenProject::Cache.fetch(*section_cache_key(section)) do
               ::API::V3::Projects::Schemas::ProjectCustomFieldSectionRepresenter
                 .new(section, current_user:)
+                .to_hash
             end
           end
 


### PR DESCRIPTION
Otherwise, we'll try to cache the entire class