### PR TITLE
[fix] remove superfluous escaping of location in ctor

### DIFF
--- a/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/nextcloud/queries/files_query.rb
@@ -88,7 +88,7 @@ module Storages
                 last = list.last
                 prefix = last.nil? || last.location[-1] != "/" ? "/" : ""
                 location = "#{last&.location}#{prefix}#{item}"
-                list.append(forge_ancestor(CGI.unescape(location)))
+                list.append(forge_ancestor(location))
               end
             end
 
@@ -99,7 +99,7 @@ module Storages
             end
 
             def name(location)
-              location == "/" ? "Root" : CGI.unescape(location.split("/").last)
+              location == "/" ? "Root" : location.split("/").last
             end
 
             def storage_file_transformer

--- a/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
+++ b/modules/storages/app/common/storages/adapters/providers/one_drive/queries/files_query.rb
@@ -115,7 +115,7 @@ module Storages
               path_elements[0..-2].map do |component|
                 next root if component.blank?
 
-                Results::StorageFileAncestor.new(name: component, location: component)
+                Results::StorageFileAncestor.new(name: component, location: "/#{component}")
               end
             end
 

--- a/modules/storages/app/common/storages/adapters/providers/sharepoint/storage_file_transformer.rb
+++ b/modules/storages/app/common/storages/adapters/providers/sharepoint/storage_file_transformer.rb
@@ -91,7 +91,7 @@ module Storages
           end
 
           def build_ancestor(name, location)
-            Results::StorageFileAncestor.new(name:, location: CGI.unescape(location))
+            Results::StorageFileAncestor.new(name:, location:)
           end
 
           private

--- a/modules/storages/app/common/storages/adapters/results/storage_file_ancestor.rb
+++ b/modules/storages/app/common/storages/adapters/results/storage_file_ancestor.rb
@@ -33,10 +33,7 @@ module Storages
     module Results
       class StorageFileAncestor < StorageFile
         def initialize(name:, location:)
-          super(name:,
-                location: UrlBuilder.path(location),
-                id: Digest::SHA256.hexdigest(name),
-                permissions: %i[readable writeable])
+          super(name:, location:, id: Digest::SHA256.hexdigest(name), permissions: %i[readable writeable])
         end
       end
     end


### PR DESCRIPTION
# Ticket
[#73855](https://community.openproject.org/wp/73855)

# What are you trying to accomplish?
- according to [#73855](https://community.openproject.org/wp/73855) the escaping must only happen in the representer
- the escaping in the constructor of the storage file ancestors was missed, so it was removed now
