### PR TITLE
[#74900] fix(ui): Support semantic IDs in the spent time calendar

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -20,6 +20,7 @@ import {
 } from '@fullcalendar/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
 import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
+import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import interactionPlugin from '@fullcalendar/interaction';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
@@ -619,7 +620,10 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
 
   private entityName(entry:TimeEntryResource):string {
     const entity = entry.entity;
-    return `#${idFromLink(entity.href)}: ${entity.name}`;
+    const formattedId = entity instanceof WorkPackageResource
+      ? entity.formattedId
+      : `#${idFromLink(entity.href)}`;
+    return `${formattedId}: ${entity.name}`;
   }
 
   private popoverHtml(

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -101,7 +101,11 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
   }
 
   public entityName(entry:TimeEntryResource):string {
-    return `#${entry.entity.id!}: ${entry.entity.name}`;
+    const entity = entry.entity;
+    const formattedId = entity instanceof WorkPackageResource
+      ? entity.formattedId
+      : `#${idFromLink(entity.href)}`;
+    return `${formattedId}: ${entity.name}`;
   }
 
   public entityId(entry:TimeEntryResource):string {
@@ -145,7 +149,7 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
       showClose: true,
       closeByDocument: true,
       passedData: [
-        `#${idFromLink(entry.workPackage?.href)} ${entry.workPackage?.name}`,
+        entry.entity ? this.entityName(entry) : '',
         `${this.i18n.t(
           'js.units.hour',
           { count: this.timezone.toHours(entry.hours) },

--- a/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
+++ b/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
@@ -76,14 +76,21 @@ module API
 
         def create_link_lambda(name, getter: "#{name}_id")
           ->(*) {
-            v3_path = API::V3::TimeEntries::EntityRepresenterFactory.representer_type(represented.send(name))
-            title_attribute = API::V3::TimeEntries::EntityRepresenterFactory.title_attribute(represented.send(name))
+            entity = represented.send(name)
+            v3_path = API::V3::TimeEntries::EntityRepresenterFactory.representer_type(entity)
+            title_attribute = API::V3::TimeEntries::EntityRepresenterFactory.title_attribute(entity)
 
-            instance_exec(&self.class.associated_resource_default_link_lambda(name,
-                                                                              v3_path:,
-                                                                              skip_link: -> { false },
-                                                                              title_attribute:,
-                                                                              getter:))
+            link = instance_exec(&self.class.associated_resource_default_link_lambda(name,
+                                                                                     v3_path:,
+                                                                                     skip_link: -> { false },
+                                                                                     title_attribute:,
+                                                                                     getter:))
+
+            if link.is_a?(Hash) && entity.is_a?(WorkPackage)
+              link.merge(displayId: entity.display_id.to_s)
+            else
+              link
+            end
           }
         end
 

--- a/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
+++ b/modules/costs/spec/lib/api/v3/time_entries/time_entry_representer_rendering_spec.rb
@@ -98,6 +98,23 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "rendering" do
         let(:href) { api_v3_paths.work_package work_package.id }
         let(:title) { work_package.subject }
       end
+
+      it "includes displayId in the entity link (classic mode numeric id)" do
+        expect(subject)
+          .to be_json_eql(work_package.display_id.to_s.to_json)
+          .at_path("_links/entity/displayId")
+      end
+
+      context "with semantic identifier mode active",
+              with_settings: { work_packages_identifier: "semantic" } do
+        let(:work_package) { build_stubbed(:work_package, identifier: "PROJ-42", project: workspace) }
+
+        it "includes the semantic displayId in the entity link" do
+          expect(subject)
+            .to be_json_eql("PROJ-42".to_json)
+            .at_path("_links/entity/displayId")
+        end
+      end
     end
 
     context "with a time entry logged on a meeting" do
@@ -113,6 +130,10 @@ RSpec.describe API::V3::TimeEntries::TimeEntryRepresenter, "rendering" do
 
       it_behaves_like "has no link" do
         let(:link) { "workPackage" }
+      end
+
+      it "does not include displayId in the entity link" do
+        expect(subject).not_to have_json_path("_links/entity/displayId")
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74900

# What are you trying to accomplish?
**Plan:** https://gist.github.com/thykel/75cb7e4061aa7598df79635d2fbbe452

On instances with semantic work package IDs enabled, the spent time calendar widget on the My Page showed the numeric database ID (e.g. `#42`) instead of the semantic identifier (e.g. `PROJ-42`) in both the calendar event title and the hover tooltip. This occurred because:

1. The API's `_links.entity` link object for time entries only carried `href` and `title` — no `displayId` field — so the frontend had no way to recover the semantic identifier from the link alone.
2. Both the calendar component and the My Page list widget constructed the displayed ID by extracting the trailing path segment from the href via `idFromLink`, which always yields the numeric primary key.

# What approach did you choose and why?

**Backend** (`entity_representer_factory.rb`): `create_link_lambda` now merges `displayId: entity.display_id.to_s` into the HAL link hash whenever the entity is a `WorkPackage`. This mirrors the established pattern used for `children` and `ancestors` links in the work package representer. The change is purely additive — no existing fields are removed or renamed. Meetings are unaffected: the `entity.is_a?(WorkPackage)` guard ensures `displayId` is never added to meeting links. A nil entity (time entry with no associated entity) is handled by the existing `link.is_a?(Hash)` guard.

**Frontend** (`te-calendar.component.ts`, `time-entries-list.component.ts`): Both components now use `WorkPackageResource#formattedId` instead of extracting the numeric ID from the href. `formattedId` reads `$source.displayId` (present on fully-embedded work packages), falls back to `$source._links.self.displayId` (present on link-only stubs, sourced from the backend change above), and finally falls back to the numeric `id` — so it works correctly in both classic and semantic mode, including during rolling deploys where the new `displayId` field may be absent from cached responses. An `instanceof WorkPackageResource` guard keeps meetings on the existing `#${idFromLink}` path.

An alternative of embedding the full work package resource in the time entry collection response was considered but rejected — it would embed the entire WP payload for every entry in the collection, adding significant response size and rendering overhead for a field that is already derivable from a small link extension.

## Screenshots
<img width="945" height="811" alt="Screenshot 2026-05-27 at 16 41 09" src="https://github.com/user-attachments/assets/236544d2-dcd0-4095-8e7b-db1d89493e32" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)