### PR TITLE
Follow-up refactors for the text-macro preload cache

### DIFF
--- a/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
+++ b/lib/open_project/text_formatting/filters/pattern_matcher_filter.rb
@@ -42,7 +42,7 @@ module OpenProject::TextFormatting
       end
 
       def call
-        with_matcher_preloads(self.class.matchers.dup) { process_text_nodes }
+        run_with_matcher_preloads { process_text_nodes }
         doc
       end
 
@@ -50,17 +50,18 @@ module OpenProject::TextFormatting
 
       # Wraps the per-node loop in each matcher's `with_preloaded_resources`
       # hook so matchers can warm per-render caches and save/restore them
-      # around nested `format_text` calls. Opt-in: matchers without the hook
-      # are skipped.
-      def with_matcher_preloads(matchers, &)
-        matcher = matchers.shift
-        return yield if matcher.nil?
+      # around nested `format_text` calls. Wrapping happens in reverse so the
+      # first matcher's hook is the outermost frame; matchers without the
+      # hook pass through untouched.
+      def run_with_matcher_preloads(&block)
+        wrapped = block
+        self.class.matchers.reverse_each do |matcher|
+          next unless matcher.respond_to?(:with_preloaded_resources)
 
-        if matcher.respond_to?(:with_preloaded_resources)
-          matcher.with_preloaded_resources(doc, context) { with_matcher_preloads(matchers, &) }
-        else
-          with_matcher_preloads(matchers, &)
+          inner = wrapped
+          wrapped = -> { matcher.with_preloaded_resources(doc, context, &inner) }
         end
+        wrapped.call
       end
 
       def process_text_nodes

--- a/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
+++ b/lib/open_project/text_formatting/matchers/resource_links_matcher.rb
@@ -132,9 +132,10 @@ module OpenProject::TextFormatting
 
       # Returns the preloaded WorkPackage for the given identifier (numeric
       # or semantic), or nil if no preload is active (classic mode, no `#N`
-      # references) or the WP couldn't be resolved.
+      # references) or the WP couldn't be resolved. Lookup keys are always
+      # strings — see `index_by_id_and_identifier`.
       def self.work_package_for(identifier)
-        RequestStore.store[WORK_PACKAGES_LOOKUP_KEY]&.[](identifier.to_s)
+        RequestStore.store.dig(WORK_PACKAGES_LOOKUP_KEY, identifier.to_s)
       end
 
       # Doc-level preload called by `PatternMatcherFilter`. Save/restores
@@ -195,10 +196,13 @@ module OpenProject::TextFormatting
         lookup
       end
 
+      # Keys are stringified at write time so callers can read with a single
+      # `identifier.to_s` regardless of whether the input is a numeric id or
+      # a semantic identifier.
       def self.index_by_id_and_identifier(work_packages)
         work_packages.each_with_object({}) do |wp, lookup|
           lookup[wp.id.to_s] = wp
-          lookup[wp.identifier] = wp if wp.identifier.present?
+          lookup[wp.identifier.to_s] = wp if wp.identifier.present?
         end
       end
       private_class_method :index_by_id_and_identifier

--- a/spec/lib/open_project/text_formatting/matchers/link_handlers/work_packages_spec.rb
+++ b/spec/lib/open_project/text_formatting/matchers/link_handlers/work_packages_spec.rb
@@ -234,13 +234,18 @@ RSpec.describe OpenProject::TextFormatting::Matchers::LinkHandlers::WorkPackages
         rendered = nil
         recorder = ActiveRecord::QueryRecorder.new { rendered = format_text("see #OLDPROJ-1") }
 
-        # Two database round-trips: (1) `where_display_id_in` runs a
+        # Two targeted round-trips: (1) `where_display_id_in` runs a
         # single WP SELECT whose WHERE clause includes an EXISTS
         # subquery against the alias table; (2) a sidecar alias pluck
         # maps the historical input string back to its WP for the
-        # cache. A third statement would indicate an N+1 regression.
-        expect(recorder.log.size).to eq(2)
-        expect(recorder.log.last).to match(/FROM "work_package_semantic_aliases"/)
+        # cache. Scoped greps ignore incidental Setting/permission
+        # queries — a second match on either grep would indicate an
+        # N+1 regression.
+        wp_selects    = recorder.log.grep(/FROM "work_packages"/)
+        alias_selects = recorder.log.grep(/FROM "work_package_semantic_aliases"/)
+                                .grep_v(/FROM "work_packages"/)
+        expect(wp_selects.size).to eq(1)
+        expect(alias_selects.size).to eq(1)
 
         # Renders against the WP's CURRENT display_id, not the historical
         # alias the user typed — old content stays alive but points at the


### PR DESCRIPTION
https://community.openproject.org/wp/74948

Follow-up to #23221  addresses three Should-Fix items from the code review there. No new behaviour; the rendered output is identical to what #23221 already ships:

* The N+1 guard in the alias-fold-in spec was counting the entire `QueryRecorder` log, which meant any incidental Setting or permission query landing on the same render path could flip the test red without indicating a real regression. The guard now greps for the two SELECTs it actually cares about — the batched work_packages query and the sidecar alias pluck — and asserts each appears exactly once.

* The matcher preload wrapping in `PatternMatcherFilter#call` was a recursive shift-and-recurse that mutated a duplicated array and forwarded an anonymous block at every frame. The new shape walks the matcher list in reverse and folds a lambda, so the nesting order — first matcher outermost, opt-in matchers only — is visible without unwinding a recursion. Behaviour is unchanged; only one matcher implements the hook today.

* The work-package preload cache keys are now stringified at write time inside `index_by_id_and_identifier`, matching the read site's `identifier.to_s` and removing an ambient assumption that the `identifier` column never changes type. The single-line read in `work_package_for` also moves from `RequestStore.store[KEY]&.[](identifier.to_s)` to `RequestStore.store.dig(KEY, identifier.to_s)`, and a terse note above the builder documents the stringified-key invariant so a future reader doesn't have to grep call sites to convince themselves a numeric input will resolve.