### PR TITLE
[#75362] Inconsistent naming on admin page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4181,7 +4181,7 @@ en:
   label_home: "Home"
   label_subject_or_id: "Subject or ID"
   label_calendar_subscriptions: "Calendar subscriptions"
-  label_identifier: "Identifier"
+  label_identifier: "Identifiers"
   label_project_identifier: "Project identifier"
   label_in: "in"
   label_in_less_than: "in less than"


### PR DESCRIPTION
https://community.openproject.org/wp/75362

Change to plural form so it's consistent with the other menu entries.

## Screenshots
<img width="1001" height="472" alt="image" src="https://github.com/user-attachments/assets/feb81659-fc36-4cdf-9dd4-7ec59837495f" />


# Merge checklist

