### PR TITLE
fix(ui): Numeric ID copied instead of semantic ID in "Copy work package ID" on Backlogs page

### DIFF
--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -62,7 +62,7 @@ See COPYRIGHT and LICENSE files for more details.
       id: dom_target(work_package, :menu, :copy_work_package_id),
       tag: :"clipboard-copy",
       label: t(".action_menu.copy_work_package_id"),
-      content_arguments: { value: work_package.id }
+      content_arguments: { value: work_package.display_id }
     ) do |item|
       item.with_leading_visual_icon(icon: :hash)
     end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -153,11 +153,12 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
         expect(clipboard[:value]).not_to include("/work_packages/#{work_package.id}")
       end
 
-      it "still copies the numeric primary key for the 'Copy work package ID' action" do
+      it "copies the semantic identifier for the 'Copy work package ID' action" do
         render_component
 
         clipboard_id = page.find("clipboard-copy##{"work_package_#{work_package.id}_menu_copy_work_package_id"}")
-        expect(clipboard_id[:value]).to eq(work_package.id.to_s)
+        semantic_id = work_package.reload.identifier
+        expect(clipboard_id[:value]).to eq(semantic_id)
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74826

# What are you trying to accomplish?
**Plan:** https://gist.github.com/thykel/70d42eab651becfd4b56bd455db2153b

On the Backlogs page, the "Copy work package ID" menu action was copying the numeric database primary key even when semantic IDs were enabled. Users pasting the result would get e.g. `123` instead of `PROJ-42`.

The `clipboard-copy` element in the card menu component was hardcoded to `work_package.id`, bypassing the `display_id` helper that already handles the semantic/classic mode distinction correctly.

# What approach did you choose and why?

Changed `value: work_package.id` to `value: work_package.display_id` in `work_package_card_menu_component.html.erb` (one line).

`display_id` is defined on `WorkPackage::SemanticIdentifier` and returns:
- the project-prefixed semantic identifier (e.g. `"PROJ-42"`) when semantic mode is active and an identifier has been assigned
- the numeric `id` as a fallback when semantic mode is active but no identifier exists yet (new work packages not yet processed)
- the numeric `id` in classic mode — identical to the previous behaviour

No behaviour change in classic mode; no schema, route, or I18n changes required.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
