### PR TITLE
Bug/STC-747: Use semantic work package identifier in sharing email links

### DIFF
--- a/app/controllers/concerns/work_packages/with_split_view.rb
+++ b/app/controllers/concerns/work_packages/with_split_view.rb
@@ -35,9 +35,5 @@ module WorkPackages
     included do
       helper_method :split_view_base_route
     end
-
-    def split_view_work_package_id
-      params[:work_package_id].to_i
-    end
   end
 end

--- a/app/mailers/sharing_mailer.rb
+++ b/app/mailers/sharing_mailer.rb
@@ -40,8 +40,7 @@ class SharingMailer < ApplicationMailer
     @work_package = membership.entity
 
     role = membership.roles.first
-    @url = optionally_activated_url(work_package_url(@work_package.id), @invitation_token)
-    @notification_url = optionally_activated_url(details_notifications_url(@work_package.id, tab: :activity), @invitation_token)
+    @url = optionally_activated_url(work_package_url(@work_package), @invitation_token)
 
     set_open_project_headers(@work_package)
     message_id(membership, sharer)

--- a/app/views/mailer/_notification_row.html.erb
+++ b/app/views/mailer/_notification_row.html.erb
@@ -1,5 +1,5 @@
 <a style="text-decoration: none;display: block;"
-   href="<%= local_assigns[:notification_url] || details_notifications_url(work_package.id, tab: :activity) %>"
+   href="<%= local_assigns[:notification_url] || details_notifications_url(work_package, tab: :activity) %>"
    target="_blank">
   <%= render layout: "mailer/border_table" do %>
     <tr>
@@ -105,7 +105,7 @@
 </table>
 
 <a style="margin-left: 12px;"
-   href="<%= defined?(open_in_browser_path) ? open_in_browser_path : details_notifications_url(work_package.id, tab: :activity) %>"
+   href="<%= defined?(open_in_browser_path) ? open_in_browser_path : details_notifications_url(work_package, tab: :activity) %>"
    target="_blank"
    rel="noopener noreferrer">
   <%= I18n.t("mail.work_packages.open_in_browser") %>

--- a/app/views/sharing_mailer/shared_work_package.text.erb
+++ b/app/views/sharing_mailer/shared_work_package.text.erb
@@ -18,9 +18,9 @@
 %>
 <%= "-" * 100 %>
 
-<%= "=" * (("# " + @work_package.id.to_s + @work_package.subject).length + 4) %>
-= #<%= @work_package.id %> <%= @work_package.subject %> =
-<%= "=" * (("# " + @work_package.id.to_s + @work_package.subject).length + 4) %>
+<%= "=" * ("#{@work_package.formatted_id} #{@work_package.subject}".length + 4) %>
+= <%= @work_package.formatted_id %> <%= @work_package.subject %> =
+<%= "=" * ("#{@work_package.formatted_id} #{@work_package.subject}".length + 4) %>
 
 <%= I18n.t("mail.work_packages.reason.shared") %>:
 <%= t("mail.sharing.work_packages.allowed_actions_html", allowed_actions: @allowed_work_package_actions.to_sentence) %>

--- a/app/views/work_package_mailer/mentioned.html.erb
+++ b/app/views/work_package_mailer/mentioned.html.erb
@@ -11,7 +11,7 @@
       <%= render partial: "mailer/mailer_header",
                  locals: {
                    summary: I18n.t(:"mail.work_packages.mentioned_by", user: @journal.user),
-                   button_href: details_notifications_url(@work_package.id, tab: :activity),
+                   button_href: details_notifications_url(@work_package, tab: :activity),
                    button_text: I18n.t(:"mail.notification.see_in_center"),
                    user: @user
                  } %>

--- a/spec/mailers/sharing_mailer_spec.rb
+++ b/spec/mailers/sharing_mailer_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe SharingMailer do
         expect(mail.subject)
           .to eq(I18n.t("mail.sharing.work_packages.subject", id: "##{work_package.id}"))
       end
+
+      it "links to the work package by its numeric id" do
+        expect(mail.html_part.body.encoded).to include("/work_packages/#{work_package.id}")
+        expect(mail.text_part.body.encoded).to include("/work_packages/#{work_package.id}")
+      end
     end
 
     context "with semantic mode",
@@ -80,6 +85,19 @@ RSpec.describe SharingMailer do
       it "sets the subject with the semantic identifier without # prefix" do
         expect(mail.subject)
           .to eq(I18n.t("mail.sharing.work_packages.subject", id: "PROJ-42"))
+      end
+
+      it "links to the work package by its semantic identifier, not the numeric id" do
+        expect(mail.html_part.body.encoded).to include("/work_packages/PROJ-42")
+        expect(mail.html_part.body.encoded).not_to include("/work_packages/#{work_package.id}")
+
+        expect(mail.text_part.body.encoded).to include("/work_packages/PROJ-42")
+        expect(mail.text_part.body.encoded).not_to include("/work_packages/#{work_package.id}")
+      end
+
+      it "renders the text-part heading with the semantic identifier, not the numeric id" do
+        expect(mail.text_part.body.encoded).to include("= PROJ-42 #{work_package.subject} =")
+        expect(mail.text_part.body.encoded).not_to include("##{work_package.id}")
       end
     end
 

--- a/spec/mailers/work_package_mailer_spec.rb
+++ b/spec/mailers/work_package_mailer_spec.rb
@@ -150,18 +150,30 @@ RSpec.describe WorkPackageMailer do
         it "renders the hash-prefixed numeric id in the text body" do
           expect(mail.text_part.body.to_s).to include("##{referenced_wp.id}")
         end
+
+        it "links to the work package by its numeric id" do
+          expect(mail.html_part.body.to_s)
+            .to include("/notifications/details/#{parent_wp.id}/activity")
+        end
       end
 
       context "with semantic mode",
               with_settings: { work_packages_identifier: "semantic" } do
         before do
           referenced_wp.update_columns(identifier: "DEMO-1", sequence_number: 1)
+          parent_wp.update_columns(identifier: "DEMO-2", sequence_number: 2)
         end
 
         it "renders the bare semantic identifier in the text body" do
           body = mail.text_part.body.to_s
           expect(body).to include("DEMO-1")
           expect(body).not_to match(/##{referenced_wp.id}\b/)
+        end
+
+        it "links to the work package by its semantic identifier, not the numeric id" do
+          body = mail.html_part.body.to_s
+          expect(body).to include("/notifications/details/DEMO-2/activity")
+          expect(body).not_to include("/notifications/details/#{parent_wp.id}/activity")
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-747

# What are you trying to accomplish?

On an instance running semantic work package identifiers, sharing a work package sends an email whose "Open work package" button — and the link a recipient copies from it — points at the numeric URL (`/work_packages/9522`) instead of the semantic one (`/work_packages/NTS-1`).

## Screenshots

Same shared work package (`NTS-1`), rendered by the mailer preview with semantic identifiers enabled — before and after the fix:

<img width="920" height="820" alt="pr-stc747-before-numeric" src="https://github.com/user-attachments/assets/4b6eab0e-39e6-490b-b1c0-b7e870cdc75f" />


# What approach did you choose and why?

`WorkPackage#to_param` already returns the display id, so any URL helper handed the record produces a semantic URL on its own; only call sites that pass the raw id bypass it. The fix is simply to stop passing the raw id, and to let the plain-text heading reuse the shared identifier formatting rather than carrying its own.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
