### PR TITLE
[69526] Text overflow in Baseline modal banner

### DIFF
--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -52,7 +52,7 @@ $op-enterprise-banner-fixed-height-large: 320px
   display: grid
   grid-auto-flow: column
   grid-template-areas: "visual content dismiss"
-  grid-template-columns: min-content minmax(0, 1fr) min-content
+  grid-template-columns: min-content 1fr min-content
   grid-template-rows: min-content
   border: var(--borderWidth-thin) solid var(--enterprise-upsell-color)
   border-radius: var(--borderRadius-medium)

--- a/app/components/enterprise_edition/banner_component.sass
+++ b/app/components/enterprise_edition/banner_component.sass
@@ -52,7 +52,7 @@ $op-enterprise-banner-fixed-height-large: 320px
   display: grid
   grid-auto-flow: column
   grid-template-areas: "visual content dismiss"
-  grid-template-columns: min-content 1fr min-content
+  grid-template-columns: min-content minmax(0, 1fr) min-content
   grid-template-rows: min-content
   border: var(--borderWidth-thin) solid var(--enterprise-upsell-color)
   border-radius: var(--borderRadius-medium)
@@ -133,6 +133,9 @@ $op-enterprise-banner-fixed-height-large: 320px
 
   &--content
     padding: var(--base-size-6) var(--base-size-8)
+
+  &--upsell-buttons
+    gap: var(--base-size-8)
 
   &--dismiss
     margin-left: var(--controlStack-medium-gap-condensed)

--- a/app/components/enterprise_edition/upsell_buttons_component.rb
+++ b/app/components/enterprise_edition/upsell_buttons_component.rb
@@ -40,14 +40,19 @@ module EnterpriseEdition
 
       @system_arguments = system_arguments
       @system_arguments[:align_items] ||= :center
+      @system_arguments[:flex_wrap] ||= :wrap
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "op-enterprise-banner--upsell-buttons"
+      )
       @feature_key = feature_key
       @show_buy_now = show_buy_now
     end
 
     def call
       flex_layout(**@system_arguments) do |flex|
-        buttons.each_with_index do |button, i|
-          flex.with_column(ml: (i == 0 ? 0 : 2)) do
+        buttons.each do |button|
+          flex.with_column do
             button
           end
         end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/69526
<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The upsell button row now wraps instead of overflowing horizontally. Spacing between buttons is handled with a flex gap, so wrapped buttons keep consistent spacing without relying on per-button left margins.

## Screenshotss
<img width="516" height="461" alt="Screenshot 2026-05-28 at 13 42 38" src="https://github.com/user-attachments/assets/d32293ce-b3ba-4ab0-ad73-ce2cb2609bac" />
