### PR TITLE
[#75382] No way to find jira import run history page

### DIFF
--- a/app/views/admin/import/jira/import_runs/show.html.erb
+++ b/app/views/admin/import/jira/import_runs/show.html.erb
@@ -45,6 +45,15 @@ See COPYRIGHT and LICENSE files for more details.
         "#{I18n.t(:"admin.jira.run.title")} #{@jira_import.id.to_s}"
       ]
     )
+    header.with_description(underlined_links: false) do 
+      render(
+        Primer::Beta::Link.new(
+          href: history_admin_import_jira_run_path(jira_id: @jira_import.jira.id, id: @jira_import.id),
+          underline: false,
+      )) do |link|
+        I18n.t(:"admin.jira.run.history")
+      end
+    end
   end
 %>
 <%=


### PR DESCRIPTION
https://community.openproject.org/wp/75382

- Adds jira import run history link to jira import run page header.

<img width="2629" height="1422" alt="image" src="https://github.com/user-attachments/assets/fd2c5a64-dff2-43c6-9334-99d70334e2fc" />

