### PR TITLE
[#69526] Text overflow in Baseline modal banner  

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
@@ -1,5 +1,5 @@
 <div class="op-baseline--header"
-  [class.op-baseline--header_banner-active]="!available"
+  [class.op-baseline--header_banner-active]="Banner.showBannerFor('baseline_comparison')"
   [class.op-baseline_tab]="!showActionBar">
 
   <op-enterprise-banner-frame feature="baseline_comparison"


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/69526

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Fix condition for when the wider width is applied - it needs to be wider when the feature is unavailable _and_ when being trialed (and thus technically available)

## Screenshots

<img width="591" height="517" alt="image" src="https://github.com/user-attachments/assets/1219a470-c7a6-4fbc-94fe-87aa7f86b1cd" />
