### PR TITLE
bug/74156 Lists of work packages should sort correctly in semantic mode

### DIFF
--- a/app/models/queries/work_packages/selects/property_select.rb
+++ b/app/models/queries/work_packages/selects/property_select.rb
@@ -37,7 +37,19 @@ class Queries::WorkPackages::Selects::PropertySelect < Queries::WorkPackages::Se
 
   self.property_selects = {
     id: {
-      sortable: "#{WorkPackage.table_name}.id",
+      # Sorting by "ID" follows the displayed identifier. In semantic mode, the
+      # visible ID is `<project_identifier>-<sequence_number>`, so the database
+      # primary key is the wrong sort key — a work package moved between projects
+      # keeps its PK but receives a new sequence in the target project. Order by
+      # (project_id, sequence_number) keeps each project's rows monotone in their
+      # visible numbering and is backed by an existing partial unique index.
+      sortable: -> {
+        if Setting::WorkPackageIdentifier.semantic_mode_active?
+          ["#{WorkPackage.table_name}.project_id", "#{WorkPackage.table_name}.sequence_number"]
+        else
+          "#{WorkPackage.table_name}.id"
+        end
+      },
       groupable: false
     },
     project: {

--- a/app/models/queries/work_packages/selects/work_package_select.rb
+++ b/app/models/queries/work_packages/selects/work_package_select.rb
@@ -81,7 +81,8 @@ class Queries::WorkPackages::Selects::WorkPackageSelect
   end
 
   def sortable
-    name_or_value_or_false(@sortable)
+    resolved = @sortable.respond_to?(:call) ? @sortable.call : @sortable
+    name_or_value_or_false(resolved)
   end
 
   def groupable

--- a/spec/models/query/results_sort_by_id_spec.rb
+++ b/spec/models/query/results_sort_by_id_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Query::Results, "sort by id" do
+  let(:user) { create(:admin) }
+
+  # Three work packages in one project arranged so primary-key order does not
+  # match sequence-number order. Mirrors a moved-in work package: its row was
+  # inserted earliest (lowest PK) but received a later sequence in this project.
+  def build_three_with_inverted_sequence(project)
+    moved_in = create(:work_package, project:, subject: "Moved in", skip_semantic_id_allocation: true)
+    native_first = create(:work_package, project:, subject: "Native first", skip_semantic_id_allocation: true)
+    native_second = create(:work_package, project:, subject: "Native second", skip_semantic_id_allocation: true)
+
+    moved_in.update_columns(sequence_number: 3, identifier: "#{project.identifier}-3")
+    native_first.update_columns(sequence_number: 1, identifier: "#{project.identifier}-1")
+    native_second.update_columns(sequence_number: 2, identifier: "#{project.identifier}-2")
+
+    [moved_in, native_first, native_second]
+  end
+
+  def build_query(project, sort_criteria: [%w[id asc]])
+    build_stubbed(:query,
+                  user:,
+                  project:,
+                  show_hierarchies: false,
+                  sort_criteria:,
+                  column_names: %i[id subject])
+  end
+
+  current_user { user }
+
+  context "in semantic mode",
+          with_flag: { semantic_work_package_ids: true },
+          with_settings: { work_packages_identifier: "semantic" } do
+    let(:project) { create(:project, identifier: "LARGE") }
+    let!(:wps) { build_three_with_inverted_sequence(project) }
+    let(:moved_in) { wps[0] }
+    let(:native_first) { wps[1] }
+    let(:native_second) { wps[2] }
+
+    it "orders ascending by sequence number, not primary key" do
+      results = described_class.new(build_query(project)).work_packages
+
+      expect(results.pluck(:id)).to eq([native_first.id, native_second.id, moved_in.id])
+    end
+
+    it "orders descending by sequence number" do
+      results = described_class.new(build_query(project, sort_criteria: [%w[id desc]])).work_packages
+
+      expect(results.pluck(:id)).to eq([moved_in.id, native_second.id, native_first.id])
+    end
+
+    context "with rows from two projects" do
+      let(:other_project) { create(:project, identifier: "SMALL") }
+      let!(:other_wp) do
+        wp = create(:work_package, project: other_project, subject: "Other", skip_semantic_id_allocation: true)
+        wp.update_columns(sequence_number: 1, identifier: "SMALL-1")
+        wp
+      end
+
+      let(:query) do
+        build_stubbed(:query,
+                      user:,
+                      project: nil,
+                      show_hierarchies: false,
+                      sort_criteria: [%w[id asc]],
+                      column_names: %i[id subject])
+      end
+
+      it "groups by project before ordering by sequence number" do
+        results = described_class.new(query).work_packages.pluck(:id, :project_id)
+        large_ids = results.select { it[1] == project.id }.map(&:first)
+        small_ids = results.select { it[1] == other_project.id }.map(&:first)
+
+        expect(large_ids).to eq([native_first.id, native_second.id, moved_in.id])
+        expect(small_ids).to eq([other_wp.id])
+      end
+    end
+
+    context "with a non-ID primary sort and a tie" do
+      before do
+        WorkPackage.where(id: wps.map(&:id)).update_all(subject: "Same subject")
+      end
+
+      it "breaks the tie deterministically using the semantic ID sort key" do
+        query = build_query(project, sort_criteria: [%w[subject asc]])
+        results = described_class.new(query).work_packages
+
+        # The implicit `id` tiebreaker resolves through the same sort key as an
+        # explicit ID sort — so ties break by (project_id, sequence_number) DESC,
+        # i.e. highest sequence first.
+        expect(results.pluck(:id)).to eq([moved_in.id, native_second.id, native_first.id])
+      end
+    end
+
+    context "with a sequence_number still NULL (pre-backfill row)" do
+      let!(:unsequenced) do
+        wp = create(:work_package, project:, subject: "Unsequenced", skip_semantic_id_allocation: true)
+        wp.update_columns(sequence_number: nil, identifier: nil)
+        wp
+      end
+
+      it "places unsequenced rows at the end on ascending sort" do
+        ids = described_class.new(build_query(project)).work_packages.pluck(:id)
+
+        expect(ids.last).to eq(unsequenced.id)
+        expect(ids.first(3)).to eq([native_first.id, native_second.id, moved_in.id])
+      end
+    end
+  end
+
+  context "in classic mode",
+          with_flag: { semantic_work_package_ids: false },
+          with_settings: { work_packages_identifier: "classic" } do
+    let(:project) { create(:project, identifier: "large") }
+    let!(:wps) { build_three_with_inverted_sequence(project) }
+    let(:moved_in) { wps[0] }
+    let(:native_first) { wps[1] }
+    let(:native_second) { wps[2] }
+
+    it "orders ascending by primary key, ignoring sequence_number" do
+      results = described_class.new(build_query(project)).work_packages
+
+      expect(results.pluck(:id)).to eq([moved_in.id, native_first.id, native_second.id])
+    end
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/74156

# What are you trying to accomplish?

Sorting still relied on pre-existing numerical primary key based sorting `#N` - which does not work in semantic mode.

After this change, sorting by ID in semantic mode orders by `(project_id, sequence_number)`. Canonical rows and moved-in rows now sit in the same order as their user facing semantic IDs. Classic mode keeps sorting by the primary key — there is no per-project sequence there to switch to.

## Screenshots

**Before — sort by ID ↑ (semantic mode, current bug):**

<!-- drop pr-wp-sort-before.png here -->
<img width="1200" height="1226" alt="pr-wp-sort-before" src="https://github.com/user-attachments/assets/a3137a98-ee16-448a-a91f-5938ef81311b" />

**After — sort by ID ↑ (semantic mode, this PR):**

<!-- drop pr-wp-sort-after.png here -->

<img width="1200" height="1226" alt="pr-wp-sort-after" src="https://github.com/user-attachments/assets/1a82c1dc-4e70-4459-8e07-da0039e85f39" />

# What approach did you choose and why?

The "ID" sortable on `Queries::WorkPackages::Selects::PropertySelect` is now a lambda that resolves at request time:

- semantic mode → `["work_packages.project_id", "work_packages.sequence_number"]`
- classic mode → `"work_packages.id"`

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)