### PR TITLE
fix(ui): Admin page for semantic IDs: long ids cause overflow (WP #74730)

### DIFF
--- a/app/components/work_packages/admin/settings/identifier_autofix_section_component.html.erb
+++ b/app/components/work_packages/admin/settings/identifier_autofix_section_component.html.erb
@@ -41,7 +41,7 @@
 <%=
   render(border_box_container(mb: 3)) do |component|
     component.with_header(font_weight: :bold) do
-      flex_layout do |header|
+      flex_layout(classes: "gap-3") do |header|
         header.with_column(flex: 1) do
           render(Primer::Beta::Text.new(font_weight: :semibold)) do
             I18n.t("admin.settings.work_packages_identifier.box_header.label_project")
@@ -67,13 +67,13 @@
 
     displayed.each do |entry|
       component.with_row do
-        flex_layout(align_items: :center) do |row|
-          row.with_column(flex: 1) do
+        flex_layout(align_items: :center, classes: "gap-3") do |row|
+          row.with_column(flex: 1, classes: "min-width-0") do
             render(Primer::Beta::Link.new(href: project_path(entry[:project]))) do
               entry[:project].name
             end
           end
-          row.with_column(flex: 1) do
+          row.with_column(flex: 1, classes: "min-width-0 wp-identifier-cell") do
             flex_layout(direction: :column) do |col|
               col.with_row do
                 render(Primer::Beta::Text.new) { entry[:current_identifier] }
@@ -85,10 +85,10 @@
               end
             end
           end
-          row.with_column(flex: 1) do
+          row.with_column(flex: 1, classes: "min-width-0 wp-identifier-cell") do
             render(Primer::Beta::Text.new) { entry[:suggested_identifier] }
           end
-          row.with_column(flex: 1) do
+          row.with_column(flex: 1, classes: "min-width-0 wp-identifier-cell") do
             render(Primer::Beta::Text.new) { sample_wp_id(entry[:suggested_identifier]) }
           end
         end

--- a/app/components/work_packages/admin/settings/identifier_autofix_section_component.sass
+++ b/app/components/work_packages/admin/settings/identifier_autofix_section_component.sass
@@ -1,0 +1,2 @@
+.wp-identifier-cell
+  word-break: break-word


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74730

# What are you trying to accomplish?
**Plan:** https://gist.github.com/thykel/aca5803ce2dc88acbfb16ac94f5bf646

On the admin identifier page (`/admin/settings/work_packages/identifier`), switching to project-based IDs shows a preview table with four flex columns. When a project has a long current or suggested identifier the text ran flush against the adjacent column and could overflow its container, because the flex items had no gap and no `min-width: 0` constraint.

## Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

# What approach did you choose and why?

Three targeted presentational changes to `IdentifierAutofixSectionComponent`, no logic or data changes:

1. **Column gap** — added `classes: "gap-3"` to both `flex_layout` calls (header row and each data row). `gap-3` is a Primer utility class (8 px gap) and matches the pattern already used in `phase_component.html.erb` and `row_component.html.erb`.

2. **`min-width: 0` on flex children** — added `classes: "min-width-0"` to all four `with_column` calls in the data row. Without this, flex items default to `min-width: auto` and refuse to shrink below their content width, so long strings overflow regardless of `flex: 1`. This is the canonical Primer fix and is already applied the same way in `row_component.html.erb`.

3. **`word-break: break-word` on identifier columns** — added a co-located SASS file (`identifier_autofix_section_component.sass`) defining `.wp-identifier-cell`, applied to the three identifier/ID columns. The project name column is excluded because it breaks naturally at word boundaries. A co-located SASS file was chosen over a `word_break:` system arg on `Primer::Beta::Text` because the latter is not a verified supported arg for that component.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
