### PR TITLE
[#74303] Cancel occurence action item is called 'Delete' on My Meetings page and Meeting index page 'Past' tab  

### DIFF
--- a/modules/meeting/app/components/meetings/delete_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.rb
@@ -49,7 +49,7 @@ module Meetings
 
     def title
       if recurring_meeting.present?
-        I18n.t("meeting.delete_dialog.occurrence.title")
+        I18n.t("meeting.delete_dialog.#{occurrence_key}.title")
       else
         template = @meeting.onetime_template? ? ".template" : ""
         I18n.t("meeting.delete_dialog.one_time#{template}.title")
@@ -58,7 +58,7 @@ module Meetings
 
     def heading
       if recurring_meeting.present?
-        I18n.t("meeting.delete_dialog.occurrence.heading")
+        I18n.t("meeting.delete_dialog.#{occurrence_key}.heading")
       else
         template = @meeting.onetime_template? ? ".template" : ""
         I18n.t("meeting.delete_dialog.one_time#{template}.heading")
@@ -67,7 +67,7 @@ module Meetings
 
     def confirmation_message
       if recurring_meeting.present?
-        t("meeting.delete_dialog.occurrence.confirmation_message_html")
+        t("meeting.delete_dialog.#{occurrence_key}.confirmation_message_html")
       else
         template = @meeting.onetime_template? ? ".template" : ""
         t("meeting.delete_dialog.one_time#{template}.confirmation_message_html")
@@ -76,7 +76,7 @@ module Meetings
 
     def confirm_button_text
       if recurring_meeting.present?
-        I18n.t("meeting.delete_dialog.occurrence.confirm_button")
+        I18n.t("meeting.delete_dialog.#{occurrence_key}.confirm_button")
       else
         I18n.t("button_delete")
       end
@@ -88,6 +88,14 @@ module Meetings
       else
         I18n.t("button_cancel")
       end
+    end
+
+    def past?
+      @meeting.start_time + @meeting.duration.hours < Time.current
+    end
+
+    def occurrence_key
+      past? ? "occurrence_past" : "occurrence"
     end
   end
 end

--- a/modules/meeting/app/components/meetings/delete_dialog_component.rb
+++ b/modules/meeting/app/components/meetings/delete_dialog_component.rb
@@ -90,12 +90,8 @@ module Meetings
       end
     end
 
-    def past?
-      @meeting.start_time + @meeting.duration.hours < Time.current
-    end
-
     def occurrence_key
-      past? ? "occurrence_past" : "occurrence"
+      @meeting.past? ? "occurrence_past" : "occurrence"
     end
   end
 end

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -150,7 +150,12 @@ module Meetings
       return unless delete_allowed?
 
       back_url = current_project ? nil : meetings_path
-      menu.with_item(label: recurring_meeting.present? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_meeting_delete),
+      label = if recurring_meeting.present?
+                past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel)
+              else
+                I18n.t(:label_meeting_delete)
+              end
+      menu.with_item(label:,
                      scheme: :danger,
                      href: delete_dialog_project_meeting_path(project, model, back_url:),
                      tag: :a,
@@ -159,6 +164,10 @@ module Meetings
                      }) do |item|
         item.with_leading_visual_icon(icon: :trash)
       end
+    end
+
+    def past?
+      model.start_time + model.duration.hours < Time.current
     end
 
     def recurring_label

--- a/modules/meeting/app/components/meetings/row_component.rb
+++ b/modules/meeting/app/components/meetings/row_component.rb
@@ -151,7 +151,7 @@ module Meetings
 
       back_url = current_project ? nil : meetings_path
       label = if recurring_meeting.present?
-                past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel)
+                model.past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel)
               else
                 I18n.t(:label_meeting_delete)
               end
@@ -164,10 +164,6 @@ module Meetings
                      }) do |item|
         item.with_leading_visual_icon(icon: :trash)
       end
-    end
-
-    def past?
-      model.start_time + model.duration.hours < Time.current
     end
 
     def recurring_label

--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -189,7 +189,7 @@ module RecurringMeetings
       return unless delete_allowed? && !cancelled? && instantiated?
 
       menu.with_item(
-        label: past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel),
+        label: meeting.past? ? I18n.t(:label_recurring_meeting_delete) : I18n.t(:label_recurring_meeting_cancel),
         scheme: :danger,
         href: delete_dialog_project_meeting_path(project, meeting),
         tag: :a,
@@ -247,8 +247,5 @@ module RecurringMeetings
       instantiated? && meeting.start_time != occurrence_time
     end
 
-    def past?
-      meeting.start_time + meeting.duration.hours < Time.current
-    end
   end
 end

--- a/modules/meeting/app/components/recurring_meetings/row_component.rb
+++ b/modules/meeting/app/components/recurring_meetings/row_component.rb
@@ -248,7 +248,7 @@ module RecurringMeetings
     end
 
     def past?
-      occurrence_time < Time.current
+      meeting.start_time + meeting.duration.hours < Time.current
     end
   end
 end

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -216,6 +216,10 @@ class Meeting < ApplicationRecord
     start_time + duration.hours
   end
 
+  def past?
+    end_time < Time.current
+  end
+
   def to_s
     title
   end

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -338,6 +338,12 @@ en:
 
           Do you want to continue?
         confirm_button: "Cancel occurrence"
+      occurrence_past:
+        title: "Delete occurrence"
+        heading: "Delete this occurrence?"
+        confirmation_message_html: >
+          This action is not reversible. Please proceed with caution.
+        confirm_button: "Delete occurrence"
     blankslate:
       title: "There are no meetings to display"
       desc: "You can create a new meeting or change filter criteria"

--- a/modules/meeting/spec/components/meetings/destroy_confirmation_dialog_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/destroy_confirmation_dialog_component_spec.rb
@@ -79,4 +79,20 @@ RSpec.describe Meetings::DeleteDialogComponent, type: :component do
       expect(subject).to have_text "Any meeting information not in the template will be lost."
     end
   end
+
+  context "with a past recurring occurrence" do
+    let(:series) { build_stubbed(:recurring_meeting, project:) }
+    let(:meeting) do
+      build_stubbed(:meeting, recurring_meeting: series, project:,
+                              start_time: 2.days.ago, duration: 1)
+    end
+
+    it "shows the delete heading" do
+      expect(subject).to have_text "Delete this occurrence?"
+    end
+
+    it "shows a warning saying it is not reversible" do
+      expect(subject).to have_text "This action is not reversible. Please proceed with caution."
+    end
+  end
 end

--- a/modules/meeting/spec/components/meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/meetings/row_component_spec.rb
@@ -102,6 +102,31 @@ RSpec.describe Meetings::RowComponent, type: :component do
         let(:meeting) { build_stubbed(:meeting_template, recurring_meeting: series, project:) }
 
         context "without a current project" do
+          it "shows cancel menu item with a back url" do
+            back_url = meetings_path
+            expect(subject).to have_link "Cancel this occurrence",
+                                         href: delete_dialog_project_meeting_path(project, meeting, back_url:)
+          end
+        end
+
+        context "with a current project" do
+          let(:current_project) { project }
+
+          it "shows cancel menu item" do
+            expect(subject).to have_link "Cancel this occurrence",
+                                         href: delete_dialog_project_meeting_path(project, meeting)
+          end
+        end
+      end
+
+      context "with a past recurring occurrence" do
+        let(:series) { build_stubbed(:recurring_meeting, project:) }
+        let(:meeting) do
+          build_stubbed(:meeting, recurring_meeting: series, project:,
+                                  start_time: 2.days.ago, duration: 1)
+        end
+
+        context "without a current project" do
           it "shows delete menu item with a back url" do
             back_url = meetings_path
             expect(subject).to have_link "Delete occurrence",
@@ -113,7 +138,8 @@ RSpec.describe Meetings::RowComponent, type: :component do
           let(:current_project) { project }
 
           it "shows delete menu item" do
-            expect(subject).to have_link "Delete occurrence", href: delete_dialog_project_meeting_path(project, meeting)
+            expect(subject).to have_link "Delete occurrence",
+                                         href: delete_dialog_project_meeting_path(project, meeting)
           end
         end
       end

--- a/modules/meeting/spec/components/recurring_meetings/row_component_spec.rb
+++ b/modules/meeting/spec/components/recurring_meetings/row_component_spec.rb
@@ -135,6 +135,40 @@ RSpec.describe RecurringMeetings::RowComponent, type: :component do
           end
         end
       end
+
+      context "with an ongoing instantiated meeting" do
+        let(:meeting) do
+          build_stubbed(:meeting,
+                        project:,
+                        recurring_meeting:,
+                        recurrence_start_time: 30.minutes.ago,
+                        start_time: 30.minutes.ago,
+                        duration: 2)
+        end
+        let(:row_model) { meeting }
+
+        it "shows cancel menu item" do
+          expect(subject).to have_link "Cancel this occurrence",
+                                       href: delete_dialog_project_meeting_path(project, meeting)
+        end
+      end
+
+      context "with a past instantiated meeting" do
+        let(:meeting) do
+          build_stubbed(:meeting,
+                        project:,
+                        recurring_meeting:,
+                        recurrence_start_time: 2.days.ago,
+                        start_time: 2.days.ago,
+                        duration: 1)
+        end
+        let(:row_model) { meeting }
+
+        it "shows delete menu item" do
+          expect(subject).to have_link "Delete occurrence",
+                                       href: delete_dialog_project_meeting_path(project, meeting)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/74303

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Update button labels and confirmation dialog strings to match the actual behaviour
   - Upcoming meetings use "Cancel" since they are visible in the planned section of a series and can be restored from there
   - Past meetings use "Delete" since they are not visible anywhere and thus can't be restored

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
