### PR TITLE
[OP-19456] Date custom field filter "is empty" does not return all work packages with empty values

### DIFF
--- a/app/models/custom_value/date_strategy.rb
+++ b/app/models/custom_value/date_strategy.rb
@@ -31,6 +31,10 @@
 class CustomValue::DateStrategy < CustomValue::FormatStrategy
   include Redmine::I18n
 
+  def parse_value(val)
+    val.presence
+  end
+
   def typed_value
     return if value.blank?
 

--- a/config/constants/settings/definition.rb
+++ b/config/constants/settings/definition.rb
@@ -479,12 +479,14 @@ module Settings
       emails_footer: {
         default: {
           "en" => ""
-        }
+        },
+        string_values: true
       },
       emails_header: {
         default: {
           "en" => ""
-        }
+        },
+        string_values: true
       },
       # use email address as login, hide login in registration form
       email_login: {

--- a/spec/models/custom_value/date_strategy_spec.rb
+++ b/spec/models/custom_value/date_strategy_spec.rb
@@ -133,4 +133,27 @@ RSpec.describe CustomValue::DateStrategy do
       end
     end
   end
+
+  describe "#parse_value" do
+    subject { instance.parse_value(val) }
+    let(:value) { nil } # unused by parse_value but required by the double
+
+    context "when value is a valid date string" do
+      let(:val) { "2025-07-03" }
+
+      it { is_expected.to eq "2025-07-03" }
+    end
+
+    context "when value is an empty string" do
+      let(:val) { "" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when value is nil" do
+      let(:val) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/OP-19456

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

- Add `parse_value` override for `DateStrategy` that makes empty strings equivalent to nil, fixing the bug for new values

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
