### PR TITLE
Add checksums header back to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1795,6 +1795,7 @@ DEPENDENCIES
   yabeda-puma-plugin
   yabeda-rails
 
+CHECKSUMS
   Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
   action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
   actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0


### PR DESCRIPTION
- Trying to fix the CI failing complaining about a dirty `Gemfile.lock` (like https://github.com/opf/openproject/actions/runs/26950117974/job/79515102730)
- Reverses the removal of the 'CHECKSUMS' header in https://github.com/opf/openproject/pull/23547/changes#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fL1798, but idk why that was removed in the first place