### PR TITLE
Migrate remaining mailers to format_mail_html / format_mail_text

### DIFF
--- a/app/views/announcement_mailer/announce.html.erb
+++ b/app/views/announcement_mailer/announce.html.erb
@@ -13,20 +13,20 @@
           <% if body_subheader %>
             <tr>
               <td style="<%= placeholder_text_styles("font-weight": "bold") %>">
-                <%= format_text body_subheader %>
+                <%= format_mail_html body_subheader %>
               </td>
             </tr>
           <% end %>
           <% if body_header %>
             <tr>
               <td style="<%= placeholder_text_styles(color: "#333333", "line-height": "36px", "font-size": "18px", "font-weight": "bold") %>">
-                <%= format_text body_header %>
+                <%= format_mail_html body_header %>
               </td>
             </tr>
           <% end %>
           <tr>
             <td style="<%= placeholder_text_styles %>">
-              <%= format_text body %>
+              <%= format_mail_html body %>
             </td>
           </tr>
         </table>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -102,7 +102,7 @@ See COPYRIGHT and LICENSE files for more details.
       <table class="header">
         <tr>
           <td>
-            <%= OpenProject::TextFormatting::Renderer.format_text(Setting.localized_emails_header) %>
+            <%= format_mail_html(Setting.localized_emails_header) %>
           </td>
         </tr>
       </table>
@@ -118,7 +118,7 @@ See COPYRIGHT and LICENSE files for more details.
       <table class="footer">
         <tr>
           <td>
-            <%= OpenProject::TextFormatting::Renderer.format_text(Setting.localized_emails_footer) %>
+            <%= format_mail_html(Setting.localized_emails_footer) %>
           </td>
         </tr>
       </table>

--- a/app/views/member_mailer/added_project.html.erb
+++ b/app/views/member_mailer/added_project.html.erb
@@ -6,7 +6,7 @@
   )
 %>
 
-<%= format_text(@message) %>
+<%= format_mail_html(@message) %>
 
 <%= I18n.t(:"mail_member_added_project.body.roles") %>
 <ul>

--- a/app/views/member_mailer/updated_global.html.erb
+++ b/app/views/member_mailer/updated_global.html.erb
@@ -5,7 +5,7 @@
   )
 %>
 
-<%= format_text(@message) %>
+<%= format_mail_html(@message) %>
 
 <%= I18n.t(:"mail_member_updated_global.body.roles") %>
 <ul>

--- a/app/views/member_mailer/updated_project.html.erb
+++ b/app/views/member_mailer/updated_project.html.erb
@@ -6,7 +6,7 @@
   )
 %>
 
-<%= format_text(@message) %>
+<%= format_mail_html(@message) %>
 
 <%= I18n.t(:"mail_member_updated_project.body.roles") %>
 <ul>

--- a/app/views/project_artifacts_mailer/creation_wizard_submitted.html.erb
+++ b/app/views/project_artifacts_mailer/creation_wizard_submitted.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <h1><%= link_to @project.name, project_url(@project) %></h1>
 
-<%= format_text(@notification_text, project: @project) %>
+<%= format_mail_html(@notification_text, project: @project) %>
 
 <% if @work_package&.visible? %>
   <p>

--- a/app/views/project_mailer/project_created.html.erb
+++ b/app/views/project_mailer/project_created.html.erb
@@ -29,7 +29,7 @@ See COPYRIGHT and LICENSE files for more details.
 
 <h1><%= link_to @project.name, project_url(@project) %></h1>
 
-<%= format_text(@notification_text, project: @project) %>
+<%= format_mail_html(@notification_text, project: @project) %>
 
 <% if @project.project_creation_wizard_enabled? %>
   <p>

--- a/app/views/user_mailer/message_posted.html.erb
+++ b/app/views/user_mailer/message_posted.html.erb
@@ -32,4 +32,4 @@ See COPYRIGHT and LICENSE files for more details.
 </h1>
 <em><%= @message.author %></em>
 
-<%= format_text @message.content, object: @message, only_path: false %>
+<%= format_mail_html @message.content, object: @message %>

--- a/app/views/user_mailer/news_added.html.erb
+++ b/app/views/user_mailer/news_added.html.erb
@@ -30,4 +30,4 @@ See COPYRIGHT and LICENSE files for more details.
 <h1><%= link_to @news.title, project_news_url(@news.project, @news) %></h1>
 <em><%= @news.author&.name %></em>
 
-<%= format_text @news.description, only_path: false %>
+<%= format_mail_html @news.description %>

--- a/app/views/user_mailer/news_comment_added.html.erb
+++ b/app/views/user_mailer/news_comment_added.html.erb
@@ -31,4 +31,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <p><%= t(:text_user_wrote, value: @comment.author) %></p>
 
-<%= format_text @comment.text, only_path: false %>
+<%= format_mail_html @comment.text %>

--- a/modules/documents/app/views/documents_mailer/document_added.html.erb
+++ b/modules/documents/app/views/documents_mailer/document_added.html.erb
@@ -29,4 +29,4 @@ See COPYRIGHT and LICENSE files for more details.
 
 <p><%= link_to(@document.title, document_url(@document)) %> (<%= @document.type.name %>)</p>
 
-<%= format_text @document.description %>
+<%= format_mail_html @document.description %>

--- a/modules/documents/spec/mailers/documents_mailer_spec.rb
+++ b/modules/documents/spec/mailers/documents_mailer_spec.rb
@@ -60,4 +60,41 @@ RSpec.describe DocumentsMailer do
       expect(contents).to all include("http://my.openproject.com/documents/#{document.id}")
     end
   end
+
+  describe "document description referencing a work package",
+           with_settings: { host_name: "my.openproject.com" } do
+    shared_let(:persisted_project) { create(:project, identifier: "docsproj") }
+    shared_let(:persisted_user) { create(:admin) }
+    shared_let(:referenced_wp) { create(:work_package, project: persisted_project) }
+    shared_let(:document) do
+      create(:document,
+             project: persisted_project,
+             title: "Doc Title",
+             description: "see ##{referenced_wp.id}")
+    end
+
+    let(:html_body) do
+      User.execute_as(persisted_user) do
+        described_class.document_added(persisted_user, document).html_part.body.to_s
+      end
+    end
+
+    context "with classic mode",
+            with_settings: { work_packages_identifier: "classic" } do
+      it "renders the numeric reference as an absolute work-package link" do
+        expect(html_body).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+      end
+    end
+
+    context "with semantic mode",
+            with_settings: { work_packages_identifier: "semantic" } do
+      before do
+        referenced_wp.update_columns(identifier: "DOCSPROJ-1", sequence_number: 1)
+      end
+
+      it "renders the formatted_id in the html body" do
+        expect(html_body).to include("DOCSPROJ-1")
+      end
+    end
+  end
 end

--- a/spec/mailers/announcement_mailer_spec.rb
+++ b/spec/mailers/announcement_mailer_spec.rb
@@ -70,5 +70,39 @@ RSpec.describe AnnouncementMailer do
         expect(mail.to).to be_nil
       end
     end
+
+    describe "rendering a body that references a work package" do
+      shared_let(:persisted_project) { create(:project, identifier: "announceproj") }
+      shared_let(:persisted_recipient) { create(:admin) }
+      shared_let(:referenced_wp) { create(:work_package, project: persisted_project) }
+
+      let(:html_body) do
+        User.execute_as(persisted_recipient) do
+          described_class.announce(persisted_recipient,
+                                   subject: announcement_subject,
+                                   body: "see ##{referenced_wp.id}")
+                         .html_part.body.to_s
+        end
+      end
+
+      context "with classic mode",
+              with_settings: { work_packages_identifier: "classic" } do
+        it "renders the numeric reference as an absolute work-package link" do
+          expect(html_body).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+        end
+      end
+
+      context "with semantic mode",
+              with_settings: { work_packages_identifier: "semantic" } do
+        before do
+          referenced_wp.update_columns(identifier: "ANNOUNCEPROJ-1", sequence_number: 1)
+        end
+
+        it "renders the formatted_id as an absolute work-package link" do
+          expect(html_body).to include("ANNOUNCEPROJ-1")
+          expect(html_body).to match(%r{href="http[^"]*/work_packages/ANNOUNCEPROJ-1"})
+        end
+      end
+    end
   end
 end

--- a/spec/mailers/member_mailer_spec.rb
+++ b/spec/mailers/member_mailer_spec.rb
@@ -168,6 +168,41 @@ RSpec.describe MemberMailer do
       end
     end
     it_behaves_like "fails for a group"
+
+    describe "with a custom message referencing a work package" do
+      shared_let(:persisted_project) { create(:project, identifier: "memberproj") }
+      shared_let(:persisted_principal) { create(:admin) }
+      shared_let(:persisted_role) { create(:project_role) }
+      shared_let(:persisted_member) do
+        create(:member, principal: persisted_principal, project: persisted_project, roles: [persisted_role])
+      end
+      shared_let(:referenced_wp) { create(:work_package, project: persisted_project) }
+
+      let(:html_body) do
+        User.execute_as(persisted_principal) do
+          mail = described_class.added_project(persisted_principal, persisted_member, "see ##{referenced_wp.id}")
+          mail.body.parts.detect { |part| part["Content-Type"].value == "text/html" }.body.to_s
+        end
+      end
+
+      context "with classic mode",
+              with_settings: { work_packages_identifier: "classic" } do
+        it "renders the numeric reference as an absolute work-package link" do
+          expect(html_body).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+        end
+      end
+
+      context "with semantic mode",
+              with_settings: { work_packages_identifier: "semantic" } do
+        before do
+          referenced_wp.update_columns(identifier: "MEMBERPROJ-1", sequence_number: 1)
+        end
+
+        it "renders the formatted_id in the html body" do
+          expect(html_body).to include("MEMBERPROJ-1")
+        end
+      end
+    end
   end
 
   describe "#updated_project" do

--- a/spec/mailers/project_artifacts_mailer_spec.rb
+++ b/spec/mailers/project_artifacts_mailer_spec.rb
@@ -81,6 +81,30 @@ RSpec.describe ProjectArtifactsMailer do
       end
     end
 
+    context "with notification text referencing a work package" do
+      shared_let(:persisted_project) { create(:project, identifier: "wizardproj") }
+      shared_let(:persisted_user) { create(:admin) }
+      shared_let(:referenced_wp) { create(:work_package, project: persisted_project) }
+
+      subject(:mail) { described_class.creation_wizard_submitted(persisted_user, persisted_project, referenced_wp) }
+
+      before do
+        allow(persisted_project).to receive_messages(
+          project_creation_wizard_notification_text: "see ##{referenced_wp.id}",
+          project_creation_wizard_enabled?: false
+        )
+      end
+
+      let(:rendered_html) do
+        User.execute_as(persisted_user) { mail.html_part.body.encoded }
+      end
+
+      it "rewrites work-package links to absolute URLs",
+         with_settings: { work_packages_identifier: "classic" } do
+        expect(rendered_html).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+      end
+    end
+
     context "with work package" do
       it "includes a link to the work package" do
         expect(mail.html_part.body.encoded)

--- a/spec/mailers/project_mailer_spec.rb
+++ b/spec/mailers/project_mailer_spec.rb
@@ -73,6 +73,28 @@ RSpec.describe ProjectMailer do
       end
     end
 
+    context "with custom notification text referencing a work package" do
+      shared_let(:persisted_project) { create(:project, identifier: "absurlproj") }
+      shared_let(:persisted_user) { create(:admin) }
+      shared_let(:referenced_wp) { create(:work_package, project: persisted_project) }
+
+      subject(:mail) { described_class.project_created(persisted_project, user: persisted_user) }
+
+      before do
+        allow(Setting).to receive(:new_project_notification_text)
+          .and_return("see ##{referenced_wp.id}")
+      end
+
+      let(:rendered_html) do
+        User.execute_as(persisted_user) { mail.html_part.body.encoded }
+      end
+
+      it "rewrites work-package links to absolute URLs",
+         with_settings: { work_packages_identifier: "classic" } do
+        expect(rendered_html).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+      end
+    end
+
     context "with the creation wizard enabled" do
       before do
         allow(project).to receive_messages(

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -366,6 +366,71 @@ RSpec.describe UserMailer do
     end
   end
 
+  describe "#news_added rendering a description that references a work package" do
+    shared_let(:persisted_project) { create(:project, identifier: "demo") }
+    shared_let(:persisted_recipient) { create(:admin) }
+    shared_let(:referenced_wp) do
+      create(:work_package, project: persisted_project, subject: "watched")
+    end
+    shared_let(:news) do
+      create(:news,
+             project: persisted_project,
+             description: "Heads up on work package ##{referenced_wp.id}")
+    end
+
+    let(:html_body) do
+      User.execute_as(persisted_recipient) do
+        described_class.news_added(persisted_recipient, news).html_part.body.to_s
+      end
+    end
+
+    context "with classic mode",
+            with_settings: { work_packages_identifier: "classic" } do
+      it "renders the numeric reference as an absolute work-package link" do
+        expect(html_body).to include("##{referenced_wp.id}")
+        expect(html_body).to match(%r{href="http[^"]*/work_packages/#{referenced_wp.id}"})
+      end
+    end
+
+    context "with semantic mode",
+            with_settings: { work_packages_identifier: "semantic" } do
+      before do
+        referenced_wp.update_columns(identifier: "DEMO-1", sequence_number: 1)
+      end
+
+      it "renders the formatted_id as an absolute work-package link" do
+        expect(html_body).to include("DEMO-1")
+        expect(html_body).to match(%r{href="http[^"]*/work_packages/DEMO-1"})
+      end
+    end
+  end
+
+  describe "layout rendering Setting.localized_emails_header through the static-HTML pipeline",
+           with_settings: { work_packages_identifier: "semantic" } do
+    shared_let(:persisted_project) { create(:project, identifier: "demo") }
+    shared_let(:persisted_recipient) { create(:admin) }
+    shared_let(:referenced_wp) do
+      create(:work_package, project: persisted_project, subject: "header-target").tap do |wp|
+        wp.update_columns(identifier: "DEMO-1", sequence_number: 1)
+      end
+    end
+
+    context "with a header referencing a work package" do
+      before do
+        allow(Setting).to receive(:localized_emails_header)
+          .and_return("See ##{referenced_wp.id}")
+      end
+
+      it "renders the formatted_id as plain text without leaking subject" do
+        expect { described_class.test_mail(persisted_recipient).deliver_now }.not_to raise_error
+
+        html = deliveries.first.html_part.body.to_s
+        expect(html).to include("DEMO-1")
+        expect(html).not_to include("header-target")
+      end
+    end
+  end
+
   describe "localization" do
     context "with the user having a language configured",
             with_settings: { available_languages: %w[en de],


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/75389

Follow-up to #23337. Stacked on that PR — the diff will collapse once #23337 lands in `dev`.

> [!NOTE]
> Related: [opf/rubocop-openproject#5](https://github.com/opf/rubocop-openproject/pull/5) introduces `OpenProject/UseRenderModeInsteadOfPrimitives`, which flags the pre-migration shape (`static_html: true` / `plain_text: true` / `only_path: false` on `format_text`). 

# What are you trying to accomplish?

Mailer views still carry the `static_html: true` / `only_path: false` / `plain_text: true` boilerplate on every `format_text` call. This PR routes the remaining sites through `format_mail_html` / `format_mail_text` so `render_mode:` is pinned once at the helper layer.

Migrated surfaces:
- [x] **UserMailer** — `message_posted`, `news_added`, `news_comment_added`
- [x] **ProjectMailer** — `project_created`
- [x] **ProjectArtifactsMailer** — `creation_wizard_submitted`
- [x] **MemberMailer** — `added_project`, `updated_project`, `updated_global`
- [x] **AnnouncementMailer** — `announce` (body, header, subheader)
- [x] **DocumentsMailer** — `document_added`
- [x] **Shared layout** — `localized_emails_header`, `localized_emails_footer` (previously called `OpenProject::TextFormatting::Renderer.format_text` directly, bypassing the helper)

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)