### PR TITLE
[#75362] Inconsistent naming on admin page (2)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5737,7 +5737,7 @@ en:
       section_work_week: "Work week"
       section_holidays_and_closures: "Holidays and closures"
     work_packages:
-      work_package_identifier: "Work package identifier"
+      work_package_identifier: "Work package identifiers"
       not_allowed_text: "You do not have the necessary permissions to view this page."
       activities:
         enable_internal_comments: "Enable internal comments"


### PR DESCRIPTION
https://community.openproject.org/wp/75362

Before:
<img width="695" height="346" alt="image" src="https://github.com/user-attachments/assets/5f6cf9ba-de1e-496d-9188-31713583b799" />


After:
<img width="695" height="346" alt="image" src="https://github.com/user-attachments/assets/dd67a52a-5a91-4894-b24d-559422649656" />
