### PR TITLE
[OP-19404] Section cannot be dragged and dropped outside of current view

### DIFF
--- a/app/components/work_package_types/form_configuration/main_content_component.html.erb
+++ b/app/components/work_package_types/form_configuration/main_content_component.html.erb
@@ -1,7 +1,6 @@
 <%=
   component_wrapper(
-    class: "type-form-configuration-page--main-inner",
-    data: main_inner_data
+    class: "type-form-configuration-page--main-inner"
   ) do
     flex_layout do |main|
       main.with_row do

--- a/app/components/work_package_types/form_configuration/main_content_component.rb
+++ b/app/components/work_package_types/form_configuration/main_content_component.rb
@@ -47,13 +47,6 @@ module WorkPackageTypes
         @ee_available
       end
 
-      def main_inner_data
-        {
-          controller: "admin--type-form-configuration--drag-and-drop",
-          "admin--type-form-configuration--drag-and-drop-handle-selector-value": ".group-handle"
-        }
-      end
-
       def groups_container_data
         {
           "test-selector": "type-form-configuration-groups-container",

--- a/app/components/work_package_types/form_configuration_component.html.erb
+++ b/app/components/work_package_types/form_configuration_component.html.erb
@@ -42,7 +42,10 @@ See COPYRIGHT and LICENSE files for more details.
     <% end %>
 
     <% content.with_main(classes: "type-form-configuration-page--main") do %>
-      <div class="type-form-configuration-page--active-list" data-admin--type-form-configuration--rows-drag-and-drop-target="scrollContainer">
+      <%= tag.div(
+            class: "type-form-configuration-page--active-list",
+            data: active_list_data
+          ) do %>
         <%= render(EnterpriseEdition::BannerComponent.new(:edit_attribute_groups, mb: 3)) %>
 
         <% unless ee_available? %>
@@ -58,7 +61,7 @@ See COPYRIGHT and LICENSE files for more details.
                 ee_available: ee_available?
               )
             ) %>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/work_package_types/form_configuration_component.rb
+++ b/app/components/work_package_types/form_configuration_component.rb
@@ -55,6 +55,15 @@ module WorkPackageTypes
       }
     end
 
+    def active_list_data
+      {
+        controller: "admin--type-form-configuration--drag-and-drop",
+        "admin--type-form-configuration--drag-and-drop-handle-selector-value": ".group-handle",
+        "admin--type-form-configuration--drag-and-drop-target": "scrollContainer",
+        "admin--type-form-configuration--rows-drag-and-drop-target": "scrollContainer"
+      }
+    end
+
     def group_components
       @groups.map.with_index do |group, i|
         WorkPackageTypes::FormConfiguration::GroupComponent.new(


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/OP-19404

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Move the section drag controller onto the scrollable form configuration area so it can use the same auto-scroll container as attribute rows. This allows dragging sections below the visible fold.