### PR TITLE
Fix CTRL+Z in documents

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -88,9 +88,14 @@ class BlockNoteElement extends HTMLElement {
     this.reactRoot = createRoot(this.editorMount);
 
     this.renderCallback = (provider:HocuspocusProvider) => {
-      this.reactRoot?.render(
-        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
-      );
+      // Do NOT wrap in React.StrictMode. StrictMode's dev-mode double-mount causes
+      // BlockNoteView to destroy and recreate the ProseMirror view between the two mounts.
+      // y-prosemirror's `yUndoPlugin` destroys the Y.UndoManager on view-destroy (removing
+      // its `afterTransaction` handler from the Y.Doc), but the plugin's STATE retains the
+      // now-destroyed UndoManager reference. On the second mount the editor reuses the
+      // destroyed UndoManager, no `afterTransaction` handler is ever re-attached, no stack
+      // items are recorded, and Ctrl+Z becomes a no-op.
+      this.reactRoot?.render(this.BlockNoteReactContainer(provider));
     };
 
     LiveCollaborationManager.onReady(this.renderCallback);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -122,7 +122,11 @@ export function OpBlockNoteEditor({
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 
-  const editor = useCreateBlockNote(editorParams, [activeUser]);
+  // Create the editor exactly once per mount. `useCreateBlockNote(options, deps)` uses `deps`
+  // as the sole `useMemo` key — `options` is intentionally NOT in deps. `[activeUser]` rebuilt
+  // the editor (wiping `Y.UndoManager` history) whenever a fresh `activeUser` reference
+  // reached this component, e.g. on Stimulus reconnect / Turbo morph.
+  const editor = useCreateBlockNote(editorParams, []);
   useInlineWpEvents(editor);
   type EditorType = typeof editor;
   const theme = useOpTheme();

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -74,6 +74,17 @@ export default class extends Controller {
   connect():void {
     this.currentToken = this.tokenPayloadValue;
 
+    // If a provider for this document is already live, don't build a duplicate
+    // — adopt it. Stimulus can fire connect() a second time (HMR replay, Turbo
+    // morph, parent re-attach) without firing disconnect(); building a fresh
+    // Y.Doc + provider in that case would destroy the live one and wipe the
+    // editor's Y.UndoManager mid-session.
+    const existing = LiveCollaborationManager.getCurrentSessionFor(this.documentNameValue);
+    if (existing) {
+      this.ownedProvider = existing.provider;
+      return;
+    }
+
     const ydoc:Doc = new Y.Doc();
     const provider = new HocuspocusProvider({
       url: this.hocuspocusUrlValue,
@@ -87,7 +98,7 @@ export default class extends Controller {
       },
     });
 
-    LiveCollaborationManager.initializeYjsProvider(provider, ydoc);
+    LiveCollaborationManager.initializeYjsProvider(provider, ydoc, this.documentNameValue);
     this.ownedProvider = provider;
 
     if (this.refreshUrlValue && this.tokenExpiresInSecondsValue) {

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -36,21 +36,47 @@ type Listener = (provider:HocuspocusProvider) => void;
 class LiveCollaborationManagerClass {
   yjsProviderInstance:HocuspocusProvider|null = null;
   yjsDocInstance:Doc|null = null;
+  private currentDocumentName:string|null = null;
 
   private listeners:Listener[] = [];
 
   /**
-   * Initializes the YJS Provider
+   * Returns the active session for the given document, or null if none.
+   *
+   * Used by the init-yjs-provider Stimulus controller to detect that a
+   * provider for the same document is already live — letting it adopt the
+   * existing session instead of building a duplicate Y.Doc + provider pair.
+   * Stimulus can fire `connect()` a second time (HMR replay, Turbo morph)
+   * without firing `disconnect()`; without this check, the spurious re-init
+   * would tear down the live Y.Doc and wipe the editor's Y.UndoManager
+   * history mid-session.
+   */
+  getCurrentSessionFor(documentName:string):{provider:HocuspocusProvider; doc:Doc} | null {
+    if (this.yjsProviderInstance && this.yjsDocInstance && this.currentDocumentName === documentName) {
+      return { provider: this.yjsProviderInstance, doc: this.yjsDocInstance };
+    }
+    return null;
+  }
+
+  /**
+   * Initializes the YJS Provider for the given document.
+   *
+   * Callers SHOULD first check {@link getCurrentSessionFor} and adopt any
+   * existing session rather than calling this with a fresh provider, since
+   * this method unconditionally tears down the previous provider/doc.
+   *
    * @param provider The provider to use
    * @param doc The Y.Doc instance to use
+   * @param documentName Logical identifier of the document being edited
    * @returns void
    */
-  initializeYjsProvider(provider:HocuspocusProvider, doc:Doc) {
+  initializeYjsProvider(provider:HocuspocusProvider, doc:Doc, documentName:string) {
     this.destroyYjsProvider();
     this.destroyYjsDoc();
 
     this.yjsProviderInstance = provider;
     this.yjsDocInstance = doc;
+    this.currentDocumentName = documentName;
     this.listeners.forEach((listener) => listener(this.yjsProviderInstance!));
   }
 
@@ -82,6 +108,7 @@ class LiveCollaborationManagerClass {
   private destroy():void {
     this.destroyYjsProvider();
     this.destroyYjsDoc();
+    this.currentDocumentName = null;
 
     this.listeners = [];
   }


### PR DESCRIPTION
[STC-779](https://community.openproject.org/wp/STC-779)

## Summary

Ctrl+Z stopped working in the documents module on release/17.5. Three independent defects together caused the BlockNote editor's `Y.UndoManager` to lose its tracking and/or be rebuilt mid-session, so the redo stack was perpetually empty.

- **`OpBlockNoteEditor.tsx`** — `useCreateBlockNote(editorParams, [activeUser])` used `[activeUser]` as the recreation key. BlockNote's `useCreateBlockNote(options, deps)` uses `deps` as the sole `useMemo` key (options is intentionally NOT in deps). `block-note-element.ts` parses a fresh `activeUser` via `JSON.parse` on every `renderCallback`, so any path that re-rendered the React tree handed in a new reference and rebuilt the editor (along with its UndoManager). Recreation key reduced to `[]` — the editor lives for the full mount lifetime.

- **`LiveCollaborationManager` + `init-yjs-provider.controller`** — `initializeYjsProvider` was not idempotent. Stimulus's controller can fire `connect()` a second time without firing `disconnect()` (HMR replay, Turbo morph, parent re-attach). The duplicate call destroyed the live Y.Doc + provider and rebuilt both, remounting the editor. Added `LiveCollaborationManager.getCurrentSessionFor(documentName)`; the controller now adopts the existing session instead of building a duplicate.

- **`block-note-element.ts`** — the `React.StrictMode` wrap caused `BlockNoteView` to destroy and recreate the ProseMirror view between StrictMode's two dev-mode mounts. `y-prosemirror`'s `yUndoPlugin` destroys the `Y.UndoManager` on view-destroy (removing its `afterTransaction` handler from the Y.Doc), but the plugin's state retains the now-dead UndoManager reference. After the second mount the editor reused the destroyed UndoManager, no handler was re-attached, and Ctrl+Z became a no-op. StrictMode is dev-only and incompatible with the current y-prosemirror lifecycle, so it is removed from the BlockNote tree.

## Test plan

- [ ] Open a document in a project's documents module
- [ ] Type a few characters, press Ctrl+Z → previous state restored
- [ ] Press Ctrl+Shift+Z → reapplies
- [ ] Type, wait > 5s, edit again → second edit can be undone independently
- [ ] DevTools: Y.Doc has exactly one `afterTransaction` observer (the UndoManager's); plugin's `undoStack.length` grows with each capture window
- [ ] Two clients editing the same document — remote changes do NOT appear in the local undo stack (verify `addToHistory` semantics still hold)
- [ ] Navigate to a different document, edit, undo — works for the new document; navigating back does not resurrect the old undo stack
- [ ] Turbo navigation in/out of the document page does not double-mount the editor
- [ ] Verify the docs module's collaboration features (presence cursors, multi-user editing, auto-save banner) still behave correctly

## Notes for reviewers

- Reproduces 100% on `release/17.5` against any existing document. Worked on `release/17.4` because the WP-link / "#" notation changes in `release/17.5` (`#73664`) interact with StrictMode in a way that surfaces the latent y-prosemirror view-lifecycle bug; root cause is dev-mode StrictMode, not the WP-link commit itself, but only the new tree triggers it consistently.
- StrictMode removal is dev-only behavior — production React doesn't double-mount, so no shipped-behavior change there.
- The idempotent-init guard does NOT refcount; if a future flow legitimately needs to re-init with a different document name (Turbo nav to another doc) the existing `destroyIfOwner` path handles it. Same-document re-`connect()` is the only thing being absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)