### PR TITLE
Upgrade IfcConvert (IfcOpenShell) to v0.8.5

### DIFF
--- a/docker/dev/backend/scripts/setup-bim
+++ b/docker/dev/backend/scripts/setup-bim
@@ -21,8 +21,8 @@ unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
-unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
+wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.8.5-a51b2c5-linux64.zip
+unzip -q IfcConvert-v0.8.5-a51b2c5-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
 wget --no-verbose --tries 3 https://github.com/opf/xeokit-metadata/releases/download/v1.1.0/xeokit-metadata-linux-x64.tar.gz

--- a/docker/prod/setup/preinstall-common.sh
+++ b/docker/prod/setup/preinstall-common.sh
@@ -71,8 +71,8 @@ if [ ! "$BIM_SUPPORT" = "false" ]; then
   mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
   # IFCconvert
-  wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
-  unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
+  wget --no-verbose --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.8.5-a51b2c5-linux64.zip
+  unzip -q IfcConvert-v0.8.5-a51b2c5-linux64.zip
   mv IfcConvert "/usr/local/bin/IfcConvert"
 
   wget --no-verbose --tries 3 https://github.com/opf/xeokit-metadata/releases/download/v1.1.0/xeokit-metadata-linux-x64.tar.gz

--- a/modules/bim/bin/setup_dev.sh
+++ b/modules/bim/bin/setup_dev.sh
@@ -25,8 +25,8 @@ unzip -q COLLADA2GLTF-v2.1.5-linux.zip
 mv COLLADA2GLTF-bin "/usr/local/bin/COLLADA2GLTF"
 
 # IFCconvert
-wget --quiet --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.7.11-fea8e3a-linux64.zip
-unzip -q IfcConvert-v0.7.11-fea8e3a-linux64.zip
+wget --quiet --tries 3 https://s3.amazonaws.com/ifcopenshell-builds/IfcConvert-v0.8.5-a51b2c5-linux64.zip
+unzip -q IfcConvert-v0.8.5-a51b2c5-linux64.zip
 mv IfcConvert "/usr/local/bin/IfcConvert"
 
 wget --quiet --tries 3 https://github.com/bimspot/xeokit-metadata/releases/download/1.0.1/xeokit-metadata-linux-x64.tar.gz


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/XEO-30

Follow-up to PR #23469 (the .NET → web-ifc replacement).

# What this PR does
Bumps the prebuilt `IfcConvert` binary from `v0.7.11-fea8e3a` to `v0.8.5-a51b2c5` so the BIM IFC conversion pipeline can convert IFC4x3 Add2 geometry. Combined with #23469, this lets users upload an IFC4x3 Add2 file and view it in the OpenProject BCF/BIM viewer.

Three install scripts updated, same one-line change each:

- `docker/prod/setup/preinstall-common.sh`
- `docker/dev/backend/scripts/setup-bim`
- `modules/bim/bin/setup_dev.sh`

# Why pin a commit hash instead of a version tag
IfcOpenShell `0.8.5` has no git tag — it's a build-version label stamped on rolling CI artifacts in the `ifcopenshell-builds` S3 bucket. There is no "latest 0.8.5" URL. We pin the 2026-03-17 linux64 build (commit `a51b2c5`) which is the newest 0.8.5-labelled Linux build before the line moves to `0.8.6-alpha`.

# Compatibility notes
- **CLI flags unchanged.** `Bim::IfcModels::ViewConverterService` passes `--use-element-guids`, `--no-progress`, `--verbose`, `--threads N`, `--exclude entities IfcOpeningElement`, and a positional DAE output — all still valid in 0.8.x per the [IfcConvert 0.8.5 docs](https://docs.ifcopenshell.org/ifcconvert/usage.html). Locally verified: IFC2X3, IFC4, and IFC4X3_ADD2 fixtures all convert to valid COLLADA.
- **Open CASCADE bumped 7.5.3 → 7.8.1.** Same model produces a slightly different DAE (e.g. 817 → 803 lines for the IFC4 Building-Architecture fixture) — expected from the geometry-kernel upgrade.
- **Glibc.** 0.8.5 binaries are built on Rocky Linux 9 (glibc 2.34). Our prod and dev base images are Debian 13 trixie (glibc 2.41). No incompatibility.
- **Version string is correct in the pinned build.** Earlier 0.8.x builds had a known cosmetic bug ([IfcOpenShell#6898](https://github.com/IfcOpenShell/IfcOpenShell/issues/6898)) where `IfcConvert --version` self-reported `0.8.0`; verified locally that `a51b2c5` reports `0.8.5-a51b2c5` correctly.

# Behavioural change worth flagging
- v0.8.5 segfaults (exit 139, no stderr) when given a non-existent input path, where v0.7.11 returned `[Error] Input file '<path>' does not exist`. Harmless for `ViewConverterService` — it symlinks the real attachment into a `Dir.mktmpdir` before invoking IfcConvert, so the path is always valid — but worth knowing about for any future code path that ever hands IfcConvert a user-supplied path directly.

# Dev-environment gotcha (not a code change)
`docker/dev/backend/scripts/setup-bim` is baked into the worker image at build time as `/usr/sbin/setup-bim`. After editing the script, `docker compose exec -u root worker setup-bim` will NOT pick up the change — it runs the baked copy. Either rebuild the worker image or run the live script: `bash /home/dev/openproject/docker/dev/backend/scripts/setup-bim`.

# Test plan
- [x] In the dev `worker` container, install the new binary and confirm `IfcConvert --version` reports `0.8.5-a51b2c5 (OCC 7.8.1)`
- [x] IFC2X3 regression — `modules/bim/spec/fixtures/files/minimal.ifc` → DAE (260,848 B)
- [x] IFC4 regression — `Building-Architecture-IFC4.ifc` → DAE (348,940 B) with the full `ViewConverterService` flagset
- [x] **IFC4x3 Add2 goal — `Building-Architecture-IFC4X3.ifc` → DAE (348,940 B), stamped `<authoring_tool>IfcOpenShell 0.8.5-a51b2c5</authoring_tool>`, byte-distinct from the IFC4 output**
- [x] Stretch — `Infra-Rail-IFC4X3.ifc` → DAE (605,031 B) in a fresh tmpdir (mimicking the Rails service's `Dir.mktmpdir` pattern)
- [ ] End-to-end via the BIM module UI — upload `Building-Architecture-IFC4X3.ifc` and confirm it renders in the xeokit viewer with a populated spatial tree. Requires #23469 to be present for the metadata stage; this PR's branch off `dev` still uses the old .NET-based `xeokit-metadata`, which can't parse IFC4x3.
- [ ] `bundle exec rspec modules/bim/spec/services/ifc_models/view_conversion_service_spec.rb` (mocks Open3; should still pass)

<img width="4608" height="2880" alt="Screenshot from 2026-06-01 14-41-09" src="https://github.com/user-attachments/assets/f3e7c78e-fff3-451a-8b6a-287c9eed9e38" />
Import of IFC4x3_ADD2 Infra sample files taken from [buildingSMART](https://github.com/buildingSMART/Sample-Test-Files/tree/main/IFC%204.3.2.0%20(IFC4X3_ADD2)/PCERT-Sample-Scene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)