### PR TITLE
bug/74844 Show work package identifier in autocompleter dropdowns

### DIFF
--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
@@ -38,6 +38,11 @@ import { HalResourceService } from 'core-app/features/hal/services/hal-resource.
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 
 import { OpAutocompleterService } from './op-autocompleter.service';
+import { TOpAutocompleterResource } from '../typings';
+
+interface CreateParamsAccess {
+  createParams:(resource:TOpAutocompleterResource) => Record<string, string>;
+}
 
 describe('OpAutocompleterService', () => {
   let service:OpAutocompleterService;
@@ -66,11 +71,15 @@ describe('OpAutocompleterService', () => {
     httpMock.verify();
   });
 
+  describe('work_packages select params', () => {
+    it('requests elements/_type for work_packages', () => {
+      const params = (service as unknown as CreateParamsAccess).createParams('work_packages');
+
+      expect(params.select).toContain('elements/_type');
+    });
+  });
+
   describe('loadAvailable("work_packages")', () => {
-    // Pins the dispatch outcome: a Collection payload whose elements carry
-    // _type: 'WorkPackage' must materialise as WorkPackageResource instances so
-    // typed getters resolve. Catches both backend regressions that drop _type and
-    // any future client-side change that breaks the HAL factory wiring.
     it('emits WorkPackageResource instances for elements typed as WorkPackage', async () => {
       const pending = firstValueFrom(service.loadAvailable('demo', 'work_packages'));
 

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
@@ -32,17 +32,12 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { firstValueFrom } from 'rxjs';
 
 import { States } from 'core-app/core/states/states.service';
+import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
-import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 
 import { OpAutocompleterService } from './op-autocompleter.service';
-import { TOpAutocompleterResource } from '../typings';
-
-interface CreateParamsAccess {
-  createParams:(resource:TOpAutocompleterResource) => Record<string, string>;
-}
 
 describe('OpAutocompleterService', () => {
   let service:OpAutocompleterService;
@@ -50,7 +45,6 @@ describe('OpAutocompleterService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [OpenprojectHalModule],
       providers: [
         States,
         OpAutocompleterService,
@@ -60,26 +54,16 @@ describe('OpAutocompleterService', () => {
       ],
     });
 
-    // Force ApplicationInitStatus to run, which registers WorkPackage with HalResourceService.
-    TestBed.inject(HalResourceService);
+    const halResourceService = TestBed.inject(HalResourceService);
+    halResourceService.registerResource('Collection', { cls: CollectionResource });
+    halResourceService.registerResource('WorkPackage', { cls: WorkPackageResource });
+
     service = TestBed.inject(OpAutocompleterService);
     httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
     httpMock.verify();
-  });
-
-  describe('work_packages select params', () => {
-    // Pins the wire contract so future edits to createParams can't silently drop _type
-    // from the select string. The dispatch consequence (typed WorkPackageResource vs
-    // generic HalResource) is asserted end-to-end by the loadAvailable test below.
-    // Regression: https://community.openproject.org/wp/74844
-    it('requests elements/_type for work_packages', () => {
-      const params = (service as unknown as CreateParamsAccess).createParams('work_packages');
-
-      expect(params.select).toContain('elements/_type');
-    });
   });
 
   describe('loadAvailable("work_packages")', () => {

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
@@ -28,8 +28,14 @@
 
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { firstValueFrom } from 'rxjs';
+
 import { States } from 'core-app/core/states/states.service';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { HalResourceService } from 'core-app/features/hal/services/hal-resource.service';
+import { OpenprojectHalModule } from 'core-app/features/hal/openproject-hal.module';
+import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 
 import { OpAutocompleterService } from './op-autocompleter.service';
 import { TOpAutocompleterResource } from '../typings';
@@ -40,28 +46,76 @@ interface CreateParamsAccess {
 
 describe('OpAutocompleterService', () => {
   let service:OpAutocompleterService;
+  let httpMock:HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [OpenprojectHalModule],
       providers: [
         States,
         OpAutocompleterService,
+        { provide: SchemaCacheService, useValue: { ensureLoaded: () => Promise.resolve() } },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],
     });
 
+    // Force ApplicationInitStatus to run, which registers WorkPackage with HalResourceService.
+    TestBed.inject(HalResourceService);
     service = TestBed.inject(OpAutocompleterService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   describe('work_packages select params', () => {
-    // _type drives HAL factory dispatch to WorkPackageResource; without it dropdown items
-    // are parsed as generic HalResource and the formattedId getter never resolves.
+    // Pins the wire contract so future edits to createParams can't silently drop _type
+    // from the select string. The dispatch consequence (typed WorkPackageResource vs
+    // generic HalResource) is asserted end-to-end by the loadAvailable test below.
     // Regression: https://community.openproject.org/wp/74844
-    it('requests elements/_type so each element is parsed as WorkPackageResource', () => {
+    it('requests elements/_type for work_packages', () => {
       const params = (service as unknown as CreateParamsAccess).createParams('work_packages');
 
       expect(params.select).toContain('elements/_type');
+    });
+  });
+
+  describe('loadAvailable("work_packages")', () => {
+    // Pins the dispatch outcome: a Collection payload whose elements carry
+    // _type: 'WorkPackage' must materialise as WorkPackageResource instances so
+    // typed getters resolve. Catches both backend regressions that drop _type and
+    // any future client-side change that breaks the HAL factory wiring.
+    it('emits WorkPackageResource instances for elements typed as WorkPackage', async () => {
+      const pending = firstValueFrom(service.loadAvailable('demo', 'work_packages'));
+
+      const request = httpMock.expectOne((req) => req.url.startsWith('/api/v3/work_packages'));
+      request.flush({
+        _type: 'Collection',
+        _links: { self: { href: request.request.url } },
+        _embedded: {
+          elements: [
+            {
+              _type: 'WorkPackage',
+              id: 42,
+              displayId: 'DEMO-7',
+              subject: 'Pick me',
+              _links: { self: { href: '/api/v3/work_packages/42' } },
+            },
+          ],
+        },
+        count: 1,
+        total: 1,
+        pageSize: 30,
+        offset: 1,
+      });
+
+      const elements = await pending;
+
+      expect(elements).toHaveLength(1);
+      expect(elements[0]).toBeInstanceOf(WorkPackageResource);
+      expect((elements[0] as WorkPackageResource).displayId).toBe('DEMO-7');
     });
   });
 });

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.spec.ts
@@ -1,0 +1,67 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { States } from 'core-app/core/states/states.service';
+
+import { OpAutocompleterService } from './op-autocompleter.service';
+import { TOpAutocompleterResource } from '../typings';
+
+interface CreateParamsAccess {
+  createParams:(resource:TOpAutocompleterResource) => Record<string, string>;
+}
+
+describe('OpAutocompleterService', () => {
+  let service:OpAutocompleterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        States,
+        OpAutocompleterService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(OpAutocompleterService);
+  });
+
+  describe('work_packages select params', () => {
+    // _type drives HAL factory dispatch to WorkPackageResource; without it dropdown items
+    // are parsed as generic HalResource and the formattedId getter never resolves.
+    // Regression: https://community.openproject.org/wp/74844
+    it('requests elements/_type so each element is parsed as WorkPackageResource', () => {
+      const params = (service as unknown as CreateParamsAccess).createParams('work_packages');
+
+      expect(params.select).toContain('elements/_type');
+    });
+  });
+});

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -59,8 +59,10 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
   protected createParams(resource:TOpAutocompleterResource):Record<string, string> {
     if (resource === 'work_packages') {
       return {
-        // see op-autocompleter/op-autocompleter.component.html for required attributes
-        select: 'elements/id,elements/displayId,elements/subject,elements/author,elements/type,elements/project,elements/status',
+        // Fields are listed in op-autocompleter/op-autocompleter.component.html. `_type` is the
+        // HAL class discriminator: omitting it causes the factory to fall back to a generic
+        // HalResource, and getters like `formattedId` on WorkPackageResource never resolve.
+        select: 'elements/id,elements/_type,elements/displayId,elements/subject,elements/author,elements/type,elements/project,elements/status',
         sortBy: '[["updatedAt","desc"]]',
       };
     }

--- a/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
+++ b/frontend/src/app/shared/components/autocompleter/op-autocompleter/services/op-autocompleter.service.ts
@@ -62,7 +62,7 @@ export class OpAutocompleterService extends UntilDestroyedMixin {
         // Fields are listed in op-autocompleter/op-autocompleter.component.html. `_type` is the
         // HAL class discriminator: omitting it causes the factory to fall back to a generic
         // HalResource, and getters like `formattedId` on WorkPackageResource never resolve.
-        select: 'elements/id,elements/_type,elements/displayId,elements/subject,elements/author,elements/type,elements/project,elements/status',
+        select: 'elements/id,elements/displayId,elements/subject,elements/author,elements/type,elements/project,elements/status,elements/_type',
         sortBy: '[["updatedAt","desc"]]',
       };
     }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74844

# What are you trying to accomplish?

The work package autocompleter dropdown — used by the meeting agenda item picker, the Log time modal, the Time & costs report, and the relations picker — renders the identifier column as empty in both semantic and classic modes. Users searching for a work package see the type and subject, but the `PROJ-42` / `#42` chip is missing.

The autocompleter's narrow-select request omitted `_type`, the SQL representer stripped it from the response (`Sql::Hal#selected` slices the property allowlist), and the factory fell back to generic `HalResource` — where `formattedId` is undefined.

## Screenshots

### Before

<img width="1520" height="932" alt="Screenshot 2026-05-22 at 5 44 39 PM" src="https://github.com/user-attachments/assets/c0b28d4f-2f51-4188-9f4c-f71d8a245076" />


### After

<img width="1234" height="886" alt="Screenshot 2026-05-22 at 5 45 20 PM" src="https://github.com/user-attachments/assets/755b05af-1858-4347-b25a-189852e17e10" />


# What approach did you choose and why?

This PR adds `elements/_type` to the autocompleter's select parameter so that the resource can be correctly typed to `WorkPackageResource` instead of the generic `HalResource`. 

Considered a wider fix: make `_type` a default (unfilterable) property at the representer layer to mitigate similar bugs- but I noticed existing convetion in the project autocompleter (`project-autocompleter.component.ts:180`) and the workspaces/portfolios/programs index specs already request `_type` explicitly.

Either way, I suppose a regression tests should have flagged this- so that's also included here.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)