### PR TITLE
Set UTF-8 charset for text attachments served inline

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -126,7 +126,7 @@ class Attachment < ApplicationRecord
   def served_content_type
     if is_text?
       # Even if the text mime type might differ, always output plain text so it
-      # isn't interpreted as e.g. a script or html file. Pin UTF-8 so browsers
+      # isn't interpreted as e.g. a script. Pin UTF-8 so browsers
       # don't mis-decode non-ASCII content shown inline.
       "text/plain; charset=utf-8"
     elsif inlineable?

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -93,7 +93,9 @@ class Attachment < ApplicationRecord
   # specifically when using S3 for attachments. In the case of S3 the file name for the downloaded
   # file will still be correct as it's part of the URL before the query.
   def external_url_options(expires_in: nil)
-    { content_disposition: content_disposition(include_filename: false), expires_in: }
+    options = { content_disposition: content_disposition(include_filename: false), expires_in: }
+    options[:content_type] = served_content_type if inlineable?
+    options
   end
 
   def external_storage?
@@ -116,6 +118,22 @@ class Attachment < ApplicationRecord
       "#{disposition}; filename=#{filename}"
     else
       disposition
+    end
+  end
+
+  # Content type used when serving this attachment over HTTP, both for the local
+  # API response and for the S3 presigned URL, so both paths stay in sync.
+  def served_content_type
+    if is_text?
+      # Even if the text mime type might differ, always output plain text so it
+      # isn't interpreted as e.g. a script or html file. Pin UTF-8 so browsers
+      # don't mis-decode non-ASCII content shown inline.
+      "text/plain; charset=utf-8"
+    elsif inlineable?
+      content_type
+    else
+      # For security reasons, mark all non-inlinable files as an octet-stream first
+      "application/octet-stream"
     end
   end
 

--- a/app/uploaders/fog_file_uploader.rb
+++ b/app/uploaders/fog_file_uploader.rb
@@ -74,6 +74,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
   #
   # @param options [Hash] Options hash.
   # @option options [String] :content_disposition Pass this content disposition to S3 so that it serves the file with it.
+  # @option options [String] :content_type Pass this content type to S3 so that it serves the file with it.
   # @option options [DateTime] :expires_at Date at which the link should expire (default: now + 5 minutes)
   # @option options [ActiveSupport::Duration] :expires_in Duration in which the link should expire.
   #
@@ -82,6 +83,7 @@ class FogFileUploader < CarrierWave::Uploader::Base
     url_options = {}
 
     set_content_disposition!(url_options, options:)
+    set_content_type!(url_options, options:)
     set_expires_at!(url_options, options:)
 
     remote_file.url url_options
@@ -112,6 +114,14 @@ class FogFileUploader < CarrierWave::Uploader::Base
         "response-content-disposition" => options[:content_disposition]
       }
     end
+  end
+
+  def set_content_type!(url_options, options:)
+    return if options[:content_type].blank?
+
+    # Like the content disposition above, this makes S3 serve the file with the
+    # given Content-Type, overriding the stored object type.
+    (url_options[:query] ||= {})["response-content-type"] = options[:content_type]
   end
 
   def set_expires_at!(url_options, options:)

--- a/lib/api/helpers/attachment_renderer.rb
+++ b/lib/api/helpers/attachment_renderer.rb
@@ -90,26 +90,13 @@ module API
           raise ::API::Errors::NotFound.new
         end
 
-        content_type attachment_content_type(attachment)
+        content_type attachment.served_content_type
         header["Content-Disposition"] = attachment.content_disposition
         # Ensure we set nosniff on attachments served from our app
         # so that browsers do not reinterpret the content
         header["X-Content-Type-Options"] = "nosniff"
         env["api.format"] = :binary
         sendfile attachment.diskfile.path
-      end
-
-      def attachment_content_type(attachment)
-        if attachment.is_text?
-          # Even if the text mime type might differ, always output plain text
-          # so this doesn't get interpreted as e.g., a script or html file
-          "text/plain"
-        elsif attachment.inlineable?
-          attachment.content_type
-        else
-          # For security reasons, mark all non-inlinable files as an octet-stream first
-          "application/octet-stream"
-        end
       end
 
       def set_cache_headers

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -320,6 +320,11 @@ RSpec.describe Attachment do
       it_behaves_like "it uses content disposition inline" do
         let(:attachment) { text_attachment }
       end
+
+      it "makes S3 serve text inline as UTF-8 plain text" do
+        expect(text_attachment.external_url.to_s)
+          .to include "response-content-type=text%2Fplain%3B%20charset%3Dutf-8"
+      end
     end
 
     describe "for a video file" do
@@ -350,6 +355,10 @@ RSpec.describe Attachment do
       it "makes S3 use content_disposition 'attachment; filename=...'" do
         expect(binary_attachment.content_disposition).to eq "attachment; filename=textfile.txt.gz"
         expect(binary_attachment.external_url.to_s).to include "response-content-disposition=attachment"
+      end
+
+      it "does not override the response content type for downloads" do
+        expect(binary_attachment.external_url.to_s).not_to include "response-content-type="
       end
     end
   end

--- a/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
+++ b/spec/requests/api/v3/attachments/attachment_resource_shared_examples.rb
@@ -488,7 +488,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
 
       context "for a local text file" do
         it_behaves_like "for a local file" do
-          let(:expected_content_type) { "text/plain" }
+          let(:expected_content_type) { "text/plain; charset=utf-8" }
           let(:mock_file) { FileHelpers.mock_uploaded_file name: "foobar.txt" }
           let(:content_disposition) { "inline; filename=foobar.txt" }
         end
@@ -496,7 +496,7 @@ RSpec.shared_examples "an APIv3 attachment resource", content_type: :json, type:
 
       context "for a local JS file" do
         it_behaves_like "for a local file" do
-          let(:expected_content_type) { "text/plain" }
+          let(:expected_content_type) { "text/plain; charset=utf-8" }
           let(:mock_file) { FileHelpers.mock_uploaded_file name: "foobar.js", content_type: "text/x-javascript" }
           let(:content_disposition) { "inline; filename=foobar.js" }
         end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/work_packages/75402

# What are you trying to accomplish?

Text attachments shown inline `.md` `.txt` `.js` would display non-ASCII content incorrectly because the served `Content-Type` has no charset, so the browser falls back to a legacy encoding.

This PR pins `; charset=utf-8` on the content type used to serve text attachments inline, on both paths:

- local storage: `AttachmentRenderer`
- S3/fog: the presigned URL now sets `response-content-type`

This only affects inline display. Downloaded files were already correct.

# Screenshots

**Before**
<img width="1501" height="100" alt="Capture d’écran du 2026-05-27 21-27-14" src="https://github.com/user-attachments/assets/37d23f4d-a7af-4370-ae13-bf167694c828" />

**After**
<img width="1501" height="100" alt="Capture d’écran du 2026-05-27 23-44-41" src="https://github.com/user-attachments/assets/fec45abe-4deb-4e0c-b0b3-213071cb5fb0" />

# What approach did you choose and why?

**Before this PR, the two serving paths computed the content type differently, and neither set a charset. This PR adds a single method `served_content_type` that decides the type and is reused on both paths.**

Added `Attachment#served_content_type` as the single source of truth for the served content type, reused by both the API renderer and the fog presigned URL builder (mirroring the existing `Attachment#content_disposition` precedent):

- text: `text/plain; charset=utf-8`
- other inlineable (image, PDF, video): its own content type
- otherwise: `application/octet-stream`

For S3, `response-content-type` is set only for inline attachments, so downloads keep their existing behaviour. Already-uploaded files are fixed too, since the override happens when the URL is generated.

### Security

The change touches only the served `Content-Type`, not the logic gating the "view inline or download" decision, so no attachment that should be downloaded becomes inline and type detection remains content-based and not extension-based.

Verified on a local instance: a `.html` file and a `.svg` file with an embedded `<script>` were still served as `application/octet-stream` with an `attachment` disposition, even when renamed to `.txt`/`.js`; text files are served as `text/plain; charset=utf-8` with `X-Content-Type-Options: nosniff`. Images and PDFs keep their own type.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (n/a, backend header change)
- [ ] Tested major browsers (Chrome, Firefox, ...)


