### PR TITLE
[#75188] Backlogs: Missing space on mobile

### DIFF
--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -39,6 +39,10 @@
     #content-body
       padding-right: 0
 
+  @media screen and (max-width: $breakpoint-sm)
+    #content-body
+      padding-right: 15px
+
 .op-backlogs-page
   display: block
   height: 100%


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/75188

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add padding-right for the content-body in mobile mode.

## Screenshots
<img width="322" height="375" alt="Screenshot 2026-05-26 at 09 24 19" src="https://github.com/user-attachments/assets/4b28afbb-9d93-4da7-ac47-801d9983d692" />
