### PR TITLE
[19403] User cannot scroll down on page when enterprise banner is showing

### DIFF
--- a/app/components/work_package_types/form_configuration_component.html.erb
+++ b/app/components/work_package_types/form_configuration_component.html.erb
@@ -43,6 +43,14 @@ See COPYRIGHT and LICENSE files for more details.
 
     <% content.with_main(classes: "type-form-configuration-page--main") do %>
       <div class="type-form-configuration-page--active-list" data-admin--type-form-configuration--rows-drag-and-drop-target="scrollContainer">
+        <%= render(EnterpriseEdition::BannerComponent.new(:edit_attribute_groups, mb: 3)) %>
+
+        <% unless ee_available? %>
+          <%= render(Primer::Alpha::Banner.new(scheme: :default, icon: :info, mb: 3)) do %>
+            <%= t("text_form_configuration") %> <%= t("text_custom_field_hint_activate_per_project") %>
+          <% end %>
+        <% end %>
+
         <%= render(
               WorkPackageTypes::FormConfiguration::MainContentComponent.new(
                 type: @type,

--- a/app/views/work_package_types/form_configuration_tab/edit.html.erb
+++ b/app/views/work_package_types/form_configuration_tab/edit.html.erb
@@ -31,14 +31,6 @@ See COPYRIGHT and LICENSE files for more details.
 
 <%= render ::Types::EditPageHeaderComponent.new(type: @type, tabs: types_tabs) %>
 
-<%= render(EnterpriseEdition::BannerComponent.new(:edit_attribute_groups, mb: 3)) %>
-
-<% unless EnterpriseToken.allows_to?(:edit_attribute_groups) %>
-  <%= render(Primer::Alpha::Banner.new(scheme: :default, icon: :info, mb: 3)) do %>
-    <%= t("text_form_configuration") %> <%= t("text_custom_field_hint_activate_per_project") %>
-  <% end %>
-<% end %>
-
 <% no_filter_query = ::API::V3::Queries::QueryParamsRepresenter.new(Query.new_default.tap { |q| q.filters = [] }).to_json %>
 <%= render(
       WorkPackageTypes::FormConfigurationComponent.new(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19403

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# Screenshots
<img width="1220" height="719" alt="Screenshot 2026-06-01 at 16 21 22" src="https://github.com/user-attachments/assets/7566ef1d-238b-4bec-816b-a19bd8e7d828" />


# What are you trying to accomplish?
Keep the enterprise and form configuration info banners inside the active form configuration pane so they share the same scroll context.

# What approach did you choose and why?
The form configuration page has two independent scrollable areas:

- the inactive attributes sidebar
- the active form configuration list

When the banners were rendered above both panes, they reduced the available page height before the two-column layout was calculated. 
Solution: The banners only apply to the active form configuration area. So it is better to move them into the active pane and keep them in the same scroll context as the content they affect, and leave the inactive attributes sidebar with its own independent scroll.