### PR TITLE
[OP-19453] Add spec coverage for filter input forms

### DIFF
--- a/spec/forms/filters/inputs/add_filter_form_spec.rb
+++ b/spec/forms/filters/inputs/add_filter_form_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::AddFilterForm, type: :forms do
+  include ViewComponent::TestHelpers
+
+  let(:query) { UserQuery.new }
+  let(:allowed_filters) { query.available_advanced_filters }
+  let(:active_filter_names) { [] }
+
+  def render_add_filter_form(allowed_filters: self.allowed_filters,
+                             active_filter_names: self.active_filter_names)
+    form_class = described_class
+    render_in_view_context(form_class, allowed_filters, active_filter_names) do |form_class, allowed_filters, active_filter_names|
+      primer_form_with(url: "/test", method: :post) do |f|
+        render(form_class.new(f, allowed_filters:, active_filter_names:))
+      end
+    end
+  end
+
+  subject(:rendered_form) do
+    render_add_filter_form
+    page
+  end
+
+  it "renders a select named add_filter_select" do
+    expect(rendered_form).to have_select "add_filter_select"
+  end
+
+  it "has the addFilterSelect Stimulus target" do
+    expect(rendered_form).to have_element :select,
+                                          "data-filter--filters-form-target": "addFilterSelect"
+  end
+
+  it "includes a blank prompt option" do
+    select = rendered_form.find(:select, "add_filter_select")
+    expect(select).to have_selector :option, text: I18n.t(:actionview_instancetag_blank_option)
+  end
+
+  it "lists all allowed filters as options" do
+    expect(rendered_form).to have_select "add_filter_select" do |select|
+      allowed_filters.each do |af|
+        expect(select).to have_selector :option, text: af.human_name
+      end
+    end
+  end
+
+  context "with active filters" do
+    let(:active_filter_names) { [:login] }
+
+    it "disables the active filter option" do
+      select = rendered_form.find(:select, "add_filter_select")
+      login_option = select.find(:option, text: "Username")
+      expect(login_option).to be_disabled
+    end
+
+    it "does not disable inactive filter options" do
+      select = rendered_form.find(:select, "add_filter_select")
+      status_option = select.find(:option, text: "Status")
+      expect(status_option).not_to be_disabled
+    end
+  end
+end

--- a/spec/forms/filters/inputs/autocomplete_form_spec.rb
+++ b/spec/forms/filters/inputs/autocomplete_form_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::AutocompleteForm, type: :forms do
+  include_context "with rendered filter input form"
+
+  let(:query) { UserQuery.new }
+  let(:filter) { query.available_advanced_filters.find { |af| af.name == :login } }
+  let(:additional_attributes) do
+    {
+      autocomplete_options: {
+        component: "opce-autocompleter",
+        resource: "users",
+        searchKey: "login"
+      }
+    }
+  end
+
+  it_behaves_like "rendering filter row"
+  it_behaves_like "rendering operator select"
+  it_behaves_like "hidden when inactive"
+
+  it "renders an autocompleter component" do
+    expect(rendered_form).to have_element "opce-autocompleter", visible: :all
+  end
+
+  it "marks the wrapper as filter-autocomplete" do
+    expect(rendered_form).to have_element "data-filter-name": "login",
+                                          "data-filter-autocomplete": "true",
+                                          visible: :all
+  end
+
+  it "renders the autocompleter as multiple" do
+    expect(rendered_form).to have_element "opce-autocompleter",
+                                          "data-multiple": "true",
+                                          visible: :all
+  end
+end

--- a/spec/forms/filters/inputs/base_filter_form_spec.rb
+++ b/spec/forms/filters/inputs/base_filter_form_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::BaseFilterForm, type: :forms do
+  include ViewComponent::TestHelpers
+
+  let!(:date_field) { create(:user_custom_field, field_format: "date") }
+  let(:query) { UserQuery.new }
+  let(:filter) { query.available_advanced_filters.find { |af| af.name == :"cf_#{date_field.id}" } }
+  let(:active) { true }
+
+  # Concrete subclass so the abstract base can be rendered: BaseFilterForm#add_operand
+  # raises SubclassResponsibilityError, so every real subclass supplies an operand.
+  let(:form_class) do
+    Class.new(described_class) do
+      def add_operand(group)
+        group.text_field(name: operand_name, label: @filter.human_name)
+      end
+    end
+  end
+
+  def render_base_form(form_class: self.form_class, filter: self.filter, active: self.active)
+    render_in_view_context(form_class, filter, active) do |form_class, filter, active|
+      primer_form_with(url: "/test", method: :post) do |f|
+        render(form_class.new(f, filter:, additional_attributes: {}, active:))
+      end
+    end
+    page
+  end
+
+  subject(:rendered_form) { render_base_form }
+
+  it "renders the row group with filter data attributes" do
+    expect(rendered_form).to have_element "data-filter--filters-form-target": "filter",
+                                          "data-filter-name": filter.name.to_s,
+                                          "data-filter-type": filter.type.to_s
+  end
+
+  it "renders the operator select with the filter's operators" do
+    expect(rendered_form).to have_select "operator_#{filter.name}" do |select|
+      filter.available_operators.each do |op|
+        expect(select).to have_selector :option, text: op.human_name
+      end
+    end
+  end
+
+  it "marks value-less operators with data-no-value and leaves the rest untouched" do
+    select = rendered_form.find(:select, "operator_#{filter.name}", visible: :all)
+
+    filter.available_operators.each do |op|
+      option = select.find(:element, :option, value: op.symbol, visible: :all)
+
+      if op.requires_value?
+        expect(option["data-no-value"]).to be_nil
+      else
+        expect(option["data-no-value"]).to eq("true")
+      end
+    end
+  end
+
+  it "points the label at the operator select for a non-boolean filter" do
+    expect(rendered_form).to have_element :label,
+                                          text: filter.human_name,
+                                          for: "operator_#{filter.name}"
+  end
+
+  it "renders a delete button within the filter row" do
+    expect(rendered_form).to have_element "data-filter--filters-form-target": "filter" do |row|
+      expect(row).to have_element "tool-tip", text: I18n.t("button_delete")
+    end
+  end
+
+  context "when inactive" do
+    let(:active) { false }
+
+    it "hides the row" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": "filter",
+                                            "data-filter-name": filter.name.to_s,
+                                            hidden: "hidden",
+                                            visible: :all
+    end
+  end
+
+  context "with a boolean filter" do
+    let!(:bool_field) { create(:user_custom_field, field_format: "bool") }
+    let(:filter) { query.available_advanced_filters.find { |af| af.name == :"cf_#{bool_field.id}" } }
+
+    it "hides the operator select" do
+      expect(rendered_form).to have_select "operator_#{filter.name}", visible: :hidden
+    end
+  end
+
+  context "when add_operand is not overridden" do
+    let(:form_class) { Class.new(described_class) }
+
+    it "raises SubclassResponsibilityError when rendered" do
+      expect { render_base_form }.to raise_error(SubclassResponsibilityError)
+    end
+  end
+end

--- a/spec/forms/filters/inputs/boolean_form_spec.rb
+++ b/spec/forms/filters/inputs/boolean_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::BooleanForm, type: :forms do
+  include_context "with rendered filter input form"
+
+  let(:query) { UserQuery.new }
+  let(:filter) { query.available_advanced_filters.find { |af| af.name == :blocked } }
+
+  it_behaves_like "rendering filter row"
+  it_behaves_like "hidden when inactive"
+
+  it "includes the operator select (hidden by Primer)" do
+    expect(rendered_form).to have_select "operator_blocked", visible: :all
+  end
+
+  it "renders a segmented control with Yes and No" do
+    expect(rendered_form).to have_element "data-filter-name": "blocked" do |row|
+      expect(row).to have_button I18n.t("general_text_Yes")
+      expect(row).to have_button I18n.t("general_text_No")
+    end
+  end
+end

--- a/spec/forms/filters/inputs/date_form_spec.rb
+++ b/spec/forms/filters/inputs/date_form_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::DateForm, type: :forms do
+  include_context "with rendered filter input form"
+
+  let!(:date_field) { create(:user_custom_field, field_format: "date") }
+  let(:query) { UserQuery.new }
+  let(:operator) { "=d" }
+  let(:values) { [Date.current.iso8601] }
+  let(:filter) do
+    f = query.available_advanced_filters.find { |af| af.name == :"cf_#{date_field.id}" }
+    f.operator = operator
+    f.values = values
+    f
+  end
+
+  it_behaves_like "rendering filter row"
+  it_behaves_like "rendering operator select"
+  it_behaves_like "hidden when inactive"
+
+  context "with a days operator (>t-)" do
+    let(:operator) { ">t-" }
+    let(:values) { ["7"] }
+
+    it "renders a days number input" do
+      expect(rendered_form).to have_element :input,
+                                            "data-filter--filters-form-target": "days",
+                                            type: "number",
+                                            visible: :all
+    end
+  end
+
+  context "with an on-date operator (=d)" do
+    let(:operator) { "=d" }
+    let(:values) { [Date.current.iso8601] }
+
+    it "renders the value container with the filter name" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": /filterValueContainer/,
+                                            "data-filter-name": filter.name.to_s,
+                                            visible: :all
+    end
+
+    it "hides the days input" do
+      days_input = rendered_form.find(:element, "data-filter--filters-form-target": "days", visible: :all)
+      expect(days_input["hidden"]).to eq("hidden")
+    end
+  end
+
+  context "with a between-dates operator (<>d)" do
+    let(:operator) { "<>d" }
+    let(:values) { [1.week.ago.to_date.iso8601, Date.current.iso8601] }
+
+    it "renders the value container with the filter name" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": /filterValueContainer/,
+                                            "data-filter-name": filter.name.to_s,
+                                            visible: :all
+    end
+
+    it "hides the days input" do
+      days_input = rendered_form.find(:element, "data-filter--filters-form-target": "days", visible: :all)
+      expect(days_input["hidden"]).to eq("hidden")
+    end
+  end
+end

--- a/spec/forms/filters/inputs/list_form_spec.rb
+++ b/spec/forms/filters/inputs/list_form_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::ListForm, type: :forms do
+  include_context "with rendered filter input form"
+
+  let(:query) { UserQuery.new }
+  let(:filter) { query.available_advanced_filters.find { |af| af.name == :status } }
+
+  it_behaves_like "rendering filter row"
+  it_behaves_like "rendering operator select"
+  it_behaves_like "hidden when inactive"
+
+  it "renders an autocompleter component" do
+    expect(rendered_form).to have_element "opce-autocompleter", visible: :all
+  end
+
+  it "marks the autocompleter as multiple" do
+    expect(rendered_form).to have_element "opce-autocompleter",
+                                          "data-multiple": "true",
+                                          visible: :all
+  end
+
+  it "sets data-filter-autocomplete on the wrapper" do
+    expect(rendered_form).to have_element "data-filter-name": "status",
+                                          "data-filter-autocomplete": "true",
+                                          visible: :all
+  end
+
+  context "with additional autocomplete options" do
+    let(:additional_attributes) { { autocomplete_options: { appendTo: "#dialog" } } }
+
+    it "merges the appendTo option into the autocompleter" do
+      autocompleter = rendered_form.find(:element, "opce-autocompleter", visible: :all)
+      expect(autocompleter["data-append-to"]).to be_json_eql(%("#dialog"))
+    end
+  end
+end

--- a/spec/forms/filters/inputs/text_form_spec.rb
+++ b/spec/forms/filters/inputs/text_form_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Filters::Inputs::TextForm, type: :forms do
+  include_context "with rendered filter input form"
+
+  let(:query) { UserQuery.new }
+  let(:filter) do
+    f = query.available_advanced_filters.find { |af| af.name == :login }
+    f.operator = "~"
+    f.values = ["admin"]
+    f
+  end
+
+  it_behaves_like "rendering filter row"
+  it_behaves_like "rendering operator select"
+  it_behaves_like "hidden when inactive"
+
+  it "renders a text input with the filter value" do
+    expect(rendered_form).to have_field type: :text, with: "admin"
+  end
+
+  it "names the input after the filter" do
+    expect(rendered_form).to have_element :input, name: "login_value", visible: :all
+  end
+
+  context "with a numeric filter" do
+    let!(:integer_field) { create(:user_custom_field, :integer) }
+    let(:filter) do
+      query.available_advanced_filters.find { |af| af.name == :"cf_#{integer_field.id}" }
+    end
+
+    it "renders a number input with step" do
+      expect(rendered_form).to have_element :input,
+                                            type: "number",
+                                            step: "any",
+                                            visible: :all
+    end
+  end
+end

--- a/spec/lib/primer/open_project/forms/segmented_control_spec.rb
+++ b/spec/lib/primer/open_project/forms/segmented_control_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe Primer::OpenProject::Forms::SegmentedControl, type: :forms do
+  include ViewComponent::TestHelpers
+
+  describe "rendering" do
+    let(:value) { "t" }
+    let(:items) do
+      [
+        { value: "f", label: "No" },
+        { value: "t", label: "Yes" }
+      ]
+    end
+    let(:wrapper_data_attributes) do
+      { "filter--filters-form-target": "filterValueContainer", "filter-name": "blocked" }
+    end
+
+    def render_form
+      render_in_view_context(value, items, wrapper_data_attributes) do |value, items, wrapper_data_attributes|
+        primer_form_with(url: "/foo") do |f|
+          render_inline_form(f) do |form|
+            form.segmented_control(
+              name: :blocked_value,
+              label: "Blocked",
+              value:,
+              items:,
+              wrapper_data_attributes:
+            )
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "renders the label" do
+      expect(rendered_form).to have_element :label, text: "Blocked"
+    end
+
+    it "renders one button per item" do
+      expect(rendered_form).to have_button "No"
+      expect(rendered_form).to have_button "Yes"
+      expect(rendered_form).to have_button count: 2
+    end
+
+    it "renders a hidden field carrying the current value" do
+      field = rendered_form.find(:element, "data-filter--segmented-control-target": "field", visible: :all)
+
+      expect(field[:type]).to eq("hidden")
+      expect(field[:value]).to eq("t")
+    end
+
+    it "marks the item matching the value as current" do
+      expect(rendered_form).to have_button "Yes", aria: { current: true }
+      expect(rendered_form).to have_button aria: { current: true }, count: 1
+    end
+
+    context "when no value is given" do
+      let(:value) { nil }
+
+      it "falls back to the first item" do
+        field = rendered_form.find(:element, "data-filter--segmented-control-target": "field", visible: :all)
+
+        expect(field[:value]).to eq("f")
+        expect(rendered_form).to have_button "No", aria: { current: true }
+        expect(rendered_form).to have_button aria: { current: true }, count: 1
+      end
+    end
+
+    it "applies wrapper data attributes to the form control" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": "filterValueContainer",
+                                            "data-filter-name": "blocked"
+    end
+  end
+end

--- a/spec/support/forms/rendered_filter_input_form.rb
+++ b/spec/support/forms/rendered_filter_input_form.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.shared_context "with rendered filter input form" do
+  include ViewComponent::TestHelpers
+
+  let(:additional_attributes) { {} }
+  let(:active) { true }
+
+  def vc_render_filter_form(
+    form_class = described_class,
+    filter: self.filter,
+    additional_attributes: self.additional_attributes,
+    active: self.active
+  )
+    render_in_view_context(form_class, filter, additional_attributes, active) do |form_class, filter, attrs, active|
+      primer_form_with(url: "/test", method: :post) do |f|
+        render(form_class.new(f, filter:, additional_attributes: attrs, active:))
+      end
+    end
+  end
+
+  subject(:rendered_form) do
+    vc_render_filter_form
+    page
+  end
+
+  shared_examples "rendering filter row" do
+    it "renders a filter row with data attributes" do
+      expect(rendered_form).to have_element "data-filter--filters-form-target": "filter",
+                                            "data-filter-name": filter.name.to_s
+    end
+
+    it "renders a label with the filter's human name" do
+      expect(rendered_form).to have_element :label, text: filter.human_name
+    end
+
+    it "renders a delete button" do
+      expect(rendered_form).to have_element "data-action": /filter--filters-form#removeFilter/
+    end
+  end
+
+  shared_examples "rendering operator select" do
+    it "renders an operator select with available operators" do
+      expect(rendered_form).to have_select "operator_#{filter.name}" do |select|
+        filter.available_operators.each do |op|
+          expect(select).to have_selector :option, text: op.human_name
+        end
+      end
+    end
+  end
+
+  shared_examples "hidden when inactive" do
+    context "when inactive" do
+      let(:active) { false }
+
+      it "renders the row with hidden attribute" do
+        expect(rendered_form).to have_element "data-filter--filters-form-target": "filter",
+                                              "data-filter-name": filter.name.to_s,
+                                              hidden: "hidden",
+                                              visible: :all
+      end
+    end
+  end
+end


### PR DESCRIPTION
> [!NOTE]
> This PR is based on #23488. Please review/merge that PR first.

# Ticket

https://community.openproject.org/wp/OP-19453

# What are you trying to accomplish?

Backfills spec coverage for the filter input form layer. Covers the per-type filter inputs (text, list, date, boolean, autocomplete) and the "add filter" select through a shared render context, the `FilterFormComponent` wrapper (controller wrapping, hidden input, output format, system-argument merging), the `SegmentedControl` form DSL input behind boolean rows, and the shared `BaseFilterForm` row contract. 

## Screenshots

No visual changes.

# What approach did you choose and why?

Specs render through the existing Primer form-DSL test harnesses and assert on accessible roles/names and semantic attributes rather than CSS, so they track behaviour rather than markup. `BaseFilterForm` is exercised directly via a throwaway concrete subclass so the abstract base's shared row logic is covered in one place instead of only transitively through each subclass.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)