### PR TITLE
Expose installation uuid via well-known endpoint

### DIFF
--- a/app/controllers/openproject_metadata_controller.rb
+++ b/app/controllers/openproject_metadata_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class OpenprojectMetadataController < ApplicationController
+  no_authorization_required! :show
+
+  skip_before_action :check_if_login_required
+
+  def show
+    render json: {
+      installation_uuid: Setting.installation_uuid
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,8 +75,12 @@ Rails.application.routes.draw do
   get "/auth/:provider", to: proc { [404, {}, [""]] }, as: "omni_auth_start"
   match "/auth/:provider/callback", to: "omni_auth_login#callback", as: "omni_auth_callback", via: %i[get post]
 
-  get "/.well-known/oauth-authorization-server", to: "oauth_metadata#authorization_server", as: :authorization_server_metadata
-  get "/.well-known/oauth-protected-resource", to: "oauth_metadata#protected_resource", as: :protected_resource_metadata
+  scope ".well-known" do
+    get "oauth-authorization-server", to: "oauth_metadata#authorization_server", as: :authorization_server_metadata
+    get "oauth-protected-resource", to: "oauth_metadata#protected_resource", as: :protected_resource_metadata
+
+    get "openproject-metadata", to: "openproject_metadata#show"
+  end
 
   # In case assets are actually delivered by a node server (e.g. in test env)
   # forward requests to the proxy

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,6 +12,7 @@ OpenProject offers different APIs:
 * SCIM (System for Cross-domain Identity Management)
 * MCP (Model Context Protocol)
 * BCF API v2.1 api targeted towards BIM use cases
+* .well-known endpoints
 
 Please note that we intend to keep this specification as accurate and stable as possible, however work on APIs is still ongoing
 and not all resources and actions in OpenProject are yet accessible through the APIs.
@@ -53,3 +54,19 @@ This API supports BCF management in the context of BIM projects.
 While this API supports way less use cases than the more generic *API v3* it is compatible with the generic specification of a BCF API as [defined by the standard](https://github.com/buildingSMART/BCF-API/blob/release_2_1/README.md). Clients implementing the specification can manage topics and viewpoints.
 
 ➔ [Go to BCF API](./bcf-rest-api/)
+
+## .well-known endpoints
+
+Each OpenProject installation exposes some endpoints under the `/.well-known/` path:
+
+* `/.well-known/oauth-authorization-server`: [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414): OAuth 2.0 Authorization Server Metadata
+* `/.well-known/oauth-protected-resource`: [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728): OAuth 2.0 Protected Resource Metadata
+* `/.well-known/openproject-metadata`: Exposing non-confidential metadata about the OpenProject installation
+
+### OpenProject Metadata
+
+The `/.well-known/openproject-metadata` endpoint exposes some non-confidential metadata about the OpenProject instance in JSON format. This endpoint is accessible without authentication.
+
+The following keys are exposed:
+
+* `installation_uuid`: A unique identifier that's different per installation of OpenProject


### PR DESCRIPTION
The main purpose is to make a deduplicating identifier available for interaction with integrations. We want to start using it for the integration with XWiki, but the underlying problem occurs regularly in integrations:

It's possible for an OP instance to integrate with more than one XWiki instance. Vice versa it's also possible for one XWiki to integrate with multiple OPs. When this happens, API calls like "show me wiki pages that point to work package 123" become ambiguous, because WP 123 might exist on multiple OpenProject instances. Thus it makes sense to have a global identifier for the OpenProject instance. Different identifiers look good and unique at first, but they are not working well in detail:

* Base URL (e.g. https://openproject.example.com):
    * Some instances are available via more than one URL, e.g. inside cluster vs. outside cluster.
    * or the URL changes over time (e.g. when companies rename themselves)
* OAuth client ID: Usually not known to other party, and not guaranteed to be unique, because multiple authentication providers could be involved

Hence we decided to use a uniquely generated ID and expose it in a way that doesn't require additional configuration by the users, but can be automatically discovered during integration setup.

# Ticket
https://community.openproject.org/wp/75442

# Security implications

We've been considering which security impact exposing this information publicly (without prior authentication) has. This is also why I am requesting additional review by @oliverguenther for an additional pair of eyes from that perspective.

As far as I can tell this new endpoint allows two things to external parties

**Software fingerprinting:** The presence of `/.well-known/openproject-metadata` is an unambiguous sign that the given web server is running an installation of OpenProject at the given base path. Since this endpoint is recently introduced it also gives the ability to see that the version must be _at least_ 17.6 (or whenever we release this), but no version information beyond that should be exposed.

I'd argue that this is fine. Even our other existing responses are pretty unique. Even without authentication, requesting `/api/v3` can probably with sufficient confidence tell you, that you are talking to an OpenProject.

**Instance identification:** This is possible because it's the point of the feature. What does it mean? If you have two URLs https://tickets.example.com and https://helpdesk.example.com that both respond as if they hosted an OpenProject, you can use this endpoint to figure out whether they are the _same_ instance (e.g. available under different CNAMEs) or _different_ instances. Similarly when an OpenProject installation is migrated and changes its base url in the process, this endpoint can be used to confirm that the instance formerly reachable under URL A must have been the same as the one now reachable under URL B.

This is a new capability (and kind of what we wanted to achieve). I'd consider it a low risk capability.

## Could we expose more?

For convenience reasons, I briefly considered exposing additional information via this endpoint, such as the instance name. However, since this is user generated, I wasn't sure whether this could expose truly confidential information.