### PR TITLE
[#73494] Role not created properly when unselecting all permissions  

### DIFF
--- a/app/services/roles/set_attributes_service.rb
+++ b/app/services/roles/set_attributes_service.rb
@@ -38,8 +38,10 @@ module Roles
       end
     end
 
-    def set_default_attributes(*)
-      model.permissions = ProjectRole.non_member.permissions if model.permissions.blank? && model.is_a?(ProjectRole)
+    def set_default_attributes(params)
+      if model.permissions.blank? && model.is_a?(ProjectRole) && !params.key?(:permissions)
+        model.permissions = ProjectRole.non_member.permissions
+      end
     end
   end
 end

--- a/spec/services/roles/set_attributes_service_spec.rb
+++ b/spec/services/roles/set_attributes_service_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe Roles::SetAttributesService, type: :model do
         expect(model_instance.permissions).to match_array(OpenProject::AccessControl.public_permissions.map(&:name) + permissions)
       end
 
-      context "when no permissions are given" do
-        let(:permissions) { [] }
+      context "when permissions are explicitly set to empty" do
+        let(:permissions) { [""] }
 
-        it "assigns the permissions the non member role has" do
-          expect(model_instance.permissions).to match_array(ProjectRole.non_member.permissions) # public permissions are included via the factory
+        it "assigns only the public permissions" do
+          expect(model_instance.permissions).to match_array(OpenProject::AccessControl.public_permissions.map(&:name))
         end
       end
     end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/73494

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add another condition when setting default attributes to check if the `permissions` key is present or not
- When that key is present and `model.permissions` is blank (because of the `.compact_blank` [here](https://github.com/opf/openproject/blob/dev/app/models/role.rb#L113)), this means that the permissions were explicitly set to all unchecked and so applying defaults is wrong

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
