### PR TITLE
[STC-811] Fix pagination for filtered Documents & Reserved identifiers

### DIFF
--- a/app/components/admin/settings/project_reserved_identifiers/table_component.rb
+++ b/app/components/admin/settings/project_reserved_identifiers/table_component.rb
@@ -47,5 +47,7 @@ module Admin::Settings::ProjectReservedIdentifiers
     def blank_title       = t("admin.reserved_identifiers.empty_heading")
     def blank_description = t("admin.reserved_identifiers.empty_body")
     def blank_icon        = :"check-circle"
+
+    def pagination_params = { params: { action: "index" } }
   end
 end

--- a/app/components/op_primer/border_box_table_component.html.erb
+++ b/app/components/op_primer/border_box_table_component.html.erb
@@ -140,5 +140,5 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 
 <% if paginated? %>
-  <%= helpers.pagination_links_full rows, params: { action: "index" } %>
+  <%= helpers.pagination_links_full rows, **pagination_params %>
 <% end %>

--- a/app/components/op_primer/border_box_table_component.html.erb
+++ b/app/components/op_primer/border_box_table_component.html.erb
@@ -140,5 +140,5 @@ See COPYRIGHT and LICENSE files for more details.
   <% end %>
 
 <% if paginated? %>
-  <%= helpers.pagination_links_full rows %>
+  <%= helpers.pagination_links_full rows, params: { action: "index" } %>
 <% end %>

--- a/app/components/op_primer/border_box_table_component.rb
+++ b/app/components/op_primer/border_box_table_component.rb
@@ -77,6 +77,8 @@ module OpPrimer
       self.class.main_column.include?(column)
     end
 
+    def pagination_params = {}
+
     def column_title(name)
       _, header_options = headers.assoc(name)
       header_options&.dig(:caption)

--- a/modules/documents/app/components/documents/list_component.html.erb
+++ b/modules/documents/app/components/documents/list_component.html.erb
@@ -56,7 +56,7 @@
         end
 
         component.with_row(py: 0) do
-          helpers.pagination_links_full(documents)
+          helpers.pagination_links_full(documents, params: { action: "index" })
         end
       end
     else

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -214,6 +214,22 @@ RSpec.describe DocumentsController do
     end
   end
 
+  describe "#search", with_settings: { per_page_options: "1 5 10" } do
+    let!(:document2) { create(:document, title: "Second Document", project:, type: document_type) }
+
+    it "returns a turbo_stream response" do
+      get :search, params: { project_id: project.identifier, per_page: 1 }, format: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders pagination links that target the index action, not the search action (regression #STC-811)" do
+      get :search, params: { project_id: project.identifier, per_page: 1 }, format: :turbo_stream
+
+      expect(response.body).not_to include("#{search_project_documents_path(project)}?")
+    end
+  end
+
   describe "#render_avatars" do
     let(:user) { create(:user, member_with_permissions: { project => [:view_documents] }) }
     let!(:non_member) { create(:user) }

--- a/modules/documents/spec/controllers/documents_controller_spec.rb
+++ b/modules/documents/spec/controllers/documents_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe DocumentsController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "renders pagination links that target the index action, not the search action (regression #STC-811)" do
+    it "renders pagination links that target the index action, not the search action" do
       get :search, params: { project_id: project.identifier, per_page: 1 }, format: :turbo_stream
 
       expect(response.body).not_to include("#{search_project_documents_path(project)}?")

--- a/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
+++ b/spec/controllers/admin/settings/project_reserved_identifiers_controller_spec.rb
@@ -73,11 +73,29 @@ RSpec.describe Admin::Settings::ProjectReservedIdentifiersController do
     end
   end
 
-  describe "GET #search", with_settings: { work_packages_identifier: "classic" } do
+  describe "GET #search", with_settings: { work_packages_identifier: "classic", per_page_options: "1 5 10" } do
+    render_views
+
     it "responds with turbo stream" do
       get :search, format: :turbo_stream
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    end
+
+    context "with multiple reserved slugs triggering pagination" do
+      let!(:project1) { create(:project, identifier: "proj-a") }
+      let!(:project2) { create(:project, identifier: "proj-b") }
+
+      before do
+        FriendlyId::Slug.create!(sluggable: project1, slug: "old-a")
+        FriendlyId::Slug.create!(sluggable: project2, slug: "old-b")
+      end
+
+      it "renders pagination links that target the index action, not the search action (regression #STC-811)" do
+        get :search, params: { per_page: 1 }, format: :turbo_stream
+
+        expect(response.body).not_to include("#{search_admin_settings_project_reserved_identifiers_path}?")
+      end
     end
 
     context "with a reserved slug" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-811
https://community.openproject.org/projects/STC/work_packages/STC-815

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
The search action on both the Documents and Reserved Identifiers controllers renders a paginated list component via turbo stream, then uses `push_state` to rewrite the browser URL to the index path. But since the component renders its pagination links using `url_for` in the context of the search action, those links pointed back at `search` (not `index`).

Clicking "next page" or changing page size then hit the search action with a plain HTML request. 
* Documents returns 406 (only handles turbo_stream format)
* Reserved Identifiers returns a raw turbo-stream fragment (the route defaults to format: :turbo_stream).

# What approach did you choose and why?
Fix: pass `params: { action: "index" }` to `pagination_links_full` in both components so pagination links always target index regardless of the rendering context.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
