### PR TITLE
Remove component identifier op-git-actions-menu

### DIFF
--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -36,7 +36,6 @@ import { ISnippet } from 'core-app/features/plugins/linked/openproject-github_in
 
 
 @Component({
-  selector: 'op-git-actions-menu',
   templateUrl: './git-actions-menu.template.html',
   styleUrls: [
     './styles/git-actions-menu.sass',

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.component.ts
@@ -37,7 +37,6 @@ import { I18nService } from "core-app/core/i18n/i18n.service";
 
 
 @Component({
-  selector: 'op-git-actions-menu',
   templateUrl: './git-actions-menu.template.html',
   styleUrls: [
     './styles/git-actions-menu.sass'


### PR DESCRIPTION
They are being used as dropdown components, and referenced by class anyway
https://community.openproject.org/work_packages/75311