### PR TITLE
Allow serialization of safebuffer without encoding issues

### DIFF
--- a/lib/open_project/patches/message_pack_safe_buffer.rb
+++ b/lib/open_project/patches/message_pack_safe_buffer.rb
@@ -30,25 +30,23 @@
 
 module OpenProject
   module Patches
-    # Rails registers ActiveSupport::SafeBuffer as MessagePack ext type 18 with
-    # unpacker: :new. ActionView::OutputBuffer (a SafeBuffer subclass) uses "".b
-    # internally, so the ext payload bytes are BINARY. The default unpacker calls
-    # SafeBuffer.new(binary_bytes) which reconstructs with ASCII-8BIT encoding,
-    # causing Encoding::CompatibilityError when the cached HTML is later
-    # concatenated into a UTF-8 output buffer (e.g. via ActionView concat).
+    # Upstream fix: https://github.com/rails/rails/pull/57429 (merged, not yet released)
     #
-    # We prepend to MessagePack::Factory so that when Extensions.install registers
-    # type 18, our override replaces the unpacker with one that force_encodes to
-    # UTF-8 before constructing the SafeBuffer.
+    # Rails registers ActiveSupport::SafeBuffer as MessagePack ext type 18 with
+    # packer: :to_s, unpacker: :new. Ext payload bytes are always BINARY, so
+    # SafeBuffer.new(payload) reconstructs with ASCII-8BIT encoding, causing
+    # Encoding::CompatibilityError when cached HTML is later concatenated into a
+    # UTF-8 output buffer.
+    #
+    # The upstream fix switches to recursive: true with nested packer.write /
+    # unpacker.read so the MessagePack string codec preserves the original
+    # encoding across the round-trip.
     module MessagePackSafeBufferFix
       def register_type(type_id, klass = nil, **options, &)
-        if klass == ActiveSupport::SafeBuffer && options[:unpacker] == :new
-          options[:unpacker] = ->(bytes) {
-            retagged = bytes.force_encoding(Encoding::UTF_8)
-            raise EncodingError, "Cached SafeBuffer payload is not valid UTF-8" unless retagged.valid_encoding?
-
-            ActiveSupport::SafeBuffer.new(retagged)
-          }
+        if klass == ActiveSupport::SafeBuffer
+          options[:packer] = ->(buffer, packer) { packer.write(buffer.to_str) }
+          options[:unpacker] = ->(unpacker) { ActiveSupport::SafeBuffer.new(unpacker.read) }
+          options[:recursive] = true
         end
 
         super

--- a/lib/open_project/patches/message_pack_safe_buffer.rb
+++ b/lib/open_project/patches/message_pack_safe_buffer.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module OpenProject
+  module Patches
+    # Rails registers ActiveSupport::SafeBuffer as MessagePack ext type 18 with
+    # unpacker: :new. ActionView::OutputBuffer (a SafeBuffer subclass) uses "".b
+    # internally, so the ext payload bytes are BINARY. The default unpacker calls
+    # SafeBuffer.new(binary_bytes) which reconstructs with ASCII-8BIT encoding,
+    # causing Encoding::CompatibilityError when the cached HTML is later
+    # concatenated into a UTF-8 output buffer (e.g. via ActionView concat).
+    #
+    # We prepend to MessagePack::Factory so that when Extensions.install registers
+    # type 18, our override replaces the unpacker with one that force_encodes to
+    # UTF-8 before constructing the SafeBuffer.
+    module MessagePackSafeBufferFix
+      def register_type(type_id, klass = nil, **options, &)
+        if klass == ActiveSupport::SafeBuffer && options[:unpacker] == :new
+          options[:unpacker] = ->(bytes) {
+            retagged = bytes.force_encoding(Encoding::UTF_8)
+            raise EncodingError, "Cached SafeBuffer payload is not valid UTF-8" unless retagged.valid_encoding?
+
+            ActiveSupport::SafeBuffer.new(retagged)
+          }
+        end
+
+        super
+      end
+    end
+  end
+end
+
+OpenProject::Patches.patch_gem_version "activesupport", "8.1.3" do
+  MessagePack::Factory.prepend OpenProject::Patches::MessagePackSafeBufferFix
+end

--- a/spec/lib/open_project/patches/message_pack_safe_buffer_fix_spec.rb
+++ b/spec/lib/open_project/patches/message_pack_safe_buffer_fix_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+# Rails registers ActiveSupport::SafeBuffer as MessagePack ext type 18 with
+# unpacker: :new. MessagePack ext payloads are raw bytes (BINARY), so the default
+# unpacker reconstructs SafeBuffer with ASCII-8BIT encoding, even when the
+# original was UTF-8. This patch overrides the unpacker to force UTF-8.
+RSpec.describe OpenProject::Patches::MessagePackSafeBufferFix do
+  # Use the same serializer the cache store uses to cover the real path.
+  let(:serializer) { ActiveSupport::MessagePack::CacheSerializer }
+  let(:html) { "<p>Héllo &amp; wörld — «quoted»</p>" }
+
+  def round_trip(value)
+    serializer.load(serializer.dump(value))
+  end
+
+  shared_examples "a correctly round-tripped SafeBuffer", :aggregate_failures do
+    it "returns a utf-8 SafeBuffer, preserving the original content and html safety" do
+      expect(round_trip(subject)).to be_a(ActiveSupport::SafeBuffer)
+      expect(round_trip(subject).to_s).to eq(subject.to_s.dup.force_encoding(Encoding::UTF_8))
+      expect(round_trip(subject).encoding).to eq(Encoding::UTF_8)
+      expect(round_trip(subject)).to be_html_safe
+    end
+  end
+
+  context "with a UTF-8 SafeBuffer (normal render output)" do
+    subject { ActiveSupport::SafeBuffer.new(html) }
+
+    include_examples "a correctly round-tripped SafeBuffer"
+  end
+
+  context "with a BINARY-encoded SafeBuffer (e.g. content assembled from binary bytes)" do
+    subject { ActiveSupport::SafeBuffer.new(html.b) }
+
+    it "has BINARY encoding before round-trip (confirms precondition)" do
+      expect(subject.encoding).to eq(Encoding::BINARY)
+    end
+
+    include_examples "a correctly round-tripped SafeBuffer"
+  end
+end

--- a/spec/lib/open_project/patches/message_pack_safe_buffer_fix_spec.rb
+++ b/spec/lib/open_project/patches/message_pack_safe_buffer_fix_spec.rb
@@ -31,9 +31,11 @@
 require "spec_helper"
 
 # Rails registers ActiveSupport::SafeBuffer as MessagePack ext type 18 with
-# unpacker: :new. MessagePack ext payloads are raw bytes (BINARY), so the default
-# unpacker reconstructs SafeBuffer with ASCII-8BIT encoding, even when the
-# original was UTF-8. This patch overrides the unpacker to force UTF-8.
+# packer: :to_s, unpacker: :new. Ext payloads are raw bytes (BINARY), so the
+# default unpacker reconstructs SafeBuffer with ASCII-8BIT encoding even when
+# the original was UTF-8. The patch (mirroring rails/rails#57429) switches to
+# recursive: true with nested packer.write / unpacker.read so the MessagePack
+# string codec preserves the original encoding across the round-trip.
 RSpec.describe OpenProject::Patches::MessagePackSafeBufferFix do
   # Use the same serializer the cache store uses to cover the real path.
   let(:serializer) { ActiveSupport::MessagePack::CacheSerializer }
@@ -43,28 +45,28 @@ RSpec.describe OpenProject::Patches::MessagePackSafeBufferFix do
     serializer.load(serializer.dump(value))
   end
 
-  shared_examples "a correctly round-tripped SafeBuffer", :aggregate_failures do
-    it "returns a utf-8 SafeBuffer, preserving the original content and html safety" do
-      expect(round_trip(subject)).to be_a(ActiveSupport::SafeBuffer)
-      expect(round_trip(subject).to_s).to eq(subject.to_s.dup.force_encoding(Encoding::UTF_8))
-      expect(round_trip(subject).encoding).to eq(Encoding::UTF_8)
-      expect(round_trip(subject)).to be_html_safe
-    end
-  end
-
   context "with a UTF-8 SafeBuffer (normal render output)" do
     subject { ActiveSupport::SafeBuffer.new(html) }
 
-    include_examples "a correctly round-tripped SafeBuffer"
+    it "roundtrips as a UTF-8 html_safe SafeBuffer and concatenates without error", :aggregate_failures do
+      result = round_trip(subject)
+      expect(result).to be_a(ActiveSupport::SafeBuffer)
+      expect(result).to be_html_safe
+      expect(result.encoding).to eq(Encoding::UTF_8)
+      expect(result.to_s).to eq(html)
+      expect("prefix " + result).to eq("prefix #{html}")
+    end
   end
 
-  context "with a BINARY-encoded SafeBuffer (e.g. content assembled from binary bytes)" do
+  context "with a BINARY-encoded SafeBuffer" do
     subject { ActiveSupport::SafeBuffer.new(html.b) }
 
-    it "has BINARY encoding before round-trip (confirms precondition)" do
-      expect(subject.encoding).to eq(Encoding::BINARY)
+    it "preserves BINARY encoding across the round-trip", :aggregate_failures do
+      result = round_trip(subject)
+      expect(result).to be_a(ActiveSupport::SafeBuffer)
+      expect(result).to be_html_safe
+      expect(result.encoding).to eq(Encoding::BINARY)
+      expect(result.to_str).to eq(html.b)
     end
-
-    include_examples "a correctly round-tripped SafeBuffer"
   end
 end


### PR DESCRIPTION
When caching a SafeBuffer, it is being returned as a binary string and using concat or similar on something that is cached like that will result in a => #<Encoding::CompatibilityError: incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT)> error.

we introduce a patch to ensure SafeBuffers are returned as utf-8 instead

Related:

https://github.com/rails/rails/issues/57426
