### PR TITLE
[#74927] Unable to change a parent on bulk edit of work packages with semantic ID

### DIFF
--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -139,6 +139,8 @@ class WorkPackages::BulkController < ApplicationController
     return attributes unless WorkPackage::SemanticIdentifier.semantic_id?(raw.to_s)
 
     wp = WorkPackage.find_by_display_id(raw)
+    # If the semantic ID hasn't resolved to a proper package, default to 0, which is an invalid value
+    # that will trigger errors in the main update service
     attributes.merge(parent_id: wp ? wp.id : 0)
   end
 

--- a/app/controllers/work_packages/bulk_controller.rb
+++ b/app/controllers/work_packages/bulk_controller.rb
@@ -130,7 +130,16 @@ class WorkPackages::BulkController < ApplicationController
 
     attributes = permitted_params.update_work_package
     attributes[:custom_field_values] = transform_attributes(attributes[:custom_field_values])
+    attributes = attributes_with_normalized_parent_id(attributes)
     transform_attributes(attributes)
+  end
+
+  def attributes_with_normalized_parent_id(attributes)
+    raw = attributes[:parent_id]
+    return attributes unless WorkPackage::SemanticIdentifier.semantic_id?(raw.to_s)
+
+    wp = WorkPackage.find_by_display_id(raw)
+    attributes.merge(parent_id: wp ? wp.id : 0)
   end
 
   def user

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -625,6 +625,42 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
         expect(new_parent.due_date).to eq(task2.due_date)
       end
     end
+
+    describe "bulk parent assignment with semantic identifiers",
+             with_settings: { work_packages_identifier: "semantic" } do
+      let(:sem_project) do
+        create(:project, identifier: "SEMPROJ", types: [type]).tap do |p|
+          create(:member, project: p, principal: user, roles: [role])
+        end
+      end
+      let(:parent_wp) { create(:work_package, project: sem_project).reload }
+      let(:child1)    { create(:work_package, project: sem_project).reload }
+      let(:child2)    { create(:work_package, project: sem_project).reload }
+
+      it "accepts a semantic identifier and assigns the parent" do
+        put :update,
+            params: {
+              ids: [child1.id, child2.id],
+              work_package: { parent_id: parent_wp.identifier }
+            }
+
+        expect(response).to have_http_status(:found)
+        expect(child1.reload.parent_id).to eq(parent_wp.id)
+        expect(child2.reload.parent_id).to eq(parent_wp.id)
+      end
+
+      it "reports an error for an unknown semantic identifier" do
+        put :update,
+            params: {
+              ids: [child1.id, child2.id],
+              work_package: { parent_id: "SEMPROJ-9999" }
+            }
+
+        expect(flash[:error]).to be_present
+        expect(child1.reload.parent_id).to be_nil
+        expect(child2.reload.parent_id).to be_nil
+      end
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74927

# What are you trying to accomplish?

When bulk-editing work packages with semantic IDs enabled, entering a semantic ID (e.g. `PROJ-42`) in the Parent field was silently ignored — only numeric IDs were accepted.

# What approach did you choose and why?

The bulk edit form submits `parent_id` as a raw string. Before passing attributes to the update service, the controller now checks whether `parent_id` is a semantic ID string and resolves it to a numeric primary key via `WorkPackage.find_by_display_id`. If the ID isn't found, it falls back to `0` so the contract produces the normal "parent does not exist" error rather than silently doing nothing.

The resolution is placed in `attributes_with_normalized_parent_id` called from `attributes_for_update`, following the existing pattern that controllers are the right layer for display-ID resolution (consistent with `app/CLAUDE.md`). The single-WP edit path is unaffected — it goes through the V3 API with a HAL link and was already working correctly.

# Merge checklist

- [x] Added/updated tests