### PR TITLE
Set host setting for docker tls setup to avoid broken links with port

### DIFF
--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -2,6 +2,7 @@
 x-op-env-override: &environment
   OPENPROJECT_CLI_PROXY: "${OPENPROJECT_DEV_URL}"
   OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST}"
+  OPENPROJECT_HOST__NAME: "${OPENPROJECT_DEV_HOST}"
   OPENPROJECT_HTTPS: true
   SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
   # uncomment and set all the envs below to integrate keycloak with OpenProject


### PR DESCRIPTION
Before:

<img width="334" height="263" alt="Screenshot from 2026-06-01 09-51-26" src="https://github.com/user-attachments/assets/7aff4eae-3829-414a-94c4-3f3060a1d1fc" />

After:

<img width="334" height="263" alt="Screenshot from 2026-06-01 09-57-16" src="https://github.com/user-attachments/assets/9f39e291-587a-4083-a345-fe9b0ed11e98" />

