### PR TITLE
[#75380] Jira Migrator shows 0 issues info if server does not include the data in serverInfo endpoint

### DIFF
--- a/app/components/admin/import/jira/import_runs/wizard_component.rb
+++ b/app/components/admin/import/jira/import_runs/wizard_component.rb
@@ -39,11 +39,12 @@ module Admin::Import::Jira::ImportRuns
 
     def import_selection
       [
-        { label: projects_label(selected_projects_count), checked: true },
-        { label: issues_label(selected_issues_count), checked: true },
-        { label: statuses_label(selected_statuses_count), checked: true },
-        { label: types_label(selected_types_count), checked: true }
-      ]
+        projects_label(selected_projects_count),
+        issues_label(selected_issues_count),
+        statuses_label(selected_statuses_count),
+        types_label(selected_types_count)
+      ].compact
+       .map { |label| { label:, checked: true } }
     end
 
     def selected_projects_count
@@ -51,15 +52,15 @@ module Admin::Import::Jira::ImportRuns
     end
 
     def selected_issues_count
-      model.selected["issues_count"] || 0
+      model.selected["issues_count"]
     end
 
     def selected_types_count
-      model.selected["issue_type_ids"]&.count || 0
+      model.selected["issue_type_ids"]&.count
     end
 
     def selected_statuses_count
-      model.selected["status_ids"]&.count || 0
+      model.selected["status_ids"]&.count
     end
   end
 end

--- a/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.rb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_confirm_import_component.rb
@@ -40,6 +40,7 @@ module Admin::Import::Jira::ImportRuns
         statuses_label(selected_statuses_count),
         types_label(selected_types_count)
       ]
+        .compact
         .map { |label| { label:, checked: true } }
         .push({ label: I18n.t(:"admin.jira.run.wizard.sections.confirm_import.label_users_import_explanation") })
     end
@@ -49,15 +50,15 @@ module Admin::Import::Jira::ImportRuns
     end
 
     def selected_issues_count
-      model.selected["issues_count"] || 0
+      model.selected["issues_count"]
     end
 
     def selected_types_count
-      model.selected["issue_type_ids"]&.count || 0
+      model.selected["issue_type_ids"]&.count
     end
 
     def selected_statuses_count
-      model.selected["status_ids"]&.count || 0
+      model.selected["status_ids"]&.count
     end
   end
 end

--- a/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.rb
+++ b/app/components/admin/import/jira/import_runs/wizard_step_import_scope_component.rb
@@ -40,7 +40,7 @@ module Admin::Import::Jira::ImportRuns
         statuses_label(available_statuses_count),
         types_label(available_types_count),
         users_label(available_users_count)
-      ].map { |label| { label:, checked: true } }
+      ].compact.map { |label| { label:, checked: true } }
     end
 
     def server_info

--- a/app/helpers/admin/import/jira/import_runs_helper.rb
+++ b/app/helpers/admin/import/jira/import_runs_helper.rb
@@ -34,7 +34,9 @@ module Admin::Import::Jira::ImportRunsHelper
   end
 
   def issues_label(count)
-    I18n.t(:"admin.jira.run.wizard.parts.issues", count: count || 0)
+    return nil if count.nil?
+
+    I18n.t(:"admin.jira.run.wizard.parts.issues", count:)
   end
 
   def work_packages_label(count)
@@ -42,11 +44,15 @@ module Admin::Import::Jira::ImportRunsHelper
   end
 
   def statuses_label(count)
-    I18n.t(:"admin.jira.run.wizard.parts.statuses", count: count || 0)
+    return nil if count.nil?
+
+    I18n.t(:"admin.jira.run.wizard.parts.statuses", count:)
   end
 
   def types_label(count)
-    I18n.t(:"admin.jira.run.wizard.parts.types", count: count || 0)
+    return nil if count.nil?
+
+    I18n.t(:"admin.jira.run.wizard.parts.types", count:)
   end
 
   def users_label(count)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/75380

# What are you trying to achieve?

The total_issues field in Jira DC API responses is documented as optional - when calculating it is too expensive (e.g. on large instances). We should hide the misleading 0 issues, 0 types or 0 statuses.

# What approach did you choose and why?

Hide the lines for issue, type or status, if we don't have any info about that.
