### PR TITLE
fix(ui): Numeric ID instead of semantic one in bulk edit work packages (WP #74926)

### DIFF
--- a/app/views/work_packages/bulk/edit.html.erb
+++ b/app/views/work_packages/bulk/edit.html.erb
@@ -42,7 +42,7 @@ See COPYRIGHT and LICENSE files for more details.
 <ul>
   <% @work_packages.each do |wp| %>
     <li>
-      <%= link_to(h("#{wp.type} ##{wp.id}"), work_package_path(wp)) %>:
+      <%= link_to(h("#{wp.type} #{wp.formatted_id}"), work_package_path(wp)) %>:
       <%= wp.subject %>
     </li>
   <% end %>

--- a/spec/controllers/work_packages/bulk_controller_spec.rb
+++ b/spec/controllers/work_packages/bulk_controller_spec.rb
@@ -141,6 +141,39 @@ RSpec.describe WorkPackages::BulkController, with_settings: { journal_aggregatio
           it { assert_select "input", attributes: { name: "work_package[parent_id]" } }
         end
 
+        context "with work package list" do
+          context "with classic (numeric) identifiers" do
+            it "displays a hash-prefixed numeric id link for each work package" do
+              assert_select "ul li a", text: /\A#{Regexp.escape(work_package1.type.to_s)} ##{work_package1.id}\z/
+              assert_select "ul li a", text: /\A#{Regexp.escape(work_package2.type.to_s)} ##{work_package2.id}\z/
+            end
+          end
+
+          context "with semantic identifiers" do
+            let(:semantic_prefix) { "TESTPROJ" }
+
+            before do
+              allow(Setting::WorkPackageIdentifier).to receive_messages(semantic?: true, classic?: false)
+              work_package1.update_columns(identifier: "#{semantic_prefix}-1", sequence_number: 1)
+              work_package2.update_columns(identifier: "#{semantic_prefix}-2", sequence_number: 2)
+            end
+
+            it "displays the semantic identifier in each link" do
+              get :edit, params: { ids: [work_package1.id, work_package2.id] }
+
+              assert_select "ul li a", text: /#{semantic_prefix}-1/
+              assert_select "ul li a", text: /#{semantic_prefix}-2/
+            end
+
+            it "does not display a bare numeric id in the links" do
+              get :edit, params: { ids: [work_package1.id, work_package2.id] }
+
+              assert_select "ul li a", text: /##{work_package1.id}/, count: 0
+              assert_select "ul li a", text: /##{work_package2.id}/, count: 0
+            end
+          end
+        end
+
         context "custom_field" do
           describe "#type" do
             it { assert_select "input", attributes: { name: "work_package[custom_field_values][#{custom_field1.id}]" } }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/work_packages/74926

# What are you trying to accomplish?
**Plan:** https://gist.github.com/thykel/6c83d48fc6895d54498edca95cdbbb00

On instances with semantic identifiers enabled, the bulk edit work packages page was showing the raw numeric database ID (e.g. `#123`) instead of the semantic identifier (e.g. `PROJ-42`) in the list of work packages being edited.

# What approach did you choose and why?

The template at `app/views/work_packages/bulk/edit.html.erb` was hard-coding `##{wp.id}`, bypassing the existing `WorkPackage#formatted_id` method entirely.

The fix replaces `##{wp.id}` with `#{wp.formatted_id}`. `formatted_id` already handles both modes correctly:
- **Semantic mode**: returns the project-scoped identifier, e.g. `PROJ-42` (no hash prefix — it is self-describing)
- **Classic mode**: returns `#42` — identical output to the old code

No controller changes were needed; `work_package_path(wp)` was already using `to_param`, which delegates to `display_id` and already produced correct semantic URLs. Only the visible link label was wrong.

Two alternative approaches were considered and rejected:
- Calling `wp.display_id` directly and manually prepending `#` in classic mode would duplicate the logic already encapsulated in `formatted_id`.
- Changing the controller to pass a pre-formatted string would push view-layer concerns into the controller unnecessarily.

# Screenshots
<img width="439" height="191" alt="Screenshot 2026-05-26 at 23 29 03" src="https://github.com/user-attachments/assets/3d750c16-b323-410c-b02f-32808385575a" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
