### PR TITLE
Add translation for 'agile/sprint' model

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2628,6 +2628,7 @@ en:
           other: "%{count} errors prohibited this %{model} from being saved"
 
     models:
+      "agile/sprint": "Sprint"
       attachment: "File"
       attribute_help_text:
         one: "Attribute help text"


### PR DESCRIPTION
Allow to translate Agile::Sprint.human_model_name
