### PR TITLE
[#75275] Fix hellip/expandable text alignment

### DIFF
--- a/app/components/op_primer/expandable_text_component.html.erb
+++ b/app/components/op_primer/expandable_text_component.html.erb
@@ -1,0 +1,15 @@
+<%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
+  <%= render Primer::Beta::Truncate.new(
+        data: { truncation_target: "truncate" },
+        flex: 1
+      ) do %>
+    <%= content %>
+  <% end %>
+
+  <%= render Primer::Alpha::HiddenTextExpander.new(
+        hidden: true,
+        mt: 1,
+        aria: { label: t(:"js.label_expand_text") },
+        data: { truncation_target: "expander" }
+      ) %>
+<% end %>

--- a/app/components/op_primer/expandable_text_component.rb
+++ b/app/components/op_primer/expandable_text_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+module OpPrimer
+  class ExpandableTextComponent < Primer::Component # rubocop:disable OpenProject/AddPreviewForViewComponent
+    def initialize(**system_arguments)
+      super()
+
+      @system_arguments = deny_tag_argument(**system_arguments)
+      @system_arguments[:tag] = :div
+      @system_arguments[:display] = :flex
+      @system_arguments[:align_items] = :baseline
+      @system_arguments[:data] = merge_data(
+        @system_arguments,
+        data: { controller: "truncation" }
+      )
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "gap-1 min-width-0"
+      )
+    end
+  end
+end

--- a/app/views/roles/report.html.erb
+++ b/app/views/roles/report.html.erb
@@ -154,8 +154,7 @@ See COPYRIGHT and LICENSE files for more details.
                           Primer::BaseComponent.new(
                             tag: :div,
                             display: :flex,
-                            align_items: :center,
-                            data: { controller: "truncation" },
+                            align_items: :flex_start,
                             classes: "gap-1",
                             ml: 1,
                             mr: 3
@@ -180,25 +179,9 @@ See COPYRIGHT and LICENSE files for more details.
                             )
                           )
                         %>
-                        <%=
-                          render(
-                            Primer::Beta::Truncate.new(
-                              data: { truncation_target: "truncate" },
-                              flex: 1
-                            )
-                          ) do
-                            humanized_permission_name
-                          end
-                        %>
-                        <%=
-                          render(
-                            Primer::Alpha::HiddenTextExpander.new(
-                              hidden: true,
-                              aria: { label: t(:"js.label_expand_text") },
-                              data: { truncation_target: "expander" }
-                            )
-                          )
-                        %>
+                        <%= render(OpPrimer::ExpandableTextComponent.new(flex: 1)) do %>
+                          <%= humanized_permission_name %>
+                        <% end %>
                       <% end %>
                     </th>
                     <% @roles.each.with_index do |role, i| %>

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -139,8 +139,7 @@ See COPYRIGHT and LICENSE files for more details.
                   Primer::BaseComponent.new(
                     tag: :div,
                     display: :flex,
-                    align_items: :center,
-                    data: { controller: "truncation" },
+                    align_items: :flex_start,
                     classes: "gap-1",
                     ml: 1,
                     mr: 3
@@ -165,25 +164,9 @@ See COPYRIGHT and LICENSE files for more details.
                     )
                   )
                 %>
-                <%=
-                  render(
-                    Primer::Beta::Truncate.new(
-                      data: { truncation_target: "truncate" },
-                      flex: 1
-                    )
-                  ) do
-                    old_status.name
-                  end
-                %>
-                <%=
-                  render(
-                    Primer::Alpha::HiddenTextExpander.new(
-                      hidden: true,
-                      aria: { label: t(:"js.label_expand_text") },
-                      data: { truncation_target: "expander" }
-                    )
-                  )
-                %>
+                <%= render(OpPrimer::ExpandableTextComponent.new(flex: 1)) do %>
+                  <%= old_status.name %>
+                <% end %>
               <% end %>
             </th>
             <% @statuses.each do |new_status| -%>

--- a/spec/components/op_primer/expandable_text_component_spec.rb
+++ b/spec/components/op_primer/expandable_text_component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe OpPrimer::ExpandableTextComponent, type: :component do
+  def render_component(**, &)
+    render_inline(described_class.new(**), &)
+  end
+
+  it "renders expandable truncated text" do
+    render_component { "Long permission label" }
+
+    expect(page).to have_css("div.d-flex.flex-items-baseline.gap-1.min-width-0[data-controller='truncation']")
+    expect(page).to have_css(".Truncate.flex-1[data-truncation-target='truncate']", text: "Long permission label")
+    expect(page).to have_css(".hidden-text-expander[data-truncation-target='expander'][hidden]", visible: :hidden)
+    expect(page).to have_css("button.ellipsis-expander[aria-label='Show full text']", visible: :hidden)
+  end
+
+  it "merges classes and data attributes" do
+    render_component(classes: "custom-class", data: { test_selector: "expandable-text" }) { "Long permission label" }
+
+    expect(page).to have_css(
+      "div.custom-class.gap-1.min-width-0[data-controller='truncation'][data-test-selector='expandable-text']"
+    )
+  end
+
+  it "supports flex system arguments" do
+    render_component(flex: 1) { "Long permission label" }
+
+    expect(page).to have_css("div.flex-1")
+  end
+end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/75275

# What are you trying to accomplish?

Extracts a shared `ExpandableTextComponent` for truncation with `HiddenTextExpander`, preserving caller classes and data attributes. Implements it on on the permissions report and workflows matrices so expanded labels keep the ellipsis aligned with the first line.


## Screenshots

| State  | Collapsed | Expanded |
|--------|--------|--------|
| **Before** | <img width="574" height="58" alt="Screenshot 2026-05-22 at 15 08 23" src="https://github.com/user-attachments/assets/3364b9e2-2ee0-4730-bfed-6a067d6756a8" />| <img width="576" height="78" alt="Screenshot 2026-05-22 at 15 08 30" src="https://github.com/user-attachments/assets/46c49f91-a663-462e-b25b-174a22d9ce95" />| 
| **After** | <img width="559" height="54" alt="Screenshot 2026-05-22 at 15 07 42" src="https://github.com/user-attachments/assets/a5246348-9e50-46a1-94a5-120ea8879ddf" />| <img width="553" height="73" alt="Screenshot 2026-05-22 at 15 07 32" src="https://github.com/user-attachments/assets/a4431eeb-83e0-43b5-be19-2840f7167f95" />|

# What approach did you choose and why?

Creates a shared `ExpandableTextComponent` for truncation with `HiddenTextExpander`. Does not yet add documentation - this will be addressed in OP [#75274](https://community.openproject.org/work_packages/75274)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
