### PR TITLE
Fix DefaultHourlyRate#rate_updated using pre-save dirty API in after_update

### DIFF
--- a/modules/costs/app/models/default_hourly_rate.rb
+++ b/modules/costs/app/models/default_hourly_rate.rb
@@ -77,10 +77,10 @@ class DefaultHourlyRate < Rate
 
   def rate_updated
     # FIXME: This might be extremely slow. Consider using an implementation like in HourlyRateObserver
-    unless valid_from_changed?
+    unless saved_change_to_valid_from?
       # We have not moved a rate, maybe just changed the rate value
 
-      return unless rate_changed?
+      return unless saved_change_to_rate?
 
       # Only the rate value was changed so just update the currently assigned entries
       return rate_created

--- a/modules/costs/spec/models/default_hourly_rate_spec.rb
+++ b/modules/costs/spec/models/default_hourly_rate_spec.rb
@@ -57,4 +57,28 @@ RSpec.describe DefaultHourlyRate do
       it { expect(rate.user).to eq(DeletedUser.first) }
     end
   end
+
+  describe "#rate_updated (after_update callback)" do
+    # Regression: rate_updated runs in an after_update callback, where the pre-save
+    # dirty API (`valid_from_changed?` / `rate_changed?`) always returns false because
+    # ActiveRecord has already cleared the dirty state. The override must use the
+    # post-save API (`saved_change_to_*?`) — matching the parent Rate#rate_updated.
+    # Without the fix, editing only the rate value silently fails to regenerate the
+    # costs on existing TimeEntry rows.
+    let(:user) { create(:user) }
+    let!(:default_rate) do
+      create(:default_hourly_rate, user:, rate: 100.0, valid_from: 30.days.ago.to_date)
+    end
+    let!(:time_entry) do
+      create(:time_entry, user:, spent_on: 1.day.ago.to_date, hours: 1.0)
+    end
+
+    it "regenerates dependent TimeEntry#costs when only the rate value changes" do
+      expect(time_entry.reload.costs).to eq(100.0)
+
+      default_rate.update!(rate: 120.0)
+
+      expect(time_entry.reload.costs).to eq(120.0)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`DefaultHourlyRate#rate_updated` runs from `after_update :rate_updated` (inherited from `Rate`) but guards on the **pre-save** dirty API: `valid_from_changed?` / `rate_changed?`. By the time `after_update` callbacks run, ActiveRecord has already cleared the pre-save dirty state, so both guards always return `false`. The method early-returns without invoking `rate_created`, leaving dependent `TimeEntry` rows with stale `costs`.

The parent class `Rate#rate_updated` already uses the post-save `saved_change_to_valid_from?` / `saved_change_to_rate?` API — this PR brings the `DefaultHourlyRate` subclass in line. `HourlyRate` is unaffected because it doesn't override `rate_updated` and transparently uses the parent's (already-correct) version.

**Symptom:** editing only the rate value (same `valid_from`) on a user's default hourly rate silently leaves Cost Report values unchanged until something else forces a recalculation.

Fixes https://community.openproject.org/projects/openproject/work_packages/49669

## Test plan

- [x] Added regression spec in `modules/costs/spec/models/default_hourly_rate_spec.rb`
  - Creates a `DefaultHourlyRate(rate: 100)` and a `TimeEntry(hours: 1)` for the same user
  - Updates the rate to `120`
  - Expects `TimeEntry#costs` to reload as `120.0`
  - Fails on the prior `*_changed?` implementation, passes after the fix

## Manual repro

1. Create a user with `DefaultHourlyRate(rate: 100, valid_from: <past date>)`.
2. Log 1h on a work package → `TimeEntry.costs == 100`.
3. Admin → Users → that user → Rates → change rate to `120` (same `valid_from`), save.
4. Before fix: Cost Report still shows 100. After fix: 120.
