### PR TITLE
DRY up Stimulus specs

### DIFF
--- a/frontend/src/stimulus/controllers/check-all.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/check-all.controller.spec.ts
@@ -62,8 +62,7 @@ describe('CheckAllController', () => {
 
   describe('without checkable controller', () => {
     beforeEach(async () => {
-      ctx.appendHTML(checkAllTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(checkAllTemplate);
     });
 
     it('does nothing and does not error', () => {
@@ -76,9 +75,10 @@ describe('CheckAllController', () => {
 
   describe('with checkable controller', () => {
     beforeEach(async () => {
-      ctx.appendHTML(checkableTemplate);
-      ctx.appendHTML(checkAllTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(`
+        ${checkableTemplate}
+        ${checkAllTemplate}
+      `);
     });
 
     it('toggles checkboxes', async () => {

--- a/frontend/src/stimulus/controllers/disable-when-checked.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/disable-when-checked.controller.spec.ts
@@ -44,7 +44,7 @@ describe('OpDisableWhenCheckedController', () => {
 
   describe('basic disable on check', () => {
     beforeEach(async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="disable-when-checked">
           <label>
             <input type="checkbox"
@@ -58,7 +58,6 @@ describe('OpDisableWhenCheckedController', () => {
                  aria-label="Text field">
         </div>
       `);
-      await ctx.nextFrame();
     });
 
     it('disables effect targets when cause is checked', async () => {
@@ -91,7 +90,7 @@ describe('OpDisableWhenCheckedController', () => {
 
   describe('reversed mode', () => {
     beforeEach(async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="disable-when-checked"
              data-disable-when-checked-reversed-value="true">
           <label>
@@ -106,7 +105,6 @@ describe('OpDisableWhenCheckedController', () => {
                  aria-label="Text field">
         </div>
       `);
-      await ctx.nextFrame();
     });
 
     it('enables effect targets when cause is checked', async () => {
@@ -122,7 +120,7 @@ describe('OpDisableWhenCheckedController', () => {
 
   describe('select option handling', () => {
     it('resets select value when selected option becomes disabled', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="disable-when-checked">
           <label>
             <input type="checkbox"
@@ -140,7 +138,6 @@ describe('OpDisableWhenCheckedController', () => {
           </select>
         </div>
       `);
-      await ctx.nextFrame();
 
       const select = ctx.container.querySelector<HTMLSelectElement>('select[aria-label="Options"]')!;
 

--- a/frontend/src/stimulus/controllers/disable-when-clicked.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/disable-when-clicked.controller.spec.ts
@@ -43,12 +43,11 @@ describe('DisableWhenClickedController', () => {
   afterEach(() => ctx.dispose());
 
   it('disables button after click', async () => {
-    ctx.appendHTML(`
+    await ctx.mount(`
       <button data-controller="disable-when-clicked">
         Submit
       </button>
     `);
-    await ctx.nextFrame();
 
     const button = ctx.screen.getByRole('button', { name: 'Submit' });
 
@@ -60,13 +59,12 @@ describe('DisableWhenClickedController', () => {
   });
 
   it('replaces button text when text value is set', async () => {
-    ctx.appendHTML(`
+    await ctx.mount(`
       <button data-controller="disable-when-clicked"
               data-disable-when-clicked-text-value="Processing...">
         Submit
       </button>
     `);
-    await ctx.nextFrame();
 
     const button = ctx.screen.getByRole('button', { name: 'Submit' });
 

--- a/frontend/src/stimulus/controllers/flash.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/flash.controller.spec.ts
@@ -45,14 +45,13 @@ describe('FlashController', () => {
 
   describe('without autohide', () => {
     it('keeps flash items visible', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="flash">
           <div data-flash-target="item" data-autohide="true" role="alert">
             Success message
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       expect(ctx.screen.getByRole('alert')).toBeInTheDocument();
     });
@@ -62,14 +61,13 @@ describe('FlashController', () => {
     it('schedules removal of autohide items', async () => {
       const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
 
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="flash" data-flash-autohide-value="true">
           <div data-flash-target="item" data-autohide="true" role="alert">
             Success message
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       const autohideCall = timeoutSpy.mock.calls.find(([, delay]) => delay === SUCCESS_AUTOHIDE_TIMEOUT);
 
@@ -81,14 +79,13 @@ describe('FlashController', () => {
     it('does not schedule removal for items without data-autohide', async () => {
       const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
 
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="flash" data-flash-autohide-value="true">
           <div data-flash-target="item" role="alert">
             Error message
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       const autohideCall = timeoutSpy.mock.calls.find(([, delay]) => delay === SUCCESS_AUTOHIDE_TIMEOUT);
 
@@ -100,13 +97,12 @@ describe('FlashController', () => {
 
   describe('flashTargetDisconnected', () => {
     it('removes empty item containers when flash target is removed', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="flash">
           <div data-flash-target="item" data-testid="item-container"></div>
           <div data-flash-target="flash" data-testid="flash-content">Content</div>
         </div>
       `);
-      await ctx.nextFrame();
 
       ctx.screen.getByTestId('flash-content').remove();
       await ctx.nextFrame();

--- a/frontend/src/stimulus/controllers/scroll-into-view.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/scroll-into-view.controller.spec.ts
@@ -46,13 +46,12 @@ describe('ScrollIntoViewController', () => {
   it('calls scrollIntoView on connect', async () => {
     const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView');
 
-    ctx.appendHTML(`
+    await ctx.mount(`
       <div data-controller="scroll-into-view">
         Target element
       </div>
     `);
-    // Two frames: one for Stimulus connect, one for the setTimeout(fn, 0)
-    await ctx.nextFrame();
+    // One extra frame for the setTimeout(fn, 0)
     await ctx.nextFrame();
 
     expect(scrollSpy).toHaveBeenCalledWith({ block: 'center' });

--- a/frontend/src/stimulus/controllers/select-autosize.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/select-autosize.controller.spec.ts
@@ -45,14 +45,13 @@ describe('SelectAutosizeController', () => {
 
   // updateSize is debounced (100ms), so assertions use waitFor
   it('sets size to option count on connect', async () => {
-    ctx.appendHTML(`
+    await ctx.mount(`
       <select data-controller="select-autosize" aria-label="Items">
         <option>A</option>
         <option>B</option>
         <option>C</option>
       </select>
     `);
-    await ctx.nextFrame();
 
     const select = ctx.container.querySelector('select')!;
 
@@ -64,14 +63,13 @@ describe('SelectAutosizeController', () => {
   it('respects size limit', async () => {
     const options = Array.from({ length: 15 }, (_, i) => `<option>Item ${i}</option>`).join('');
 
-    ctx.appendHTML(`
+    await ctx.mount(`
       <select data-controller="select-autosize"
               data-select-autosize-size-limit-value="5"
               aria-label="Items">
         ${options}
       </select>
     `);
-    await ctx.nextFrame();
 
     const select = ctx.container.querySelector('select')!;
 
@@ -83,12 +81,11 @@ describe('SelectAutosizeController', () => {
   it('defaults size limit to 10', async () => {
     const options = Array.from({ length: 20 }, (_, i) => `<option>Item ${i}</option>`).join('');
 
-    ctx.appendHTML(`
+    await ctx.mount(`
       <select data-controller="select-autosize" aria-label="Items">
         ${options}
       </select>
     `);
-    await ctx.nextFrame();
 
     const select = ctx.container.querySelector('select')!;
 

--- a/frontend/src/stimulus/controllers/show-when-checked.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/show-when-checked.controller.spec.ts
@@ -44,7 +44,7 @@ describe('OpShowWhenCheckedController', () => {
 
   describe('show-when="checked"', () => {
     beforeEach(async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-checked">
           <label>
             <input type="checkbox"
@@ -61,7 +61,6 @@ describe('OpShowWhenCheckedController', () => {
           </div>
         </div>
       `);
-      await ctx.nextFrame();
     });
 
     it('shows element when checkbox is checked', async () => {
@@ -91,7 +90,7 @@ describe('OpShowWhenCheckedController', () => {
 
   describe('show-when="unchecked"', () => {
     it('hides element when checkbox is checked, shows when unchecked', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-checked">
           <label>
             <input type="checkbox"
@@ -108,7 +107,6 @@ describe('OpShowWhenCheckedController', () => {
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       const checkbox = ctx.screen.getByRole('checkbox', { name: 'Toggle' });
       const el = ctx.screen.getByTestId('conditional');
@@ -129,7 +127,7 @@ describe('OpShowWhenCheckedController', () => {
 
   describe('reversed mode', () => {
     it('inverts the checked/unchecked logic', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-checked"
              data-show-when-checked-reversed-value="true">
           <label>
@@ -146,7 +144,6 @@ describe('OpShowWhenCheckedController', () => {
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       const el = ctx.screen.getByTestId('conditional');
 
@@ -159,7 +156,7 @@ describe('OpShowWhenCheckedController', () => {
 
   describe('visibility toggle via data-set-visibility', () => {
     it('uses CSS visibility instead of hidden attribute', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-checked">
           <label>
             <input type="checkbox"
@@ -177,7 +174,6 @@ describe('OpShowWhenCheckedController', () => {
           </div>
         </div>
       `);
-      await ctx.nextFrame();
 
       const el = ctx.screen.getByTestId('conditional');
 

--- a/frontend/src/stimulus/controllers/show-when-value-selected.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/show-when-value-selected.controller.spec.ts
@@ -44,7 +44,7 @@ describe('OpShowWhenValueSelectedController', () => {
 
   describe('data-value matching', () => {
     beforeEach(async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-value-selected">
           <select data-show-when-value-selected-target="cause"
                   data-target-name="type"
@@ -69,7 +69,6 @@ describe('OpShowWhenValueSelectedController', () => {
                  aria-label="Effect B">
         </div>
       `);
-      await ctx.nextFrame();
     });
 
     it('shows matching effect and hides non-matching', async () => {
@@ -119,7 +118,7 @@ describe('OpShowWhenValueSelectedController', () => {
 
   describe('data-not-value matching', () => {
     it('hides effect when select matches not-value', async () => {
-      ctx.appendHTML(`
+      await ctx.mount(`
         <div data-controller="show-when-value-selected">
           <select data-show-when-value-selected-target="cause"
                   data-target-name="mode"
@@ -136,7 +135,6 @@ describe('OpShowWhenValueSelectedController', () => {
                  aria-label="Advanced options">
         </div>
       `);
-      await ctx.nextFrame();
 
       const select = ctx.container.querySelector<HTMLSelectElement>('select[aria-label="Mode"]')!;
       const effect = ctx.container.querySelector<HTMLInputElement>('input[aria-label="Advanced options"]')!;

--- a/frontend/src/stimulus/controllers/table-highlighting.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/table-highlighting.controller.spec.ts
@@ -63,8 +63,7 @@ describe('TableHighlightingController', () => {
       controllers: { 'table-highlighting': TableHighlightingController },
     });
 
-    ctx.appendHTML(tableTemplate);
-    await ctx.nextFrame();
+    await ctx.mount(tableTemplate);
   });
 
   afterEach(() => ctx.dispose());
@@ -101,13 +100,12 @@ describe('TableHighlightingController', () => {
   });
 
   it('does not error on tables without colgroup', async () => {
-    ctx.appendHTML(`
+    await ctx.mount(`
       <table data-controller="table-highlighting">
         <thead><tr><th>Col</th></tr></thead>
         <tbody><tr><td>Val</td></tr></tbody>
       </table>
     `);
-    await ctx.nextFrame();
 
     expect(() => {
       ctx.screen.getAllByRole('columnheader').at(-1)!

--- a/frontend/src/stimulus/controllers/truncation.controller.spec.ts
+++ b/frontend/src/stimulus/controllers/truncation.controller.spec.ts
@@ -81,8 +81,7 @@ describe('TruncationController', () => {
 
   describe('initialization', () => {
     beforeEach(async () => {
-      ctx.appendHTML(truncationTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(truncationTemplate);
     });
 
     it('connects successfully', () => {
@@ -113,8 +112,7 @@ describe('TruncationController', () => {
 
   describe('expander button click', () => {
     beforeEach(async () => {
-      ctx.appendHTML(truncationTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(truncationTemplate);
     });
 
     it('toggles expanded state', async () => {
@@ -142,8 +140,7 @@ describe('TruncationController', () => {
 
   describe('expandedValue changes', () => {
     beforeEach(async () => {
-      ctx.appendHTML(truncationTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(truncationTemplate);
     });
 
     it('updates aria-label when expanded', async () => {
@@ -209,8 +206,8 @@ describe('TruncationController', () => {
         </div>
       `;
 
-      ctx.appendHTML(shortTextTemplate);
-      await waitForResize();
+      await ctx.mount(shortTextTemplate);
+      await ctx.nextFrame();
 
       const expander = ctx.container.querySelector<HTMLElement>('[data-truncation-target="expander"]')!;
 
@@ -247,8 +244,7 @@ describe('TruncationController', () => {
 
   describe('resize() method', () => {
     it('updates expander visibility when content dimensions change', async () => {
-      ctx.appendHTML(truncationTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(truncationTemplate);
 
       const controller = ctx.getController<TruncationController>('truncation');
       const expander = ctx.container.querySelector<HTMLElement>('[data-truncation-target="expander"]')!;
@@ -284,8 +280,7 @@ describe('TruncationController', () => {
     });
 
     it('keeps expander visible when expanded even if not truncated', async () => {
-      ctx.appendHTML(truncationTemplate);
-      await ctx.nextFrame();
+      await ctx.mount(truncationTemplate);
 
       const controller = ctx.getController<TruncationController>('truncation');
       const expander = ctx.container.querySelector<HTMLElement>('[data-truncation-target="expander"]')!;

--- a/frontend/src/stimulus/test-helpers.ts
+++ b/frontend/src/stimulus/test-helpers.ts
@@ -37,6 +37,7 @@ export interface StimulusTestContext {
   container:HTMLElement;
   screen:BoundFunctions<typeof queries>;
   appendHTML(html:string):void;
+  mount(html:string):Promise<void>;
   getController<T extends Controller>(identifier:string, element?:Element):T;
   nextFrame():Promise<void>;
   dispose():void;
@@ -72,6 +73,11 @@ export async function setupStimulusTest(options:SetupOptions):Promise<StimulusTe
       const template = document.createElement('template');
       template.innerHTML = html.trim();
       container.appendChild(template.content.cloneNode(true));
+    },
+
+    async mount(html:string) {
+      this.appendHTML(html);
+      await this.nextFrame();
     },
 
     getController<T extends Controller>(identifier:string, element?:Element):T {


### PR DESCRIPTION
# Ticket

relates to https://community.openproject.org/wp/75300

# What are you trying to accomplish?

Small follow up for #23329

Adds a shared mount helper to the Stimulus test context for the common append-and-wait setup pattern. Uses it across the controller specs introduced with the shared Stimulus test helper infrastructure.

# Merge checklist

- [X] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
