### PR TITLE
Allow viewing Activity attachments in shared WPs

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -163,9 +163,9 @@ class Journal < ApplicationRecord
 
   def attachments_visible?(user = User.current)
     if internal?
-      super && user.allowed_in_project?(:view_internal_comments, project)
+      journable.attachments_visible?(user) && user.allowed_in_project?(:view_internal_comments, project)
     else
-      super
+      journable.attachments_visible?(user)
     end
   end
 

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe Journal do
           end
         end
       end
+
+      context "with a non-project-member who has the work package shared with them" do
+        let(:shared_user) { create(:user) }
+        let(:journal) { create(:work_package_journal, journable: work_package, version: 2) }
+
+        before do
+          create(:work_package_member, entity: work_package, user: shared_user,
+                                       roles: [create(:view_work_package_role)])
+          login_as(shared_user)
+        end
+
+        it "is visible" do
+          expect(journal).to be_attachments_visible(shared_user)
+        end
+      end
     end
   end
 

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Journal do
         it "is visible" do
           expect(journal).to be_attachments_visible(shared_user)
         end
+
+        context "when the journal is internal" do
+          let(:journal) { create(:work_package_journal, journable: work_package, version: 2, internal: true) }
+
+          it "is not visible without the internal comments permission" do
+            expect(journal).not_to be_attachments_visible(shared_user)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-524/activity

# What are you trying to accomplish?
According to the ticket, whenever a work package is shared with a non-member user, that user is prevented from loading attachments. Let's correct that.

# What approach did you choose and why?
Follow up on Oliver's permission model improvements from https://github.com/opf/openproject/pull/23246.

The code has been determining attachment visibility based on the _journal entry_, which doesn't hold enough context -- by default the `acts_as_attachable` extension only checks whether the user is a member of the project.

This fix switches the code to determine visibility based on the _journaled item_ (= work package), which respects the context of package sharing. This is the same pattern already used in the `visible?` method just below the fixed one.

# Screenshots

Before:
<img width="940" height="331" alt="Screenshot 2026-06-03 at 16 06 56" src="https://github.com/user-attachments/assets/1fb1da19-b886-4179-a2b3-e446c1aaf3e7" />


After:
<img width="939" height="399" alt="Screenshot 2026-06-03 at 16 07 33" src="https://github.com/user-attachments/assets/c21df472-f5de-47bc-94b6-a58895afd739" />



# Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
