### PR TITLE
[74853] Missing space between user avatar and name

### DIFF
--- a/app/components/shares/user_details_component.html.erb
+++ b/app/components/shares/user_details_component.html.erb
@@ -2,7 +2,7 @@
 component_wrapper do
   flex_layout do |flex|
     flex.with_row do
-      helpers.primer_link_to_user(user, font_weight: :semibold, href: principal_show_path)
+      helpers.link_to_user(user, font_weight: :semibold, href: principal_show_path, target: :_blank)
     end
 
     flex.with_row(classes: "ellipsis") do

--- a/app/components/users/row_component.rb
+++ b/app/components/users/row_component.rb
@@ -47,7 +47,7 @@ module Users
       icon = helpers.avatar user, size: :mini
 
       link = helpers.link_to_user(user,
-                                  class: "op-principal--name",
+                                  classes: "op-principal--name",
                                   name: user.login,
                                   href: helpers.allowed_management_user_profile_path(user))
 

--- a/app/components/work_packages/activities_tab/shared_helpers.rb
+++ b/app/components/work_packages/activities_tab/shared_helpers.rb
@@ -38,7 +38,7 @@ module WorkPackages
       end
 
       def truncated_user_name(user, hover_card: false)
-        helpers.primer_link_to_user(user, scheme: :primary, font_weight: :bold, hover_card:)
+        helpers.link_to_user(user, scheme: :primary, font_weight: :bold, hover_card:, target: :_blank)
       end
 
       def activity_anchor_link(journal)

--- a/lib/open_project/object_linking.rb
+++ b/lib/open_project/object_linking.rb
@@ -44,28 +44,49 @@ module OpenProject
     # Displays a link to user's account page if active or registered
     # Will attach a user hover card to the link.
     def link_to_user(user, options = {}) # rubocop:disable Metrics/AbcSize
-      return h(user.to_s) unless user.is_a?(User)
-      return h(user.name) if (user.locked? || user.deleted?) && !User.current.admin?
+      return content_tag(:span, h(user.to_s), class: options[:classes]) unless user.is_a?(User)
+      return content_tag(:span, h(user.name), class: options[:classes]) if user_not_linkable?(user)
 
-      only_path = options.delete(:only_path) { true }
+      only_path = options[:only_path].nil? || options[:only_path]
       name = options.delete(:name) { user.name }
-      options[:title] ||= I18n.t(:label_user_named, name:)
+      options[:href] ||= user_url(user, only_path:)
+      options[:underline] ||= false
 
-      add_hover_card_options(user, options, only_path:)
+      options = add_hover_card_options(user, options, only_path:)
 
-      link_to(name, user_url(user, only_path:), options)
+      if respond_to?(:render)
+        render Primer::Beta::Link.new(**options) do
+          name
+        end
+      else
+        # Fallback for non-render contexts like mailers, filters, etc.
+        link_to name, options[:href],
+                target: options[:target],
+                class: options[:classes],
+                title: options[:title],
+                data: options[:data]
+      end
     end
 
     # Displays a link to group's account page
-    def link_to_group(group, options = {})
-      return h(group.to_s) unless group.is_a?(Group)
+    def link_to_group(group, options = {}) # rubocop:disable Metrics/AbcSize
+      return content_tag(:span, h(group.to_s), class: options[:classes]) unless group.is_a?(Group)
 
-      name = group.name
-      href = show_group_url(group,
-                            only_path: options.delete(:only_path) { true })
-      options[:title] ||= I18n.t(:label_group_named, name:)
+      only_path = options[:only_path].nil? || options[:only_path]
+      options[:href] ||= show_group_url(group, only_path:)
+      options[:title] ||= I18n.t(:label_group_named, name: group.name)
 
-      link_to(name, href, options)
+      if respond_to?(:render)
+        render Primer::Beta::Link.new(**options) do
+          group.name
+        end
+      else
+        # Fallback for non-render contexts like mailers, filters, etc.
+        link_to group.name, options[:href],
+                class: options[:classes],
+                title: options[:title],
+                data: options[:data]
+      end
     end
 
     # Generates a link to an attachment.
@@ -135,19 +156,6 @@ module OpenProject
       end
     end
 
-    # Like #link_to_user, but will render a Primer link instead of a regular link.
-    def primer_link_to_user(user, options = {})
-      options[:href] ||= user_path(user)
-      options[:target] ||= "_blank"
-      options[:underline] ||= false
-
-      options = add_hover_card_options(user, options)
-
-      render Primer::Beta::Link.new(**options) do
-        user.name
-      end
-    end
-
     private
 
     # Accepts a user and an options hash. Will apply a hover card config for the user to the options hash.
@@ -196,6 +204,10 @@ module OpenProject
     def v3_paths
       # Including the module breaks the application in strange and mysterious ways
       API::V3::Utilities::PathHelper::ApiV3Path
+    end
+
+    def user_not_linkable?(user)
+      (user.locked? || user.deleted?) && !User.current.admin?
     end
   end
 end

--- a/lib/open_project/text_formatting/filters/mention_filter.rb
+++ b/lib/open_project/text_formatting/filters/mention_filter.rb
@@ -65,13 +65,13 @@ module OpenProject::TextFormatting
       def user_mention(user)
         link_to_user(user,
                      only_path: context[:only_path],
-                     class: "user-mention")
+                     classes: "user-mention")
       end
 
       def group_mention(group)
         link_to_group(group,
                       only_path: context[:only_path],
-                      class: "user-mention")
+                      classes: "user-mention")
       end
 
       def work_package_mention(work_package, mention)

--- a/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/colon_separator.rb
@@ -139,7 +139,7 @@ module OpenProject::TextFormatting::Matchers
 
       def render_user
         if (user = User.visible.find_by(login: oid))
-          link_to_user(user, only_path: context[:only_path], class: "user-mention")
+          link_to_user(user, only_path: context[:only_path], classes: "user-mention")
         end
       end
 

--- a/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
+++ b/lib/open_project/text_formatting/matchers/link_handlers/hash_separator.rb
@@ -109,7 +109,7 @@ module OpenProject::TextFormatting::Matchers
         if user
           link_to_user(user,
                        only_path: context[:only_path],
-                       class: "user-mention")
+                       classes: "user-mention")
         end
       end
 
@@ -119,7 +119,7 @@ module OpenProject::TextFormatting::Matchers
         if group
           link_to_group(group,
                         only_path: context[:only_path],
-                        class: "user-mention")
+                        classes: "user-mention")
         end
       end
 

--- a/modules/meeting/app/components/meetings/header_infoline_component.html.erb
+++ b/modules/meeting/app/components/meetings/header_infoline_component.html.erb
@@ -10,14 +10,14 @@
         t(:label_meeting_created_by)
       end
     %>
-    <%= helpers.primer_link_to_user(@meeting.author, underline: true) %>.
+    <%= helpers.link_to_user(@meeting.author, underline: true, target: :_blank) %>.
   <% elsif @meeting.onetime_template? %>
     <%=
       render(Primer::Beta::Text.new(mr: 1)) do
         t(:label_meeting_created_by)
       end
     %>
-    <%= helpers.primer_link_to_user(@meeting.author, underline: true) %>.
+    <%= helpers.link_to_user(@meeting.author, underline: true, target: :_blank) %>.
   <% elsif @series %>
     <%= render(Primer::BaseComponent.new(tag: :div, classes: "hidden-for-mobile", mr: 2)) do %>
       <%= render(Meetings::SidePanel::StatusButtonComponent.new(meeting: @meeting, size: :small)) %>
@@ -36,7 +36,7 @@
         t(:label_meeting_created_by)
       end
     %>
-    <%= helpers.primer_link_to_user(@meeting.author, underline: true) %>.
+    <%= helpers.link_to_user(@meeting.author, underline: true, target: :_blank) %>.
   <% end %>
   <%=
     render(Primer::Beta::Text.new(ml: 1, mr: 1)) do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe ApplicationHelper do
       end
 
       context "right now" do
-        let(:time) { Time.now }
+        let(:time) { Time.zone.now }
 
         it { is_expected.to match /^<a/ }
         it { is_expected.to match /less than a minute/ }
@@ -138,7 +138,7 @@ RSpec.describe ApplicationHelper do
       context "some time ago" do
         let(:time) do
           Timecop.travel(2.weeks.ago) do
-            Time.now
+            Time.zone.now
           end
         end
 
@@ -150,7 +150,7 @@ RSpec.describe ApplicationHelper do
 
     context "without project" do
       context "right now" do
-        let(:time) { Time.now }
+        let(:time) { Time.zone.now }
 
         it { is_expected.to match /^<time/ }
         it { is_expected.to match /datetime="#{Regexp.escape(time.xmlschema)}"/ }
@@ -161,7 +161,7 @@ RSpec.describe ApplicationHelper do
       context "some time ago" do
         let(:time) do
           Timecop.travel(1.week.ago) do
-            Time.now
+            Time.zone.now
           end
         end
 
@@ -181,10 +181,11 @@ RSpec.describe ApplicationHelper do
 
       esc_name = "&lt;b&gt;Hello&lt;/b&gt; world"
 
-      exp_str = <<-HTML.squish
+      exp_str = <<~HTML.squish
         Added by
-        <a title="User #{esc_name}" data-hover-card-url="/users/#{author.id}/hover_card"
-           data-hover-card-trigger-target="trigger" href="/users/#{author.id}">#{esc_name}</a>
+        <a data-hover-card-url="/users/#{author.id}/hover_card"
+           data-hover-card-trigger-target="trigger" href="/users/#{author.id}"
+           data-view-component="true" class="Link">#{esc_name}</a>
         on 2023-06-02
       HTML
 

--- a/spec/lib/open_project/object_linking_spec.rb
+++ b/spec/lib/open_project/object_linking_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe OpenProject::ObjectLinking, type: :helper do
+  describe "#link_to_user" do
+    let(:user) { build_stubbed(:user) }
+
+    context "when given a non-User object" do
+      it "returns a span with the object's string representation" do
+        result = helper.link_to_user("some string")
+        expect(result).to have_css("span", text: "some string")
+      end
+    end
+
+    context "when given a locked user and current user is not admin" do
+      let(:user) { build_stubbed(:user, :locked) }
+
+      before { allow(User.current).to receive(:admin?).and_return(false) }
+
+      it "returns a span with the user's name" do
+        result = helper.link_to_user(user)
+        expect(result).to have_css("span", text: user.name)
+      end
+    end
+
+    context "when given an active user" do
+      it "renders a link to the user's profile" do
+        result = helper.link_to_user(user)
+        expect(result).to have_css("a[href*='/users/#{user.id}']", text: user.name)
+      end
+
+      it "includes hover card data attributes" do
+        result = helper.link_to_user(user)
+        expect(result).to have_css("a[data-hover-card-url]")
+        expect(result).to have_css("a[data-hover-card-trigger-target='trigger']")
+      end
+    end
+
+    context "when given a locked user and current user is admin" do
+      let(:user) { build_stubbed(:user, :locked) }
+
+      before { allow(User.current).to receive(:admin?).and_return(true) }
+
+      it "still renders a link to the user's profile" do
+        result = helper.link_to_user(user)
+        expect(result).to have_css("a[href*='/users/#{user.id}']")
+      end
+    end
+  end
+
+  describe "#link_to_group" do
+    let(:group) { build_stubbed(:group) }
+
+    context "when given a non-Group object" do
+      it "returns a span with the object's string representation" do
+        result = helper.link_to_group("not a group")
+        expect(result).to have_css("span", text: "not a group")
+      end
+    end
+
+    context "when given a group" do
+      it "renders a link to the group page" do
+        result = helper.link_to_group(group)
+        expect(result).to have_css("a[href*='/groups/#{group.id}']", text: group.name)
+      end
+
+      it "includes a title attribute" do
+        result = helper.link_to_group(group)
+        expect(result).to have_css("a[title]")
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
+++ b/spec/lib/open_project/text_formatting/markdown/mentions_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                 <p class="op-uc-p">
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
-                            title: "User #{linked_project_member.name}",
                             class: 'user-mention op-uc-link',
                             target: '_top',
                             data: {
@@ -184,7 +183,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                 <p class="op-uc-p">
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
-                            title: "User #{linked_project_member.name}",
                             class: 'user-mention op-uc-link',
                             target: '_top',
                             data: {
@@ -212,7 +210,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                 <p class="op-uc-p">
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
-                            title: "User #{linked_project_member.name}",
                             class: 'user-mention op-uc-link',
                             target: '_top',
                             data: {
@@ -241,7 +238,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                   <p class="op-uc-p">
                     #{link_to(linked_project_member.name,
                               { controller: :users, action: :show, id: linked_project_member.id },
-                              title: "User #{linked_project_member.name}",
                               class: 'user-mention op-uc-link',
                               target: '_top',
                               data: {
@@ -273,7 +269,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                   <p class="op-uc-p">
                     #{link_to(linked_project_member.name,
                               { controller: :users, action: :show, id: linked_project_member.id },
-                              title: "User #{linked_project_member.name}",
                               class: 'user-mention op-uc-link',
                               target: '_top',
                               data: {
@@ -302,7 +297,6 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                 <p class="op-uc-p">
                   #{link_to(linked_project_member.name,
                             { controller: :users, action: :show, id: linked_project_member.id },
-                            title: "User #{linked_project_member.name}",
                             class: 'user-mention op-uc-link',
                             target: '_top',
                             data: {
@@ -372,8 +366,7 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                         target="_top"
                         data-hover-card-trigger-target="trigger"
                         data-hover-card-url="/users/#{user.id}/hover_card"
-                        href="/users/#{user.id}"
-                        title="User Foo Barrit">Foo Barrit</a>
+                        href="/users/#{user.id}">Foo Barrit</a>
                   </p>
                 EXPECTED
               end
@@ -399,8 +392,7 @@ RSpec.describe OpenProject::TextFormatting, "mentions" do # rubocop:disable RSpe
                         target="_top"
                         data-hover-card-trigger-target="trigger"
                         data-hover-card-url="http://openproject.org/users/#{user.id}/hover_card"
-                        href="http://openproject.org/users/#{user.id}"
-                        title="User Foo Barrit">Foo Barrit</a>
+                        href="http://openproject.org/users/#{user.id}">Foo Barrit</a>
                   </p>
                 EXPECTED
               end

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe MemberMailer do
   include OpenProject::ObjectLinking
   include ActionView::Helpers::UrlHelper
   include OpenProject::StaticRouting::UrlHelpers
+  include ViewComponent::TestHelpers
+
+  def render(component, &)
+    vc_test_controller.view_context.render(component, &)
+  end
 
   let(:current_user) { build_stubbed(:user) }
   let(:member) do


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/74853

# What are you trying to accomplish?
Merge the duplicated methods `link_to_user` and `primer_link_to_user` into one. Further, the passed classes are also passed to non-linkable objects.

