### PR TITLE
[#21892] Unable to delete wiki page if it is a parent of another page

### DIFF
--- a/app/controllers/wiki_controller.rb
+++ b/app/controllers/wiki_controller.rb
@@ -52,7 +52,8 @@ class WikiController < ApplicationController
                                               history
                                               diff
                                               annotate
-                                              destroy]
+                                              destroy
+                                              destroy_confirmation]
   before_action :find_wiki_page, only: %i[show]
   before_action :handle_new_wiki_page, only: %i[show]
   before_action :build_wiki_page, only: %i[new]
@@ -302,7 +303,10 @@ class WikiController < ApplicationController
           child.update_attribute(:parent, reassign_to)
         end
       else
-        @reassignable_to = @wiki.pages - @page.self_and_descendants
+        redirect_to(
+          { controller: "wiki", action: "destroy_confirmation", project_id: @project, id: @page },
+          status: :see_other
+        )
         return
       end
     end
@@ -314,6 +318,12 @@ class WikiController < ApplicationController
     else
       redirect_to project_path(@project), status: :see_other
     end
+  end
+
+  def destroy_confirmation
+    @descendants_count = @page.descendants.size
+    @reassignable_to = @wiki.pages - @page.self_and_descendants
+    render :destroy
   end
 
   # Export wiki to a single html file

--- a/app/views/wiki/destroy.html.erb
+++ b/app/views/wiki/destroy.html.erb
@@ -35,7 +35,8 @@ See COPYRIGHT and LICENSE files for more details.
     )
   end
 %>
-<%= form_tag({}, method: :delete, class: "form") do %>
+<%= form_tag(url_for(controller: "wiki", action: "destroy", project_id: @project, id: @page),
+              method: :delete, class: "form") do %>
   <p><strong><%= t(:text_wiki_page_destroy_question, descendants: @descendants_count) %></strong></p>
 
   <div class="form--field">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -440,6 +440,7 @@ Rails.application.routes.draw do
         match :rename, via: %i[get patch]
         get :parent_page, action: "edit_parent_page"
         patch :parent_page, action: "update_parent_page"
+        get :destroy_confirmation
         get :history
         post :protect
         get :select_main_menu_item, to: "wiki_menu_items#select_main_menu_item"

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -506,12 +506,12 @@ RSpec.describe WikiController do
           { project_id: project, id: parent_page }
         end
 
-        it "responds with success" do
+        it "redirects to destroy_confirmation" do
           expect(subject)
-            .to have_http_status(:ok)
+            .to redirect_to action: "destroy_confirmation", project_id: project, id: parent_page
         end
 
-        it "destroys the page" do
+        it "does not destroy the page" do
           expect { subject }
             .not_to change(WikiPage, :count)
         end


### PR DESCRIPTION
**Work package:** https://qa.openproject-edge.com//work_packages/21892 — plan & discussion in the comments.

# Ticket
https://qa.openproject-edge.com/work_packages/21892

# What are you trying to accomplish?

Deleting a wiki page that is a parent of another page silently did nothing. After clicking Delete in the more menu and confirming the native dialog, the user was returned to the same page with no feedback and no deletion.

**Root cause:** `WikiController#destroy` has an `else` branch that fires when a page has children and no `todo` param is supplied. It called `return`, which rendered `destroy.html.erb` with HTTP 200. Because the delete button uses `data-turbo-method="delete"`, Turbo Drive sends a DELETE request. Turbo Drive silently discards 200 HTML responses to non-GET requests (it expects a redirect). The existing child-handling form was never shown.

**After this fix:** a DELETE request without a `todo` param on a parent page receives a 303 redirect to a new `destroy_confirmation` GET action, which renders the existing child-handling form. The user can then choose to nullify (reparent children to root), destroy all descendants, or reassign children to another page. Leaf pages are unaffected.

## Screenshots

N/A

# What approach did you choose and why?

The `destroy.html.erb` form — which lets the user choose what to do with child pages — already existed and was correct. The only problem was that it was never displayed because Turbo dropped the 200 response.

The minimal fix is to make the `else` branch redirect (303 See Other) to a new `destroy_confirmation` GET action instead of rendering in-place. Turbo follows the redirect as a GET, the form is shown, and the existing DELETE + `todo` param flow completes as designed.

**Alternatives considered:**

- *Add `todo=nullify` to the delete button directly* — would silently reparent children without telling the user, which is surprising and potentially data-lossy.
- *Replace the native confirm dialog with a custom modal that handles children inline* — better long-term UX, but significantly more scope and JavaScript work for what is otherwise a backend-only bug.
- *Disable the delete button when children exist* — users would have no path to deletion without first manually reassigning children; too restrictive.

The redirect approach required one new route, one new controller action (6 lines), a fix to `form_tag`'s target URL, and a spec update — no frontend changes needed.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)