### PR TITLE
[chore] add forms dsl input for filterable tree views

### DIFF
--- a/lib/primer/open_project/forms/_index.sass
+++ b/lib/primer/open_project/forms/_index.sass
@@ -1,1 +1,2 @@
 @import "advanced_form_group"
+@import "filterable_tree_view"

--- a/lib/primer/open_project/forms/dsl/filterable_tree_view_input.rb
+++ b/lib/primer/open_project/forms/dsl/filterable_tree_view_input.rb
@@ -23,36 +23,44 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  class LinkExistingWikiPageForm < ApplicationForm
-    form do |f|
-      f.hidden(name: :provider_id)
-      f.hidden(name: :linkable_type)
-      f.hidden(name: :linkable_id)
+module Primer
+  module OpenProject
+    module Forms
+      module Dsl
+        # :nodoc:
+        class FilterableTreeViewInput < Primer::Forms::Dsl::Input
+          attr_reader :name, :label, :block
 
-      f.filterable_tree_view(
-        name: "wiki_page_selection",
-        src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
-        filter_mode_control_arguments: { hidden: true },
-        filter_input_arguments: {
-          placeholder: I18n.t("wikis.link_existing_wiki_page_form.placeholder"),
-          # every other property is just refilling the default values,
-          # as those are not merged into custom arguments
-          name: :filter,
-          label: I18n.t(:button_filter),
-          type: :search,
-          leading_visual: { icon: :search },
-          visually_hide_label: true,
-          show_clear_button: true
-        },
-        include_sub_items_check_box_arguments: { hidden: true },
-        no_results_node_arguments: { label: I18n.t("wikis.link_existing_wiki_page_form.no_results") }
-      )
+          def initialize(name:, label: nil, **system_arguments, &block)
+            @name = name
+            @label = label
+            @block = block
+
+            super(**system_arguments)
+          end
+
+          def to_component
+            FilterableTreeView.new(input: self)
+          end
+
+          # :nocov:
+          def type
+            :filterable_tree_view
+          end
+          # :nocov:
+
+          # :nocov:
+          def focusable?
+            true
+          end
+          # :nocov:
+        end
+      end
     end
   end
 end

--- a/lib/primer/open_project/forms/dsl/filterable_tree_view_input.rb
+++ b/lib/primer/open_project/forms/dsl/filterable_tree_view_input.rb
@@ -59,6 +59,10 @@ module Primer
             true
           end
           # :nocov:
+
+          def supports_validation?
+            false
+          end
         end
       end
     end

--- a/lib/primer/open_project/forms/dsl/input_methods.rb
+++ b/lib/primer/open_project/forms/dsl/input_methods.rb
@@ -84,6 +84,10 @@ module Primer
             add_input SelectPanelInput.new(builder:, form:, **decorate_options(**), &)
           end
 
+          def filterable_tree_view(**, &)
+            add_input FilterableTreeViewInput.new(builder:, form:, **decorate_options(**), &)
+          end
+
           def decorate_options(include_help_text: true, help_text_options: {}, **options)
             if include_help_text && supports_help_texts?(form.model)
               attribute_name = help_text_options[:attribute_name] || options[:name]

--- a/lib/primer/open_project/forms/filterable_tree_view.html.erb
+++ b/lib/primer/open_project/forms/filterable_tree_view.html.erb
@@ -1,0 +1,7 @@
+<%=
+  render(FormControl.new(input: @input)) do
+    render(Primer::OpenProject::FilterableTreeView.new(**@input.input_arguments)) do |tree_view|
+      @input.block&.call(tree_view)
+    end
+  end
+%>

--- a/lib/primer/open_project/forms/filterable_tree_view.html.erb
+++ b/lib/primer/open_project/forms/filterable_tree_view.html.erb
@@ -1,7 +1,19 @@
-<%=
-  render(FormControl.new(input: @input)) do
-    render(Primer::OpenProject::FilterableTreeView.new(**@input.input_arguments)) do |tree_view|
-      @input.block&.call(tree_view)
-    end
-  end
-%>
+<div class="FormControl-filterable-tree-view-wrap">
+  <%= content_tag(:fieldset, **@fieldset_arguments) do %>
+    <% if @input.label %>
+      <%= content_tag(:legend, **@input.label_arguments) do %>
+        <%= @input.label %>
+      <% end %>
+    <% end %>
+    <div class="mb-2">
+      <%= render(Caption.new(input: @input)) %>
+    </div>
+    <%= render(SpacingWrapper.new) do %>
+      <%=
+        render(Primer::OpenProject::FilterableTreeView.new(**@tree_view_arguments)) do |tree_view|
+          @input.block&.call(tree_view)
+        end
+      %>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/primer/open_project/forms/filterable_tree_view.rb
+++ b/lib/primer/open_project/forms/filterable_tree_view.rb
@@ -23,36 +23,29 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Wikis
-  class LinkExistingWikiPageForm < ApplicationForm
-    form do |f|
-      f.hidden(name: :provider_id)
-      f.hidden(name: :linkable_type)
-      f.hidden(name: :linkable_id)
+module Primer
+  module OpenProject
+    module Forms
+      # :nodoc:
+      class FilterableTreeView < Primer::Forms::BaseComponent
+        delegate :builder, :form, to: :@input
 
-      f.filterable_tree_view(
-        name: "wiki_page_selection",
-        src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
-        filter_mode_control_arguments: { hidden: true },
-        filter_input_arguments: {
-          placeholder: I18n.t("wikis.link_existing_wiki_page_form.placeholder"),
-          # every other property is just refilling the default values,
-          # as those are not merged into custom arguments
-          name: :filter,
-          label: I18n.t(:button_filter),
-          type: :search,
-          leading_visual: { icon: :search },
-          visually_hide_label: true,
-          show_clear_button: true
-        },
-        include_sub_items_check_box_arguments: { hidden: true },
-        no_results_node_arguments: { label: I18n.t("wikis.link_existing_wiki_page_form.no_results") }
-      )
+        def initialize(input:)
+          super()
+
+          @input = input
+
+          @input.input_arguments[:form_arguments] = {
+            name: @input.name,
+            builder: builder
+          }
+        end
+      end
     end
   end
 end

--- a/lib/primer/open_project/forms/filterable_tree_view.rb
+++ b/lib/primer/open_project/forms/filterable_tree_view.rb
@@ -39,10 +39,18 @@ module Primer
           super()
 
           @input = input
+          @input.add_label_classes("FormControl-label")
 
-          @input.input_arguments[:form_arguments] = {
-            name: @input.name,
-            builder: builder
+          @fieldset_arguments = @input.input_arguments.extract!(:hidden, :class, :classes)
+          Primer::Forms::Utils.classify(@fieldset_arguments)
+          @fieldset_arguments.delete(:class) if @fieldset_arguments[:class].blank?
+
+          @tree_view_arguments = {
+            **@input.input_arguments,
+            form_arguments: {
+              name: @input.name,
+              builder: builder
+            }
           }
         end
       end

--- a/lib/primer/open_project/forms/filterable_tree_view.sass
+++ b/lib/primer/open_project/forms/filterable_tree_view.sass
@@ -1,0 +1,5 @@
+.FormControl-filterable-tree-view-wrap
+  & fieldset
+    padding: 0
+    margin: 0
+    border: 0

--- a/modules/wikis/app/forms/wikis/link_existing_wiki_page_form.rb
+++ b/modules/wikis/app/forms/wikis/link_existing_wiki_page_form.rb
@@ -37,6 +37,7 @@ module Wikis
 
       f.filterable_tree_view(
         name: "wiki_page_selection",
+        label: I18n.t("wikis.link_existing_wiki_page_form.label"),
         src: helpers.search_wiki_pages_path(provider_id: model.provider_id, name: "wiki_page_selection"),
         filter_mode_control_arguments: { hidden: true },
         filter_input_arguments: {

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -151,6 +151,7 @@ en:
     link_existing_wiki_page_dialog:
       title: Add existing wiki page
     link_existing_wiki_page_form:
+      label: Wiki page
       no_results: No wiki pages found
       placeholder: Search for a wiki page
     oauth_login_component:

--- a/modules/wikis/spec/forms/wikis/link_existing_wiki_page_form_spec.rb
+++ b/modules/wikis/spec/forms/wikis/link_existing_wiki_page_form_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe Wikis::LinkExistingWikiPageForm, type: :forms do
+  include Rails.application.routes.url_helpers
+
+  include_context "with rendered form"
+
+  let(:model) { build_stubbed(:relation_wiki_page_link) }
+
+  it "renders the link attributes as hidden fields", :aggregate_failures do
+    expect(page).to have_field("wikis_relation_page_link[provider_id]", type: :hidden, with: model.provider_id)
+    expect(page).to have_field("wikis_relation_page_link[linkable_type]", type: :hidden, with: model.linkable_type)
+    expect(page).to have_field("wikis_relation_page_link[linkable_id]", type: :hidden, with: model.linkable_id)
+  end
+
+  it "renders the wiki page selection", :aggregate_failures do
+    expect(page).to have_selector :fieldset, "Wiki page"
+    expect(page).to have_element :"filterable-tree-view",
+                                 src: search_wiki_pages_path(provider_id: model.provider_id,
+                                                             name: "wiki_page_selection")
+    expect(page).to have_field "Filter", type: :search, placeholder: "Search for a wiki page"
+  end
+end

--- a/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
+++ b/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
@@ -280,11 +280,10 @@ RSpec.describe Primer::OpenProject::Forms::Dsl::InputMethods, type: :forms do
     end
 
     describe "#filterable_tree_view" do
-      let(:field_group) { form_dsl.filterable_tree_view(name:, **options) }
+      let(:field_group) { form_dsl.filterable_tree_view(name:, label:, **options) }
 
       include_examples "input class", Primer::OpenProject::Forms::Dsl::FilterableTreeViewInput
-      # TODO: Should the filterable tree view support a label?
-      # it_behaves_like "supporting help texts"
+      it_behaves_like "supporting help texts"
     end
 
     describe "#segmented_control" do

--- a/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
+++ b/spec/lib/primer/open_project/forms/dsl/input_methods_spec.rb
@@ -279,6 +279,14 @@ RSpec.describe Primer::OpenProject::Forms::Dsl::InputMethods, type: :forms do
       it_behaves_like "supporting help texts"
     end
 
+    describe "#filterable_tree_view" do
+      let(:field_group) { form_dsl.filterable_tree_view(name:, **options) }
+
+      include_examples "input class", Primer::OpenProject::Forms::Dsl::FilterableTreeViewInput
+      # TODO: Should the filterable tree view support a label?
+      # it_behaves_like "supporting help texts"
+    end
+
     describe "#segmented_control" do
       let(:field_group) do
         form_dsl.segmented_control(name:, label:, value: "a", items: [{ value: "a", label: "A" }], **options)

--- a/spec/lib/primer/open_project/forms/filterable_tree_view_spec.rb
+++ b/spec/lib/primer/open_project/forms/filterable_tree_view_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+#
+require "spec_helper"
+
+RSpec.describe Primer::OpenProject::Forms::FilterableTreeView, type: :forms do
+  include ViewComponent::TestHelpers
+
+  describe "rendering" do
+    let(:params) { {} }
+    let(:model) { build_stubbed(:comment) }
+
+    def render_form
+      render_in_view_context(model, params) do |model, params|
+        primer_form_with(url: "/foo", model:) do |f|
+          render_inline_form(f) do |form|
+            form.filterable_tree_view(name: :ingredients, **params) do |tree|
+              tree.with_leaf(select_variant: :multiple, label: "flour")
+              tree.with_leaf(select_variant: :multiple, label: "sugar")
+              tree.with_leaf(select_variant: :multiple, label: "eggs")
+            end
+          end
+        end
+      end
+    end
+
+    subject(:rendered_form) do
+      render_form
+      page
+    end
+
+    it "renders the filterable-tree-view" do
+      expect(rendered_form).to have_element :"filterable-tree-view"
+    end
+
+    it "renders the leafs", :aggregate_failures do
+      expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "flour")
+      expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "sugar")
+      expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "eggs")
+    end
+  end
+end

--- a/spec/lib/primer/open_project/forms/filterable_tree_view_spec.rb
+++ b/spec/lib/primer/open_project/forms/filterable_tree_view_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Primer::OpenProject::Forms::FilterableTreeView, type: :forms do
       render_in_view_context(model, params) do |model, params|
         primer_form_with(url: "/foo", model:) do |f|
           render_inline_form(f) do |form|
-            form.filterable_tree_view(name: :ingredients, **params) do |tree|
+            form.filterable_tree_view(name: :ingredients, label: "Ingredients", **params) do |tree|
               tree.with_leaf(select_variant: :multiple, label: "flour")
               tree.with_leaf(select_variant: :multiple, label: "sugar")
               tree.with_leaf(select_variant: :multiple, label: "eggs")
@@ -60,10 +60,30 @@ RSpec.describe Primer::OpenProject::Forms::FilterableTreeView, type: :forms do
       expect(rendered_form).to have_element :"filterable-tree-view"
     end
 
+    it "renders the fieldset" do
+      expect(rendered_form).to have_selector :fieldset, "Ingredients"
+    end
+
+    it "renders the label as the fieldset legend" do
+      expect(rendered_form).to have_element :legend, class: "FormControl-label", text: "Ingredients"
+    end
+
     it "renders the leafs", :aggregate_failures do
       expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "flour")
       expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "sugar")
       expect(rendered_form).to have_element(:li, class: "TreeViewItem", role: "none", text: "eggs")
+    end
+
+    it "wires the tree view up for form submission" do
+      expect(rendered_form).to have_element :input, type: "hidden", name: "comment[ingredients][]", visible: :all
+    end
+
+    context "when hidden" do
+      let(:params) { { hidden: true } }
+
+      it "hides the whole fieldset" do
+        expect(rendered_form).to have_selector :fieldset, visible: :hidden
+      end
     end
   end
 end


### PR DESCRIPTION
# What are you trying to accomplish?
- get a forms dsl input `filterable_tree_view`

# What approach did you choose and why?
- pass every input argument unchanged to filterable tree view component
- no default logic
- label defaults to `nil`
