### PR TITLE
Fix intermittent setTimeout frontend test failures

### DIFF
--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,9 +1,14 @@
 import { I18n } from 'i18n-js';
 import lodash from 'lodash';
 import '@testing-library/jest-dom/vitest';
+import { afterEach, vi } from 'vitest';
 import { registerDialogStreamAction } from 'core-turbo/dialog-stream-action';
 
 registerDialogStreamAction();
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 (window as any).global = window;

--- a/frontend/src/turbo/helpers.spec.ts
+++ b/frontend/src/turbo/helpers.spec.ts
@@ -22,8 +22,8 @@ describe('TurboHelpers.showProgressBar / hideProgressBar', () => {
   afterEach(() => {
     TurboHelpers.hideProgressBar();
     Turbo.config.drive.progressBarDelay = savedDelay;
-    vi.restoreAllMocks();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('sets value to 0 immediately', () => {


### PR DESCRIPTION
# Ticket

n/a

# What are you trying to accomplish?

Fix intermittent `TypeError: setTimeout is not a function` failures in the frontend test suite, seen in CI after recent merges (e.g. [this run](https://github.com/opf/openproject/actions/runs/26501404177/job/78042510555)). The victim was `tab-header.component.spec.ts`, but any spec could be affected depending on execution order.

# What approach did you choose and why?

Specs that use `vi.useFakeTimers()` can leak fake-timer state between files in vitest browser mode. A global `afterEach` in `test-setup.ts` now restores real timers after every test, preventing cross-file contamination. Also reordered cleanup in `turbo/helpers.spec.ts` to restore timers before mocks.

# Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation in Lookbook~~
- [ ] ~~Tested major browsers~~