### PR TITLE
fix: Render a proper error when releasing a 404d project identifier

### DIFF
--- a/app/controllers/admin/settings/project_reserved_identifiers_controller.rb
+++ b/app/controllers/admin/settings/project_reserved_identifiers_controller.rb
@@ -73,7 +73,10 @@ module Admin::Settings
     def find_slug
       @slug = Project.identifier_slugs.historically_reserved.find(params.expect(:id))
     rescue ActiveRecord::RecordNotFound
-      render_404
+      render_error_flash_message_via_turbo_stream(
+        message: t("admin.reserved_identifiers.identifier_not_found")
+      )
+      respond_with_turbo_streams(status: :not_found)
     end
 
     def build_query

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
       filter_label: "Filter identifiers"
       btn_release: "Release"
       released_notice: "Identifier \"%{identifier}\" has been released."
+      identifier_not_found: "The reserved identifier could not be found. It may have already been released or the project may have been deleted. Please refresh the page."
       dialog:
         title: "Release identifier"
         heading: "Release \"%{identifier}\"?"

--- a/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
+++ b/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
@@ -117,9 +117,11 @@ RSpec.describe Admin::Settings::ProjectReservedIdentifiersController do
       end
 
       context "with an unknown id" do
-        it "renders 404" do
+        it "responds with a turbo stream error flash" do
           get :confirm_dialog, params: { id: 0 }, format: :turbo_stream
           expect(response).to have_http_status(:not_found)
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(response.body).to include(I18n.t("admin.reserved_identifiers.identifier_not_found"))
         end
       end
     end
@@ -127,9 +129,11 @@ RSpec.describe Admin::Settings::ProjectReservedIdentifiersController do
     context "when the slug is the project's own current active identifier" do
       let!(:slug) { project.slugs.find_by!(slug: "current-id") }
 
-      it "renders 404 because the slug is not historically reserved" do
+      it "responds with a turbo stream error flash because the slug is not historically reserved" do
         get :confirm_dialog, params: { id: slug.id }, format: :turbo_stream
         expect(response).to have_http_status(:not_found)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(response.body).to include(I18n.t("admin.reserved_identifiers.identifier_not_found"))
       end
     end
   end
@@ -147,9 +151,11 @@ RSpec.describe Admin::Settings::ProjectReservedIdentifiersController do
     end
 
     context "with an unknown id" do
-      it "renders 404" do
-        delete :destroy, params: { id: 0 }
+      it "responds with a turbo stream error flash" do
+        delete :destroy, params: { id: 0 }, format: :turbo_stream
         expect(response).to have_http_status(:not_found)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(response.body).to include(I18n.t("admin.reserved_identifiers.identifier_not_found"))
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-798/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Properly handle releasing identifiers of deleted projects.

## Screenshots
<img width="1335" height="389" alt="Screenshot 2026-06-02 at 12 11 52" src="https://github.com/user-attachments/assets/a217c437-da15-4bb0-9359-ad74846844cc" />


# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
