### PR TITLE
Defer rendering of components via turbo_streams

### DIFF
--- a/app/components/projects/settings/versions/overview_widget_component.rb
+++ b/app/components/projects/settings/versions/overview_widget_component.rb
@@ -41,7 +41,7 @@ module Projects
         def call
           widget_wrapper do |widget|
             widget.with_body(padding: :default) do
-              render partial: "versions/overview", locals: { version: }
+              render partial: "versions/overview", locals: { version: }, formats: [:html]
             end
           end
         end

--- a/app/components/projects/settings/versions/wiki_widget_component.rb
+++ b/app/components/projects/settings/versions/wiki_widget_component.rb
@@ -43,7 +43,7 @@ module Projects
 
           widget_wrapper do |widget|
             widget.with_body(padding: :default) do
-              render partial: "wiki/text", locals: { page: version.wiki_page }
+              render partial: "wiki/text", locals: { page: version.wiki_page }, formats: [:html]
             end
           end
         end

--- a/app/controllers/admin/import/jira/import_runs/select_projects_controller.rb
+++ b/app/controllers/admin/import/jira/import_runs/select_projects_controller.rb
@@ -131,7 +131,7 @@ module Admin::Import::Jira::ImportRuns
               method: "morph"
             )
           end
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
       end
     end
@@ -143,7 +143,7 @@ module Admin::Import::Jira::ImportRuns
             component: project_list_counter_component,
             method: "morph"
           )
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
       end
     end

--- a/app/controllers/concerns/admin/import/jira/import_runs/component_streams.rb
+++ b/app/controllers/concerns/admin/import/jira/import_runs/component_streams.rb
@@ -46,7 +46,7 @@ module Admin::Import::Jira::ImportRuns
             component: ::Admin::Import::Jira::ImportRuns::StreamableStatusBadgeComponent.new(@jira_import.current_state),
             method: "morph"
           )
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html do
           redirect_to(admin_import_jira_run_path(jira_id: @jira.id, id: @jira_import.id))

--- a/app/controllers/concerns/op_turbo/component_stream.rb
+++ b/app/controllers/concerns/op_turbo/component_stream.rb
@@ -50,7 +50,7 @@ module OpTurbo
 
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: turbo_streams, status: resolved_status
+          render turbo_stream: resolve_turbo_streams, status: resolved_status
         end
 
         yield(format) if format_block
@@ -83,11 +83,7 @@ module OpTurbo
 
     def modify_via_turbo_stream(component:, action:, status:, **)
       @turbo_status = status
-      turbo_streams << component.render_as_turbo_stream(
-        view_context:,
-        action:,
-        **
-      )
+      turbo_streams << -> { component.render_as_turbo_stream(view_context:, action:, **) }
     end
 
     def insert_via_turbo_stream(action:, component:, target_component:)
@@ -100,15 +96,15 @@ module OpTurbo
     end
 
     def append_via_turbo_stream(component:, target_component:)
-      turbo_streams << target_component.insert_as_turbo_stream(component:, view_context:, action: :append)
+      turbo_streams << -> { target_component.insert_as_turbo_stream(component:, view_context:, action: :append) }
     end
 
     def prepend_via_turbo_stream(component:, target_component:)
-      turbo_streams << target_component.insert_as_turbo_stream(component:, view_context:, action: :prepend)
+      turbo_streams << -> { target_component.insert_as_turbo_stream(component:, view_context:, action: :prepend) }
     end
 
     def add_before_via_turbo_stream(component:, target_component:)
-      turbo_streams << target_component.insert_as_turbo_stream(component:, view_context:, action: :before)
+      turbo_streams << -> { target_component.insert_as_turbo_stream(component:, view_context:, action: :before) }
     end
 
     def render_success_flash_message_via_turbo_stream(message:, **)
@@ -129,7 +125,7 @@ module OpTurbo
       return if message.blank?
 
       instance = component.new(**).with_content(message)
-      turbo_streams << instance.render_as_turbo_stream(view_context:, action: :flash)
+      turbo_streams << -> { instance.render_as_turbo_stream(view_context:, action: :flash) }
     end
 
     def scroll_into_view_via_turbo_stream(target, behavior: :auto, block: :start)
@@ -188,6 +184,15 @@ module OpTurbo
 
     def turbo_streams
       @turbo_streams ||= []
+    end
+
+    ##
+    # Resolves the content that shall be rendered in each queued up stream.
+    # turbo_streams supports directly adding content to it via a rendering method,
+    # but also doing so through a callable. Using a callable has the advantage that rendering
+    # is only executed in case the response is served with format turbo_stream
+    def resolve_turbo_streams
+      turbo_streams.map { |s| s.respond_to?(:call) ? s.call : s }
     end
 
     def turbo_status

--- a/app/controllers/enterprise_tokens_controller.rb
+++ b/app/controllers/enterprise_tokens_controller.rb
@@ -69,7 +69,7 @@ class EnterpriseTokensController < ApplicationController
         format.turbo_stream do
           component = Admin::EnterpriseTokens::FormComponent.new(@token)
           update_via_turbo_stream(component: component)
-          render turbo_stream: turbo_streams, status: :unprocessable_entity
+          render turbo_stream: resolve_turbo_streams, status: :unprocessable_entity
         end
       end
     end

--- a/app/controllers/portfolios_controller.rb
+++ b/app/controllers/portfolios_controller.rb
@@ -70,7 +70,7 @@ class PortfoliosController < ProjectsController
 
         turbo_streams << turbo_stream.replace("flash-messages", helpers.render_flash_messages)
 
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end

--- a/app/controllers/projects/queries_controller.rb
+++ b/app/controllers/projects/queries_controller.rb
@@ -59,7 +59,7 @@ class Projects::QueriesController < ApplicationController
           component: Projects::IndexPageHeaderComponent.new(query: @query, current_user:, state: :edit, params:)
         )
 
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end
@@ -76,7 +76,7 @@ class Projects::QueriesController < ApplicationController
           component: Projects::IndexPageHeaderComponent.new(query: @query, current_user:, state: :rename, params:)
         )
 
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end
@@ -110,7 +110,7 @@ class Projects::QueriesController < ApplicationController
         # Load shares and replace the modal
         strategy = SharingStrategies::ProjectQueryStrategy.new(@query, user: current_user, query_params: {})
         replace_via_turbo_stream(component: Shares::ModalBodyComponent.new(strategy:, errors: []))
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
 
       format.html do

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -93,7 +93,7 @@ class ProjectsController < ApplicationController
 
         turbo_streams << turbo_stream.replace("flash-messages", helpers.render_flash_messages)
 
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -479,7 +479,7 @@ class UsersController < ApplicationController
     replace_via_turbo_stream(component: Users::TableComponent.new(rows: @query, current_user:))
     turbo_streams << turbo_stream.push_state(url_for(params.permit(:filters, :sortBy, :sort, :page, :per_page, :columns)))
     turbo_streams << helpers.render_flash_messages_as_turbo_streams
-    render turbo_stream: turbo_streams
+    render turbo_stream: resolve_turbo_streams
   end
 
   def prepare_views_for_tab # rubocop:disable Metrics/AbcSize

--- a/app/controllers/work_package_relations_tab_controller.rb
+++ b/app/controllers/work_package_relations_tab_controller.rb
@@ -43,7 +43,7 @@ class WorkPackageRelationsTabController < ApplicationController
       end
       format.turbo_stream do
         replace_via_turbo_stream(component:, method: "morph")
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end

--- a/app/helpers/no_results_helper.rb
+++ b/app/helpers/no_results_helper.rb
@@ -66,6 +66,7 @@ module NoResultsHelper
              title_text:,
              action_text:,
              action_url:
-           }
+           },
+           formats: [:html]
   end
 end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -33,7 +33,7 @@ module TabsHelper
   def render_tabs(tabs, form = nil)
     if tabs.any?
       selected = selected_tab(tabs)
-      render partial: "common/tabs", locals: { f: form, tabs:, selected_tab: selected }
+      render partial: "common/tabs", locals: { f: form, tabs:, selected_tab: selected }, formats: [:html]
     else
       content_tag "p", I18n.t(:label_no_data), class: "nodata"
     end

--- a/docs/development/concepts/hotwire-view-components/README.md
+++ b/docs/development/concepts/hotwire-view-components/README.md
@@ -205,7 +205,7 @@ class JournalController < ApplicationController
           component: JournalShowComponent.new(journal: journal)
         )
 
-        render turbo_stream: turbo_streams, status: :ok
+        render turbo_stream: resolve_turbo_streams, status: :ok
       end
     end
   end
@@ -221,7 +221,7 @@ TODO: is `turbo: true` required here?
 ```ruby
 <%=
   component_wrapper do
-    # ...  
+    # ...
     primer_form_with(
       model: journal,
       method: :put,
@@ -240,7 +240,7 @@ Rendering of a cancel button to remove the edition form. The button calls the `c
 ```ruby
 <%=
   component_wrapper do
-    # ...  
+    # ...
     render(Primer::Beta::Button.new(
       href: cancel_edit_journal_path(journal.id),
       data: { turbo: true, turbo_stream: true } # add this!

--- a/lib/redmine/menu_manager/top_menu/user_menu.rb
+++ b/lib/redmine/menu_manager/top_menu/user_menu.rb
@@ -163,7 +163,7 @@ module Redmine::MenuManager::TopMenu::UserMenu
         "account/login"
       end
 
-    render partial:
+    render partial:, formats: [:html]
   end
 
   def show_avatar?(avatar)

--- a/lookbook/docs/components/quick-filters.md.erb
+++ b/lookbook/docs/components/quick-filters.md.erb
@@ -86,7 +86,7 @@ def index
 
       # Re-render other components as well...
 
-      render turbo_stream: turbo_streams
+      render turbo_stream: resolve_turbo_streams
     end
   end
 end

--- a/modules/auth_saml/app/controllers/saml/providers_controller.rb
+++ b/modules/auth_saml/app/controllers/saml/providers_controller.rb
@@ -22,7 +22,7 @@ module Saml
         format.turbo_stream do
           update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
           scroll_into_view_via_turbo_stream("saml-providers-edit-form", behavior: :instant)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html
       end
@@ -113,7 +113,7 @@ module Saml
       respond_to do |format|
         format.turbo_stream do
           update_view_component(new_mode: @new_mode, edit_state: @next_edit_state, view_mode: :show)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html do
           if @next_edit_state

--- a/modules/meeting/app/controllers/meetings_controller.rb
+++ b/modules/meeting/app/controllers/meetings_controller.rb
@@ -84,7 +84,7 @@ class MeetingsController < ApplicationController
         )
         turbo_streams << turbo_stream.push_state(current_url)
 
-        render turbo_stream: turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
     end
   end
@@ -118,7 +118,7 @@ class MeetingsController < ApplicationController
       format.turbo_stream do
         update_header_component_via_turbo_stream(state: :edit)
 
-        render turbo_stream: @turbo_streams
+        render turbo_stream: resolve_turbo_streams
       end
       format.html do
         render :edit

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -81,7 +81,7 @@ module OpenIDConnect
         format.turbo_stream do
           update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
           scroll_into_view_via_turbo_stream("openid-connect-providers-edit-form", behavior: :instant)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html
       end
@@ -151,7 +151,7 @@ module OpenIDConnect
       respond_to do |format|
         format.turbo_stream do
           update_view_component(new_mode: @new_mode, edit_state: @next_edit_state, view_mode: :show)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html do
           if @next_edit_state
@@ -171,7 +171,7 @@ module OpenIDConnect
       respond_to do |format|
         format.turbo_stream do
           update_view_component(new_mode: @new_mode, edit_state: @edit_state, view_mode: :show)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
         format.html do
           render action: action_to_render, status: :unprocessable_entity

--- a/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
+++ b/modules/openid_connect/app/controllers/openid_connect/providers_controller.rb
@@ -58,10 +58,20 @@ module OpenIDConnect
       @provider = OpenIDConnect::Provider.new(oidc_provider:)
     end
 
+    def edit
+      respond_to do |format|
+        format.turbo_stream do
+          update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
+          scroll_into_view_via_turbo_stream("openid-connect-providers-edit-form", behavior: :instant)
+          render turbo_stream: resolve_turbo_streams
+        end
+        format.html
+      end
+    end
+
     def create
       create_params = params
-                        .require(:openid_connect_provider)
-                        .permit(:display_name, :oidc_provider, :tenant)
+                        .expect(openid_connect_provider: %i[display_name oidc_provider tenant])
 
       call = ::OpenIDConnect::Providers::CreateService
         .new(user: User.current)
@@ -76,22 +86,10 @@ module OpenIDConnect
       end
     end
 
-    def edit
-      respond_to do |format|
-        format.turbo_stream do
-          update_view_component(view_mode: :edit, new_mode: @new_mode, edit_state: @edit_state)
-          scroll_into_view_via_turbo_stream("openid-connect-providers-edit-form", behavior: :instant)
-          render turbo_stream: resolve_turbo_streams
-        end
-        format.html
-      end
-    end
-
     def update
       update_params = params
-                        .require(:openid_connect_provider)
-                        .permit(:display_name, :oidc_provider, :limit_self_registration,
-                                *OpenIDConnect::Provider.stored_attributes[:options])
+                        .expect(openid_connect_provider: [:display_name, :oidc_provider, :limit_self_registration,
+                                                          *OpenIDConnect::Provider.stored_attributes[:options]])
       call = OpenIDConnect::Providers::UpdateService
         .new(model: @provider, user: User.current, fetch_metadata: fetch_metadata?)
         .call(update_params)
@@ -139,10 +137,10 @@ module OpenIDConnect
     end
 
     def find_provider
-      @provider = OpenIDConnect::Provider.find(params[:id])
+      @provider = OpenIDConnect::Provider.find(params.expect(:id))
     end
 
-    def successful_save_response
+    def successful_save_response # rubocop:disable Metrics/AbcSize
       if @new_mode && !@next_edit_state
         flash[:notice] = I18n.t("openid_connect.providers.notice_created")
         return redirect_to openid_connect_provider_path(@provider)
@@ -186,9 +184,9 @@ module OpenIDConnect
     end
 
     def set_edit_state
-      @edit_state = params[:edit_state].to_sym if params.key?(:edit_state)
+      @edit_state = params.expect(:edit_state).to_sym if params.key?(:edit_state)
       @new_mode = ActiveRecord::Type::Boolean.new.cast(params[:new_mode])
-      @next_edit_state = params[:next_edit_state].to_sym if params.key?(:next_edit_state)
+      @next_edit_state = params.expect(:next_edit_state).to_sym if params.key?(:next_edit_state)
     end
 
     def fetch_metadata?

--- a/modules/wikis/app/controllers/wikis/wiki_pages_controller.rb
+++ b/modules/wikis/app/controllers/wikis/wiki_pages_controller.rb
@@ -47,7 +47,7 @@ module Wikis
         format.turbo_stream do
           replace_via_turbo_stream component: Wikis::WikiPages::IndexResultsComponent.new(wiki_pages: @wiki_pages)
           turbo_streams << turbo_stream.push_state(current_state)
-          render turbo_stream: turbo_streams
+          render turbo_stream: resolve_turbo_streams
         end
       end
     end


### PR DESCRIPTION
This ensures that the rendering does not happen the moment they are queued up (e.g. when using replace_via_turbo_stream), but only once the response is rendered as a turbo_stream. Thus they are not needlessly rendered for other response formats.

This uncovered an issue with some of our `render partial:` calls that has been fixed in a subsequent commit.