### PR TITLE
ignore one keys on interpolation check

### DIFF
--- a/config/i18n-tasks-all-files.yml
+++ b/config/i18n-tasks-all-files.yml
@@ -19,3 +19,10 @@ data:
     - modules/*/config/locales/crowdin/%{locale}.seeders.yml
     - modules/*/config/locales/crowdin/%{locale}.yml
     - modules/*/config/locales/crowdin/js-%{locale}.yml
+
+ignore_inconsistent_interpolations:
+  # Ignore interpolations checks in the singular form.
+  # Some languages have simple pluralization form where 'one' is only used for exactly 1 item.
+  # Other languages such as Ukrainian and Serbian use 'one' also for 21, 31, 101, etc.
+  # Those will use the %{count} interpolation while the english source language will not have it.
+  - '*.one'


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Ignore interpolation inconsistencies on '.one' i18n keys. The reason for this is that in languages such as Ukrainian, Serbian and Russian, the singular form is used whenever the number ends with a 1 (excluding 11). The I18n gem will in such cases correctly use the 'one' form of the key. But the translation for that reason need to include the '%{count}'  interpolation key in the 'one' form which is not necessary in other languages. Since in the source language is English which does not have this characteristic, oftentimes "One" is simply written instead of having the interpolation key in. E.g.

"One role"  vs "%{count} role" -> "1 role"  
