### PR TITLE
[#21896] Press on ESC in new relations tab works unexpected

### DIFF
--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.html
@@ -4,6 +4,7 @@
     <div class="wp-relations-input-section">
       <wp-relations-autocomplete [workPackage]="workPackage"
           (change)="onSelected($event)"
+          (cancel)="cancel()"
           [filters]="queryFilters"
           [filterCandidatesFor]="relationType"
           data-test-selector="wp-relations-autocomplete"

--- a/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/embedded/inline/add-existing/wp-relation-inline-add-existing.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   WorkPackageInlineCreateService,
@@ -127,6 +127,12 @@ export class WpRelationInlineAddExistingComponent {
 
   public get workPackage() {
     return this.wpInlineCreate.referenceTarget!;
+  }
+
+  @HostListener('keydown.escape', ['$event'])
+  public onEscapeKey(event:KeyboardEvent):void {
+    event.stopPropagation();
+    this.cancel();
   }
 
   public cancel() {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-autocomplete/wp-relations-autocomplete.component.ts
@@ -26,7 +26,7 @@
 // See COPYRIGHT and LICENSE files for more details.
 //++
 
-import { ChangeDetectionStrategy, Component, HostListener, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import { from, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -76,9 +76,9 @@ export class WorkPackageRelationsAutocompleteComponent extends OpAutocompleterCo
 
   getOptionsFn = this.getAutocompleterData.bind(this);
 
-  @HostListener('keydown.escape')
-  public reset() {
-    this.cancel.emit();
+  public override canceled(event:unknown):void {
+    (event as Event)?.stopPropagation();
+    super.canceled(event);
   }
 
   changed(workPackage:IWorkPackageAutocompleteItem|null) {

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relations-create.component.ts
@@ -1,5 +1,5 @@
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, inject } from '@angular/core';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { HalEventsService } from 'core-app/features/hal/services/hal-events.service';
 import { WorkPackageNotificationService } from 'core-app/features/work-packages/services/notifications/work-package-notification.service';
@@ -65,6 +65,14 @@ export class WorkPackageRelationsCreateComponent {
         this.notificationService.handleRawError(err, this.workPackage);
         this.toggleRelationsCreateForm();
       });
+  }
+
+  @HostListener('keydown.escape', ['$event'])
+  public onEscapeKey(event:KeyboardEvent):void {
+    if (this.showRelationsCreateForm) {
+      event.stopPropagation();
+      this.toggleRelationsCreateForm();
+    }
   }
 
   public toggleRelationsCreateForm() {


### PR DESCRIPTION
🤖 AI-generated PR! Please review it for accuracy and then remove this line.

**Work package:** https://qa.openproject-edge.com//work_packages/21896 — plan & discussion in the comments.

# Ticket
https://qa.openproject-edge.com/work_packages/21896

# What are you trying to accomplish?

Pressing ESC in the "add relation" form on the relations tab only worked when the autocomplete input field had focus. If the user had clicked away to the relation-type `<select>` dropdown or the cancel (×) button, ESC did nothing. The same problem affected the embedded inline "add relation" row.

After this fix, ESC closes the form regardless of which element inside it has focus.

# What approach did you choose and why?

The root cause was that ESC handling lived on the `WorkPackageRelationsAutocompleteComponent` host via `@HostListener('keydown.escape')`. Angular's `@HostListener` only fires when the host element or one of its children has browser focus — so ESC was silently ignored whenever focus was on a sibling element (the relation-type `<select>` or cancel button).

**Fix:** move the ESC handler up to the parent form component, which wraps the entire form surface, so it receives ESC regardless of which child element has focus.

Two form surfaces needed fixing:

1. **`WorkPackageRelationsCreateComponent`** — the main "add relation" row. Added `@HostListener('keydown.escape', ['$event'])` that calls `toggleRelationsCreateForm()` when the form is visible.

2. **`WpRelationInlineAddExistingComponent`** — the embedded inline "add relation" row. Same pattern; added `@HostListener('keydown.escape', ['$event'])` calling `cancel()`. Also added the previously missing `(cancel)="cancel()"` output binding on `<wp-relations-autocomplete>` in its template, which meant the autocomplete's own cancel path was silently ignored there.

To prevent double-close (both the autocomplete's ng-select binding and the new parent handler firing for the same keystroke), the `@HostListener` on the autocomplete was replaced with an override of `canceled()` that calls `event.stopPropagation()` before delegating to the base class. This stops the ESC event from bubbling to the parent handler when the autocomplete has already handled it.

**Alternatives considered:**

- Keeping the `@HostListener` on the autocomplete and adding `document:keydown.escape` on the parent — rejected because a document-level listener would fire even when the form doesn't have focus.
- Adding `(keydown.escape)` directly to the form `<div>` in the template — rejected because it creates a double-close race condition without `stopPropagation` coordination, which is harder to reason about than the component-level approach.

## Screenshots

N/A

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [x] Tested major browsers (Chrome, Firefox, Edge, ...)