### PR TITLE
fix(ui): Numeric ID in URL of the wp link when opened from search results (WP #74834)

### DIFF
--- a/app/models/work_package/journalized.rb
+++ b/app/models/work_package/journalized.rb
@@ -79,7 +79,7 @@ module WorkPackage::Journalized
 
       def self.event_url
         Proc.new do |o|
-          { controller: :work_packages, action: :show, id: o.id }
+          { controller: :work_packages, action: :show, id: o.display_id }
         end
       end
     end

--- a/frontend/src/app/core/global_search/input/global-search-input.component.html
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.html
@@ -79,8 +79,8 @@
       } @else {
         <a
           class="global-search--option"
-          [href]="wpPath(item.id)"
-          (click)="redirectToWp(item.id, $event)"
+          [href]="wpPath(item.displayId)"
+          (click)="redirectToWp(item.displayId, $event)"
           style="line-height: 1"
           >
           <div class="global-search--option-meta">

--- a/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
@@ -27,65 +27,74 @@
 //++
 
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { GlobalSearchInputComponent } from './global-search-input.component';
 
+// followItem is verified through the prototype against a stand-in context, avoiding
+// a real component instance whose many injected dependencies this branch never uses.
 describe('GlobalSearchInputComponent#followItem', () => {
-  let wpPathSpy:jasmine.Spy<(id:string) => string>;
-  let searchInScopeSpy:jasmine.Spy;
-  let context:Pick<GlobalSearchInputComponent, 'wpPath'|'selectedItem'> & { searchInScope:jasmine.Spy };
+  let wpPathArgs:string[];
+  let searchInScopeArgs:string[];
+  let context:Pick<GlobalSearchInputComponent, 'wpPath'|'selectedItem'> & { searchInScope:(scope:string) => void };
 
   function callFollowItem(item:unknown):void {
     GlobalSearchInputComponent.prototype.followItem.call(context, item);
   }
 
   beforeEach(() => {
-    wpPathSpy = jasmine.createSpy('wpPath').and.returnValue('/work_packages/PROJ-42');
-    searchInScopeSpy = jasmine.createSpy('searchInScope');
+    wpPathArgs = [];
+    searchInScopeArgs = [];
     context = {
-      wpPath: wpPathSpy,
+      wpPath: (id:string):string => {
+        wpPathArgs.push(id);
+        // A fragment keeps followItem's window.location assignment from navigating the runner.
+        return '#stub';
+      },
       selectedItem: undefined,
-      searchInScope: searchInScopeSpy,
+      searchInScope: (scope:string):void => {
+        searchInScopeArgs.push(scope);
+      },
     };
   });
 
   describe('when item is a HalResource', () => {
-    let item:HalResource;
+    let item:WorkPackageResource;
 
     beforeEach(() => {
-      item = Object.create(HalResource.prototype) as HalResource;
+      item = Object.create(HalResource.prototype) as WorkPackageResource;
       Object.defineProperty(item, 'id', { get: () => '42', configurable: true });
       Object.defineProperty(item, 'displayId', { get: () => 'PROJ-42', configurable: true });
     });
 
     it('calls wpPath with displayId', () => {
       callFollowItem(item);
-      expect(wpPathSpy).toHaveBeenCalledWith('PROJ-42');
+      expect(wpPathArgs).toEqual(['PROJ-42']);
     });
 
     it('does not call wpPath with the numeric id', () => {
       callFollowItem(item);
-      expect(wpPathSpy).not.toHaveBeenCalledWith('42');
+      expect(wpPathArgs).not.toContain('42');
     });
 
     it('sets selectedItem to the item', () => {
       callFollowItem(item);
-      expect(context.selectedItem).toBe(item as any);
+      expect(context.selectedItem).toBe(item);
     });
   });
 
   describe('when item is a scope option (not a HalResource)', () => {
     it('delegates to searchInScope and does not call wpPath', () => {
       callFollowItem({ projectScope: 'current_project', text: 'In this project ↵' });
-      expect(searchInScopeSpy).toHaveBeenCalledWith('current_project');
-      expect(wpPathSpy).not.toHaveBeenCalled();
+      expect(searchInScopeArgs).toEqual(['current_project']);
+      expect(wpPathArgs).toEqual([]);
     });
   });
 
   describe('when item is undefined', () => {
     it('does nothing', () => {
       callFollowItem(undefined);
-      expect(wpPathSpy).not.toHaveBeenCalled();
-      expect(searchInScopeSpy).not.toHaveBeenCalled();
+      expect(wpPathArgs).toEqual([]);
+      expect(searchInScopeArgs).toEqual([]);
     });
   });
 });

--- a/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
@@ -1,0 +1,91 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { GlobalSearchInputComponent } from './global-search-input.component';
+
+describe('GlobalSearchInputComponent#followItem', () => {
+  let wpPathSpy:jasmine.Spy<(id:string) => string>;
+  let searchInScopeSpy:jasmine.Spy;
+  let context:Pick<GlobalSearchInputComponent, 'wpPath'|'selectedItem'> & { searchInScope:jasmine.Spy };
+
+  function callFollowItem(item:unknown):void {
+    GlobalSearchInputComponent.prototype.followItem.call(context, item);
+  }
+
+  beforeEach(() => {
+    wpPathSpy = jasmine.createSpy('wpPath').and.returnValue('/work_packages/PROJ-42');
+    searchInScopeSpy = jasmine.createSpy('searchInScope');
+    context = {
+      wpPath: wpPathSpy,
+      selectedItem: undefined,
+      searchInScope: searchInScopeSpy,
+    };
+  });
+
+  describe('when item is a HalResource', () => {
+    let item:HalResource;
+
+    beforeEach(() => {
+      item = Object.create(HalResource.prototype) as HalResource;
+      Object.defineProperty(item, 'id', { get: () => '42', configurable: true });
+      Object.defineProperty(item, 'displayId', { get: () => 'PROJ-42', configurable: true });
+    });
+
+    it('calls wpPath with displayId', () => {
+      callFollowItem(item);
+      expect(wpPathSpy).toHaveBeenCalledWith('PROJ-42');
+    });
+
+    it('does not call wpPath with the numeric id', () => {
+      callFollowItem(item);
+      expect(wpPathSpy).not.toHaveBeenCalledWith('42');
+    });
+
+    it('sets selectedItem to the item', () => {
+      callFollowItem(item);
+      expect(context.selectedItem).toBe(item as any);
+    });
+  });
+
+  describe('when item is a scope option (not a HalResource)', () => {
+    it('delegates to searchInScope and does not call wpPath', () => {
+      callFollowItem({ projectScope: 'current_project', text: 'In this project ↵' });
+      expect(searchInScopeSpy).toHaveBeenCalledWith('current_project');
+      expect(wpPathSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when item is undefined', () => {
+    it('does nothing', () => {
+      callFollowItem(undefined);
+      expect(wpPathSpy).not.toHaveBeenCalled();
+      expect(searchInScopeSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
@@ -37,7 +37,7 @@ describe('GlobalSearchInputComponent#followItem', () => {
   let searchInScopeArgs:string[];
   let context:Pick<GlobalSearchInputComponent, 'wpPath'|'selectedItem'> & { searchInScope:(scope:string) => void };
 
-  function callFollowItem(item:unknown):void {
+  function callFollowItem(item:Parameters<GlobalSearchInputComponent['followItem']>[0]):void {
     GlobalSearchInputComponent.prototype.followItem.call(context, item);
   }
 

--- a/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.spec.ts
@@ -57,28 +57,43 @@ describe('GlobalSearchInputComponent#followItem', () => {
     };
   });
 
-  describe('when item is a HalResource', () => {
-    let item:WorkPackageResource;
+  describe('when item is a work package resource', () => {
+    // Build a real WorkPackageResource off its prototype and feed it a HAL $source,
+    // so followItem exercises the production displayId getter rather than a stub.
+    function buildWorkPackage(source:{ id:number, displayId?:string }):WorkPackageResource {
+      const item = Object.create(WorkPackageResource.prototype) as WorkPackageResource;
+      item.$source = source;
+      return item;
+    }
 
-    beforeEach(() => {
-      item = Object.create(HalResource.prototype) as WorkPackageResource;
-      Object.defineProperty(item, 'id', { get: () => '42', configurable: true });
-      Object.defineProperty(item, 'displayId', { get: () => 'PROJ-42', configurable: true });
+    it('is recognised as a HalResource', () => {
+      expect(buildWorkPackage({ id: 42 }) instanceof HalResource).toBe(true);
     });
 
-    it('calls wpPath with displayId', () => {
-      callFollowItem(item);
-      expect(wpPathArgs).toEqual(['PROJ-42']);
+    describe('in semantic mode (source carries a semantic displayId)', () => {
+      let item:WorkPackageResource;
+
+      beforeEach(() => {
+        item = buildWorkPackage({ id: 42, displayId: 'PROJ-42' });
+      });
+
+      it('navigates via the semantic displayId, not the numeric id', () => {
+        callFollowItem(item);
+        expect(wpPathArgs).toEqual(['PROJ-42']);
+        expect(wpPathArgs).not.toContain('42');
+      });
+
+      it('sets selectedItem to the item', () => {
+        callFollowItem(item);
+        expect(context.selectedItem).toBe(item);
+      });
     });
 
-    it('does not call wpPath with the numeric id', () => {
-      callFollowItem(item);
-      expect(wpPathArgs).not.toContain('42');
-    });
-
-    it('sets selectedItem to the item', () => {
-      callFollowItem(item);
-      expect(context.selectedItem).toBe(item);
+    describe('in classic mode (source has only the numeric id)', () => {
+      it('falls back to the numeric id through displayId', () => {
+        callFollowItem(buildWorkPackage({ id: 42 }));
+        expect(wpPathArgs).toEqual(['42']);
+      });
     });
   });
 

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -262,7 +262,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
 
   public followItem(item:WorkPackageResource|SearchOptionItem|undefined):void {
     this.selectedItem = item;
-    if (item instanceof HalResource) {
+    if (item instanceof WorkPackageResource) {
       window.location.href = this.wpPath(item.displayId);
     } else if (item) {
       this.searchInScope(item.projectScope);

--- a/frontend/src/app/core/global_search/input/global-search-input.component.ts
+++ b/frontend/src/app/core/global_search/input/global-search-input.component.ts
@@ -263,7 +263,7 @@ export class GlobalSearchInputComponent implements AfterViewInit, OnDestroy {
   public followItem(item:WorkPackageResource|SearchOptionItem|undefined):void {
     this.selectedItem = item;
     if (item instanceof HalResource) {
-      window.location.href = this.wpPath(item.id!);
+      window.location.href = this.wpPath(item.displayId);
     } else if (item) {
       this.searchInScope(item.projectScope);
     }

--- a/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
+++ b/lib_static/plugins/acts_as_event/lib/acts_as_event.rb
@@ -28,9 +28,9 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-# This now only seems to be used when rendering atom responses.
-# Search as well as activities do not rely on it.
-# Thus, whenever an atom link is removed for a resource, acts_as_event within that model can also be removed.
+# The event_* methods defined here power the server-rendered search results page
+# and atom feeds. The Activities subsystem renders through its own providers, so
+# a model can drop acts_as_event only once neither search nor atom references it.
 
 module Redmine
   module Acts

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -461,6 +461,28 @@ RSpec.describe "Search", :js, :selenium, with_settings: { per_page_options: "5" 
     end
   end
 
+  describe "when semantic work package IDs are active" do
+    let(:run_visit) { false }
+    let(:semantic_identifier) { "#{project.identifier}-99" }
+    let!(:semantic_wp) do
+      create(:work_package, subject: "SemanticIdentifierTest WP", project:).tap do |wp|
+        wp.update_column(:identifier, semantic_identifier)
+      end
+    end
+
+    before do
+      allow(Setting::WorkPackageIdentifier).to receive(:semantic_mode_active?).and_return(true)
+      visit search_path(scope: "all", q: "SemanticIdentifierTest")
+    end
+
+    it "classic results link to the semantic identifier URL, not the numeric ID" do
+      within("dt.work_package-edit") do
+        expect(page).to have_link(href: %r{/work_packages/#{Regexp.escape(semantic_identifier)}})
+        expect(page).not_to have_link(href: %r{/work_packages/#{semantic_wp.id}[^-]})
+      end
+    end
+  end
+
   describe "search for notes" do
     let(:work_package) { work_packages[0] }
     let!(:note_one) do

--- a/spec/features/search/search_spec.rb
+++ b/spec/features/search/search_spec.rb
@@ -461,24 +461,25 @@ RSpec.describe "Search", :js, :selenium, with_settings: { per_page_options: "5" 
     end
   end
 
-  describe "when semantic work package IDs are active" do
+  describe "when semantic work package IDs are active",
+           with_settings: { work_packages_identifier: "semantic" } do
     let(:run_visit) { false }
-    let(:semantic_identifier) { "#{project.identifier}-99" }
-    let!(:semantic_wp) do
-      create(:work_package, subject: "SemanticIdentifierTest WP", project:).tap do |wp|
-        wp.update_column(:identifier, semantic_identifier)
-      end
+    let(:semantic_project) { create(:project, :semantic) }
+    let(:semantic_wp) do
+      create(:work_package, subject: "SemanticIdentifierTest WP", project: semantic_project)
     end
 
     before do
-      allow(Setting::WorkPackageIdentifier).to receive(:semantic_mode_active?).and_return(true)
+      semantic_wp
       visit search_path(scope: "all", q: "SemanticIdentifierTest")
     end
 
-    it "classic results link to the semantic identifier URL, not the numeric ID" do
+    it "links results to the semantic identifier URL, not the numeric ID" do
+      identifier = semantic_wp.reload.identifier
+
       within("dt.work_package-edit") do
-        expect(page).to have_link(href: %r{/work_packages/#{Regexp.escape(semantic_identifier)}})
-        expect(page).not_to have_link(href: %r{/work_packages/#{semantic_wp.id}[^-]})
+        expect(page).to have_link(href: %r{/work_packages/#{Regexp.escape(identifier)}(?:$|[#?])})
+        expect(page).to have_no_link(href: %r{/work_packages/#{semantic_wp.id}(?:$|[#?])})
       end
     end
   end

--- a/spec/models/work_package/work_package_acts_as_event_spec.rb
+++ b/spec/models/work_package/work_package_acts_as_event_spec.rb
@@ -35,9 +35,21 @@ RSpec.describe WorkPackage do
     let(:stub_work_package) { build_stubbed(:work_package) }
 
     describe "#event_url" do
-      let(:expected_url) { { controller: :work_packages, action: :show, id: stub_work_package.id } }
+      context "in classic mode" do
+        let(:expected_url) { { controller: :work_packages, action: :show, id: stub_work_package.id } }
 
-      it { expect(stub_work_package.event_url).to eq(expected_url) }
+        it { expect(stub_work_package.event_url).to eq(expected_url) }
+      end
+
+      context "in semantic mode", with_settings: { work_packages_identifier: "semantic" } do
+        let(:project) { create(:project, :semantic) }
+        let(:work_package) { create(:work_package, project:) }
+
+        it "links to the semantic identifier rather than the numeric id" do
+          expect(work_package.event_url)
+            .to eq(controller: :work_packages, action: :show, id: work_package.reload.identifier)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74834

# What are you trying to accomplish?

On instances with semantic work package IDs enabled, opening a work package from global search navigated to a URL built from the numeric database ID instead of the semantic identifier — e.g. `/work_packages/21456` rather than `/work_packages/SGS-349`.

The numeric ID leaked in through two independent link-generation paths:

1. **Autocomplete dropdown** — the suggestion list built its link from the raw HAL `id`, both on the visible result link and when a suggestion was opened directly with the keyboard.
2. **Search results page** — work package rows on `/search` build their link through the activity-event URL definition, which passed the numeric primary key. The activity feed itself already resolves the identifier correctly; the results page is a separate path that did not.

## Screenshots

**Before** — numeric ID in the search result link

<img width="1389" height="910" alt="pr23342-before-numeric" src="https://github.com/user-attachments/assets/fc932ed0-0a8b-40f0-961a-05b25adf7a43" />

**After** — semantic identifier in the search result link

<img width="1389" height="910" alt="pr23342-after-semantic" src="https://github.com/user-attachments/assets/961e8eae-0831-47c8-ad21-935f322716ba" />

# What approach did you choose and why?

The identifier a user should see in a URL already has a single source of truth: `WorkPackage#display_id` returns the semantic identifier in semantic mode and the numeric ID in classic mode, and `WorkPackage#to_param` already routes the standard Rails URL helpers through it. The fix makes the two remaining stragglers follow the same convention.

On the frontend, the global search component routes both the visible dropdown link and the keyboard-open path through `displayId`, which the API already serializes — so the link target matches the identifier shown in the result row. Inside the `HalResource` branch the value is a `WorkPackageResource` and `displayId` is a non-null string, which also removes a non-null assertion the numeric `id` required.

On the backend, the activity-event URL definition passes `display_id` instead of the primary key. In classic mode `display_id` is the numeric ID, so behaviour there is unchanged.

Normalising numeric-ID bookmarks (and other redirect entry points) to semantic URLs is a broader concern that affects API consumers and external integrations, so it is left out of scope for its own change.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
