### PR TITLE
[69451] Mobile - Include project on WP list is missing spacing

### DIFF
--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button op-project-include--button"
+    class="button button_flex op-project-include--button"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
     data-test-selector="project-include-button"

--- a/frontend/src/app/shared/components/project-include/project-include.component.html
+++ b/frontend/src/app/shared/components/project-include/project-include.component.html
@@ -6,7 +6,7 @@
   <button
     slot="trigger"
     type="button"
-    class="button"
+    class="button op-project-include--button"
     (click)="toggleOpen()"
     [title]="text.toggle_title"
     data-test-selector="project-include-button"

--- a/frontend/src/app/shared/components/project-include/project-include.component.sass
+++ b/frontend/src/app/shared/components/project-include/project-include.component.sass
@@ -1,6 +1,7 @@
-@import '../../../spot/styles/sass/variables'
-
 .op-project-include
+  &--button
+    gap: var(--base-size-8, 0.5rem)
+
   &--include-all
     display: flex
     align-items: center
@@ -9,9 +10,9 @@
     &-text
       // A true center aligned text does not look center aligned
       padding-top: 1px
-      margin-left: $spot-spacing-0_5
+      margin-left: var(--base-size-8, 0.5rem)
 
   &--list
     // If there is only one item and it is disabled, we'll need to be able to view the
     // tooltip message. If we wouldn't have a default height here, the user would need to scroll
-    min-height: $spot-spacing-9
+    min-height: 9rem


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69451

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Add more spacing around the number in the button.

## Screenshots
<img width="439" height="332" alt="Screenshot 2026-05-27 at 11 13 35" src="https://github.com/user-attachments/assets/71012d28-fc65-4368-a89d-4f33139311cc" />
