### PR TITLE
[72219] Closed, duplicated meeting disappears from synced calendar

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -656,6 +656,11 @@ module Settings
         default: {},
         writable: false # cached in global variable
       },
+      ical_feed_keep_closed_meetings_days: {
+        description: "Number of days to keep closed and in-progress one-time meetings in iCal feeds",
+        format: :integer,
+        default: 30
+      },
       impressum_link: {
         description: "Impressum link to be set, hidden by default",
         format: :string,

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -34,8 +34,6 @@ class Meeting < ApplicationRecord
   include ChronicDuration
   include OpenProject::Journal::AttachmentHelper
 
-  RECENTLY_STARTED_CUTOFF = 1.month
-
   self.table_name = "meetings"
 
   belongs_to :project
@@ -71,7 +69,7 @@ class Meeting < ApplicationRecord
   scope :from_tomorrow, -> { where(start_time: Date.tomorrow.beginning_of_day..) }
   scope :from_today, -> { where(start_time: Time.zone.today.beginning_of_day..) }
   scope :started, -> { where(state: [states[:in_progress], states[:closed]]) }
-  scope :from_today_or_recently_started, -> { from_today.or(Meeting.started.where(start_time: RECENTLY_STARTED_CUTOFF.ago..)) }
+  scope :from_today_or_recently_started, -> { from_today.or(Meeting.started.where(start_time: Setting.ical_feed_keep_closed_meetings_days.days.ago..)) }
 
   scope :upcoming, -> { where("start_time + (interval '1 hour' * duration) >= ?", Time.current) }
   scope :past, -> { where("start_time + (interval '1 hour' * duration) < ?", Time.current) }

--- a/modules/meeting/app/models/meeting.rb
+++ b/modules/meeting/app/models/meeting.rb
@@ -34,6 +34,8 @@ class Meeting < ApplicationRecord
   include ChronicDuration
   include OpenProject::Journal::AttachmentHelper
 
+  RECENTLY_STARTED_CUTOFF = 1.month
+
   self.table_name = "meetings"
 
   belongs_to :project
@@ -68,6 +70,8 @@ class Meeting < ApplicationRecord
 
   scope :from_tomorrow, -> { where(start_time: Date.tomorrow.beginning_of_day..) }
   scope :from_today, -> { where(start_time: Time.zone.today.beginning_of_day..) }
+  scope :started, -> { where(state: [states[:in_progress], states[:closed]]) }
+  scope :from_today_or_recently_started, -> { from_today.or(Meeting.started.where(start_time: RECENTLY_STARTED_CUTOFF.ago..)) }
 
   scope :upcoming, -> { where("start_time + (interval '1 hour' * duration) >= ?", Time.current) }
   scope :past, -> { where("start_time + (interval '1 hour' * duration) < ?", Time.current) }

--- a/modules/meeting/app/services/all_meetings/ical_service.rb
+++ b/modules/meeting/app/services/all_meetings/ical_service.rb
@@ -72,7 +72,7 @@ module AllMeetings
       @single_meetings ||= if include_historic
                              Meeting.not_recurring.visible(user).participated_by(user)
                            else
-                             Meeting.not_recurring.from_today.visible(user).participated_by(user)
+                             Meeting.not_recurring.from_today_or_recently_started.visible(user).participated_by(user)
                            end
     end
   end

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Meeting do
   describe ".from_today_or_recently_started" do
     subject { described_class.from_today_or_recently_started }
 
-    let(:cutoff) { Meeting::RECENTLY_STARTED_CUTOFF }
+    let(:cutoff) { Setting.ical_feed_keep_closed_meetings_days.days }
     let(:today) { Time.zone.today.beginning_of_day }
 
     context "with an in_progress meeting within the cutoff" do

--- a/modules/meeting/spec/models/meeting_spec.rb
+++ b/modules/meeting/spec/models/meeting_spec.rb
@@ -314,6 +314,95 @@ RSpec.describe Meeting do
     end
   end
 
+  describe ".from_today" do
+    subject { described_class.from_today }
+
+    let(:today) { Time.zone.today.beginning_of_day }
+
+    context "with a meeting starting today" do
+      let!(:meeting) { create(:meeting, project:, start_time: today) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with a future meeting" do
+      let!(:meeting) { create(:meeting, project:, start_time: today + 1.day) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with a past meeting" do
+      let!(:meeting) { create(:meeting, project:, start_time: today - 1.day) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+  end
+
+  describe ".started" do
+    subject { described_class.started }
+
+    context "with an in_progress meeting" do
+      let!(:meeting) { create(:meeting, project:, state: :in_progress) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with a closed meeting" do
+      let!(:meeting) { create(:meeting, project:, state: :closed) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with an open meeting" do
+      let!(:meeting) { create(:meeting, project:, state: :open) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+
+    context "with a draft meeting" do
+      let!(:meeting) { create(:meeting, project:, state: :draft) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+
+    context "with a cancelled meeting" do
+      let!(:meeting) { create(:meeting, project:, state: :cancelled) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+  end
+
+  describe ".from_today_or_recently_started" do
+    subject { described_class.from_today_or_recently_started }
+
+    let(:cutoff) { Meeting::RECENTLY_STARTED_CUTOFF }
+    let(:today) { Time.zone.today.beginning_of_day }
+
+    context "with an in_progress meeting within the cutoff" do
+      let!(:meeting) { create(:meeting, project:, state: :in_progress, start_time: today - cutoff + 1.day) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with a closed meeting within the cutoff" do
+      let!(:meeting) { create(:meeting, project:, state: :closed, start_time: today - cutoff + 1.day) }
+
+      it { is_expected.to include(meeting) }
+    end
+
+    context "with an in_progress meeting beyond the cutoff" do
+      let!(:meeting) { create(:meeting, project:, state: :in_progress, start_time: today - cutoff - 1.day) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+
+    context "with a closed meeting beyond the cutoff" do
+      let!(:meeting) { create(:meeting, project:, state: :closed, start_time: today - cutoff - 1.day) }
+
+      it { is_expected.not_to include(meeting) }
+    end
+  end
+
   describe "recurrence_start_time" do
     let(:recurring_meeting) { create(:recurring_meeting, project:) }
 

--- a/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
+++ b/modules/meeting/spec/services/all_meetings/ical_service_spec.rb
@@ -158,6 +158,49 @@ RSpec.describe AllMeetings::ICalService, type: :model do
         expect(uids).to contain_exactly(meeting.uid, past_meeting.uid)
       end
     end
+
+    context "without historic meetings but with recently started past meetings" do
+      let(:include_historic) { false }
+
+      let!(:closed_recent_meeting) do
+        create(:meeting,
+               author: user,
+               project:,
+               title: "Closed recent meeting",
+               state: :closed,
+               participants: [MeetingParticipant.new(user:)],
+               start_time: relevant_time - 1.week,
+               duration: 1.0)
+      end
+
+      let!(:in_progress_recent_meeting) do
+        create(:meeting,
+               author: user,
+               project:,
+               title: "In progress recent meeting",
+               state: :in_progress,
+               participants: [MeetingParticipant.new(user:)],
+               start_time: relevant_time - 3.days,
+               duration: 1.0)
+      end
+
+      let!(:closed_old_meeting) do
+        create(:meeting,
+               author: user,
+               project:,
+               title: "Closed old meeting",
+               state: :closed,
+               participants: [MeetingParticipant.new(user:)],
+               start_time: relevant_time - 2.months,
+               duration: 1.0)
+      end
+
+      it "includes closed and in_progress meetings within the past month, but not older ones" do
+        uids = ical.events.map(&:uid)
+        expect(uids).to include(closed_recent_meeting.uid, in_progress_recent_meeting.uid)
+        expect(uids).not_to include(closed_old_meeting.uid)
+      end
+    end
   end
 
   context "with recurring meetings" do


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

https://community.openproject.org/wp/72219

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The default iCal subscription feed filtered meetings by `start_time >= today`, causing past meetings to disappear from synced calendar clients the day after they occurred.
    
One-time meetings in `in_progress` or `closed` state are now included in the feed for up to one month past their start date. Meetings in `open` or `draft` state continue to vanish the day after, as they meetings that never effectively started.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

Added a `from_today_or_recently_started` scope to `Meeting` that combines the existing `from_today` filter with all `started` meetings within the last month, and used it in `AllMeetings::ICalService` in place of `from_today`.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major clients (Thunderbird, ...)
