### PR TITLE
Bug/74773 closed work packages are still considered to be part of the bucket

### DIFF
--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.rb
@@ -35,14 +35,13 @@ module Backlogs
     include OpPrimer::ComponentHelpers
     include CommonHelper
 
-    attr_reader :work_package, :project, :max_position, :current_user, :open_sprints_exist
+    attr_reader :work_package, :project, :open_sprints_exist, :current_user
 
-    def initialize(work_package:, project:, max_position:, open_sprints_exist:, current_user: User.current)
+    def initialize(work_package:, project:, open_sprints_exist:, current_user: User.current)
       super()
 
       @work_package = work_package
       @project = project
-      @max_position = max_position
       @open_sprints_exist = open_sprints_exist
       @current_user = current_user
     end
@@ -72,33 +71,49 @@ module Backlogs
 
     def build_move_menu(menu)
       unless first_item?
-        build_move_item(menu, label: I18n.t(:label_sort_highest), direction: "highest", icon: :"move-to-top")
-        build_move_item(menu, label: I18n.t(:label_sort_higher), direction: "higher", icon: :"chevron-up")
+        build_move_item(menu, label: :label_sort_highest, direction: "highest", icon: :"move-to-top")
+        build_move_item(menu, label: :label_sort_higher, prev_id: work_package.prev_prev_id, icon: :"chevron-up")
       end
       unless last_item?
-        build_move_item(menu, label: I18n.t(:label_sort_lower), direction: "lower", icon: :"chevron-down")
-        build_move_item(menu, label: I18n.t(:label_sort_lowest), direction: "lowest", icon: :"move-to-bottom")
+        build_move_item(menu, label: :label_sort_lower, prev_id: work_package.next_id, icon: :"chevron-down")
+        build_move_item(menu, label: :label_sort_lowest, direction: "lowest", icon: :"move-to-bottom")
       end
     end
 
-    def build_move_item(menu, label:, direction:, icon:)
+    def build_move_item(menu, label:, icon:, direction: nil, prev_id: nil)
+      inputs = if direction
+                 [{ name: "direction", value: direction }]
+               else
+                 [{ name: "target_id", value: move_target_id }, { name: "prev_id", value: prev_id }]
+               end
+
       menu.with_item(
-        id: dom_target(work_package, :menu, direction),
-        label:,
+        id: dom_target(work_package, :menu, label),
+        label: I18n.t(label),
         tag: :button,
         href: move_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
-        form_arguments: { method: :put, inputs: [{ name: "direction", value: direction }] }
+        form_arguments: { method: :put, inputs: }
       ) do |item|
         item.with_leading_visual_icon(icon:)
       end
     end
 
     def first_item?
-      work_package.position == 1
+      work_package.prev_id.nil?
     end
 
     def last_item?
-      work_package.position == max_position
+      work_package.next_id.nil?
+    end
+
+    def move_target_id
+      @move_target_id ||= if work_package.backlog_bucket_id?
+                            "backlog_bucket:#{work_package.backlog_bucket_id}"
+                          elsif work_package.sprint_id?
+                            "sprint:#{work_package.sprint_id}"
+                          else
+                            "inbox"
+                          end
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -36,7 +36,7 @@ module Backlogs
 
     # Deferred ActionMenu items (Primer include-fragment).
     def menu
-      max_position = displayed_work_packages.maximum(:position) || 0
+      work_package = displayed_work_packages.with_backlogs_neighbours.find(@work_package.id)
 
       open_sprints_exist = Sprint.for_project(@project)
                                  .visible
@@ -45,9 +45,8 @@ module Backlogs
                                  .exists?
 
       render(Backlogs::WorkPackageCardMenuComponent.new(
-               work_package: @work_package,
                project: @project,
-               max_position:,
+               work_package:,
                open_sprints_exist:,
                current_user:
              ),
@@ -112,7 +111,7 @@ module Backlogs
     end
 
     def load_work_package
-      @work_packages = WorkPackage.visible.where(project: @project)
+      @work_packages = WorkPackage.visible.where(project: @project).order_by_position
       @work_package = @work_packages.find(params.expect(:id))
     end
 

--- a/modules/backlogs/app/models/work_packages/scopes/with_backlogs_neighbours.rb
+++ b/modules/backlogs/app/models/work_packages/scopes/with_backlogs_neighbours.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,45 +26,24 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module OpenProject::Backlogs::Patches::WorkPackagePatch
+module WorkPackages::Scopes::WithBacklogsNeighbours
   extend ActiveSupport::Concern
 
-  included do
-    prepend InstanceMethods
-    extend ClassMethods
-
-    register_journal_formatted_fields "story_points", "position", formatter_key: :decimal
-
-    validates_numericality_of :story_points, only_integer: true,
-                                             allow_nil: true,
-                                             greater_than_or_equal_to: 0,
-                                             less_than: 10_000,
-                                             if: -> { backlogs_enabled? }
-
-    belongs_to :sprint, optional: true
-    belongs_to :backlog_bucket, optional: true
-
-    include OpenProject::Backlogs::List
-
-    scopes :backlogs_inbox_for
-    scopes :with_backlogs_neighbours
-    scopes :without_status_considered_closed
-    scopes :without_excluded_type
-  end
-
-  module ClassMethods
-    def order_by_position
-      order(arel_table[:position].asc.nulls_last)
-    end
-  end
-
-  module InstanceMethods
-    def backlogs_enabled?
-      project&.backlogs_enabled?
+  class_methods do
+    def with_backlogs_neighbours
+      # The subquery is required because window functions run before WHERE clauses.
+      # Chaining .find(id) directly would filter rows first, leaving the window function
+      # with a single row and returning nil for all neighbours. Wrapping in a subquery
+      # lets the window function see the full scope, then the outer query filters to the
+      # requested record.
+      subquery = order_by_position.select(
+        "*, LAG(id)    OVER (ORDER BY position) AS prev_id,
+            LAG(id, 2) OVER (ORDER BY position) AS prev_prev_id,
+            LEAD(id)   OVER (ORDER BY position) AS next_id"
+      )
+      WorkPackage.from(subquery, :work_packages)
     end
   end
 end
-
-WorkPackage.include OpenProject::Backlogs::Patches::WorkPackagePatch

--- a/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/permitted_params_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #-- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
@@ -42,4 +44,3 @@ module OpenProject::Backlogs::Patches::PermittedParamsPatch
     end
   end
 end
-PermittedParams.include OpenProject::Backlogs::Patches::PermittedParamsPatch

--- a/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/project_patch.rb
@@ -45,5 +45,3 @@ module OpenProject::Backlogs::Patches::ProjectPatch
     module_enabled? "backlogs"
   end
 end
-
-Project.include OpenProject::Backlogs::Patches::ProjectPatch

--- a/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
+++ b/modules/backlogs/lib/open_project/backlogs/patches/work_package_patch.rb
@@ -66,5 +66,3 @@ module OpenProject::Backlogs::Patches::WorkPackagePatch
     end
   end
 end
-
-WorkPackage.include OpenProject::Backlogs::Patches::WorkPackagePatch

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -40,27 +40,36 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
 
   let(:project) { create(:project, types: [type_feature, type_task]) }
   let(:sprint) { create(:sprint, project:, name: "Sprint 1", start_date: Date.yesterday, finish_date: Date.tomorrow) }
-  let(:position) { 2 }
-  let(:max_position) { 3 }
-  let(:work_package) do
+  let!(:first_story) { create_story(position: 1) }
+  let!(:second_story) { create_story(position: 2) }
+  let!(:third_story) { create_story(position: 3) }
+  let!(:fourth_story) { create_story(position: 4) }
+  let(:displayed_work_packages) { WorkPackage.where(sprint:).order_by_position }
+  let(:work_package) { enrich_with_neighbours(second_story) }
+
+  def enrich_with_neighbours(work_package, scope: displayed_work_packages)
+    scope.with_backlogs_neighbours.find(work_package.id)
+  end
+
+  def create_story(position:, subject: "Test Story", story_points: 5)
     create(:work_package,
-           subject: "Test Story",
+           subject:,
            project:,
            type: type_feature,
            status: default_status,
            priority: default_priority,
-           story_points: 5,
+           story_points:,
            position:,
            sprint:)
   end
 
-  def render_component(position: 2, max_position: 3, open_sprints_exist: true)
-    work_package.update!(position:)
-    render_inline(described_class.new(work_package:,
-                                      project:,
-                                      max_position:,
-                                      open_sprints_exist:,
-                                      current_user: user))
+  def render_component(work_package: self.work_package, open_sprints_exist: true)
+    render_inline(described_class.new(
+                    work_package:,
+                    project:,
+                    open_sprints_exist:,
+                    current_user: user
+                  ))
   end
 
   describe "standard items" do
@@ -204,55 +213,80 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       expect(page).to have_text(I18n.t(:label_sort_lowest))
       expect(page).to have_octicon(:"move-to-bottom")
     end
-  end
 
-  describe "position logic" do
-    context "when item is first (position=1)" do
+    context "when item is first" do
+      let(:work_package) { enrich_with_neighbours(first_story) }
+
       it "hides Move to top and Move up" do
-        render_component(position: 1, max_position: 3)
+        render_component
 
         expect(page).to have_no_text(I18n.t(:label_sort_highest))
         expect(page).to have_no_text(I18n.t(:label_sort_higher))
       end
 
-      it "shows Move down and Move to bottom" do
-        render_component(position: 1, max_position: 3)
+      it "shows Move down and Move to bottom, sending next_id as prev_id" do
+        render_component
 
         expect(page).to have_text(I18n.t(:label_sort_lower))
         expect(page).to have_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_field("prev_id", type: :hidden, count: 1)
+        expect(page).to have_field("prev_id", type: :hidden, with: second_story.id.to_s)
       end
     end
 
-    context "when item is last (position=max)" do
+    context "when item is in the middle with one predecessor" do
+      it "shows all move options, sending nil prev_id for Move up and next_id as prev_id for Move down" do
+        render_component
+
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_field("prev_id", type: :hidden, count: 2)
+        expect(page).to have_field("prev_id", type: :hidden, with: third_story.id.to_s)
+      end
+    end
+
+    context "when item is in the middle with two predecessors" do
+      let(:work_package) { enrich_with_neighbours(third_story) }
+
+      it "shows all move options, sending prev_prev_id and next_id as prev_id" do
+        render_component
+
+        expect(page).to have_text(I18n.t(:label_sort_highest))
+        expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_text(I18n.t(:label_sort_lower))
+        expect(page).to have_text(I18n.t(:label_sort_lowest))
+        expect(page).to have_field("prev_id", type: :hidden, with: first_story.id.to_s)
+        expect(page).to have_field("prev_id", type: :hidden, with: fourth_story.id.to_s)
+      end
+    end
+
+    context "when item is last" do
+      let(:work_package) { enrich_with_neighbours(fourth_story) }
+
       it "hides Move down and Move to bottom" do
-        render_component(position: 3, max_position: 3)
+        render_component
 
         expect(page).to have_no_text(I18n.t(:label_sort_lower))
         expect(page).to have_no_text(I18n.t(:label_sort_lowest))
       end
 
-      it "shows Move to top and Move up" do
-        render_component(position: 3, max_position: 3)
+      it "shows Move to top and Move up, sending prev_prev_id as prev_id" do
+        render_component
 
         expect(page).to have_text(I18n.t(:label_sort_highest))
         expect(page).to have_text(I18n.t(:label_sort_higher))
+        expect(page).to have_field("prev_id", type: :hidden, count: 1)
+        expect(page).to have_field("prev_id", type: :hidden, with: second_story.id.to_s)
       end
     end
 
-    context "when item is in the middle" do
-      it "shows all move options" do
-        render_component(position: 2, max_position: 3)
+    context "when there is only one item" do
+      let(:displayed_work_packages) { WorkPackage.where(id: second_story.id).order_by_position }
 
-        expect(page).to have_text(I18n.t(:label_sort_highest))
-        expect(page).to have_text(I18n.t(:label_sort_higher))
-        expect(page).to have_text(I18n.t(:label_sort_lower))
-        expect(page).to have_text(I18n.t(:label_sort_lowest))
-      end
-    end
-
-    context "when there is only one item (position=1, max=1)" do
       it "hides all move options" do
-        render_component(position: 1, max_position: 1)
+        render_component
 
         expect(page).to have_no_text(I18n.t(:label_sort_highest))
         expect(page).to have_no_text(I18n.t(:label_sort_higher))
@@ -261,12 +295,9 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       end
 
       it "hides the Move submenu when no other open sprints exist" do
-        render_component(position: 1, max_position: 1, open_sprints_exist: false)
+        render_component(open_sprints_exist: false)
 
-        expect(page).to have_no_selector(
-          :menuitem,
-          text: "Move"
-        )
+        expect(page).to have_no_selector(:menuitem, text: "Move")
       end
     end
   end

--- a/modules/backlogs/spec/models/work_packages/scopes/with_backlogs_neighbours_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/scopes/with_backlogs_neighbours_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe WorkPackages::Scopes::WithBacklogsNeighbours do
+  let(:project) { create(:project) }
+  let(:open_status) { create(:status, is_closed: false) }
+  let(:closed_status) { create(:status, is_closed: true) }
+
+  def neighbours(work_package, scope: WorkPackage.where(project:).order_by_position)
+    scope.with_backlogs_neighbours.find(work_package.id)
+  end
+
+  describe ".with_backlogs_neighbours" do
+    context "with four items" do
+      # Created in scrambled order so id sequence is not the same as the position
+      let!(:wp1) { create(:work_package, project:, status: open_status, position: 1) }
+      let!(:wp4) { create(:work_package, project:, status: open_status, position: 4) }
+      let!(:wp2) { create(:work_package, project:, status: open_status, position: 2) }
+      let!(:wp3) { create(:work_package, project:, status: open_status, position: 3) }
+
+      context "for the first item" do
+        subject { neighbours(wp1) }
+
+        it { is_expected.to have_attributes(prev_prev_id: nil, prev_id: nil, next_id: wp2.id) }
+      end
+
+      context "for the second item" do
+        subject { neighbours(wp2) }
+
+        it { is_expected.to have_attributes(prev_prev_id: nil, prev_id: wp1.id, next_id: wp3.id) }
+      end
+
+      context "for a middle item with two predecessors" do
+        subject { neighbours(wp3) }
+
+        it { is_expected.to have_attributes(prev_prev_id: wp1.id, prev_id: wp2.id, next_id: wp4.id) }
+      end
+
+      context "for the last item" do
+        subject { neighbours(wp4) }
+
+        it { is_expected.to have_attributes(prev_prev_id: wp2.id, prev_id: wp3.id, next_id: nil) }
+      end
+    end
+
+    context "when the scope excludes closed work packages" do
+      let(:project) { create(:project) }
+      let!(:first_open) { create(:work_package, project:, status: open_status, position: 1) }
+      let!(:closed_wp) { create(:work_package, project:, status: closed_status, position: 2) }
+      let!(:last_open) { create(:work_package, project:, status: open_status, position: 3) }
+
+      subject { neighbours(last_open, scope: WorkPackage.where(project:, status: open_status).order_by_position) }
+
+      it { is_expected.to have_attributes(prev_prev_id: nil, prev_id: first_open.id, next_id: nil) }
+    end
+
+    context "when the scope excludes work packages of an excluded type" do
+      let(:project) { create(:project) }
+      let(:included_type) { create(:type_feature) }
+      let(:excluded_type) { create(:type_task) }
+      let!(:first_included) { create(:work_package, project:, status: open_status, type: included_type, position: 1) }
+      let!(:excluded_wp) { create(:work_package, project:, status: open_status, type: excluded_type, position: 2) }
+      let!(:last_included) { create(:work_package, project:, status: open_status, type: included_type, position: 3) }
+
+      subject { neighbours(last_included, scope: WorkPackage.where(project:, type: included_type).order_by_position) }
+
+      it { is_expected.to have_attributes(prev_prev_id: nil, prev_id: first_included.id, next_id: nil) }
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74773

# What are you trying to accomplish?
Not consider excluded work packages from the list when moving a work package up or down on the list.

# What approach did you choose and why?
- [X] Rely on the `prev_id` instead of the position when rendering move up/down menu items. Position was unreliable, because we do exclude items from the list for example, closed work packages and excluded work package types. This feature will also enable us to render move up/down buttons with correct actions when filtering of work packages will be implemented in the sprints page.
- [X] Implement a work package scope that loads `prev_prev_id`, `prev_id` and `next_id` on the database level. So each filtered work package scope can have its own neighbouring ids included. This is required for rendering the correct `prev_id` for move up/down actions.
- [X] Remove the now redundant `max_position` from the menu component argument. Rely on the `prev_id`, `next_id` instead in the `first_item?`, `last_item?` methods.

# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
