### PR TITLE
[72837] Click position is lost when activating an inline edit field

### DIFF
--- a/frontend/src/stimulus/controllers/dynamic/inplace-edit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/inplace-edit.controller.ts
@@ -164,11 +164,25 @@ export default class extends Controller {
       requestAnimationFrame(() => {
         try {
           element.setSelectionRange(offset, offset);
+          this.scrollToCursor(element, offset);
         } catch {
           // ignore
         }
       });
     }
+  }
+
+  // setSelectionRange moves the cursor but does not update scrollLeft.
+  // Approximate the cursor's pixel position proportionally via scrollWidth
+  // and center it in the visible area.
+  private scrollToCursor(element:HTMLInputElement|HTMLTextAreaElement, offset:number):void {
+    const { scrollWidth, clientWidth, value } = element;
+    if (!value.length) return;
+    // Estimate the cursor's pixel position proportionally within the full text width.
+    // Then shift scrollLeft so the cursor lands in the center of the visible area.
+    // Math.max(0, ...) prevents a negative scroll when the cursor is near the start.
+    const cursorX = (offset / value.length) * scrollWidth;
+    element.scrollLeft = Math.max(0, cursorX - clientWidth / 2);
   }
 
   private storeCursorPositionData(e:Event):void {

--- a/frontend/src/stimulus/controllers/dynamic/inplace-edit.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/inplace-edit.controller.ts
@@ -32,6 +32,10 @@
 import { Controller } from '@hotwired/stimulus';
 import { renderStreamMessage } from '@hotwired/turbo';
 
+// Module-level store for cursor offsets, keyed by the field's stable key.
+// This survives Turbo Stream DOM replacement, while still being scoped per field.
+const cursorOffsets = new Map<string, number>();
+
 export default class extends Controller {
   static values = {
     url: String,
@@ -49,6 +53,10 @@ export default class extends Controller {
     if (form) {
       this.boundFormDataHandler = (e:FormDataEvent) => this.appendStableKeySystemArguments(e);
       form.addEventListener('formdata', this.boundFormDataHandler);
+    }
+
+    if (this.element instanceof HTMLInputElement || this.element instanceof HTMLTextAreaElement) {
+      this.setCursorPosition(this.element);
     }
   }
 
@@ -71,6 +79,8 @@ export default class extends Controller {
     if (target.tagName === 'a' || target.closest('a')) {
       return;
     }
+
+    this.storeCursorPositionData(e);
 
     const response = await fetch(this.urlValue, {
       method: 'GET',
@@ -137,5 +147,73 @@ export default class extends Controller {
       current = current.parentElement!;
     }
     return false;
+  }
+
+  // When the controller is connected to a text input (i.e. the edit field has
+  // just been rendered), apply the stored char offset so the cursor lands where
+  // the user clicked in the display field.
+  private setCursorPosition(element:HTMLInputElement|HTMLTextAreaElement):void {
+    const key = this.stableKey;
+    const offset = key !== undefined ? cursorOffsets.get(key) : undefined;
+    if (key !== undefined) cursorOffsets.delete(key);
+
+    if (offset !== undefined) {
+      // requestAnimationFrame ensures autofocus has run and the element is focused.
+      // setSelectionRange is not supported on all input types (e.g. number, date) —
+      // those will silently keep the browser's default cursor placement.
+      requestAnimationFrame(() => {
+        try {
+          element.setSelectionRange(offset, offset);
+        } catch {
+          // ignore
+        }
+      });
+    }
+  }
+
+  private storeCursorPositionData(e:Event):void {
+    const key = this.stableKey;
+    if (!key) return;
+
+    if (e instanceof MouseEvent) {
+      const container = e.currentTarget as HTMLElement;
+
+      // For plain-text inputs: store the char offset at the click position so
+      // the rendered text input can place the cursor accurately via setSelectionRange.
+      let range:Range | null = null;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+      if ((e as any).rangeParent) {
+        range = document.createRange();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+        range.setStart((e as any).rangeParent, (e as any).rangeOffset);
+      } else {
+        const legacyDocument = document as { caretRangeFromPoint?:(x:number, y:number) => Range };
+        range = legacyDocument.caretRangeFromPoint?.(e.clientX, e.clientY) ?? null;
+      }
+
+      if (range && container.contains(range.startContainer)) {
+        cursorOffsets.set(key, this.getCharOffset(container, range.startContainer, range.startOffset));
+      } else {
+        cursorOffsets.delete(key);
+      }
+    } else {
+      cursorOffsets.delete(key);
+    }
+  }
+
+  private get stableKey():string | undefined {
+    return this.element.closest<HTMLElement>('[data-inplace-edit-stable-key]')?.dataset.inplaceEditStableKey;
+  }
+
+  private getCharOffset(root:Element, targetNode:Node, targetOffset:number):number {
+    let count = 0;
+    let node:Node|null;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+
+    while ((node = walker.nextNode())) {
+      if (node === targetNode) return count + targetOffset;
+      count += (node as Text).length;
+    }
+    return count;
   }
 }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/72837

# What are you trying to accomplish?
Remember click position when switching from display to edit field. Due to the limit of of the `setSelectionRange` method this only works for inputs of type text.

# What approach did you choose and why?
                                                                        
On click, the char offset is determined and stored in a module-level Map, keyed by the field's `data-inplace-edit-stable-key`. When the edit field controller connects to the rendered input, it reads the stored offset and applies it via `setSelectionRange`.