### PR TITLE
[#72945] Container header (Sprint/Bucket/Inbox) restyling [FOLLOW UP]

### DIFF
--- a/app/components/open_project/common/border_box_list_component.sass
+++ b/app/components/open_project/common/border_box_list_component.sass
@@ -66,12 +66,6 @@
   &--heading
     min-width: 0
 
-  &--description
-    display: flex
-    align-items: center
-    gap: var(--stack-gap-normal)
-    color: var(--fgColor-muted)
-
   &--actions,
   &--menu
     margin-left: var(--stack-gap-normal)

--- a/app/components/open_project/common/border_box_list_component/header.html.erb
+++ b/app/components/open_project/common/border_box_list_component/header.html.erb
@@ -43,7 +43,7 @@ See COPYRIGHT and LICENSE files for more details.
           )
         ) do |collapsible|
       %>
-        <% collapsible.with_title(tag: title_tag) { title } %>
+        <% collapsible.with_title(**title_arguments, tag: title_tag) { title } %>
         <% if render_count? %>
           <% collapsible.with_count(**counter_arguments) %>
         <% end %>
@@ -57,7 +57,7 @@ See COPYRIGHT and LICENSE files for more details.
   <% else %>
     <% grid.with_area(:heading) do %>
       <%= render(Primer::BaseComponent.new(tag: :div, classes: "op-border-box-list-header--heading-line")) do %>
-        <%= render(Primer::Beta::Truncate.new(tag: title_tag, classes: "Box-title")) { title } %>
+        <%= render(Primer::Beta::Truncate.new(**title_arguments, tag: title_tag, classes: title_classes)) { title } %>
         <% if render_count? %>
           <%= render(Primer::Beta::Counter.new(**counter_arguments)) %>
         <% end %>

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -88,6 +88,7 @@ module OpenProject
                     :count_label,
                     :count_arguments,
                     :title_tag,
+                    :title_arguments,
                     :list_id,
                     :interactive,
                     :collapsed,
@@ -105,6 +106,7 @@ module OpenProject
         # @param count_arguments [Hash] forwarded to `Primer::Beta::Counter`.
         #   Values are merged over the default counter arguments.
         # @param title_tag [Symbol] tag used for the title heading.
+        # @param title_arguments [Hash] forwarded to the title heading.
         # @param list_id [String, nil] id of the collapsible list body.
         # @param interactive [Boolean] whether counter updates should be
         #   announced politely to assistive technology.
@@ -119,6 +121,7 @@ module OpenProject
           count_label: nil,
           count_arguments: {},
           title_tag: :h4,
+          title_arguments: {},
           list_id: nil,
           interactive: false,
           collapsed: false,
@@ -132,6 +135,7 @@ module OpenProject
           @count_label = count_label
           @count_arguments = count_arguments
           @title_tag = title_tag
+          @title_arguments = title_arguments.except(:tag)
           @list_id = list_id
           @interactive = interactive
           @collapsible_id = list_id
@@ -174,6 +178,11 @@ module OpenProject
             merged
           )
           merged
+        end
+
+        # @return [String] classes forwarded to the non-collapsible title.
+        def title_classes
+          class_names("Box-title", title_arguments[:classes])
         end
 
         # @return [String, nil] ids controlled by the collapsible header.

--- a/app/components/open_project/common/border_box_list_component/header.rb
+++ b/app/components/open_project/common/border_box_list_component/header.rb
@@ -56,10 +56,19 @@ module OpenProject
         # @!parse
         #   # Adds secondary content below the header title.
         #   #
+        #   # The content is wrapped in `Primer::Beta::Text` with muted text
+        #   # color by default. Pass Primer system arguments to adjust layout,
+        #   # spacing, or color for more structured descriptions.
+        #   #
+        #   # @param system_arguments [Hash] forwarded to `Primer::Beta::Text`.
         #   # @return [ViewComponent::Slot]
-        #   def with_description(&block)
+        #   def with_description(**system_arguments, &block)
         #   end
-        renders_one :description
+        renders_one :description, ->(**system_arguments) do
+          system_arguments[:color] ||= :muted
+
+          Primer::Beta::Text.new(**system_arguments)
+        end
 
         # @!parse
         #   # Adds a button to the header actions area.

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -46,7 +46,7 @@ See COPYRIGHT and LICENSE files for more details.
           }
         )
       ) do |list| %>
-    <% list.with_header(title: t(".title"), count: work_packages.size) %>
+    <% list.with_header(title: t(".title"), count: work_packages.size, title_arguments: { font_size: 4 }) %>
 
     <% list.with_empty_state(
          title: t(".blankslate_title"),

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -36,7 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
           interactive: true,
           scheme: :transparent,
           padding: :condensed,
-          header_padding: :spacious,
+          header_padding: :default,
           test_selector: "backlog-inbox",
           data: {
             generic_drag_and_drop_target: "container",

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -43,17 +43,19 @@ See COPYRIGHT and LICENSE files for more details.
         )
       ) do |list| %>
     <% list.with_header(title: sprint.name) do |header| %>
-      <% header.with_description do %>
-        <%= render(Backlogs::SprintStatusBadgeComponent.new(sprint:)) %>
+      <% header.with_description(display: :flex, direction: :column, classes: "row-gap-2") do %>
+        <%= render(Primer::Alpha::Stack.new(direction: :horizontal, align: :center)) do %>
+          <%= render(Backlogs::SprintStatusBadgeComponent.new(sprint:)) %>
 
-        <%= render(Primer::Beta::Text.new(classes: "velocity", aria: { live: "polite" })) do %>
-          <%= story_points_total %>&nbsp;<%= t(:"backlogs.points_label", count: story_points_total) %>
-        <% end %>
+          <%= render(Primer::Beta::Text.new(classes: "velocity", aria: { live: "polite" })) do %>
+            <%= story_points_total %>&nbsp;<%= t(:"backlogs.points_label", count: story_points_total) %>
+          <% end %>
 
-        <% if sprint.date_range_set? %>
-          <%= render(Primer::Beta::Text.new(role: :group, ml: :auto, mr: 2)) do %>
-            <%= render(Primer::Beta::Octicon.new(:calendar, size: :small, mr: 1)) %>
-            <%= format_date_range([sprint.start_date, sprint.finish_date]) %>
+          <% if sprint.date_range_set? %>
+            <%= render(Primer::Beta::Text.new(role: :group, ml: :auto, mr: 2)) do %>
+              <%= render(Primer::Beta::Octicon.new(:calendar, size: :small, mr: 1)) %>
+              <%= format_date_range([sprint.start_date, sprint.finish_date]) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -62,7 +62,7 @@ module Backlogs
 
       @system_arguments = system_arguments
       @system_arguments[:padding] = :condensed
-      @system_arguments[:header_padding] = :spacious
+      @system_arguments[:header_padding] = :default
       merge_drag_and_drop_data! if drag_and_drop
 
       @list = OpenProject::Common::BorderBoxListComponent.new(

--- a/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_list_component.rb
@@ -81,6 +81,9 @@ module Backlogs
       **system_arguments,
       &
     )
+      system_arguments[:title_arguments] ||= {}
+      system_arguments[:title_arguments][:font_size] ||= 4
+
       @list.with_header(
         title:,
         count:,

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
 
       it "renders the bucket title in the header" do
         expect(rendered_component).to have_heading "Ready for development", level: 4
+        expect(rendered_component).to have_css("h4.f4", text: "Ready for development")
       end
 
       it "renders the generic work-package count in the header" do

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
 
     it "renders the inbox title" do
       expect(page).to have_heading "Inbox", level: 4
+      expect(page).to have_css("h4.f4", text: "Inbox")
     end
 
     it "renders the work-package count" do

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
 
       it "renders the sprint title in the header" do
         expect(rendered_component).to have_heading "Sprint 1", level: 4
+        expect(rendered_component).to have_css("h4.f4", text: "Sprint 1")
       end
 
       it "renders the story points total in the header description" do

--- a/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_list_component_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Backlogs::WorkPackageCardListComponent, type: :component do
 
     it "keeps condensed row padding with spacious header padding" do
       expect(rendered_component).to have_css(
-        ".Box.Box--condensed.op-border-box-list_header-padding-spacious"
+        ".Box.Box--condensed.op-border-box-list_header-padding-default"
       )
     end
 

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -198,6 +198,23 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(".op-border-box-list-header--description", text: "Some description")
     end
 
+    it "forwards system arguments to the description text" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-description-args")
+      ) do |list|
+        list.with_header(title: "My title") do |header|
+          header.with_description(display: :flex, direction: :column, classes: "row-gap-2") do
+            "Some description"
+          end
+        end
+        list.with_item { "row" }
+      end
+
+      expect(rendered)
+        .to have_css(".op-border-box-list-header--description .d-flex.flex-column.row-gap-2.color-fg-muted",
+                     text: "Some description")
+    end
+
     it "renders multiple action buttons" do
       rendered = render_inline(
         described_class.new(container: "hdr-actions")

--- a/spec/components/open_project/common/border_box_list_component_spec.rb
+++ b/spec/components/open_project/common/border_box_list_component_spec.rb
@@ -408,6 +408,31 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
 
       expect(rendered).to have_heading("Custom title", level: 3)
     end
+
+    it "forwards title arguments" do
+      rendered = render_inline(
+        described_class.new(container: "hdr-title-args")
+      ) do |list|
+        list.with_header(
+          title: "Described title",
+          title_tag: :h4,
+          title_arguments: {
+            tag: :h2,
+            id: "custom-title",
+            classes: "custom-title-class",
+            data: { title: "custom" },
+            aria: { describedby: "goal-text" }
+          }
+        )
+        list.with_item { "row" }
+      end
+
+      expect(rendered).to have_css(
+        "h4#custom-title.Box-title.custom-title-class[data-title='custom']",
+        text: "Described title",
+        aria: { describedby: "goal-text" }
+      )
+    end
   end
 
   describe "header collapsible behavior" do
@@ -439,6 +464,25 @@ RSpec.describe OpenProject::Common::BorderBoxListComponent, type: :component do
       expect(rendered).to have_css(
         "[aria-controls='collapse-no-footer_list']"
       )
+    end
+
+    it "forwards title arguments to the collapsible title" do
+      rendered = render_inline(
+        described_class.new(container: "collapse-title-args", collapsible: true)
+      ) do |list|
+        list.with_header(
+          title: "Collapsible",
+          title_arguments: { aria: { describedby: "collapsible-help" } }
+        )
+        list.with_item(id: "collapsible-help") { "Helpful row" }
+      end
+
+      expect(rendered).to have_heading(
+        "Collapsible",
+        level: 4,
+        accessible_description: "Helpful row"
+      )
+      expect(rendered).to have_css("h4", text: "Collapsible", aria: { describedby: "collapsible-help" })
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72945 (follow up)

# What are you trying to accomplish?

Addresses feedback from design round - adjusting header padding and text size

See original PR #23215 

## Screenshots

<img width="1228" height="705" alt="image" src="https://github.com/user-attachments/assets/8c52bbcd-a45a-4694-97c4-e836786a8811" />


# Merge checklist

- [X] Added/updated tests
- [X] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
