### PR TITLE
[#21889] testtest

### DIFF
--- a/app/models/setting/work_package_identifier.rb
+++ b/app/models/setting/work_package_identifier.rb
@@ -32,7 +32,7 @@ class Setting
   module WorkPackageIdentifier
     CLASSIC  = "classic"
     SEMANTIC = "semantic"
-    ALLOWED_VALUES = [CLASSIC, SEMANTIC].freeze
+    ALLOWED_VALUES = [SEMANTIC, CLASSIC].freeze
 
     def self.semantic? = Setting[:work_packages_identifier] == SEMANTIC
     def self.classic?  = Setting[:work_packages_identifier] == CLASSIC

--- a/spec/models/setting/work_package_identifier_spec.rb
+++ b/spec/models/setting/work_package_identifier_spec.rb
@@ -31,6 +31,12 @@
 require "spec_helper"
 
 RSpec.describe Setting::WorkPackageIdentifier do
+  describe "ALLOWED_VALUES" do
+    it "lists semantic before classic" do
+      expect(described_class::ALLOWED_VALUES).to eq [described_class::SEMANTIC, described_class::CLASSIC]
+    end
+  end
+
   context "when the setting is 'semantic'", with_settings: { work_packages_identifier: "semantic" } do
     it { expect(described_class.semantic?).to be true }
     it { expect(described_class.classic?).to be false }


### PR DESCRIPTION
**Work package:** https://qa.openproject-edge.com//work_packages/21889 — plan & discussion in the comments.

# What are you trying to accomplish?

The work package identifier admin settings page displayed the radio button options in the wrong order: **Numeric (classic)** appeared first, **Semantic** second. The options should be shown with **Semantic** first and **Numeric (classic)** second.

The root cause was the order of constants in `ALLOWED_VALUES` inside `Setting::WorkPackageIdentifier`. The view component iterates this array directly to render the radio buttons, so the display order matched the array order.

## Screenshots

N/A

# What approach did you choose and why?

Swapped the two entries in `ALLOWED_VALUES`:

```ruby
# Before
ALLOWED_VALUES = [CLASSIC, SEMANTIC].freeze

# After
ALLOWED_VALUES = [SEMANTIC, CLASSIC].freeze
```

This is the only change required. The view component (`identifier_settings_form_component.rb`) maps `ALLOWED_VALUES` directly to radio button options, so correcting the array order fixes the display order without touching any template, translation, controller, or migration. The default value (`"classic"`) is defined independently in `config/constants/settings/definition.rb` and is unaffected.

A dedicated spec assertion (`"lists semantic before classic"`) was added to `spec/models/setting/work_package_identifier_spec.rb` to pin this order and prevent future regressions.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)