### PR TITLE
Work around SSRF issue

### DIFF
--- a/lib/open_project/httpx_ssrf_filter.rb
+++ b/lib/open_project/httpx_ssrf_filter.rb
@@ -46,7 +46,13 @@ module OpenProject
       end
 
       def addresses=(addrs)
-        addrs.reject!(&SsrfProtection.method(:unsafe_ip_address?)) # rubocop:disable Performance/MethodObjectAsBlock
+        addrs.reject! do |addr|
+          # working around an error in IPAddr that fails to check address inclusion if the passed address is not an
+          # IPAddr, but a SimpleDelegator to an IPAddr (like HTTPX::Resolver::Entry).
+          addr = addr.address if addr.respond_to?(:address)
+
+          SsrfProtection.send(:unsafe_ip_address?, addr)
+        end
 
         raise ServerSideRequestForgeryError, "#{@origin.host} has no public IP addresses" if addrs.empty?
 

--- a/modules/storages/spec/common/storages/adapters/authentication_strategies/basic_auth_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/authentication_strategies/basic_auth_spec.rb
@@ -34,7 +34,7 @@ require_module_spec_helper
 module Storages
   module Adapters
     module AuthenticationStrategies
-      RSpec.describe BasicAuth, :webmock do
+      RSpec.describe BasicAuth, :disable_ssrf_filter, :webmock do
         let(:user) { create(:user) }
 
         let(:storage) do

--- a/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_client_credentials_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_client_credentials_spec.rb
@@ -34,7 +34,7 @@ require_module_spec_helper
 module Storages
   module Adapters
     module AuthenticationStrategies
-      RSpec.describe OAuthClientCredentials, :webmock do
+      RSpec.describe OAuthClientCredentials, :disable_ssrf_filter, :webmock do
         let(:user) { create(:user) }
         let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
 

--- a/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_user_token_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/authentication_strategies/oauth_user_token_spec.rb
@@ -34,7 +34,7 @@ require_module_spec_helper
 module Storages
   module Adapters
     module AuthenticationStrategies
-      RSpec.describe OAuthUserToken, :webmock do
+      RSpec.describe OAuthUserToken, :disable_ssrf_filter, :webmock do
         let(:user) { create(:user) }
         let(:storage) do
           create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/add_user_to_group_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/add_user_to_group_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe AddUserToGroupCommand, :webmock do
+          RSpec.describe AddUserToGroupCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed, username: "vcr") }
             let(:auth_strategy) { Registry.resolve("nextcloud.authentication.userless").call }
             let(:input_data) { Input::AddUserToGroup.build(group:, user:).value! }

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/create_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe CreateFolderCommand, :webmock do
+          RSpec.describe CreateFolderCommand, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/delete_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/delete_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe DeleteFolderCommand, :webmock do
+          RSpec.describe DeleteFolderCommand, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/remove_user_from_group_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/remove_user_from_group_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe RemoveUserFromGroupCommand, :webmock do
+          RSpec.describe RemoveUserFromGroupCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed, username: "vcr") }
             let(:auth_strategy) { Registry.resolve("nextcloud.authentication.userless").call }
             let(:input_data) { Input::RemoveUserFromGroup.build(group:, user:).value! }

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/rename_file_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe RenameFileCommand, :webmock do
+          RSpec.describe RenameFileCommand, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/set_permissions_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe SetPermissionsCommand, :webmock do
+          RSpec.describe SetPermissionsCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed, username: "vcr") }
             let(:auth_strategy) { Registry.resolve("nextcloud.authentication.userless").call }
 

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/upload_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/commands/upload_file_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Commands
-          RSpec.describe UploadFileCommand, :webmock do
+          RSpec.describe UploadFileCommand, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_automatically_managed)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/capabilities_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/capabilities_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe CapabilitiesQuery, :webmock do
+          RSpec.describe CapabilitiesQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/download_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe DownloadLinkQuery, :webmock do
+          RSpec.describe DownloadLinkQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_info_query_spec.rb
@@ -35,7 +35,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe FileInfoQuery, :webmock do
+          RSpec.describe FileInfoQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/file_path_to_id_map_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe FilePathToIdMapQuery, :webmock do
+          RSpec.describe FilePathToIdMapQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_info_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe FilesInfoQuery, :webmock do
+          RSpec.describe FilesInfoQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:auth_strategy) { Registry["nextcloud.authentication.user_bound"].call(user, storage) }
             let(:storage) do

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/files_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe FilesQuery, :vcr, :webmock do
+          RSpec.describe FilesQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection,

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/group_users_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/group_users_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe GroupUsersQuery, :webmock do
+          RSpec.describe GroupUsersQuery, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed, username: "vcr") }
             let(:auth_strategy) { Registry.resolve("nextcloud.authentication.userless").call }
 

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/upload_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe UploadLinkQuery, :webmock do
+          RSpec.describe UploadLinkQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed, oauth_client_token_user: user)

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/user_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/queries/user_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Queries
-          RSpec.describe UserQuery, :webmock do
+          RSpec.describe UserQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) do
               create(:nextcloud_storage_with_local_connection, :as_automatically_managed,

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/ampf_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/ampf_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Validators
-          RSpec.describe AmpfConfigurationValidator, :webmock do
+          RSpec.describe AmpfConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_automatically_managed) }
             let(:project_folder_id) { "1337" }
             let!(:project_storage) do

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/authentication_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/authentication_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Validators
-          RSpec.describe AuthenticationValidator, :webmock do
+          RSpec.describe AuthenticationValidator, :disable_ssrf_filter, :webmock do
             subject(:validator) { described_class.new(storage) }
 
             context "when using OAuth2" do

--- a/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/nextcloud/validators/storage_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Nextcloud
         module Validators
-          RSpec.describe StorageConfigurationValidator, :webmock do
+          RSpec.describe StorageConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:nextcloud_storage_with_local_connection, :as_not_automatically_managed) }
 
             subject(:validator) { described_class.new(storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/copy_template_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/copy_template_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Commands
-          RSpec.describe CopyTemplateFolderCommand, :webmock do
+          RSpec.describe CopyTemplateFolderCommand, :disable_ssrf_filter, :webmock do
             shared_let(:storage) { create(:one_drive_sandbox_storage) }
 
             shared_let(:original_folders) do

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/create_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Commands
-          RSpec.describe CreateFolderCommand, :webmock do
+          RSpec.describe CreateFolderCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage) }
             let(:auth_strategy) { Registry.resolve("one_drive.authentication.userless").call }
             let(:input_data) { Input::CreateFolder.build(folder_name:, parent_location:).value! }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/delete_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/delete_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Commands
-          RSpec.describe DeleteFolderCommand, :vcr, :webmock do
+          RSpec.describe DeleteFolderCommand, :disable_ssrf_filter, :vcr, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage) }
             let(:auth_strategy) { Registry["one_drive.authentication.userless"].call }
 

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/rename_file_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Commands
-          RSpec.describe RenameFileCommand, :webmock do
+          RSpec.describe RenameFileCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage) }
             let(:auth_strategy) { Registry.resolve("one_drive.authentication.userless").call }
             let(:input_data) { Input::RenameFile.build(location: file_id, new_name: name).value! }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/commands/set_permissions_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Commands
-          RSpec.describe SetPermissionsCommand, :webmock do
+          RSpec.describe SetPermissionsCommand, :disable_ssrf_filter, :webmock do
             let(:storage) do
               create(:one_drive_sandbox_storage,
                      drive_id: "b!dmVLG22QlE2PSW0AqVB7UOhZ8n7tjkVGkgqLNnuw2ODRDvn3haLiQIhB5UYNdqMy")

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/download_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe DownloadLinkQuery, :vcr, :webmock do
+          RSpec.describe DownloadLinkQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry["one_drive.authentication.user_bound"].call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_info_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe FileInfoQuery, :webmock do
+          RSpec.describe FileInfoQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
 

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/file_path_to_id_map_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe FilePathToIdMapQuery, :webmock do
+          RSpec.describe FilePathToIdMapQuery, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage) }
             let(:auth_strategy) { Adapters::Registry["one_drive.authentication.userless"].call }
             let(:depth) { Float::INFINITY }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_info_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe FilesInfoQuery, :vcr, :webmock do
+          RSpec.describe FilesInfoQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry["one_drive.authentication.user_bound"].call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/files_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe FilesQuery, :webmock do
+          RSpec.describe FilesQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry["one_drive.authentication.user_bound"].call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_file_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe OpenFileLinkQuery, :vcr, :webmock do
+          RSpec.describe OpenFileLinkQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry.resolve("one_drive.authentication.user_bound").call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_storage_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/open_storage_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe OpenStorageQuery, :webmock do
+          RSpec.describe OpenStorageQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:one_drive_sandbox_storage, oauth_client_token_user: user) }
             let(:auth_strategy) do

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/upload_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe UploadLinkQuery, :webmock do
+          RSpec.describe UploadLinkQuery, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage) }
             let(:auth_strategy) { Registry["one_drive.authentication.userless"].call }
 

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/user_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/queries/user_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Queries
-          RSpec.describe UserQuery, :webmock do
+          RSpec.describe UserQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
 
             let(:storage) do

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/ampf_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/ampf_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Validators
-          RSpec.describe AmpfConfigurationValidator, :webmock do
+          RSpec.describe AmpfConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage, :as_automatically_managed) }
             let(:auth_strategy) { Registry["one_drive.authentication.userless"].call }
             let(:folder_name) { described_class::TEST_FOLDER_NAME }

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/authentication_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/authentication_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Validators
-          RSpec.describe AuthenticationValidator, :webmock do
+          RSpec.describe AuthenticationValidator, :disable_ssrf_filter, :webmock do
             subject(:validator) { described_class.new(storage) }
 
             context "when using OAuth2" do

--- a/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/storage_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/one_drive/validators/storage_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module OneDrive
         module Validators
-          RSpec.describe StorageConfigurationValidator, :webmock do
+          RSpec.describe StorageConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:one_drive_sandbox_storage, :as_automatically_managed) }
             let(:auth_strategy) { Registry["one_drive.authentication.userless"].call }
             let(:error) { Results::Error.new(code: error_code, source: self) }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/copy_template_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/copy_template_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe CopyTemplateFolderCommand, :webmock do
+          RSpec.describe CopyTemplateFolderCommand, :disable_ssrf_filter, :webmock do
             shared_let(:storage) { create(:sharepoint_storage, :sandbox) }
             shared_let(:base_drive) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW" }
 

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe CreateFolderCommand, :webmock do
+          RSpec.describe CreateFolderCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Registry.resolve("sharepoint.authentication.userless").call(false) }
             let(:base_drive) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW" }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_list_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/create_list_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe CreateListCommand, :webmock do
+          RSpec.describe CreateListCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
 
             let(:site_url) { URI.parse(storage.host).host }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/delete_folder_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/delete_folder_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe DeleteFolderCommand, :vcr, :webmock do
+          RSpec.describe DeleteFolderCommand, :disable_ssrf_filter, :vcr, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Registry["sharepoint.authentication.userless"].call }
             let(:base_drive) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW" }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/rename_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/rename_file_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe RenameFileCommand, :webmock do
+          RSpec.describe RenameFileCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Registry.resolve("sharepoint.authentication.userless").call }
             let(:input_data) { Input::RenameFile.build(location: file_id, new_name: name).value! }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/set_permissions_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/set_permissions_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe SetPermissionsCommand, :webmock do
+          RSpec.describe SetPermissionsCommand, :disable_ssrf_filter, :webmock do
             let(:storage) do
               create(:sharepoint_storage, :sandbox)
             end

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/upload_file_command_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/commands/upload_file_command_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Commands
-          RSpec.describe UploadFileCommand, :webmock do
+          RSpec.describe UploadFileCommand, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Registry["sharepoint.authentication.userless"].call }
             let(:base_drive) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW" }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/download_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/download_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe DownloadLinkQuery, :vcr, :webmock do
+          RSpec.describe DownloadLinkQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:sharepoint_storage, :sandbox, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry["one_drive.authentication.user_bound"].call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/drive_item_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/drive_item_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe Internal::DriveItemQuery, :vcr, :webmock do
+          RSpec.describe Internal::DriveItemQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Adapters::Registry["sharepoint.authentication.userless"].call }
             let(:drive_id) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY8Qconfm2i6SKEoCmuGYqQK" }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_info_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe FileInfoQuery, :webmock do
+          RSpec.describe FileInfoQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:sharepoint_storage, :sandbox, oauth_client_token_user: user) }
             let(:drive_id) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY87vnZ6fgfvQanZHX-XCAyw" }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/file_path_to_id_map_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe FilePathToIdMapQuery, :webmock do
+          RSpec.describe FilePathToIdMapQuery, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:base_drive) { "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY9jo6leJDqrT7muzvmiWjFW" }
             let(:auth_strategy) { Adapters::Registry["sharepoint.authentication.userless"].call }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_info_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_info_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe FilesInfoQuery, :vcr, :webmock do
+          RSpec.describe FilesInfoQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:sharepoint_storage, :sandbox, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry["sharepoint.authentication.user_bound"].call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/files_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe FilesQuery, :webmock do
+          RSpec.describe FilesQuery, :disable_ssrf_filter, :webmock do
             let(:user) { create(:admin) }
             let(:storage) { create(:sharepoint_storage, :sandbox, oauth_client_token_user: user) }
 

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/open_file_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/open_file_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe OpenFileLinkQuery, :vcr, :webmock do
+          RSpec.describe OpenFileLinkQuery, :disable_ssrf_filter, :vcr, :webmock do
             let(:user) { create(:user) }
             let(:storage) { create(:sharepoint_storage, :sandbox, oauth_client_token_user: user) }
             let(:auth_strategy) { Registry.resolve("sharepoint.authentication.user_bound").call(user, storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/upload_link_query_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/queries/upload_link_query_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Queries
-          RSpec.describe UploadLinkQuery, :webmock do
+          RSpec.describe UploadLinkQuery, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
             let(:auth_strategy) { Registry["sharepoint.authentication.userless"].call }
             let(:upload_method) { :put }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_folders_service_spec.rb
@@ -38,7 +38,7 @@ module Storages
     module Providers
       module Sharepoint
         module Services
-          RSpec.describe CreateManagedFoldersService, :webmock do
+          RSpec.describe CreateManagedFoldersService, :disable_ssrf_filter, :webmock do
             shared_let(:admin) { create(:admin) }
             shared_let(:storage) do
               create(:sharepoint_storage, :sandbox,

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_list_service_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/create_managed_list_service_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Services
-          RSpec.describe CreateManagedListService, :webmock do
+          RSpec.describe CreateManagedListService, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox) }
 
             subject(:instance) { described_class.new(storage) }

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/set_permissions_on_managed_folders_service_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/services/set_permissions_on_managed_folders_service_spec.rb
@@ -38,7 +38,7 @@ module Storages
     module Providers
       module Sharepoint
         module Services
-          RSpec.describe SetPermissionsOnManagedFoldersService, :webmock do
+          RSpec.describe SetPermissionsOnManagedFoldersService, :disable_ssrf_filter, :webmock do
             shared_let(:admin) { create(:admin) }
             shared_let(:storage) do
               # Automatically Managed Project Folder Drive

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/ampf_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/ampf_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Validators
-          RSpec.describe AmpfConfigurationValidator, :webmock do
+          RSpec.describe AmpfConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) do
               create(:sharepoint_storage, :sandbox, :as_automatically_managed,
                      managed_drive_id: "b!FeOZEMfQx0eGQKqVBLcP__BG8mq-4-9FuRqOyk3MXY-uqLcDyJy5Rp1j0luD0b1v",

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/authentication_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/authentication_validator_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe Storages::Adapters::Providers::Sharepoint::Validators::AuthenticationValidator, :webmock do
+RSpec.describe Storages::Adapters::Providers::Sharepoint::Validators::AuthenticationValidator, :disable_ssrf_filter, :webmock do
   subject(:validator) { described_class.new(storage) }
 
   context "when using OAuth2" do

--- a/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/storage_configuration_validator_spec.rb
+++ b/modules/storages/spec/common/storages/adapters/providers/sharepoint/validators/storage_configuration_validator_spec.rb
@@ -36,7 +36,7 @@ module Storages
     module Providers
       module Sharepoint
         module Validators
-          RSpec.describe StorageConfigurationValidator, :webmock do
+          RSpec.describe StorageConfigurationValidator, :disable_ssrf_filter, :webmock do
             let(:storage) { create(:sharepoint_storage, :sandbox, :as_automatically_managed) }
             let(:error) { Results::Error.new(code: error_code, source: self) }
 

--- a/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
+++ b/modules/storages/spec/requests/api/v3/storages/storage_files_api_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe "API v3 storage files", :storage_server_helpers, :webmock, content_type: :json do
+RSpec.describe "API v3 storage files", :disable_ssrf_filter, :storage_server_helpers, :webmock, content_type: :json do
   include API::V3::Utilities::PathHelper
 
   let(:permissions) { %i(view_work_packages view_file_links) }

--- a/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
+++ b/modules/storages/spec/requests/storages/project_settings/oauth_access_grant_flow_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_access_grant", :webmock do
+RSpec.describe "GET /projects/:project_id/settings/project_storages/:id/oauth_access_grant", :disable_ssrf_filter, :webmock do
   let(:user) { create(:user, preferences: { time_zone: "Etc/UTC" }) }
 
   let(:role) do

--- a/modules/storages/spec/services/storages/nextcloud_managed_folder_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_managed_folder_create_service_spec.rb
@@ -41,7 +41,7 @@ module Storages
     end
   end
 
-  RSpec.describe NextcloudManagedFolderCreateService, :webmock do
+  RSpec.describe NextcloudManagedFolderCreateService, :disable_ssrf_filter, :webmock do
     before do
       Adapters::Registry.stub("nextcloud.models.managed_folder_identifier", TestIdentifier)
     end

--- a/modules/storages/spec/services/storages/nextcloud_managed_folder_permissions_service_spec.rb
+++ b/modules/storages/spec/services/storages/nextcloud_managed_folder_permissions_service_spec.rb
@@ -41,7 +41,7 @@ module Storages
     end
   end
 
-  RSpec.describe NextcloudManagedFolderPermissionsService, :webmock do
+  RSpec.describe NextcloudManagedFolderPermissionsService, :disable_ssrf_filter, :webmock do
     shared_let(:oidc_provider) { create(:oidc_provider) }
 
     shared_let(:admin) { create(:admin) }

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_create_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_create_service_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_module_spec_helper
 
 module Storages
-  RSpec.describe OneDriveManagedFolderCreateService, :webmock do
+  RSpec.describe OneDriveManagedFolderCreateService, :disable_ssrf_filter, :webmock do
     shared_let(:admin) { create(:admin) }
     shared_let(:storage) do
       # Automatically Managed Project Folder Drive

--- a/modules/storages/spec/services/storages/one_drive_managed_folder_permissions_service_spec.rb
+++ b/modules/storages/spec/services/storages/one_drive_managed_folder_permissions_service_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_module_spec_helper
 
 module Storages
-  RSpec.describe OneDriveManagedFolderPermissionsService, :webmock do
+  RSpec.describe OneDriveManagedFolderPermissionsService, :disable_ssrf_filter, :webmock do
     shared_let(:admin) { create(:admin) }
     shared_let(:storage) do
       # Automatically Managed Project Folder Drive

--- a/modules/storages/spec/services/storages/storage_file_service_spec.rb
+++ b/modules/storages/spec/services/storages/storage_file_service_spec.rb
@@ -32,7 +32,7 @@ require "spec_helper"
 require_module_spec_helper
 
 module Storages
-  RSpec.describe StorageFileService, :webmock do
+  RSpec.describe StorageFileService, :disable_ssrf_filter, :webmock do
     shared_examples "storage file service: successful response" do
       it "returns a success with a Adapters::Results::StorageFileInfo" do
         service_result = described_class.call(storage:, user:, file_id:)

--- a/modules/storages/spec/services/storages/upload_file_service_spec.rb
+++ b/modules/storages/spec/services/storages/upload_file_service_spec.rb
@@ -41,7 +41,7 @@ module Storages
     end
   end
 
-  RSpec.describe UploadFileService, :webmock, type: :model do
+  RSpec.describe UploadFileService, :disable_ssrf_filter, :webmock, type: :model do
     before do
       Adapters::Registry.stub("nextcloud.models.managed_folder_identifier", TestIdentifier)
     end

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/search_pages_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/search_pages_spec.rb
@@ -30,7 +30,7 @@
 
 require "spec_helper"
 
-RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::SearchPages, :webmock do
+RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::SearchPages, :disable_ssrf_filter, :webmock do
   subject { described_class.new(model: provider).call(input_data:, auth_strategy:) }
 
   let(:provider) { create(:xwiki_provider, :for_local_connection, connected_user: user) }

--- a/spec/support/disable_ssrf_filter.rb
+++ b/spec/support/disable_ssrf_filter.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+RSpec.configure do |config|
+  config.before do |example|
+    next unless example.metadata[:disable_ssrf_filter]
+
+    allow(OpenProject::Configuration).to receive(:ssrf_protection_ip_allowlist)
+      .and_return([IPAddr.new("0.0.0.0/0"), IPAddr.new("::0/0")])
+  end
+end


### PR DESCRIPTION
Ingredients needed for the issue to occur are:

* an allowed IPv4 range
* a checked IPv6 address
* the checked address must be wrapped in HTTPX::Resolver::Entry

This leads to a failure in checking address inclusion by IPAddr.

# References

This has preemptively been reported  as https://gitlab.com/os85/httpx/-/work_items/385 to `httpx`. Hopefully once we switch to the official `ssrf_filter` provided by the gem, this will not be an issue anymore.

A proper fix is pending.