### PR TITLE
Introduce visible scope for backlog buckets

### DIFF
--- a/modules/backlogs/app/models/backlog_buckets/scopes/visible.rb
+++ b/modules/backlogs/app/models/backlog_buckets/scopes/visible.rb
@@ -28,30 +28,14 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-class BacklogBucket < ApplicationRecord
-  include ::Scopes::Scoped
+module BacklogBuckets::Scopes
+  module Visible
+    extend ActiveSupport::Concern
 
-  self.table_name = "backlog_buckets"
-
-  belongs_to :project
-  has_many :work_packages, inverse_of: :backlog_bucket, dependent: :nullify
-  has_many :displayed_work_packages, # rubocop:disable Rails/HasManyOrHasOneDependent
-           -> do
-             visible(User.current)
-               .without_status_considered_closed
-               .without_excluded_type
-               .order_by_position
-           end,
-           class_name: "WorkPackage",
-           inverse_of: :backlog_bucket
-
-  scope :order_alphabetically, -> { order(:name) }
-
-  scopes :visible
-
-  validates :name, :project, presence: true
-
-  def self.for_project(project)
-    where(project:).order_alphabetically.includes(displayed_work_packages: %i[assigned_to priority parent])
+    class_methods do
+      def visible(user = User.current)
+        where(project: Project.allowed_to(user, :view_sprints))
+      end
+    end
   end
 end

--- a/modules/backlogs/spec/models/backlog_buckets/scopes/visible_spec.rb
+++ b/modules/backlogs/spec/models/backlog_buckets/scopes/visible_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe BacklogBuckets::Scopes::Visible do
+  shared_let(:project) { create(:project) }
+  shared_let(:other_project) { create(:project) }
+
+  shared_let(:bucket) { create(:backlog_bucket, project:) }
+  shared_let(:other_bucket) { create(:backlog_bucket, project: other_project) }
+
+  shared_let(:user_with_permission) do
+    create(:user, member_with_permissions: { project => %i[view_sprints] })
+  end
+  shared_let(:user_without_permission) do
+    create(:user, member_with_permissions: { project => %i[view_work_packages] })
+  end
+  shared_let(:user_without_membership) { create(:user) }
+
+  subject { BacklogBucket.visible(current_user) }
+
+  context "for a user with view_sprints in the project" do
+    current_user { user_with_permission }
+
+    it "returns only the buckets in projects the user has permission for" do
+      expect(subject).to contain_exactly(bucket)
+    end
+  end
+
+  context "for a user without view_sprints permission" do
+    current_user { user_without_permission }
+
+    it "returns no buckets" do
+      expect(subject).to be_empty
+    end
+  end
+
+  context "for a user without any project membership" do
+    current_user { user_without_membership }
+
+    it "returns no buckets" do
+      expect(subject).to be_empty
+    end
+  end
+
+  context "when called without a user argument" do
+    current_user { user_with_permission }
+
+    it "uses User.current" do
+      expect(BacklogBucket.visible).to contain_exactly(bucket)
+    end
+  end
+end


### PR DESCRIPTION
Extracted this from #23534 to achieve smaller PRs

Introduces a `visible` scope for Backlog Buckets. Does not change any logic to actually use it. This will be done separately.

# Merge checklist

- [x] Added/updated tests
