### PR TITLE
[JIM-111] Jira Migrator: Do not disable the button if the instance is not switched to semantic identifiers

### DIFF
--- a/app/views/admin/import/jira/instances/index.html.erb
+++ b/app/views/admin/import/jira/instances/index.html.erb
@@ -49,8 +49,7 @@ See COPYRIGHT and LICENSE files for more details.
       label: t("admin.jira.configuration.title"),
       scheme: :primary,
       tag: :a,
-      href: new_admin_import_jira_path,
-      disabled: !Setting::WorkPackageIdentifier.semantic?
+      href: new_admin_import_jira_path
     ) { t("admin.jira.configuration.title") }
   end
 %>


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/JIM-111

# What are you trying to achieve?

It is not clear for users why they cannot create a Jira configuration. The red banner about semantic identifiers is shown, but there is no immediate connection to the disabled button. 

(Especially if they already created a configuration before the semantic identifiers requirement was added)

# What approach did you choose and why?

Make the button always enabled.
