### PR TITLE
feat: Support semantic WP identifiers in GitHub webhook handler

### DIFF
--- a/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
+++ b/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
@@ -44,9 +44,7 @@ module OpenProject::GithubIntegration
         # Or with the following prefix: OP#
         # e.g.,: This is a reference to OP#1234 or OP#PROJ-42
         host_name = Regexp.escape(Setting.host_name)
-        classic   = /\d+/
-        semantic  = WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN
-        wp_id     = /#{semantic}|#{classic}/
+        wp_id     = WorkPackage::SemanticIdentifier::ID_ROUTE_CONSTRAINT
         wp_regex  = /
           OP\#(#{wp_id})
           |

--- a/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
+++ b/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
@@ -30,7 +30,9 @@ module OpenProject::GithubIntegration
   module NotificationHandler
     module Helper
       ##
-      # Parses the given `text` and returns a list of work_package ids mentioned in that text.
+      # Parses the given `text` and returns a list of work package display identifiers mentioned
+      # in that text. Returns strings (e.g. "1234" or "PROJ-42") supporting both classic and
+      # semantic identifier modes.
       def extract_work_package_ids(text)
         # matches the following things (given that `Setting.host_name` equals 'www.openproject.org')
         #  - http://www.openproject.org/wp/1234
@@ -40,29 +42,35 @@ module OpenProject::GithubIntegration
         #  - https://www.openproject.org/projects/:identifier/wp/1234
         #  - https://www.openproject.org/any/sub/directories/work_packages/1234
         # Or with the following prefix: OP#
-        # e.g.,: This is a reference to OP#1234
+        # e.g.,: This is a reference to OP#1234 or OP#PROJ-42
         host_name = Regexp.escape(Setting.host_name)
-        wp_regex = /OP#(\d+)|http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/([0-9]+)/
+        classic   = /\d+/
+        semantic  = WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN
+        wp_id     = /#{semantic}|#{classic}/
+        wp_regex  = /
+          OP\#(#{wp_id})
+          |
+          http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/(#{wp_id})
+        /x
 
         String(text)
           .scan(wp_regex)
-          .map { |first, second| (first || second).to_i }
-          .select(&:positive?)
+          .filter_map { |first, second| first || second }
           .uniq
       end
 
       ##
-      # Given a list of work package ids, this methods returns all work packages that match those ids
-      # and are visible by the given user.
+      # Given a list of work package display identifiers (numeric strings or semantic IDs like
+      # "PROJ-42"), returns all work packages that match and are visible by the given user.
       # Params:
-      #  - Array<int>: An list of WorkPackage ids
+      #  - Array<String>: A list of WorkPackage display identifiers
       #  - User: The user who may (or may not) see those WorkPackages
       # Returns:
       #  - Array<WorkPackage>
       def find_visible_work_packages(ids, user)
         WorkPackage
           .includes(:project)
-          .where(id: ids)
+          .where_display_id_in(ids)
           .select { |wp| user.allowed_in_work_package?(:add_work_package_comments, wp) }
       end
 

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
@@ -46,27 +46,42 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::Helper do
 
     it "finds a work package by code" do
       source = "Blabla\nOP#1234\n"
-      expect(handler.extract_work_package_ids(source)).to eq([1234])
+      expect(handler.extract_work_package_ids(source)).to eq(["1234"])
+    end
+
+    it "finds a work package by semantic code" do
+      source = "Blabla\nOP#PROJ-42\n"
+      expect(handler.extract_work_package_ids(source)).to eq(["PROJ-42"])
     end
 
     it "finds a plain work package url" do
       source = 'Blabla\nhttps://example.net/work_packages/234\n'
-      expect(handler.extract_work_package_ids(source)).to eq([234])
+      expect(handler.extract_work_package_ids(source)).to eq(["234"])
+    end
+
+    it "finds a plain work package url with a semantic id" do
+      source = 'Blabla\nhttps://example.net/work_packages/PROJ-42\n'
+      expect(handler.extract_work_package_ids(source)).to eq(["PROJ-42"])
     end
 
     it "finds a work package url in markdown link syntax" do
       source = 'Blabla\n[WP 234](https://example.net/work_packages/234)\n'
-      expect(handler.extract_work_package_ids(source)).to eq([234])
+      expect(handler.extract_work_package_ids(source)).to eq(["234"])
     end
 
     it "finds multiple work package urls" do
       source = "I reference https://example.net/work_packages/434\n and Blabla\n[WP 234](https://example.net/wp/234)\n"
-      expect(handler.extract_work_package_ids(source)).to eq([434, 234])
+      expect(handler.extract_work_package_ids(source)).to eq(["434", "234"])
     end
 
     it "finds multiple occurrences of a work package only once" do
       source = "I reference https://example.net/work_packages/434\n and Blabla\n[WP 234](https://example.net/work_packages/434)\n"
-      expect(handler.extract_work_package_ids(source)).to eq([434])
+      expect(handler.extract_work_package_ids(source)).to eq(["434"])
+    end
+
+    it "finds mixed numeric and semantic ids" do
+      source = "OP#1234 and https://example.net/wp/PROJ-99"
+      expect(handler.extract_work_package_ids(source)).to eq(["1234", "PROJ-99"])
     end
   end
 
@@ -80,7 +95,7 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::Helper do
 
       before do
         allow(WorkPackage).to receive(:includes).and_return(WorkPackage)
-        allow(WorkPackage).to receive(:where).with(id: ids).and_return(work_packages)
+        allow(WorkPackage).to receive(:where_display_id_in).with(ids).and_return(work_packages)
 
         mock_permissions_for(user) do |mock|
           mock.allow_in_project :add_work_package_comments, project: :project_with_permissions


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-jira-exit/work_packages/74364

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Update `extract_work_package_ids` to recognise semantic URLs in addition to numeric ones. This will pick up semantic links from PRs.

## Screenshots
<img width="997" height="343" alt="Screenshot 2026-05-20 at 10 19 15" src="https://github.com/user-attachments/assets/9a9c731e-0fd3-4a25-97eb-69741c5ee772" />
<img width="539" height="751" alt="Screenshot 2026-05-20 at 10 19 23" src="https://github.com/user-attachments/assets/b7d926bf-b732-449e-beb0-20145ea9873d" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
