### PR TITLE
[#75159] Past meetings filter is missing sorting query on mWeb  

### DIFF
--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -452,10 +452,14 @@ class MeetingsController < ApplicationController
   end
 
   def apply_default_time_filter_and_sort(query)
-    return if query.filters.any? { |f| f.name == :time }
+    time_filter = query.filters.find { |f| f.name == :time }
 
-    query.where("time", "=", Queries::Meetings::Filters::TimeFilter::FUTURE_VALUE)
-    query.order(start_time: :asc)
+    if time_filter.nil?
+      query.where("time", "=", Queries::Meetings::Filters::TimeFilter::FUTURE_VALUE)
+      query.order(start_time: :asc)
+    elsif time_filter.past? && query.orders.none?
+      query.order(start_time: :desc)
+    end
   end
 
   def apply_default_filter_if_none_given(query)

--- a/modules/meeting/spec/features/meetings_index_spec.rb
+++ b/modules/meeting/spec/features/meetings_index_spec.rb
@@ -202,6 +202,50 @@ RSpec.describe "Meetings", "Index", :js do
         end
       end
 
+      context 'when applying the "Past" time filter without sortBy (Bug #75159)' do
+        let(:one_hour_ago_meeting) do
+          create(:meeting,
+                 project:,
+                 title: "One hour ago meeting",
+                 start_time: business_day_at_noon - 1.hour)
+        end
+        let(:three_hours_ago_meeting) do
+          create(:meeting,
+                 project:,
+                 title: "Three hours ago meeting",
+                 start_time: business_day_at_noon - 3.hours)
+        end
+
+        before do
+          three_hours_ago_meeting
+          one_hour_ago_meeting
+        end
+
+        it "shows past meetings sorted by descending start time" do
+          # On mobile the segmented quick filter is hidden, so users apply the past
+          # filter via the all filters form. That form does not add sortBy to the URL.
+          # The backend must apply start_time: :desc as a default in this case
+          time_filters = [{ "time" => { "operator" => "=", "values" => ["past"] } }].to_json
+
+          if context == :global
+            visit meetings_path(filters: time_filters)
+          else
+            visit project_meetings_path(project, filters: time_filters)
+          end
+
+          wait_for_network_idle
+
+          meetings_page.expect_meetings_listed_in_order(
+            meeting,
+            ongoing_meeting,
+            one_hour_ago_meeting,
+            three_hours_ago_meeting,
+            yesterdays_meeting
+          )
+          meetings_page.expect_meetings_not_listed(tomorrows_meeting)
+        end
+      end
+
       context 'with the "Attendee" filter' do
         before do
           meetings_page.set_sidebar_filter "Attended"


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/75159

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- The quick filter combines a sort order with the filter options
- This was missing when the quick filter is hidden for mobile and a user filters for past meetings via the advanced filters
- This fix adds a default sort order when filtering for past meetings

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
