### PR TITLE
[OP-18996] fix: Do not adjust capitalization of new document types

### DIFF
--- a/modules/documents/app/models/document_type.rb
+++ b/modules/documents/app/models/document_type.rb
@@ -38,7 +38,7 @@ class DocumentType < ApplicationRecord
                        dependent: :nullify,
                        inverse_of: :type
 
-  normalizes :name, with: ->(name) { name.strip.capitalize }
+  normalizes :name, with: ->(name) { name.strip }
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 

--- a/modules/documents/spec/models/document_type_spec.rb
+++ b/modules/documents/spec/models/document_type_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DocumentType do
   end
 
   describe "Normalizations" do
-    it { is_expected.to normalize(:name).from("  reImburseMEnt RequeSt  ").to("Reimbursement request") }
+    it { is_expected.to normalize(:name).from("  reImburseMEnt RequeSt  ").to("reImburseMEnt RequeSt") }
   end
 
   describe "Validations" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/projects/OP/work_packages/OP-18996/activity

# What are you trying to accomplish?

Document type names had their capitalisation silently corrupted on save. Any capital letter after a space was downcased, so a name like `"My Custom Type"` was stored and displayed as `"My custom type"`. This was caused by Ruby's `String#capitalize` in the `normalizes` callback on `DocumentType`: it uppercases only the first character and **lowercases every subsequent character**, which is almost never the desired behaviour for a user-supplied label.

# What approach did you choose and why?

The fix removes the destructive `.capitalize` call and retains only `.strip`, preserving whatever casing the user entered while still trimming surrounding whitespace.

## Screenshots
<img width="619" height="417" alt="Screenshot 2026-06-12 at 16 22 48" src="https://github.com/user-attachments/assets/665edd87-bd62-4452-8643-9e83fe81e834" />

Before:
<img width="225" height="79" alt="Screenshot 2026-06-12 at 16 23 02" src="https://github.com/user-attachments/assets/064373cf-5f05-4e6c-82cc-519aa90db9df" />

After:
<img width="287" height="91" alt="Screenshot 2026-06-12 at 16 22 23" src="https://github.com/user-attachments/assets/127e546f-d1e2-47f1-addc-4cd2bb6cd0bb" />


# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)