### PR TITLE
[#74304] User cannot restore a cancelled occurrence if series has a deleted WP on the agenda  

### DIFF
--- a/modules/meeting/app/services/meetings/copy_service.rb
+++ b/modules/meeting/app/services/meetings/copy_service.rb
@@ -113,14 +113,19 @@ module Meetings
                      attachment_target])
     end
 
-    def copy_meeting_agenda(copy)
+    def copy_meeting_agenda(copy) # rubocop:disable Metrics/AbcSize
       meeting.sections.each do |section|
         copy.sections << section.dup
         copied_section = copy.reload.sections.last
         section.agenda_items.each do |agenda_item|
           copied_agenda_item = agenda_item.dup
           copied_agenda_item.meeting_id = copy.id
-          copied_section.agenda_items << copied_agenda_item
+          copied_agenda_item.meeting_section = copied_section
+
+          # A work_package agenda item whose WP was deleted has work_package_id nullified but
+          # item_type still set. Skip validations for this state
+          skip_validation = copied_agenda_item.work_package? && copied_agenda_item.work_package_id.nil?
+          copied_agenda_item.save!(validate: !skip_validation)
         end
       end
     end

--- a/modules/meeting/app/services/recurring_meetings/reset_to_template_service.rb
+++ b/modules/meeting/app/services/recurring_meetings/reset_to_template_service.rb
@@ -90,10 +90,13 @@ module RecurringMeetings
           section.attributes.except("id", "meeting_id", "created_at", "updated_at")
         )
         section.agenda_items.each do |item|
-          # copy_attributes excludes :id and :meeting_id; we supply both FKs explicitly
-          new_section.agenda_items.create!(
-            item.copy_attributes.except("meeting_section_id").merge("meeting_id" => meeting.id)
-          )
+          new_item = item.dup
+          new_item.meeting_section = new_section
+
+          # A work_package agenda item whose WP was deleted has work_package_id nullified but
+          # item_type still set. Skip validations for this state
+          skip_validation = new_item.work_package? && new_item.work_package_id.nil?
+          new_item.save!(validate: !skip_validation)
         end
       end
     end

--- a/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
+++ b/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
@@ -196,4 +196,20 @@ RSpec.describe Meetings::CopyService, "integration", type: :model do
       end
     end
   end
+
+  context "with a work_package agenda item whose work package was deleted" do
+    before do
+      item = create(:wp_meeting_agenda_item, meeting:)
+      # Simulate the work package being destroyed (dependent: :nullify)
+      item.update_columns(work_package_id: nil)
+    end
+
+    it "copies the deleted-WP agenda item preserving its type and nil work_package_id" do
+      expect(service_result).to be_success
+      deleted_item = copy.reload.agenda_items.last
+      expect(deleted_item).to be_present
+      expect(deleted_item).to be_work_package
+      expect(deleted_item.work_package_id).to be_nil
+    end
+  end
 end

--- a/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
+++ b/modules/meeting/spec/services/meetings/copy_service_integration_spec.rb
@@ -206,9 +206,34 @@ RSpec.describe Meetings::CopyService, "integration", type: :model do
 
     it "copies the deleted-WP agenda item preserving its type and nil work_package_id" do
       expect(service_result).to be_success
-      deleted_item = copy.reload.agenda_items.last
+      deleted_item = copy.reload.agenda_items.find_by(item_type: :work_package, work_package_id: nil)
       expect(deleted_item).to be_present
       expect(deleted_item).to be_work_package
+      expect(deleted_item.work_package_id).to be_nil
+    end
+  end
+
+  context "with a mix of valid and deleted work_package agenda items" do
+    let(:work_package) { create(:work_package, project:) }
+
+    before do
+      create(:wp_meeting_agenda_item, meeting:, work_package:)
+      deleted_item = create(:wp_meeting_agenda_item, meeting:)
+      # Simulate the work package being destroyed (dependent: :nullify)
+      deleted_item.update_columns(work_package_id: nil)
+    end
+
+    it "copies both the valid and deleted-WP agenda items" do
+      expect(service_result).to be_success
+      agenda_items = copy.reload.agenda_items
+      expect(agenda_items.count).to eq(2)
+
+      valid_item = agenda_items.find_by(item_type: :work_package, work_package_id: work_package.id)
+      expect(valid_item).to be_present
+      expect(valid_item.work_package_id).to eq(work_package.id)
+
+      deleted_item = agenda_items.find_by(item_type: :work_package, work_package_id: nil)
+      expect(deleted_item).to be_present
       expect(deleted_item.work_package_id).to be_nil
     end
   end

--- a/modules/meeting/spec/services/recurring_meetings/reset_to_template_service_spec.rb
+++ b/modules/meeting/spec/services/recurring_meetings/reset_to_template_service_spec.rb
@@ -135,4 +135,33 @@ RSpec.describe RecurringMeetings::ResetToTemplateService, type: :model do
       expect(cancelled_occurrence.reload.participants.count).to eq(template_participant_count)
     end
   end
+
+  context "when the template has a work package agenda item whose work package was deleted" do
+    before do
+      template_section = series.template.sections.first
+      wp_item = MeetingAgendaItem.create!(
+        meeting: series.template,
+        meeting_section: template_section,
+        item_type: :work_package,
+        work_package: create(:work_package, project:),
+        author: user,
+        position: 2
+      )
+
+      # Simulate the work package being destroyed (dependent: :nullify)
+      wp_item.update_columns(work_package_id: nil)
+    end
+
+    it "returns a successful service result" do
+      expect(service_result).to be_success
+    end
+
+    it "copies the deleted WP agenda item preserving its type and nil work_package_id" do
+      service_result
+      deleted_item = cancelled_occurrence.reload.agenda_items.last
+      expect(deleted_item).to be_present
+      expect(deleted_item).to be_work_package
+      expect(deleted_item.work_package_id).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/74304

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Skip validations when trying to copy WP agenda items referencing no work packages so that the items are still copied over when opening an occurrence or restoring a cancelled one

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
