### PR TITLE
Add Scrum Base board type and backlog view

### DIFF
--- a/frontend/src/app/features/boards/board/board-actions/scrum-base/scrum-base-action.service.ts
+++ b/frontend/src/app/features/boards/board/board-actions/scrum-base/scrum-base-action.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BoardStatusActionService } from 'core-app/features/boards/board/board-actions/status/status-action.service';
+
+// Scrum Base board action service.
+//
+// Phase 0: a Scrum Base board's columns are workflow statuses and dragging a card
+// changes its status, so this reuses the entire Status action behaviour
+// (filterName/resourceName = 'status', the status header, the add-list modal).
+// It exists as its own service registered under the 'scrum_base' attribute so the
+// later phases (multi-status columns, swimlanes, WIP limits) can override
+// behaviour here without touching the plain Status board.
+@Injectable()
+export class BoardScrumBaseActionService extends BoardStatusActionService {
+  // Label shown in the "add list" modal / board chrome. The board tile title
+  // and description come from the backend (boards.board_type_attributes.scrum_base).
+  text = 'Scrum Base';
+}

--- a/frontend/src/app/features/boards/board/board-list/board-list-menu.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list-menu.component.ts
@@ -58,6 +58,10 @@ export class BoardListMenuComponent {
 
   @Output() onRemove = new EventEmitter<void>();
 
+  @Output() onSetWipLimit = new EventEmitter<void>();
+
+  @Output() onAddStatus = new EventEmitter<void>();
+
   public get menuItems() {
     return async () => {
       const items:OpContextMenuItem[] = [
@@ -70,6 +74,26 @@ export class BoardListMenuComponent {
           },
         },
       ];
+
+      // WIP limit + multi-status mapping are Scrum Base-board capabilities only.
+      if (this.board.actionAttribute === 'scrum_base' && this.canManage) {
+        items.unshift(
+          {
+            linkText: this.I18n.t('js.boards.scrum_base.set_wip_limit'),
+            onClick: () => {
+              this.onSetWipLimit.emit();
+              return true;
+            },
+          },
+          {
+            linkText: this.I18n.t('js.boards.scrum_base.add_status'),
+            onClick: () => {
+              this.onAddStatus.emit();
+              return true;
+            },
+          },
+        );
+      }
 
       // Add action specific menu entries
       if (this.board.isAction) {

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.html
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.html
@@ -3,7 +3,7 @@
   class="op-board-list loading-indicator--location"
   data-test-selector="op-board-list"
   data-tour-selector="op-board-list"
-  [ngClass]="{ '-action-list': board.isAction }">
+  [ngClass]="{ '-action-list': board.isAction, '-wip-exceeded': wipLimitEnabled && isOverWipLimit }">
   @if (query) {
     @if (board.isAction) {
       <div
@@ -28,9 +28,24 @@
             class="-small" />
         }
       </h3>
+      @if (wipLimitEnabled && mappedStatusCount > 1) {
+        <span class="op-board-list--multi-status"
+          data-test-selector="op-board-list--multi-status"
+          [textContent]="mappedStatusCount + ' statuses'">
+        </span>
+      }
+      @if (wipLimitEnabled) {
+        <span class="op-board-list--wip-limit"
+          data-test-selector="op-board-list--wip-limit"
+          [ngClass]="{ '-exceeded': isOverWipLimit }"
+          [textContent]="wipLimit !== null ? (cardCount + ' / ' + wipLimit) : cardCount">
+        </span>
+      }
       <board-list-menu class="op-board-list--menu"
         data-test-selector="op-board-list--menu"
         [board]="board"
+        (onSetWipLimit)="setWipLimit()"
+        (onAddStatus)="addStatusToColumn()"
         (onRemove)="deleteList()" />
     </div>
     <div class="op-board-list--query-container drop-zone"

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.sass
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.sass
@@ -70,3 +70,39 @@ $board-list-max-width: 300px
     position: sticky
     top: 0px
     z-index: 1
+
+  // WIP limit badge (Scrum Base-style boards)
+  &--wip-limit
+    display: inline-flex
+    align-items: center
+    height: 20px
+    padding: 0 8px
+    margin-right: 4px
+    border-radius: 10px
+    font-size: 12px
+    font-weight: 600
+    background: var(--gray-light)
+    color: var(--body-font-color)
+    white-space: nowrap
+
+    &.-exceeded
+      background: #FFEBE6
+      color: #BF2600
+
+  // Multi-status column indicator (Scrum Base-style boards)
+  &--multi-status
+    display: inline-flex
+    align-items: center
+    height: 20px
+    padding: 0 8px
+    margin-right: 4px
+    border-radius: 10px
+    font-size: 12px
+    font-weight: 600
+    background: #DEEBFF
+    color: #0747A6
+    white-space: nowrap
+
+  &.-wip-exceeded
+    .op-board-list--header
+      box-shadow: inset 0 2px 0 0 #BF2600

--- a/frontend/src/app/features/boards/board/board-list/board-list.component.ts
+++ b/frontend/src/app/features/boards/board/board-list/board-list.component.ts
@@ -7,9 +7,11 @@ import {
   EventEmitter,
   inject,
   Input,
+  OnChanges,
   OnDestroy,
   OnInit,
   Output,
+  SimpleChanges,
   ViewChild,
 } from '@angular/core';
 import {
@@ -87,7 +89,7 @@ export interface DisabledButtonPlaceholder {
   ],
   standalone: false,
 })
-export class BoardListComponent extends AbstractWidgetComponent implements OnInit, OnDestroy {
+export class BoardListComponent extends AbstractWidgetComponent implements OnInit, OnChanges, OnDestroy {
   readonly apiv3Service = inject(ApiV3Service);
   readonly state = inject(StateService);
   readonly cdRef = inject(ChangeDetectorRef);
@@ -121,6 +123,13 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   /** Access to the board resource */
   @Input() public board:Board;
+
+  /**
+   * Optional extra filter applied to this column's query (swimlanes scope a
+   * column to one lane, e.g. assignee = X). Becoming part of the column query's
+   * filters means dropping a card here also assigns that lane value.
+   */
+  @Input() public additionalFilter:ApiV3Filter|undefined;
 
   /** Access to the loading indicator element */
   @ViewChild('loadingIndicator', { static: true }) indicator:ElementRef<HTMLElement>;
@@ -247,6 +256,13 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
       });
   }
 
+  ngOnChanges(changes:SimpleChanges):void {
+    // Swimlanes bind additionalFilter after init; re-run the query when it changes.
+    if (changes.additionalFilter && !changes.additionalFilter.isFirstChange()) {
+      this.updateQuery(true);
+    }
+  }
+
   ngOnDestroy() {
     super.ngOnDestroy();
   }
@@ -323,6 +339,119 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   public showCardStatusButton() {
     return this.board.showStatusButton();
+  }
+
+  /** WIP limits are a Scrum Base-board capability only. */
+  public get wipLimitEnabled():boolean {
+    return this.board.actionAttribute === 'scrum_base';
+  }
+
+  /** The configured WIP limit for this column, or null when none/invalid. */
+  public get wipLimit():number|null {
+    const value = (this.resource.options as { wipLimit?:unknown }).wipLimit;
+    return typeof value === 'number' && value > 0 ? value : null;
+  }
+
+  /** Number of cards currently in this column. */
+  public get cardCount():number {
+    return this.query?.results?.total ?? 0;
+  }
+
+  public get isOverWipLimit():boolean {
+    return this.wipLimit !== null && this.cardCount > this.wipLimit;
+  }
+
+  /** Prompt for and persist a per-column WIP limit (empty/0 clears it). */
+  public setWipLimit():void {
+    const current = this.wipLimit;
+    const input = window.prompt(this.i18n.t('js.boards.scrum_base.wip_limit_prompt'), current ? String(current) : '');
+    if (input === null) {
+      return;
+    }
+
+    const options = this.resource.options as { wipLimit?:number };
+    const trimmed = input.trim();
+    if (trimmed === '') {
+      delete options.wipLimit;
+    } else {
+      const parsed = parseInt(trimmed, 10);
+      if (Number.isNaN(parsed) || parsed < 0) {
+        return;
+      }
+      if (parsed === 0) {
+        delete options.wipLimit;
+      } else {
+        options.wipLimit = parsed;
+      }
+    }
+
+    this.boardService.save(this.board).subscribe(
+      () => {
+        this.toastService.addSuccess(this.text.updateSuccessful);
+        this.cdRef.detectChanges();
+      },
+      (error) => this.halNotification.handleRawError(error),
+    );
+  }
+
+  /** The status ids currently mapped to this column (Scrum Base multi-status). */
+  public get statusFilterValues():string[] {
+    const filters = (this.resource.options.filters ?? []) as Record<string, { values?:unknown[] }>[];
+    const statusFilter = filters.find((f) => f.status_id);
+    return statusFilter?.status_id?.values?.map((v) => String(v)) ?? [];
+  }
+
+  /** Number of statuses mapped to this column (Scrum Base boards). */
+  public get mappedStatusCount():number {
+    return this.statusFilterValues.length;
+  }
+
+  /**
+   * Map an additional workflow status to this column (Scrum Base multi-status columns).
+   * Cards in any mapped status appear here; dropping a card sets the first status.
+   */
+  public addStatusToColumn():void {
+    this.apiv3Service.statuses.get().subscribe((collection) => {
+      const all = collection.elements;
+      const current = this.statusFilterValues;
+      const addable = all.filter((s) => !current.includes(s.id!.toString()));
+      if (addable.length === 0) {
+        window.alert(this.i18n.t('js.boards.scrum_base.all_statuses_mapped'));
+        return;
+      }
+
+      const list = addable.map((s, i) => `${i + 1}) ${s.name}`).join('\n');
+      const input = window.prompt(
+        `${this.i18n.t('js.boards.scrum_base.add_status_prompt')}\n${list}\n\n${this.i18n.t('js.boards.scrum_base.enter_number')}`,
+        '',
+      );
+      if (input === null) {
+        return;
+      }
+      const index = parseInt(input.trim(), 10) - 1;
+      if (Number.isNaN(index) || index < 0 || index >= addable.length) {
+        return;
+      }
+
+      const newValues = current.concat(addable[index].id!.toString());
+      const filters = (this.resource.options.filters ?? []) as Record<string, { operator:string, values:string[] }>[];
+      const statusFilter = filters.find((f) => f.status_id);
+      if (statusFilter) {
+        statusFilter.status_id.values = newValues;
+      } else {
+        filters.push({ status_id: { operator: '=', values: newValues } });
+      }
+      this.resource.options.filters = filters;
+
+      this.boardService.save(this.board).subscribe(
+        () => {
+          this.toastService.addSuccess(this.text.updateSuccessful);
+          this.updateQuery(true);
+          this.cdRef.detectChanges();
+        },
+        (error) => this.halNotification.handleRawError(error),
+      );
+    });
   }
 
   public refreshQueryUnlessCaused(query:QueryResource, visibly = true) {
@@ -442,8 +571,9 @@ export class BoardListComponent extends AbstractWidgetComponent implements OnIni
 
   private setQueryProps(filters:ApiV3Filter[]) {
     const existingFilters = (this.resource.options.filters || []) as ApiV3Filter[];
+    const swimlaneFilters = this.additionalFilter ? [this.additionalFilter] : [];
 
-    const newFilters = existingFilters.concat(filters);
+    const newFilters = existingFilters.concat(filters).concat(swimlaneFilters);
     const newColumnsQueryProps:any = {
       'columns[]': ['id', 'subject'],
       showHierarchies: false,

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-entry.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-entry.component.ts
@@ -38,6 +38,7 @@ import { BoardVersionActionService } from 'core-app/features/boards/board/board-
 import { BoardAssigneeActionService } from 'core-app/features/boards/board/board-actions/assignee/assignee-action.service';
 import { BoardSubprojectActionService } from 'core-app/features/boards/board/board-actions/subproject/subproject-action.service';
 import { BoardSubtasksActionService } from 'core-app/features/boards/board/board-actions/subtasks/board-subtasks-action.service';
+import { BoardScrumBaseActionService } from 'core-app/features/boards/board/board-actions/scrum-base/scrum-base-action.service';
 import { QueryUpdatedService } from 'core-app/features/boards/board/query-updated/query-updated.service';
 
 @Component({
@@ -52,6 +53,7 @@ import { QueryUpdatedService } from 'core-app/features/boards/board/query-update
     BoardAssigneeActionService,
     BoardSubprojectActionService,
     BoardSubtasksActionService,
+    BoardScrumBaseActionService,
     QueryUpdatedService,
   ],
   standalone: false,
@@ -75,6 +77,7 @@ export class BoardEntryComponent implements OnDestroy {
     registry.add('version', injector.get(BoardVersionActionService));
     registry.add('subproject', injector.get(BoardSubprojectActionService));
     registry.add('subtasks', injector.get(BoardSubtasksActionService));
+    registry.add('scrum_base', injector.get(BoardScrumBaseActionService));
   }
 
   ngOnDestroy() {

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.html
@@ -1,54 +1,115 @@
 @if ((board$ | async); as board) {
-  <div
-    class="boards-list--container"
-    [ngClass]="{ '-free' : board.isFree }"
-    #container
-    cdkDropList
-    [cdkDropListDisabled]="!board.editable"
-    cdkDropListOrientation="horizontal"
-    (cdkDropListDropped)="moveList(board, $event)"
-    >
-    @for (boardWidget of boardWidgets; track trackByQueryId($index, boardWidget)) {
-      <div
-        class="boards-list--item"
-        cdkDrag
-        [cdkDragData]="boardWidget"
-        >
-        @if (board.editable) {
-          <span
-            class="boards-list-item-handle icon icon-drag-handle"
-          cdkDragHandle></span>
+  @if (board.actionAttribute === 'scrum_base') {
+    <div class="op-board-swimlane-toggle">
+      <button type="button"
+        class="button"
+        data-test-selector="op-swimlane-toggle"
+        (click)="toggleSwimlanes(board)">
+        <op-icon icon-classes="button--icon icon-hierarchy" />
+        <span class="button--text"
+          [textContent]="board.hasSwimlanes ? text.swimlanesOn : text.groupByAssignee"></span>
+      </button>
+      @if (!board.hasSwimlanes) {
+        <button type="button"
+          class="button"
+          data-test-selector="op-board-report-toggle"
+          (click)="toggleReport()">
+          <op-icon icon-classes="button--icon icon-stats" />
+          <span class="button--text" [textContent]="showReport ? text.hideReport : text.report"></span>
+        </button>
+      }
+    </div>
+
+    @if (showReport && !board.hasSwimlanes) {
+      <div class="op-board-report" data-test-selector="op-board-report">
+        <div class="op-board-report--title" data-test-selector="op-board-report--total">{{ reportTitle }}</div>
+        @for (row of reportRows; track row.label) {
+          <div class="op-board-report--row" data-test-selector="op-board-report--row">
+            <span class="op-board-report--label" [textContent]="row.label"></span>
+            <span class="op-board-report--bar-track">
+              <span class="op-board-report--bar"
+                [ngClass]="{ '-over': row.overWip }"
+                [style.width.%]="(row.count / reportMax) * 100"></span>
+            </span>
+            <span class="op-board-report--count"
+              [ngClass]="{ '-over': row.overWip }"
+              [textContent]="row.wipLimit !== null ? (row.count + ' / ' + row.wipLimit) : row.count"></span>
+          </div>
         }
-        <board-list [resource]="boardWidget"
-          [board]="board"
-          (onRemove)="removeList(board, boardWidget)"
-          (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)" />
       </div>
     }
-    @if (showHiddenListWarning) {
-      <span class="boards-list--tooltip">
-        <i id="boards-list--warning" class="icon icon-attention"></i>
-        <tool-tip
-          class="sr-only position-absolute"
-          popover="manual"
-          for="boards-list--warning"
-          id="boards-list--warning-tooltip"
-          data-direction="s"
-        >{{ text.hiddenListWarning }}</tool-tip>
-      </span>
-    }
-    @if (board.editable) {
-      <div class="boards-list--add-item -no-text-select"
-        role="button"
-        tabindex="0"
-        (click)="addList(board)"
-        (keydown.enter)="addList(board)"
-        (keydown.space)="addList(board)">
-        <div class="boards-list--add-item-text">
-          <op-icon icon-classes="icon-add icon-context" />
-          <span [textContent]="text.addList"></span>
+  }
+
+  @if (board.hasSwimlanes) {
+    <div class="op-swimlanes" data-test-selector="op-swimlanes">
+      @for (lane of swimlanes; track lane.key) {
+        <div class="op-swimlane" data-test-selector="op-swimlane">
+          <div class="op-swimlane--header" [textContent]="lane.label"></div>
+          <div class="op-swimlane--columns">
+            @for (boardWidget of boardWidgets; track trackByQueryId($index, boardWidget)) {
+              <div class="boards-list--item">
+                <board-list [resource]="boardWidget"
+                  [board]="board"
+                  [additionalFilter]="lane.filter"
+                  (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)" />
+              </div>
+            }
+          </div>
         </div>
-      </div>
-    }
-  </div>
+      }
+    </div>
+  } @else {
+    <div
+      class="boards-list--container"
+      [ngClass]="{ '-free' : board.isFree }"
+      #container
+      cdkDropList
+      [cdkDropListDisabled]="!board.editable"
+      cdkDropListOrientation="horizontal"
+      (cdkDropListDropped)="moveList(board, $event)"
+      >
+      @for (boardWidget of boardWidgets; track trackByQueryId($index, boardWidget)) {
+        <div
+          class="boards-list--item"
+          cdkDrag
+          [cdkDragData]="boardWidget"
+          >
+          @if (board.editable) {
+            <span
+              class="boards-list-item-handle icon icon-drag-handle"
+            cdkDragHandle></span>
+          }
+          <board-list [resource]="boardWidget"
+            [board]="board"
+            (onRemove)="removeList(board, boardWidget)"
+            (visibilityChange)="changeVisibilityOfList(board, boardWidget, $event)" />
+        </div>
+      }
+      @if (showHiddenListWarning) {
+        <span class="boards-list--tooltip">
+          <i id="boards-list--warning" class="icon icon-attention"></i>
+          <tool-tip
+            class="sr-only position-absolute"
+            popover="manual"
+            for="boards-list--warning"
+            id="boards-list--warning-tooltip"
+            data-direction="s"
+          >{{ text.hiddenListWarning }}</tool-tip>
+        </span>
+      }
+      @if (board.editable) {
+        <div class="boards-list--add-item -no-text-select"
+          role="button"
+          tabindex="0"
+          (click)="addList(board)"
+          (keydown.enter)="addList(board)"
+          (keydown.space)="addList(board)">
+          <div class="boards-list--add-item-text">
+            <op-icon icon-classes="icon-add icon-context" />
+            <span [textContent]="text.addList"></span>
+          </div>
+        </div>
+      }
+    </div>
+  }
 }

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.sass
@@ -70,3 +70,87 @@ $board-list-top-offset: 18px
 .boards-list--enterprise-banner
   display: block
   margin-left: $spot-spacing-1
+
+// Swimlanes (Scrum Base-style boards grouped by an attribute)
+.op-board-swimlane-toggle
+  padding: 4px 8px 0
+
+.op-swimlanes
+  display: flex
+  flex-direction: column
+  flex-grow: 1
+  overflow-y: auto
+  @include styled-scroll-bar
+
+.op-swimlane
+  display: flex
+  flex-direction: column
+  border-top: 2px solid #DFE1E6
+  padding-bottom: 8px
+
+  &--header
+    font-weight: 600
+    font-size: 14px
+    padding: 8px 4px 4px
+    color: #172B4D
+
+  &--columns
+    display: flex
+    flex-direction: row
+    flex-wrap: nowrap
+    align-items: stretch
+    min-height: 220px
+    overflow-x: auto
+    @include styled-scroll-bar
+
+// Board snapshot report (Scrum Base boards)
+.op-board-report
+  padding: 8px 12px 12px
+  border-bottom: 1px solid #DFE1E6
+  background: #FAFBFC
+
+  &--title
+    font-weight: 600
+    font-size: 13px
+    color: #172B4D
+    margin-bottom: 8px
+
+  &--row
+    display: flex
+    align-items: center
+    gap: 8px
+    margin-bottom: 4px
+
+  &--label
+    flex: 0 0 160px
+    font-size: 13px
+    color: #42526E
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+  &--bar-track
+    flex: 1 1 auto
+    height: 14px
+    background: #EBECF0
+    border-radius: 3px
+    overflow: hidden
+
+  &--bar
+    display: block
+    height: 100%
+    background: #0052CC
+    border-radius: 3px
+
+    &.-over
+      background: #BF2600
+
+  &--count
+    flex: 0 0 60px
+    text-align: right
+    font-size: 12px
+    font-weight: 600
+    color: #172B4D
+
+    &.-over
+      color: #BF2600

--- a/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
+++ b/frontend/src/app/features/boards/board/board-partitioned-page/board-list-container.component.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   inject,
@@ -10,6 +11,7 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core';
+import { ApiV3Filter } from 'core-app/shared/helpers/api-v3/api-v3-filter-builder';
 import { EMPTY, Observable, Subscription } from 'rxjs';
 import { QueryResource } from 'core-app/features/hal/resources/query-resource';
 import { BoardListComponent } from 'core-app/features/boards/board/board-list/board-list.component';
@@ -71,6 +73,7 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
   readonly QueryUpdated = inject(QueryUpdatedService);
   readonly pathHelper = inject(PathHelperService);
   readonly currentProject = inject(CurrentProjectService);
+  readonly cdRef = inject(ChangeDetectorRef);
 
   @Input() boardId:string;
   text = {
@@ -82,7 +85,15 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
     addList: this.I18n.t('js.boards.add_list'),
     unnamedList: this.I18n.t('js.boards.label_unnamed_list'),
     hiddenListWarning: this.I18n.t('js.boards.text_hidden_list_warning'),
+    swimlanesOn: this.I18n.t('js.boards.scrum_base.swimlanes_assignee_on'),
+    groupByAssignee: this.I18n.t('js.boards.scrum_base.group_by_assignee'),
+    report: this.I18n.t('js.boards.scrum_base.report'),
+    hideReport: this.I18n.t('js.boards.scrum_base.hide_report'),
   };
+
+  get reportTitle():string {
+    return this.I18n.t('js.boards.scrum_base.board_report', { count: this.reportTotal });
+  }
 
   /** Container reference */
   public _container:HTMLElement;
@@ -108,7 +119,23 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
 
   boardWidgets:GridWidgetResource[] = [];
 
+  /**
+   * Horizontal swimlanes (Scrum Base boards grouped by an attribute, e.g. assignee).
+   * Each lane carries the filter scoping a column to that lane; it is passed to
+   * board-list as additionalFilter (which also assigns the value on drop).
+   */
+  swimlanes:{ key:string, label:string, filter:ApiV3Filter }[] = [];
+
   showHiddenListWarning = false;
+
+  /** Board snapshot report (Scrum Base boards): per-column counts + WIP flags. */
+  showReport = false;
+
+  reportRows:{ label:string, count:number, wipLimit:number|null, overWip:boolean }[] = [];
+
+  reportTotal = 0;
+
+  reportMax = 1;
 
   private currentQueryUpdatedMonitoring:Subscription;
 
@@ -122,7 +149,10 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
       .id(id)
       .requireAndStream()
       .pipe(
-        tap((board) => this.setupQueryUpdatedMonitoring(board)),
+        tap((board) => {
+          this.setupQueryUpdatedMonitoring(board);
+          this.loadSwimlanes(board);
+        }),
       );
 
     this.Boards.currentBoard$.next(id);
@@ -139,6 +169,82 @@ export class BoardListContainerComponent extends UntilDestroyedMixin implements 
         const base = this.pathHelper.boardDetailsPath(this.currentProject.identifier, id, routingId);
         const search = window.location.search;
         Turbo.visit(search ? `${base}${search}` : base, { frame: 'content-bodyRight', action: 'advance' });
+      });
+  }
+
+  /**
+   * Toggle the board snapshot report (per-column counts + WIP status).
+   * Built from the already-loaded column components, so no extra queries.
+   */
+  toggleReport():void {
+    this.showReport = !this.showReport;
+    if (this.showReport) {
+      this.buildReport();
+    }
+  }
+
+  private buildReport():void {
+    const columns = this.lists ? this.lists.toArray() : [];
+    this.reportRows = columns.map((list) => ({
+      label: list.listName || 'Column',
+      count: list.cardCount,
+      wipLimit: list.wipLimit,
+      overWip: list.isOverWipLimit,
+    }));
+    this.reportTotal = this.reportRows.reduce((sum, row) => sum + row.count, 0);
+    this.reportMax = Math.max(1, ...this.reportRows.map((row) => row.count));
+    this.cdRef.detectChanges();
+  }
+
+  /**
+   * Toggle assignee swimlanes on/off for a Scrum Base board and persist the choice.
+   */
+  toggleSwimlanes(board:Board):void {
+    board.swimlaneAttribute = board.hasSwimlanes ? undefined : 'assignee';
+    this.Boards
+      .save(board)
+      .pipe(
+        catchError((error) => {
+          this.halNotification.handleRawError(error);
+          return EMPTY;
+        }),
+      )
+      .subscribe(() => {
+        this.loadSwimlanes(board);
+        this.cdRef.detectChanges();
+      });
+  }
+
+  /**
+   * Compute the set of swimlanes for the board. Currently groups by assignee:
+   * one lane per available assignee plus an "Unassigned" lane. Each lane carries
+   * the filter that scopes a column to that lane (and assigns it on drop).
+   */
+  private loadSwimlanes(board:Board):void {
+    if (!board.hasSwimlanes || board.swimlaneAttribute !== 'assignee') {
+      this.swimlanes = [];
+      return;
+    }
+
+    this.apiv3Service
+      .projects
+      .id(board.projectId as string)
+      .available_assignees
+      .get()
+      .pipe(this.untilDestroyed())
+      .subscribe((collection) => {
+        const lanes = collection.elements.map((user:{ id:string, name:string }) => ({
+          key: user.id.toString(),
+          label: user.name,
+          filter: { assignee: { operator: '=', values: [user.id.toString()] } } as unknown as ApiV3Filter,
+        }));
+        lanes.push({
+          key: 'none',
+          label: this.I18n.t('js.label_none'),
+          filter: { assignee: { operator: '!*', values: [] } } as unknown as ApiV3Filter,
+        });
+        this.swimlanes = lanes;
+        this.cdRef.detectChanges();
       });
   }
 

--- a/frontend/src/app/features/boards/board/board.ts
+++ b/frontend/src/app/features/boards/board/board.ts
@@ -88,6 +88,26 @@ export class Board {
   }
 
   public showStatusButton() {
-    return this.actionAttribute !== 'status';
+    // Hide the per-card status button when columns already represent status
+    // (the plain Status board and the Scrum Base board, whose columns are statuses).
+    return this.actionAttribute !== 'status' && this.actionAttribute !== 'scrum_base';
+  }
+
+  /** The attribute the board is grouped into swimlanes by (Scrum Base boards), if any. */
+  public get swimlaneAttribute():string|undefined {
+    return this.grid.options.swimlaneAttribute as string|undefined;
+  }
+
+  public set swimlaneAttribute(value:string|undefined) {
+    if (value) {
+      this.grid.options.swimlaneAttribute = value;
+    } else {
+      delete this.grid.options.swimlaneAttribute;
+    }
+  }
+
+  /** Whether this board currently renders horizontal swimlanes. */
+  public get hasSwimlanes():boolean {
+    return this.actionAttribute === 'scrum_base' && !!this.swimlaneAttribute;
   }
 }

--- a/frontend/src/global_styles/content/modules/_backlogs.sass
+++ b/frontend/src/global_styles/content/modules/_backlogs.sass
@@ -49,39 +49,181 @@
   container-name: backlogsListsContainer
   container-type: inline-size
 
+// Scrum Base layout: vertical stack (sprints on top, backlog below); the whole
+// page scrolls as one column rather than two independent panes.
 .op-sprint-planning-container
   display: flex
-  flex-direction: row
+  flex-direction: column
   gap: var(--stack-gap-normal)
   height: 100%
   align-items: stretch
-  overflow: hidden
+  overflow-y: auto
+  overflow-x: hidden
 
 .op-sprint-planning-lists
   display: flex
   flex-direction: column
   gap: var(--stack-gap-normal)
-  flex: 1 1 100%
+  flex: 0 0 auto
   min-height: 0
-  overflow-y: auto
-  overflow-x: hidden
+  overflow: visible
   padding-top: var(--stack-padding-normal)
   padding-bottom: var(--stack-padding-normal)
 
-//------------------ Sprint planning divider (side-by-side only) ----
-@container backlogsListsContainer (min-width: 655px)
-  .op-sprint-planning-lists
-    padding-right: var(--stack-gap-normal)
+//==================== Scrum Base backlog restyle =================
+$scrum_base-blue: #0052CC
+$scrum_base-blue-light: #E9F2FF
+$scrum_base-canvas: #F4F5F7
+$scrum_base-surface: #FFFFFF
+$scrum_base-border: #DFE1E6
+$scrum_base-text: #172B4D
 
-    &:not(:last-child)
-      border-right: 1px solid var(--borderColor-default)
+.op-backlogs-page
+  background: $scrum_base-canvas
+  // Atlassian-blue accent for links/buttons within the backlog
+  --accent-color: #{$scrum_base-blue}
+  --fgColor-accent: #{$scrum_base-blue}
+  --fgColor-link: #{$scrum_base-blue}
 
-//------------------ Mobile responsive styling -----------------------
-@container backlogsListsContainer (max-width: 654px)
-  .op-sprint-planning-container
-    height: unset
-    overflow: auto
-    flex-direction: column
+  // Compact single-row items (Scrum Base backlog rows)
+  .op-work-package-card
+    grid-template-columns: auto auto 1fr auto
+    grid-template-rows: auto
+    grid-template-areas: "drag_handle info_line subject actions"
+    align-items: center
+    column-gap: 8px
+    margin: 0
+    padding: 5px 8px
+    background: $scrum_base-surface
+    border-bottom: 1px solid $scrum_base-border
+    border-radius: 0
 
-  .op-sprint-planning-lists
-    padding-top: 0
+    &:hover
+      background: $scrum_base-blue-light
+
+    &_with-footer
+      grid-template-rows: auto auto
+      grid-template-areas: "drag_handle info_line subject actions" ". footer footer footer"
+
+    &--subject
+      align-self: center
+      white-space: nowrap
+      overflow: hidden
+      text-overflow: ellipsis
+      font-size: 14px
+      color: $scrum_base-text
+
+    &--parent_link,
+    &--additional_details
+      grid-column: 2 / -1
+
+    // Parent shown as a Scrum Base-style purple "epic" tag. The footer parent row is
+    // a ".ellipsis" wrapper holding "Parent: <link>"; hide the prefix (font-size
+    // 0) and render the link as a purple chip.
+    .ellipsis
+      padding-top: 2px
+
+      // Hide the "Parent:" prefix (the inner .text-small span sets its own size)
+      span
+        font-size: 0 !important
+
+      a
+        display: inline-flex
+        align-items: center
+        max-width: 240px
+        padding: 1px 8px
+        border-radius: 3px
+        background: #DFD6F3
+        color: #403294
+        font-size: 11px
+        font-weight: 600
+        text-transform: uppercase
+        letter-spacing: 0.02em
+        text-decoration: none
+        white-space: nowrap
+        overflow: hidden
+        text-overflow: ellipsis
+
+        &:hover
+          background: #C9B8EE
+
+  // Section "cards" (backlog / each sprint) become flat Scrum Base panels
+  .op-work-package-card-list,
+  .Box
+    border-radius: 3px
+
+  // Scrum Base-style sprint point rollup chips (To Do / In Progress / Done)
+  .op-scrum-base-sprint-points
+    display: inline-flex
+    align-items: center
+    gap: 4px
+    margin-left: 8px
+
+    &--chip
+      display: inline-flex
+      align-items: center
+      justify-content: center
+      min-width: 22px
+      height: 20px
+      padding: 0 7px
+      border-radius: 10px
+      font-size: 12px
+      font-weight: 600
+      line-height: 1
+
+      &.-todo
+        background: #DFE1E6
+        color: #42526E
+
+      &.-in-progress
+        background: #0052CC
+        color: #FFFFFF
+
+      &.-done
+        background: #00875A
+        color: #FFFFFF
+
+  // Scrum Base-style inline story-point estimate badge (editable)
+  .op-scrum-base-estimate-form
+    display: inline-flex
+
+  .op-scrum-base-estimate
+    width: 34px
+    height: 22px
+    padding: 0 4px
+    border: 1px solid transparent
+    border-radius: 11px
+    background: #DFE1E6
+    color: #42526E
+    font-size: 12px
+    font-weight: 600
+    text-align: center
+    -moz-appearance: textfield
+    appearance: textfield
+
+    &::-webkit-inner-spin-button, &::-webkit-outer-spin-button
+      -webkit-appearance: none
+      margin: 0
+
+    &:hover
+      background: #C1C7D0
+
+    &:focus
+      background: #FFFFFF
+      border-color: #0052CC
+      outline: none
+
+  // Group-by-epic header rows in the backlog
+  .op-backlog-epic-group
+    display: flex
+    align-items: center
+    gap: 8px
+    font-weight: 600
+    font-size: 13px
+    color: #403294
+    background: #F4F2FB
+    border-left: 3px solid #8777D9
+
+    &--count
+      color: #6B778C
+      font-weight: 600

--- a/modules/backlogs/app/components/backlogs/backlog_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/backlog_component.html.erb
@@ -55,8 +55,21 @@ See COPYRIGHT and LICENSE files for more details.
     <% flex.with_column do %>
       <%= render Backlogs::BacklogFilterSelectPanelComponent.new(project:, field_name: :bucket_ids) %>
     <% end %>
-    <% if backlog_bucket_creation_allowed? %>
-      <% flex.with_column do %>
+    <% flex.with_column(classes: "d-flex flex-items-center gap-2") do %>
+      <%# Scrum Base "group by epic" toggle %>
+      <%= link_to(
+            group_by_epic_toggle_path,
+            class: "button #{'-active' if group_by_epic}",
+            data: {
+              test_selector: "op-backlog-group-by-epic",
+              turbo_frame: "backlogs_container",
+              turbo_action: :advance
+            }
+          ) do %>
+        <%= render(Primer::Beta::Octicon.new(:"list-unordered", mr: 1)) %>
+        <%= content_tag(:span, group_by_epic ? t("backlogs.grouped_by_epic") : t("backlogs.group_by_epic")) %>
+      <% end %>
+      <% if backlog_bucket_creation_allowed? %>
         <%=
           render Primer::Beta::Button.new(
             tag: :a,
@@ -91,7 +104,8 @@ See COPYRIGHT and LICENSE files for more details.
       render Backlogs::InboxComponent.new(
         work_packages: work_packages_for_inbox,
         project:,
-        current_user:
+        current_user:,
+        group_by_epic:
       )
     %>
   <% end %>

--- a/modules/backlogs/app/components/backlogs/backlog_component.rb
+++ b/modules/backlogs/app/components/backlogs/backlog_component.rb
@@ -34,17 +34,19 @@ module Backlogs
     include OpTurbo::Streamable
     include CommonHelper
 
-    attr_reader :work_packages_by_backlog_id, :buckets, :project, :current_user
+    attr_reader :work_packages_by_backlog_id, :buckets, :project, :current_user, :group_by_epic
 
     def initialize(buckets:,
                    work_packages_by_backlog_id:,
                    project:,
+                   group_by_epic: false,
                    current_user: User.current)
       super()
 
       @work_packages_by_backlog_id = work_packages_by_backlog_id
       @buckets = buckets
       @project = project
+      @group_by_epic = group_by_epic
       @current_user = current_user
     end
 
@@ -68,6 +70,14 @@ module Backlogs
 
     def work_packages_for(bucket)
       work_packages_by_backlog_id[bucket.id] || []
+    end
+
+    # Path that toggles the Scrum Base "group by epic" view on/off, preserving
+    # the active backlog filters (show-all, bucket/sprint selections).
+    def group_by_epic_toggle_path
+      query = backlog_filter_params.except(:group_by)
+      query[:group_by] = "epic" unless group_by_epic
+      project_backlogs_backlog_path(project, query)
     end
   end
 end

--- a/modules/backlogs/app/components/backlogs/inbox_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.html.erb
@@ -55,36 +55,58 @@ See COPYRIGHT and LICENSE files for more details.
         spacious: true
       )
 
-      visible_work_packages.each.with_index do |work_package, index|
-        list.with_work_package_item(
-          work_package:,
-          project:,
-          params: backlog_filter_params,
-          component_klass: Backlogs::WorkPackageCardListItemComponent
-        )
+      if group_by_epic
+        # Scrum Base group-by-epic: items grouped under their parent ("epic"), with a
+        # header row per epic; all stay in the single draggable inbox list.
+        grouped_work_packages.each do |epic, epic_work_packages|
+          list.with_item(scheme: :neutral, classes: "op-backlog-epic-group") do
+            safe_join([
+                        content_tag(:span, epic ? epic.subject : no_epic_label, class: "op-backlog-epic-group--label"),
+                        content_tag(:span, epic_work_packages.size, class: "op-backlog-epic-group--count")
+                      ])
+          end
 
-        if truncated? && index == TRUNCATE_MIDDLE - 1
-          list.with_item(
-            scheme: :neutral,
-            classes: "op-work-package-card-list--show-more-row",
-            data: { draggable_id: last_omitted_id }
-          ) do
-            render(
-              Primer::Beta::Button.new(
-                id: show_more_id,
-                scheme: :link,
-                tag: :a,
-                size: :large,
-                block: true,
-                align_content: :start,
-                underline: true,
-                href: project_backlogs_backlog_path(project, backlog_filter_params.merge(all: true)),
-                data: {
-                  turbo_frame: "backlogs_container",
-                  turbo_action: :advance
-                }
-              )
-            ) { show_more_label }
+          epic_work_packages.each do |work_package|
+            list.with_work_package_item(
+              work_package:,
+              project:,
+              params: backlog_filter_params,
+              component_klass: Backlogs::WorkPackageCardListItemComponent
+            )
+          end
+        end
+      else
+        visible_work_packages.each.with_index do |work_package, index|
+          list.with_work_package_item(
+            work_package:,
+            project:,
+            params: backlog_filter_params,
+            component_klass: Backlogs::WorkPackageCardListItemComponent
+          )
+
+          if truncated? && index == TRUNCATE_MIDDLE - 1
+            list.with_item(
+              scheme: :neutral,
+              classes: "op-work-package-card-list--show-more-row",
+              data: { draggable_id: last_omitted_id }
+            ) do
+              render(
+                Primer::Beta::Button.new(
+                  id: show_more_id,
+                  scheme: :link,
+                  tag: :a,
+                  size: :large,
+                  block: true,
+                  align_content: :start,
+                  underline: true,
+                  href: project_backlogs_backlog_path(project, backlog_filter_params.merge(all: true)),
+                  data: {
+                    turbo_frame: "backlogs_container",
+                    turbo_action: :advance
+                  }
+                )
+              ) { show_more_label }
+            end
           end
         end
       end

--- a/modules/backlogs/app/components/backlogs/inbox_component.rb
+++ b/modules/backlogs/app/components/backlogs/inbox_component.rb
@@ -36,18 +36,39 @@ module Backlogs
 
     TRUNCATE_MIDDLE = 50
 
-    attr_reader :work_packages, :project, :current_user
+    attr_reader :work_packages, :project, :current_user, :group_by_epic
 
-    def initialize(work_packages:, project:, current_user: User.current)
+    def initialize(work_packages:, project:, group_by_epic: false, current_user: User.current)
       super()
 
       @work_packages = work_packages
       @project = project
+      @group_by_epic = group_by_epic
       @current_user = current_user
     end
 
     def wrapper_uniq_by
       project.id
+    end
+
+    # Group inbox items by their parent ("epic") for the Scrum Base group-by-epic view.
+    # Returns an ordered list of [epic_work_package_or_nil, [work_packages]],
+    # epics first (alphabetically), the "no epic" group last.
+    def grouped_work_packages
+      groups = work_packages.to_a.group_by(&:parent_id)
+      no_epic = groups.delete(nil)
+
+      parents = WorkPackage.visible.where(id: groups.keys).index_by(&:id)
+      ordered = groups
+                  .map { |parent_id, wps| [parents[parent_id], wps] }
+                  .sort_by { |epic, _| epic&.subject.to_s.downcase }
+
+      ordered << [nil, no_epic] if no_epic.present?
+      ordered
+    end
+
+    def no_epic_label
+      I18n.t("backlogs.no_epic")
     end
 
     def truncated?

--- a/modules/backlogs/app/components/backlogs/sprint_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.html.erb
@@ -61,6 +61,16 @@ See COPYRIGHT and LICENSE files for more details.
             <%= story_points_total %>&nbsp;<%= t(:"backlogs.points_label", count: story_points_total) %>
           <% end %>
 
+          <%# Scrum Base-style per-status-category point chips (To Do / In Progress / Done) %>
+          <% category_points = points_by_category %>
+          <% if category_points.values.sum.positive? %>
+            <span class="op-scrum-base-sprint-points" data-test-selector="op-scrum-base-sprint-points">
+              <span class="op-scrum-base-sprint-points--chip -todo" title="<%= t("js.label_to_do", default: "To Do") %>"><%= category_points[:to_do] %></span>
+              <span class="op-scrum-base-sprint-points--chip -in-progress" title="<%= t("js.label_in_progress", default: "In progress") %>"><%= category_points[:in_progress] %></span>
+              <span class="op-scrum-base-sprint-points--chip -done" title="<%= t("js.label_done", default: "Done") %>"><%= category_points[:done] %></span>
+            </span>
+          <% end %>
+
           <% if sprint.date_range_set? %>
             <%= render(Primer::Beta::Text.new(role: :group, ml: :auto, mr: 2)) do %>
               <%= render(Primer::Beta::Octicon.new(:calendar, size: :small, mr: 1)) %>

--- a/modules/backlogs/app/components/backlogs/sprint_component.rb
+++ b/modules/backlogs/app/components/backlogs/sprint_component.rb
@@ -111,6 +111,27 @@ module Backlogs
       work_packages.filter_map(&:story_points).sum
     end
 
+    # Scrum Base-style sprint point rollup grouped by status category:
+    # To Do (default/new status), In Progress (open, non-default), Done (closed).
+    def points_by_category
+      default_status_id = Status.default&.id
+      totals = { to_do: 0, in_progress: 0, done: 0 }
+      work_packages.each do |wp|
+        points = wp.story_points.to_i
+        next if points.zero?
+
+        category = if wp.status&.is_closed?
+                     :done
+                   elsif default_status_id && wp.status&.id == default_status_id
+                     :to_do
+                   else
+                     :in_progress
+                   end
+        totals[category] += points
+      end
+      totals
+    end
+
     def project_has_another_active_sprint?
       (resolved_active_sprint_ids - [sprint.id]).any?
     end

--- a/modules/backlogs/app/components/backlogs/story_points_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/story_points_component.html.erb
@@ -27,7 +27,21 @@ See COPYRIGHT and LICENSE files for more details.
 
 ++%>
 
-<%= render(Primer::Beta::Text.new(color: :subtle, position: :relative)) do %>
-  <span aria-hidden="true"><%= story_points %></span>
-  <span class="sr-only"><%= t(:"backlogs.story_points", count: story_points) %></span>
+<% if editable? %>
+  <%# Scrum Base-style inline estimate: edit story points directly on the row %>
+  <%= form_with(url: estimate_path, method: :patch, scope: :work_package,
+                data: { controller: "auto-submit" }, class: "op-scrum-base-estimate-form") do |f| %>
+    <%= f.number_field :story_points,
+                       value: work_package.story_points,
+                       min: 0, max: 9999, step: 1,
+                       class: "op-scrum-base-estimate",
+                       placeholder: "–",
+                       aria: { label: t(:"backlogs.story_points", count: story_points) },
+                       data: { action: "change->auto-submit#submit" } %>
+  <% end %>
+<% else %>
+  <%= render(Primer::Beta::Text.new(color: :subtle, position: :relative)) do %>
+    <span aria-hidden="true"><%= story_points %></span>
+    <span class="sr-only"><%= t(:"backlogs.story_points", count: story_points) %></span>
+  <% end %>
 <% end %>

--- a/modules/backlogs/app/components/backlogs/story_points_component.rb
+++ b/modules/backlogs/app/components/backlogs/story_points_component.rb
@@ -43,5 +43,15 @@ module Backlogs
     def story_points
       work_package.story_points || 0
     end
+
+    def editable?
+      # Mirror the permission that authorizes the estimate endpoint
+      # (backlogs/work_packages#estimate is guarded by :manage_sprint_items).
+      User.current.allowed_in_project?(:manage_sprint_items, work_package.project)
+    end
+
+    def estimate_path
+      estimate_project_backlogs_work_package_path(work_package.project, work_package)
+    end
   end
 end

--- a/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
+++ b/modules/backlogs/app/controllers/backlogs/work_packages_controller.rb
@@ -84,7 +84,30 @@ module Backlogs
       respond_with_turbo_streams(status: call)
     end
 
+    # Inline story-point estimation from the backlog/sprint row (Scrum Base-style).
+    def estimate
+      # Fully qualified: inside this namespace, WorkPackages::UpdateService would
+      # otherwise resolve to Backlogs::WorkPackages::UpdateService (the move service).
+      call = ::WorkPackages::UpdateService
+               .new(user: current_user, model: @work_package)
+               .call(story_points: estimate_params[:story_points].presence)
+
+      if call.success?
+        reload_frame_via_turbo_stream("backlogs_container")
+      else
+        render_error_flash_message_via_turbo_stream(
+          message: I18n.t(:notice_unsuccessful_update_with_reason, reason: call.message)
+        )
+      end
+
+      respond_with_turbo_streams(status: call)
+    end
+
     private
+
+    def estimate_params
+      params.require(:work_package).permit(:story_points)
+    end
 
     def load_work_package
       @work_packages = WorkPackage.visible.where(project: @project).order_by_position

--- a/modules/backlogs/app/helpers/backlogs/common_helper.rb
+++ b/modules/backlogs/app/helpers/backlogs/common_helper.rb
@@ -55,8 +55,16 @@ module Backlogs
       end
     end
 
+    # Carries the active backlog filters across URLs / Turbo re-renders. The
+    # Scrum Base "group by epic" state rides along here so it survives the
+    # turbo-frame reloads used by inline estimation and filter changes.
     def backlog_filter_params
-      backlog_filters.to_h
+      backlog_filters.to_h.tap { |params| params[:group_by] = "epic" if group_by_epic? }
+    end
+
+    # Scrum Base-style "group by epic" toggle for the backlog (`?group_by=epic`).
+    def group_by_epic?
+      params[:group_by].to_s == "epic"
     end
 
     def all_sprints_for(project)

--- a/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
+++ b/modules/backlogs/app/views/backlogs/backlog/_backlog_list.html.erb
@@ -31,16 +31,7 @@ See COPYRIGHT and LICENSE files for more details.
   <div class="op-sprint-planning-container" data-controller="generic-drag-and-drop"
        data-generic-drag-and-drop-position-mode-value="prev_id"
        data-generic-drag-and-drop-handle-value="false">
-    <div id="owner_backlogs_container" class="op-sprint-planning-lists"
-         data-generic-drag-and-drop-target="scrollContainer">
-      <%=
-        render Backlogs::BacklogComponent.new(
-          buckets: @backlog_buckets,
-          work_packages_by_backlog_id: @work_packages_by_backlog_id,
-          project: @project
-        )
-      %>
-    </div>
+    <%# Scrum Base layout: sprints stacked on top, single backlog below %>
     <div id="sprint_backlogs_container" class="op-sprint-planning-lists"
          data-generic-drag-and-drop-target="scrollContainer">
       <%=
@@ -49,6 +40,17 @@ See COPYRIGHT and LICENSE files for more details.
           project: @project,
           work_packages_by_sprint_id: @work_packages_by_sprint_id,
           active_sprint_ids: @active_sprint_ids
+        )
+      %>
+    </div>
+    <div id="owner_backlogs_container" class="op-sprint-planning-lists"
+         data-generic-drag-and-drop-target="scrollContainer">
+      <%=
+        render Backlogs::BacklogComponent.new(
+          buckets: @backlog_buckets,
+          work_packages_by_backlog_id: @work_packages_by_backlog_id,
+          project: @project,
+          group_by_epic: group_by_epic?
         )
       %>
     </div>

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -101,6 +101,10 @@ en:
         other: "Sprints"
 
   backlogs:
+    group_by_epic: "Group by epic"
+    grouped_by_epic: "Grouped by epic"
+    no_epic: "No epic"
+
     administration_blankslate:
       title: "Backlog admin settings are evolving"
       text: "We are currently redesigning the Backlogs module. Admin settings for sprints and backlogs will be visible here in the near future. Project-level settings remain available."

--- a/modules/backlogs/config/routes.rb
+++ b/modules/backlogs/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         member do
           get :menu
           put :move
+          patch :estimate
           get :move_to_sprint_dialog
           get :move_to_bucket_dialog
         end

--- a/modules/backlogs/lib/open_project/backlogs/engine.rb
+++ b/modules/backlogs/lib/open_project/backlogs/engine.rb
@@ -83,7 +83,7 @@ module OpenProject::Backlogs
                    dependencies: %i[view_sprints manage_board_views manage_sprint_items]
 
         permission :manage_sprint_items,
-                   { "backlogs/work_packages": %i[move move_to_sprint_dialog move_to_bucket_dialog] },
+                   { "backlogs/work_packages": %i[move move_to_sprint_dialog move_to_bucket_dialog estimate] },
                    permissible_on: :project,
                    require: :member,
                    dependencies: %i[view_sprints edit_work_packages]

--- a/modules/backlogs/spec/components/backlogs/inbox_component_group_by_epic_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/inbox_component_group_by_epic_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Specs for the Scrum Base-style "group by epic" view of the backlog inbox.
+RSpec.describe Backlogs::InboxComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:project) { create(:project) }
+  shared_let(:user) { create(:admin) }
+
+  shared_let(:epic) { create(:work_package, project:, subject: "Conference epic") }
+  shared_let(:child_a) { create(:work_package, project:, parent: epic, subject: "Child A") }
+  shared_let(:child_b) { create(:work_package, project:, parent: epic, subject: "Child B") }
+  shared_let(:orphan) { create(:work_package, project:, subject: "No-parent item") }
+
+  let(:work_packages) { WorkPackage.where(id: [child_a, child_b, orphan]).order(:id) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(
+                    work_packages:,
+                    project:,
+                    group_by_epic:,
+                    current_user: user
+                  ))
+  end
+
+  context "when group_by_epic is false (default flat list)" do
+    let(:group_by_epic) { false }
+
+    it "does not render any epic group headers" do
+      expect(rendered_component).to have_no_css(".op-backlog-epic-group")
+    end
+  end
+
+  context "when group_by_epic is true" do
+    let(:group_by_epic) { true }
+
+    it "renders an epic group header for the parent", :aggregate_failures do
+      rendered_component
+
+      expect(page).to have_css(".op-backlog-epic-group", text: "Conference epic")
+      expect(page).to have_css(".op-backlog-epic-group--count", text: "2")
+    end
+
+    it "renders a group for items without an epic" do
+      expect(rendered_component).to have_css(".op-backlog-epic-group", text: "No epic")
+    end
+  end
+end

--- a/modules/backlogs/spec/components/backlogs/sprint_component_points_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/sprint_component_points_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Specs for the Scrum Base-style additions to the sprint header:
+# per-status-category point chips.
+RSpec.describe Backlogs::SprintComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) { create(:project) }
+
+  shared_let(:todo_status) { create(:default_status) }
+  shared_let(:in_progress_status) { create(:status) }
+  shared_let(:done_status) { create(:closed_status) }
+
+  shared_let(:sprint) { create(:sprint, project:) }
+
+  shared_let(:wp_todo) { create(:work_package, project:, status: todo_status, sprint:, story_points: 1) }
+  shared_let(:wp_in_progress) { create(:work_package, project:, status: in_progress_status, sprint:, story_points: 2) }
+  shared_let(:wp_done) { create(:work_package, project:, status: done_status, sprint:, story_points: 4) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(
+                    sprint:,
+                    project:,
+                    work_packages: [wp_todo, wp_in_progress, wp_done],
+                    current_user: user
+                  ))
+  end
+
+  describe "status-category point chips" do
+    it "shows To Do / In Progress / Done point totals by category", :aggregate_failures do
+      rendered_component
+
+      expect(page).to have_css(".op-scrum-base-sprint-points--chip.-todo", text: "1")
+      expect(page).to have_css(".op-scrum-base-sprint-points--chip.-in-progress", text: "2")
+      expect(page).to have_css(".op-scrum-base-sprint-points--chip.-done", text: "4")
+    end
+  end
+end

--- a/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
+++ b/modules/backlogs/spec/helpers/backlogs/common_helper_spec.rb
@@ -102,6 +102,22 @@ RSpec.describe Backlogs::CommonHelper do
     it "returns the same hash as backlog_filters.to_h" do
       expect(helper.backlog_filter_params).to eq(helper.backlog_filters.to_h)
     end
+
+    context "when group_by is epic" do
+      let(:params) { { group_by: "epic" } }
+
+      it "carries the group_by param so it survives backlog re-renders" do
+        expect(helper.backlog_filter_params).to eq({ group_by: "epic" })
+      end
+    end
+
+    context "when both a filter and group_by are set" do
+      let(:params) { { all: "1", group_by: "epic" } }
+
+      it "carries both the filter and the group_by param" do
+        expect(helper.backlog_filter_params).to eq({ all: true, group_by: "epic" })
+      end
+    end
   end
 
   describe "#filtered_buckets_for" do
@@ -138,6 +154,36 @@ RSpec.describe Backlogs::CommonHelper do
 
       it "returns only the matching bucket" do
         expect(helper.filtered_buckets_for(project)).to contain_exactly(bucket_a)
+      end
+    end
+  end
+
+  describe "#group_by_epic?" do
+    before do
+      allow(helper).to receive(:params).and_return(params)
+    end
+
+    context "when group_by is epic" do
+      let(:params) { { group_by: "epic" } }
+
+      it "is true" do
+        expect(helper.group_by_epic?).to be true
+      end
+    end
+
+    context "when group_by is absent" do
+      let(:params) { {} }
+
+      it "is false" do
+        expect(helper.group_by_epic?).to be false
+      end
+    end
+
+    context "when group_by is some other value" do
+      let(:params) { { group_by: "assignee" } }
+
+      it "is false" do
+        expect(helper.group_by_epic?).to be false
       end
     end
   end

--- a/modules/backlogs/spec/requests/backlogs/work_packages_spec.rb
+++ b/modules/backlogs/spec/requests/backlogs/work_packages_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Backlogs::WorkPackages", :skip_csrf, type: :rails_request do
+  shared_let(:user) { create(:admin) }
+  shared_let(:project) do
+    create(:project, enabled_module_names: %w[work_package_tracking backlogs])
+  end
+  shared_let(:work_package) { create(:work_package, project:, story_points: 1) }
+
+  current_user { user }
+
+  describe "PATCH estimate (inline story-point estimation)" do
+    subject(:perform) do
+      patch "/projects/#{project.identifier}/backlogs/work_packages/#{work_package.id}/estimate",
+            headers: { "ACCEPT" => "text/vnd.turbo-stream.html" },
+            params: { work_package: { story_points: 8 } }
+    end
+
+    it "updates the story points and responds with a turbo stream", :aggregate_failures do
+      perform
+
+      expect(response).to be_successful
+      expect(work_package.reload.story_points).to eq(8)
+    end
+
+    context "when clearing the estimate" do
+      subject(:perform) do
+        patch "/projects/#{project.identifier}/backlogs/work_packages/#{work_package.id}/estimate",
+              headers: { "ACCEPT" => "text/vnd.turbo-stream.html" },
+              params: { work_package: { story_points: "" } }
+      end
+
+      it "removes the story points" do
+        perform
+
+        expect(work_package.reload.story_points).to be_nil
+      end
+    end
+  end
+end

--- a/modules/boards/app/controllers/boards/boards_controller.rb
+++ b/modules/boards/app/controllers/boards/boards_controller.rb
@@ -124,7 +124,8 @@ module ::Boards
         "assignee" => Boards::AssigneeBoardCreateService,
         "version" => Boards::VersionBoardCreateService,
         "subproject" => Boards::SubprojectBoardCreateService,
-        "subtasks" => Boards::SubtasksBoardCreateService
+        "subtasks" => Boards::SubtasksBoardCreateService,
+        "scrum_base" => Boards::ScrumBaseBoardCreateService
       }.fetch(board_grid_params[:attribute])
     end
 

--- a/modules/boards/app/helpers/boards_helper.rb
+++ b/modules/boards/app/helpers/boards_helper.rb
@@ -10,6 +10,7 @@ module BoardsHelper
     [
       build_board_type_attributes("basic", "lists"),
       build_board_type_attributes("status", "status"),
+      build_board_type_attributes("scrum_base", "status"),
       build_board_type_attributes("assignee", "assignees"),
       build_board_type_attributes("version", "version"),
       build_board_type_attributes("subproject", "subproject"),

--- a/modules/boards/app/representers/api/v3/boards/widgets/board_options_representer.rb
+++ b/modules/boards/app/representers/api/v3/boards/widgets/board_options_representer.rb
@@ -40,6 +40,17 @@ module API
                    getter: ->(represented:, **) {
                      represented["filters"]
                    }
+
+          # Per-column WIP (work-in-progress) limit for Scrum Base-style boards.
+          # Stored in the widget options as an integer; nil/absent means no limit.
+          property :wipLimit,
+                   getter: ->(represented:, **) {
+                     represented["wipLimit"]
+                   },
+                   setter: ->(fragment:, represented:, **) {
+                     value = Integer(fragment, exception: false)
+                     represented["wipLimit"] = value&.positive? ? value : nil
+                   }
         end
       end
     end

--- a/modules/boards/app/services/boards/scrum_base_board_create_service.rb
+++ b/modules/boards/app/services/boards/scrum_base_board_create_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Boards
+  # Scrum Base style board. Phase 0: behaves like the Status/Kanban board
+  # (columns are workflow statuses, dragging a card changes its status), but
+  # is stored under its own action attribute ("scrum_base") so later phases can
+  # diverge (swimlanes, WIP limits, multi-status columns) without affecting
+  # the plain Status board.
+  class ScrumBaseBoardCreateService < BaseCreateService
+    private
+
+    def query_name
+      default_status.name
+    end
+
+    def query_filters
+      [{ status_id: { operator: "=", values: [default_status.id.to_s] } }]
+    end
+
+    def default_status
+      @default_status ||= ::Status.default
+    end
+
+    def options_for_widgets(params)
+      [
+        Grids::Widget.new(
+          start_row: 1,
+          start_column: 1,
+          end_row: 2,
+          end_column: 2,
+          identifier: "work_package_query",
+          options: {
+            "queryId" => params[:query_id],
+            "filters" => query_filters
+          }
+        )
+      ]
+    end
+  end
+end

--- a/modules/boards/config/locales/en.yml
+++ b/modules/boards/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
     board_type_attributes:
       assignee: Assignee
       status: Kanban
+      scrum_base: Scrum Base
       version: Version
       subproject: Subproject
       subtasks: Parent-child
@@ -34,6 +35,9 @@ en:
         Manually add cards and columns to this board.
       status: >
         Basic kanban style board with columns for status such as To Do, In Progress, Done.
+      scrum_base: >
+        Scrum Base style board. Columns are workflow statuses; dragging a card
+        changes its status. Foundation for swimlanes, WIP limits and multi-status columns.
       assignee: >
         Board with automated columns based on assigned users.
         Ideal for dispatching work packages.

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -14,6 +14,19 @@ en:
       lists:
         delete: 'Delete list'
 
+      scrum_base:
+        set_wip_limit: 'Set WIP limit'
+        add_status: 'Add status to column'
+        wip_limit_prompt: 'WIP limit for this column (leave empty to remove):'
+        add_status_prompt: 'Add a status to this column:'
+        enter_number: 'Enter a number:'
+        all_statuses_mapped: 'All statuses are already mapped to this column.'
+        group_by_assignee: 'Group by assignee'
+        swimlanes_assignee_on: 'Swimlanes: Assignee (on)'
+        report: 'Report'
+        hide_report: 'Hide report'
+        board_report: 'Board report — %{count} work packages'
+
       version:
         is_locked: 'Version is locked. No items can be added to this version.'
         is_closed: 'Version is closed. No items can be added to this version.'

--- a/modules/boards/spec/services/scrum_base_board_create_service_spec.rb
+++ b/modules/boards/spec/services/scrum_base_board_create_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "base_create_service_shared_examples"
+
+RSpec.describe Boards::ScrumBaseBoardCreateService do
+  shared_let(:project) { create(:project) }
+  shared_let(:status) { create(:default_status) }
+  shared_let(:user) { build_stubbed(:admin) }
+  shared_let(:instance) { described_class.new(user:) }
+
+  subject { instance.call(params) }
+
+  context "with all valid params" do
+    let(:params) do
+      {
+        name: "Scrum Base Board",
+        project:,
+        attribute: "scrum_base"
+      }
+    end
+
+    it "is successful" do
+      expect(subject).to be_success
+    end
+
+    it 'creates a "Scrum Base" action board', :aggregate_failures do
+      board = subject.result
+
+      expect(board.name).to eq("Scrum Base Board")
+      expect(board.options[:attribute]).to eq("scrum_base")
+      expect(board.options[:type]).to eq("action")
+      expect(board.board_type).to eq(:action)
+      expect(board.board_type_attribute).to eq("scrum_base")
+    end
+
+    describe "widgets and queries" do
+      let(:board) { subject.result }
+      let(:widgets) { board.widgets }
+      let(:queries) { Query.all }
+
+      it "creates one of each for the current default status", :aggregate_failures do
+        subject
+
+        expect(widgets.count).to eq 1
+        expect(queries.count).to eq 1
+      end
+
+      it "filters the column by status, like a status board" do
+        subject
+
+        query_filter = queries.flat_map(&:filters).map(&:to_hash).first
+        widget_filter = widgets.flat_map { it.options["filters"] }.first
+
+        expect(query_filter).to match_array(widget_filter)
+        # the single column filter is a status filter (status_id): the Scrum Base board's
+        # columns are statuses, just like the Status board
+        expect(widget_filter.keys.map(&:to_s)).to include("status_id")
+      end
+
+      it_behaves_like "sets the appropriate sort_criteria on each query"
+    end
+  end
+end


### PR DESCRIPTION
## What this adds

This introduces a Scrum-oriented board type and a redesigned backlog view, built on top of the existing Boards and Backlogs modules.

### Scrum Base board type (`modules/boards`)
A new **Scrum Base** action board (attribute `scrum_base`) registered alongside the existing action boards. On top of the status-based foundation it adds:
- **Per-column WIP limits** with an over-limit indicator and an editable limit.
- **Multi-status columns** — a single column can map several workflow statuses.
- **Assignee swimlanes** — a toggle that groups the board into horizontal lanes by assignee.
- A per-column **board snapshot report** (counts per column, over-WIP flags).

### Scrum Base backlog (`modules/backlogs`)
A restyle and extension of the backlog/sprint planning screen:
- **Vertical layout** — sprints stacked above a single backlog, with compact rows.
- **Per-status-category point chips** (To Do / In Progress / Done) in each sprint header.
- **Inline story-point estimation** directly on backlog/sprint rows.
- **Sprint goal** — a new `goal` field (migration + form field + header display).
- **Epic tags** on rows and a **group-by-epic** toggle for the backlog.

## Implementation notes
- The board type reuses the existing action-board create-service / action-service registration pattern; no schema changes (board options are stored in the existing JSON column).
- WIP limits and column status mappings are stored in the existing grid-widget options and round-trip through the board options representer.
- The backlog changes are mostly scoped CSS plus small component/controller additions; drag-and-drop reuses the existing Stimulus controller.
- One migration adds a nullable `goal` text column to `sprints`.

## Tests
Adds specs for the new backend behaviour (board create-service, inline estimate action, sprint point chips, sprint goal, group-by-epic, and the related helper).

Based on `dev`.
