### PR TITLE
[STC-779] Investigate Ctrl+Z (Undo) Does Not Work in the Document Editor

### DIFF
--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -28,7 +28,7 @@
  * ++
  */
 
-import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { BlockNoteEditorOptions, BlockNoteSchema, createExtension } from '@blocknote/core';
 import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
 import { User } from '@blocknote/core/comments';
@@ -44,7 +44,9 @@ import {
   useOpBlockNoteExtensions,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
+import { Plugin, PluginKey } from 'prosemirror-state';
 import { useCallback, useEffect, useMemo } from 'react';
+import { yUndoPluginKey } from 'y-prosemirror';
 import * as Y from 'yjs';
 import { useBlockNoteAttachments } from '../hooks/useBlockNoteAttachments';
 import { useBlockNoteLocale } from '../hooks/useBlockNoteLocale';
@@ -73,6 +75,45 @@ const schema = BlockNoteSchema.create().extend({
   inlineContentSpecs: {
     openProjectWorkPackageInline: openProjectWorkPackageInlineSpec,
   },
+});
+
+// registerPlugin() triggers destroyPluginViews → yUndoPlugin.view.destroy() →
+// undoManager.destroy() → ydoc.off('afterTransaction'). Plugin state is carried
+// over by reconfigure, so init() never re-runs and the handler is never restored.
+// This plugin's view() fires on every initPluginViews pass and re-attaches it.
+//
+// Relies on UndoManager.afterTransactionHandler being a stable instance property —
+// verify this still holds when upgrading yjs or y-prosemirror.
+const undoManagerGuardKey = new PluginKey('opUndoManagerGuard');
+const UndoManagerGuardExtension = createExtension({
+  key: 'opUndoManagerGuard',
+  prosemirrorPlugins: [
+    new Plugin({
+      key: undoManagerGuardKey,
+      view(editorView) {
+        interface UMWithHandler { afterTransactionHandler?:(...args:unknown[]) => void }
+
+        function ensureSubscribed() {
+          const undoState = yUndoPluginKey.getState(editorView.state);
+          if (!undoState?.undoManager) return;
+          const um = undoState.undoManager;
+          const handler = (um as unknown as UMWithHandler).afterTransactionHandler;
+          if (um.doc && handler) {
+            um.doc.on('afterTransaction', handler);
+          }
+        }
+
+        ensureSubscribed();
+        return {
+          update(_view, prevState) {
+            if (prevState.plugins !== editorView.state.plugins) {
+              ensureSubscribed();
+            }
+          },
+        };
+      },
+    }),
+  ],
 });
 
 function generateRandomColor() {
@@ -120,6 +161,7 @@ export function OpBlockNoteEditor({
       extensions: [
         ExternalLinkA11yExtension,
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
+        UndoManagerGuardExtension,
       ],
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-779

# What are you trying to accomplish?
Fix Ctrl+Z (undo) not working in the collaborative document editor on page load.
On load, undo was silently losing its connection to the Y.Doc - the undo manager was alive but had stopped tracking changes, so the undo history was always empty.

# What approach did you choose and why?
The editor registers extensions after the initial build. That late registerPlugin call rebuilds the ProseMirror plugin views, which destroys the yUndoPlugin view and calls undoManager.destroy(). This removes the afterTransaction listener from the Y.Doc. ProseMirror carries the existing plugin state over without re-running init(), so the listener is never restored and the undo history stays empty.
Added a small guard extension (UndoManagerGuardExtension) to the initial editor config. It runs on every plugin-view rebuild and re-attaches the undo manager's afterTransaction listener to the Y.Doc if it has become disconnected. No changes to external packages required.
Verified manually: Ctrl+Z works immediately after page load and remains stable across multiple consecutive rebuilds.
**Note**: the guard relies on the UndoManager's internal afterTransactionHandler field (yjs internal API). If yjs is upgraded, this should be re-verified. A cleaner long-term fix would be to register these extensions in the initial editor config so the post-mount rebuild never happens - tracked as a follow-up.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
