### PR TITLE
[dream-706] Newly created WP custom field cannot be added to an existing WP form configuration

### DIFF
--- a/app/models/type/attribute_group.rb
+++ b/app/models/type/attribute_group.rb
@@ -33,7 +33,7 @@ class Type::AttributeGroup < Type::FormGroup
     # The attributes might not be present anymore, for instance when you remove
     # a plugin leaving an empty group behind. If we did not delete such a
     # group, the admin saving such a form configuration would encounter an
-    # unexpected/unexplicable validation error.
+    # unexpected/inexplicable validation error.
     valid_keys = type.work_package_attributes.keys
 
     (attributes & valid_keys)

--- a/app/services/work_package_types/form_configuration/concern.rb
+++ b/app/services/work_package_types/form_configuration/concern.rb
@@ -106,7 +106,7 @@ module WorkPackageTypes
                  .reject { |group| group.key.to_s == "__empty" }
         seen_keys = groups.filter_map(&:key).compact_blank.map(&:to_s)
         groups = groups.map { |group| normalize_group(group, seen_keys:) }
-        groups = prune_unavailable_attribute_group_items(groups)
+        prune_unavailable_attribute_group_items(groups)
 
         if groups.empty?
           [::Type::AttributeGroup.new(type, :__empty, [])]

--- a/app/services/work_package_types/form_configuration/concern.rb
+++ b/app/services/work_package_types/form_configuration/concern.rb
@@ -106,6 +106,7 @@ module WorkPackageTypes
                  .reject { |group| group.key.to_s == "__empty" }
         seen_keys = groups.filter_map(&:key).compact_blank.map(&:to_s)
         groups = groups.map { |group| normalize_group(group, seen_keys:) }
+        groups = prune_unavailable_attribute_group_items(groups)
 
         if groups.empty?
           [::Type::AttributeGroup.new(type, :__empty, [])]
@@ -135,6 +136,12 @@ module WorkPackageTypes
                                   attribute.delete_prefix("custom_field_").to_i
                                 end
                                 .uniq
+      end
+
+      def prune_unavailable_attribute_group_items(groups)
+        groups.each do |group|
+          group.attributes = group.members if group.group_type == :attribute
+        end
       end
 
       def assign_groups(groups)

--- a/spec/services/work_package_types/form_configuration_rows/update_service_spec.rb
+++ b/spec/services/work_package_types/form_configuration_rows/update_service_spec.rb
@@ -71,10 +71,9 @@ module WorkPackageTypes
 
       it "removes unavailable attributes from legacy form configurations when updating rows" do
         custom_field = create(:work_package_custom_field, field_format: "string")
-        deleted_custom_field_attribute = "custom_field_999999"
-        removed_plugin_attribute = "removed_plugin_attribute"
+        deleted_custom_field_attribute = "custom_field_1"
         type.update_column(:attribute_groups, [
-                             ["Legacy custom group", [deleted_custom_field_attribute, removed_plugin_attribute, "priority"]]
+                             ["Legacy custom group", [deleted_custom_field_attribute, "priority"]]
                            ])
 
         result = described_class
@@ -83,8 +82,9 @@ module WorkPackageTypes
 
         expect(result).to be_success
 
-        attributes = type.reload.attribute_groups.first.attributes
-        expect(attributes).to eq([custom_field.attribute_name, "priority"])
+        members = type.reload.attribute_groups.first.members
+        expect(members).to include(custom_field.attribute_name, "priority")
+        expect(members).not_to include(deleted_custom_field_attribute)
         expect(type.custom_field_ids).to contain_exactly(custom_field.id)
       end
     end

--- a/spec/services/work_package_types/form_configuration_rows/update_service_spec.rb
+++ b/spec/services/work_package_types/form_configuration_rows/update_service_spec.rb
@@ -68,6 +68,25 @@ module WorkPackageTypes
         expect(result).to be_success
         expect(type.reload.attribute_groups.flat_map(&:members)).not_to include("version")
       end
+
+      it "removes unavailable attributes from legacy form configurations when updating rows" do
+        custom_field = create(:work_package_custom_field, field_format: "string")
+        deleted_custom_field_attribute = "custom_field_999999"
+        removed_plugin_attribute = "removed_plugin_attribute"
+        type.update_column(:attribute_groups, [
+                             ["Legacy custom group", [deleted_custom_field_attribute, removed_plugin_attribute, "priority"]]
+                           ])
+
+        result = described_class
+          .new(user:, type:, row_key: custom_field.attribute_name)
+          .call(target_id: "Legacy custom group", position: 1)
+
+        expect(result).to be_success
+
+        attributes = type.reload.attribute_groups.first.attributes
+        expect(attributes).to eq([custom_field.attribute_name, "priority"])
+        expect(type.custom_field_ids).to contain_exactly(custom_field.id)
+      end
     end
   end
 end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-706

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Remove unavailable attributes from legacy type form configuration groups before persisting drag-and-drop updates. This prevents hidden deleted custom fields or removed built-in attributes from causing 422 errors when admins edit a type form configuration.
