### PR TITLE
Pluck matcher

### DIFF
--- a/modules/backlogs/spec/models/work_packages/position_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/position_spec.rb
@@ -66,29 +66,34 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   let!(:bucket2_wp2) { create_work_package(subject: "Bucket 2 WorkPackage 2", backlog_bucket: bucket2) }
   let!(:bucket2_wp3) { create_work_package(subject: "Bucket 2 WorkPackage 3", backlog_bucket: bucket2) }
 
-  def wp_of_sprint_by_id_and_position(sprint)
-    WorkPackage.where(sprint:).pluck(:id, :position).to_h
+  def sprint_wps(sprint)
+    WorkPackage.where(sprint:)
   end
 
-  def wp_of_inbox_by_id_and_position
-    WorkPackage.where(sprint: nil, backlog_bucket: nil).pluck(:id, :position).to_h
+  def bucket_wps(bucket)
+    WorkPackage.where(backlog_bucket: bucket)
   end
 
-  def wp_of_bucket_by_id_and_position(bucket)
-    WorkPackage.where(backlog_bucket: bucket).pluck(:id, :position).to_h
+  def inbox_wps
+    WorkPackage.where(sprint: nil, backlog_bucket: nil)
+  end
+
+  def have_positions(**) # rubocop:disable Naming/PredicatePrefix
+    have_attr(:position, identified_by: :subject, **)
   end
 
   context "when creating a work_package in a sprint" do
     it "puts them in order" do
       new_work_package = create_work_package(subject: "Newest WorkPackage", sprint: sprint1)
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp2.id => 2,
-               sprint1_wp3.id => 3,
-               sprint1_wp4.id => 4,
-               sprint1_wp5.id => 5,
-               new_work_package.id => 6)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp2 => 2,
+        sprint1_wp3 => 3,
+        sprint1_wp4 => 4,
+        sprint1_wp5 => 5,
+        new_work_package => 6
+      )
     end
   end
 
@@ -96,11 +101,12 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "puts them in order" do
       new_work_package = create_work_package(subject: "Newest WorkPackage")
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp1.id => 1,
-               inbox_wp2.id => 2,
-               inbox_wp3.id => 3,
-               new_work_package.id => 4)
+      expect(inbox_wps).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp2 => 2,
+        inbox_wp3 => 3,
+        new_work_package => 4
+      )
     end
   end
 
@@ -108,13 +114,14 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "puts them in order" do
       new_work_package = create_work_package(subject: "Newest WorkPackage", backlog_bucket: bucket1)
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp2.id => 2,
-               bucket1_wp3.id => 3,
-               bucket1_wp4.id => 4,
-               bucket1_wp5.id => 5,
-               new_work_package.id => 6)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp3 => 3,
+        bucket1_wp4 => 4,
+        bucket1_wp5 => 5,
+        new_work_package => 6
+      )
     end
   end
 
@@ -123,17 +130,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       sprint1_wp2.sprint = sprint2
       sprint1_wp2.save!
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp3.id => 2,
-               sprint1_wp4.id => 3,
-               sprint1_wp5.id => 4)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp3 => 2,
+        sprint1_wp4 => 3,
+        sprint1_wp5 => 4
+      )
 
-      expect(wp_of_sprint_by_id_and_position(sprint2))
-        .to eq(sprint2_wp1.id => 1,
-               sprint2_wp2.id => 2,
-               sprint2_wp3.id => 3,
-               sprint1_wp2.id => 4)
+      expect(sprint_wps(sprint2)).to have_positions(
+        sprint2_wp1 => 1,
+        sprint2_wp2 => 2,
+        sprint2_wp3 => 3,
+        sprint1_wp2 => 4
+      )
     end
   end
 
@@ -142,17 +151,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       sprint1_wp2.sprint = nil
       sprint1_wp2.save!
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp3.id => 2,
-               sprint1_wp4.id => 3,
-               sprint1_wp5.id => 4)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp3 => 2,
+        sprint1_wp4 => 3,
+        sprint1_wp5 => 4
+      )
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp1.id => 1,
-               inbox_wp2.id => 2,
-               inbox_wp3.id => 3,
-               sprint1_wp2.id => 4)
+      expect(inbox_wps).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp2 => 2,
+        inbox_wp3 => 3,
+        sprint1_wp2 => 4
+      )
     end
   end
 
@@ -161,17 +172,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       inbox_wp2.sprint = sprint1
       inbox_wp2.save!
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp1.id => 1,
-               inbox_wp3.id => 2)
+      expect(inbox_wps).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp3 => 2
+      )
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp2.id => 2,
-               sprint1_wp3.id => 3,
-               sprint1_wp4.id => 4,
-               sprint1_wp5.id => 5,
-               inbox_wp2.id => 6)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp2 => 2,
+        sprint1_wp3 => 3,
+        sprint1_wp4 => 4,
+        sprint1_wp5 => 5,
+        inbox_wp2 => 6
+      )
     end
   end
 
@@ -179,11 +192,12 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "reorders the existing work_packages" do
       sprint1_wp3.destroy!
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp2.id => 2,
-               sprint1_wp4.id => 3,
-               sprint1_wp5.id => 4)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp2 => 2,
+        sprint1_wp4 => 3,
+        sprint1_wp5 => 4
+      )
     end
   end
 
@@ -191,9 +205,10 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "reorders the existing work_packages" do
       inbox_wp1.destroy!
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp2.id => 1,
-               inbox_wp3.id => 2)
+      expect(inbox_wps).to have_positions(
+        inbox_wp2 => 1,
+        inbox_wp3 => 2
+      )
     end
   end
 
@@ -202,17 +217,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       bucket1_wp2.backlog_bucket = bucket2
       bucket1_wp2.save!
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp3.id => 2,
-               bucket1_wp4.id => 3,
-               bucket1_wp5.id => 4)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp3 => 2,
+        bucket1_wp4 => 3,
+        bucket1_wp5 => 4
+      )
 
-      expect(wp_of_bucket_by_id_and_position(bucket2))
-        .to eq(bucket2_wp1.id => 1,
-               bucket2_wp2.id => 2,
-               bucket2_wp3.id => 3,
-               bucket1_wp2.id => 4)
+      expect(bucket_wps(bucket2)).to have_positions(
+        bucket2_wp1 => 1,
+        bucket2_wp2 => 2,
+        bucket2_wp3 => 3,
+        bucket1_wp2 => 4
+      )
     end
   end
 
@@ -221,17 +238,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       bucket1_wp2.backlog_bucket = nil
       bucket1_wp2.save!
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp3.id => 2,
-               bucket1_wp4.id => 3,
-               bucket1_wp5.id => 4)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp3 => 2,
+        bucket1_wp4 => 3,
+        bucket1_wp5 => 4
+      )
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp1.id => 1,
-               inbox_wp2.id => 2,
-               inbox_wp3.id => 3,
-               bucket1_wp2.id => 4)
+      expect(inbox_wps).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp2 => 2,
+        inbox_wp3 => 3,
+        bucket1_wp2 => 4
+      )
     end
   end
 
@@ -240,17 +259,19 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       inbox_wp2.backlog_bucket = bucket1
       inbox_wp2.save!
 
-      expect(wp_of_inbox_by_id_and_position)
-        .to eq(inbox_wp1.id => 1,
-               inbox_wp3.id => 2)
+      expect(inbox_wps).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp3 => 2
+      )
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp2.id => 2,
-               bucket1_wp3.id => 3,
-               bucket1_wp4.id => 4,
-               bucket1_wp5.id => 5,
-               inbox_wp2.id => 6)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp3 => 3,
+        bucket1_wp4 => 4,
+        bucket1_wp5 => 5,
+        inbox_wp2 => 6
+      )
     end
   end
 
@@ -258,11 +279,12 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "reorders the existing work_packages" do
       bucket1_wp3.destroy!
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp2.id => 2,
-               bucket1_wp4.id => 3,
-               bucket1_wp5.id => 4)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp4 => 3,
+        bucket1_wp5 => 4
+      )
     end
   end
 
@@ -272,19 +294,21 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       sprint1_wp4.sprint = nil
       sprint1_wp4.save!
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp2.id => 2,
-               sprint1_wp3.id => 3,
-               sprint1_wp5.id => 4)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp2 => 2,
+        sprint1_wp3 => 3,
+        sprint1_wp5 => 4
+      )
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp2.id => 2,
-               bucket1_wp3.id => 3,
-               bucket1_wp4.id => 4,
-               bucket1_wp5.id => 5,
-               sprint1_wp4.id => 6)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp3 => 3,
+        bucket1_wp4 => 4,
+        bucket1_wp5 => 5,
+        sprint1_wp4 => 6
+      )
     end
   end
 
@@ -292,19 +316,21 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
     it "reorders the remaining sprint work_packages and the ones in the bucket" do
       bucket1_wp3.update(backlog_bucket: nil, sprint: sprint1)
 
-      expect(wp_of_bucket_by_id_and_position(bucket1))
-        .to eq(bucket1_wp1.id => 1,
-               bucket1_wp2.id => 2,
-               bucket1_wp4.id => 3,
-               bucket1_wp5.id => 4)
+      expect(bucket_wps(bucket1)).to have_positions(
+        bucket1_wp1 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp4 => 3,
+        bucket1_wp5 => 4
+      )
 
-      expect(wp_of_sprint_by_id_and_position(sprint1))
-        .to eq(sprint1_wp1.id => 1,
-               sprint1_wp2.id => 2,
-               sprint1_wp3.id => 3,
-               sprint1_wp4.id => 4,
-               sprint1_wp5.id => 5,
-               bucket1_wp3.id => 6)
+      expect(sprint_wps(sprint1)).to have_positions(
+        sprint1_wp1 => 1,
+        sprint1_wp2 => 2,
+        sprint1_wp3 => 3,
+        sprint1_wp4 => 4,
+        sprint1_wp5 => 5,
+        bucket1_wp3 => 6
+      )
     end
   end
 
@@ -313,12 +339,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the beginning of the sprint" do
         sprint1_wp4.move_after(position: 1)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp4.id => 1,
-                 sprint1_wp1.id => 2,
-                 sprint1_wp2.id => 3,
-                 sprint1_wp3.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp4 => 1,
+          sprint1_wp1 => 2,
+          sprint1_wp2 => 3,
+          sprint1_wp3 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -326,12 +353,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the sprint" do
         sprint1_wp1.move_after(position: 3)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp2.id => 1,
-                 sprint1_wp3.id => 2,
-                 sprint1_wp1.id => 3,
-                 sprint1_wp4.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp2 => 1,
+          sprint1_wp3 => 2,
+          sprint1_wp1 => 3,
+          sprint1_wp4 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -339,12 +367,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the sprint" do
         sprint1_wp5.move_after(position: 3)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp1.id => 1,
-                 sprint1_wp2.id => 2,
-                 sprint1_wp5.id => 3,
-                 sprint1_wp3.id => 4,
-                 sprint1_wp4.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp1 => 1,
+          sprint1_wp2 => 2,
+          sprint1_wp5 => 3,
+          sprint1_wp3 => 4,
+          sprint1_wp4 => 5
+        )
       end
     end
 
@@ -352,12 +381,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the end of the sprint" do
         sprint1_wp2.move_after(position: 5)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp1.id => 1,
-                 sprint1_wp3.id => 2,
-                 sprint1_wp4.id => 3,
-                 sprint1_wp5.id => 4,
-                 sprint1_wp2.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp1 => 1,
+          sprint1_wp3 => 2,
+          sprint1_wp4 => 3,
+          sprint1_wp5 => 4,
+          sprint1_wp2 => 5
+        )
       end
     end
 
@@ -365,12 +395,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the sprint" do
         sprint1_wp2.move_after(position: 6)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp2.id => 1,
-                 sprint1_wp1.id => 2,
-                 sprint1_wp3.id => 3,
-                 sprint1_wp4.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp2 => 1,
+          sprint1_wp1 => 2,
+          sprint1_wp3 => 3,
+          sprint1_wp4 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -378,12 +409,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the second position" do
         sprint1_wp4.move_after(prev_id: sprint1_wp1.id)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp1.id => 1,
-                 sprint1_wp4.id => 2,
-                 sprint1_wp2.id => 3,
-                 sprint1_wp3.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp1 => 1,
+          sprint1_wp4 => 2,
+          sprint1_wp2 => 3,
+          sprint1_wp3 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -391,12 +423,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         sprint1_wp1.move_after(prev_id: sprint1_wp3.id)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp2.id => 1,
-                 sprint1_wp3.id => 2,
-                 sprint1_wp1.id => 3,
-                 sprint1_wp4.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp2 => 1,
+          sprint1_wp3 => 2,
+          sprint1_wp1 => 3,
+          sprint1_wp4 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -404,12 +437,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         sprint1_wp5.move_after(prev_id: sprint1_wp3.id)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp1.id => 1,
-                 sprint1_wp2.id => 2,
-                 sprint1_wp3.id => 3,
-                 sprint1_wp5.id => 4,
-                 sprint1_wp4.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp1 => 1,
+          sprint1_wp2 => 2,
+          sprint1_wp3 => 3,
+          sprint1_wp5 => 4,
+          sprint1_wp4 => 5
+        )
       end
     end
 
@@ -417,12 +451,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         sprint1_wp1.move_after(prev_id: sprint1_wp5.id)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp2.id => 1,
-                 sprint1_wp3.id => 2,
-                 sprint1_wp4.id => 3,
-                 sprint1_wp5.id => 4,
-                 sprint1_wp1.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp2 => 1,
+          sprint1_wp3 => 2,
+          sprint1_wp4 => 3,
+          sprint1_wp5 => 4,
+          sprint1_wp1 => 5
+        )
       end
     end
 
@@ -430,12 +465,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the sprint" do
         sprint1_wp4.move_after(prev_id: sprint2_wp2.id)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp4.id => 1,
-                 sprint1_wp1.id => 2,
-                 sprint1_wp2.id => 3,
-                 sprint1_wp3.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp4 => 1,
+          sprint1_wp1 => 2,
+          sprint1_wp2 => 3,
+          sprint1_wp3 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -443,12 +479,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the sprint" do
         sprint1_wp4.move_after(prev_id: nil)
 
-        expect(wp_of_sprint_by_id_and_position(sprint1))
-          .to eq(sprint1_wp4.id => 1,
-                 sprint1_wp1.id => 2,
-                 sprint1_wp2.id => 3,
-                 sprint1_wp3.id => 4,
-                 sprint1_wp5.id => 5)
+        expect(sprint_wps(sprint1)).to have_positions(
+          sprint1_wp4 => 1,
+          sprint1_wp1 => 2,
+          sprint1_wp2 => 3,
+          sprint1_wp3 => 4,
+          sprint1_wp5 => 5
+        )
       end
     end
 
@@ -456,10 +493,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the beginning of the sprint" do
         inbox_wp3.move_after(position: 1)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp3.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp3 => 1,
+          inbox_wp1 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -467,10 +505,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the sprint" do
         inbox_wp1.move_after(position: 2)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp2.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp3.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp2 => 1,
+          inbox_wp1 => 2,
+          inbox_wp3 => 3
+        )
       end
     end
 
@@ -478,10 +517,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the sprint" do
         inbox_wp3.move_after(position: 2)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp1.id => 1,
-                 inbox_wp3.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp1 => 1,
+          inbox_wp3 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -489,10 +529,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the end of the sprint" do
         inbox_wp1.move_after(position: 3)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp2.id => 1,
-                 inbox_wp3.id => 2,
-                 inbox_wp1.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp2 => 1,
+          inbox_wp3 => 2,
+          inbox_wp1 => 3
+        )
       end
     end
 
@@ -500,10 +541,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the sprint" do
         inbox_wp2.move_after(position: 4)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp2.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp3.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp2 => 1,
+          inbox_wp1 => 2,
+          inbox_wp3 => 3
+        )
       end
     end
 
@@ -511,10 +553,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the sprint" do
         inbox_wp3.move_after(prev_id: nil)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp3.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp3 => 1,
+          inbox_wp1 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -522,10 +565,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the second position" do
         inbox_wp3.move_after(prev_id: inbox_wp1.id)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp1.id => 1,
-                 inbox_wp3.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp1 => 1,
+          inbox_wp3 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -533,10 +577,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         inbox_wp1.move_after(prev_id: inbox_wp2.id)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp2.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp3.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp2 => 1,
+          inbox_wp1 => 2,
+          inbox_wp3 => 3
+        )
       end
     end
 
@@ -544,10 +589,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         inbox_wp3.move_after(prev_id: inbox_wp1.id)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp1.id => 1,
-                 inbox_wp3.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp1 => 1,
+          inbox_wp3 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -555,10 +601,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         inbox_wp1.move_after(prev_id: inbox_wp3.id)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp2.id => 1,
-                 inbox_wp3.id => 2,
-                 inbox_wp1.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp2 => 1,
+          inbox_wp3 => 2,
+          inbox_wp1 => 3
+        )
       end
     end
 
@@ -566,10 +613,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top position" do
         inbox_wp3.move_after(prev_id: sprint2_wp2.id)
 
-        expect(wp_of_inbox_by_id_and_position)
-          .to eq(inbox_wp3.id => 1,
-                 inbox_wp1.id => 2,
-                 inbox_wp2.id => 3)
+        expect(inbox_wps).to have_positions(
+          inbox_wp3 => 1,
+          inbox_wp1 => 2,
+          inbox_wp2 => 3
+        )
       end
     end
 
@@ -577,12 +625,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the beginning of the bucket" do
         bucket1_wp4.move_after(position: 1)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp4.id => 1,
-                 bucket1_wp1.id => 2,
-                 bucket1_wp2.id => 3,
-                 bucket1_wp3.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp4 => 1,
+          bucket1_wp1 => 2,
+          bucket1_wp2 => 3,
+          bucket1_wp3 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -590,12 +639,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the bucket" do
         bucket1_wp1.move_after(position: 3)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp2.id => 1,
-                 bucket1_wp3.id => 2,
-                 bucket1_wp1.id => 3,
-                 bucket1_wp4.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp2 => 1,
+          bucket1_wp3 => 2,
+          bucket1_wp1 => 3,
+          bucket1_wp4 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -603,12 +653,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the middle of the bucket" do
         bucket1_wp5.move_after(position: 3)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp1.id => 1,
-                 bucket1_wp2.id => 2,
-                 bucket1_wp5.id => 3,
-                 bucket1_wp3.id => 4,
-                 bucket1_wp4.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp1 => 1,
+          bucket1_wp2 => 2,
+          bucket1_wp5 => 3,
+          bucket1_wp3 => 4,
+          bucket1_wp4 => 5
+        )
       end
     end
 
@@ -616,12 +667,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the end of the bucket" do
         bucket1_wp2.move_after(position: 5)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp1.id => 1,
-                 bucket1_wp3.id => 2,
-                 bucket1_wp4.id => 3,
-                 bucket1_wp5.id => 4,
-                 bucket1_wp2.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp1 => 1,
+          bucket1_wp3 => 2,
+          bucket1_wp4 => 3,
+          bucket1_wp5 => 4,
+          bucket1_wp2 => 5
+        )
       end
     end
 
@@ -629,12 +681,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the second position" do
         bucket1_wp4.move_after(prev_id: bucket1_wp1.id)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp1.id => 1,
-                 bucket1_wp4.id => 2,
-                 bucket1_wp2.id => 3,
-                 bucket1_wp3.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp1 => 1,
+          bucket1_wp4 => 2,
+          bucket1_wp2 => 3,
+          bucket1_wp3 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -642,12 +695,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package after the previous" do
         bucket1_wp1.move_after(prev_id: bucket1_wp3.id)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp2.id => 1,
-                 bucket1_wp3.id => 2,
-                 bucket1_wp1.id => 3,
-                 bucket1_wp4.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp2 => 1,
+          bucket1_wp3 => 2,
+          bucket1_wp1 => 3,
+          bucket1_wp4 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -655,12 +709,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the last position" do
         bucket1_wp1.move_after(prev_id: bucket1_wp5.id)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp2.id => 1,
-                 bucket1_wp3.id => 2,
-                 bucket1_wp4.id => 3,
-                 bucket1_wp5.id => 4,
-                 bucket1_wp1.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp2 => 1,
+          bucket1_wp3 => 2,
+          bucket1_wp4 => 3,
+          bucket1_wp5 => 4,
+          bucket1_wp1 => 5
+        )
       end
     end
 
@@ -668,12 +723,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the bucket" do
         bucket1_wp4.move_after(prev_id: nil)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp4.id => 1,
-                 bucket1_wp1.id => 2,
-                 bucket1_wp2.id => 3,
-                 bucket1_wp3.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp4 => 1,
+          bucket1_wp1 => 2,
+          bucket1_wp2 => 3,
+          bucket1_wp3 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -681,12 +737,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
       it "moves the work_package to the top of the bucket" do
         bucket1_wp4.move_after(prev_id: bucket2_wp2.id)
 
-        expect(wp_of_bucket_by_id_and_position(bucket1))
-          .to eq(bucket1_wp4.id => 1,
-                 bucket1_wp1.id => 2,
-                 bucket1_wp2.id => 3,
-                 bucket1_wp3.id => 4,
-                 bucket1_wp5.id => 5)
+        expect(bucket_wps(bucket1)).to have_positions(
+          bucket1_wp4 => 1,
+          bucket1_wp1 => 2,
+          bucket1_wp2 => 3,
+          bucket1_wp3 => 4,
+          bucket1_wp5 => 5
+        )
       end
     end
 
@@ -695,23 +752,25 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
         it "moves the work_package to the beginning of the sprint" do
           sprint1_wp4.move_after(position: "1")
 
-          expect(wp_of_sprint_by_id_and_position(sprint1))
-            .to eq(sprint1_wp4.id => 1,
-                   sprint1_wp1.id => 2,
-                   sprint1_wp2.id => 3,
-                   sprint1_wp3.id => 4,
-                   sprint1_wp5.id => 5)
+          expect(sprint_wps(sprint1)).to have_positions(
+            sprint1_wp4 => 1,
+            sprint1_wp1 => 2,
+            sprint1_wp2 => 3,
+            sprint1_wp3 => 4,
+            sprint1_wp5 => 5
+          )
         end
 
         it "moves the work_package to the middle of the sprint" do
           sprint1_wp1.move_after(position: "3")
 
-          expect(wp_of_sprint_by_id_and_position(sprint1))
-            .to eq(sprint1_wp2.id => 1,
-                   sprint1_wp3.id => 2,
-                   sprint1_wp1.id => 3,
-                   sprint1_wp4.id => 4,
-                   sprint1_wp5.id => 5)
+          expect(sprint_wps(sprint1)).to have_positions(
+            sprint1_wp2 => 1,
+            sprint1_wp3 => 2,
+            sprint1_wp1 => 3,
+            sprint1_wp4 => 4,
+            sprint1_wp5 => 5
+          )
         end
       end
 
@@ -719,12 +778,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
         it "moves the work_package after the previous" do
           sprint1_wp4.move_after(prev_id: sprint1_wp1.id.to_s)
 
-          expect(wp_of_sprint_by_id_and_position(sprint1))
-            .to eq(sprint1_wp1.id => 1,
-                   sprint1_wp4.id => 2,
-                   sprint1_wp2.id => 3,
-                   sprint1_wp3.id => 4,
-                   sprint1_wp5.id => 5)
+          expect(sprint_wps(sprint1)).to have_positions(
+            sprint1_wp1 => 1,
+            sprint1_wp4 => 2,
+            sprint1_wp2 => 3,
+            sprint1_wp3 => 4,
+            sprint1_wp5 => 5
+          )
         end
       end
 
@@ -732,10 +792,11 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
         it "moves the work_package to the beginning of the inbox" do
           inbox_wp3.move_after(position: "1")
 
-          expect(wp_of_inbox_by_id_and_position)
-            .to eq(inbox_wp3.id => 1,
-                   inbox_wp1.id => 2,
-                   inbox_wp2.id => 3)
+          expect(inbox_wps).to have_positions(
+            inbox_wp3 => 1,
+            inbox_wp1 => 2,
+            inbox_wp2 => 3
+          )
         end
       end
 
@@ -743,12 +804,13 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
         it "moves the work_package to the beginning of the bucket" do
           bucket1_wp4.move_after(position: "1")
 
-          expect(wp_of_bucket_by_id_and_position(bucket1))
-            .to eq(bucket1_wp4.id => 1,
-                   bucket1_wp1.id => 2,
-                   bucket1_wp2.id => 3,
-                   bucket1_wp3.id => 4,
-                   bucket1_wp5.id => 5)
+          expect(bucket_wps(bucket1)).to have_positions(
+            bucket1_wp4 => 1,
+            bucket1_wp1 => 2,
+            bucket1_wp2 => 3,
+            bucket1_wp3 => 4,
+            bucket1_wp5 => 5
+          )
         end
       end
     end

--- a/modules/backlogs/spec/models/work_packages/position_spec.rb
+++ b/modules/backlogs/spec/models/work_packages/position_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe WorkPackage, "positions" do # rubocop:disable RSpec/SpecFilePathF
   end
 
   def have_positions(**) # rubocop:disable Naming/PredicatePrefix
-    have_attr(:position, identified_by: :subject, **)
+    pluck(:position, identified_by: :subject).eq(**)
   end
 
   context "when creating a work_package in a sprint" do

--- a/modules/backlogs/spec/services/backlogs/work_packages/rebuild_positions_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/rebuild_positions_service_integration_spec.rb
@@ -75,55 +75,53 @@ RSpec.describe Backlogs::WorkPackages::RebuildPositionsService, "integration", t
   shared_let(:bucket2_wp2) { create_work_package(subject: "Bucket 2 WorkPackage 2", backlog_bucket: bucket2, position: nil) }
   shared_let(:bucket2_wp3) { create_work_package(subject: "Bucket 2 WorkPackage 3", backlog_bucket: bucket2, position: nil) }
 
+  def have_positions(**) # rubocop:disable Naming/PredicatePrefix
+    have_attr(:position, identified_by: :subject, **)
+  end
+
   context "with the project provided" do
     before do
       described_class.new(project: project1).call
     end
 
     it "fixes the positions in that project while keeping those that have some in the same order" do # rubocop:disable RSpec/ExampleLength
-      expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint1_wp2.subject => 1,
-          sprint1_wp3.subject => 2,
-          sprint1_wp4.subject => 3,
-          sprint1_wp1.subject => 4,
-          sprint1_wp5.subject => 5
-        )
+      expect(WorkPackage.where(sprint: sprint1)).to have_positions(
+        sprint1_wp2 => 1,
+        sprint1_wp3 => 2,
+        sprint1_wp4 => 3,
+        sprint1_wp1 => 4,
+        sprint1_wp5 => 5
+      )
 
-      expect(WorkPackage.where(sprint: sprint2).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint2_wp3.subject => 1,
-          sprint2_wp2.subject => 2,
-          sprint2_wp1.subject => 3
-        )
+      expect(WorkPackage.where(sprint: sprint2)).to have_positions(
+        sprint2_wp3 => 1,
+        sprint2_wp2 => 2,
+        sprint2_wp1 => 3
+      )
 
-      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
-        .to eql(
-          inbox_wp1.subject => 1,
-          inbox_wp2.subject => 2,
-          inbox_wp3.subject => 3
-        )
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1)).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp2 => 2,
+        inbox_wp3 => 3
+      )
 
-      expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint3_wp1.subject => nil,
-          sprint3_wp2.subject => nil,
-          sprint3_wp3.subject => nil
-        )
+      expect(WorkPackage.where(sprint: sprint3)).to have_positions(
+        sprint3_wp1 => nil,
+        sprint3_wp2 => nil,
+        sprint3_wp3 => nil
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket1_wp3.subject => 1,
-          bucket1_wp2.subject => 2,
-          bucket1_wp1.subject => 3
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket1)).to have_positions(
+        bucket1_wp3 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp1 => 3
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket2_wp1.subject => nil,
-          bucket2_wp2.subject => nil,
-          bucket2_wp3.subject => nil
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket2)).to have_positions(
+        bucket2_wp1 => nil,
+        bucket2_wp2 => nil,
+        bucket2_wp3 => nil
+      )
     end
   end
 
@@ -133,49 +131,43 @@ RSpec.describe Backlogs::WorkPackages::RebuildPositionsService, "integration", t
     end
 
     it "fixes only the work packages in the other project" do # rubocop:disable RSpec/ExampleLength
-      expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint1_wp1.subject => nil,
-          sprint1_wp2.subject => 1,
-          sprint1_wp3.subject => 2,
-          sprint1_wp4.subject => 2,
-          sprint1_wp5.subject => nil
-        )
+      expect(WorkPackage.where(sprint: sprint1)).to have_positions(
+        sprint1_wp1 => nil,
+        sprint1_wp2 => 1,
+        sprint1_wp3 => 2,
+        sprint1_wp4 => 2,
+        sprint1_wp5 => nil
+      )
 
-      expect(WorkPackage.where(sprint: sprint2).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint2_wp3.subject => 1,
-          sprint2_wp2.subject => 2,
-          sprint2_wp1.subject => 3
-        )
+      expect(WorkPackage.where(sprint: sprint2)).to have_positions(
+        sprint2_wp3 => 1,
+        sprint2_wp2 => 2,
+        sprint2_wp1 => 3
+      )
 
-      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
-        .to eql(
-          inbox_wp1.subject => nil,
-          inbox_wp2.subject => nil,
-          inbox_wp3.subject => nil
-        )
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1)).to have_positions(
+        inbox_wp1 => nil,
+        inbox_wp2 => nil,
+        inbox_wp3 => nil
+      )
 
-      expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint3_wp1.subject => 1,
-          sprint3_wp2.subject => 2,
-          sprint3_wp3.subject => 3
-        )
+      expect(WorkPackage.where(sprint: sprint3)).to have_positions(
+        sprint3_wp1 => 1,
+        sprint3_wp2 => 2,
+        sprint3_wp3 => 3
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket1_wp1.subject => nil,
-          bucket1_wp2.subject => 2,
-          bucket1_wp3.subject => 1
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket1)).to have_positions(
+        bucket1_wp1 => nil,
+        bucket1_wp2 => 2,
+        bucket1_wp3 => 1
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket2_wp1.subject => 1,
-          bucket2_wp2.subject => 2,
-          bucket2_wp3.subject => 3
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket2)).to have_positions(
+        bucket2_wp1 => 1,
+        bucket2_wp2 => 2,
+        bucket2_wp3 => 3
+      )
     end
   end
 
@@ -185,49 +177,43 @@ RSpec.describe Backlogs::WorkPackages::RebuildPositionsService, "integration", t
     end
 
     it "fixes the positions while keeping those that have some in the same order in all projects" do # rubocop:disable RSpec/ExampleLength
-      expect(WorkPackage.where(sprint: sprint1).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint1_wp2.subject => 1,
-          sprint1_wp3.subject => 2,
-          sprint1_wp4.subject => 3,
-          sprint1_wp1.subject => 4,
-          sprint1_wp5.subject => 5
-        )
+      expect(WorkPackage.where(sprint: sprint1)).to have_positions(
+        sprint1_wp2 => 1,
+        sprint1_wp3 => 2,
+        sprint1_wp4 => 3,
+        sprint1_wp1 => 4,
+        sprint1_wp5 => 5
+      )
 
-      expect(WorkPackage.where(sprint: sprint2).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint2_wp3.subject => 1,
-          sprint2_wp2.subject => 2,
-          sprint2_wp1.subject => 3
-        )
+      expect(WorkPackage.where(sprint: sprint2)).to have_positions(
+        sprint2_wp3 => 1,
+        sprint2_wp2 => 2,
+        sprint2_wp1 => 3
+      )
 
-      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1).to_h { [it.subject, it.position] })
-        .to eql(
-          inbox_wp1.subject => 1,
-          inbox_wp2.subject => 2,
-          inbox_wp3.subject => 3
-        )
+      expect(WorkPackage.where(sprint: nil, backlog_bucket: nil, project: project1)).to have_positions(
+        inbox_wp1 => 1,
+        inbox_wp2 => 2,
+        inbox_wp3 => 3
+      )
 
-      expect(WorkPackage.where(sprint: sprint3).to_h { [it.subject, it.position] })
-        .to eql(
-          sprint3_wp1.subject => 1,
-          sprint3_wp2.subject => 2,
-          sprint3_wp3.subject => 3
-        )
+      expect(WorkPackage.where(sprint: sprint3)).to have_positions(
+        sprint3_wp1 => 1,
+        sprint3_wp2 => 2,
+        sprint3_wp3 => 3
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket1).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket1_wp3.subject => 1,
-          bucket1_wp2.subject => 2,
-          bucket1_wp1.subject => 3
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket1)).to have_positions(
+        bucket1_wp3 => 1,
+        bucket1_wp2 => 2,
+        bucket1_wp1 => 3
+      )
 
-      expect(WorkPackage.where(backlog_bucket: bucket2).to_h { [it.subject, it.position] })
-        .to eql(
-          bucket2_wp1.subject => 1,
-          bucket2_wp2.subject => 2,
-          bucket2_wp3.subject => 3
-        )
+      expect(WorkPackage.where(backlog_bucket: bucket2)).to have_positions(
+        bucket2_wp1 => 1,
+        bucket2_wp2 => 2,
+        bucket2_wp3 => 3
+      )
     end
   end
 end

--- a/modules/backlogs/spec/services/backlogs/work_packages/rebuild_positions_service_integration_spec.rb
+++ b/modules/backlogs/spec/services/backlogs/work_packages/rebuild_positions_service_integration_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Backlogs::WorkPackages::RebuildPositionsService, "integration", t
   shared_let(:bucket2_wp3) { create_work_package(subject: "Bucket 2 WorkPackage 3", backlog_bucket: bucket2, position: nil) }
 
   def have_positions(**) # rubocop:disable Naming/PredicatePrefix
-    have_attr(:position, identified_by: :subject, **)
+    pluck(:position).eq(**)
   end
 
   context "with the project provided" do

--- a/spec/support/matchers/have_attr.rb
+++ b/spec/support/matchers/have_attr.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+# When you need to check an attribute for multiple records:
+#
+#   expect(WorkPackage.where(sprint:)).to have_attr(:position,
+#     wp1 => 1,
+#     wp2 => 2,
+#     wp3 => nil
+#   )
+#
+# Specify `identified_by` attribute to be used instead of `id` to differentiate
+# records in failurediff, it must be unique:
+#
+#   expect(WorkPackage.where(sprint:)).to have_attr(:position, identified_by: :subject,
+#     wp1 => 1,
+#     wp2 => 2
+#   )
+RSpec::Matchers.define :have_attr do |attribute, identified_by: :id, **expected|
+  match do |actual|
+    @actual   = actual.pluck(identified_by, attribute).to_h
+    @expected = expected.transform_keys { it.public_send(identified_by) }
+    @actual == @expected
+  end
+
+  diffable
+
+  define_method(:expected) { @expected }
+
+  failure_message do |_|
+    "expected #{attribute.inspect} (identified by #{identified_by.inspect}) to match"
+  end
+end

--- a/spec/support/matchers/pluck.rb
+++ b/spec/support/matchers/pluck.rb
@@ -30,23 +30,48 @@
 
 # When you need to check an attribute for multiple records:
 #
-#   expect(WorkPackage.where(sprint:)).to have_attr(:position,
-#     wp1 => 1,
-#     wp2 => 2,
-#     wp3 => nil
+#   expect(WorkPackage.where(sprint:)).to pluck(:position).eq(
+#     sprint1_wp2 => 1,
+#     sprint1_wp3 => 2,
+#     sprint1_wp4 => 3,
+#     sprint1_wp1 => 4,
+#     sprint1_wp5 => 6
 #   )
+#
+# Fails with:
+#
+#    582 => 1,
+#    583 => 2,
+#    584 => 3,
+#   -585 => 6,
+#   +585 => 5,
 #
 # Specify `identified_by` attribute to be used instead of `id` to differentiate
 # records in failurediff, it must be unique:
 #
-#   expect(WorkPackage.where(sprint:)).to have_attr(:position, identified_by: :subject,
-#     wp1 => 1,
-#     wp2 => 2
+#   expect(WorkPackage.where(sprint:)).to pluck(:position, identified_by: :subject).eq(
+#     sprint1_wp2 => 1,
+#     sprint1_wp3 => 2,
+#     sprint1_wp4 => 3,
+#     sprint1_wp1 => 4,
+#     sprint1_wp5 => 6
 #   )
-RSpec::Matchers.define :have_attr do |attribute, identified_by: :id, **expected|
-  match do |actual|
-    @actual   = actual.pluck(identified_by, attribute).to_h
+#
+# Fails with:
+#
+#    "Sprint 1 WorkPackage 2" => 1,
+#    "Sprint 1 WorkPackage 3" => 2,
+#    "Sprint 1 WorkPackage 4" => 3,
+#   -"Sprint 1 WorkPackage 5" => 6,
+#   +"Sprint 1 WorkPackage 5" => 5,
+
+RSpec::Matchers.define :pluck do |attribute, identified_by: :id|
+  chain :eq do |expected|
     @expected = expected.transform_keys { it.public_send(identified_by) }
+  end
+
+  match do |actual|
+    @actual = actual.pluck(identified_by, attribute).to_h
     @actual == @expected
   end
 


### PR DESCRIPTION
pluck matcher extracted while working on https://community.openproject.org/wp/74386

The idea overall is both to remove repetition in `expect(…)` and `eq(…)` part, while also ensuring easily understandable failure

second chain commit is a readability experiment