### PR TITLE
attempt to fix flickering activity spec

### DIFF
--- a/spec/support/components/work_packages/activities.rb
+++ b/spec/support/components/work_packages/activities.rb
@@ -369,25 +369,21 @@ module Components
         end
       end
 
-      def filter_journals(filter, default_sorting: User.current.preference&.comments_sorting || "desc")
+      def filter_journals(filter)
         retry_block do
-          page.find_test_selector("op-wp-journals-filter-menu").click
+          wait_for_turbo_stream do
+            page.find_test_selector("op-wp-journals-filter-menu").click
 
-          case filter
-          when :all
-            page.find_test_selector("op-wp-journals-filter-show-all").click
-          when :only_comments
-            page.find_test_selector("op-wp-journals-filter-show-only-comments").click
-          when :only_changes
-            page.find_test_selector("op-wp-journals-filter-show-only-changes").click
+            case filter
+            when :all
+              page.find_test_selector("op-wp-journals-filter-show-all").click
+            when :only_comments
+              page.find_test_selector("op-wp-journals-filter-show-only-comments").click
+            when :only_changes
+              page.find_test_selector("op-wp-journals-filter-show-only-changes").click
+            end
           end
         end
-
-        # Ensure the journals are reloaded
-        wait_for { page }.to have_test_selector("op-wp-journals-#{filter}-#{default_sorting}")
-        # the wait_for will not work on its own as the selector will be switched to the target filter before the page is updated
-        # so we still need to wait statically unfortunately to avoid flakyness
-        sleep 1
       end
 
       def set_journal_sorting(sorting, default_filter: :all)


### PR DESCRIPTION
rspec ./spec/features/activities/work_package/activities_spec.rb:678

The attempt is to have the frontend wait for the turbo stream response rather than a fixed timeout. The removed wait_for seems to be non-functional.


