### PR TITLE
simplify enterprise banner on sprint sharing

### DIFF
--- a/app/helpers/enterprise_helper.rb
+++ b/app/helpers/enterprise_helper.rb
@@ -33,17 +33,24 @@ module EnterpriseHelper
   # Renders the enterprise banner component with a guard for the given feature key.
   # If the feature is not enabled, it will not render the given block.
   #
-  # Parameters:
-  # - feature_key: The key that identifies the specific enterprise feature.
-  # - inactive_guard: A boolean flag determining whether the guard should be active
+  # @param feature_key [Symbol] The key identifying the specific enterprise feature.
+  # @param inactive_guard [Boolean] Determines whether the guard should be active
   #   or bypassed. If set to `true`, the guard is bypassed and only the block is executed.
   #   Defaults to `false`.
-  # - **args: Additional keyword arguments to be passed to the banner component.
+  # @param inline_fallback [Boolean] Enables the banner to switch to the inline variant if true. In that case,
+  #   the block is yielded as well.
+  #   Defaults to `false`.
+  # @param args [Hash] Additional keyword arguments to be passed to the banner component.
   #
-  # Yields:
-  # - Executes the provided block within the guard's context.
-  def with_enterprise_banner_guard(feature_key, inactive_guard: false, **args)
+  # @yield: Executes the provided block within the guard's context.
+  def with_enterprise_banner_guard(feature_key,
+                                   inactive_guard: false,
+                                   inline_fallback: false,
+                                   **args)
     if inactive_guard
+      yield
+    elsif inline_fallback
+      concat(render(EnterpriseEdition::BannerComponent.new(feature_key, **args, variant: :inline)))
       yield
     else
       concat(render(EnterpriseEdition::BannerComponent.new(feature_key, **args)))

--- a/modules/backlogs/app/views/projects/settings/backlog_sharings/show.html.erb
+++ b/modules/backlogs/app/views/projects/settings/backlog_sharings/show.html.erb
@@ -37,15 +37,12 @@ See COPYRIGHT and LICENSE files for more details.
 
   <% with_enterprise_banner_guard(
        :sprint_sharing,
+       variant: :large,
        # We want to enable users to migrate out of sprint sharing if their token expired.
        # If that happens, an inline banner is to be displayed.
-       # But there is the special case of trial tokens. For those, two inline banners would be displayed
-       # which is why this is handled explicitly here.
-       inactive_guard: !@project.not_sharing_sprints? || EnterpriseToken.trialling?(:sprint_sharing),
-       variant: :large,
+       inline_fallback: !@project.not_sharing_sprints?,
        video: "enterprise/sprint-sharing.mp4"
      ) do %>
-    <%= render(EnterpriseEdition::BannerComponent.new(:sprint_sharing, variant: :inline)) %>
     <%= render(
           Projects::Settings::Backlogs::SharingFormComponent.new(
             project: @project,


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

By including the functionality in the with_enterprise_banner_guard, less cases need to be handled by the caller. Especially, the knowledge about `EnterpriseToken.trialling?` no longer needs to be present with the caller.