### PR TITLE
[#75353] Use xlarge dialog size for Jira Migrator backup warning.

### DIFF
--- a/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.html.erb
+++ b/app/components/admin/import/jira/import_runs/import_confirm_dialog_component.html.erb
@@ -34,7 +34,7 @@ See COPYRIGHT and LICENSE files for more details.
       title:,
       form_arguments:,
       confirm_button_text:,
-      size: :large
+      size: :xlarge
     )
   ) do |dialog|
     dialog.with_confirmation_message do |message|


### PR DESCRIPTION
https://community.openproject.org/wp/75353

See the comment for details: https://community.openproject.org/projects/jira-migration/work_packages/75353/activity#comment-1679353

<img width="2336" height="1340" alt="image" src="https://github.com/user-attachments/assets/e2443dfe-67ea-4d94-a80e-119e37defe4c" />

