### PR TITLE
[#75170] fix: Prevent classic identifier conversion job from getting stuck

### DIFF
--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -51,12 +51,24 @@ module ProjectIdentifiers
     attr_reader :project
 
     def restore_classic_identifier
-      generator = ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
-      classic = generator.restore_identifier(project) || generator.suggest_identifier(project.name)
+      classic = identifier_generator.restore_identifier(project) ||
+                identifier_generator.suggest_identifier(project.name)
       # Suppress notifications: this is a background system operation, not a user edit.
       Journal::NotificationConfiguration.with(false) do
         project.update!(identifier: classic)
+      rescue ActiveRecord::RecordInvalid => e
+        handle_identifier_conflict(classic, e)
       end
+    end
+
+    def handle_identifier_conflict(classic, error)
+      Rails.logger.warn "#{self.class}: identifier '#{classic}' taken for project #{project.id}, " \
+                        "falling back. (#{error.message})"
+      project.update!(identifier: identifier_generator.suggest_identifier(project.name))
+    end
+
+    def identifier_generator
+      ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
     end
   end
 end

--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -51,24 +51,26 @@ module ProjectIdentifiers
     attr_reader :project
 
     def restore_classic_identifier
-      classic = identifier_generator.restore_identifier(project) ||
-                identifier_generator.suggest_identifier(project.name)
+      classic_id = identifier_generator.restore_identifier(project) ||
+                   identifier_generator.suggest_identifier(project.name)
       # Suppress notifications: this is a background system operation, not a user edit.
       Journal::NotificationConfiguration.with(false) do
-        project.update!(identifier: classic)
+        project.update!(identifier: classic_id)
       rescue ActiveRecord::RecordInvalid => e
-        handle_identifier_conflict(classic, e)
+        handle_update_failure(classic_id, e)
       end
     end
 
-    def handle_identifier_conflict(classic, error)
-      Rails.logger.warn "#{self.class}: identifier '#{classic}' taken for project #{project.id}, " \
-                        "falling back. (#{error.message})"
-      project.update!(identifier: identifier_generator.suggest_identifier(project.name))
+    def handle_update_failure(classic_id, error)
+      Rails.logger.warn "#{self.class}: Could not set identifier '#{classic_id}' for project #{project.id}; " \
+                        "falling back to a randomized suffix. (#{error.message})"
+      suffix = SecureRandom.alphanumeric(5).downcase
+      base = classic_id.first(Projects::Identifier::CLASSIC_IDENTIFIER_MAX_LENGTH - 6)
+      project.update!(identifier: "#{base}-#{suffix}")
     end
 
     def identifier_generator
-      ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
+      @identifier_generator ||= ProjectIdentifiers::ClassicIdentifierSuggestionGenerator.new
     end
   end
 end

--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -64,9 +64,7 @@ module ProjectIdentifiers
     def handle_update_failure(classic_id, error)
       Rails.logger.warn "#{self.class}: Could not set identifier '#{classic_id}' for project #{project.id}; " \
                         "falling back to a randomized suffix. (#{error.message})"
-      suffix = SecureRandom.alphanumeric(5).downcase
-      base = classic_id.first(Projects::Identifier::CLASSIC_IDENTIFIER_MAX_LENGTH - 6)
-      project.update!(identifier: "#{base}-#{suffix}")
+      project.update!(identifier: "project-#{SecureRandom.alphanumeric(5).downcase}")
     end
 
     def identifier_generator

--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -64,7 +64,7 @@ module ProjectIdentifiers
     def handle_update_failure(classic_id, error)
       Rails.logger.warn "#{self.class}: Could not set identifier '#{classic_id}' for project #{project.id}; " \
                         "falling back to a randomized suffix. (#{error.message})"
-      project.update!(identifier: "project-#{SecureRandom.alphanumeric(5).downcase}")
+      project.update!(identifier: "project-#{SecureRandom.alphanumeric(10).downcase}")
     end
 
     def identifier_generator

--- a/app/services/project_identifiers/revert_project_to_classic_service.rb
+++ b/app/services/project_identifiers/revert_project_to_classic_service.rb
@@ -64,7 +64,7 @@ module ProjectIdentifiers
     def handle_update_failure(classic_id, error)
       Rails.logger.warn "#{self.class}: Could not set identifier '#{classic_id}' for project #{project.id}; " \
                         "falling back to a randomized suffix. (#{error.message})"
-      project.update!(identifier: "project-#{SecureRandom.alphanumeric(10).downcase}")
+      project.update!(identifier: "project-#{SecureRandom.alphanumeric(5).downcase}")
     end
 
     def identifier_generator

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -116,7 +116,13 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
       let!(:project) do
         create(:project).tap do |p|
           p.update_columns(identifier: "MYAPP", wp_sequence_counter: 0)
-          FriendlyId::Slug.create!(sluggable: p, slug: "my-app")
+          # Remove p's own initial slug so "my-app" is the only entry in its slug history.
+          # Without this, the factory slug (newer created_at) would be returned first by
+          # restore_identifier, the update would succeed, and the conflict path would never fire.
+          FriendlyId::Slug.where(sluggable_id: p.id, sluggable_type: "Project").delete_all
+          # blocking_project already owns the "my-app" FriendlyId slug; reassign it so that
+          # restore_identifier returns "my-app" and project.update! conflicts with blocking_project.
+          FriendlyId::Slug.where(slug: "my-app", sluggable_type: "Project").update_all(sluggable_id: p.id)
         end
       end
 
@@ -124,11 +130,9 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
         expect { described_class.new(project).call }.not_to raise_error
       end
 
-      it "assigns a valid classic identifier that is not the conflicting one" do
+      it "assigns the conflicting identifier with a 5-character random suffix" do
         described_class.new(project).call
-        reloaded = project.reload
-        expect(reloaded.identifier).to match(Projects::Identifier::CLASSIC_FORMAT)
-        expect(reloaded.identifier).not_to eq("my-app")
+        expect(project.reload.identifier).to match(/\Amy-app-[a-z0-9]{5}\z/)
       end
 
       it "logs a warning containing the project id and the conflicting identifier" do

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -109,5 +109,34 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
         expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
     end
+
+    context "when the classic slug from FriendlyId history is already taken by another project" do
+      let!(:blocking_project) { create(:project, identifier: "my-app") }
+
+      let!(:project) do
+        create(:project).tap do |p|
+          p.update_columns(identifier: "MYAPP", wp_sequence_counter: 0)
+          FriendlyId::Slug.create!(sluggable: p, slug: "my-app")
+        end
+      end
+
+      it "does not raise" do
+        expect { described_class.new(project).call }.not_to raise_error
+      end
+
+      it "assigns a valid classic identifier that is not the conflicting one" do
+        described_class.new(project).call
+        reloaded = project.reload
+        expect(reloaded.identifier).to match(Projects::Identifier::CLASSIC_FORMAT)
+        expect(reloaded.identifier).not_to eq("my-app")
+      end
+
+      it "logs a warning containing the project id and the conflicting identifier" do
+        allow(Rails.logger).to receive(:warn)
+        described_class.new(project).call
+        expect(Rails.logger).to have_received(:warn)
+          .with(a_string_including(project.id.to_s, "my-app"))
+      end
+    end
   end
 end

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -130,9 +130,9 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
         expect { described_class.new(project).call }.not_to raise_error
       end
 
-      it "assigns the conflicting identifier with a 5-character random suffix" do
+      it "assigns a project-NNNNN fallback identifier" do
         described_class.new(project).call
-        expect(project.reload.identifier).to match(/\Amy-app-[a-z0-9]{5}\z/)
+        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
 
       it "logs a warning containing the project id and the conflicting identifier" do

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
       end
 
       it "assigns a project-NNNNN fallback identifier" do
-        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
+        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
     end
 

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
       end
 
       it "assigns a project-NNNNN fallback identifier" do
-        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
+        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
       end
     end
 
@@ -132,7 +132,7 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
 
       it "assigns a project-NNNNN fallback identifier" do
         described_class.new(project).call
-        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
+        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
       end
 
       it "logs a warning containing the project id and the conflicting identifier" do

--- a/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
+++ b/spec/services/project_identifiers/revert_project_to_classic_service_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ProjectIdentifiers::RevertProjectToClassicService do
 
       it "assigns a project-NNNNN fallback identifier" do
         described_class.new(project).call
-        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
+        expect(project.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
       end
 
       it "logs a warning containing the project id and the conflicting identifier" do

--- a/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
+++ b/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
@@ -130,7 +130,8 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
         let!(:project_conflict) do
           create(:project).tap do |p|
             p.update_columns(identifier: "CONFLICT1")
-            FriendlyId::Slug.create!(sluggable: p, slug: "conflict-slug")
+            FriendlyId::Slug.where(sluggable_id: p.id, sluggable_type: "Project").delete_all
+            FriendlyId::Slug.where(slug: "conflict-slug", sluggable_type: "Project").update_all(sluggable_id: p.id)
           end
         end
 
@@ -154,10 +155,8 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
           expect(project_after.reload.identifier).to eq("project-after")
         end
 
-        it "assigns project_conflict a valid classic identifier that is not the conflicting one" do
-          reloaded = project_conflict.reload
-          expect(reloaded.identifier).to match(Projects::Identifier::CLASSIC_FORMAT)
-          expect(reloaded.identifier).not_to eq("conflict-slug")
+        it "assigns project_conflict a project-NNNNN fallback identifier" do
+          expect(project_conflict.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
         end
       end
     end

--- a/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
+++ b/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
@@ -112,6 +112,54 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
             .to match(Projects::Identifier::CLASSIC_FORMAT)
         end
       end
+
+      context "when one project has a conflicting restored identifier" do
+        # project_before and project_after bracket the conflict project to confirm
+        # the find_each loop is not aborted — both must be processed.
+        let!(:project_before) do
+          create(:project).tap do |p|
+            p.update_columns(identifier: "BEFORE1")
+            FriendlyId::Slug.create!(sluggable: p, slug: "project-before")
+          end
+        end
+
+        # Holds "conflict-slug" as its current identifier, blocking project_conflict
+        # from reclaiming it.
+        let!(:blocking_project) { create(:project, identifier: "conflict-slug") }
+
+        let!(:project_conflict) do
+          create(:project).tap do |p|
+            p.update_columns(identifier: "CONFLICT1")
+            FriendlyId::Slug.create!(sluggable: p, slug: "conflict-slug")
+          end
+        end
+
+        let!(:project_after) do
+          create(:project).tap do |p|
+            p.update_columns(identifier: "AFTER1")
+            FriendlyId::Slug.create!(sluggable: p, slug: "project-after")
+          end
+        end
+
+        before do
+          allow(Setting::WorkPackageIdentifier).to receive_messages(classic?: true, semantic?: false)
+          described_class.new.perform
+        end
+
+        it "still reverts project_before (loop not aborted before the conflict)" do
+          expect(project_before.reload.identifier).to eq("project-before")
+        end
+
+        it "still reverts project_after (loop not aborted after the conflict)" do
+          expect(project_after.reload.identifier).to eq("project-after")
+        end
+
+        it "assigns project_conflict a valid classic identifier that is not the conflicting one" do
+          reloaded = project_conflict.reload
+          expect(reloaded.identifier).to match(Projects::Identifier::CLASSIC_FORMAT)
+          expect(reloaded.identifier).not_to eq("conflict-slug")
+        end
+      end
     end
   end
 end

--- a/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
+++ b/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
         end
 
         it "assigns project_conflict a project-NNNNN fallback identifier" do
-          expect(project_conflict.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
+          expect(project_conflict.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
         end
       end
     end

--- a/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
+++ b/spec/workers/project_identifiers/revert_instance_to_classic_ids_job_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ProjectIdentifiers::RevertInstanceToClassicIdsJob do
         end
 
         it "assigns project_conflict a project-NNNNN fallback identifier" do
-          expect(project_conflict.reload.identifier).to match(/\Aproject-[a-z0-9]{5}\z/)
+          expect(project_conflict.reload.identifier).to match(/\Aproject-[a-z0-9]{10}\z/)
         end
       end
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/75170

# What are you trying to accomplish?

**Plan:** https://gist.github.com/thykel/6fded951ed43f4cce78c0109e4c0ec19

When switching an instance back from "Project-based semantic identifiers" to "Instance-wide numerical sequence (default)", the background job `RevertInstanceToClassicIdsJob` iterates over all projects via `find_each` and calls `RevertProjectToClassicService` for each one. The service attempts to restore the project's most-recent classic-format slug from `FriendlyId::Slug` history and assigns it via `project.update!`.

If that historical slug is already taken as another project's current identifier (e.g. due to a case-insensitive uniqueness conflict or corrupt slug data), `update!` raises `ActiveRecord::RecordInvalid`. Because this exception was unhandled, it propagated up through the `find_each` loop and crashed the entire job. GoodJob then retried the job up to 8 times, but the conflicting state was unchanged, so every attempt failed identically — leaving the instance permanently stuck mid-conversion with no user-visible recovery path.

# What approach did you choose and why?

The fix wraps only the `project.update!(identifier: classic)` call inside a `rescue ActiveRecord::RecordInvalid` block. The rescue scope is intentionally narrow: it covers only the write, not the preceding DB reads (`restore_identifier`, `suggest_identifier`), so a genuine upstream error still surfaces.

On conflict, the rescue:
1. Logs a `Rails.logger.warn` containing the project ID and the conflicting identifier so the reason is traceable in the error log (as requested in the issue).
2. Appends a 5-character random alphanumeric suffix to the conflicting identifier (e.g. `my-app` → `my-app-x4k9z`), keeping the result recognisably derived from the original slug while guaranteeing uniqueness.

The result is that no single project's identifier conflict can abort the `find_each` loop — all remaining projects are still processed.

**Alternatives considered:**
- Pre-checking availability before calling `update!` (TOCTOU race).
- Generating a completely new identifier via `suggest_identifier(project.name)` — discarded because it loses the connection to the original slug, making post-hoc debugging harder.
- Method-level rescue (too broad — would swallow misleading errors from the read path).

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)