### PR TITLE
fix and cleanup linter actions

### DIFF
--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -1,0 +1,31 @@
+name: ERB lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.erb'
+      - '.erb_lint.yml'
+      - '.erb_linters/**'
+
+jobs:
+  erb-lint:
+    name: ERB lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
+      - name: Install erb_lint
+        run: gem install -N erb_lint erblint-github
+      - name: Run erb-lint
+        uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b # v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          fail_on_error: true

--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install erb_lint
         run: gem install -N erb_lint erblint-github
       - name: Run erb-lint
-        uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b # v1
+        uses: opf/action-erblint@49c54b56c60d0c50885065468cf149b61d5c2a60 # main
         with:
           reporter: github-pr-check

--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           bundler-cache: true
-      - name: Run erb-lint
+      - name: Run ERB lint
         uses: opf/action-erblint@49c54b56c60d0c50885065468cf149b61d5c2a60 # main
         with:
           reporter: github-pr-check

--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -26,6 +26,4 @@ jobs:
       - name: Run erb-lint
         uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b # v1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
-          fail_on_error: true

--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -21,9 +21,10 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
-      - name: Install erb_lint
-        run: gem install -N erb_lint erblint-github
+        with:
+          bundler-cache: true
       - name: Run erb-lint
         uses: opf/action-erblint@49c54b56c60d0c50885065468cf149b61d5c2a60 # main
         with:
           reporter: github-pr-check
+          use_bundler: true

--- a/.github/workflows/erb-lint-core.yml
+++ b/.github/workflows/erb-lint-core.yml
@@ -16,7 +16,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set up Ruby

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/eslint-core.yml
+++ b/.github/workflows/eslint-core.yml
@@ -1,4 +1,5 @@
-name: eslint
+name: ESLint
+
 on:
   pull_request:
     branches:
@@ -11,23 +12,26 @@ on:
 
 jobs:
   eslint:
-    name: eslint
+    name: ESLint
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22.15'
           package-manager-cache: false
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
+      - name: Run ESLint
+        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
         with:
           reporter: github-pr-check
           workdir: 'frontend/'

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -1,4 +1,4 @@
-name: rubocop
+name: RuboCop
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   rubocop:
-    name: rubocop
+    name: RuboCop
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
-      - name: Run Rubocop
+      - name: Run RuboCop
         uses: reviewdog/action-rubocop@b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d # v2
         with:
           reporter: github-pr-check

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Rubocop
         uses: reviewdog/action-rubocop@b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d # v2
         with:
-          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
           rubocop_version: gemfile
           rubocop_extensions: >
             rubocop-capybara:gemfile
@@ -32,5 +32,4 @@ jobs:
             rubocop-rails:gemfile
             rubocop-rspec:gemfile
             rubocop-rspec_rails:gemfile
-          reporter: github-pr-check
           only_changed: true

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -14,7 +14,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Set up Ruby

--- a/.github/workflows/rubocop-core.yml
+++ b/.github/workflows/rubocop-core.yml
@@ -34,11 +34,3 @@ jobs:
             rubocop-rspec_rails:gemfile
           reporter: github-pr-check
           only_changed: true
-      - name: Install erb_lint
-        run: gem install -N erb_lint erblint-github
-      - name: Run erb-lint
-        uses: tk0miya/action-erblint@44c5fe3552356fe8bff23f30d534aa4258aa3f7b # v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-check
-          fail_on_error: true

--- a/.github/workflows/yamllint-core.yml
+++ b/.github/workflows/yamllint-core.yml
@@ -1,4 +1,4 @@
-name: yamllint
+name: Yamllint
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   yamllint:
-    name: yamllint
+    name: Yamllint
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Run Yamllint
         uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0 # v1.21.0
         with:

--- a/.github/workflows/yamllint-core.yml
+++ b/.github/workflows/yamllint-core.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Run Yamllint
         uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0 # v1.21.0
         with:
-          github_token: ${{ secrets.github_token }}
-          fail_level: error
+          reporter: github-pr-check
           yamllint_flags: >
             .yamllint.yml
             config/locales/en.yml

--- a/.github/workflows/yamllint-core.yml
+++ b/.github/workflows/yamllint-core.yml
@@ -9,12 +9,13 @@ on:
       - 'modules/*/config/locales/en.yml'
       - 'modules/*/config/locales/js-en.yml'
 
-permissions: {}
-
 jobs:
-  rubocop:
+  yamllint:
     name: yamllint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
* yamllint was not showing error because permissions didn't allow it, so I fixed and removed `fail_level`, as it is not needed anymore
* cleanup options to linters:
  * remove explicit `github_token`, as it is set by default
  * set `reporter: github-pr-check` for all, as `eslint` has different default and better to have consistency
* extract `erb_lint` to a separate workflow and use our fork with [multiple fixes](https://github.com/tk0miya/action-erblint/compare/main...opf:action-erblint:main)

AFAIU `CLA Assistant / ` is an issue on github side, but anyway `fail_level` is not needed:
<img width="714" height="250" alt="image" src="https://github.com/user-attachments/assets/5d16917c-70ef-4555-9609-88d1594f11fa" />

Switched to annotations in https://github.com/opf/openproject/pull/23640 to remove the `CLA Assistant / ` oddity.
Also check https://github.com/opf/openproject/pull/23641