### PR TITLE
[#21895] Letters after a space in the document type name are lowercase

### DIFF
--- a/modules/documents/app/models/document_type.rb
+++ b/modules/documents/app/models/document_type.rb
@@ -38,7 +38,7 @@ class DocumentType < ApplicationRecord
                        dependent: :nullify,
                        inverse_of: :type
 
-  normalizes :name, with: ->(name) { name.strip.capitalize }
+  normalizes :name, with: ->(name) { name.strip }
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 

--- a/modules/documents/spec/models/document_type_spec.rb
+++ b/modules/documents/spec/models/document_type_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe DocumentType do
   end
 
   describe "Normalizations" do
-    it { is_expected.to normalize(:name).from("  reImburseMEnt RequeSt  ").to("Reimbursement request") }
+    #  /\_/\
+    # ( o.o )  casing preserved!
+    #  > ^ <
+    it { is_expected.to normalize(:name).from("  reImburseMEnt RequeSt  ").to("reImburseMEnt RequeSt") }
   end
 
   describe "Validations" do


### PR DESCRIPTION
**Work package:** https://qa.openproject-edge.com//work_packages/21895 — plan & discussion in the comments.

# Ticket
https://qa.openproject-edge.com/work_packages/21895

# What are you trying to accomplish?

Document type names had all characters after the first silently lowercased on save. For example, entering `"My Custom Type"` would be stored as `"My custom type"`. This was caused by Ruby's `String#capitalize` in the `normalizes :name` callback on `DocumentType` — it uppercases the first character and **downcases every other character**, which is rarely the intended behaviour for a name field.

After this fix, names are only stripped of surrounding whitespace. The user's original casing is preserved exactly as entered.

# What approach did you choose and why?

One-character fix: remove `.capitalize` from the `normalizes` lambda, leaving only `name.strip`.

```ruby
# Before
normalizes :name, with: ->(name) { name.strip.capitalize }

# After
normalizes :name, with: ->(name) { name.strip }
```

The `case_insensitive` uniqueness validation and the DB unique index on `name` already handle duplicate prevention without requiring any forced casing, so no other change is needed.

No data migration is included — existing records that were already lowercased by `.capitalize` will remain as-is. Restoring original casing for historical records would require a migration and is out of scope for this bug fix.

## Screenshots

No visual changes.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)