### PR TITLE
Fix flaky menu-based reorder specs, also renaming `wait_for_` Cuprite helpers

### DIFF
--- a/modules/backlogs/spec/features/backlogs/edit_spec.rb
+++ b/modules/backlogs/spec/features/backlogs/edit_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Edit", :js do
       it "moves a work package to a different sprint" do
         planning_page.expect_story_in_sprint(work_package, first_sprint)
 
-        planning_page.click_in_sprint_story_move_menu(work_package, "Move to sprint")
+        planning_page.click_in_sprint_story_move_menu(work_package, "Move to sprint", wait: false)
 
         within("#move-to-sprint-dialog") do
           expect(page).to have_no_select("target_id", with_options: [first_sprint.name])

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       before { planning_page.visit! }
 
       it "moves the item to the bottom of the selected sprint" do
-        planning_page.click_in_inbox_move_menu(inbox_wp1, "Move to sprint")
+        planning_page.click_in_inbox_move_menu(inbox_wp1, "Move to sprint", wait: false)
 
         within("#move-to-sprint-dialog") do
           # Expect to have all sprints listed
@@ -287,7 +287,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
 
       context "when the target sprint is completed (race condition #73750)" do
         it "shows an error and does not move the item" do
-          planning_page.click_in_inbox_move_menu(inbox_wp1, "Move to sprint")
+          planning_page.click_in_inbox_move_menu(inbox_wp1, "Move to sprint", wait: false)
 
           within("#move-to-sprint-dialog") do
             expect(page).to have_select("target_id", with_options: ["Sprint 1", "Sprint 2"])
@@ -453,7 +453,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       planning_page.expect_no_inbox_show_more
 
       # Move an inbox item to the sprint via the dialog
-      planning_page.click_in_inbox_move_menu(inbox_items.last, "Move to sprint")
+      planning_page.click_in_inbox_move_menu(inbox_items.last, "Move to sprint", wait: false)
       within("#move-to-sprint-dialog") do
         select sprint.name, from: "target_id"
         click_button "Move"

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -268,13 +268,15 @@ module Pages
       end
     end
 
-    def click_in_inbox_move_menu(work_package, item_name)
+    def click_in_inbox_move_menu(work_package, item_name, wait: true)
       button = within(work_package_selector(work_package)) do
         find(:button, accessible_name: "Work package actions")
       end
       menu = open_controlled_menu(button)
       submenu = open_move_submenu(menu)
-      submenu.find(:menuitem, text: item_name).click
+      wait_for_turbo_stream(wait:) do
+        submenu.find(:menuitem, text: item_name).click
+      end
     end
 
     def within_sprint_story_menu(story, &)
@@ -292,13 +294,15 @@ module Pages
       end
     end
 
-    def click_in_sprint_story_move_menu(story, item_name)
+    def click_in_sprint_story_move_menu(story, item_name, wait: true)
       button = within(work_package_selector(story)) do
         find(:button, accessible_name: "Work package actions")
       end
       menu = open_controlled_menu(button)
       submenu = open_move_submenu(menu)
-      submenu.find(:menuitem, text: item_name).click
+      wait_for_turbo_stream(wait:) do
+        submenu.find(:menuitem, text: item_name).click
+      end
     end
 
     def drag_inbox_item_to_sprint(work_package, sprint)

--- a/spec/support/shared/cuprite_helpers.rb
+++ b/spec/support/shared/cuprite_helpers.rb
@@ -86,12 +86,18 @@ end
 #   wait_for_turbo_stream { click_button "Save" }
 #   expect(page).to have_text("Saved")
 #
-def wait_for_turbo_stream(timeout: 10, &block)
+def wait_for_turbo_stream(wait: 10, &block)
   unless using_cuprite?
     yield if block
     return
   end
 
+  unless wait
+    yield if block
+    return
+  end
+
+  timeout = wait == true ? 10 : wait
   timeout_ms = timeout * 1000
   page.execute_script(<<~JS, timeout_ms)
     window.__opTurboStreamRendered = new Promise((resolve, reject) => {
@@ -124,12 +130,18 @@ end
 #   wait_for_turbo { click_link_or_button "Save" }
 #   expect(page).to have_text("Saved")
 #
-def wait_for_turbo(timeout: 10, &block)
+def wait_for_turbo(wait: 10, &block)
   unless using_cuprite?
     yield if block
     return
   end
 
+  unless wait
+    yield if block
+    return
+  end
+
+  timeout = wait == true ? 10 : wait
   timeout_ms = timeout * 1000
   page.execute_script(<<~JS, timeout_ms)
     window.__opTurboLoaded = new Promise((resolve, reject) => {
@@ -162,12 +174,18 @@ end
 #   wait_for_turbo_frame { click_link "Remove column" }
 #   expect(page).to have_text("Updated")
 #
-def wait_for_turbo_frame(timeout: 10, &block)
+def wait_for_turbo_frame(wait: 10, &block)
   unless using_cuprite?
     yield if block
     return
   end
 
+  unless wait
+    yield if block
+    return
+  end
+
+  timeout = wait == true ? 10 : wait
   timeout_ms = timeout * 1000
   page.execute_script(<<~JS, timeout_ms)
     window.__opTurboFrameLoaded = new Promise((resolve, reject) => {
@@ -205,8 +223,8 @@ end
 #   wait_for_ckeditor
 #   wait_for_turbo_stream { description_field.fill_and_submit_value(...) }
 #
-def wait_for_ckeditor(timeout: 20)
-  expect(page).to have_css(".ck-content", wait: timeout)
+def wait_for_ckeditor(wait: 20)
+  expect(page).to have_css(".ck-content", wait:)
 end
 
 def using_cuprite?


### PR DESCRIPTION

# Ticket

n/a

# What are you trying to accomplish?

> [!NOTE]
> This PR also renames the `timeout:` param provided by our Cuprite `wait_for_` helpers to `wait:` to better align with the Capybara API.

Wraps the directional-move menu click in `wait_for_turbo_stream` so the Turbo Stream morph completes before subsequent assertions or actions. Drag-and-drop methods already did this; menu-based moves did not, causing intermittent CI failures.

Example failure:

    1) Inbox column in sprint planning view with work packages in the inbox allows reordering items via the kebab menu
      Failure/Error: Unable to find matching line from backtrace

        expected to find css "[data-test-selector=\"work-package-32\"] + [data-test-selector=\"work-package-31\"] + [data-test-selector=\"work-package-33\"]" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[2]/DIV[1]/MAIN[1]/DIV[1]/DIV[2]/TURBO-FRAME[1]/DIV[1]/DIV[1]/TURBO-FRAME[1]/SECTION[1]/DIV[1]"> but there were no matches

    rspec ./modules/backlogs/spec/features/inbox_column_spec.rb:224

Example failed run:

https://github.com/opf/openproject/actions/runs/26572171285/job/78281849140?pr=23430


# Merge checklist

- [X] Added/updated tests

