### PR TITLE
Add dependabot groups for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
         patterns:
           - '@hotwired/turbo'
           - '@hotwired/turbo-rails'
+      jquery:
+        patterns:
+          - 'jquery'
+          - 'jquery-migrate'
       ng-select:
         patterns:
           - '@ng-select/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
       fullcalendar:
         patterns:
           - '@fullcalendar/*'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-plugin-*'
+          - '@eslint/*'
+          - '@stylistic/eslint-plugin'
+          - 'globals'
       html-eslint:
         patterns:
           - '@html-eslint/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,9 @@ updates:
         patterns:
           - 'typescript-eslint'
           - '@typescript-eslint/*'
+      uirouter:
+        patterns:
+          - '@uirouter/*'
     ignore:
       - dependency-name: "@angular/*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,9 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
+      testing-library:
+        patterns:
+          - '@testing-library/*'
     ignore:
       - dependency-name: "@angular/*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,10 @@ updates:
       uirouter:
         patterns:
           - '@uirouter/*'
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
     ignore:
       - dependency-name: "@angular/*"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,10 @@ updates:
       html-eslint:
         patterns:
           - '@html-eslint/*'
+      hotwired:
+        patterns:
+          - '@hotwired/turbo'
+          - '@hotwired/turbo-rails'
       ng-select:
         patterns:
           - '@ng-select/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,13 @@ updates:
     groups:
       angular:
         patterns:
-          - '@angular*'
+          - '@angular/*'
+          - '@angular-devkit/*'
+          - '@angular-builders/*'
+      angular-eslint:
+        patterns:
+          - 'angular-eslint'
+          - '@angular-eslint/*'
       blocknote:
         patterns:
           - '@blocknote/*'
@@ -36,7 +42,15 @@ updates:
           - '@types/react'
           - '@types/react-dom'
     ignore:
-      - dependency-name: "@angular*"
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-builders/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-devkit/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "angular-eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@angular-eslint/*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@openproject/octicons"
       - dependency-name: "@openproject/primer-view-components"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,9 @@ updates:
         patterns:
           - 'jquery'
           - 'jquery-migrate'
+      mantine:
+        patterns:
+          - '@mantine/*'
       ng-select:
         patterns:
           - '@ng-select/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,10 @@ updates:
       testing-library:
         patterns:
           - '@testing-library/*'
+      typescript-eslint:
+        patterns:
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
     ignore:
       - dependency-name: "@angular/*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Reduce dependabot PR noise by grouping tightly-coupled npm dependencies so they bump together in a single PR instead of individually.

# What approach did you choose and why?

Split the broad `@angular*` pattern into specific groups (`@angular/*`, `@angular-devkit/*`, `@angular-builders/*`) and added a separate `angular-eslint` group. Then added groups for other dependency families that share a monorepo or must stay in sync:

- **eslint** — `eslint`, `eslint-plugin-*`, `@eslint/*`, `@stylistic/eslint-plugin`, `globals`
- **hotwired** — `@hotwired/turbo`, `@hotwired/turbo-rails` (stimulus excluded — versioned independently)
- **jquery** — `jquery`, `jquery-migrate`
- **mantine** — `@mantine/*`
- **testing-library** — `@testing-library/*`
- **typescript-eslint** — `typescript-eslint`, `@typescript-eslint/*`
- **uirouter** — `@uirouter/*`
- **vitest** — `vitest`, `@vitest/*`

Major-version ignore rules added only for Angular ecosystem packages (consistent with existing Primer ignores).