### PR TITLE
Bug/75239 backlog settings tab switching doesn t persist in url

### DIFF
--- a/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.html.erb
+++ b/modules/backlogs/app/components/projects/settings/backlogs/settings_header_component.html.erb
@@ -39,7 +39,8 @@ See COPYRIGHT and LICENSE files for more details.
     header.with_tab_nav(label: nil) do |tab_nav|
       tab_nav.with_tab(
         selected: selected_tab?(:types_and_statuses),
-        href: project_settings_backlogs_path(project)
+        href: project_settings_backlogs_path(project),
+        data: { turbo_action: "advance" }
       ) do |t|
         t.with_text { t("backlogs.types_and_statuses") }
       end
@@ -47,7 +48,8 @@ See COPYRIGHT and LICENSE files for more details.
       if User.current.allowed_in_project?(:share_sprint, project)
         tab_nav.with_tab(
           selected: selected_tab?(:sharing),
-          href: project_settings_backlog_sharing_path(project)
+          href: project_settings_backlog_sharing_path(project),
+          data: { turbo_action: "advance" }
         ) do |t|
           t.with_text { t("backlogs.sharing") }
         end

--- a/modules/backlogs/app/controllers/projects/settings/backlogs_controller.rb
+++ b/modules/backlogs/app/controllers/projects/settings/backlogs_controller.rb
@@ -42,7 +42,7 @@ class Projects::Settings::BacklogsController < Projects::SettingsController
 
     if call.success?
       flash[:notice] = I18n.t(:notice_successful_update)
-      redirect_to_backlogs_settings
+      redirect_back_or_to_backlogs_settings
     else
       flash.now[:error] = I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
       render action: :show, status: :unprocessable_entity
@@ -53,13 +53,13 @@ class Projects::Settings::BacklogsController < Projects::SettingsController
     WorkPackages::RebuildPositionsService.new(project: @project).call
     flash[:notice] = I18n.t("backlogs.positions_rebuilt_successfully")
 
-    redirect_to_backlogs_settings
+    redirect_back_or_to_backlogs_settings
   rescue ActiveRecord::ActiveRecordError
     flash[:error] = I18n.t("backlogs.positions_could_not_be_rebuilt")
 
     log_rebuild_position_error
 
-    redirect_to_backlogs_settings
+    redirect_back_or_to_backlogs_settings
   end
 
   private
@@ -75,8 +75,8 @@ class Projects::Settings::BacklogsController < Projects::SettingsController
     permitted
   end
 
-  def redirect_to_backlogs_settings
-    redirect_to project_settings_backlogs_path(@project)
+  def redirect_back_or_to_backlogs_settings
+    redirect_back_or_to project_settings_backlogs_path(@project)
   end
 
   def log_rebuild_position_error

--- a/modules/backlogs/spec/features/projects/backlogs_settings_spec.rb
+++ b/modules/backlogs/spec/features/projects/backlogs_settings_spec.rb
@@ -57,6 +57,33 @@ RSpec.describe "Backlogs Project Settings", :js do
     login_as current_user
   end
 
+  context "when navigating between tabs" do
+    let(:role) do
+      create(:project_role,
+             permissions: %i[select_backlog_types_and_statuses share_sprint])
+    end
+
+    it "persists the active tab in the URL when switching tabs" do
+      settings_page.visit!
+
+      expect(page).to have_heading "Backlogs"
+
+      expect(page).to have_current_path(project_settings_backlogs_path(project))
+
+      click_link I18n.t("backlogs.sharing")
+
+      expect(page).to have_current_path(project_settings_backlog_sharing_path(project))
+
+      page.refresh
+
+      expect(page).to have_current_path(project_settings_backlog_sharing_path(project))
+
+      click_link I18n.t("backlogs.types_and_statuses")
+
+      expect(page).to have_current_path(project_settings_backlogs_path(project))
+    end
+  end
+
   it "allows setting a status as done although it is not closed" do
     settings_page.visit!
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/75239

# What are you trying to accomplish?
Ensure navigation when switching between backlog settings tabs

# What approach did you choose and why?
Set turbo action to `advance`
Also stop header size jumping by inserting invisible button on the tab without action menu

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
