### PR TITLE
Feature/74386 add existing work packages within sprint and backlog containers menu

### DIFF
--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -566,7 +566,6 @@ class PermittedParams
         new_work_package: [
           :assigned_to_id,
           { attachments: %i[file description] },
-          :backlog_bucket_id,
           :category_id,
           :description,
           :done_ratio,
@@ -579,7 +578,6 @@ class PermittedParams
           :priority_id,
           :remaining_hours,
           :responsible_id,
-          :sprint_id,
           :start_date,
           :status_id,
           :type_id,

--- a/app/models/permitted_params.rb
+++ b/app/models/permitted_params.rb
@@ -566,6 +566,7 @@ class PermittedParams
         new_work_package: [
           :assigned_to_id,
           { attachments: %i[file description] },
+          :backlog_bucket_id,
           :category_id,
           :description,
           :done_ratio,

--- a/app/models/queries/filters/shared/boolean_filter.rb
+++ b/app/models/queries/filters/shared/boolean_filter.rb
@@ -43,4 +43,11 @@ module Queries::Filters::Shared::BooleanFilter
   def type_strategy
     @type_strategy ||= ::Queries::Filters::Strategies::BooleanList.new self
   end
+
+  private
+
+  def filtering_for_true?
+    (operator_strategy == ::Queries::Operators::BooleanEquals && values == [OpenProject::Database::DB_VALUE_TRUE]) ||
+      (operator_strategy == ::Queries::Operators::BooleanNotEquals && values == [OpenProject::Database::DB_VALUE_FALSE])
+  end
 end

--- a/app/models/queries/projects/filters/favorited_filter.rb
+++ b/app/models/queries/projects/filters/favorited_filter.rb
@@ -57,8 +57,7 @@ class Queries::Projects::Filters::FavoritedFilter < Queries::Projects::Filters::
   end
 
   def apply_to(_query_scope)
-    if (values.first == OpenProject::Database::DB_VALUE_TRUE && operator_strategy == Queries::Operators::BooleanEquals) ||
-      (values.first == OpenProject::Database::DB_VALUE_FALSE && operator_strategy == Queries::Operators::BooleanNotEquals)
+    if filtering_for_true?
       super.where(id: favorited_project_ids)
     else
       super.where.not(id: favorited_project_ids)

--- a/app/models/queries/work_packages/filter/milestone_filter.rb
+++ b/app/models/queries/work_packages/filter/milestone_filter.rb
@@ -44,16 +44,11 @@ class Queries::WorkPackages::Filter::MilestoneFilter < Queries::WorkPackages::Fi
   end
 
   def where
-    if positive?
+    if filtering_for_true?
       "type_id IN (#{milestone_subselect})"
     else
       "type_id NOT IN (#{milestone_subselect})"
     end
-  end
-
-  def positive?
-    (operator == "=" && values == [OpenProject::Database::DB_VALUE_TRUE]) ||
-      (operator == "!" && values == [OpenProject::Database::DB_VALUE_FALSE])
   end
 
   def human_name

--- a/app/models/queries/work_packages/filter/shared_with_me_filter.rb
+++ b/app/models/queries/work_packages/filter/shared_with_me_filter.rb
@@ -44,16 +44,11 @@ class Queries::WorkPackages::Filter::SharedWithMeFilter < Queries::WorkPackages:
   end
 
   def where
-    if positive?
+    if filtering_for_true?
       "work_packages.id IN (#{shared_work_packages.to_sql})"
     else
       "work_packages.id NOT IN (#{shared_work_packages.to_sql})"
     end
-  end
-
-  def positive?
-    (operator == "=" && values == [OpenProject::Database::DB_VALUE_TRUE]) ||
-      (operator == "!" && values == [OpenProject::Database::DB_VALUE_FALSE])
   end
 
   def human_name

--- a/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.html.erb
@@ -1,0 +1,58 @@
+<%# -- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++# %>
+
+<%=
+  render(Primer::Alpha::Dialog.new(title: t(".title", name: container_name), id: DIALOG_ID, size: :large)) do |d|
+    d.with_header(variant: :large)
+
+    d.with_body(classes: "Overlay-body_autocomplete_height") do
+      primer_form_with(
+        url: form_url,
+        method: :post,
+        id: FORM_ID
+      ) do |f|
+        render(Backlogs::AddExistingWorkPackageForm.new(f, project:, target_id:))
+      end
+    end
+
+    d.with_footer(mt: 2) do
+      component_collection do |buttons|
+        buttons.with_component(Primer::Beta::Button.new(data: { close_dialog_id: DIALOG_ID })) do
+          t(:button_cancel)
+        end
+
+        buttons.with_component(
+          Primer::Beta::Button.new(scheme: :primary, form: FORM_ID, type: :submit)
+        ) do
+          t(:button_add)
+        end
+      end
+    end
+  end
+%>

--- a/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.html.erb
@@ -28,7 +28,7 @@ See COPYRIGHT and LICENSE files for more details.
 ++# %>
 
 <%=
-  render(Primer::Alpha::Dialog.new(title: t(".title", name: container_name), id: DIALOG_ID, size: :large)) do |d|
+  render(Primer::Alpha::Dialog.new(title: t(".title", name: container.name), id: DIALOG_ID, size: :large)) do |d|
     d.with_header(variant: :large)
 
     d.with_body(classes: "Overlay-body_autocomplete_height") do

--- a/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class AddExistingWorkPackageDialogComponent < ApplicationComponent
+    include OpTurbo::Streamable
+    include OpPrimer::ComponentHelpers
+
+    DIALOG_ID = "add-existing-work-package-dialog"
+    FORM_ID = "add-existing-work-package-form"
+
+    attr_reader :project, :target_id
+
+    def initialize(project:, target_id:)
+      super()
+
+      @project = project
+      @target_id = target_id
+    end
+
+    private
+
+    def container_name
+      case Target.parse(target_id)
+      in Target::SprintId[id]
+        Sprint.for_project(project).visible.where(id:).pick(:name) || Sprint.human_model_name
+      in Target::BucketId[id]
+        BacklogBucket.for_project(project).visible.where(id:).pick(:name) || BacklogBucket.human_model_name
+      in Target::InboxId
+        I18n.t(:label_inbox)
+      else
+        nil
+      end
+    end
+
+    def form_url
+      add_existing_project_backlogs_work_packages_path(project, target_id:)
+    end
+  end
+end

--- a/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
@@ -48,15 +48,13 @@ module Backlogs
     private
 
     def container_name
-      case Target.parse(target_id)
+      case target_id
       in Target::SprintId[id]
         Sprint.for_project(project).visible.where(id:).pick(:name) || Sprint.human_model_name
       in Target::BucketId[id]
         BacklogBucket.for_project(project).visible.where(id:).pick(:name) || BacklogBucket.human_model_name
       in Target::InboxId
         I18n.t(:label_inbox)
-      else
-        nil
       end
     end
 

--- a/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
+++ b/modules/backlogs/app/components/backlogs/add_existing_work_package_dialog_component.rb
@@ -36,27 +36,18 @@ module Backlogs
     DIALOG_ID = "add-existing-work-package-dialog"
     FORM_ID = "add-existing-work-package-form"
 
-    attr_reader :project, :target_id
+    attr_reader :project, :container
 
-    def initialize(project:, target_id:)
+    def initialize(project:, container:)
       super()
 
       @project = project
-      @target_id = target_id
+      @container = container
     end
+
+    def target_id = Target.for(container)
 
     private
-
-    def container_name
-      case target_id
-      in Target::SprintId[id]
-        Sprint.for_project(project).visible.where(id:).pick(:name) || Sprint.human_model_name
-      in Target::BucketId[id]
-        BacklogBucket.for_project(project).visible.where(id:).pick(:name) || BacklogBucket.human_model_name
-      in Target::InboxId
-        I18n.t(:label_inbox)
-      end
-    end
 
     def form_url
       add_existing_project_backlogs_work_packages_path(project, target_id:)

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -71,7 +71,9 @@ See COPYRIGHT and LICENSE files for more details.
               if user_allowed?(:manage_sprint_items)
                 menu.with_item(
                   id: dom_target(backlog_bucket, :menu, :add_new_work_package),
-                  label: t(".action_menu.add_new_work_package")
+                  label: t(".action_menu.add_new_work_package"),
+                  href: new_project_work_packages_dialog_path(project, backlog_bucket_id: backlog_bucket.id),
+                  content_arguments: { data: { controller: "async-dialog" } }
                 ) do |item|
                   item.with_leading_visual_icon(icon: :plus)
                 end

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -66,6 +66,24 @@ See COPYRIGHT and LICENSE files for more details.
                 item.with_leading_visual_icon(icon: :trash)
               end
             end
+
+            with_item_group(menu) do
+              if user_allowed?(:manage_sprint_items)
+                menu.with_item(
+                  id: dom_target(backlog_bucket, :menu, :add_new_work_package),
+                  label: t(".action_menu.add_new_work_package")
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :plus)
+                end
+
+                menu.with_item(
+                  id: dom_target(backlog_bucket, :menu, :add_existing_work_package),
+                  label: t(".action_menu.add_existing_work_package")
+                ) do |item|
+                  item.with_leading_visual_icon(icon: :link)
+                end
+              end
+            end
           end
         end
       end

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -44,9 +44,9 @@ See COPYRIGHT and LICENSE files for more details.
       )
     ) do |list|
       list.with_header(title: backlog_bucket.name) do |header|
-        if show_menu?
-          header.with_menu(button_aria_label: t(".label_actions")) do |menu|
-            with_item_group(menu) do
+        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+          with_item_group(menu) do
+            if user_allowed?(:create_sprints)
               menu.with_item(
                 id: dom_target(backlog_bucket, :menu, :edit_backlog_bucket),
                 label: t(".action_menu.edit_backlog_bucket"),
@@ -66,26 +66,26 @@ See COPYRIGHT and LICENSE files for more details.
                 item.with_leading_visual_icon(icon: :trash)
               end
             end
+          end
 
-            with_item_group(menu) do
-              if user_allowed?(:manage_sprint_items)
-                menu.with_item(
-                  id: dom_target(backlog_bucket, :menu, :add_new_work_package),
-                  label: t(".action_menu.add_new_work_package"),
-                  href: new_project_work_packages_dialog_path(project, backlog_bucket_id: backlog_bucket.id),
-                  content_arguments: { data: { controller: "async-dialog" } }
-                ) do |item|
-                  item.with_leading_visual_icon(icon: :plus)
-                end
+          with_item_group(menu) do
+            if user_allowed?(:manage_sprint_items)
+              menu.with_item(
+                id: dom_target(backlog_bucket, :menu, :add_new_work_package),
+                label: t(".action_menu.add_new_work_package"),
+                href: new_project_work_packages_dialog_path(project, backlog_bucket_id: backlog_bucket.id),
+                content_arguments: { data: { controller: "async-dialog" } }
+              ) do |item|
+                item.with_leading_visual_icon(icon: :plus)
+              end
 
-                menu.with_item(
-                  id: dom_target(backlog_bucket, :menu, :add_existing_work_package),
-                  label: t(".action_menu.add_existing_work_package"),
-                  href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(backlog_bucket)),
-                  content_arguments: { data: { controller: "async-dialog" } }
-                ) do |item|
-                  item.with_leading_visual_icon(icon: :link)
-                end
+              menu.with_item(
+                id: dom_target(backlog_bucket, :menu, :add_existing_work_package),
+                label: t(".action_menu.add_existing_work_package"),
+                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(backlog_bucket)),
+                content_arguments: { data: { controller: "async-dialog" } }
+              ) do |item|
+                item.with_leading_visual_icon(icon: :link)
               end
             end
           end

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -68,27 +68,7 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
 
-          with_item_group(menu) do
-            if user_allowed?(:manage_sprint_items)
-              menu.with_item(
-                id: dom_target(backlog_bucket, :menu, :add_new_work_package),
-                label: t(".action_menu.add_new_work_package"),
-                href: new_project_work_packages_dialog_path(project, backlog_bucket_id: backlog_bucket.id),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :plus)
-              end
-
-              menu.with_item(
-                id: dom_target(backlog_bucket, :menu, :add_existing_work_package),
-                label: t(".action_menu.add_existing_work_package"),
-                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(backlog_bucket)),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :link)
-              end
-            end
-          end
+          with_add_work_package_menu_group(menu, backlog_bucket)
         end
       end
 

--- a/modules/backlogs/app/components/backlogs/bucket_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.html.erb
@@ -80,7 +80,9 @@ See COPYRIGHT and LICENSE files for more details.
 
                 menu.with_item(
                   id: dom_target(backlog_bucket, :menu, :add_existing_work_package),
-                  label: t(".action_menu.add_existing_work_package")
+                  label: t(".action_menu.add_existing_work_package"),
+                  href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(backlog_bucket)),
+                  content_arguments: { data: { controller: "async-dialog" } }
                 ) do |item|
                   item.with_leading_visual_icon(icon: :link)
                 end

--- a/modules/backlogs/app/components/backlogs/bucket_component.rb
+++ b/modules/backlogs/app/components/backlogs/bucket_component.rb
@@ -49,11 +49,5 @@ module Backlogs
     def wrapper_uniq_by
       backlog_bucket.id
     end
-
-    private
-
-    def show_menu?
-      backlog_bucket.persisted? && current_user.allowed_in_project?(:create_sprints, project)
-    end
   end
 end

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -52,7 +52,9 @@ See COPYRIGHT and LICENSE files for more details.
             if user_allowed?(:manage_sprint_items)
               menu.with_item(
                 id: dom_target(:inbox, :menu, :add_new_work_package),
-                label: t(".action_menu.add_new_work_package")
+                label: t(".action_menu.add_new_work_package"),
+                href: new_project_work_packages_dialog_path(project),
+                content_arguments: { data: { controller: "async-dialog" } }
               ) do |item|
                 item.with_leading_visual_icon(icon: :plus)
               end

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -46,7 +46,27 @@ See COPYRIGHT and LICENSE files for more details.
         }
       )
     ) do |list|
-      list.with_header(title: t(".title"), count: work_packages.size, title_arguments: { font_size: 4 })
+      list.with_header(title: t(".title"), count: work_packages.size, title_arguments: { font_size: 4 }) do |header|
+        header.with_menu(button_aria_label: t(".label_actions")) do |menu|
+          with_item_group(menu) do
+            if user_allowed?(:manage_sprint_items)
+              menu.with_item(
+                id: dom_target(:inbox, :menu, :add_new_work_package),
+                label: t(".action_menu.add_new_work_package")
+              ) do |item|
+                item.with_leading_visual_icon(icon: :plus)
+              end
+
+              menu.with_item(
+                id: dom_target(:inbox, :menu, :add_existing_work_package),
+                label: t(".action_menu.add_existing_work_package")
+              ) do |item|
+                item.with_leading_visual_icon(icon: :link)
+              end
+            end
+          end
+        end
+      end
 
       list.with_empty_state(
         title: t(".blankslate_title"),

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -48,27 +48,7 @@ See COPYRIGHT and LICENSE files for more details.
     ) do |list|
       list.with_header(title: t(".title"), count: work_packages.size, title_arguments: { font_size: 4 }) do |header|
         header.with_menu(button_aria_label: t(".label_actions")) do |menu|
-          with_item_group(menu) do
-            if user_allowed?(:manage_sprint_items)
-              menu.with_item(
-                id: dom_target(:inbox, :menu, :add_new_work_package),
-                label: t(".action_menu.add_new_work_package"),
-                href: new_project_work_packages_dialog_path(project),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :plus)
-              end
-
-              menu.with_item(
-                id: dom_target(:inbox, :menu, :add_existing_work_package),
-                label: t(".action_menu.add_existing_work_package"),
-                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target::InboxId),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :link)
-              end
-            end
-          end
+          with_add_work_package_menu_group(menu, Backlogs::Target::Inbox)
         end
       end
 

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -61,7 +61,9 @@ See COPYRIGHT and LICENSE files for more details.
 
               menu.with_item(
                 id: dom_target(:inbox, :menu, :add_existing_work_package),
-                label: t(".action_menu.add_existing_work_package")
+                label: t(".action_menu.add_existing_work_package"),
+                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target::InboxId),
+                content_arguments: { data: { controller: "async-dialog" } }
               ) do |item|
                 item.with_leading_visual_icon(icon: :link)
               end

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -33,6 +33,7 @@ module Backlogs
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
     include CommonHelper
+    include ContainerComponentHelper
 
     TRUNCATE_MIDDLE = 50
 

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -107,12 +107,19 @@ See COPYRIGHT and LICENSE files for more details.
           with_item_group(menu) do
             if user_allowed?(:manage_sprint_items)
               menu.with_item(
-                id: dom_target(sprint, :menu, :new_story),
+                id: dom_target(sprint, :menu, :add_new_work_package),
                 label: t(".action_menu.add_new_work_package"),
                 href: new_project_work_packages_dialog_path(project, sprint_id: sprint.id),
                 content_arguments: { data: { turbo_stream: true } }
               ) do |item|
                 item.with_leading_visual_icon(icon: :plus)
+              end
+
+              menu.with_item(
+                id: dom_target(sprint, :menu, :add_existing_work_package),
+                label: t(".action_menu.add_existing_work_package")
+              ) do |item|
+                item.with_leading_visual_icon(icon: :link)
               end
             end
           end

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -104,27 +104,7 @@ See COPYRIGHT and LICENSE files for more details.
             end
           end
 
-          with_item_group(menu) do
-            if user_allowed?(:manage_sprint_items)
-              menu.with_item(
-                id: dom_target(sprint, :menu, :add_new_work_package),
-                label: t(".action_menu.add_new_work_package"),
-                href: new_project_work_packages_dialog_path(project, sprint_id: sprint.id),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :plus)
-              end
-
-              menu.with_item(
-                id: dom_target(sprint, :menu, :add_existing_work_package),
-                label: t(".action_menu.add_existing_work_package"),
-                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(sprint)),
-                content_arguments: { data: { controller: "async-dialog" } }
-              ) do |item|
-                item.with_leading_visual_icon(icon: :link)
-              end
-            end
-          end
+          with_add_work_package_menu_group(menu, sprint)
 
           with_item_group(menu) do
             if show_task_board_link?

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -117,7 +117,9 @@ See COPYRIGHT and LICENSE files for more details.
 
               menu.with_item(
                 id: dom_target(sprint, :menu, :add_existing_work_package),
-                label: t(".action_menu.add_existing_work_package")
+                label: t(".action_menu.add_existing_work_package"),
+                href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id: Backlogs::Target.for(sprint)),
+                content_arguments: { data: { controller: "async-dialog" } }
               ) do |item|
                 item.with_leading_visual_icon(icon: :link)
               end

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -110,7 +110,7 @@ See COPYRIGHT and LICENSE files for more details.
                 id: dom_target(sprint, :menu, :add_new_work_package),
                 label: t(".action_menu.add_new_work_package"),
                 href: new_project_work_packages_dialog_path(project, sprint_id: sprint.id),
-                content_arguments: { data: { turbo_stream: true } }
+                content_arguments: { data: { controller: "async-dialog" } }
               ) do |item|
                 item.with_leading_visual_icon(icon: :plus)
               end

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -108,7 +108,7 @@ See COPYRIGHT and LICENSE files for more details.
             if user_allowed?(:manage_sprint_items)
               menu.with_item(
                 id: dom_target(sprint, :menu, :new_story),
-                label: t(".action_menu.add_work_package"),
+                label: t(".action_menu.add_new_work_package"),
                 href: new_project_work_packages_dialog_path(project, sprint_id: sprint.id),
                 content_arguments: { data: { turbo_stream: true } }
               ) do |item|

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -34,6 +34,7 @@ module Backlogs
     include OpPrimer::ComponentHelpers
     include OpTurbo::Streamable
     include CommonHelper
+    include ContainerComponentHelper
     include Redmine::I18n
 
     attr_reader :sprint, :project, :work_packages, :current_user, :active_sprint_ids

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -67,7 +67,7 @@ module Backlogs
     end
 
     def move # rubocop:disable Metrics/AbcSize
-      call = ::Backlogs::WorkPackages::UpdateService.new(user: current_user, story: @work_package)
+      call = ::Backlogs::WorkPackages::UpdateService.new(user: current_user, work_package: @work_package)
                                    .call(**move_params.to_h.symbolize_keys)
 
       if call.success?

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -60,14 +60,10 @@ module Backlogs
           container:
         )
       elsif target_id
-        render_error_flash_message_via_turbo_stream(
-          message: I18n.t("backlogs.add_existing_work_package_dialog_component.target_not_found")
-        )
+        render_error_flash_message_via_turbo_stream(message: t(".target_not_found"))
         respond_with_turbo_streams(status: :not_found)
       else
-        render_error_flash_message_via_turbo_stream(
-          message: I18n.t("backlogs.work_packages.update_service.invalid_target_type")
-        )
+        render_error_flash_message_via_turbo_stream(message: t(".invalid_target"))
         respond_with_turbo_streams(status: :unprocessable_entity)
       end
     end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -66,7 +66,7 @@ module Backlogs
         respond_with_turbo_streams(status: :not_found)
       else
         render_error_flash_message_via_turbo_stream(
-          message: I18n.t("backlogs.stories.update_service.invalid_target_type")
+          message: I18n.t("backlogs.work_packages.update_service.invalid_target_type")
         )
         respond_with_turbo_streams(status: :unprocessable_entity)
       end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -52,12 +52,18 @@ module Backlogs
 
     def add_existing_dialog
       target_id = Target.parse(params[:target_id])
+      container = target_id&.container_for(@project)
 
-      if target_id
+      if container
         respond_with_dialog Backlogs::AddExistingWorkPackageDialogComponent.new(
           project: @project,
-          target_id:
+          container:
         )
+      elsif target_id
+        render_error_flash_message_via_turbo_stream(
+          message: I18n.t("backlogs.add_existing_work_package_dialog_component.target_not_found")
+        )
+        respond_with_turbo_streams(status: :not_found)
       else
         render_error_flash_message_via_turbo_stream(
           message: I18n.t("backlogs.stories.update_service.invalid_target_type")

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -51,10 +51,19 @@ module Backlogs
     end
 
     def add_existing_dialog
-      respond_with_dialog Backlogs::AddExistingWorkPackageDialogComponent.new(
-        project: @project,
-        target_id: params.expect(:target_id)
-      )
+      target_id = Target.parse(params[:target_id])
+
+      if target_id
+        respond_with_dialog Backlogs::AddExistingWorkPackageDialogComponent.new(
+          project: @project,
+          target_id:
+        )
+      else
+        render_error_flash_message_via_turbo_stream(
+          message: I18n.t("backlogs.stories.update_service.invalid_target_type")
+        )
+        respond_with_turbo_streams(status: :unprocessable_entity)
+      end
     end
 
     def move_to_sprint_dialog

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -36,7 +36,7 @@ module Backlogs
     # split view open on the moved work package (see backlogs.controller.ts).
     WORK_PACKAGE_MOVED_EVENT = "#{OpTurbo::ComponentStream::DISPATCHED_EVENT_PREFIX}backlogs:work-package-moved".freeze
 
-    before_action :load_work_package
+    before_action :load_work_package, only: %i[menu move_to_sprint_dialog move_to_bucket_dialog move]
 
     # Deferred ActionMenu items (Primer include-fragment).
     def menu
@@ -48,6 +48,13 @@ module Backlogs
                current_user:
              ),
              layout: false)
+    end
+
+    def add_existing_dialog
+      respond_with_dialog Backlogs::AddExistingWorkPackageDialogComponent.new(
+        project: @project,
+        target_id: params.expect(:target_id)
+      )
     end
 
     def move_to_sprint_dialog
@@ -66,10 +73,27 @@ module Backlogs
       )
     end
 
-    def move # rubocop:disable Metrics/AbcSize
-      call = ::Backlogs::WorkPackages::UpdateService.new(user: current_user, work_package: @work_package)
-                                   .call(**move_params.to_h.symbolize_keys)
+    def add_existing
+      work_package = WorkPackage.visible.where(project: @project).find(params.expect(:work_package_id))
 
+      call = ::Backlogs::WorkPackages::UpdateService
+        .new(user: current_user, work_package:)
+        .call(target_id: params.expect(:target_id))
+
+      render_update_turbo_streams(call)
+    end
+
+    def move
+      call = ::Backlogs::WorkPackages::UpdateService
+        .new(user: current_user, work_package: @work_package)
+        .call(**move_params.to_h.symbolize_keys)
+
+      render_update_turbo_streams(call)
+    end
+
+    private
+
+    def render_update_turbo_streams(call)
       if call.success?
         reload_frame_via_turbo_stream("backlogs_container")
 
@@ -95,8 +119,6 @@ module Backlogs
 
       respond_with_turbo_streams(status: call)
     end
-
-    private
 
     def load_work_package
       @work_packages = WorkPackage.visible.where(project: @project).order_by_position

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -116,12 +116,7 @@ module Backlogs
           detail: { work_package_id: call.result.id }
         )
 
-        if work_package_invisible_after_move?(call.result)
-          backlog_name = call.result.backlog_bucket&.name || I18n.t(:label_inbox)
-          render_flash_message_via_turbo_stream(
-            message: I18n.t(:notice_work_package_invisible_after_move, backlog: backlog_name)
-          )
-        end
+        render_invisible_after_move_flash(call.result)
       else
         render_error_flash_message_via_turbo_stream(
           message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
@@ -129,6 +124,15 @@ module Backlogs
       end
 
       respond_with_turbo_streams(status: call)
+    end
+
+    def render_invisible_after_move_flash(work_package)
+      return unless work_package_invisible_after_move?(work_package)
+
+      backlog_name = work_package.backlog_bucket&.name || I18n.t(:label_inbox)
+      render_flash_message_via_turbo_stream(
+        message: I18n.t(:notice_work_package_invisible_after_move, backlog: backlog_name)
+      )
     end
 
     def load_work_package

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -70,7 +70,7 @@ module Backlogs
       respond_with_dialog Backlogs::MoveToSprintDialogComponent.new(
         work_package: @work_package,
         project: @project,
-        move_action: move_project_backlogs_work_package_path(@project, @work_package, backlog_filter_params)
+        move_action: move_path
       )
     end
 
@@ -78,7 +78,7 @@ module Backlogs
       respond_with_dialog Backlogs::MoveToBucketDialogComponent.new(
         work_package: @work_package,
         project: @project,
-        move_action: move_project_backlogs_work_package_path(@project, @work_package, backlog_filter_params)
+        move_action: move_path
       )
     end
 
@@ -132,6 +132,10 @@ module Backlogs
     def load_work_package
       @work_packages = WorkPackage.visible.where(project: @project).order_by_position
       @work_package = @work_packages.find(params.expect(:id))
+    end
+
+    def move_path
+      move_project_backlogs_work_package_path(@project, @work_package, backlog_filter_params)
     end
 
     def move_params

--- a/modules/backlogs/app/forms/backlogs/add_existing_work_package_form.rb
+++ b/modules/backlogs/app/forms/backlogs/add_existing_work_package_form.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Backlogs
+  class AddExistingWorkPackageForm < ApplicationForm
+    def initialize(project:, target_id: nil)
+      super()
+
+      @project = project
+      @target_id = target_id
+    end
+
+    form do |f|
+      f.work_package_autocompleter(
+        name: :work_package_id,
+        label: WorkPackage.model_name.human,
+        required: true,
+        autocomplete_options: {
+          url: autocomplete_url,
+          dropdownPosition: "bottom",
+          appendTo: "##{AddExistingWorkPackageDialogComponent::DIALOG_ID}",
+          filters:
+        }
+      )
+    end
+
+    private
+
+    def autocomplete_url
+      ::API::V3::Utilities::PathHelper::ApiV3Path.work_packages_by_project(@project.id)
+    end
+
+    def filters
+      [
+        { name: "status", operator: Queries::Operators::OpenWorkPackages.symbol }
+      ].tap do |filters|
+        case Target.parse(@target_id)
+        in Target::SprintId[sprint_id]
+          filters << { name: "sprint", operator: "!", values: [sprint_id] }
+        in Target::BucketId[backlog_bucket_id]
+          filters << { name: "backlogBucket", operator: "!", values: [backlog_bucket_id] }
+        in Target::InboxId
+          # TODO: inbox filter needed
+          inbox_ids = WorkPackage.in_inbox_for(project: @project).limit(200).pluck(:id).map(&:to_s)
+          filters << { name: "id", operator: "!", values: inbox_ids } if inbox_ids.any?
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/app/forms/backlogs/add_existing_work_package_form.rb
+++ b/modules/backlogs/app/forms/backlogs/add_existing_work_package_form.rb
@@ -59,17 +59,9 @@ module Backlogs
 
     def filters
       [
-        { name: "status", operator: Queries::Operators::OpenWorkPackages.symbol }
-      ].tap do |filters|
-        case Target.parse(@target_id)
-        in Target::SprintId[sprint_id]
-          filters << { name: "sprint", operator: "!", values: [sprint_id] }
-        in Target::BucketId[backlog_bucket_id]
-          filters << { name: "backlogBucket", operator: "!", values: [backlog_bucket_id] }
-        in Target::InboxId
-          filters << { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
-        end
-      end
+        { name: "status", operator: Queries::Operators::OpenWorkPackages.symbol },
+        Target.parse(@target_id).to_filter
+      ]
     end
   end
 end

--- a/modules/backlogs/app/helpers/backlogs/container_component_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/container_component_helper.rb
@@ -29,26 +29,32 @@
 #++
 
 module Backlogs
-  class BucketComponent < ApplicationComponent
-    include OpPrimer::ComponentHelpers
-    include OpTurbo::Streamable
-    include CommonHelper
-    include ContainerComponentHelper
+  module ContainerComponentHelper
+    def with_add_work_package_menu_group(menu, container)
+      target_id = Backlogs::Target.for(container)
+      dom_key = container == Backlogs::Target::Inbox ? :inbox : container
 
-    attr_reader :backlog_bucket, :work_packages, :project, :current_user
+      with_item_group(menu) do
+        next unless user_allowed?(:manage_sprint_items)
 
-    def initialize(backlog_bucket:, project:, work_packages: nil, current_user: User.current)
-      super()
+        menu.with_item(
+          id: dom_target(dom_key, :menu, :add_new_work_package),
+          label: t(".action_menu.add_new_work_package"),
+          href: new_project_work_packages_dialog_path(project, **target_id.to_container_params),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :plus)
+        end
 
-      @backlog_bucket = backlog_bucket
-      @project = project
-      @current_user = current_user
-      @work_packages = work_packages || backlog_bucket.displayed_work_packages
-                                                      .includes(:status, :type, :assigned_to, :priority, :parent)
-    end
-
-    def wrapper_uniq_by
-      backlog_bucket.id
+        menu.with_item(
+          id: dom_target(dom_key, :menu, :add_existing_work_package),
+          label: t(".action_menu.add_existing_work_package"),
+          href: add_existing_dialog_project_backlogs_work_packages_path(project, target_id:),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :link)
+        end
+      end
     end
   end
 end

--- a/modules/backlogs/app/models/backlogs/target.rb
+++ b/modules/backlogs/app/models/backlogs/target.rb
@@ -32,6 +32,11 @@ module Backlogs
   # Discriminated union representing a backlog container target.
   # Serialized format: "sprint:{id}", "backlog_bucket:{id}", or "inbox".
   module Target
+    # Counterpart of InboxId
+    Inbox = Data.define do
+      def name = I18n.t(:label_inbox)
+    end.new
+
     SprintId = Data.define(:id) do
       def type = :sprint
 
@@ -40,6 +45,8 @@ module Backlogs
       def to_h = { type:, id: }
 
       def to_filter = { name: "sprint", operator: "!", values: [id] }
+
+      def container_for(project) = Sprint.for_project(project).visible.find_by(id:)
     end
 
     BucketId = Data.define(:id) do
@@ -50,6 +57,8 @@ module Backlogs
       def to_h = { type:, id: }
 
       def to_filter = { name: "backlogBucket", operator: "!", values: [id] }
+
+      def container_for(project) = BacklogBucket.for_project(project).visible.find_by(id:)
     end
 
     InboxId = Data.define do
@@ -60,14 +69,18 @@ module Backlogs
       def to_h = { type: }
 
       def to_filter = { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
+
+      def container_for(_project) = Inbox
     end.new
 
     def self.for(container)
       case container
-      when Sprint
+      in Sprint
         SprintId[container.id]
-      when BacklogBucket
+      in BacklogBucket
         BucketId[container.id]
+      in Inbox
+        InboxId
       end
     end
 

--- a/modules/backlogs/app/models/backlogs/target.rb
+++ b/modules/backlogs/app/models/backlogs/target.rb
@@ -38,6 +38,8 @@ module Backlogs
       def to_s = "#{type}:#{id}"
 
       def to_h = { type:, id: }
+
+      def to_filter = { name: "sprint", operator: "!", values: [id] }
     end
 
     BucketId = Data.define(:id) do
@@ -46,6 +48,8 @@ module Backlogs
       def to_s = "#{type}:#{id}"
 
       def to_h = { type:, id: }
+
+      def to_filter = { name: "backlogBucket", operator: "!", values: [id] }
     end
 
     InboxId = Data.define do
@@ -54,6 +58,8 @@ module Backlogs
       delegate :to_s, to: :type
 
       def to_h = { type: }
+
+      def to_filter = { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
     end.new
 
     def self.for(container)

--- a/modules/backlogs/app/models/backlogs/target.rb
+++ b/modules/backlogs/app/models/backlogs/target.rb
@@ -46,6 +46,8 @@ module Backlogs
 
       def to_filter = { name: "sprint", operator: "!", values: [id] }
 
+      def to_container_params = { sprint_id: id }
+
       def container_for(project) = Sprint.for_project(project).visible.find_by(id:)
     end
 
@@ -58,6 +60,8 @@ module Backlogs
 
       def to_filter = { name: "backlogBucket", operator: "!", values: [id] }
 
+      def to_container_params = { backlog_bucket_id: id }
+
       def container_for(project) = BacklogBucket.for_project(project).visible.find_by(id:)
     end
 
@@ -69,6 +73,8 @@ module Backlogs
       def to_h = { type: }
 
       def to_filter = { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
+
+      def to_container_params = {}
 
       def container_for(_project) = Inbox
     end.new

--- a/modules/backlogs/app/models/queries/work_packages/filter/backlog_inbox_filter.rb
+++ b/modules/backlogs/app/models/queries/work_packages/filter/backlog_inbox_filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#-- copyright
+# -- copyright
 # OpenProject is an open source project management software.
 # Copyright (C) the OpenProject GmbH
 #
@@ -26,50 +26,38 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
-#++
+# ++
 
-module Backlogs
-  class AddExistingWorkPackageForm < ApplicationForm
-    def initialize(project:, target_id: nil)
-      super()
+module Queries::WorkPackages::Filter
+  class BacklogInboxFilter < ::Queries::WorkPackages::Filter::WorkPackageFilter
+    include Queries::Filters::Shared::BooleanFilter
 
-      @project = project
-      @target_id = target_id
-    end
-
-    form do |f|
-      f.work_package_autocompleter(
-        name: :work_package_id,
-        label: WorkPackage.model_name.human,
-        required: true,
-        autocomplete_options: {
-          url: autocomplete_url,
-          dropdownPosition: "bottom",
-          appendTo: "##{AddExistingWorkPackageDialogComponent::DIALOG_ID}",
-          filters:
-        }
-      )
-    end
-
-    private
-
-    def autocomplete_url
-      ::API::V3::Utilities::PathHelper::ApiV3Path.work_packages_by_project(@project.id)
-    end
-
-    def filters
-      [
-        { name: "status", operator: Queries::Operators::OpenWorkPackages.symbol }
-      ].tap do |filters|
-        case Target.parse(@target_id)
-        in Target::SprintId[sprint_id]
-          filters << { name: "sprint", operator: "!", values: [sprint_id] }
-        in Target::BucketId[backlog_bucket_id]
-          filters << { name: "backlogBucket", operator: "!", values: [backlog_bucket_id] }
-        in Target::InboxId
-          filters << { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
-        end
+    def available?
+      if project.present?
+        User.current.allowed_in_project?(:view_sprints, project)
+      else
+        User.current.allowed_in_any_project?(:view_sprints)
       end
+    end
+
+    def available_operators
+      [::Queries::Operators::BooleanEquals]
+    end
+
+    def dependency_class
+      "::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter"
+    end
+
+    def where
+      if values == [OpenProject::Database::DB_VALUE_TRUE]
+        "work_packages.sprint_id IS NULL AND work_packages.backlog_bucket_id IS NULL"
+      else
+        "work_packages.sprint_id IS NOT NULL OR work_packages.backlog_bucket_id IS NOT NULL"
+      end
+    end
+
+    def human_name
+      I18n.t("query_fields.backlog_inbox")
     end
   end
 end

--- a/modules/backlogs/app/models/queries/work_packages/filter/backlog_inbox_filter.rb
+++ b/modules/backlogs/app/models/queries/work_packages/filter/backlog_inbox_filter.rb
@@ -40,16 +40,12 @@ module Queries::WorkPackages::Filter
       end
     end
 
-    def available_operators
-      [::Queries::Operators::BooleanEquals]
-    end
-
     def dependency_class
       "::API::V3::Queries::Schemas::BooleanFilterDependencyRepresenter"
     end
 
     def where
-      if values == [OpenProject::Database::DB_VALUE_TRUE]
+      if filtering_for_true?
         "work_packages.sprint_id IS NULL AND work_packages.backlog_bucket_id IS NULL"
       else
         "work_packages.sprint_id IS NOT NULL OR work_packages.backlog_bucket_id IS NOT NULL"

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -29,16 +29,16 @@
 #++
 
 class Backlogs::WorkPackages::UpdateService
-  attr_accessor :user, :story
+  attr_accessor :user, :work_package
 
-  def initialize(user:, story:)
+  def initialize(user:, work_package:)
     self.user = user
-    self.story = story
+    self.work_package = work_package
   end
 
   def call(direction: nil, target_id: nil, position: nil, prev_id: nil)
     resolve_required_attributes(direction:, target_id:)
-      .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: story).call(**attrs) }
+      .bind { |attrs| ::WorkPackages::UpdateService.new(user:, model: work_package).call(**attrs) }
       .on_success do |call|
         if prev_id
           call.result.move_after(prev_id:)

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -29,11 +29,11 @@
 #++
 
 class Backlogs::WorkPackages::UpdateService
-  attr_accessor :user, :work_package
+  attr_reader :user, :work_package
 
   def initialize(user:, work_package:)
-    self.user = user
-    self.work_package = work_package
+    @user = user
+    @work_package = work_package
   end
 
   def call(direction: nil, target_id: nil, position: nil, prev_id: nil)

--- a/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
+++ b/modules/backlogs/app/services/backlogs/work_packages/update_service.rb
@@ -52,13 +52,13 @@ class Backlogs::WorkPackages::UpdateService
 
   def resolve_required_attributes(direction:, target_id:)
     if target_id && direction
-      ServiceResult.failure(message: I18n.t("backlogs.stories.update_service.ambiguous_target"))
+      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.ambiguous_target"))
     elsif target_id
       attributes_result_from_target(target_id)
     elsif direction
       attributes_result_from_direction(direction)
     else
-      ServiceResult.failure(message: I18n.t("backlogs.stories.update_service.missing_target"))
+      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.missing_target"))
     end
   end
 
@@ -71,7 +71,7 @@ class Backlogs::WorkPackages::UpdateService
     in Backlogs::Target::InboxId
       ServiceResult.success(result: { backlog_bucket_id: nil, sprint_id: nil })
     else
-      ServiceResult.failure(message: I18n.t("backlogs.stories.update_service.invalid_target_type"))
+      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.invalid_target_type"))
     end
   end
 
@@ -79,7 +79,7 @@ class Backlogs::WorkPackages::UpdateService
     if direction.in? %w(higher highest lower lowest)
       ServiceResult.success(result: { move_to: direction })
     else
-      ServiceResult.failure(message: I18n.t("backlogs.stories.update_service.invalid_direction"))
+      ServiceResult.failure(message: I18n.t("backlogs.work_packages.update_service.invalid_direction"))
     end
   end
 end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -97,6 +97,9 @@ en:
         other: "Sprints"
 
   backlogs:
+    add_existing_work_package_dialog_component:
+      title: "Add existing work package to %{name}"
+
     administration_blankslate:
       text: "We are currently redesigning the Backlogs module. Admin settings for sprints and backlogs will be visible here in the near future. Project-level settings remain available."
       title: "Backlog admin settings are evolving"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -179,7 +179,7 @@ en:
 
     sprint_component:
       action_menu:
-        add_work_package: "Add work package"
+        add_new_work_package: "Add new work package"
         edit_sprint: "Edit sprint"
       blankslate_description: "No items planned yet. Drag items here to add them."
       blankslate_title: "%{name} is empty"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -99,7 +99,6 @@ en:
 
   backlogs:
     add_existing_work_package_dialog_component:
-      target_not_found: "The sprint or backlog you are trying to add to was not found."
       title: "Add existing work package to %{name}"
 
     administration_blankslate:
@@ -247,6 +246,9 @@ en:
     work_package_is_closed: "Work package is done, when"
 
     work_packages:
+      add_existing_dialog:
+        invalid_target: "The target you are trying to add to is invalid."
+        target_not_found: "The sprint or backlog you are trying to add to was not found."
       update_service:
         ambiguous_target: "target_id and direction cannot both be present."
         invalid_direction: "direction must be one of: higher, highest, lower, lowest."

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -224,13 +224,6 @@ en:
       Choose the statuses that represent a closed or finished state in your workflow.
       These will be treated as the "Closed" state across reporting (e.g. burndown) and sprint planning.
       For example, statuses like Done, Resolved, or Won't Fix may all represent a closed work item in your process.
-    stories:
-      update_service:
-        ambiguous_target: "target_id and direction cannot both be present."
-        invalid_direction: "direction must be one of: higher, highest, lower, lowest."
-        invalid_target_type: "target_type must be one of: backlog_bucket:<backlog_bucket_id>, sprint:<sprint_id>, inbox."
-        missing_target: "target_id or direction must be present."
-
     story_points:
       one: "%{count} story point"
       other: "%{count} story points"
@@ -252,6 +245,13 @@ en:
         move_to_sprint: "Move to sprint"
 
     work_package_is_closed: "Work package is done, when"
+
+    work_packages:
+      update_service:
+        ambiguous_target: "target_id and direction cannot both be present."
+        invalid_direction: "direction must be one of: higher, highest, lower, lowest."
+        invalid_target_type: "target_type must be one of: backlog_bucket:<backlog_bucket_id>, sprint:<sprint_id>, inbox."
+        missing_target: "target_id or direction must be present."
 
   burndown:
     story_points: "Story points"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -116,6 +116,8 @@ en:
       select_panel_title: "Select items"
     bucket_component:
       action_menu:
+        add_existing_work_package: "Add existing work package"
+        add_new_work_package: "Add new work package"
         delete_backlog_bucket: "Delete backlog bucket"
         edit_backlog_bucket: "Edit backlog bucket"
       blankslate_description: "Drag items here to add them."
@@ -147,8 +149,12 @@ en:
       title: "There are work in progress items"
 
     inbox_component:
+      action_menu:
+        add_existing_work_package: "Add existing work package"
+        add_new_work_package: "Add new work package"
       blankslate_description: "All open work packages in this project will automatically appear here."
       blankslate_title: "Backlog inbox is empty"
+      label_actions: "Inbox actions"
       show_more:
         one: "Show 1 more item"
         other: "Show %{count} more items"
@@ -179,6 +185,7 @@ en:
 
     sprint_component:
       action_menu:
+        add_existing_work_package: "Add existing work package"
         add_new_work_package: "Add new work package"
         edit_sprint: "Edit sprint"
       blankslate_description: "No items planned yet. Drag items here to add them."

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
         text: "Sprint goal"
       work_package:
         backlog_bucket: "Backlog bucket"
+        backlog_inbox: "Backlog inbox"
         backlogs_work_package_type: "Backlog type"
         position: "Position"
         sprint: "Sprint"
@@ -325,5 +326,8 @@ en:
         sharing_form_component:
           sharing_description: "This project can either share its own sprints, receive shared sprints or handle sprints independently (no sharing)."
           sharing_fallback_description: "Lacking a corporate enterprise plan, the sharing options are limited to the project's own sprints. The currently active setting remains active."
+
+  query_fields:
+    backlog_inbox: "Backlog inbox"
 
   remaining_hours: "remaining work"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
 
   backlogs:
     add_existing_work_package_dialog_component:
+      target_not_found: "The sprint or backlog you are trying to add to was not found."
       title: "Add existing work package to %{name}"
 
     administration_blankslate:

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -92,6 +92,11 @@ Rails.application.routes.draw do
       end
 
       resources :work_packages, controller: :work_packages, only: [] do
+        collection do
+          get :add_existing_dialog
+          post :add_existing
+        end
+
         member do
           get :menu
           put :move

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -83,7 +83,8 @@ module OpenProject::Backlogs
                    dependencies: %i[view_sprints manage_board_views manage_sprint_items]
 
         permission :manage_sprint_items,
-                   { "backlogs/work_packages": %i[move move_to_sprint_dialog move_to_bucket_dialog] },
+                   { "backlogs/work_packages": %i[move move_to_sprint_dialog move_to_bucket_dialog add_existing_dialog
+                                                  add_existing] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: %i[view_sprints edit_work_packages]

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -150,6 +150,8 @@ module OpenProject::Backlogs
     patch_with_namespace :API, :V3, :WorkPackages, :EagerLoading, :Checksum
     patch_with_namespace :API, :V3, :WorkPackages, :Schema, :SpecificWorkPackageSchema
 
+    additional_permitted_attributes new_work_package: %i[backlog_bucket_id sprint_id]
+
     extend_api_response(:v3, :work_packages, :work_package,
                         &::OpenProject::Backlogs::Patches::API::WorkPackageRepresenter.extension)
 

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -246,6 +246,7 @@ module OpenProject::Backlogs
 
       ::Queries::Register.register(::Query) do
         filter Queries::WorkPackages::Filter::BacklogBucketFilter
+        filter Queries::WorkPackages::Filter::BacklogInboxFilter
         filter Queries::WorkPackages::Filter::SprintFilter
 
         select OpenProject::Backlogs::QueryBacklogsSelect

--- a/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe Backlogs::AddExistingWorkPackageDialogComponent, type: :component
   current_user { admin }
 
   let(:project) { create(:project) }
+  let(:target_id) { Backlogs::Target.for(container) }
   let(:expected_url) { add_existing_project_backlogs_work_packages_path(project, target_id:) }
 
   before do
-    render_inline(described_class.new(project:, target_id:))
+    render_inline(described_class.new(project:, container:))
   end
 
   shared_examples "renders the dialog correctly" do
@@ -70,23 +71,21 @@ RSpec.describe Backlogs::AddExistingWorkPackageDialogComponent, type: :component
   end
 
   context "when target is a sprint" do
-    let!(:sprint) { create(:sprint, project:, name: "My Sprint") }
-    let(:target_id) { Backlogs::Target.for(sprint) }
+    let(:container) { build_stubbed(:sprint, project:, name: "My Sprint") }
     let(:title) { "Add existing work package to My Sprint" }
 
     include_examples "renders the dialog correctly"
   end
 
   context "when target is a backlog bucket" do
-    let!(:bucket) { create(:backlog_bucket, project:, name: "My Bucket") }
-    let(:target_id) { Backlogs::Target.for(bucket) }
+    let(:container) { build_stubbed(:backlog_bucket, project:, name: "My Bucket") }
     let(:title) { "Add existing work package to My Bucket" }
 
     include_examples "renders the dialog correctly"
   end
 
   context "when target is inbox" do
-    let(:target_id) { Backlogs::Target::InboxId }
+    let(:container) { Backlogs::Target::Inbox }
     let(:title) { "Add existing work package to Inbox" }
 
     include_examples "renders the dialog correctly"

--- a/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Backlogs::AddExistingWorkPackageDialogComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:admin) { create(:admin) }
+  current_user { admin }
+
+  let(:project) { create(:project) }
+  let(:expected_url) { add_existing_project_backlogs_work_packages_path(project, target_id:) }
+
+  before do
+    render_inline(described_class.new(project:, target_id:))
+  end
+
+  shared_examples "renders the dialog correctly" do
+    it "renders the dialog title" do
+      expect(page).to have_element(:h1, text: title)
+    end
+
+    it "uses correct form action" do
+      expect(page).to have_element(:form, action: expected_url)
+    end
+
+    it "assigns DIALOG_ID to the dialog element" do
+      expect(page).to have_css("dialog##{described_class::DIALOG_ID}")
+    end
+
+    it "assigns FORM_ID to the form element" do
+      expect(page).to have_css("form##{described_class::FORM_ID}")
+    end
+
+    it "links the Cancel button to the dialog" do
+      expect(page).to have_css("[data-close-dialog-id='#{described_class::DIALOG_ID}']", text: I18n.t(:button_cancel))
+    end
+
+    it "links the Add button to the form as a submit" do
+      expect(page).to have_css("button[form='#{described_class::FORM_ID}'][type='submit']", text: I18n.t(:button_add))
+    end
+  end
+
+  context "when target is a sprint" do
+    let!(:sprint) { create(:sprint, project:, name: "My Sprint") }
+    let(:target_id) { "sprint:#{sprint.id}" }
+    let(:title) { "Add existing work package to My Sprint" }
+
+    include_examples "renders the dialog correctly"
+  end
+
+  context "when target is a backlog bucket" do
+    let!(:bucket) { create(:backlog_bucket, project:, name: "My Bucket") }
+    let(:target_id) { "backlog_bucket:#{bucket.id}" }
+    let(:title) { "Add existing work package to My Bucket" }
+
+    include_examples "renders the dialog correctly"
+  end
+
+  context "when target is inbox" do
+    let(:target_id) { "inbox" }
+    let(:title) { "Add existing work package to Inbox" }
+
+    include_examples "renders the dialog correctly"
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/add_existing_work_package_dialog_component_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Backlogs::AddExistingWorkPackageDialogComponent, type: :component
 
   context "when target is a sprint" do
     let!(:sprint) { create(:sprint, project:, name: "My Sprint") }
-    let(:target_id) { "sprint:#{sprint.id}" }
+    let(:target_id) { Backlogs::Target.for(sprint) }
     let(:title) { "Add existing work package to My Sprint" }
 
     include_examples "renders the dialog correctly"
@@ -79,14 +79,14 @@ RSpec.describe Backlogs::AddExistingWorkPackageDialogComponent, type: :component
 
   context "when target is a backlog bucket" do
     let!(:bucket) { create(:backlog_bucket, project:, name: "My Bucket") }
-    let(:target_id) { "backlog_bucket:#{bucket.id}" }
+    let(:target_id) { Backlogs::Target.for(bucket) }
     let(:title) { "Add existing work package to My Bucket" }
 
     include_examples "renders the dialog correctly"
   end
 
   context "when target is inbox" do
-    let(:target_id) { "inbox" }
+    let(:target_id) { Backlogs::Target::InboxId }
     let(:title) { "Add existing work package to Inbox" }
 
     include_examples "renders the dialog correctly"

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -193,16 +193,15 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
              position: 1)
     end
 
-    it "does not render the bucket header menu" do
-      expect(rendered_component).to have_no_button(accessible_name: "Backlog bucket actions")
+    it "still renders the add work package menu actions" do
+      expect(rendered_component).to have_button(accessible_name: "Backlog bucket actions")
+      expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
+      expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
     end
-  end
 
-  context "when the bucket is not persisted" do
-    let(:backlog_bucket) { BacklogBucket.new(project:, name: "Ready for development") }
-
-    it "does not render the bucket header menu" do
-      expect(rendered_component).to have_no_button(accessible_name: "Backlog bucket actions")
+    it "does not render the edit or delete bucket menu items" do
+      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Edit backlog bucket")
+      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Delete backlog bucket")
     end
   end
 
@@ -224,6 +223,12 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}.Box-row--draggable")
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}[data-draggable-id]")
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}[data-drop-url]")
+    end
+
+    it "still renders the edit and delete bucket menu items" do
+      expect(rendered_component).to have_button(accessible_name: "Backlog bucket actions")
+      expect(rendered_component).to have_css("[role='menuitem']", text: "Edit backlog bucket")
+      expect(rendered_component).to have_css("[role='menuitem']", text: "Delete backlog bucket")
     end
 
     it "does not render the add work package menu actions" do

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -104,7 +104,10 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       end
 
       it "renders the bucket menu actions" do
-        expect(rendered_component.to_html).to include("Edit backlog bucket", "Delete backlog bucket")
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Edit backlog bucket")
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Delete backlog bucket")
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
       end
 
       it "renders one shared-card row per work package" do
@@ -221,6 +224,11 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}.Box-row--draggable")
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}[data-draggable-id]")
       expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package.id}[data-drop-url]")
+    end
+
+    it "does not render the add work package menu actions" do
+      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add new work package")
+      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add existing work package")
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -104,10 +104,20 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       end
 
       it "renders the bucket menu actions" do
-        expect(rendered_component).to have_selector(:menuitem, "Edit backlog bucket")
-        expect(rendered_component).to have_selector(:menuitem, "Delete backlog bucket")
-        expect(rendered_component).to have_selector(:menuitem, "Add new work package")
-        expect(rendered_component).to have_selector(:menuitem, "Add existing work package")
+        expect(rendered_component).to have_selector(:menuitem, "Edit backlog bucket") do |link|
+          expect(link[:href]).to eq edit_dialog_project_backlogs_bucket_path(project, backlog_bucket)
+        end
+        expect(rendered_component).to have_selector(:menuitem, "Delete backlog bucket") do |link|
+          expect(link[:href]).to eq destroy_dialog_project_backlogs_bucket_path(project, backlog_bucket)
+        end
+        expect(rendered_component).to have_selector(:menuitem, "Add new work package") do |link|
+          expect(link[:href]).to eq new_project_work_packages_dialog_path(project, backlog_bucket_id: backlog_bucket.id)
+        end
+        expect(rendered_component).to have_selector(:menuitem, "Add existing work package") do |link|
+          expect(link[:href]).to eq add_existing_dialog_project_backlogs_work_packages_path(
+            project, target_id: "backlog_bucket:#{backlog_bucket.id}"
+          )
+        end
       end
 
       it "renders one shared-card row per work package" do

--- a/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/bucket_component_spec.rb
@@ -104,10 +104,10 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
       end
 
       it "renders the bucket menu actions" do
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Edit backlog bucket")
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Delete backlog bucket")
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
+        expect(rendered_component).to have_selector(:menuitem, "Edit backlog bucket")
+        expect(rendered_component).to have_selector(:menuitem, "Delete backlog bucket")
+        expect(rendered_component).to have_selector(:menuitem, "Add new work package")
+        expect(rendered_component).to have_selector(:menuitem, "Add existing work package")
       end
 
       it "renders one shared-card row per work package" do
@@ -195,13 +195,13 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
 
     it "still renders the add work package menu actions" do
       expect(rendered_component).to have_button(accessible_name: "Backlog bucket actions")
-      expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
-      expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
+      expect(rendered_component).to have_selector(:menuitem, "Add new work package")
+      expect(rendered_component).to have_selector(:menuitem, "Add existing work package")
     end
 
     it "does not render the edit or delete bucket menu items" do
-      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Edit backlog bucket")
-      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Delete backlog bucket")
+      expect(rendered_component).to have_no_selector(:menuitem, "Edit backlog bucket")
+      expect(rendered_component).to have_no_selector(:menuitem, "Delete backlog bucket")
     end
   end
 
@@ -227,13 +227,13 @@ RSpec.describe Backlogs::BucketComponent, type: :component do
 
     it "still renders the edit and delete bucket menu items" do
       expect(rendered_component).to have_button(accessible_name: "Backlog bucket actions")
-      expect(rendered_component).to have_css("[role='menuitem']", text: "Edit backlog bucket")
-      expect(rendered_component).to have_css("[role='menuitem']", text: "Delete backlog bucket")
+      expect(rendered_component).to have_selector(:menuitem, "Edit backlog bucket")
+      expect(rendered_component).to have_selector(:menuitem, "Delete backlog bucket")
     end
 
     it "does not render the add work package menu actions" do
-      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add new work package")
-      expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add existing work package")
+      expect(rendered_component).to have_no_selector(:menuitem, "Add new work package")
+      expect(rendered_component).to have_no_selector(:menuitem, "Add existing work package")
     end
   end
 end

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it "renders the add work package menu actions" do
-      expect(page).to have_css("[role='menuitem']", text: "Add new work package")
-      expect(page).to have_css("[role='menuitem']", text: "Add existing work package")
+      expect(page).to have_selector(:menuitem, "Add new work package")
+      expect(page).to have_selector(:menuitem, "Add existing work package")
     end
 
     context "when the user lacks the manage_sprint_items permission" do
@@ -112,8 +112,8 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
       end
 
       it "does not render the add work package menu actions" do
-        expect(page).to have_no_css("[role='menuitem']", text: "Add new work package")
-        expect(page).to have_no_css("[role='menuitem']", text: "Add existing work package")
+        expect(page).to have_no_selector(:menuitem, "Add new work package")
+        expect(page).to have_no_selector(:menuitem, "Add existing work package")
       end
     end
   end

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -99,8 +99,12 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
     end
 
     it "renders the add work package menu actions" do
-      expect(page).to have_selector(:menuitem, "Add new work package")
-      expect(page).to have_selector(:menuitem, "Add existing work package")
+      expect(page).to have_selector(:menuitem, "Add new work package") do |link|
+        expect(link[:href]).to eq new_project_work_packages_dialog_path(project)
+      end
+      expect(page).to have_selector(:menuitem, "Add existing work package") do |link|
+        expect(link[:href]).to eq add_existing_dialog_project_backlogs_work_packages_path(project, target_id: "inbox")
+      end
     end
 
     context "when the user lacks the manage_sprint_items permission" do

--- a/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_spec.rb
@@ -97,6 +97,25 @@ RSpec.describe Backlogs::InboxComponent, type: :component do
         aria: { label: I18n.t(:label_x_items, count: 2) }
       )
     end
+
+    it "renders the add work package menu actions" do
+      expect(page).to have_css("[role='menuitem']", text: "Add new work package")
+      expect(page).to have_css("[role='menuitem']", text: "Add existing work package")
+    end
+
+    context "when the user lacks the manage_sprint_items permission" do
+      let(:user) do
+        create(:user,
+               member_with_roles: {
+                 project => create(:project_role, permissions: %i[view_sprints view_work_packages])
+               })
+      end
+
+      it "does not render the add work package menu actions" do
+        expect(page).to have_no_css("[role='menuitem']", text: "Add new work package")
+        expect(page).to have_no_css("[role='menuitem']", text: "Add existing work package")
+      end
+    end
   end
 
   describe "empty state" do

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -129,8 +129,13 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
 
       it "renders the add work package menu actions" do
-        expect(rendered_component).to have_selector(:menuitem, "Add new work package")
-        expect(rendered_component).to have_selector(:menuitem, "Add existing work package")
+        expect(rendered_component).to have_selector(:menuitem, "Add new work package") do |link|
+          expect(link[:href]).to eq new_project_work_packages_dialog_path(project, sprint_id: sprint.id)
+        end
+        expect(rendered_component).to have_selector(:menuitem, "Add existing work package") do |link|
+          expect(link[:href])
+            .to eq add_existing_dialog_project_backlogs_work_packages_path(project, target_id: "sprint:#{sprint.id}")
+        end
       end
     end
 

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -127,6 +127,11 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       it "renders the sprint kebab menu in the header" do
         expect(rendered_component).to have_element :"action-menu"
       end
+
+      it "renders the add work package menu actions" do
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
+        expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
+      end
     end
 
     context "when the user lacks the manage_sprint_items permission" do
@@ -142,6 +147,11 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package1.id}.Box-row--draggable")
         expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package1.id}[data-draggable-id]")
         expect(rendered_component).to have_no_css(".Box-row#work_package_#{work_package1.id}[data-drop-url]")
+      end
+
+      it "does not render the add work package menu actions" do
+        expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add new work package")
+        expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add existing work package")
       end
     end
 
@@ -312,9 +322,18 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
         it "preserves the grouped sprint action-menu structure" do
           rendered_component
 
-          expect(menu_items).to eq(["Edit sprint", "Add work package", "Sprint board", "Burndown chart"])
+          expect(menu_items).to eq(
+            [
+              "Edit sprint",
+              "Add new work package",
+              "Add existing work package",
+              "Sprint board",
+              "Burndown chart"
+            ]
+          )
           # The three item groups are separated by presentation-only dividers.
-          expect(page).to have_css("li[role='presentation']", count: 2)
+          expect(page).to have_css('li[role="presentation"]:nth-child(2)')
+          expect(page).to have_css('li[role="presentation"]:nth-child(5)')
         end
       end
     end

--- a/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
 
       it "renders the add work package menu actions" do
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Add new work package")
-        expect(rendered_component).to have_css("[role='menuitem']", text: "Add existing work package")
+        expect(rendered_component).to have_selector(:menuitem, "Add new work package")
+        expect(rendered_component).to have_selector(:menuitem, "Add existing work package")
       end
     end
 
@@ -150,8 +150,8 @@ RSpec.describe Backlogs::SprintComponent, type: :component do
       end
 
       it "does not render the add work package menu actions" do
-        expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add new work package")
-        expect(rendered_component).to have_no_css("[role='menuitem']", text: "Add existing work package")
+        expect(rendered_component).to have_no_selector(:menuitem, "Add new work package")
+        expect(rendered_component).to have_no_selector(:menuitem, "Add existing work package")
       end
     end
 

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -699,6 +699,26 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with a Backlog bucket that can't be found" do
+      let(:target_id) { "backlog_bucket:#{bucket.id + 1}" }
+
+      it "responds with 404 and an error flash instead of a dialog", :aggregate_failures do
+        expect(response).to have_http_status :not_found
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "dialog"
+      end
+    end
+
+    context "with a Sprint that can't be found" do
+      let(:target_id) { "sprint:#{sprint.id + 1}" }
+
+      it "responds with 404 and an error flash instead of a dialog", :aggregate_failures do
+        expect(response).to have_http_status :not_found
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "dialog"
+      end
+    end
+
     context "with an empty target_id" do
       let(:target_id) { nil }
 

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -699,6 +699,26 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
     end
 
+    context "with an empty target_id" do
+      let(:target_id) { nil }
+
+      it "responds with 422 and an error flash instead of a blank dialog", :aggregate_failures do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "dialog"
+      end
+    end
+
+    context "with an invalid target_id" do
+      let(:target_id) { "garbage" }
+
+      it "responds with 422 and an error flash instead of a blank dialog", :aggregate_failures do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "dialog"
+      end
+    end
+
     context "with a user lacking manage_sprint_items permission" do
       let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints view_work_packages] }) }
       let(:target_id) { "inbox" }

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe Backlogs::WorkPackagesController do
   let(:sprint) { create(:sprint, name: "Agile Sprint 1", project:) }
   let(:work_package) { create(:work_package, status:, sprint:, project:, type: type_feature) }
 
+  shared_examples "shows a flash message after moving a work package that turns invisible" do |target_name|
+    it "shows a flash message after moving the work package" do
+      message = "The work package was moved to #{target_name} but is not visible"
+      expect(response).to be_successful
+      expect(response).to have_http_status :ok
+      expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+      expect(turbo_stream_template(action: "flash")).to include(message)
+    end
+  end
+
   describe "load_work_package" do
     let(:params) { { project_id: project.id, id: work_package.id } }
 
@@ -84,16 +94,6 @@ RSpec.describe Backlogs::WorkPackagesController do
     end
 
     context "with a Sprint as source" do
-      shared_examples "shows a flash message after moving a work package that turns invisible" do |target_name|
-        it "shows a flash message after moving the work package" do
-          message = "The work package was moved to #{target_name} but is not visible"
-          expect(response).to be_successful
-          expect(response).to have_http_status :ok
-          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
-          expect(turbo_stream_template(action: "flash")).to include(message)
-        end
-      end
-
       context "with the same Sprint as target" do
         let(:target_id) { "sprint:#{sprint.id}" }
 
@@ -636,6 +636,342 @@ RSpec.describe Backlogs::WorkPackagesController do
             expect(body).not_to include(I18n.t(:label_sort_lower))
           end
         end
+      end
+    end
+  end
+
+  describe "GET #add_existing_dialog" do
+    let(:sprint) { create(:sprint, name: "Sprint 1", project:) }
+    let(:bucket) { create(:backlog_bucket, name: "My Bucket", project:) }
+
+    let(:form_action) { "backlogs/work_packages/add_existing?target_id=#{URI.encode_www_form_component(target_id)}" }
+
+    subject(:response) { get :add_existing_dialog, params: { project_id: project.id, target_id: }, format: :turbo_stream }
+
+    context "with a Sprint as target" do
+      let(:target_id) { "sprint:#{sprint.id}" }
+
+      it "responds with a dialog turbo stream", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dialog"
+      end
+
+      it "includes the sprint name in the dialog title" do
+        expect(body).to include(sprint.name)
+      end
+
+      it "sets the form action to the add_existing endpoint with the sprint target" do
+        expect(body).to include(form_action)
+      end
+    end
+
+    context "with a Backlog bucket as target" do
+      let(:target_id) { "backlog_bucket:#{bucket.id}" }
+
+      it "responds with a dialog turbo stream", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dialog"
+      end
+
+      it "includes the bucket name in the dialog title" do
+        expect(body).to include(bucket.name)
+      end
+
+      it "sets the form action to the add_existing endpoint with the bucket target" do
+        expect(body).to include(form_action)
+      end
+    end
+
+    context "with Inbox as target" do
+      let(:target_id) { "inbox" }
+
+      it "responds with a dialog turbo stream", :aggregate_failures do
+        expect(response).to be_successful
+        expect(response).to have_turbo_stream action: "dialog"
+      end
+
+      it "includes 'Inbox' in the dialog title" do
+        expect(body).to include(I18n.t(:label_inbox))
+      end
+
+      it "sets the form action to the add_existing endpoint with the inbox target" do
+        expect(body).to include(form_action)
+      end
+    end
+
+    context "with a user lacking manage_sprint_items permission" do
+      let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints view_work_packages] }) }
+      let(:target_id) { "inbox" }
+
+      it "responds with 403" do
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+      let(:target_id) { "inbox" }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
+      end
+    end
+  end
+
+  describe "POST #add_existing" do
+    shared_let(:sprint) { create(:sprint, name: "Sprint 1", project:) }
+    shared_let(:target_sprint) { create(:sprint, name: "Sprint 2", project:) }
+    shared_let(:bucket) { create(:backlog_bucket, name: "Bucket 1", project:) }
+    shared_let(:target_bucket) { create(:backlog_bucket, name: "Bucket 2", project:) }
+
+    let(:work_package_id) { work_package.id }
+
+    subject(:response) do
+      post :add_existing, params: { project_id: project.id, work_package_id:, target_id: }, format: :turbo_stream
+    end
+
+    context "when the work package is in a sprint" do
+      let(:work_package) { create(:work_package, status:, sprint:, project:) }
+
+      context "with another sprint as target" do
+        let(:target_id) { "sprint:#{target_sprint.id}" }
+
+        it "responds with success and reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package to the target sprint" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint: target_sprint, backlog_bucket_id: nil)
+        end
+      end
+
+      context "with inbox as target" do
+        let(:target_id) { "inbox" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package to the inbox" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint_id: nil, backlog_bucket_id: nil)
+        end
+
+        context "when the work package turns invisible (excluded status)" do
+          before { project.done_statuses << status }
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Inbox"
+        end
+
+        context "when the work package turns invisible (excluded type)" do
+          before { project.backlog_excluded_types << type_feature }
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Inbox"
+        end
+      end
+
+      context "with a backlog bucket as target" do
+        let(:target_id) { "backlog_bucket:#{bucket.id}" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package into the bucket" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint_id: nil, backlog_bucket: bucket)
+        end
+
+        context "when the work package turns invisible (excluded status)" do
+          before { project.done_statuses << status }
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Bucket 1"
+        end
+      end
+
+      context "with the same sprint as target" do
+        let(:target_id) { "sprint:#{sprint.id}" }
+
+        it "responds with success and reloads the backlogs container without a flash", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+          expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        end
+
+        it "does not change the WP backlog container attributes" do
+          expect { response }.not_to change { work_package.reload.attributes.slice(:sprint_id, :backlog_bucket_id) }
+        end
+      end
+    end
+
+    context "when the work package is in the inbox" do
+      let(:work_package) { create(:work_package, status:, project:) }
+
+      context "with a sprint as target" do
+        let(:target_id) { "sprint:#{target_sprint.id}" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package into the sprint" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint: target_sprint, backlog_bucket_id: nil)
+        end
+      end
+
+      context "with a backlog bucket as target" do
+        let(:target_id) { "backlog_bucket:#{bucket.id}" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package into the bucket" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint_id: nil, backlog_bucket: bucket)
+        end
+
+        context "when the work package turns invisible (excluded type)" do
+          before { project.backlog_excluded_types << type_feature }
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Bucket 1"
+        end
+      end
+
+      context "with inbox as target" do
+        let(:target_id) { "inbox" }
+
+        it "responds with success and reloads the backlogs container without a flash", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+          expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        end
+
+        it "does not change the WP backlog container attributes" do
+          expect { response }.not_to change { work_package.reload.attributes.slice(:sprint_id, :backlog_bucket_id) }
+        end
+      end
+    end
+
+    context "when the work package is in a backlog bucket" do
+      shared_let(:work_package) { create(:work_package, status:, project:, backlog_bucket: bucket) }
+
+      context "with a sprint as target" do
+        let(:target_id) { "sprint:#{target_sprint.id}" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package into the sprint" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint: target_sprint, backlog_bucket_id: nil)
+        end
+      end
+
+      context "with inbox as target" do
+        let(:target_id) { "inbox" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package to the inbox" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint_id: nil, backlog_bucket_id: nil)
+        end
+      end
+
+      context "with another backlog bucket as target" do
+        let(:target_id) { "backlog_bucket:#{target_bucket.id}" }
+
+        it "reloads the backlogs container", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+        end
+
+        it "moves the work package into the target bucket" do
+          response
+
+          expect(work_package.reload).to have_attributes(sprint_id: nil, backlog_bucket: target_bucket)
+        end
+      end
+
+      context "with the same backlog bucket as target" do
+        let(:target_id) { "backlog_bucket:#{bucket.id}" }
+
+        it "responds with success and reloads the backlogs container without a flash", :aggregate_failures do
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "turbo_frame_reload", target: "backlogs_container"
+          expect(response).not_to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        end
+
+        it "does not change the WP backlog container attributes" do
+          expect { response }.not_to change { work_package.reload.attributes.slice(:sprint_id, :backlog_bucket_id) }
+        end
+      end
+    end
+
+    context "when service call fails" do
+      let(:target_id) { "inbox" }
+
+      before do
+        allow(Backlogs::WorkPackages::UpdateService)
+          .to receive(:new)
+          .and_return(instance_double(Backlogs::WorkPackages::UpdateService, call: ServiceResult.failure(message: "Error")))
+      end
+
+      it "renders an error flash with 422", :aggregate_failures do
+        expect(response).to have_http_status :unprocessable_entity
+        expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+        expect(response).not_to have_turbo_stream action: "replace", target: "backlogs-sprint-component-#{sprint.id}"
+      end
+    end
+
+    context "when the work package belongs to another project" do
+      let(:work_package) { create(:work_package, status:) }
+      let(:target_id) { "inbox" }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
+      end
+    end
+
+    context "with a user lacking manage_sprint_items permission" do
+      let(:user) { create(:user, member_with_permissions: { project => %i[view_sprints view_work_packages] }) }
+      let(:target_id) { "inbox" }
+
+      it "responds with 403" do
+        expect(response).to have_http_status :forbidden
+      end
+    end
+
+    context "with a user lacking project permission" do
+      let(:user) { create(:user) }
+      let(:target_id) { "inbox" }
+
+      it "responds with 404" do
+        expect(response).to have_http_status :not_found
       end
     end
   end

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Edit", :js do
   end
 
   it "adds a work package to a sprint" do
-    planning_page.click_in_sprint_menu(first_sprint, "Add work package")
+    planning_page.click_in_sprint_menu(first_sprint, "Add new work package")
     planning_page.expect_create_work_package_dialog
 
     page.within("#create-work-package-dialog") do
@@ -111,7 +111,7 @@ RSpec.describe "Edit", :js do
         planning_page.within_sprint_menu(first_sprint) do |menu|
           expect(menu).to have_selector :menuitem, count: 2
           expect(menu).to have_selector :menuitem, "Edit sprint"
-          expect(menu).to have_selector :menuitem, "Add work package"
+          expect(menu).to have_selector :menuitem, "Add new work package"
         end
       end
 
@@ -167,7 +167,7 @@ RSpec.describe "Edit", :js do
             expect(menu).to have_selector :menuitem, count: 1
             expect(menu).to have_selector :menuitem, "Edit sprint"
 
-            expect(menu).to have_no_selector :menuitem, "Add work package"
+            expect(menu).to have_no_selector :menuitem, "Add new work package"
           end
         end
       end

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -109,9 +109,10 @@ RSpec.describe "Edit", :js do
     context "when editing a sprint" do
       it "displays all menu entries" do
         planning_page.within_sprint_menu(first_sprint) do |menu|
-          expect(menu).to have_selector :menuitem, count: 2
+          expect(menu).to have_selector :menuitem, count: 3
           expect(menu).to have_selector :menuitem, "Edit sprint"
           expect(menu).to have_selector :menuitem, "Add new work package"
+          expect(menu).to have_selector :menuitem, "Add existing work package"
         end
       end
 

--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -87,24 +87,6 @@ RSpec.describe "Edit", :js do
     planning_page.expect_work_package_not_in_sprint(work_package, second_sprint)
   end
 
-  it "adds a work package to a sprint" do
-    planning_page.click_in_sprint_menu(first_sprint, "Add new work package")
-    planning_page.expect_create_work_package_dialog
-
-    page.within("#create-work-package-dialog") do
-      page.fill_in "Subject", with: "Story created in sprint"
-
-      click_on "Create"
-    end
-
-    wait_for_reload
-
-    expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
-    created_wp = first_sprint.reload.work_packages.last
-    expect(created_wp.subject).to eq("Story created in sprint")
-    planning_page.expect_work_package_in_sprint(created_wp, first_sprint)
-  end
-
   context "with the 'create_sprints' permissions" do
     context "when editing a sprint" do
       it "displays all menu entries" do

--- a/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/filter_panel_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "Backlog filter panel", :js do
         backlogs_page.expect_no_sprint(Sprint.find_by!(project:, name: "Sprint C"))
         expect_selected_filters_preserved
 
-        backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Edit backlog bucket")
+        backlogs_page.click_in_bucket_menu(bucket_a, "Edit backlog bucket")
         within_dialog "Edit backlog bucket" do
           fill_in "Name", with: "Bucket A Renamed"
           click_on "Save"

--- a/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/pagination_state_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Backlog pagination state", :js do
     bucket = BacklogBucket.find_by!(project:, name: "New bucket")
 
     # Edit backlog bucket
-    backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
+    backlogs_page.click_in_bucket_menu(bucket, "Edit backlog bucket")
 
     within_dialog "Edit backlog bucket" do
       fill_in "Name", with: "Renamed bucket"
@@ -94,7 +94,7 @@ RSpec.describe "Backlog pagination state", :js do
     backlogs_page.expect_no_inbox_show_more
 
     # Delete backlog bucket
-    backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
+    backlogs_page.click_in_bucket_menu(bucket, "Delete backlog bucket")
 
     backlogs_page.expect_and_confirm_backlog_bucket_delete_modal
 

--- a/modules/backlogs/spec/features/buckets/delete_spec.rb
+++ b/modules/backlogs/spec/features/buckets/delete_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Backlog bucket deletion", :js do
     backlogs_page.visit!
     backlogs_page.expect_bucket_names_in_order("Deprecated bucket")
 
-    backlogs_page.click_in_backlog_bucket_menu(bucket, "Delete backlog bucket")
+    backlogs_page.click_in_bucket_menu(bucket, "Delete backlog bucket")
 
     backlogs_page.expect_and_confirm_backlog_bucket_delete_modal
 

--- a/modules/backlogs/spec/features/buckets/edit_spec.rb
+++ b/modules/backlogs/spec/features/buckets/edit_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Backlog bucket renaming", :js do
     backlogs_page.visit!
     backlogs_page.expect_bucket_names_in_order("Draft bucket")
 
-    backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
+    backlogs_page.click_in_bucket_menu(bucket, "Edit backlog bucket")
 
     within_dialog "Edit backlog bucket" do
       expect(page).to have_field "Name", with: "Draft bucket"
@@ -68,7 +68,7 @@ RSpec.describe "Backlog bucket renaming", :js do
   it "validates that the name is present when saving" do
     backlogs_page.visit!
 
-    backlogs_page.click_in_backlog_bucket_menu(bucket, "Edit backlog bucket")
+    backlogs_page.click_in_bucket_menu(bucket, "Edit backlog bucket")
 
     within_dialog "Edit backlog bucket" do
       fill_in "Name", with: ""

--- a/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Add existing work package", :js do
 
     it "can be added to a bucket" do
       backlogs_page.visit!
-      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_a.name}" do
         select_autocomplete(find("ng-select"), query: work_package.subject)
@@ -72,7 +72,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
       backlogs_page.expect_no_inbox_item(work_package)
 
-      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package to #{bucket_a.name}" do
         search_autocomplete(find("ng-select"), query: work_package.subject)
         expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
@@ -123,7 +123,7 @@ RSpec.describe "Add existing work package", :js do
 
     it "can be added to another bucket" do
       backlogs_page.visit!
-      backlogs_page.click_in_backlog_bucket_menu(bucket_b, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_b, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_b.name}" do
         select_autocomplete(find("ng-select"), query: work_package.subject)
@@ -133,7 +133,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_b)
       backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
 
-      backlogs_page.click_in_backlog_bucket_menu(bucket_b, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_b, "Add existing work package")
       within_modal "Add existing work package to #{bucket_b.name}" do
         search_autocomplete(find("ng-select"), query: work_package.subject)
         expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
@@ -184,7 +184,7 @@ RSpec.describe "Add existing work package", :js do
 
     it "can be added to a bucket" do
       backlogs_page.visit!
-      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_a.name}" do
         select_autocomplete(find("ng-select"), query: work_package.subject)
@@ -194,7 +194,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
       backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
 
-      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package to #{bucket_a.name}" do
         search_autocomplete(find("ng-select"), query: work_package.subject)
         expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)

--- a/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+require_relative "../../support/pages/backlog"
+
+RSpec.describe "Add existing work package", :js do
+  include Components::Autocompleter::NgSelectAutocompleteHelpers
+
+  shared_let(:default_status) { create(:default_status) }
+  shared_let(:default_priority) { create(:default_priority) }
+  shared_let(:project) { create(:project) }
+  shared_let(:sprint_a) { create(:sprint, project:, name: "Sprint 1") }
+  shared_let(:sprint_b) { create(:sprint, project:, name: "Sprint 2") }
+  shared_let(:bucket_a) { create(:backlog_bucket, project:, name: "Bucket A") }
+  shared_let(:bucket_b) { create(:backlog_bucket, project:, name: "Bucket B") }
+
+  let(:user) { create(:user, member_with_permissions: { project => permissions }) }
+  let(:permissions) do
+    %i[
+      add_work_packages
+      create_sprints
+      manage_sprint_items
+      view_sprints
+      view_work_packages
+    ]
+  end
+
+  let(:backlogs_page) { Pages::Backlog.new(project) }
+
+  current_user { user }
+
+  context "when existing work package is in inbox" do
+    let!(:work_package) { create(:work_package, project:) }
+
+    it "can be added to a bucket" do
+      backlogs_page.visit!
+      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+
+      within_modal "Add existing work package to #{bucket_a.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
+      backlogs_page.expect_no_inbox_item(work_package)
+
+      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      within_modal "Add existing work package to #{bucket_a.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+
+    it "can be added to a sprint" do
+      backlogs_page.visit!
+      backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
+
+      within_modal "Add existing work package to #{sprint_a.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_sprint(work_package, sprint_a)
+      backlogs_page.expect_no_inbox_item(work_package)
+
+      backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
+      within_modal "Add existing work package to #{sprint_a.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+  end
+
+  context "when existing work package is in a bucket" do
+    let!(:work_package) { create(:work_package, project:, backlog_bucket: bucket_a) }
+
+    it "can be added to inbox" do
+      backlogs_page.visit!
+      backlogs_page.click_in_inbox_menu("Add existing work package")
+
+      within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_inbox_item(work_package)
+      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+
+      backlogs_page.click_in_inbox_menu("Add existing work package")
+      within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+
+    it "can be added to another bucket" do
+      backlogs_page.visit!
+      backlogs_page.click_in_backlog_bucket_menu(bucket_b, "Add existing work package")
+
+      within_modal "Add existing work package to #{bucket_b.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_b)
+      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+
+      backlogs_page.click_in_backlog_bucket_menu(bucket_b, "Add existing work package")
+      within_modal "Add existing work package to #{bucket_b.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+
+    it "can be added to a sprint" do
+      backlogs_page.visit!
+      backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
+
+      within_modal "Add existing work package to #{sprint_a.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_sprint(work_package, sprint_a)
+      backlogs_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
+
+      backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
+      within_modal "Add existing work package to #{sprint_a.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+  end
+
+  context "when existing work package is in a sprint" do
+    let!(:work_package) { create(:work_package, project:, sprint: sprint_a) }
+
+    it "can be added to inbox" do
+      backlogs_page.visit!
+      backlogs_page.click_in_inbox_menu("Add existing work package")
+
+      within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_inbox_item(work_package)
+      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+
+      backlogs_page.click_in_inbox_menu("Add existing work package")
+      within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+
+    it "can be added to a bucket" do
+      backlogs_page.visit!
+      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+
+      within_modal "Add existing work package to #{bucket_a.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_backlog_bucket(work_package, bucket_a)
+      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+
+      backlogs_page.click_in_backlog_bucket_menu(bucket_a, "Add existing work package")
+      within_modal "Add existing work package to #{bucket_a.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+
+    it "can be added to another sprint" do
+      backlogs_page.visit!
+      backlogs_page.click_in_sprint_menu(sprint_b, "Add existing work package")
+
+      within_modal "Add existing work package to #{sprint_b.name}" do
+        select_autocomplete(find("ng-select"), query: work_package.subject)
+        wait_for_turbo_stream { click_on I18n.t(:button_add) }
+      end
+
+      backlogs_page.expect_work_package_in_sprint(work_package, sprint_b)
+      backlogs_page.expect_work_package_not_in_sprint(work_package, sprint_a)
+
+      backlogs_page.click_in_sprint_menu(sprint_b, "Add existing work package")
+      within_modal "Add existing work package to #{sprint_b.name}" do
+        search_autocomplete(find("ng-select"), query: work_package.subject)
+        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+      end
+    end
+  end
+
+  context "when not having enough permissions" do
+    let(:permissions) { super() - %i[manage_sprint_items] }
+
+    it "hides the menu item to add existing work packages" do
+      backlogs_page.visit!
+
+      backlogs_page.within_sprint_menu(sprint_a) do |menu|
+        expect(menu).to have_no_selector(:menuitem, text: "Add existing work package")
+      end
+
+      backlogs_page.within_backlog_bucket_menu(bucket_a) do |menu|
+        expect(menu).to have_no_selector(:menuitem, text: "Add existing work package")
+      end
+
+      # only one action can be there, so without it menu will not be rendered
+      backlogs_page.expect_no_inbox_menu
+    end
+  end
+end

--- a/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/add_existing_spec.rb
@@ -32,8 +32,6 @@ require "spec_helper"
 require_relative "../../support/pages/backlog"
 
 RSpec.describe "Add existing work package", :js do
-  include Components::Autocompleter::NgSelectAutocompleteHelpers
-
   shared_let(:default_status) { create(:default_status) }
   shared_let(:default_priority) { create(:default_priority) }
   shared_let(:project) { create(:project) }
@@ -54,6 +52,7 @@ RSpec.describe "Add existing work package", :js do
   end
 
   let(:backlogs_page) { Pages::Backlog.new(project) }
+  let(:autocomplete) { FormFields::Primerized::AutocompleteField.new(:work_package_id, selector: "ng-select") }
 
   current_user { user }
 
@@ -65,7 +64,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_a.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -74,8 +73,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package to #{bucket_a.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
 
@@ -84,7 +83,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
 
       within_modal "Add existing work package to #{sprint_a.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -93,8 +92,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
       within_modal "Add existing work package to #{sprint_a.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
   end
@@ -107,7 +106,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_inbox_menu("Add existing work package")
 
       within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -116,8 +115,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_inbox_menu("Add existing work package")
       within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
 
@@ -126,7 +125,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_bucket_menu(bucket_b, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_b.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -135,8 +134,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_bucket_menu(bucket_b, "Add existing work package")
       within_modal "Add existing work package to #{bucket_b.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
 
@@ -145,7 +144,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
 
       within_modal "Add existing work package to #{sprint_a.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -154,8 +153,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_sprint_menu(sprint_a, "Add existing work package")
       within_modal "Add existing work package to #{sprint_a.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
   end
@@ -168,7 +167,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_inbox_menu("Add existing work package")
 
       within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -177,8 +176,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_inbox_menu("Add existing work package")
       within_modal "Add existing work package to #{I18n.t(:label_inbox)}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
 
@@ -187,7 +186,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
 
       within_modal "Add existing work package to #{bucket_a.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -196,8 +195,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_bucket_menu(bucket_a, "Add existing work package")
       within_modal "Add existing work package to #{bucket_a.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
 
@@ -206,7 +205,7 @@ RSpec.describe "Add existing work package", :js do
       backlogs_page.click_in_sprint_menu(sprint_b, "Add existing work package")
 
       within_modal "Add existing work package to #{sprint_b.name}" do
-        select_autocomplete(find("ng-select"), query: work_package.subject)
+        autocomplete.search_and_select_option work_package.subject
         wait_for_turbo_stream { click_on I18n.t(:button_add) }
       end
 
@@ -215,8 +214,8 @@ RSpec.describe "Add existing work package", :js do
 
       backlogs_page.click_in_sprint_menu(sprint_b, "Add existing work package")
       within_modal "Add existing work package to #{sprint_b.name}" do
-        search_autocomplete(find("ng-select"), query: work_package.subject)
-        expect(page).to have_no_css(".ng-option", text: work_package.subject, wait: 5)
+        autocomplete.search work_package.subject
+        autocomplete.expect_not_selected work_package.subject
       end
     end
   end

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Create work package", :js do
 
   context "in a backlog bucket" do
     it "allows creating a new story" do
-      backlogs_page.click_in_backlog_bucket_menu(bucket, "Add new work package")
+      backlogs_page.click_in_bucket_menu(bucket, "Add new work package")
 
       within_dialog "New work package" do
         fill_in "Subject", with: "The new item"

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_relative "../../support/pages/backlog"
 
-RSpec.describe "Create work package in sprint", :js do
+RSpec.describe "Create work package", :js do
   let!(:project) do
     create(:project,
            types: [type, type2],
@@ -59,6 +59,7 @@ RSpec.describe "Create work package in sprint", :js do
 
   let!(:sprint1) { create(:sprint, project:) }
   let!(:sprint2) { create(:sprint, project:) }
+  let!(:bucket) { create(:backlog_bucket, project:) }
 
   let!(:sprint1_wp1) { create(:work_package, sprint: sprint1, type:, project:) }
   let!(:sprint1_wp2) { create(:work_package, sprint: sprint1, type:, project:) }
@@ -170,6 +171,36 @@ RSpec.describe "Create work package in sprint", :js do
     end
   end
 
+  context "in a backlog bucket" do
+    it "allows creating a new story" do
+      backlogs_page.click_in_backlog_bucket_menu(bucket, "Add new work package")
+
+      within_dialog "New work package" do
+        fill_in "Subject", with: "The new item"
+        click_on "Create"
+      end
+
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
+
+      backlogs_page.expect_work_package_in_backlog_bucket(WorkPackage.last, bucket)
+    end
+  end
+
+  context "in the inbox" do
+    it "allows creating a new story" do
+      backlogs_page.click_in_inbox_menu("Add new work package")
+
+      within_dialog "New work package" do
+        fill_in "Subject", with: "The new item"
+        click_on "Create"
+      end
+
+      expect_and_dismiss_flash type: :success, exact_message: "Successful creation."
+
+      backlogs_page.expect_inbox_item(WorkPackage.last)
+    end
+  end
+
   context "when lacking the permission to create work packages" do
     current_user do
       create(:user,
@@ -186,6 +217,8 @@ RSpec.describe "Create work package in sprint", :js do
       # backlogs_page.expect_no_sprint_menu_item(sprint1, "Add new work package")
 
       backlogs_page.expect_no_sprint_menu(sprint1)
+      backlogs_page.expect_no_backlog_bucket_menu(bucket)
+      backlogs_page.expect_no_inbox_menu
     end
   end
 end

--- a/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/create_work_package_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Create work package in sprint", :js do
 
   context "in a non shared sprint" do
     it "allows creating a new story" do
-      backlogs_page.click_in_sprint_menu(sprint1, "Add work package")
+      backlogs_page.click_in_sprint_menu(sprint1, "Add new work package")
 
       within_dialog "New work package" do
         fill_in "Subject", with: "The new item"
@@ -102,7 +102,7 @@ RSpec.describe "Create work package in sprint", :js do
       # xpect(page).to have_css(".velocity", text: "12")
 
       # this will ensure that the page refresh is through before we check the order
-      backlogs_page.click_in_sprint_menu(sprint1, "Add work package")
+      backlogs_page.click_in_sprint_menu(sprint1, "Add new work package")
 
       within_dialog "New work package" do
         fill_in "Subject", with: "Another story"
@@ -129,7 +129,7 @@ RSpec.describe "Create work package in sprint", :js do
 
   context "in an empty non shared sprint" do
     it "allows creating a new story" do
-      backlogs_page.click_in_sprint_menu(sprint2, "Add work package")
+      backlogs_page.click_in_sprint_menu(sprint2, "Add new work package")
 
       within_dialog "New work package" do
         fill_in "Subject", with: "The new item"
@@ -151,7 +151,7 @@ RSpec.describe "Create work package in sprint", :js do
     let(:backlogs_page) { Pages::Backlog.new(project2) }
 
     it "allows creating a new story" do
-      backlogs_page.click_in_sprint_menu(sprint1, "Add work package")
+      backlogs_page.click_in_sprint_menu(sprint1, "Add new work package")
 
       within_dialog "New work package" do
         fill_in "Subject", with: "The new item"
@@ -183,7 +183,7 @@ RSpec.describe "Create work package in sprint", :js do
       # Once we add more and more menu items back, the menu will be rendered, but the action
       # will be missing. When that happens, the expectation has to be adjusted for something like
       # this:
-      # backlogs_page.expect_no_sprint_menu_item(sprint1, "Add work package")
+      # backlogs_page.expect_no_sprint_menu_item(sprint1, "Add new work package")
 
       backlogs_page.expect_no_sprint_menu(sprint1)
     end

--- a/modules/backlogs/spec/forms/backlogs/add_existing_work_package_form_spec.rb
+++ b/modules/backlogs/spec/forms/backlogs/add_existing_work_package_form_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Backlogs::AddExistingWorkPackageForm, type: :forms do
+  include_context "with rendered form"
+
+  let(:project) { build_stubbed(:project, id: 99) }
+  let(:form_arguments) { { url: "/foo" } }
+  let(:params) { { project:, target_id: } }
+
+  subject(:form) { page }
+
+  describe "#autocompleter" do
+    context "when target is a sprint" do
+      let(:target_id) { "sprint:7" }
+
+      it "filters for work packages with open status and not in target sprint" do
+        expect(form).to have_element "opce-autocompleter" do |autocompleter|
+          expect(autocompleter["data-filters"]).to be_json_eql <<-JSON
+            [
+              {"name": "status", "operator": "o"},
+              {"name": "sprint", "operator": "!", "values": [7]}
+            ]
+          JSON
+        end
+      end
+    end
+
+    context "when target is a backlog bucket" do
+      let(:target_id) { "backlog_bucket:3" }
+
+      it "filters for work packages with open status and not in target backlog bucket" do
+        expect(form).to have_element "opce-autocompleter" do |autocompleter|
+          expect(autocompleter["data-filters"]).to be_json_eql <<-JSON
+            [
+              {"name": "status", "operator": "o"},
+              {"name": "backlogBucket", "operator": "!", "values": [3]}
+            ]
+          JSON
+        end
+      end
+    end
+
+    context "when target is inbox" do
+      let(:target_id) { "inbox" }
+
+      it "filters for work packages with open status and not in inbox" do
+        expect(form).to have_element "opce-autocompleter" do |autocompleter|
+          expect(autocompleter["data-filters"]).to be_json_eql <<-JSON
+            [
+              {"name": "status", "operator": "o"},
+              {"name": "backlogInbox", "operator": "=", "values": ["f"]}
+            ]
+          JSON
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/lib/open_project/backlogs/patches/permitted_params_patch_spec.rb
+++ b/modules/backlogs/spec/lib/open_project/backlogs/patches/permitted_params_patch_spec.rb
@@ -33,9 +33,37 @@ require "rails_helper"
 RSpec.describe PermittedParams do
   let(:user) { build_stubbed(:user) }
 
-  subject(:permitted) { described_class.new(params, user).backlog_filters.to_h }
+  describe "#update_work_package" do
+    subject(:permitted) { described_class.new(params, user).update_work_package.to_h }
+
+    context "with sprint_id" do
+      let(:params) { ActionController::Parameters.new(work_package: { sprint_id: "1" }) }
+
+      it "permits it" do
+        expect(permitted).to eq("sprint_id" => "1")
+      end
+    end
+
+    context "with backlog_bucket_id" do
+      let(:params) { ActionController::Parameters.new(work_package: { backlog_bucket_id: "1" }) }
+
+      it "permits it" do
+        expect(permitted).to eq("backlog_bucket_id" => "1")
+      end
+    end
+
+    context "with story_points" do
+      let(:params) { ActionController::Parameters.new(work_package: { story_points: "5" }) }
+
+      it "permits it" do
+        expect(permitted).to eq("story_points" => "5")
+      end
+    end
+  end
 
   describe "#backlog_filters" do
+    subject(:permitted) { described_class.new(params, user).backlog_filters.to_h }
+
     context "with bucket_ids and sprint_ids" do
       let(:params) { ActionController::Parameters.new(bucket_ids: %w[1 2], sprint_ids: %w[3]) }
 

--- a/modules/backlogs/spec/models/backlogs/target_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/target_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Backlogs::Target do
         type: :sprint,
         to_s: "sprint:42",
         to_h: { type: :sprint, id: 42 },
-        to_filter: { name: "sprint", operator: "!", values: [42] }
+        to_filter: { name: "sprint", operator: "!", values: [42] },
+        to_container_params: { sprint_id: 42 }
       )
     end
   end
@@ -62,7 +63,8 @@ RSpec.describe Backlogs::Target do
         type: :backlog_bucket,
         to_s: "backlog_bucket:13",
         to_h: { type: :backlog_bucket, id: 13 },
-        to_filter: { name: "backlogBucket", operator: "!", values: [13] }
+        to_filter: { name: "backlogBucket", operator: "!", values: [13] },
+        to_container_params: { backlog_bucket_id: 13 }
       )
     end
   end
@@ -75,7 +77,8 @@ RSpec.describe Backlogs::Target do
         type: :inbox,
         to_s: "inbox",
         to_h: { type: :inbox },
-        to_filter: { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
+        to_filter: { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] },
+        to_container_params: {}
       )
     end
   end

--- a/modules/backlogs/spec/models/backlogs/target_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/target_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Backlogs::Target do
         id: 42,
         type: :sprint,
         to_s: "sprint:42",
-        to_h: { type: :sprint, id: 42 }
+        to_h: { type: :sprint, id: 42 },
+        to_filter: { name: "sprint", operator: "!", values: [42] }
       )
     end
   end
@@ -52,7 +53,8 @@ RSpec.describe Backlogs::Target do
         id: 13,
         type: :backlog_bucket,
         to_s: "backlog_bucket:13",
-        to_h: { type: :backlog_bucket, id: 13 }
+        to_h: { type: :backlog_bucket, id: 13 },
+        to_filter: { name: "backlogBucket", operator: "!", values: [13] }
       )
     end
   end
@@ -60,7 +62,14 @@ RSpec.describe Backlogs::Target do
   describe "InboxId" do
     subject { described_class::InboxId }
 
-    it { is_expected.to have_attributes(type: :inbox, to_s: "inbox", to_h: { type: :inbox }) }
+    it do
+      expect(subject).to have_attributes(
+        type: :inbox,
+        to_s: "inbox",
+        to_h: { type: :inbox },
+        to_filter: { name: "backlogInbox", operator: "=", values: [OpenProject::Database::DB_VALUE_FALSE] }
+      )
+    end
   end
 
   describe ".for" do

--- a/modules/backlogs/spec/models/backlogs/target_spec.rb
+++ b/modules/backlogs/spec/models/backlogs/target_spec.rb
@@ -31,6 +31,14 @@
 require "spec_helper"
 
 RSpec.describe Backlogs::Target do
+  describe "Inbox" do
+    subject { described_class::Inbox }
+
+    it "has the inbox label as name" do
+      expect(subject.name).to eq(I18n.t(:label_inbox))
+    end
+  end
+
   describe "SprintId" do
     subject { described_class::SprintId[42] }
 
@@ -83,8 +91,41 @@ RSpec.describe Backlogs::Target do
       expect(described_class.for(bucket)).to eq(described_class::BucketId[5])
     end
 
-    it "returns nil for an unrecognised container" do
-      expect(described_class.for(Object.new)).to be_nil
+    it "returns InboxId for the Inbox null container" do
+      expect(described_class.for(described_class::Inbox)).to eq(described_class::InboxId)
+    end
+
+    it "raises for an unrecognised container" do
+      expect { described_class.for(Object.new) }.to raise_error(NoMatchingPatternError)
+    end
+  end
+
+  describe "#container_for" do
+    shared_let(:project) { create(:project) }
+    shared_let(:sprint) { create(:sprint, project:) }
+    shared_let(:bucket) { create(:backlog_bucket, project:) }
+    shared_let(:other_project_sprint) { create(:sprint) }
+
+    current_user { create(:admin) }
+
+    it "finds the sprint for a SprintId" do
+      expect(described_class::SprintId[sprint.id].container_for(project)).to eq(sprint)
+    end
+
+    it "finds the bucket for a BucketId" do
+      expect(described_class::BucketId[bucket.id].container_for(project)).to eq(bucket)
+    end
+
+    it "returns the Inbox null container for InboxId" do
+      expect(described_class::InboxId.container_for(project)).to eq(described_class::Inbox)
+    end
+
+    it "returns nil for a sprint of another project" do
+      expect(described_class::SprintId[other_project_sprint.id].container_for(project)).to be_nil
+    end
+
+    it "returns nil for a nonexistent id" do
+      expect(described_class::SprintId[Sprint.maximum(:id).to_i + 1].container_for(project)).to be_nil
     end
   end
 

--- a/modules/backlogs/spec/models/queries/work_packages/filter/backlog_inbox_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/work_packages/filter/backlog_inbox_filter_spec.rb
@@ -104,6 +104,28 @@ RSpec.describe Queries::WorkPackages::Filter::BacklogInboxFilter do
           )
         end
       end
+
+      context 'with operator "!" and value "f"' do
+        let(:operator) { "!" }
+        let(:values) { [OpenProject::Database::DB_VALUE_FALSE] }
+
+        it "filters to work packages with no sprint and no bucket" do
+          expect(instance.where).to eq(
+            "work_packages.sprint_id IS NULL AND work_packages.backlog_bucket_id IS NULL"
+          )
+        end
+      end
+
+      context 'with operator "!" and value "t"' do
+        let(:operator) { "!" }
+        let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
+
+        it "excludes inbox work packages" do
+          expect(instance.where).to eq(
+            "work_packages.sprint_id IS NOT NULL OR work_packages.backlog_bucket_id IS NOT NULL"
+          )
+        end
+      end
     end
   end
 end

--- a/modules/backlogs/spec/models/queries/work_packages/filter/backlog_inbox_filter_spec.rb
+++ b/modules/backlogs/spec/models/queries/work_packages/filter/backlog_inbox_filter_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+require "spec_helper"
+
+RSpec.describe Queries::WorkPackages::Filter::BacklogInboxFilter do
+  it_behaves_like "basic query filter" do
+    let(:type) { :list }
+    let(:class_key) { :backlog_inbox }
+    let(:model) { WorkPackage }
+    let(:project_permissions) { [:view_sprints] }
+
+    current_user { build_stubbed(:user) }
+
+    before do
+      mock_permissions_for current_user do |mock|
+        if project
+          mock.allow_in_project(*project_permissions, project:)
+        else
+          mock.allow_in_project(*project_permissions, project: build_stubbed(:project))
+        end
+      end
+    end
+
+    describe "#available?" do
+      context "when in a project and the user has the permission" do
+        it "is true" do
+          expect(instance).to be_available
+        end
+      end
+
+      context "when in a project and the user lacks the permission" do
+        let(:project_permissions) { [] }
+
+        it "is false" do
+          expect(instance).not_to be_available
+        end
+      end
+
+      context "when outside a project and the user has the permission" do
+        let(:project) { nil }
+
+        it "is true" do
+          expect(instance).to be_available
+        end
+      end
+
+      context "when outside a project and the user lacks the permission" do
+        let(:project) { nil }
+        let(:project_permissions) { [] }
+
+        it "is false" do
+          expect(instance).not_to be_available
+        end
+      end
+    end
+
+    describe "#where" do
+      context 'with operator "=" and value "t"' do
+        let(:operator) { "=" }
+        let(:values) { [OpenProject::Database::DB_VALUE_TRUE] }
+
+        it "filters to work packages with no sprint and no bucket" do
+          expect(instance.where).to eq(
+            "work_packages.sprint_id IS NULL AND work_packages.backlog_bucket_id IS NULL"
+          )
+        end
+      end
+
+      context 'with operator "=" and value "f"' do
+        let(:operator) { "=" }
+        let(:values) { [OpenProject::Database::DB_VALUE_FALSE] }
+
+        it "excludes inbox work packages" do
+          expect(instance.where).to eq(
+            "work_packages.sprint_id IS NOT NULL OR work_packages.backlog_bucket_id IS NOT NULL"
+          )
+        end
+      end
+    end
+  end
+end

--- a/modules/backlogs/spec/routing/backlogs/work_packages_routing_spec.rb
+++ b/modules/backlogs/spec/routing/backlogs/work_packages_routing_spec.rb
@@ -67,5 +67,21 @@ RSpec.describe Backlogs::WorkPackagesController do
         id: "85"
       )
     }
+
+    it {
+      expect(get("/projects/project_42/backlogs/work_packages/add_existing_dialog")).to route_to(
+        controller: "backlogs/work_packages",
+        action: "add_existing_dialog",
+        project_id: "project_42"
+      )
+    }
+
+    it {
+      expect(post("/projects/project_42/backlogs/work_packages/add_existing")).to route_to(
+        controller: "backlogs/work_packages",
+        action: "add_existing",
+        project_id: "project_42"
+      )
+    }
   end
 end

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
     describe "error handling" do
       shared_examples "returns failure without delegating" do |call_args, i18n_key = nil|
         it "returns failure without delegating", :aggregate_failures do
-          i18n_key ||= "backlogs.stories.update_service.invalid_target_type"
+          i18n_key ||= "backlogs.work_packages.update_service.invalid_target_type"
 
           result = instance.call(**call_args)
 
@@ -62,13 +62,13 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
       context "with neither target_id nor direction" do
         it_behaves_like "returns failure without delegating",
                         {},
-                        "backlogs.stories.update_service.missing_target"
+                        "backlogs.work_packages.update_service.missing_target"
       end
 
       context "with both target_id and direction" do
         it_behaves_like "returns failure without delegating",
                         { target_id: "inbox", direction: "highest" },
-                        "backlogs.stories.update_service.ambiguous_target"
+                        "backlogs.work_packages.update_service.ambiguous_target"
       end
 
       context "when target_id contains an invalid type and id" do
@@ -108,7 +108,7 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
       context "with an invalid direction" do
         it_behaves_like "returns failure without delegating",
                         { direction: "sideways" },
-                        "backlogs.stories.update_service.invalid_direction"
+                        "backlogs.work_packages.update_service.invalid_direction"
       end
     end
 

--- a/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/update_service_spec.rb
@@ -32,15 +32,15 @@ require "spec_helper"
 
 RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
   let(:user) { build_stubbed(:user) }
-  let(:story) { build_stubbed(:work_package) }
-  let(:instance) { described_class.new(user:, story:) }
+  let(:work_package) { build_stubbed(:work_package) }
+  let(:instance) { described_class.new(user:, work_package:) }
 
   let(:inner_service) { instance_double(WorkPackages::UpdateService) }
-  let(:inner_result) { ServiceResult.success(result: story) }
+  let(:inner_result) { ServiceResult.success(result: work_package) }
 
   before do
     allow(WorkPackages::UpdateService)
-      .to receive(:new).with(user:, model: story)
+      .to receive(:new).with(user:, model: work_package)
       .and_return(inner_service)
     allow(inner_service).to receive(:call).and_return(inner_result)
   end
@@ -148,43 +148,43 @@ RSpec.describe Backlogs::WorkPackages::UpdateService, type: :model do
       let(:inner_result) { ServiceResult.failure(message: "Something went wrong") }
 
       it "returns the failure without calling move_after", :aggregate_failures do
-        allow(story).to receive(:move_after)
+        allow(work_package).to receive(:move_after)
 
         result = instance.call(target_id: "inbox")
 
         expect(result).to be_failure
-        expect(story).not_to have_received(:move_after)
+        expect(work_package).not_to have_received(:move_after)
       end
     end
 
     context "with prev_id" do
       it "calls move_after with the prev_id on success" do
-        allow(story).to receive(:move_after)
+        allow(work_package).to receive(:move_after)
 
         instance.call(target_id: "inbox", prev_id: "5")
 
-        expect(story).to have_received(:move_after).with(prev_id: "5")
+        expect(work_package).to have_received(:move_after).with(prev_id: "5")
       end
     end
 
     context "with position" do
       it "calls move_after with the position on success" do
-        allow(story).to receive(:move_after)
+        allow(work_package).to receive(:move_after)
 
         instance.call(target_id: "inbox", position: "3")
 
-        expect(story).to have_received(:move_after).with(position: "3")
+        expect(work_package).to have_received(:move_after).with(position: "3")
       end
     end
 
     context "with both prev_id and position" do
       it "prefers prev_id over position" do
-        allow(story).to receive(:move_after)
+        allow(work_package).to receive(:move_after)
 
         instance.call(target_id: "inbox", prev_id: "5", position: "3")
 
-        expect(story).to have_received(:move_after).with(prev_id: "5")
-        expect(story).not_to have_received(:move_after).with(position: "3")
+        expect(work_package).to have_received(:move_after).with(prev_id: "5")
+        expect(work_package).not_to have_received(:move_after).with(position: "3")
       end
     end
   end

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -303,6 +303,19 @@ module Pages
       end
     end
 
+    def within_inbox_menu(&)
+      within_backlog_inbox do
+        button = find(:button, accessible_name: "Inbox actions")
+        within(open_controlled_menu(button), &)
+      end
+    end
+
+    def click_in_inbox_menu(item_name)
+      within_inbox_menu do |menu|
+        menu.find(:menuitem, text: item_name).click
+      end
+    end
+
     def within_work_package_menu(work_package, &)
       within_work_package(work_package) do
         button = find(:button, accessible_name: "Work package actions")
@@ -331,6 +344,12 @@ module Pages
         wait_for_turbo_stream(wait:) do
           submenu.find(:menuitem, text: item_name).click
         end
+      end
+    end
+
+    def expect_no_inbox_menu
+      within_backlog_inbox do
+        expect(page).to have_no_button(accessible_name: "Inbox actions")
       end
     end
 

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -297,7 +297,7 @@ module Pages
       dismiss_menu(bucket)
     end
 
-    def click_in_backlog_bucket_menu(bucket, item_name)
+    def click_in_bucket_menu(bucket, item_name)
       within_backlog_bucket_menu(bucket) do |menu|
         menu.find(:menuitem, text: item_name).click
       end

--- a/spec/models/permitted_params_spec.rb
+++ b/spec/models/permitted_params_spec.rb
@@ -578,12 +578,6 @@ RSpec.describe PermittedParams do
       it_behaves_like "allows params"
     end
 
-    describe "sprint_id" do
-      let(:hash) { { "sprint_id" => "1" } }
-
-      it_behaves_like "allows params"
-    end
-
     describe "notes" do
       let(:hash) { { "journal_notes" => "blubs" } }
 

--- a/spec/support/capybara/additional_accessible_selectors.rb
+++ b/spec/support/capybara/additional_accessible_selectors.rb
@@ -46,6 +46,11 @@ end
 
 module Capybara
   module RSpecMatchers
+    # Following finder methods are defined:
+    # * have_list
+    # * have_no_list
+    # * have_list_item
+    # * have_no_list_item
     %i[list list_item].each do |selector|
       define_method :"have_#{selector}" do |locator = nil, **options, &optional_filter_block|
         Matchers::HaveSelector.new(selector, locator, **options, &optional_filter_block)

--- a/spec/support/form_fields/primerized/autocomplete_field.rb
+++ b/spec/support/form_fields/primerized/autocomplete_field.rb
@@ -33,6 +33,17 @@ module FormFields
         field_container.find(".ng-select-container input").set text
       end
 
+      # For remote typeahead autocompleters, where options are only loaded for
+      # the typed search term. Unlike select_option, it does not reopen the
+      # dropdown, as that would discard the term.
+      def search_and_select_option(*values)
+        values.each do |value|
+          search(value)
+          wait_for_autocompleter_options_to_be_loaded
+          page.find(".ng-option", text: value, visible: :all).click
+        end
+      end
+
       def close_autocompleter
         if page.has_css?(".ng-select-container input", wait: 0.1)
           field_container.find(".ng-select-container input").send_keys :escape


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-218 & https://community.openproject.org/wp/AGILE-294

# What are you trying to accomplish?

Allow users to add existing work packages to all containers and extend creating new work packages to also be available for all containers (previously only for sprints)

# What approach did you choose and why?

Using `target_id` for destination (unlike for the new WP action) to have more common code path with `move` action
Added a temporary inbox filter to filter out WPs already in inbox

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
