### PR TITLE
fix(ui): Numeric ID instead of semantic one on the error message on bulk edit (WP #74928)

### DIFF
--- a/app/views/work_packages/bulk/_errors.html.erb
+++ b/app/views/work_packages/bulk/_errors.html.erb
@@ -5,7 +5,7 @@
   selected_count = selected_work_packages.count
   selected_ids = selected_work_packages.map(&:id)
   source_ids = erroneous_results.map { |call| call.state.copied_from_work_package_id }.compact.uniq
-  source_work_packages_by_id = source_ids.any? ? WorkPackage.where(id: source_ids).index_by(&:id) : {}
+  source_work_packages_by_id = source_ids.any? ? WorkPackage.visible.where_display_id_in(*source_ids).index_by(&:id) : {}
 %>
 
 <% if total_count - error_count == 0 %>
@@ -39,7 +39,7 @@
     <% wp_id = wp&.id || call.result.id %>
 
     <li>
-      <%= link_to wp&.formatted_id || "##{wp_id}", work_package_path(wp_id) %><%= selected_ids.include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
+      <%= link_to wp&.formatted_id || "##{wp_id}", work_package_path(wp) %><%= selected_ids.include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
       <%= safe_join call.errors.full_messages, " " %>
     </li>
   <% end %>

--- a/app/views/work_packages/bulk/_errors.html.erb
+++ b/app/views/work_packages/bulk/_errors.html.erb
@@ -31,10 +31,12 @@
 
 <ul>
   <% erroneous_results.each do |call| %>
-    <% wp_id = call.state.copied_from_work_package_id || call.result.id %>
+    <% source_id = call.state.copied_from_work_package_id %>
+    <% wp = source_id ? WorkPackage.find_by(id: source_id) : call.result %>
+    <% wp_id = wp&.id || call.result.id %>
 
     <li>
-      <%= link_to "##{wp_id}", work_package_path(wp_id) %><%= selected_work_packages.map(&:id).include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
+      <%= link_to wp&.formatted_id || "##{wp_id}", work_package_path(wp_id) %><%= selected_work_packages.map(&:id).include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
       <%= safe_join call.errors.full_messages, " " %>
     </li>
   <% end %>

--- a/app/views/work_packages/bulk/_errors.html.erb
+++ b/app/views/work_packages/bulk/_errors.html.erb
@@ -3,6 +3,9 @@
   error_count = erroneous_results.count
   total_count = service_result.dependent_results.map(&:result).uniq.count
   selected_count = selected_work_packages.count
+  selected_ids = selected_work_packages.map(&:id)
+  source_ids = erroneous_results.map { |call| call.state.copied_from_work_package_id }.compact.uniq
+  source_work_packages_by_id = source_ids.any? ? WorkPackage.where(id: source_ids).index_by(&:id) : {}
 %>
 
 <% if total_count - error_count == 0 %>
@@ -32,11 +35,11 @@
 <ul>
   <% erroneous_results.each do |call| %>
     <% source_id = call.state.copied_from_work_package_id %>
-    <% wp = source_id ? WorkPackage.find_by(id: source_id) : call.result %>
+    <% wp = source_id ? source_work_packages_by_id[source_id] : call.result %>
     <% wp_id = wp&.id || call.result.id %>
 
     <li>
-      <%= link_to wp&.formatted_id || "##{wp_id}", work_package_path(wp_id) %><%= selected_work_packages.map(&:id).include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
+      <%= link_to wp&.formatted_id || "##{wp_id}", work_package_path(wp_id) %><%= selected_ids.include?(wp_id) ? "" : " (#{I18n.t('work_packages.bulk.descendant')})" %>:
       <%= safe_join call.errors.full_messages, " " %>
     </li>
   <% end %>

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -583,6 +583,29 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
       end
     end
 
+    context "with semantic identifiers",
+            with_settings: { work_packages_identifier: "semantic" } do
+      before do
+        work_package1.update_columns(identifier: "PROJ-1", sequence_number: 1)
+        work_package2.update_columns(identifier: "PROJ-2", sequence_number: 2)
+        put :update,
+            params: {
+              ids: work_package_ids,
+              work_package: { done_ratio: 150 }
+            }
+      end
+
+      it "shows semantic identifiers in the error flash" do
+        expect(flash[:error]).to include("PROJ-1")
+        expect(flash[:error]).to include("PROJ-2")
+      end
+
+      it "does not show bare numeric ids in the error flash" do
+        expect(flash[:error]).not_to include("##{work_package1.id}")
+        expect(flash[:error]).not_to include("##{work_package2.id}")
+      end
+    end
+
     describe "updating two children with dates to a new parent (Regression #28670)" do
       let(:task1) do
         create(:work_package,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74928

# What are you trying to accomplish?
~**Plan:** https://gist.github.com/thykel/f0482d4cd6b1fe521c7a27ae6cad5785~

On instances with semantic work package identifiers enabled, the bulk-edit error partial always displayed the raw numeric database ID (e.g. `#42`) in the failure list, even though every other part of the UI uses the semantic form (e.g. `PROJ-42`).

The root cause was in `app/views/work_packages/bulk/_errors.html.erb`: the loop extracted `call.result.id` (a plain integer) and hard-coded a `"#"` prefix, bypassing the `formatted_id` / `display_id` logic that the rest of the codebase uses. The fix resolves the `WorkPackage` object and calls `wp.formatted_id`, which returns `"PROJ-42"` in semantic mode and `"#42"` in classic mode — so behaviour on non-semantic instances is unchanged.

The same partial is used for bulk move and background bulk jobs; the fix is correct in all three contexts.

# What approach did you choose and why?

Instead of extracting a raw integer and formatting it with a hard-coded `"#"` prefix, the partial now resolves a `WorkPackage` object and delegates to `wp.formatted_id` and `work_package_path(wp_id)`.

- In the **edit/move flow** (`copied_from_work_package_id` is nil), `call.result` is already the work package being updated — no extra lookup needed.
- In the **copy flow** (`copied_from_work_package_id` is set), the original work package is loaded with a single `find_by` so we can call `formatted_id` on it.

## Screenshots

<img width="691" height="169" alt="Screenshot 2026-05-26 at 23 48 45" src="https://github.com/user-attachments/assets/8c716aba-0237-479d-875f-918587c58865" />

# Merge checklist

- [x] Added/updated tests (controller spec: failed `#update` under semantic mode asserts `flash[:error]` contains the semantic identifier and no bare `#<numeric-id>`)
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)