### PR TITLE
Revert "bump parallel_tests & turbo_tests"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -265,11 +265,10 @@ group :test do
   gem "rack-test", "~> 2.2.0"
   gem "shoulda-context", "~> 2.0"
 
-  gem "parallel_tests", "~> 5.7"
   # Test prof provides factories from code
   # and other niceties
   gem "test-prof", "~> 1.6.0"
-  gem "turbo_tests", github: "opf/turbo_tests", ref: "2_2_5_with_patches"
+  gem "turbo_tests", github: "opf/turbo_tests", ref: "with-patches"
 
   gem "rack_session_access"
   gem "rspec", "~> 3.13.2"
@@ -318,6 +317,8 @@ group :test do
   gem "equivalent-xml", "~> 0.6"
   gem "json_spec", "~> 1.1.4"
   gem "shoulda-matchers", "~> 7.0", require: nil
+
+  gem "parallel_tests", "~> 4.0"
 end
 
 group :ldap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,11 +54,11 @@ GIT
 
 GIT
   remote: https://github.com/opf/turbo_tests.git
-  revision: 4208e7372a7987c972dda634eb4f29ad9f1448e1
-  ref: 2_2_5_with_patches
+  revision: c1c4707f536a5642a168650d273d714dfb62d842
+  ref: with-patches
   specs:
-    turbo_tests (2.2.5)
-      parallel_tests (>= 3.3.0, < 6)
+    turbo_tests (2.2.0)
+      parallel_tests (>= 3.3.0, < 5)
       rspec (>= 3.10)
 
 GIT
@@ -1107,7 +1107,7 @@ GEM
       activerecord (>= 7.1)
       request_store (~> 1.4)
     parallel (2.1.0)
-    parallel_tests (5.7.0)
+    parallel_tests (4.10.1)
       parallel
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -1706,7 +1706,7 @@ DEPENDENCIES
   ox
   pagy
   paper_trail (~> 17.0.0)
-  parallel_tests (~> 5.7)
+  parallel_tests (~> 4.0)
   pdf-inspector (~> 1.2)
   pg (~> 1.6.2)
   plaintext (~> 0.3.7)
@@ -1849,7 +1849,6 @@ CHECKSUMS
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   budgets (1.0.0)
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-screenshot (1.0.27) sha256=afa1896cc23df77be1774e8d3b3ce3953bf060aeaa04ff87607b5daf689174f2
@@ -2146,7 +2145,7 @@ CHECKSUMS
   pagy (43.5.4) sha256=2bdf3fa6b1e0cac5bbafe5d077fb24eb971f72f3194f8c6863a0f3867261ce59
   paper_trail (17.0.0) sha256=1c2842061d3874ca7015908e821e2aa14f9b982af2acb2a7974713bf79021c85
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
-  parallel_tests (5.7.0) sha256=3f1762c46ca2c223b8af8ef877217f9d76974e191bfa934f2580b58bcf1d005c
+  parallel_tests (4.10.1) sha256=df05458c691462b210f7a41fc2651d4e4e8a881e8190e6d1e122c92c07735d70
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pdf-core (0.9.0) sha256=4f368b2f12b57ec979872d4bf4bd1a67e8648e0c81ab89801431d2fc89f4e0bb
   pdf-inspector (1.3.0) sha256=fc107579d6f29b636e2da3d6743479b2624d9e390bf2d84beef8fd4ebe1a05bd
@@ -2292,7 +2291,7 @@ CHECKSUMS
   ttfunk (1.7.0) sha256=2370ba484b1891c70bdcafd3448cfd82a32dd794802d81d720a64c15d3ef2a96
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
   turbo_power (0.7.0) sha256=ad95d147e0fa761d0023ad9ca00528c7b7ddf6bba8ca2e23755d5b21b290d967
-  turbo_tests (2.2.5)
+  turbo_tests (2.2.0)
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   tzinfo-data (1.2026.2) sha256=7db0d3d3d53b8d7601fc183fccc8c6d056a3004e14eb59ea995bf6aec4ae10bc
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc


### PR DESCRIPTION
This update broke logging of RSpec seed/shard/processes, critical for reproducing and debugging CI failures locally.

Before the revert:

```
[execute] time bundle exec turbo_tests --verbose -n 32 --runtime-log spec/support/runtime-logs/turbo_runtime_features.log {,modules/*/}spec/features/**/*_spec.rb
Using recorded test runtime
32 processes for 703 specs, ~ 22 specs per process
```

After the revert:

```
[execute] time bundle exec turbo_tests --verbose -n 32 --runtime-log spec/support/runtime-logs/turbo_runtime_features.log {,modules/*/}spec/features/**/*_spec.rb
VERBOSE
Process 1: TEST_ENV_NUMBER=1 RUBYOPT=-I/usr/local/bundle/bundler/gems/turbo_tests-c1c4707f536a/lib -r/usr/local/bundle/gems/bundler-4.0.9/lib/bundler/setup -W0 RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1 /usr/local/bundle/gems/bundler-4.0.9/exe/bundle exec rspec --seed 2151 --format TurboTests::JsonRowsFormatter --out tmp/test-pipes/subprocess-1 --format ParallelTests::RSpec::RuntimeLogger --out spec/support/runtime-logs/turbo_runtime_features.log modules/backlogs/spec/features/buckets/edit_spec.rb modules/boards/spec/features/board_index_spec.rb modules/costs/spec/features/time_entries_spec.rb modules/meeting/spec/features/meeting_scroll_position_spec.rb modules/meeting/spec/features/recurring_meetings/recurring_meeting_create_spec.rb modules/resource_management/spec/features/resource_planners_index_spec.rb modules/two_factor_authentication/spec/features/admin_edit_two_factor_devices_spec.rb spec/features/admin/custom_fields/groups/date_spec.rb spec/features/admin/custom_fields/users/float_spec.rb spec/features/admin/enterprise/enterprise_spec.rb spec/features/admin/project_phase_definitions_spec.rb spec/features/notifications/settings/reminder_email_settings_spec.rb spec/features/placeholder_users/placeholder_user_memberships_spec.rb spec/features/projects/creation_wizard/wizard_from_template_flow_spec.rb spec/features/projects/project_custom_fields/overview_page/inputs_spec.rb spec/features/work_packages/project_phases/linking_spec.rb spec/features/workflows/missing_for_sharing_wp_spec.rb spec/features/wysiwyg/bold_behavior_spec.rb spec/features/wysiwyg/linking_spec.rb
Using recorded test runtime
Process 2: TEST_ENV_NUMBER=2 RUBYOPT=-I/usr/local/bundle/bundler/gems/turbo_tests-c1c4707f536a/lib -r/usr/local/bundle/gems/bundler-4.0.9/lib/bundler/setup -W0 RSPEC_SILENCE_FILTER_ANNOUNCEMENTS=1 /usr/local/bundle/gems/bundler-4.0.9/exe/bundle exec rspec --seed 2151 --format TurboTests::JsonRowsFormatter --out tmp/test-pipes/subprocess-2 --format ParallelTests::RSpec::RuntimeLogger --out spec/support/runtime-logs/turbo_runtime_features.log modules/backlogs/spec/features/buckets/create_spec.rb modules/budgets/spec/features/work_package_filter_spec.rb modules/documents/spec/features/real_time_collaboration_spec.rb modules/team_planner/spec/features/onboarding/team_planner_onboarding_tour_spec.rb spec/features/activities/work_package/activities_spec.rb spec/features/admin/custom_fields/versions/text_spec.rb spec/features/admin/settings/project_custom_fields/attribute_help_text_spec.rb spec/features/errors/errors_handler_spec.rb spec/features/external_link_capture_spec.rb spec/features/forums/message_spec.rb spec/features/global_roles/global_role_crud_spec.rb spec/features/types/crud_spec.rb spec/features/types/reset_form_configuration_spec.rb spec/features/users/invite_user_modal/permission_lacking_current_project_spec.rb spec/features/users/invite_user_modal/subproject_invite_spec.rb spec/features/versions/edit_spec.rb spec/features/work_packages/share/notification_spec.rb spec/features/work_packages/table/group_by/group_by_boolean_spec.rb spec/features/work_packages/table/semantic_id_navigation_follow_ups_spec.rb spec/features/wysiwyg/paragraphs_in_lists_spec.rb
32 processes for 703 specs, ~ 22 specs per process

Randomized with seed 2151
```

This reverts commit 3ee9107ff5a1d4a179fe2e0bcf3bba75c2dc4a3b.
This reverts PR https://github.com/opf/openproject/pull/23164
