### PR TITLE
[#75314] Replace deprecated Pagy `max_pages` option

### DIFF
--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -52,6 +52,8 @@ class WorkPackages::ActivitiesTab::Paginator
   include Pagy::Method
   include WorkPackages::ActivitiesTab::JournalSortingInquirable
 
+  MAX_PAGES = 100
+
   def self.paginate(work_package, params = {})
     new(work_package, params).call
   end
@@ -72,7 +74,7 @@ class WorkPackages::ActivitiesTab::Paginator
         @filter = :all # Ignore filter when jumping to specific journal
         pagy_array_for_target_journal(anchor_type, target_record_id)
       else
-        pagy(:offset, base_journals, **pagy_options)
+        pagy(:offset, capped_journals, **pagy_options)
       end
 
     # For UI display: if user wants "oldest first" UI, reverse the array
@@ -87,7 +89,6 @@ class WorkPackages::ActivitiesTab::Paginator
     {
       page: params[:page] || 1,
       limit: params[:limit] || Pagy::DEFAULT[:limit],
-      max_pages: 100,
       request: { params: }
     }.compact
   end
@@ -125,6 +126,11 @@ class WorkPackages::ActivitiesTab::Paginator
 
   def base_journals
     combine_and_sort_records(fetch_journals, fetch_revisions)
+  end
+
+  def capped_journals
+    max_records = (params[:limit] || Pagy::DEFAULT[:limit]) * MAX_PAGES
+    base_journals.first(max_records)
   end
 
   def fetch_journals

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -28,7 +28,7 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# Pagy initializer file (43.0.2)
+# Pagy initializer file (43.5.4)
 # See https://ddnexus.github.io/pagy/resources/initializer/
 
 ############ Global Options ################################################################
@@ -37,8 +37,7 @@
 # For example:
 #
 # Pagy.options[:limit] = 10               # Limit the items per page
-# Pagy.options[:client_max_limit] = 100   # The client can request a limit up to 100
-# Pagy.options[:max_pages] = 200          # Allow only 200 pages
+# Pagy.options[:max_limit] = 100           # The client can request a limit up to 100
 # Pagy.options[:jsonapi] = true           # Use JSON:API compliant URLs
 
 ############ JavaScript ####################################################################

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -206,6 +206,47 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
       end
     end
 
+    context "when record count exceeds MAX_PAGES cap" do
+      let(:test_limit) { 2 }
+
+      before do
+        stub_const("#{described_class}::MAX_PAGES", 3)
+        8.times do |i|
+          create(:work_package_journal, user:, notes: "Comment #{i + 1}", journable: work_package, version: i + 2)
+        end
+        params[:limit] = test_limit
+      end
+
+      it "caps total records to limit * MAX_PAGES" do
+        pagy, _records = paginator.call
+
+        expect(pagy.count).to eq(test_limit * 3)
+        expect(pagy.pages).to eq(3)
+      end
+
+      it "keeps the newest records when truncating" do
+        _pagy, records = paginator.call
+
+        notes = records.map(&:notes)
+        expect(notes).to include("Comment 8")
+        expect(notes).not_to include("Comment 1")
+      end
+
+      it "still resolves an anchor to a journal beyond the cap" do
+        oldest_journal = work_package.journals.order(:version).first
+        params[:anchor] = "comment-#{oldest_journal.id}"
+        pagy, records = paginator.call
+
+        expect(records.map(&:id)).to include(oldest_journal.id)
+
+        aggregate_failures "breaks out of capped limit" do
+          expect(pagy.count).to eq(work_package.journals.count)
+          expect(pagy.pages).to eq(5)
+          expect(pagy.page).to eq(5), "expected oldest journal on last page (page 5), got page #{pagy.page}"
+        end
+      end
+    end
+
     context "with internal comments filtering" do
       let!(:internal_journal) do
         create(:work_package_journal,


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/75314

# What are you trying to accomplish?

Pagy 43.4.3 deprecated the `:max_pages` option, producing `[PAGY] the :max_pages option is deprecated` warnings in CI on every paginated activities tab request.

# What approach did you choose and why?

Following Pagy's recommended migration path: cap the record count before pagination instead of capping pages after. The combined journals/changesets array is truncated via `.first(limit * MAX_PAGES)` in `base_journals`, preserving the existing effective limit of 2000 records at default page size.

Approaches considered:

- **Truncate array before Pagy (chosen)** — cap the in-memory array with `.first(limit * MAX_PAGES)` before passing to Pagy. Follows Pagy's recommended migration path, minimal change.
- **Cap at DB query level** — add `.limit()` to the ActiveRecord query. More efficient for huge datasets, but complicated by changesets coming from a separate query and the combined Ruby-side sort.
- **Remove cap entirely** — activities tab unlikely to hit thousands of entries. Simplest, but changes existing behavior with no safety net.

Also updates the Pagy initializer comments to remove deprecated `max_pages` and `client_max_limit` examples.

# Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook (patterns, previews, etc)~~
- [ ] ~~Tested major browsers (Chrome, Firefox, Edge, ...)~~