### PR TITLE
[#75381] Jira Migrator give not helpful error message if user email is blank

### DIFF
--- a/app/models/import/jira_import.rb
+++ b/app/models/import/jira_import.rb
@@ -95,9 +95,11 @@ module Import
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/AbcSize
     def import_user(jira_user)
+      user_attrs = jira_user.to_op_attributes
+      user_attrs_without_password = user_attrs.except(:password)
       call = Users::CreateService
                .new(user: User.system, contract_class: EmptyContract)
-               .call(jira_user.to_op_attributes)
+               .call(user_attrs)
 
       call.on_success do |_result|
         create_reference!(
@@ -119,10 +121,10 @@ module Import
             )
           else
             raise "Existing User is expected to be found, because there was an email " \
-                  "or login collision. See attributes: #{jira_user.to_op_attributes}"
+                  "or login collision. See attributes: #{user_attrs_without_password}"
           end
         else
-          raise call.message
+          raise "Error creating a user (#{user_attrs_without_password}): #{call.message}"
         end
       end
 
@@ -155,7 +157,7 @@ module Import
               raise "Existing Group is expected to be found. Group name: #{group_name}"
             end
           else
-            raise call.message
+            raise "Error creating a group #{group_name}: #{call.message}"
           end
         end
         member_id = Import::JiraOpenProjectReference.where(

--- a/spec/models/import/jira_import_spec.rb
+++ b/spec/models/import/jira_import_spec.rb
@@ -459,5 +459,29 @@ RSpec.describe Import::JiraImport do
         )
       end
     end
+
+    context "when importing a user without email(can happen in case of LDAP)" do
+      let!(:jira_user) do
+        create(:jira_user,
+               jira:,
+               jira_import:,
+               payload: jira_user_payload(
+                 key: "JIRAUSER10109",
+                 name: "jvd@example.com",
+                 display_name: "Jean Van Der Berg",
+                 email: nil,
+                 groups: []
+               ))
+      end
+
+      it "raises useful error message" do
+        expect do
+          jira_import.import_users
+        end.to raise_error(
+          'Error creating a user ({login: "jvd@example.com", firstname: "Jean Van Der", lastname: "Berg", ' \
+          "mail: nil, status: :locked}): Email can't be blank."
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/75381

- Add user/group information to the error message in case of creation failure.
