### PR TITLE
Use formattedId in GitHub/GitLab tab empty-state messages

### DIFF
--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -36,6 +36,8 @@ describe('GitActionsService', function () {
   const createWorkPackage = (overrides = {}) => {
     const defaults = {
       id: '42',
+      displayId: '42',
+      formattedId: '#42',
       subject: "Find the question, or don't",
       description: {
         raw: "I recently found the answer is 42. We'd need to compute the correct question."
@@ -69,5 +71,14 @@ ${origin}/wp/42`);
     const origin = window.location.origin;
 
     expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m '[#42] '\\'' && rm -rf / #' -m '${origin}/wp/42'`);
+  });
+
+  it('uses semantic identifiers when in semantic mode', () => {
+    const wp = createWorkPackage({ displayId: 'PROJ-42', formattedId: 'PROJ-42' });
+    const origin = window.location.origin;
+
+    expect(service.branchName(wp)).toEqual('user-story/proj-42-find-the-question-or-don-t');
+    expect(service.commitMessage(wp)).toEqual(`[PROJ-42] Find the question, or don't\n\n${origin}/wp/PROJ-42`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m '[PROJ-42] Find the question, or don'\\''t' -m '${origin}/wp/PROJ-42'`);
   });
 });

--- a/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/github_integration/frontend/module/git-actions/git-actions.service.ts
@@ -45,14 +45,13 @@ export class GitActionsService {
 
   private formattingInput(workPackage: WorkPackageResource) {
     const type = workPackage.type.name || '';
-    const id = workPackage.id || '';
+    const id = workPackage.displayId;
+    const formattedId = workPackage.formattedId;
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackageShortPath(id);
     const description = '';
 
-    return({
-      id, type, title, url, description
-    });
+    return { id, formattedId, type, title, url, description };
   }
 
   private sanitizeShellInput(str:string):string {
@@ -65,8 +64,8 @@ export class GitActionsService {
   }
 
   private commitMessageParts(workPackage:WorkPackageResource):string[] {
-    const { title, id, description, url } = this.formattingInput(workPackage);
-    return [`[#${id}] ${title}`, description, url].filter(Boolean);
+    const { title, formattedId, description, url } = this.formattingInput(workPackage);
+    return [`[${formattedId}] ${title}`, description, url].filter(Boolean);
   }
 
   public commitMessage(workPackage:WorkPackageResource):string {

--- a/modules/github_integration/frontend/module/tab-prs/tab-prs.component.ts
+++ b/modules/github_integration/frontend/module/tab-prs/tab-prs.component.ts
@@ -58,7 +58,7 @@ export class TabPrsComponent implements OnInit {
   emptyText:string;
 
   ngOnInit():void {
-    this.emptyText = this.I18n.t('js.github_integration.tab_prs.empty', { wp_id: this.workPackage.id });
+    this.emptyText = this.I18n.t('js.github_integration.tab_prs.empty', { wp_id: this.workPackage.formattedId });
     this.pullRequests$ = this
       .githubPullRequests
       .ofWorkPackage(this.workPackage)

--- a/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
+++ b/modules/github_integration/lib/open_project/github_integration/notification_handler/helper.rb
@@ -30,7 +30,9 @@ module OpenProject::GithubIntegration
   module NotificationHandler
     module Helper
       ##
-      # Parses the given `text` and returns a list of work_package ids mentioned in that text.
+      # Parses the given `text` and returns a list of work package display identifiers mentioned
+      # in that text. Returns strings (e.g. "1234" or "PROJ-42") supporting both classic and
+      # semantic identifier modes.
       def extract_work_package_ids(text)
         # matches the following things (given that `Setting.host_name` equals 'www.openproject.org')
         #  - http://www.openproject.org/wp/1234
@@ -40,29 +42,36 @@ module OpenProject::GithubIntegration
         #  - https://www.openproject.org/projects/:identifier/wp/1234
         #  - https://www.openproject.org/any/sub/directories/work_packages/1234
         # Or with the following prefix: OP#
-        # e.g.,: This is a reference to OP#1234
+        # e.g.,: This is a reference to OP#1234 or OP#PROJ-42
         host_name = Regexp.escape(Setting.host_name)
-        wp_regex = /OP#(\d+)|http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/([0-9]+)/
+        classic   = /\d+/
+        semantic  = WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN
+        wp_id     = /#{semantic}|#{classic}/
+        wp_regex  = /
+          OP\#(#{wp_id})
+          |
+          http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/(#{wp_id})
+        /x
 
         String(text)
           .scan(wp_regex)
-          .map { |first, second| (first || second).to_i }
-          .select(&:positive?)
+          .map { |first, second| first || second }
+          .compact
           .uniq
       end
 
       ##
-      # Given a list of work package ids, this methods returns all work packages that match those ids
-      # and are visible by the given user.
+      # Given a list of work package display identifiers (numeric strings or semantic IDs like
+      # "PROJ-42"), returns all work packages that match and are visible by the given user.
       # Params:
-      #  - Array<int>: An list of WorkPackage ids
+      #  - Array<String>: A list of WorkPackage display identifiers
       #  - User: The user who may (or may not) see those WorkPackages
       # Returns:
       #  - Array<WorkPackage>
       def find_visible_work_packages(ids, user)
         WorkPackage
           .includes(:project)
-          .where(id: ids)
+          .where_display_id_in(ids)
           .select { |wp| user.allowed_in_work_package?(:add_work_package_comments, wp) }
       end
 

--- a/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
+++ b/modules/github_integration/spec/lib/open_project/github_integration/notification_handler/helper_spec.rb
@@ -46,27 +46,42 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::Helper do
 
     it "finds a work package by code" do
       source = "Blabla\nOP#1234\n"
-      expect(handler.extract_work_package_ids(source)).to eq([1234])
+      expect(handler.extract_work_package_ids(source)).to eq(["1234"])
+    end
+
+    it "finds a work package by semantic code" do
+      source = "Blabla\nOP#PROJ-42\n"
+      expect(handler.extract_work_package_ids(source)).to eq(["PROJ-42"])
     end
 
     it "finds a plain work package url" do
       source = 'Blabla\nhttps://example.net/work_packages/234\n'
-      expect(handler.extract_work_package_ids(source)).to eq([234])
+      expect(handler.extract_work_package_ids(source)).to eq(["234"])
+    end
+
+    it "finds a plain work package url with a semantic id" do
+      source = 'Blabla\nhttps://example.net/work_packages/PROJ-42\n'
+      expect(handler.extract_work_package_ids(source)).to eq(["PROJ-42"])
     end
 
     it "finds a work package url in markdown link syntax" do
       source = 'Blabla\n[WP 234](https://example.net/work_packages/234)\n'
-      expect(handler.extract_work_package_ids(source)).to eq([234])
+      expect(handler.extract_work_package_ids(source)).to eq(["234"])
     end
 
     it "finds multiple work package urls" do
       source = "I reference https://example.net/work_packages/434\n and Blabla\n[WP 234](https://example.net/wp/234)\n"
-      expect(handler.extract_work_package_ids(source)).to eq([434, 234])
+      expect(handler.extract_work_package_ids(source)).to eq(["434", "234"])
     end
 
     it "finds multiple occurrences of a work package only once" do
       source = "I reference https://example.net/work_packages/434\n and Blabla\n[WP 234](https://example.net/work_packages/434)\n"
-      expect(handler.extract_work_package_ids(source)).to eq([434])
+      expect(handler.extract_work_package_ids(source)).to eq(["434"])
+    end
+
+    it "finds mixed numeric and semantic ids" do
+      source = "OP#1234 and https://example.net/wp/PROJ-99"
+      expect(handler.extract_work_package_ids(source)).to eq(["1234", "PROJ-99"])
     end
   end
 
@@ -80,7 +95,7 @@ RSpec.describe OpenProject::GithubIntegration::NotificationHandler::Helper do
 
       before do
         allow(WorkPackage).to receive(:includes).and_return(WorkPackage)
-        allow(WorkPackage).to receive(:where).with(id: ids).and_return(work_packages)
+        allow(WorkPackage).to receive(:where_display_id_in).with(ids).and_return(work_packages)
 
         mock_permissions_for(user) do |mock|
           mock.allow_in_project :add_work_package_comments, project: :project_with_permissions

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.spec.ts
@@ -36,6 +36,7 @@ describe('GitActionsService', function () {
   const createWorkPackage = (overrides = {}) => {
     const defaults = {
       id: '42',
+      displayId: '42',
       subject: "Find the question, or don't",
       description: {
         raw: "I recently found the answer is 42. We'd need to compute the correct question."
@@ -69,5 +70,14 @@ ${origin}/work_packages/42`);
     const origin = window.location.origin;
 
     expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/42-and-and-rm-rf' && git commit --allow-empty -m 'OP#42 '\\'' && rm -rf / #' -m '${origin}/work_packages/42'`);
+  });
+
+  it('uses semantic identifiers when in semantic mode', () => {
+    const wp = createWorkPackage({ displayId: 'PROJ-42' });
+    const origin = window.location.origin;
+
+    expect(service.branchName(wp)).toEqual('user-story/proj-42-find-the-question-or-don-t');
+    expect(service.commitMessage(wp)).toEqual(`OP#PROJ-42 Find the question, or don't\n\n${origin}/work_packages/PROJ-42`);
+    expect(service.gitCommand(wp)).toEqual(`git checkout -b 'user-story/proj-42-find-the-question-or-don-t' && git commit --allow-empty -m 'OP#PROJ-42 Find the question, or don'\\''t' -m '${origin}/work_packages/PROJ-42'`);
   });
 });

--- a/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions/git-actions.service.ts
@@ -48,14 +48,12 @@ export class GitActionsService {
 
   private formattingInput(workPackage: WorkPackageResource) {
     const type = workPackage.type.name || '';
-    const id = workPackage.id || '';
+    const id = workPackage.displayId;
     const title = workPackage.subject;
     const url = window.location.origin + workPackage.pathHelper.workPackagePath(id);
     const description = '';
 
-    return({
-      id, type, title, url, description
-    });
+    return { id, type, title, url, description };
   }
 
   private sanitizeShellInput(str:string):string {

--- a/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
@@ -64,6 +64,6 @@ export class TabIssueComponent implements OnInit {
   }
 
   public getEmptyText() {
-    return this.I18n.t('js.gitlab_integration.tab_issue.empty',{ wp_id: this.workPackage.id });
+    return this.I18n.t('js.gitlab_integration.tab_issue.empty',{ wp_id: this.workPackage.formattedId });
   }
 }

--- a/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.component.ts
@@ -64,6 +64,6 @@ export class TabMrsComponent implements OnInit {
   }
 
   public getEmptyText() {
-    return this.I18n.t('js.gitlab_integration.tab_mrs.empty',{ wp_id: this.workPackage.id });
+    return this.I18n.t('js.gitlab_integration.tab_mrs.empty',{ wp_id: this.workPackage.formattedId });
   }
 }

--- a/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/helper.rb
+++ b/modules/gitlab_integration/lib/open_project/gitlab_integration/notification_handler/helper.rb
@@ -31,13 +31,14 @@ module OpenProject::GitlabIntegration
   module NotificationHandler
     module Helper
       ##
-      # Parses the given source string and returns a list of work_package ids
-      # which it finds and should be considered public or private.
-      # WorkPackages are identified by their URL.
+      # Parses the given source string and returns a list of work package display identifiers
+      # (numeric strings or semantic IDs like "PROJ-42") found in that text.
+      # WorkPackages are identified by their URL or by an OP#/PP# prefix.
       # Params:
       #  source: string
+      #  kind: "" (default) | "note" | "private"
       # Returns:
-      #   Array<int>
+      #   Array<String>
       def extract_work_package_ids(text, kind = "")
         # matches the following things (given that `Setting.host_name` equals 'www.openproject.org')
         #  - http://www.openproject.org/wp/1234
@@ -45,35 +46,52 @@ module OpenProject::GitlabIntegration
         #  - http://www.openproject.org/work_packages/1234
         #  - https://www.openproject.org/subdirectory/work_packages/1234
         # Or with the following prefix: OP# PP#
-        # e.g.,: This is a reference to OP#1234
+        # e.g.,: This is a reference to OP#1234 or OP#PROJ-42
         # For private comments you can use the prefix: PP#
         host_name = Regexp.escape(Setting.host_name)
-        wp_regex = if kind == "private"
-                     /PP#(\d+)/
-                   elsif kind != "note"
-                     /OP#(\d+)|PP#(\d+)|http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/([0-9]+)/
+        classic   = /\d+/
+        semantic  = WorkPackage::SemanticIdentifier::SEMANTIC_ID_PATTERN
+        wp_id     = /#{semantic}|#{classic}/
+        url_part  = /http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/(#{wp_id})/
+
+        wp_regex = case kind
+                   when "private"
+                     /PP\#(#{wp_id})/
+                   when "note"
+                     /
+                       OP\#(#{wp_id})
+                       |
+                       #{url_part}
+                     /x
                    else
-                     /OP#(\d+)|http(?:s?):\/\/#{host_name}\/(?:\S+?\/)*(?:work_packages|wp)\/([0-9]+)/
+                     /
+                       OP\#(#{wp_id})
+                       |
+                       PP\#(#{wp_id})
+                       |
+                       #{url_part}
+                     /x
                    end
+
         String(text)
           .scan(wp_regex)
-          .map { |first, second| (first || second).to_i }
-          .select(&:positive?)
+          .map { |groups| groups.compact.first }
+          .compact
           .uniq
       end
 
       ##
-      # Given a list of work package ids this methods returns all work packages that match those ids
-      # and are visible by the given user.
+      # Given a list of work package display identifiers this methods returns all work packages
+      # that match those identifiers and are visible by the given user.
       # Params:
-      #  - Array<int>: An list of WorkPackage ids
+      #  - Array<String>: A list of WorkPackage display identifiers
       #  - User: The user who may (or may not) see those WorkPackages
       # Returns:
       #  - Array<WorkPackage>
       def find_visible_work_packages(ids, user)
         WorkPackage
           .includes(:project)
-          .where(id: ids)
+          .where_display_id_in(ids)
           .select { |wp| user.allowed_in_work_package?(:add_work_package_comments, wp) }
       end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/stream-jira-exit/work_packages/74364

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The empty-state text in the GitHub PR tab and GitLab MR/issue tabs was passing the numeric primary key to the i18n interpolation.  Switch to formattedId so the message shows "#42" in classic mode and "PROJ-42" in semantic mode, consistent with the rest of the UI.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
