### PR TITLE
[#73150] Hide template meetings when only having view meetings permission  

### DIFF
--- a/modules/meeting/app/menus/meetings/menu.rb
+++ b/modules/meeting/app/menus/meetings/menu.rb
@@ -62,6 +62,7 @@ module Meetings
 
     def templates_menu_item
       return unless User.current.logged?
+      return unless can_create_meetings?
 
       templates_href = if project
                          templates_project_meetings_path(project)
@@ -185,6 +186,14 @@ module Meetings
         query_params: { filters: author_filter },
         selected: params[:filters].to_s.include?("author_id")
       )
+    end
+
+    def can_create_meetings?
+      if project
+        User.current.allowed_in_project?(:create_meetings, project)
+      else
+        User.current.allowed_in_any_project?(:create_meetings)
+      end
     end
   end
 end

--- a/modules/meeting/lib/open_project/meeting/engine.rb
+++ b/modules/meeting/lib/open_project/meeting/engine.rb
@@ -47,8 +47,7 @@ module OpenProject::Meeting
                                   presentation generate_pdf_dialog history],
                      "meetings/menus": %i[show],
                      work_package_meetings_tab: %i[index count],
-                     recurring_meetings: %i[index show new create download_ics],
-                     meeting_templates: %i[index]
+                     recurring_meetings: %i[index show new create download_ics]
                    },
                    permissible_on: :project
         permission :create_meetings,
@@ -57,7 +56,7 @@ module OpenProject::Meeting
                      recurring_meetings: %i[new create copy init template_completed],
                      "recurring_meetings/schedule": %i[update_text],
                      "meetings/menus": %i[show],
-                     meeting_templates: %i[new create new_dialog]
+                     meeting_templates: %i[index new create new_dialog]
                    },
                    dependencies: :view_meetings,
                    permissible_on: :project,

--- a/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
+++ b/modules/meeting/spec/features/meeting_templates/onetime_template_crud_spec.rb
@@ -212,20 +212,30 @@ RSpec.describe "Onetime templates CRUD", :js do
         visit templates_meetings_path
       end
 
-      it "can view templates but cannot see create button or action menu" do
+      it "sees a 403 error" do
+        expect(page).to have_text("You are not authorized to access this page.")
+      end
+    end
+
+    context "as user with create_meetings permission" do
+      let(:user_with_create) do
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings] })
+      end
+
+      before do
+        logout
+        login_as(user_with_create)
+        visit templates_meetings_path
+      end
+
+      it "can access templates page and see templates" do
         expect(page).to have_text("Permission test template")
-
-        expect(page).to have_no_css("#add-template-button")
-
-        within_row("Permission test template") do
-          expect(page).to have_no_css('[data-test-selector="more-button"]')
-        end
       end
     end
 
     context "as user with edit_meetings permission" do
       let(:user_with_edit) do
-        create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings] })
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings] })
       end
 
       before do
@@ -248,7 +258,7 @@ RSpec.describe "Onetime templates CRUD", :js do
 
     context "as user with delete_meetings permission" do
       let(:user_with_delete) do
-        create(:user, member_with_permissions: { project => %i[view_meetings delete_meetings] })
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings delete_meetings] })
       end
 
       before do
@@ -271,7 +281,7 @@ RSpec.describe "Onetime templates CRUD", :js do
 
     context "as user with both edit and delete permissions" do
       let(:user_with_both) do
-        create(:user, member_with_permissions: { project => %i[view_meetings edit_meetings delete_meetings] })
+        create(:user, member_with_permissions: { project => %i[view_meetings create_meetings edit_meetings delete_meetings] })
       end
 
       before do

--- a/modules/meeting/spec/requests/meeting_templates_spec.rb
+++ b/modules/meeting/spec/requests/meeting_templates_spec.rb
@@ -78,7 +78,27 @@ RSpec.describe "Meeting templates requests",
       end
     end
 
-    context "without view_meetings permission" do
+    context "with view_meetings permission only" do
+      shared_let(:user_view_only) do
+        create(:user, member_with_permissions: { project => %i[view_meetings] })
+      end
+
+      before { login_as user_view_only }
+
+      it "returns 403" do
+        get templates_project_meetings_path(project)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns 403 for global templates path" do
+        get templates_meetings_path
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "without any permission" do
       before { login_as user_without_permissions }
 
       it "returns 403" do
@@ -212,7 +232,7 @@ RSpec.describe "Meeting templates requests",
     shared_let(:unrelated_project) { create(:project, enabled_module_names: %i[meetings]) }
 
     shared_let(:user) do
-      create(:user, member_with_permissions: { current_project => %i[view_meetings] })
+      create(:user, member_with_permissions: { current_project => %i[view_meetings create_meetings] })
     end
 
     shared_let(:own_template) { create(:onetime_template, project: current_project, title: "Own template") }
@@ -248,7 +268,7 @@ RSpec.describe "Meeting templates requests",
     shared_let(:inaccessible_project) { create(:project, enabled_module_names: %i[meetings]) }
 
     shared_let(:user) do
-      create(:user, member_with_permissions: { accessible_project => %i[view_meetings] })
+      create(:user, member_with_permissions: { accessible_project => %i[view_meetings create_meetings] })
     end
 
     shared_let(:own_template) { create(:onetime_template, project: accessible_project, title: "Own template") }


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/73150

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

- Move accessing one time templates behind `create_meetings` instead of `view_meetings`

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
