### PR TITLE
[#75353] Remove extra space in Jira Migrator backup warning dialog

### DIFF
--- a/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.html.erb
@@ -39,7 +39,7 @@ See COPYRIGHT and LICENSE files for more details.
   ) do |dialog|
     dialog.with_confirmation_message do |message|
       message.with_heading(tag: :h2) { title }
-      message.with_description_content(simple_format(description))
+      message.with_description_content(description)
     end
     dialog.with_confirmation_check_box_content(confirm)
   end


### PR DESCRIPTION


# Ticket
https://community.openproject.org/wp/75353

## Screenshots
<img width="1581" height="1019" alt="image" src="https://github.com/user-attachments/assets/a124e851-2f87-4abc-96ba-34bf9836bc09" />
No extra br tags in the resulting html:
<img width="1369" height="564" alt="image" src="https://github.com/user-attachments/assets/faef98d6-bfa5-4f2e-9a75-c3098eaa7af0" />

