### PR TITLE
[#74845] Show message when WP with excluded type or status disappears

### DIFF
--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -61,7 +61,7 @@ module Backlogs
       )
     end
 
-    def move
+    def move # rubocop:disable Metrics/AbcSize
       # Capture the source before the call; the service reloads @work_package internally via #move_after.
       source = @work_package.sprint
 
@@ -70,6 +70,13 @@ module Backlogs
 
       if call.success?
         move_work_package_to_target_component_via_turbo_stream(source:, target: call.result.sprint)
+
+        if work_package_invisible_after_move?(call.result, move_params[:target_id])
+          backlog_name = call.result.backlog_bucket&.name || I18n.t(:label_inbox)
+          render_flash_message_via_turbo_stream(
+            message: I18n.t(:notice_work_package_invisible_after_move, backlog: backlog_name)
+          )
+        end
       else
         render_error_flash_message_via_turbo_stream(
           message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
@@ -127,6 +134,15 @@ module Backlogs
       else
         @work_packages.merge(WorkPackage.backlogs_inbox_for(project: @project))
       end
+    end
+
+    # After a work package is moved to the backlog, it might no longer be visible due to
+    # the project settings for excluded types and statuses.
+    def work_package_invisible_after_move?(work_package, move_target_id)
+      return false unless move_target_id&.start_with?("backlog_bucket", "inbox")
+
+      @project.backlog_excluded_type_ids.include?(work_package.type_id) ||
+        @project.done_status_ids.include?(work_package.status_id)
     end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -71,7 +71,7 @@ module Backlogs
       if call.success?
         move_work_package_to_target_component_via_turbo_stream(source:, target: call.result.sprint)
 
-        if work_package_invisible_after_move?(call.result, move_params[:target_id])
+        if work_package_invisible_after_move?(call.result)
           backlog_name = call.result.backlog_bucket&.name || I18n.t(:label_inbox)
           render_flash_message_via_turbo_stream(
             message: I18n.t(:notice_work_package_invisible_after_move, backlog: backlog_name)
@@ -138,8 +138,8 @@ module Backlogs
 
     # After a work package is moved to the backlog, it might no longer be visible due to
     # the project settings for excluded types and statuses.
-    def work_package_invisible_after_move?(work_package, move_target_id)
-      return false unless move_target_id&.start_with?("backlog_bucket", "inbox")
+    def work_package_invisible_after_move?(work_package)
+      return false if work_package.sprint_id?
 
       @project.backlog_excluded_type_ids.include?(work_package.type_id) ||
         @project.done_status_ids.include?(work_package.status_id)

--- a/modules/backlogs/app/helpers/backlogs/sprints_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/sprints_helper.rb
@@ -31,7 +31,6 @@
 module Backlogs
   module SprintsHelper
     # Returns the appropriate path for a sprint based on its status, or nil if no link applies.
-    # TODO: consider shared sprints here regarding boards.
     def href_for_sprint(sprint, project)
       if sprint.active? && (board = sprint.task_board_for(project))
         project_work_package_board_path(project, board)

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -244,7 +244,8 @@ en:
   notice_unsuccessful_start_with_reason: "The sprint could not be started: %{reason}"
   notice_unsuccessful_finish: "The sprint could not be completed."
   notice_unsuccessful_finish_with_reason: "The sprint could not be completed: %{reason}"
-
+  notice_work_package_invisible_after_move: >
+    The work package was moved to %{backlog} but is not visible because its type or status is excluded from the backlog.
   permission_create_sprints: "Create sprints"
   permission_manage_sprint_items: "Manage sprint items"
   permission_select_backlog_types_and_statuses: "Select backlog types and statuses"

--- a/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
+++ b/modules/backlogs/spec/controllers/backlogs/work_packages_controller_spec.rb
@@ -31,17 +31,23 @@
 require "rails_helper"
 
 RSpec.describe Backlogs::WorkPackagesController do
+  # Gets the html content of the template of the first turbo-stream with the
+  # given action.
+  def turbo_stream_template(action:)
+    Nokogiri("<response>#{response.body}</response>").css("turbo-stream[action=#{action}] template").first.inner_html
+  end
+
   shared_let(:type_feature) { create(:type_feature) }
   shared_let(:type_task) { create(:type_task) }
 
   current_user { user }
 
   shared_let(:user) { create(:admin) }
-  shared_let(:project) { create(:project) }
+  shared_let(:project) { create(:project, types: [type_feature, type_task]) }
   shared_let(:status) { create(:status, name: "status 1", is_default: true) }
 
   let(:sprint) { create(:sprint, name: "Agile Sprint 1", project:) }
-  let(:work_package) { create(:work_package, status:, sprint:, project:) }
+  let(:work_package) { create(:work_package, status:, sprint:, project:, type: type_feature) }
 
   shared_examples "respecting the all param for inbox pagination" do
     context "with an inbox over the pagination threshold" do
@@ -110,6 +116,18 @@ RSpec.describe Backlogs::WorkPackagesController do
     end
 
     context "with a Sprint as source" do
+      shared_examples "shows a flash message after moving a work package that turns invisible" do |target_name|
+        it "shows a flash message after moving the work package" do
+          subject
+
+          message = "The work package was moved to #{target_name} but is not visible"
+          expect(response).to be_successful
+          expect(response).to have_http_status :ok
+          expect(response).to have_turbo_stream action: "flash", target: "op-primer-flash-component"
+          expect(turbo_stream_template(action: "flash")).to include(message)
+        end
+      end
+
       context "with the same Sprint as target" do
         let(:target_id) { "sprint:#{sprint.id}" }
 
@@ -172,6 +190,22 @@ RSpec.describe Backlogs::WorkPackagesController do
           expect(assigns(:work_package)).to eq(work_package_in_sprint)
         end
 
+        context "when the project is configured to exclude the work packages status from backlogs" do
+          before do
+            project.done_statuses << status
+          end
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Inbox"
+        end
+
+        context "when the project is configured to exclude the work packages type from backlogs" do
+          before do
+            project.backlog_excluded_types << type_feature
+          end
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "Inbox"
+        end
+
         it "moves the work_package to the inbox at the given position" do
           subject
 
@@ -182,7 +216,7 @@ RSpec.describe Backlogs::WorkPackagesController do
       end
 
       context "with a Backlog Bucket as target" do
-        let(:bucket) { create(:backlog_bucket, project:) }
+        let(:bucket) { create(:backlog_bucket, name: "My Bucket", project:) }
         let!(:bucket_items) { create_list(:work_package, 2, project:, status:, backlog_bucket: bucket) }
         let(:target_id) { "backlog_bucket:#{bucket.id}" }
         let(:prev_id) { bucket_items.first.id }
@@ -196,6 +230,22 @@ RSpec.describe Backlogs::WorkPackagesController do
                                                 method: "morph"
           expect(response).to have_turbo_stream action: "replace",
                                                 target: "backlogs-backlog-component-#{project.id}"
+        end
+
+        context "when the project is configured to exclude the work packages status from backlogs" do
+          before do
+            project.done_statuses << status
+          end
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "My Bucket"
+        end
+
+        context "when the project is configured to exclude the work packages type from backlogs" do
+          before do
+            project.backlog_excluded_types << type_feature
+          end
+
+          include_examples "shows a flash message after moving a work package that turns invisible", "My Bucket"
         end
 
         it "moves the work_package into the bucket at the given position" do

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -417,6 +417,29 @@ RSpec.describe "Inbox column in sprint planning view", :js do
         planning_page.expect_inbox_item(sprint_wp1)
         planning_page.expect_inbox_item(sprint_wp2)
       end
+
+      context "when the sprint item is configured to be excluded from backlogs" do
+        let!(:status) { create(:status) }
+        let!(:sprint_wp1) { create(:work_package, project:, sprint:, status:) }
+
+        before do
+          project.done_statuses << status
+          planning_page.visit!
+        end
+
+        it "hides the work package after move and shows an explanation" do
+          planning_page.drag_sprint_item_to_inbox(sprint_wp1)
+          wait_for_network_idle
+
+          message =
+            "The work package was moved to Inbox but is not visible because " \
+            "its type or status is excluded from the backlog."
+
+          planning_page.expect_and_dismiss_flash(message:, type: :default)
+          planning_page.expect_story_not_in_sprint(sprint_wp1, sprint)
+          planning_page.expect_no_inbox_item(sprint_wp1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/74845


# What are you trying to accomplish?
Show a notification upon moving a work package that explain that it was moved successfully but that the type/status is excluded which is why it is no longer displayed.

## Screenshots

https://github.com/user-attachments/assets/06631b98-9c5d-48b0-8085-e8839b2b5be8


# What approach did you choose and why?

Decided to use a flash banner with type `default` instead of `success` so that users hopefully notice and read the flash message due to its slightly rarer nature. Additionally, success banners are automatically closed after a short time and I wanted users to have enough time to read the message as the behavior here might be surprising.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)
