### PR TITLE
[75384] Section cannot be dragged and dropped outside of current view

### DIFF
--- a/app/components/work_package_types/form_configuration_component.html.erb
+++ b/app/components/work_package_types/form_configuration_component.html.erb
@@ -41,14 +41,16 @@ See COPYRIGHT and LICENSE files for more details.
           ) %>
     <% end %>
 
-    <% content.with_main(overflow: :auto, classes: "type-form-configuration-page--main") do %>
-      <%= render(
-            WorkPackageTypes::FormConfiguration::MainContentComponent.new(
-              type: @type,
-              group_components: group_components,
-              ee_available: ee_available?
-            )
-          ) %>
+    <% content.with_main(classes: "type-form-configuration-page--main") do %>
+      <div class="type-form-configuration-page--active-list" data-admin--type-form-configuration--rows-drag-and-drop-target="scrollContainer">
+        <%= render(
+              WorkPackageTypes::FormConfiguration::MainContentComponent.new(
+                type: @type,
+                group_components: group_components,
+                ee_available: ee_available?
+              )
+            ) %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/frontend/src/global_styles/content/_types_form_configuration.sass
+++ b/frontend/src/global_styles/content/_types_form_configuration.sass
@@ -49,6 +49,10 @@ body:has(.type-form-configuration-page)
     @include styled-scroll-bar
     min-height: 0
 
+  &--active-list
+    overflow: auto
+    height: 100%
+
   &--inactive-list
     list-style: none
     margin: 0


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/75384

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Sections can now be dragged and dropped outside the visible area. The page automatically scrolls when dragging near the edges by registering the content wrapper as a scroll container for the drag-and-drop controller.
