### PR TITLE
[#65523] Log time modal dropdown's bottom border is indistignuishable from the modal's bottom border  

### DIFF
--- a/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
+++ b/modules/costs/app/components/time_entries/entry_dialog_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::Alpha::Dialog.new(title: t("caption_log_time_dialog"), size: :medium_portrait, id: MODAL_ID, data: { "keep-open-on-submit": true, "controller" => "time-entry", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
+<%= render(Primer::Alpha::Dialog.new(title: t("caption_log_time_dialog"), size: :medium, position: :right, id: MODAL_ID, data: { "keep-open-on-submit": true, "controller" => "time-entry", "time-entry-id" => time_entry.id, "ongoing" => time_entry.ongoing? })) do |d| %>
   <% d.with_header(variant: :large) %>
   <% d.with_body do %>
     <%= render(


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/65523

# What approach did you choose and why?

- Update the dialog to be full height and on the right, as it's a long form and further increasing the height for the `medium` variant was not an option


