### PR TITLE
[#72840] Jira Migrator: misalignement between the status badge and the import name

### DIFF
--- a/app/components/admin/import/jira/import_runs/streamable_status_badge_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/streamable_status_badge_component.html.erb
@@ -1,5 +1,5 @@
 <%=
-  component_wrapper(tag: :span, style: "display: inline-block; vertical-align: text-bottom") do
+  component_wrapper(tag: :span) do
     render(Admin::Import::Jira::ImportRuns::StatusBadgeComponent.new(@status, **@system_arguments))
   end
 %>

--- a/app/views/admin/import/jira/import_runs/show.html.erb
+++ b/app/views/admin/import/jira/import_runs/show.html.erb
@@ -31,10 +31,12 @@ See COPYRIGHT and LICENSE files for more details.
 <%=
   render(Primer::OpenProject::PageHeader.new) do |header|
     header.with_title do
-      concat(render(Primer::Beta::Text.new(mr: 2)) {
-        "#{I18n.t(:"admin.jira.run.title")} #{@jira_import.id.to_s}"
-      })
-      concat(render(Admin::Import::Jira::ImportRuns::StreamableStatusBadgeComponent.new(@jira_import.current_state)))
+      render(Primer::BaseComponent.new(tag: :span, display: :flex, align_items: :center, style: "line-height: 1")) do
+        concat(render(Primer::Beta::Text.new(mr: 2)) {
+          "#{I18n.t(:"admin.jira.run.title")} #{@jira_import.id.to_s}"
+        })
+        concat(render(Admin::Import::Jira::ImportRuns::StreamableStatusBadgeComponent.new(@jira_import.current_state)))
+      end
     end
     header.with_breadcrumbs(
       [


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/72840

# What are you trying to achieve?
Vertically center the badge in the page head title

# What approach did you choose and why?
Use a flex wrapper

# Merge checklist

- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
