### PR TITLE
[#21897] Documents admin page: "+Type" button has a wrong label ("+Add")

### DIFF
--- a/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
+++ b/modules/documents/app/components/documents/admin/document_types/index_component.html.erb
@@ -37,12 +37,12 @@
           subheader.with_action_button(
             scheme: :primary,
             leading_icon: :plus,
-            label: t(:button_add),
+            label: t("documents.admin.document_types.button_add"),
             tag: :a,
             href: helpers.url_for(action: :new),
             test_selector: "add-document-type-button"
           ) do
-            I18n.t(:button_add)
+            t("documents.admin.document_types.button_add")
           end
         end
       end

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -143,6 +143,8 @@ en:
         message: There must always be at least one document type configured. Create another one first if you want to delete this one.
 
     admin:
+      document_types:
+        button_add: "Type"
       collaboration_settings:
         page_header:
           description: |-


### PR DESCRIPTION
**Work package:** https://qa.openproject-edge.com//work_packages/21897 — plan & discussion in the comments.

# Ticket
https://qa.openproject-edge.com/work_packages/21897

# What are you trying to accomplish?

The button to create a new document type on the admin Documents → Types page was labelled "+Add" instead of "+Type". The `+` comes from a leading icon, so the text label alone was showing the generic "Add" string rather than the context-specific "Type".

# What approach did you choose and why?

The button in `index_component.html.erb` was using the global `t(:button_add)` key (resolves to `"Add"`) in both the `label:` attribute (used for accessibility) and the visible block content.

Added a scoped translation key `documents.admin.document_types.button_add: "Type"` to the documents module's own `en.yml` and updated both usages in the template to reference it. This keeps the global `button_add` key untouched and follows OpenProject's convention of never hard-coding UI strings.

## Screenshots

N/A

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)