### PR TITLE
Bug/STC-802: Resolve semantic work package identifiers in attribute macros

### DIFF
--- a/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.spec.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.spec.ts
@@ -1,0 +1,93 @@
+//-- copyright
+// OpenProject is an open source project management software.
+// Copyright (C) the OpenProject GmbH
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See COPYRIGHT and LICENSE files for more details.
+//++
+
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { type Mock, vi } from 'vitest';
+import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
+import { TransitionService } from '@uirouter/core';
+import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { AttributeModelLoaderService } from 'core-app/shared/components/fields/macros/attribute-model-loader.service';
+
+describe('AttributeModelLoaderService', () => {
+  let service:AttributeModelLoaderService;
+  let idSpy:Mock;
+  let filterSpy:Mock;
+  let withOptionalProjectSpy:Mock;
+
+  const wpResource = { id: '42' } as unknown as HalResource;
+
+  beforeEach(async () => {
+    idSpy = vi.fn().mockReturnValue({ get: () => of(wpResource) });
+
+    filterSpy = vi.fn().mockReturnValue({ get: () => of({ elements: [wpResource] }) });
+    withOptionalProjectSpy = vi
+      .fn()
+      .mockReturnValue({ work_packages: { filterByTypeaheadOrId: filterSpy } });
+
+    const apiV3Stub = {
+      work_packages: { id: idSpy },
+      withOptionalProject: withOptionalProjectSpy,
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        AttributeModelLoaderService,
+        { provide: ApiV3Service, useValue: apiV3Stub },
+        { provide: TransitionService, useValue: { onStart: vi.fn() } },
+        { provide: CurrentProjectService, useValue: { id: 'demo-project' } },
+        { provide: I18nService, useValue: { t: (key:string) => key } },
+      ],
+    }).compileComponents();
+
+    service = TestBed.inject(AttributeModelLoaderService);
+  });
+
+  it('resolves a numeric id directly via the show endpoint', async () => {
+    await firstValueFrom(service.require('workPackage', '42'));
+
+    expect(idSpy).toHaveBeenCalledWith('42');
+    expect(filterSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves a semantic identifier directly via the show endpoint', async () => {
+    await firstValueFrom(service.require('workPackage', 'OP-19273'));
+
+    expect(idSpy).toHaveBeenCalledWith('OP-19273');
+    expect(withOptionalProjectSpy).not.toHaveBeenCalled();
+  });
+
+  it('resolves a free-text subject reference via the typeahead filter', async () => {
+    await firstValueFrom(service.require('workPackage', 'Project start'));
+
+    expect(filterSpy).toHaveBeenCalledWith('Project start', false, { pageSize: '1' });
+    expect(idSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.spec.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.spec.ts
@@ -84,6 +84,20 @@ describe('AttributeModelLoaderService', () => {
     expect(withOptionalProjectSpy).not.toHaveBeenCalled();
   });
 
+  it('routes a zero or zero-padded id through the show endpoint rather than a subject search', async () => {
+    await firstValueFrom(service.require('workPackage', '0'));
+
+    expect(idSpy).toHaveBeenCalledWith('0');
+    expect(filterSpy).not.toHaveBeenCalled();
+
+    idSpy.mockClear();
+
+    await firstValueFrom(service.require('workPackage', '007'));
+
+    expect(idSpy).toHaveBeenCalledWith('007');
+    expect(filterSpy).not.toHaveBeenCalled();
+  });
+
   it('resolves a free-text subject reference via the typeahead filter', async () => {
     await firstValueFrom(service.require('workPackage', 'Project start'));
 

--- a/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
+++ b/frontend/src/app/shared/components/fields/macros/attribute-model-loader.service.ts
@@ -39,15 +39,19 @@ import {
   map,
   shareReplay,
   take,
-  tap,
 } from 'rxjs/operators';
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import { multiInput } from '@openproject/reactivestates';
 import { TransitionService } from '@uirouter/core';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';
 import { HalResource } from 'core-app/features/hal/resources/hal-resource';
+import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
 
 export type SupportedAttributeModels = 'project'|'workPackage';
+
+// Matches a work package reference that is a numeric ID ("1234") or a semantic
+// identifier ("PROJ-42"). Anything else is treated as a subject reference.
+const WP_ID_OR_SEMANTIC = new RegExp(`^(?:${WP_ID_URL_PATTERN})$`);
 
 @Injectable({ providedIn: 'root' })
 export class AttributeModelLoaderService {
@@ -103,7 +107,6 @@ export class AttributeModelLoaderService {
       .values$()
       .pipe(
         take(1),
-        tap({ next: (val) => console.log(`VAL ${val}`), error: (err) => console.error(`ERR ${err}`) }),
       );
   }
 
@@ -140,8 +143,9 @@ export class AttributeModelLoaderService {
       return throwError(this.text.not_found);
     }
 
-    // Return global reference to the subject
-    if (/^[1-9]\d*$/.test(id)) {
+    // Resolve a numeric ID or semantic identifier globally; the API show
+    // endpoint resolves both forms transparently.
+    if (WP_ID_OR_SEMANTIC.test(id)) {
       return this
         .apiV3Service
         .work_packages
@@ -152,7 +156,7 @@ export class AttributeModelLoaderService {
         );
     }
 
-    // Otherwise, look for subject IN the current project (if we're in project context)
+    // Otherwise, treat the reference as a subject and look it up in the current project
     return this
       .apiV3Service
       .withOptionalProject(this.currentProject.id)

--- a/spec/models/exports/pdf/common/macro_spec.rb
+++ b/spec/models/exports/pdf/common/macro_spec.rb
@@ -320,6 +320,30 @@ RSpec.describe Exports::PDF::Common::Macro do
       end
     end
 
+    describe "with a semantic work package identifier",
+             with_settings: { work_packages_identifier: "semantic" } do
+      let(:semantic_project) { create(:project, identifier: "PROJ") }
+      let(:semantic_work_package) do
+        wp = create(:work_package, project: semantic_project, type: type_task, subject: "Semantic subject")
+        wp.allocate_and_register_semantic_id
+        wp.reload
+      end
+      let(:user) do
+        create(
+          :user,
+          member_with_permissions: {
+            project => %i[view_work_packages view_project_attributes view_project],
+            semantic_project => %i[view_work_packages view_project_attributes view_project]
+          }
+        )
+      end
+      let(:markdown) { "workPackageValue:#{semantic_work_package.identifier}:subject" }
+
+      it "outputs the attribute value for the work package addressed by its semantic identifier" do
+        expect(formatted).to eq("Semantic subject")
+      end
+    end
+
     describe "with restricted work package ID and attribute" do
       let(:markdown) { "workPackageValue:#{restricted_work_package.id}:subject" }
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-802

Context: https://www.openproject.org/docs/user-guide/wysiwyg/#available-attributes-for-work-packages

# What are you trying to accomplish?

With semantic work package identifiers enabled, embedding an attribute with `workPackageValue:PROJ-42:subject` (or `workPackageLabel:`) failed to render, showing _"Cannot expand macro: Requested resource could not be found"_. 

#### (Input)
<img width="622" height="317" alt="Screenshot 2026-06-03 at 4 25 21 PM" src="https://github.com/user-attachments/assets/12f289e4-d809-4769-854f-a65163e2d502" />

#### Before

<img width="1184" height="185" alt="Screenshot 2026-06-03 at 4 24 53 PM" src="https://github.com/user-attachments/assets/ec540140-3fdb-4247-af72-34b618025e54" />

#### After

<img width="567" height="197" alt="Screenshot 2026-06-03 at 4 25 11 PM" src="https://github.com/user-attachments/assets/7efcd716-a077-4b8a-8fe5-4164d4b2adc9" />

# What approach did you choose and why?

The old guard `/^[1-9]\d*$/ `only accepted numeric ids, so semantic identifiers like PROJ-42 fell through to a project-scoped typeahead search and never matched. The fix routes both numeric and semantic ids through the shared [WP_ID_URL_PATTERN](https://github.com/opf/openproject/blob/1c59b6813cf06468232dd34427a2695b2308c36a/frontend/src/app/shared/helpers/work-package-id-pattern.ts#L8) and the WP show endpoint.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
