### PR TITLE
Code Maintenance/STC-462: Resolve `#activity-<journal-sequence>` anchors on demand dropping eager journal lateral sequencing

### DIFF
--- a/app/components/work_packages/activities_tab/journals/item_component.html.erb
+++ b/app/components/work_packages/activities_tab/journals/item_component.html.erb
@@ -12,7 +12,6 @@
               padding: :condensed,
               "aria-label": I18n.t("activities.work_packages.activity_tab.commented"),
               data: {
-                "anchor-activity-id": journal.sequence_version,
                 "anchor-comment-id": journal.id
               },
               classes: container_classes

--- a/app/components/work_packages/activities_tab/journals/item_component/details.rb
+++ b/app/components/work_packages/activities_tab/journals/item_component/details.rb
@@ -69,7 +69,6 @@ module WorkPackages
             justify_content: :space_between,
             classes: "work-packages-activities-tab-journals-item-component-details--journal-details-header-container",
             data: {
-              "anchor-activity-id": journal.sequence_version,
               "anchor-comment-id": journal.id
             }
           ) do |header_container|

--- a/app/components/work_packages/activities_tab/lazy_index_component.rb
+++ b/app/components/work_packages/activities_tab/lazy_index_component.rb
@@ -37,7 +37,7 @@ module WorkPackages
       include WorkPackages::ActivitiesTab::SharedHelpers
       include WorkPackages::ActivitiesTab::StimulusControllers
 
-      def initialize(work_package:, journals:, paginator:, last_server_timestamp:, filter: :all)
+      def initialize(work_package:, journals:, paginator:, last_server_timestamp:, filter: :all, resolved_anchor: nil)
         super
 
         @work_package = work_package
@@ -45,6 +45,7 @@ module WorkPackages
         @paginator = paginator
         @last_server_timestamp = last_server_timestamp
         @filter = filter
+        @resolved_anchor = resolved_anchor
       end
 
       def self.wrapper_key = "work-package-activities-tab-content"
@@ -59,7 +60,7 @@ module WorkPackages
 
       private
 
-      attr_reader :work_package, :journals, :paginator, :filter, :last_server_timestamp
+      attr_reader :work_package, :journals, :paginator, :filter, :last_server_timestamp, :resolved_anchor
 
       def wrapper_data_attributes # rubocop:disable Metrics/AbcSize
         stimulus_controllers = {
@@ -83,6 +84,11 @@ module WorkPackages
           polling_stimulus_controller("-show-conflict-flash-message-url-value") => show_conflict_flash_message_work_packages_path,
           polling_stimulus_controller("-update-streams-path-value") => update_streams_work_package_activities_path(work_package)
         }
+        # Only a legacy activity-N deep link sets this; it tells the client which
+        # comment anchor the activity number resolved to so it can scroll there.
+        if resolved_anchor
+          stimulus_controller_values[auto_scrolling_stimulus_controller("-resolved-comment-id-value")] = resolved_anchor
+        end
         stimulus_controller_outlets = {
           editor_stimulus_controller("-#{auto_scrolling_stimulus_controller}-outlet") => index_component_dom_selector,
           editor_stimulus_controller("-#{polling_stimulus_controller}-outlet") => index_component_dom_selector,

--- a/app/controllers/work_packages/activities_tab_controller.rb
+++ b/app/controllers/work_packages/activities_tab_controller.rb
@@ -47,7 +47,8 @@ class WorkPackages::ActivitiesTabController < ApplicationController
         journals: @paginated_journals,
         paginator: @paginator,
         filter: @filter,
-        last_server_timestamp: get_current_server_timestamp
+        last_server_timestamp: get_current_server_timestamp,
+        resolved_anchor: @resolved_anchor
       ),
       layout: false
     )
@@ -208,8 +209,9 @@ class WorkPackages::ActivitiesTabController < ApplicationController
   end
 
   def initialize_pagination
-    @paginator, @paginated_journals = WorkPackages::ActivitiesTab::Paginator
-      .paginate(@work_package, params.merge(filter: @filter, limit: 20))
+    paginator = WorkPackages::ActivitiesTab::Paginator.new(@work_package, params.merge(filter: @filter, limit: 20))
+    @paginator, @paginated_journals = paginator.call
+    @resolved_anchor = paginator.resolved_anchor
   end
 
   def respond_with_error(error_message)
@@ -237,7 +239,6 @@ class WorkPackages::ActivitiesTabController < ApplicationController
     @journal = @work_package
       .journals
       .internal_visible
-      .with_sequence_version
       .find(params[:id])
   rescue ActiveRecord::RecordNotFound
     respond_with_error(I18n.t("label_not_found"))
@@ -317,7 +318,8 @@ class WorkPackages::ActivitiesTabController < ApplicationController
         journals: @paginated_journals,
         paginator: @paginator,
         filter: @filter,
-        last_server_timestamp: get_current_server_timestamp
+        last_server_timestamp: get_current_server_timestamp,
+        resolved_anchor: @resolved_anchor
       )
     )
   end
@@ -359,7 +361,6 @@ class WorkPackages::ActivitiesTabController < ApplicationController
     journals = @work_package
                  .journals
                  .internal_visible
-                 .with_sequence_version
 
     if @filter == :only_comments
       journals = journals.where.not(notes: "")
@@ -407,7 +408,7 @@ class WorkPackages::ActivitiesTabController < ApplicationController
         next if editing_journals.include?(notification.journal_id)
 
         update_item_show_component(
-          journal: journals.find(notification.journal_id), # take the journal from the journals querried with sequence_version!
+          journal: journals.find(notification.journal_id),
           grouped_emoji_reactions: grouped_emoji_reactions.fetch(notification.journal_id, {})
         )
       end

--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -37,8 +37,10 @@
 # - :only_changes - Shows only journals with detected changes using SQL heuristics
 #
 # Anchor format:
-# - "comment-{journal_id}" - Navigate to specific journal by ID
-# - "activity-{sequence_version}" - Navigate to journal by sequence version
+# - "comment-{journal_id}" - Navigate to a specific journal by id
+# - "activity-{sequence_version}" - Legacy alias resolved on demand to the
+#   journal's comment id; the sequence version is computed only for this lookup,
+#   never for the rendered page, so the default feed avoids the window function.
 #
 # Anchored navigation bypasses the active filter so a deep link to a record
 # that wouldn't match the filter still resolves.
@@ -64,12 +66,13 @@ class WorkPackages::ActivitiesTab::Paginator
     new(work_package, params).call
   end
 
-  attr_reader :work_package, :params, :filter
+  attr_reader :work_package, :params, :filter, :resolved_anchor
 
   def initialize(work_package, params = {})
     @work_package = work_package
     @params = params
     @filter = params[:filter]&.to_sym || :all
+    @resolved_anchor = nil
   end
 
   def call
@@ -160,6 +163,11 @@ class WorkPackages::ActivitiesTab::Paginator
     activity_at, anchor_id = locate_anchor(anchor_type, target_record_id)
     return nil unless activity_at && anchor_id
 
+    # A comment anchor already matches the DOM's data-anchor-comment-id. An
+    # activity anchor has no rendered counterpart, so hand the comment id it
+    # resolved to back to the client to scroll to instead.
+    @resolved_anchor = anchor_id if anchor_type.activity?
+
     rows_ahead = scope
       .where("(journals.created_at, journals.id) > (?, ?)", activity_at, anchor_id)
       .count(:all)
@@ -195,7 +203,6 @@ class WorkPackages::ActivitiesTab::Paginator
 
   def page_journals(page_relation)
     page_relation
-      .with_sequence_version
       .includes(:user, :customizable_journals, :attachable_journals, :storable_journals, :notifications, :attachments)
       .to_a
   end

--- a/app/services/work_packages/activities_tab/paginator.rb
+++ b/app/services/work_packages/activities_tab/paginator.rb
@@ -62,10 +62,6 @@ class WorkPackages::ActivitiesTab::Paginator
   include Pagy::Method
   include WorkPackages::ActivitiesTab::JournalSortingInquirable
 
-  def self.paginate(work_package, params = {})
-    new(work_package, params).call
-  end
-
   attr_reader :work_package, :params, :filter, :resolved_anchor
 
   def initialize(work_package, params = {})
@@ -163,16 +159,20 @@ class WorkPackages::ActivitiesTab::Paginator
     activity_at, anchor_id = locate_anchor(anchor_type, target_record_id)
     return nil unless activity_at && anchor_id
 
-    # A comment anchor already matches the DOM's data-anchor-comment-id. An
-    # activity anchor has no rendered counterpart, so hand the comment id it
-    # resolved to back to the client to scroll to instead.
-    @resolved_anchor = anchor_id if anchor_type.activity?
+    record_resolved_anchor(anchor_type, anchor_id)
 
     rows_ahead = scope
       .where("(journals.created_at, journals.id) > (?, ?)", activity_at, anchor_id)
       .count(:all)
 
     (rows_ahead / limit) + 1
+  end
+
+  # A comment anchor already matches the DOM's data-anchor-comment-id. An activity
+  # anchor has no rendered counterpart, so hand the comment id it resolved to back
+  # to the client to scroll to instead.
+  def record_resolved_anchor(anchor_type, anchor_id)
+    @resolved_anchor = anchor_id if anchor_type.activity?
   end
 
   def locate_anchor(anchor_type, target_record_id)
@@ -190,9 +190,9 @@ class WorkPackages::ActivitiesTab::Paginator
       .pick(:created_at, :id)
   end
 
-  # Eager-loads and the sequence version are applied to the page slice here, not
-  # to activities_scope, so the count query stays off them. Changeset journals
-  # map back to Changeset records; work package journals go through the wrapper.
+  # Eager-loads are applied to the page slice here, not to activities_scope, so
+  # the count query stays off them. Changeset journals map back to Changeset
+  # records; work package journals go through the wrapper.
   def load_activities(page_relation)
     journals = page_journals(page_relation)
     changesets = load_changesets(journals.select { changeset?(it) }.map(&:journable_id))

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/auto-scrolling.controller.ts
@@ -39,6 +39,13 @@ interface CustomEventWithIdParam extends Event {
 }
 
 export default class AutoScrollingController extends BaseController {
+  static values = {
+    resolvedCommentId: Number,
+  };
+
+  declare readonly resolvedCommentIdValue:number;
+  declare readonly hasResolvedCommentIdValue:boolean;
+
   connect() {
     super.connect();
 
@@ -116,16 +123,35 @@ export default class AutoScrollingController extends BaseController {
   }
 
   private handleInitialScroll() {
-    const hash = window.location.hash;
-    const anchorInfo = UrlHelpers.extractActivityAnchor(hash);
+    const anchorInfo = UrlHelpers.extractActivityAnchor(window.location.hash);
 
     if (anchorInfo) {
-      const activityElement = this.getActivityAnchorElement(anchorInfo);
-      this.brieflyHighlightAndResetUrl(activityElement, hash);
+      const anchor = this.canonicalizeActivityAnchor(anchorInfo);
+      // A still-legacy activity anchor is one the server could not resolve to a
+      // comment; no element carries it anymore, so there is nothing to scroll to.
+      if (anchor.type === ActivityAnchorType.Activity) { return; }
+
+      const activityElement = this.getActivityAnchorElement(anchor);
+      this.brieflyHighlightAndResetUrl(activityElement, window.location.hash);
       this.scrollToActivity(activityElement);
     } else if (this.indexOutlet.sortingAscending && (!this.isMobile() || this.isWithinNotificationCenter())) {
       this.scrollToBottom();
     }
+  }
+
+  private canonicalizeActivityAnchor(anchorInfo:ActivityAnchor):ActivityAnchor {
+    const resolvedCommentId = this.hasResolvedCommentIdValue ? this.resolvedCommentIdValue : null;
+    const canonical = UrlHelpers.canonicalActivityAnchor(anchorInfo, resolvedCommentId);
+
+    if (canonical.type !== anchorInfo.type || canonical.id !== anchorInfo.id) {
+      // Rewrite via the full href: a bare "#…" would resolve against the page's
+      // <base href> and drop the work package path.
+      const url = new URL(window.location.href);
+      url.hash = `${canonical.type}-${canonical.id}`;
+      window.history.replaceState(null, '', url);
+    }
+
+    return canonical;
   }
 
   private scrollToActivity(activityElement:HTMLElement|null) {

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/url-helpers.spec.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/url-helpers.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { UrlHelpers, ActivityAnchorType } from './url-helpers';
+
+describe('UrlHelpers', () => {
+  describe('extractActivityAnchor', () => {
+    it('parses a comment anchor', () => {
+      expect(UrlHelpers.extractActivityAnchor('#comment-80'))
+        .toEqual({ type: ActivityAnchorType.Comment, id: '80' });
+    });
+
+    it('parses an activity anchor', () => {
+      expect(UrlHelpers.extractActivityAnchor('#activity-45'))
+        .toEqual({ type: ActivityAnchorType.Activity, id: '45' });
+    });
+
+    it('returns null for an unrelated hash', () => {
+      expect(UrlHelpers.extractActivityAnchor('#section-3')).toBeNull();
+    });
+  });
+
+  describe('canonicalActivityAnchor', () => {
+    it('translates an activity anchor to the resolved comment anchor', () => {
+      const activity = { type: ActivityAnchorType.Activity, id: '5' };
+
+      expect(UrlHelpers.canonicalActivityAnchor(activity, 456))
+        .toEqual({ type: ActivityAnchorType.Comment, id: '456' });
+    });
+
+    it('leaves a comment anchor unchanged', () => {
+      const comment = { type: ActivityAnchorType.Comment, id: '456' };
+
+      expect(UrlHelpers.canonicalActivityAnchor(comment, 999)).toEqual(comment);
+    });
+
+    it('leaves an activity anchor unchanged when nothing was resolved', () => {
+      const activity = { type: ActivityAnchorType.Activity, id: '5' };
+
+      expect(UrlHelpers.canonicalActivityAnchor(activity, null)).toEqual(activity);
+      expect(UrlHelpers.canonicalActivityAnchor(activity, 0)).toEqual(activity);
+    });
+  });
+});

--- a/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/url-helpers.ts
+++ b/frontend/src/stimulus/controllers/dynamic/work-packages/activities-tab/services/url-helpers.ts
@@ -64,4 +64,23 @@ export namespace UrlHelpers {
     }
     return null;
   }
+
+  /**
+   * Translates a legacy `activity` anchor into its canonical `comment` anchor
+   * using the comment id the server resolved it to. Comment anchors, and activity
+   * anchors the server could not resolve, are returned unchanged.
+   *
+   * @example
+   * ```typescript
+   * canonicalActivityAnchor({ type: "activity", id: "5" }, 456);
+   * // Returns: { type: "comment", id: "456" }
+   * ```
+   */
+  export function canonicalActivityAnchor(anchor:ActivityAnchor, resolvedCommentId:number | null):ActivityAnchor {
+    if (anchor.type !== ActivityAnchorType.Activity || !resolvedCommentId) {
+      return anchor;
+    }
+
+    return { type: ActivityAnchorType.Comment, id: String(resolvedCommentId) };
+  }
 }

--- a/spec/features/activities/work_package/activities_spec.rb
+++ b/spec/features/activities/work_package/activities_spec.rb
@@ -1073,6 +1073,15 @@ RSpec.describe "Work package activity", :js, :with_cuprite, with_ee: %i[internal
             page.find(:xpath, "//*[text()='created this on']").click
             expect(page).to have_no_css(".--anchor-highlighted")
           end
+
+          it "rewrites the legacy activity anchor to the resolved comment in the URL" do
+            wait_for_auto_scrolling_to_finish
+
+            initial_journal = work_package.journals.order(:version).first
+            expect(page.evaluate_script("window.location.hash")).to eq("#comment-#{initial_journal.id}")
+            # The rewrite must keep the work package path, not collapse it to "/".
+            expect(page.evaluate_script("window.location.pathname")).to include("/work_packages/#{work_package.id}")
+          end
         end
 
         context "with #comment- anchor" do

--- a/spec/requests/work_packages/activities_tab_spec.rb
+++ b/spec/requests/work_packages/activities_tab_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "Work package activities tab",
+               :aggregate_failures,
+               type: :rails_request,
+               with_settings: { journal_aggregation_time_minutes: 0 } do
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project) }
+  shared_let(:work_package) { create(:work_package, project:, author: user) }
+
+  # Created per-example so the no-aggregation setting applies; under shared_let it
+  # would be built in before_all at default settings and merged into the initial journal.
+  let!(:comment) do
+    create(:work_package_journal, user:, notes: "A comment", journable: work_package, version: 2)
+  end
+
+  # The data attribute the client reads to scroll a resolved activity anchor.
+  let(:resolved_value_attribute) { "work-packages--activities-tab--auto-scrolling-resolved-comment-id-value" }
+
+  before { login_as(user) }
+
+  # The frontend converts the legacy #activity-N URL fragment into an ?anchor=
+  # query param before requesting the tab, so the anchor arrives as a query param.
+  describe "GET index" do
+    it "exposes the resolved comment id for a legacy activity anchor" do
+      # activity-2 is the journal with sequence_version 2, i.e. the comment
+      get work_package_activities_path(work_package), params: { anchor: "activity-2" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(#{resolved_value_attribute}="#{comment.id}"))
+    end
+
+    it "omits the resolved-comment value without an activity anchor" do
+      get work_package_activities_path(work_package)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(resolved_value_attribute)
+    end
+
+    it "omits the resolved-comment value for a comment anchor" do
+      get work_package_activities_path(work_package), params: { anchor: "comment-#{comment.id}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(resolved_value_attribute)
+    end
+  end
+end

--- a/spec/requests/work_packages/activities_tab_spec.rb
+++ b/spec/requests/work_packages/activities_tab_spec.rb
@@ -73,5 +73,12 @@ RSpec.describe "Work package activities tab",
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include(resolved_value_attribute)
     end
+
+    it "omits the resolved-comment value for an unresolvable activity anchor" do
+      get work_package_activities_path(work_package), params: { anchor: "activity-999999" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include(resolved_value_attribute)
+    end
   end
 end

--- a/spec/services/work_packages/activities_tab/paginator_spec.rb
+++ b/spec/services/work_packages/activities_tab/paginator_spec.rb
@@ -208,26 +208,34 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
             expect(pagy.page).to eq(2)
             expect(records.map(&:id)).to include(journal_1.id)
           end
+
+          it "leaves resolved_anchor nil for comment anchors" do
+            params[:anchor] = "comment-#{journal_1.id}"
+            paginator.call
+
+            expect(paginator.resolved_anchor).to be_nil
+          end
         end
 
         context "with activity anchor" do
-          it "returns the page containing the target activity by sequence_version" do
+          it "returns the page containing the target activity and resolves it to the comment id" do
             params[:anchor] = "activity-2"
             pagy, records = paginator.call
 
-            # activity-2 corresponds to journal with sequence_version 2
-            # which should be journal_1
+            # activity-2 is the journal with sequence_version 2, i.e. journal_1
             expect(pagy.page).to eq(2)
-            wrapped_journal = records.find { it.is_a?(API::V3::Activities::ActivityEagerLoadingWrapper) && it.id == journal_1.id }
-            expect(wrapped_journal.sequence_version).to eq(2)
+            expect(records.map(&:id)).to include(journal_1.id)
+            expect(paginator.resolved_anchor).to eq(journal_1.id)
           end
 
-          it "handles activity anchor for initial journal" do
+          it "handles an activity anchor for the initial journal" do
             params[:anchor] = "activity-1"
             _pagy, records = paginator.call
 
-            # activity-1 should be on the last page (oldest)
-            expect(records.any? { it.respond_to?(:sequence_version) && it.sequence_version == 1 }).to be(true)
+            # activity-1 is the oldest journal, on the last page
+            initial_journal = work_package.journals.order(:version).first
+            expect(records.map(&:id)).to include(initial_journal.id)
+            expect(paginator.resolved_anchor).to eq(initial_journal.id)
           end
         end
       end
@@ -267,6 +275,24 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
         expect(recorder.count).to be < 20,
                                   "expected query count bounded regardless of history; got #{recorder.count}:\n" \
                                   "#{recorder.log.join("\n")}"
+      end
+
+      it "skips the sequence-version window function on the default render path" do
+        recorder = ActiveRecord::QueryRecorder.new do
+          described_class.new(work_package, params).call
+        end
+
+        expect(recorder.log.join("\n")).not_to match(/ROW_NUMBER|JOIN LATERAL/i),
+                                               "expected no window function without an activity anchor:\n" \
+                                               "#{recorder.log.join("\n")}"
+      end
+
+      it "computes the sequence version only when resolving an activity anchor" do
+        recorder = ActiveRecord::QueryRecorder.new do
+          described_class.new(work_package, params.merge(anchor: "activity-2")).call
+        end
+
+        expect(recorder.log.join("\n")).to match(/ROW_NUMBER|JOIN LATERAL/i)
       end
     end
 
@@ -402,11 +428,12 @@ RSpec.describe WorkPackages::ActivitiesTab::Paginator, with_settings: { journal_
           expect(pagy.page).to eq(1)
         end
 
-        it "falls back to page 1 when anchoring to an internal journal by sequence_version" do
-          params[:anchor] = "activity-#{internal_sequence_version}"
-          pagy, _records = described_class.new(work_package, params).call
+        it "falls back to page 1 and resolves no anchor for an internal journal by sequence_version" do
+          paginator = described_class.new(work_package, params.merge(anchor: "activity-#{internal_sequence_version}"))
+          pagy, _records = paginator.call
 
           expect(pagy.page).to eq(1)
+          expect(paginator.resolved_anchor).to be_nil
         end
       end
     end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-462

This builds on:
* #17721
*  #23434 

# What are you trying to accomplish?

Removes a `ROW_NUMBER() OVER (...) JOIN LATERAL` window function aka `.with_sequence_version` (~130ms/page on long histories) from the activity-tab's common render path. The legacy `#activity-N` anchor is now treated as a backwards-compatible alias and resolved lazily: when such a deep link arrives, the server resolves it to a journal id once, emits it as a resolved-comment-id Stimulus value, and the client canonicalises #activity-N → #comment-<id> in the address bar.


On a work package with 702 journals, the page-slice query goes from ~130ms to a few ms:

```sql
--- Before — on every render:
  Journal Load (130.5ms)  SELECT * FROM journals
    JOIN LATERAL (
      SELECT journals_rank.id,
             ROW_NUMBER() OVER (ORDER BY version ASC) sequence_version
      FROM journals journals_rank
      WHERE journals_rank.journable_id   = journals.journable_id
        AND journals_rank.journable_type = journals.journable_type
    ) ranked ON ranked.id = journals.id
    WHERE … ORDER BY journals.created_at DESC, journals.id DESC LIMIT 20

--- After — same render, no window function:
  Journal Load (3.0ms)  SELECT journals.id, journals.journable_id, … FROM journals
    WHERE … ORDER BY journals.created_at DESC, journals.id DESC LIMIT 20
```

https://github.com/user-attachments/assets/2a4a4a70-ef64-485c-8bad-c0af77d4789e

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
