### PR TITLE
Batch mention-filter lookups by resource type

### DIFF
--- a/lib/open_project/text_formatting/filters/mention_filter.rb
+++ b/lib/open_project/text_formatting/filters/mention_filter.rb
@@ -36,9 +36,16 @@ module OpenProject::TextFormatting
       include OpenProject::ObjectLinking
       include OpenProject::StaticRouting::UrlHelpers
 
+      MENTION_TYPES = {
+        "user" => User,
+        "group" => Group,
+        "work_package" => WorkPackage
+      }.freeze
+
       def call
+        cache = preload_mentioned_records
         doc.search("mention").each do |mention|
-          anchor = mention_anchor(mention)
+          anchor = mention_anchor(mention, cache)
           mention.replace(anchor) if anchor
         end
 
@@ -47,18 +54,33 @@ module OpenProject::TextFormatting
 
       private
 
-      def mention_anchor(mention)
-        mention_instance = class_from_mention(mention)
+      # Resolves all mentioned records in one SELECT per class. Ids stay as
+      # strings so the lookup matches raw `data-id` values without coercion.
+      def preload_mentioned_records
+        mention_ids_by_class.to_h do |klass, ids|
+          [klass, klass.visible.where(id: ids).index_by { |record| record.id.to_s }]
+        end
+      end
 
-        case mention_instance
+      def mention_ids_by_class
+        doc.search("mention").each_with_object(Hash.new { |h, k| h[k] = Set.new }) do |mention, acc|
+          id = mention_id(mention) or next
+          acc[mention_class(mention)] << id
+        end
+      end
+
+      def mention_anchor(mention, cache)
+        record = resolve_mention(mention, cache)
+
+        case record
         when Group
-          group_mention(mention_instance)
+          group_mention(record)
         when User
-          user_mention(mention_instance)
+          user_mention(record)
         when WorkPackage
-          work_package_mention(mention_instance, mention)
+          work_package_mention(record, mention)
         else
-          mention_instance
+          record
         end
       end
 
@@ -99,21 +121,14 @@ module OpenProject::TextFormatting
         end
       end
 
-      def class_from_mention(mention)
-        mention_class = case mention.attributes["data-type"].value
-                        when "user"
-                          User
-                        when "group"
-                          Group
-                        when "work_package"
-                          WorkPackage
-                        else
-                          raise ArgumentError
-                        end
+      def resolve_mention(mention, cache)
+        klass = mention_class(mention)
+        id = mention_id(mention)
+        cache.dig(klass, id) || fallback_text(mention)
+      end
 
-        mention_class
-          .visible
-          .find_by(id: mention_id(mention)) || fallback_text(mention)
+      def mention_class(mention)
+        MENTION_TYPES.fetch(mention["data-type"]) { raise ArgumentError }
       end
 
       ##
@@ -127,7 +142,7 @@ module OpenProject::TextFormatting
       def controller; end
 
       def mention_id(mention)
-        value = mention.attributes["data-id"]&.value
+        value = mention["data-id"]
         # Reject semantic-shaped data-ids: `PROJ-42` must not silently
         # resolve to WP id 42 via embedded-digit extraction.
         value if value&.match?(/\A\d+\z/)

--- a/spec/lib/open_project/text_formatting/filters/mention_filter_spec.rb
+++ b/spec/lib/open_project/text_formatting/filters/mention_filter_spec.rb
@@ -197,4 +197,84 @@ RSpec.describe OpenProject::TextFormatting::Filters::MentionFilter do
       end
     end
   end
+
+  describe "batching across mention classes" do
+    shared_let(:role) { create(:project_role, permissions: %i[view_work_packages]) }
+    shared_let(:project) { create(:project) }
+    shared_let(:author) { create(:user, member_with_roles: { project => role }) }
+
+    before { login_as(author) }
+
+    def user_mention(user)
+      %(<mention class="mention" data-id="#{user.id}" data-type="user" data-text="@#{user.name}">@#{user.name}</mention>)
+    end
+
+    def group_mention(group)
+      %(<mention class="mention" data-id="#{group.id}" data-type="group" data-text="@#{group.name}">@#{group.name}</mention>)
+    end
+
+    def work_package_mention(work_package)
+      id = work_package.id
+      %(<mention class="mention" data-id="#{id}" data-type="work_package" data-text="##{id}">##{id}</mention>)
+    end
+
+    describe "query count" do
+      let!(:users) { create_list(:user, 3, member_with_roles: { project => role }) }
+      let!(:groups) { create_list(:group, 2, member_with_roles: { project => role }) }
+      let!(:work_packages) { create_list(:work_package, 3, project:, author:) }
+
+      let(:raw) do
+        [
+          *users.map { user_mention(it) },
+          *groups.map { group_mention(it) },
+          *work_packages.map { work_package_mention(it) }
+        ].join(" ")
+      end
+
+      it "fetches each mention class with a single IN-batched SELECT and zero per-record find_bys" do
+        recorder = ActiveRecord::QueryRecorder.new { format_text(raw) }
+
+        principal_batched = recorder.log.grep(/SELECT "users"\..*FROM "users".*"users"\."id" IN/i)
+        principal_per_record = recorder.log.grep(/SELECT "users"\..*FROM "users".*"users"\."id" = .* LIMIT/i)
+        wp_batched = recorder.log.grep(/SELECT "work_packages"\..*FROM "work_packages".*"work_packages"\."id" IN/i)
+        wp_per_record = recorder.log.grep(/SELECT "work_packages"\..*FROM "work_packages".*"work_packages"\."id" = .* LIMIT/i)
+
+        # User and Group inherit Principal.visible but apply distinct STI
+        # type filters, so the batched form issues one SELECT per class.
+        expect(principal_batched.size).to eq(2),
+                                          "expected 2 batched principal SELECTs (User + Group), " \
+                                          "got #{principal_batched.size}:\n#{principal_batched.join("\n")}"
+        expect(wp_batched.size).to eq(1),
+                                   "expected 1 batched work_packages SELECT, got #{wp_batched.size}:\n" \
+                                   "#{wp_batched.join("\n")}"
+        expect(principal_per_record).to be_empty,
+                                        "expected zero per-record principal find_bys, got:\n#{principal_per_record.join("\n")}"
+        expect(wp_per_record).to be_empty,
+                                 "expected zero per-record work_package find_bys, got:\n#{wp_per_record.join("\n")}"
+      end
+    end
+
+    describe "visibility per record" do
+      let!(:visible_user) { create(:user, member_with_roles: { project => role }) }
+      let!(:invisible_user) { create(:user) } # no project membership, not visible to author
+
+      it "renders visible records as links and falls back to plain text for invisible ones in the same batch" do
+        raw = [user_mention(visible_user), user_mention(invisible_user)].join(" ")
+
+        rendered = format_text(raw)
+
+        expect(rendered).to include(%(href="/users/#{visible_user.id}"))
+        expect(rendered).not_to include(%(href="/users/#{invisible_user.id}"))
+        expect(rendered).to include("@#{invisible_user.name}")
+      end
+    end
+
+    describe "unknown data-type" do
+      it "raises ArgumentError" do
+        raw = %(<mention class="mention" data-id="1" data-type="bogus" data-text="@x">@x</mention>)
+
+        expect { format_text(raw) }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

`MentionFilter` now groups `<mention>` `data-id`s by class up front and runs one `klass.visible.where(id: ids)` per class present — capping the filter at ≤3 SELECTs (User, Group, WorkPackage STI tables) regardless of how many mentions the document holds.

## Why

Each `<mention>` previously triggered its own `klass.visible.find_by(id:)`, so a comment with N mentions ran N indexed-PK queries — bounded but trivially batchable. Follow-up to the discussion on #23221 (per-record `find_by` tightening). `ResourceLinksMatcher.with_preloaded_resources` from #23211 was considered as the shared hook but is WP-specific (alias fold-in, semantic-mode gate, runs after `MentionFilter` in the pipeline) — a filter-local batcher is the cleaner shape.

The unknown `data-type` `ArgumentError` now fires during preload rather than lazily per-node. Same exception, earlier point.

## Test plan

- [ ] \`spec/lib/open_project/text_formatting/filters/mention_filter_spec.rb\` — query-count and per-record visibility under batching
- [ ] \`spec/lib/open_project/text_formatting/markdown/mentions_spec.rb\` — existing User/Group mention rendering and visibility scenarios continue to pass