### PR TITLE
[74739] Copy workflow: Target roles dropdown flickering on scroll

### DIFF
--- a/app/forms/workflows/copies/form.rb
+++ b/app/forms/workflows/copies/form.rb
@@ -81,6 +81,7 @@ class Workflows::Copies::Form < ApplicationForm
           decorated: true,
           closeOnSelect: false,
           appendTo: @append_to,
+          dropdownPosition: "top",
           data: {
             "test-selector": "target_types_autocomplete"
           }
@@ -117,6 +118,7 @@ class Workflows::Copies::Form < ApplicationForm
           multiple: true,
           decorated: true,
           closeOnSelect: false,
+          dropdownPosition: "top",
           appendTo: @append_to,
           data: {
             "test-selector": "target_roles_autocomplete"

--- a/app/views/workflows/copies/new.turbo_stream.erb
+++ b/app/views/workflows/copies/new.turbo_stream.erb
@@ -27,54 +27,55 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++#%>
 <%= turbo_stream.dialog do
-  title = t(".title", source_type: @source_type.name)
-  dialog_id = "copy_from_type_dialog"
-  another_type_at_first = @source_role.nil?
+      title = t(".title", source_type: @source_type.name)
+      dialog_id = "copy_from_type_dialog"
+      another_type_at_first = @source_role.nil?
 
-  render(Primer::Alpha::Dialog.new(title:, size: :large, classes: "Overlay--size-large-portrait",  id: dialog_id, data: { controller: "show-when-value-selected" })) do |d|
-    d.with_header(variant: :large)
-    d.with_body(classes: "Overlay-body_autocomplete_height--lg") do
-      settings_primer_form_with(id: "copy_form") do |f|
-        render(Workflows::Copies::Form.new(f, source_type: @source_type, source_role: @source_role, other_types: @other_types, all_roles: @all_roles, append_to: "##{dialog_id}"))
+      render(Primer::Alpha::Dialog.new(title:, size: :large, classes: "Overlay--size-large-portrait", id: dialog_id, data: { controller: "show-when-value-selected" })) do |d|
+        d.with_header(variant: :large)
+        d.with_body do
+          settings_primer_form_with(id: "copy_form") do |f|
+            render(Workflows::Copies::Form.new(f, source_type: @source_type, source_role: @source_role, other_types: @other_types, all_roles: @all_roles, append_to: "##{dialog_id}"))
+          end
+        end
+        d.with_footer do
+          render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { t(:button_cancel) } +
+          render(
+            Primer::Beta::Button.new(
+              hidden: !another_type_at_first,
+              scheme: :primary,
+              tag: :button,
+              type: :submit,
+              form: "copy_form",
+              formaction: workflow_copy_from_type_path(@source_type),
+              data: {
+                target_name: "mode",
+                value: "from_type",
+                "show-when-value-selected-target": "effect",
+                turbo: true
+              }
+            )
+          ) do
+            t(:button_copy)
+          end +
+          render(
+            Primer::Beta::Button.new(
+              hidden: another_type_at_first,
+              scheme: :primary,
+              tag: :button,
+              type: :submit,
+              form: "copy_form",
+              formaction: workflow_copy_from_role_path(@source_type, source_role_id: @source_role&.id),
+              data: {
+                target_name: "mode",
+                value: "from_role",
+                "show-when-value-selected-target": "effect",
+                turbo: true
+              }
+            )
+          ) do
+            t(:button_copy)
+          end
+        end
       end
-    end
-    d.with_footer do
-      render(Primer::Beta::Button.new(data: { "close-dialog-id": dialog_id })) { t(:button_cancel) } +
-
-      render(Primer::Beta::Button.new(
-        hidden: !another_type_at_first,
-        scheme: :primary,
-        tag: :button,
-        type: :submit,
-        form: "copy_form",
-        formaction: workflow_copy_from_type_path(@source_type),
-        data: {
-           target_name: "mode",
-           value: "from_type",
-           "show-when-value-selected-target": "effect",
-           turbo: true
-         }
-      )) do
-        t(:button_copy)
-      end +
-
-      render(Primer::Beta::Button.new(
-        hidden: another_type_at_first,
-        scheme: :primary,
-        tag: :button,
-        type: :submit,
-        form: "copy_form",
-        formaction: workflow_copy_from_role_path(@source_type, source_role_id: @source_role&.id),
-        data: {
-           target_name: "mode",
-           value: "from_role",
-           "show-when-value-selected-target": "effect",
-           turbo: true
-         }
-      )) do
-        t(:button_copy)
-      end
-    end
-  end
-end
-%>
+    end %>


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74739

# What are you trying to accomplish?
Open dropdowns to the top to unnecessary white space to the bottom. The advanced radio buttons above ensure that there is enough space

## Screenshots
<img width="762" height="496" alt="May-28-2026 14-38-07" src="https://github.com/user-attachments/assets/931f3337-710b-4d5f-a676-2669aeaf9ee4" />

