### PR TITLE
[68633] Asterisks on Project attributes displaced

### DIFF
--- a/app/components/open_project/common/attribute_label_component.sass
+++ b/app/components/open_project/common/attribute_label_component.sass
@@ -27,7 +27,7 @@
 //++
 
 .op-attribute-label
-  display: inline-flex
+  display: inline
 
   > .op-attribute-help-text
     margin-left: var(--base-size-6)

--- a/app/components/open_project/common/attribute_label_component.sass
+++ b/app/components/open_project/common/attribute_label_component.sass
@@ -31,3 +31,4 @@
 
   > .op-attribute-help-text
     margin-left: var(--base-size-6)
+    vertical-align: top

--- a/app/components/open_project/common/attribute_label_component.sass
+++ b/app/components/open_project/common/attribute_label_component.sass
@@ -30,5 +30,6 @@
   display: inline
 
   > .op-attribute-help-text
+    display: inline-flex
+    align-items: center
     margin-left: var(--base-size-6)
-    vertical-align: top


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/68633

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Changing .op-attribute-label from display: inline-flex to display: inline, so the asterisk flows with the text.


## Screenshots
<img width="298" height="357" alt="Screenshot 2026-05-19 at 23 52 53" src="https://github.com/user-attachments/assets/b94f992d-4d66-4ece-a2ef-fac7a2a2e18d" />
