### PR TITLE
[#74942] fix(ui): Support semantic identifiers on related work packages table

### DIFF
--- a/frontend/src/app/shared/components/fields/display/field-types/work-package-display-field.module.spec.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/work-package-display-field.module.spec.ts
@@ -1,0 +1,109 @@
+import { WorkPackageDisplayField } from './work-package-display-field.module';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { DisplayFieldContext } from 'core-app/shared/components/fields/display/display-field.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
+import { Injector } from '@angular/core';
+
+describe('WorkPackageDisplayField', () => {
+  let field:WorkPackageDisplayField;
+
+  const mockI18n = { t: (key:string) => key };
+
+  const serviceMap = new Map<unknown, unknown>([
+    [I18nService, mockI18n],
+  ]);
+
+  function buildField(parentAttrs:Record<string, unknown> | null) {
+    const resource = {
+      parent: parentAttrs,
+    } as unknown as HalResource;
+
+    const mockInjector = {
+      get: (token:unknown, notFoundValue?:unknown) => serviceMap.get(token) ?? notFoundValue ?? {},
+    } as Injector;
+
+    field = new WorkPackageDisplayField('parent', {
+      injector: mockInjector,
+      container: null,
+      options: {},
+    } as unknown as DisplayFieldContext);
+
+    field.apply(resource, { type: 'WorkPackage' } as IFieldSchema);
+  }
+
+  describe('wpFormattedId', () => {
+    it('returns the semantic ID from a fully loaded linked WP', () => {
+      buildField({
+        $loaded: true,
+        id: '123',
+        formattedId: 'PROJ-42',
+        displayId: 'PROJ-42',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpFormattedId).toEqual('PROJ-42');
+    });
+
+    it('returns the semantic ID from an unloaded linked WP when displayId is on the link', () => {
+      buildField({
+        $loaded: false,
+        formattedId: 'PROJ-42',
+        displayId: 'PROJ-42',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpFormattedId).toEqual('PROJ-42');
+    });
+
+    it('falls back to prefixed numeric ID from an unloaded linked WP without displayId', () => {
+      buildField({
+        $loaded: false,
+        formattedId: '#123',
+        displayId: '123',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpFormattedId).toEqual('#123');
+    });
+
+    it('returns empty string when the linked WP is absent', () => {
+      buildField(null);
+
+      expect(field.wpFormattedId).toEqual('');
+    });
+  });
+
+  describe('wpRoutingId', () => {
+    it('returns the semantic displayId from a fully loaded linked WP', () => {
+      buildField({
+        $loaded: true,
+        id: '123',
+        displayId: 'PROJ-42',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpRoutingId).toEqual('PROJ-42');
+    });
+
+    it('returns the semantic displayId from an unloaded linked WP when displayId is on the link', () => {
+      buildField({
+        $loaded: false,
+        displayId: 'PROJ-42',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpRoutingId).toEqual('PROJ-42');
+    });
+
+    it('falls back to numeric displayId from an unloaded linked WP without semantic displayId', () => {
+      buildField({
+        $loaded: false,
+        displayId: '123',
+        href: '/api/v3/work_packages/123',
+      });
+
+      expect(field.wpRoutingId).toEqual('123');
+    });
+  });
+});

--- a/frontend/src/app/shared/components/fields/display/field-types/work-package-display-field.module.ts
+++ b/frontend/src/app/shared/components/fields/display/field-types/work-package-display-field.module.ts
@@ -55,38 +55,35 @@ export class WorkPackageDisplayField extends DisplayField {
       return this.value.id;
     }
 
-    // Read WP ID from href
     return this.value.href.match(/(\d+)$/)[0];
   }
 
   /**
-   * Returns the identifier for URL routing when the linked WP is loaded,
-   * falling back to the numeric ID extracted from the href.
-   *
-   * Unlike `WorkPackageBaseResource.displayId`, this handles the case
-   * where the related resource is only a HAL link (not yet fetched).
+   * Returns the identifier for URL routing.
+   * Reads `displayId` from the linked resource whether or not it is fully
+   * loaded — the API now includes `displayId` on HAL link objects (e.g.
+   * the parent link), so `WorkPackageResource#displayId` resolves
+   * correctly from `$source._links.self.displayId` even for stubs.
    */
   public get wpRoutingId():string {
     const linkedWp = this.value as WorkPackageResource | undefined;
-    if (linkedWp?.$loaded) {
+    if (linkedWp) {
       return linkedWp.displayId;
     }
-    return this.wpId as string;
+    return (this.wpId as string | null) ?? '';
   }
 
   /**
    * Returns the work package ID formatted for display.
    * Classic mode: `#123` (hash-prefixed), Semantic mode: `PROJ-42` (no prefix).
    *
-   * Delegates to `WorkPackageResource#formattedId` when the linked resource
-   * is loaded. When unloaded, falls back to the numeric ID extracted from
-   * the self-link href — an unloaded HAL link carries only the href, not
-   * the resource's properties (the API always populates `displayId`, but
-   * we can't reach it until the link is fetched).
+   * Delegates to `WorkPackageResource#formattedId` for both loaded and
+   * unloaded stubs. The API includes `displayId` on HAL link objects so
+   * `formattedId` resolves the semantic identifier without a fetch.
    */
   public get wpFormattedId():string {
     const linkedWp = this.value as WorkPackageResource | undefined;
-    if (linkedWp?.$loaded) {
+    if (linkedWp) {
       return linkedWp.formattedId;
     }
 

--- a/lib/api/v3/work_packages/work_package_representer.rb
+++ b/lib/api/v3/work_packages/work_package_representer.rb
@@ -582,7 +582,8 @@ module API
                               if represented.parent&.visible?
                                 {
                                   href: api_v3_paths.work_package(represented.parent.id),
-                                  title: represented.parent.subject
+                                  title: represented.parent.subject,
+                                  displayId: represented.parent.display_id.to_s
                                 }
                               else
                                 {

--- a/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_at_timestamp_representer_rendering_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             "title" => version.name
           },
           "parent" => {
+            "displayId" => parent.display_id.to_s,
             "href" => api_v3_paths.work_package(parent.id),
             "title" => parent.subject
           },
@@ -431,6 +432,7 @@ RSpec.describe API::V3::WorkPackages::WorkPackageAtTimestampRepresenter, "render
             "title" => version.name
           },
           "parent" => {
+            "displayId" => parent.display_id.to_s,
             "href" => api_v3_paths.work_package(parent.id),
             "title" => parent.subject
           },

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -1089,6 +1089,11 @@ RSpec.describe API::V3::WorkPackages::WorkPackageRepresenter do
             let(:href) { api_v3_paths.work_package(visible_parent.id) }
             let(:title) { visible_parent.subject }
           end
+
+          it "exposes displayId on the parent link" do
+            expect(parse_json(subject).dig("_links", "parent", "displayId"))
+              .to eq(visible_parent.display_id.to_s)
+          end
         end
 
         context "when parent not visible" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74942

# What are you trying to accomplish?

**Plan:** https://gist.github.com/thykel/28cfbefb1fbe00b7a53a96a580540de5

In instances using semantic work package identifiers (e.g. `PROJ-42`), the **Parent** column in embedded work package tables was showing the numeric form (`#123`) instead of the semantic identifier.

The bug had two layers:

1. **Backend:** The `parent` HAL link in `WorkPackageRepresenter` was serialised without a `displayId` field, even though the `children` and `ancestors` links already included one. Consumers receiving the API response had no way to know the semantic identifier of an unloaded parent without making an additional request.

2. **Frontend:** `WorkPackageDisplayField#wpFormattedId` (and `wpRoutingId`) guarded on `$loaded`, so for unloaded HAL-link stubs — which is always the case for the parent link in query results — it bypassed `linkedWp.formattedId` entirely and fell back to extracting the raw numeric segment from the href.

# What approach did you choose and why?

**Backend (`work_package_representer.rb`):** Added `displayId: represented.parent.display_id.to_s` to the parent link hash, matching the pattern already established for `children` and `ancestors`. No extra database query is introduced because `parent` is already in `to_eager_load`. The `display_id.to_s` call is safe for the invisible-parent branch because it is inside the `if represented.parent&.visible?` guard.

**Frontend (`work-package-display-field.module.ts`):** Removed the `$loaded` guard from both `wpFormattedId` and `wpRoutingId`. `WorkPackageResource#displayId` already has the correct fallback chain (`$source.displayId → $source._links.self.displayId → id`). When `createLinkedResource` builds the unloaded stub it sets `source._links.self` to the HAL link object, so `displayId` is now reachable for stubs without any fetch. Classic-mode behaviour is unchanged: when no semantic `displayId` is present the chain falls back to the numeric `id`, and `formatWorkPackageId('123')` → `'#123'` as before. Also replaced the `wpRoutingId` `null`-cast-as-string (`this.wpId as string`) with `this.wpId ?? ''` to be type-safe when the value is absent.

An alternative considered was pre-fetching parent work packages in the embedded table component, but that would add network round-trips and is unnecessary now that the identifier is available on the link object itself.

# Screenshots
<img width="1065" height="464" alt="Screenshot 2026-05-27 at 15 43 48" src="https://github.com/user-attachments/assets/6d14951d-d105-4007-ae08-b57049724d56" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
