### PR TITLE
[74697] Black font in dark mode on wp description

### DIFF
--- a/app/views/custom_styles/_primer_color_mapping.erb
+++ b/app/views/custom_styles/_primer_color_mapping.erb
@@ -39,6 +39,7 @@
     --ck-color-button-default-hover-background: var(--button-default-bgColor-hover);
     --ck-color-toolbar-background: var(--body-background);
     --ck-color-text: var(--body-font-color);
+    --ck-content-font-color: var(--body-font-color);
     --ck-color-dropdown-panel-background: var(--overlay-bgColor);
     --ck-color-list-button-hover-background: var(--control-transparent-bgColor-hover);
     --ck-color-panel-background: var(--overlay-bgColor);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74697

# What are you trying to accomplish?
Add ckEditor font color override to support dark mode again

