### PR TITLE
fix sprint field in attribute group being wrongfully cached

### DIFF
--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -212,17 +212,9 @@ module OpenProject::Backlogs
     end
 
     config.to_prepare do
-      enabled_backlogs_story = ->(_type, project: nil) do
-        project.nil? || project.backlogs_enabled?
+      %i[position story_points sprint].each do |attribute|
+        ::Type.add_constraint attribute, ->(_type, project: nil) { project.nil? || project.backlogs_enabled? }
       end
-
-      story_and_sprint_permission = ->(_type, project: nil) do
-        project.nil? || User.current.allowed_in_project?(:view_sprints, project)
-      end
-
-      ::Type.add_constraint :position, enabled_backlogs_story
-      ::Type.add_constraint :story_points, enabled_backlogs_story
-      ::Type.add_constraint :sprint, story_and_sprint_permission
 
       ::Type.add_default_mapping(:estimates_and_progress, :story_points)
       ::Type.add_default_mapping(:other, :position)

--- a/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
+++ b/modules/backlogs/spec/lib/api/v3/work_packages/schema/work_package_schema_representer_spec.rb
@@ -38,8 +38,14 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     API::V3::WorkPackages::Schema::SpecificWorkPackageSchema.new(work_package:)
   end
   let(:representer) { described_class.create(schema, form_embedded: true, self_link: nil, current_user:) }
-  let(:project) { work_package.project }
-  let(:work_package) { build_stubbed(:work_package, type: build_stubbed(:type)) }
+  let(:backlogs_enabled) { true }
+  let(:project) do
+    work_package.project.tap do |p|
+      allow(p).to receive(:backlogs_enabled?).and_return(backlogs_enabled)
+    end
+  end
+  let(:work_package_type) { build_stubbed(:type, attribute_groups: [["Agile", %w[position sprint story_points]]]) }
+  let(:work_package) { build_stubbed(:work_package, type: work_package_type) }
 
   let(:current_user) { build_stubbed(:user) }
   let(:permissions) { %i(view_work_packages edit_work_packages view_sprints manage_sprint_items) }
@@ -50,9 +56,6 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     login_as(current_user)
-
-    allow(schema.project).to receive(:backlogs_enabled?).and_return(true)
-    allow(work_package).to receive(:leaf?).and_return(true)
   end
 
   subject { representer.to_json }
@@ -67,9 +70,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     context "when backlogs module is disabled" do
-      before do
-        allow(schema.project).to receive(:backlogs_enabled?).and_return(false)
-      end
+      let(:backlogs_enabled) { false }
 
       it "does not show story points" do
         expect(subject).not_to have_json_path("storyPoints")
@@ -87,9 +88,7 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
     end
 
     context "when backlogs module is disabled" do
-      before do
-        allow(schema.project).to receive(:backlogs_enabled?).and_return(false)
-      end
+      let(:backlogs_enabled) { false }
 
       it "does not show position" do
         expect(subject).not_to have_json_path("position")
@@ -132,6 +131,33 @@ RSpec.describe API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
       it "has no reference to the sprint" do
         expect(subject).not_to have_json_path(path)
+      end
+    end
+  end
+
+  describe "attribute_groups" do
+    context "with backlogs enabled" do
+      it "has backlogs properties listed in the right group" do
+        expect(subject).to be_json_eql(%w[position sprint storyPoints])
+                             .at_path("_attributeGroups/0/attributes")
+      end
+    end
+
+    context "with backlogs enabled and permissions missing" do
+      let(:permissions) { %i(view_work_packages edit_work_packages) }
+
+      it "has backlogs properties listed in the right group" do
+        expect(subject).to be_json_eql(%w[position sprint storyPoints])
+                             .at_path("_attributeGroups/0/attributes")
+      end
+    end
+
+    context "with backlogs disabled" do
+      let(:backlogs_enabled) { false }
+
+      it "lacks the backlogs properties" do
+        expect(subject).to be_json_eql(%w[])
+                             .at_path("_attributeGroups/0/attributes")
       end
     end
   end


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/AGILE-254

# What are you trying to accomplish?

The schema should only display whether the field is present in the attribute group depending on the module being active not on the permissions of the user. Otherwise, the first user`s permission determine the contents of the attribute_group for all subsequent calls.

# Merge checklist

- [x] Added/updated tests