### PR TITLE
Treat email headers as string value

### DIFF
--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -479,12 +479,14 @@ module Settings
       emails_footer: {
         default: {
           "en" => ""
-        }
+        },
+        string_values: true
       },
       emails_header: {
         default: {
           "en" => ""
-        }
+        },
+        string_values: true
       },
       # use email address as login, hide login in registration form
       email_login: {


### PR DESCRIPTION
Treat values for emails_header and _footer as string values, preventing further processing of the values

https://community.openproject.org/work_packages/OP-19448