### PR TITLE
bug/74681: Admin page for semantic IDs: grammatical issue

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5528,7 +5528,7 @@ en:
   setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)
   setting_work_packages_identifier_classic_caption: "Every work package gets a sequential number starting with 1 (for example, #1234). The numbers are unique within the instance and remain the same even if work packages are moved between projects."
   setting_work_packages_identifier_semantic: Project-based semantic identifiers
-  setting_work_packages_identifier_semantic_caption: "Every project has a unique project identifier prefixed to a number (for example, PROJ-11). If a work package is moved to another project, a new identifier is generated but the old one will continue to function."
+  setting_work_packages_identifier_semantic_caption: "Every project has a unique project identifier prefixed to a number (for example, PROJ-11). The numbering of each project starts at 1. If a work package is moved to another project, a new identifier is generated but the old one will continue to function."
   setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
   setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"
   setting_working_days: "Working days"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5526,11 +5526,9 @@ en:
   setting_welcome_title: "Welcome block title"
   setting_welcome_on_homescreen: "Display welcome block on homescreen"
   setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)
-  setting_work_packages_identifier_classic_caption: >
-    Every work package gets a sequential number starting with 1 and incremented with every new one. The numbers are unique within this instance so they remain the same even if work packages are moved between projects.
+  setting_work_packages_identifier_classic_caption: "Every work package gets a sequential number starting with 1 (for example, #1234). The numbers are unique within the instance and remain the same even if work packages are moved between projects."
   setting_work_packages_identifier_semantic: Project-based semantic identifiers
-  setting_work_packages_identifier_semantic_caption: >
-    Every project has a unique identifier that is prefixed to the work package ID. If a work package moved to another project, a new identifier is generated but the old one continues to function.
+  setting_work_packages_identifier_semantic_caption: "Every project has a unique project identifier prefixed to a number (for example, PROJ-11). If a work package is moved to another project, a new identifier is generated but the old one will continue to function."
   setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
   setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"
   setting_working_days: "Working days"


### PR DESCRIPTION
https://community.openproject.org/projects/communicator-stream/work_packages/74681/activity#comment-1677157

<img width="962" height="327" alt="Screenshot 2026-05-25 at 11 57 52 AM" src="https://github.com/user-attachments/assets/807bd734-43c0-42ab-bdb8-4fa7c58bb214" />
