### PR TITLE
[STC-757] Support semantic IDs in the spent time calendar

### DIFF
--- a/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
+++ b/frontend/src/app/features/calendar/te-calendar/te-calendar.component.ts
@@ -19,8 +19,7 @@ import {
   SlotLaneContentArg,
 } from '@fullcalendar/core';
 import { ConfigurationService } from 'core-app/core/config/configuration.service';
-import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
-import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
+import { TimeEntryResource, formatTimeEntryEntityName } from 'core-app/features/hal/resources/time-entry-resource';
 import { CollectionResource } from 'core-app/features/hal/resources/collection-resource';
 import interactionPlugin from '@fullcalendar/interaction';
 import { HalResourceEditingService } from 'core-app/shared/components/fields/edit/services/hal-resource-editing.service';
@@ -31,7 +30,6 @@ import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { HalResourceNotificationService } from 'core-app/features/hal/services/hal-resource-notification.service';
-import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { OpCalendarService } from 'core-app/features/calendar/op-calendar.service';
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import { IFieldSchema } from 'core-app/shared/components/fields/field.base';
@@ -619,11 +617,7 @@ export class TimeEntryCalendarComponent implements AfterViewInit, OnDestroy {
   }
 
   private entityName(entry:TimeEntryResource):string {
-    const entity = entry.entity;
-    const formattedId = entity instanceof WorkPackageResource
-      ? entity.formattedId
-      : `#${idFromLink(entity.href)}`;
-    return `${formattedId}: ${entity.name}`;
+    return formatTimeEntryEntityName(entry.entity);
   }
 
   private popoverHtml(

--- a/frontend/src/app/features/hal/resources/time-entry-resource.ts
+++ b/frontend/src/app/features/hal/resources/time-entry-resource.ts
@@ -32,6 +32,8 @@ import { InputState } from '@openproject/reactivestates';
 import { WorkPackageResource } from 'core-app/features/hal/resources/work-package-resource';
 import Formattable = api.v3.Formattable;
 import { MeetingResource } from 'core-app/features/hal/resources/meeting-resource';
+import idFromLink from 'core-app/features/hal/helpers/id-from-link';
+import { formatWorkPackageId } from 'core-app/shared/helpers/work-package-id-pattern';
 
 export class TimeEntryResource extends HalResource {
   project:ProjectResource;
@@ -60,4 +62,10 @@ export class TimeEntryResource extends HalResource {
 
 export interface TimeEntryResource {
   delete():Promise<unknown>;
+}
+
+export function formatTimeEntryEntityName(entity:WorkPackageResource|MeetingResource):string {
+  const displayId = entity.$link?.displayId;
+  const formattedId = displayId ? formatWorkPackageId(displayId) : `#${idFromLink(entity.href)}`;
+  return `${formattedId}: ${entity.name}`;
 }

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.ts
@@ -7,7 +7,7 @@ import { ApiV3Service } from 'core-app/core/apiv3/api-v3.service';
 import { FilterOperator } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { TimezoneService } from 'core-app/core/datetime/timezone.service';
 import { ConfirmDialogService } from 'core-app/shared/components/modals/confirm-dialog/confirm-dialog.service';
-import { TimeEntryResource } from 'core-app/features/hal/resources/time-entry-resource';
+import { TimeEntryResource, formatTimeEntryEntityName } from 'core-app/features/hal/resources/time-entry-resource';
 import idFromLink from 'core-app/features/hal/helpers/id-from-link';
 import { SchemaResource } from 'core-app/features/hal/resources/schema-resource';
 import {
@@ -101,11 +101,7 @@ export abstract class WidgetTimeEntriesListComponent extends AbstractWidgetCompo
   }
 
   public entityName(entry:TimeEntryResource):string {
-    const entity = entry.entity;
-    const formattedId = entity instanceof WorkPackageResource
-      ? entity.formattedId
-      : `#${idFromLink(entity.href)}`;
-    return `${formattedId}: ${entity.name}`;
+    return formatTimeEntryEntityName(entry.entity);
   }
 
   public entityId(entry:TimeEntryResource):string {

--- a/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
+++ b/modules/costs/lib/api/v3/time_entries/entity_representer_factory.rb
@@ -86,11 +86,7 @@ module API
                                                                                      title_attribute:,
                                                                                      getter:))
 
-            if link.is_a?(Hash) && entity.is_a?(WorkPackage)
-              link.merge(displayId: entity.display_id.to_s)
-            else
-              link
-            end
+            entity.is_a?(WorkPackage) ? link.merge(displayId: entity.display_id.to_s) : link
           }
         end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/74900/activity

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
https://github.com/opf/openproject/pull/23344 appeared to fix this exact gap, but it seems the validation was incorrect and the screenshot was probably on a stale Angular state.

The fix added `displayId` to the entity link in the API response (correct) but then tried to read it via `entity instanceof WorkPackageResource` on the frontend (broken). The time entries list endpoint uses `embed_links: false`, so entities are created as generic `HalResource` stubs by the HAL framework (never as `WorkPackageResource`), making the `instanceof` check always false.

## Screenshots
Before:
<img width="571" height="584" alt="Screenshot 2026-06-04 at 16 41 51" src="https://github.com/user-attachments/assets/62deeca5-a4e8-4e04-805d-e5e2842de86b" />


After:
<img width="585" height="585" alt="Screenshot 2026-06-04 at 16 19 35" src="https://github.com/user-attachments/assets/4c890611-fac9-4c6a-9b6b-54743c6a5860" />


# What approach did you choose and why?
* Pull the ID from `entity.$link?.displayId`, which contains the correct semantic ID
* DRY up the ID formatter
* Remove a redundant `link.is_a?(Hash)` guard


# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
