### PR TITLE
[#75391] Enabled rate limiting on Jira instance breaks projects selector.

### DIFF
--- a/app/workers/import/jira_instance_meta_data_job.rb
+++ b/app/workers/import/jira_instance_meta_data_job.rb
@@ -85,8 +85,12 @@ module Import
     def project_browsable?(project_key)
       @client.issues(jql: "project = '#{project_key}'", max_results: 0, fields: "id")
       true
-    rescue Import::JiraClient::ApiError
-      false
+    rescue Import::JiraClient::ApiError => e
+      if e.status == 400
+        false
+      else
+        raise e
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,7 @@ en:
         parse_error: "Failed to parse Jira API response: %{message}"
         api_error: "Jira API returned error status %{status}"
         401_error: "Jira API returned a 401 error. Your authentication token may have expired or lack the required permissions. Please ensure the token belongs to a Jira administrator."
+        429_error: "Jira API returned a 429 error. It means token owner has been rate limited by the Jira instance. Please disable rate limiting for this user."
       columns:
         projects: "Projects"
         last_change: "Last change"


### PR DESCRIPTION
https://community.openproject.org/wp/75391

- Adds error message for 429 http error.
- Does not suppress Import::JiraClient::ApiError with status 429.
- Specifically expect 400 in project_browsable? check.
