### PR TITLE
Add version history to Documents

### DIFF
--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -552,6 +552,8 @@ module Journals
     end
 
     def aggregatable?(predecessor, notes, internal, cause)
+      return false if journable.try(:skip_journal_aggregation)
+
       predecessor.present? &&
         aggregation_active? &&
         within_aggregation_time?(predecessor) &&
@@ -576,12 +578,7 @@ module Journals
     end
 
     def only_one_or_same_cause?(predecessor, cause)
-      # Both plain saves (no cause): can aggregate
-      return true if cause.blank? && predecessor.cause.empty?
-      # One side has a cause, the other doesn't: never aggregate
-      return false if cause.blank? || predecessor.cause.empty?
-      # Both have a cause: aggregate only when identical
-      predecessor.cause == cause.to_hash
+      predecessor.cause.empty? || cause.blank? || predecessor.cause == cause
     end
 
     def only_one_note?(predecessor, notes)

--- a/app/services/journals/create_service.rb
+++ b/app/services/journals/create_service.rb
@@ -576,7 +576,12 @@ module Journals
     end
 
     def only_one_or_same_cause?(predecessor, cause)
-      predecessor.cause.empty? || cause.blank? || predecessor.cause == cause
+      # Both plain saves (no cause): can aggregate
+      return true if cause.blank? && predecessor.cause.empty?
+      # One side has a cause, the other doesn't: never aggregate
+      return false if cause.blank? || predecessor.cause.empty?
+      # Both have a cause: aggregate only when identical
+      predecessor.cause == cause.to_hash
     end
 
     def only_one_note?(predecessor, notes)

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -35,7 +35,9 @@ import { ShadowDomWrapper } from 'op-blocknote-extensions';
 import React from 'react';
 import type { Root } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
+import * as Y from 'yjs';
 import OpBlockNoteContainer from '../react/OpBlockNoteContainer';
+import { OpBlockNoteEditor } from '../react/components/OpBlockNoteEditor';
 
 class BlockNoteElement extends HTMLElement {
   private editorRoot:HTMLDivElement;
@@ -77,6 +79,19 @@ class BlockNoteElement extends HTMLElement {
 
   connectedCallback() {
     const collaborationEnabled = this.getAttribute('collaboration-enabled') === 'true';
+    const readOnly = this.getAttribute('read-only') === 'true';
+    const initialContent = this.getAttribute('initial-content');
+
+    // Standalone read-only mode: render from stored Y.Doc binary without Hocuspocus.
+    if (readOnly && initialContent) {
+      this.reactRoot = createRoot(this.editorMount);
+      const doc = this.loadYDocFromBase64(initialContent);
+      this.reactRoot.render(
+        React.createElement(React.StrictMode, null, this.BlockNoteReadOnlyContainer(doc))
+      );
+      return;
+    }
+
     if (!collaborationEnabled) return;
 
     this.reactRoot = createRoot(this.editorMount);
@@ -117,6 +132,40 @@ class BlockNoteElement extends HTMLElement {
           attachmentsCollectionKey: this.getAttribute('attachments-collection-key') ?? '',
           captureExternalLinks: document.body.dataset.externalLinksEnabledValue === 'true',
           hocuspocusProvider,
+        }
+      )
+    );
+  };
+
+  private loadYDocFromBase64(base64:string):Y.Doc {
+    const doc = new Y.Doc();
+    try {
+      const binaryString = atob(base64);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      Y.applyUpdate(doc, bytes);
+    } catch (e) {
+      console.error('Failed to load Y.Doc from base64 content:', e);
+    }
+    return doc;
+  }
+
+  private BlockNoteReadOnlyContainer = (doc:Y.Doc) => {
+    return React.createElement(
+      ShadowDomWrapper,
+      { target: this.editorMount },
+      React.createElement(
+        OpBlockNoteEditor,
+        {
+          activeUser: this.parseActiveUser()!,
+          readOnly: true,
+          openProjectUrl: this.getAttribute('open-project-url') ?? '',
+          attachmentsUploadUrl: this.getAttribute('attachments-upload-url') ?? '',
+          attachmentsCollectionKey: this.getAttribute('attachments-collection-key') ?? '',
+          captureExternalLinks: document.body.dataset.externalLinksEnabledValue === 'true',
+          doc,
         }
       )
     );

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -28,7 +28,8 @@
  * ++
  */
 
-import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { BlockNoteEditor, BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
+import { yXmlFragmentToBlocks } from '@blocknote/core/yjs';
 import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
 import { User } from '@blocknote/core/comments';
@@ -96,15 +97,26 @@ export function OpBlockNoteEditor({
     initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
   }, [openProjectUrl, localeString]);
 
+  // When there is no live provider (e.g. viewing a historical version), convert
+  // the pre-loaded Y.Doc to BlockNote blocks for use as initialContent.
+  const initialBlocks = useMemo(() => {
+    if (hocuspocusProvider) return undefined;
+    try {
+      const tempEditor = BlockNoteEditor.create({ schema });
+      return yXmlFragmentToBlocks(tempEditor, doc.getXmlFragment('document-store'));
+    } catch {
+      return undefined;
+    }
+  }, [hocuspocusProvider, doc]);
+
   const editorParams = useMemo<Partial<BlockNoteEditorOptions<typeof schema.blockSchema, typeof schema.inlineContentSchema, typeof schema.styleSchema>>>(() => {
     return {
       schema,
       // BlockNote 0.51 tightened `collaboration.provider` to a non-null shape
       // and `awareness: Awareness | undefined` (vs Hocuspocus's
-      // `Awareness | null`). Cast the provider at the boundary.
-      // For read-only mode without a live provider (e.g. version history),
-      // pass a no-op provider so BlockNote still loads content from the fragment.
-      ...((hocuspocusProvider || doc.getXmlFragment('document-store').length > 0) && {
+      // `Awareness | null`). Omit the whole `collaboration` block when no
+      // provider is wired up; cast the provider at the boundary otherwise.
+      ...(hocuspocusProvider && {
         collaboration: {
           fragment: doc.getXmlFragment('document-store'),
           user: {
@@ -112,10 +124,13 @@ export function OpBlockNoteEditor({
             color: generateRandomColor(),
             id: activeUser.id,
           } as unknown as CollaborativeUser,
-          provider: (hocuspocusProvider ?? { awareness: undefined }) as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
+          provider: hocuspocusProvider as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
           showCursorLabels: 'activity' as const,
         },
       }),
+      // For static read-only rendering (e.g. version history), convert the
+      // pre-loaded Y.Doc to blocks and pass as initialContent.
+      ...(!hocuspocusProvider && initialBlocks && { initialContent: initialBlocks }),
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
       extensions: [
@@ -123,7 +138,7 @@ export function OpBlockNoteEditor({
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
       ],
     };
-  }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
+  }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks, initialBlocks]);
 
   const editor = useCreateBlockNote(editorParams, [activeUser]);
   useOpBlockNoteExtensions(editor);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -28,8 +28,7 @@
  * ++
  */
 
-import { BlockNoteEditor, BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
-import { yXmlFragmentToBlocks } from '@blocknote/core/yjs';
+import { BlockNoteEditorOptions, BlockNoteSchema } from '@blocknote/core';
 import { ExternalLinkA11yExtension } from '../extensions/external-link-a11y';
 import { ExternalLinkCaptureExtension } from '../extensions/external-link-capture';
 import { User } from '@blocknote/core/comments';
@@ -97,40 +96,23 @@ export function OpBlockNoteEditor({
     initializeOpBlockNoteExtensions({ baseUrl: openProjectUrl, locale: localeString });
   }, [openProjectUrl, localeString]);
 
-  // When there is no live provider (e.g. viewing a historical version), convert
-  // the pre-loaded Y.Doc to BlockNote blocks for use as initialContent.
-  const initialBlocks = useMemo(() => {
-    if (hocuspocusProvider) return undefined;
-    try {
-      const tempEditor = BlockNoteEditor.create({ schema });
-      return yXmlFragmentToBlocks(tempEditor, doc.getXmlFragment('document-store'));
-    } catch {
-      return undefined;
-    }
-  }, [hocuspocusProvider, doc]);
-
   const editorParams = useMemo<Partial<BlockNoteEditorOptions<typeof schema.blockSchema, typeof schema.inlineContentSchema, typeof schema.styleSchema>>>(() => {
     return {
       schema,
-      // BlockNote 0.51 tightened `collaboration.provider` to a non-null shape
-      // and `awareness: Awareness | undefined` (vs Hocuspocus's
-      // `Awareness | null`). Omit the whole `collaboration` block when no
-      // provider is wired up; cast the provider at the boundary otherwise.
-      ...(hocuspocusProvider && {
-        collaboration: {
-          fragment: doc.getXmlFragment('document-store'),
-          user: {
-            name: activeUser.username,
-            color: generateRandomColor(),
-            id: activeUser.id,
-          } as unknown as CollaborativeUser,
-          provider: hocuspocusProvider as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
-          showCursorLabels: 'activity' as const,
-        },
-      }),
-      // For static read-only rendering (e.g. version history), convert the
-      // pre-loaded Y.Doc to blocks and pass as initialContent.
-      ...(!hocuspocusProvider && initialBlocks && { initialContent: initialBlocks }),
+      // Always wire up the collaboration fragment so BlockNote loads content
+      // from the Y.Doc. When no live provider is available (e.g. version history
+      // read-only view), pass a no-op provider. BlockNote's yCursor extension
+      // guards all awareness accesses with typeof checks, so undefined is safe.
+      collaboration: {
+        fragment: doc.getXmlFragment('document-store'),
+        user: {
+          name: activeUser.username,
+          color: generateRandomColor(),
+          id: activeUser.id,
+        } as unknown as CollaborativeUser,
+        provider: (hocuspocusProvider ?? { awareness: undefined }) as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
+        showCursorLabels: 'activity' as const,
+      },
       dictionary: localeDictionary,
       ...(attachmentsEnabled && { uploadFile }),
       extensions: [
@@ -138,7 +120,7 @@ export function OpBlockNoteEditor({
         ...(captureExternalLinks ? [ExternalLinkCaptureExtension] : []),
       ],
     };
-  }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks, initialBlocks]);
+  }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 
   const editor = useCreateBlockNote(editorParams, [activeUser]);
   useOpBlockNoteExtensions(editor);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -101,9 +101,10 @@ export function OpBlockNoteEditor({
       schema,
       // BlockNote 0.51 tightened `collaboration.provider` to a non-null shape
       // and `awareness: Awareness | undefined` (vs Hocuspocus's
-      // `Awareness | null`). Omit the whole `collaboration` block when no
-      // provider is wired up; cast the provider at the boundary otherwise.
-      ...(hocuspocusProvider && {
+      // `Awareness | null`). Cast the provider at the boundary.
+      // For read-only mode without a live provider (e.g. version history),
+      // pass a no-op provider so BlockNote still loads content from the fragment.
+      ...((hocuspocusProvider || doc.getXmlFragment('document-store').length > 0) && {
         collaboration: {
           fragment: doc.getXmlFragment('document-store'),
           user: {
@@ -111,7 +112,7 @@ export function OpBlockNoteEditor({
             color: generateRandomColor(),
             id: activeUser.id,
           } as unknown as CollaborativeUser,
-          provider: hocuspocusProvider as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
+          provider: (hocuspocusProvider ?? { awareness: undefined }) as unknown as { awareness?:NonNullable<HocuspocusProvider['awareness']> },
           showCursorLabels: 'activity' as const,
         },
       }),

--- a/frontend/src/stimulus/controllers/dynamic/documents/versions-scroll.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/versions-scroll.controller.ts
@@ -1,0 +1,46 @@
+/*
+ * -- copyright
+ * OpenProject is an open source project management software.
+ * Copyright (C) the OpenProject GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3.
+ *
+ * OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+ * Copyright (C) 2006-2013 Jean-Philippe Lang
+ * Copyright (C) 2010-2013 the ChiliProject Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * See COPYRIGHT and LICENSE files for more details.
+ * ++
+ */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class VersionsScrollController extends Controller {
+  static values = { targetId: String };
+
+  declare targetIdValue: string;
+
+  connect() {
+    if (this.targetIdValue) {
+      const target = document.getElementById(`journal-${this.targetIdValue}`);
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    }
+  }
+}

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -36,6 +36,7 @@
       "collaboration-enabled": collaboration_enabled,
       "active-user": active_user.to_json,
       "read-only": readonly,
+      "initial-content": (readonly && value.present? ? value : nil),
       "open-project-url": root_url,
       "attachments-upload-url": attachments_upload_url,
       "attachments-collection-key": attachments_collection_key,

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -74,13 +74,30 @@
               data: { "documents--editor-connection-target": "error" }
             ),
             tag.div(data: { "documents--editor-connection-target": "editor" }) do
-              primer_form_with(
-                model: document,
-                url: document_path(document),
-                method: :patch,
-                data: { turbo: false }
-              ) do |form|
-                render Documents::BlockNoteEditorForm.new(form, token_payload:, readonly:)
+              if version_journal && version_content_binary.present?
+                render(
+                  Primer::BaseComponent.new(
+                    tag: "op-block-note", mt: 1, mb: 1,
+                    "collaboration-enabled": false,
+                    "active-user": { id: helpers.current_user.id, username: helpers.current_user.name }.to_json,
+                    "read-only": true,
+                    "initial-content": version_content_binary,
+                    "open-project-url": helpers.root_url,
+                    "attachments-upload-url": "",
+                    "attachments-collection-key": "",
+                    "blocknote-stylesheet-url": helpers.variable_asset_path("blocknote.css"),
+                    "shadow-dom-stylesheet-url": helpers.variable_asset_path("styles.css")
+                  )
+                )
+              else
+                primer_form_with(
+                  model: document,
+                  url: document_path(document),
+                  method: :patch,
+                  data: { turbo: false }
+                ) do |form|
+                  render Documents::BlockNoteEditorForm.new(form, token_payload:, readonly:)
+                end
               end
             end
           ]

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -105,11 +105,11 @@
       end
     end
 
-    layout.with_tab(name: t(:label_attachment_plural), active: true) do
+    layout.with_tab(name: t(:label_attachment_plural), active: !version_journal) do
       render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document, readonly:)
     end
 
-    layout.with_tab(name: I18n.t("documents.versions.tab_title")) do
+    layout.with_tab(name: I18n.t("documents.versions.tab_title"), active: !!version_journal) do
       helpers.turbo_frame_tag(helpers.dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do
         tag.div(class: "loading-indicator -compact")
       end

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -29,16 +29,18 @@
   ++#
 %>
 
-<%
-  helpers.content_controller(
-    "documents--init-yjs-provider",
-    "documents--init-yjs-provider-hocuspocus-url-value": Setting.collaborative_editing_hocuspocus_url,
-    "documents--init-yjs-provider-token-payload-value": token_payload,
-    "documents--init-yjs-provider-document-name-value": resource_url,
-    "documents--init-yjs-provider-token-expires-in-seconds-value": token_expires_in_seconds,
-    "documents--init-yjs-provider-refresh-url-value": refresh_token_url
-  )
-%>
+<% unless readonly %>
+  <%
+    helpers.content_controller(
+      "documents--init-yjs-provider",
+      "documents--init-yjs-provider-hocuspocus-url-value": Setting.collaborative_editing_hocuspocus_url,
+      "documents--init-yjs-provider-token-payload-value": token_payload,
+      "documents--init-yjs-provider-document-name-value": resource_url,
+      "documents--init-yjs-provider-token-expires-in-seconds-value": token_expires_in_seconds,
+      "documents--init-yjs-provider-refresh-url-value": refresh_token_url
+    )
+  %>
+<% end %>
 
 <%=
   render(
@@ -50,7 +52,10 @@
     )
   ) do |layout|
     layout.with_header do
-      render Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:)
+      safe_join([
+        render(Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:, version_journal:)),
+        version_journal ? render(Documents::ShowEditView::VersionBannerComponent.new(document, version_journal:, project:)) : ""
+      ])
     end
 
     layout.with_tab(name: I18n.t("activerecord.models.document"), show_left: true) do
@@ -85,6 +90,12 @@
 
     layout.with_tab(name: t(:label_attachment_plural), active: true) do
       render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document, readonly:)
+    end
+
+    layout.with_tab(name: I18n.t("documents.versions.tab_title")) do
+      turbo_frame_tag(dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do
+        tag.div(class: "loading-indicator -compact")
+      end
     end
   end
 %>

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -129,11 +129,11 @@
       end
     end
 
-    layout.with_tab(name: t(:label_attachment_plural), active: !version_journal && helpers.params[:tab] != "versions") do
+    layout.with_tab(name: t(:label_attachment_plural), active: !version_journal && tab_param != "versions") do
       render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document, readonly:)
     end
 
-    layout.with_tab(name: I18n.t("documents.versions.tab_title"), active: !!version_journal || helpers.params[:tab] == "versions") do
+    layout.with_tab(name: I18n.t("documents.versions.tab_title"), active: !!version_journal || tab_param == "versions") do
       versions_src = document_versions_path(document, scroll_to: version_journal&.id)
       helpers.turbo_frame_tag(helpers.dom_id(document, :versions), src: versions_src, loading: :lazy) do
         tag.div(class: "loading-indicator -compact")

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -54,8 +54,32 @@
     layout.with_header do
       safe_join([
         render(Documents::ShowEditView::PageHeaderComponent.new(document, project:, state:, version_journal:)),
-        version_journal ? render(Documents::ShowEditView::VersionBannerComponent.new(document, version_journal:, project:)) : ""
-      ])
+        if version_journal && User.current.allowed_in_project?(:manage_documents, document.project)
+          render(Primer::OpenProject::SubHeader.new) do |subheader|
+            subheader.with_action_button(
+              tag: :a,
+              scheme: :default,
+              href: save_copy_document_path(document, version_id: version_journal.id),
+              data: { turbo_method: :post },
+              leading_icon: :copy,
+              label: I18n.t("documents.versions.save_copy"),
+              mobile_icon: :copy,
+              mobile_label: I18n.t("documents.versions.save_copy")
+            ) { I18n.t("documents.versions.save_copy") }
+
+            subheader.with_action_button(
+              tag: :a,
+              scheme: :primary,
+              href: restore_version_document_path(document, version_id: version_journal.id),
+              data: { turbo_method: :post, turbo_confirm: I18n.t("documents.versions.restore_confirm") },
+              leading_icon: :history,
+              label: I18n.t("documents.versions.restore"),
+              mobile_icon: :history,
+              mobile_label: I18n.t("documents.versions.restore")
+            ) { I18n.t("documents.versions.restore") }
+          end
+        end
+      ].compact)
     end
 
     layout.with_tab(name: I18n.t("activerecord.models.document"), show_left: true) do

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -129,12 +129,13 @@
       end
     end
 
-    layout.with_tab(name: t(:label_attachment_plural), active: !version_journal) do
+    layout.with_tab(name: t(:label_attachment_plural), active: !version_journal && helpers.params[:tab] != "versions") do
       render Documents::ShowEditView::AttachmentsSidePanelComponent.new(document, readonly:)
     end
 
-    layout.with_tab(name: I18n.t("documents.versions.tab_title"), active: !!version_journal) do
-      helpers.turbo_frame_tag(helpers.dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do
+    layout.with_tab(name: I18n.t("documents.versions.tab_title"), active: !!version_journal || helpers.params[:tab] == "versions") do
+      versions_src = document_versions_path(document, scroll_to: version_journal&.id)
+      helpers.turbo_frame_tag(helpers.dom_id(document, :versions), src: versions_src, loading: :lazy) do
         tag.div(class: "loading-indicator -compact")
       end
     end

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.html.erb
@@ -93,7 +93,7 @@
     end
 
     layout.with_tab(name: I18n.t("documents.versions.tab_title")) do
-      turbo_frame_tag(dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do
+      helpers.turbo_frame_tag(helpers.dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do
         tag.div(class: "loading-indicator -compact")
       end
     end

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
@@ -37,6 +37,7 @@ module Documents
       alias_method :document, :model
 
       options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal, :version_content_binary
+      options tab_param: nil
 
       private
 

--- a/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/block_note_editor_component.rb
@@ -36,7 +36,7 @@ module Documents
 
       alias_method :document, :model
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
+      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal, :version_content_binary
 
       private
 

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -33,7 +33,13 @@
   component_wrapper do
     flex_layout(tag: :div, align_items: :center, test_selector: "document-info-line") do |flex|
       flex.with_column(hide: :sm, mr: 3) do
-        if allowed_to_manage_documents?
+        if version_journal
+          version_type = DocumentType.find_by(id: version_journal.data.type_id)
+          render(Primer::Beta::Button.new(disabled: true)) do |button|
+            button.with_trailing_visual_icon(icon: :"triangle-down")
+            version_type&.name || document.type.name
+          end
+        elsif allowed_to_manage_documents?
           render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
             menu.with_show_button do |button|
               button.with_trailing_visual_icon(icon: :"triangle-down")

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -59,7 +59,7 @@
         end
       end
 
-      <% if version_journal %>
+      if version_journal
         flex.with_column do
           flex_layout(align_items: :center) do |author_row|
             author_row.with_column(mr: 2) do
@@ -84,11 +84,11 @@
             end
           end
         end
-      <% else %>
+      else
         flex.with_column do
           render(Documents::ShowEditView::PageHeader::ConnectionStatusComponent.new(document))
         end
-      <% end %>
+      end
     end
   end
 %>

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.html.erb
@@ -59,9 +59,36 @@
         end
       end
 
-      flex.with_column do
-        render(Documents::ShowEditView::PageHeader::ConnectionStatusComponent.new(document))
-      end
+      <% if version_journal %>
+        flex.with_column do
+          flex_layout(align_items: :center) do |author_row|
+            author_row.with_column(mr: 2) do
+              render Users::AvatarComponent.new(user: version_journal.user, show_name: false, size: :mini)
+            end
+
+            author_row.with_column(mr: 2, classes: "hidden-for-mobile") do
+              helpers.primer_link_to_user(version_journal.user, scheme: :primary)
+            end
+
+            author_row.with_column do
+              render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+                safe_join([
+                  I18n.t("documents.versions.saved_at"),
+                  " ",
+                  OpPrimer::RelativeTimeComponent.new(
+                    datetime: in_user_zone(version_journal.created_at),
+                    month: :long
+                  ).render_in(view_context)
+                ])
+              end
+            end
+          end
+        end
+      <% else %>
+        flex.with_column do
+          render(Documents::ShowEditView::PageHeader::ConnectionStatusComponent.new(document))
+        end
+      <% end %>
     end
   end
 %>

--- a/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header/info_line_component.rb
@@ -37,8 +37,11 @@ module Documents
         include OpPrimer::FormHelpers
         include OpTurbo::Streamable
         include Redmine::I18n
+        include AvatarHelper
 
         alias_method :document, :model
+
+        options version_journal: nil
 
         private
 

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -43,7 +43,7 @@
           )
         end
 
-        document.title
+        version_journal ? version_journal.data.title : document.title
       end
 
       header.with_description do

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.html.erb
@@ -47,7 +47,7 @@
       end
 
       header.with_description do
-        render(Documents::ShowEditView::PageHeader::InfoLineComponent.new(document))
+        render(Documents::ShowEditView::PageHeader::InfoLineComponent.new(document, version_journal:))
       end
 
       header.with_breadcrumbs(breadcrumbs_items)

--- a/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/page_header_component.rb
@@ -38,6 +38,7 @@ module Documents
 
       options :project
       options state: :show
+      options version_journal: nil
 
       def page_header_attributes
         {
@@ -69,7 +70,7 @@ module Documents
       end
 
       def allowed_to_manage_documents?
-        User.current.allowed_in_project?(:manage_documents, project)
+        version_journal.nil? && User.current.allowed_in_project?(:manage_documents, project)
       end
     end
   end

--- a/modules/documents/app/components/documents/show_edit_view/version_banner_component.html.erb
+++ b/modules/documents/app/components/documents/show_edit_view/version_banner_component.html.erb
@@ -29,33 +29,38 @@
   ++#
 %>
 
-<% html_title(t(:label_document_plural), @document.title) %>
+<%= render(Primer::Alpha::Banner.new(scheme: :warning, icon: :history)) do |banner| %>
+  <div class="document-version-banner--content">
+    <span>
+      <%= I18n.t(
+            "documents.versions.banner_text",
+            datetime: helpers.format_time(created_at),
+            user: helpers.link_to_user(author)
+          ).html_safe %>
+    </span>
 
-<% if @document.collaborative? %>
-  <% if Setting.real_time_text_collaboration_enabled? %>
-    <%=
-      render(
-        Documents::ShowEditView::BlockNoteEditorComponent.new(
-          @document,
-          project: @project,
-          token_payload: @token_payload,
-          state: @state,
-          resource_url: @resource_url,
-          token_expires_in_seconds: @token_expires_in_seconds,
-          readonly: @readonly,
-          version_journal: @version_journal
-        )
-      )
-    %>
-  <% else %>
-    <%=
-      render(
-        Documents::ShowEditView::CollaborationDisabledNoticeComponent.new(
-          @document, project: @project, state: :show
-        )
-      )
-    %>
-  <% end %>
-<% else %>
-  <%= render partial: "classic_show", locals: { document: @document, project: @project, attachments: @attachments, version_journal: @version_journal } %>
+    <% if can_manage? %>
+      <div class="document-version-banner--actions">
+        <%= render(Primer::Beta::Button.new(
+              tag: :a,
+              href: save_copy_path,
+              data: { turbo_method: :post },
+              size: :small,
+              scheme: :default
+            )) do %>
+          <%= I18n.t("documents.versions.save_copy") %>
+        <% end %>
+
+        <%= render(Primer::Beta::Button.new(
+              tag: :a,
+              href: restore_path,
+              data: { turbo_method: :post, turbo_confirm: I18n.t("documents.versions.restore_confirm") },
+              size: :small,
+              scheme: :primary
+            )) do %>
+          <%= I18n.t("documents.versions.restore") %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 <% end %>

--- a/modules/documents/app/components/documents/show_edit_view/version_banner_component.rb
+++ b/modules/documents/app/components/documents/show_edit_view/version_banner_component.rb
@@ -27,21 +27,34 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
 
 module Documents
   module ShowEditView
-    class BlockNoteEditorComponent < ApplicationComponent
+    class VersionBannerComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
       alias_method :document, :model
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
+      options :version_journal, :project
 
-      private
+      def author
+        version_journal.user
+      end
 
-      def refresh_token_url
-        project_document_refresh_token_path(project, document)
+      def created_at
+        version_journal.created_at
+      end
+
+      def can_manage?
+        User.current.allowed_in_project?(:manage_documents, project)
+      end
+
+      def restore_path
+        restore_version_document_path(document, version_id: version_journal.id)
+      end
+
+      def save_copy_path
+        save_copy_document_path(document, version_id: version_journal.id)
       end
     end
   end

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -29,36 +29,56 @@
   ++#
 %>
 
-<li class="op-activity-list--item">
-  <div class="op-activity-list--item-title">
-    <% if content_changed? %>
-      <%= link_to I18n.t("documents.versions.version_label", version: journal.version), version_url %>
-      <% if latest? %>
-        <span class="spot-caption">(<%= I18n.t("documents.versions.current") %>)</span>
-      <% end %>
-    <% else %>
-      <%= I18n.t("documents.versions.version_label", version: journal.version) %>
-    <% end %>
-  </div>
+<%=
+  component_wrapper(class: "documents-versions-tab--item") do
+    flex_layout(
+      my: 2,
+      border: :left,
+      pl: 3,
+      classes: "work-packages-activities-tab-journals-item-component-details--journal-details-container"
+    ) do |item_container|
+      item_container.with_row(
+        flex_layout: true,
+        align_items: :center,
+        classes: "work-packages-activities-tab-journals-item-component-details--journal-details-header ellipsis"
+      ) do |header|
+        header.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--timeline-icon") do
+          render Primer::Beta::Octicon.new(icon: "history", size: :small, color: :subtle,
+                                          "aria-label": I18n.t("documents.versions.aria_version_entry"))
+        end
 
-  <%=
-    render(
-      Activities::ItemSubtitleComponent.new(
-        user: author,
-        datetime: journal.created_at,
-        is_creation: journal.version == 1,
-        is_deletion: false,
-        is_work_package: false,
-        journable_type: "Document"
-      )
-    )
-  %>
+        header.with_column(mr: 2) do
+          render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
+        end
 
-  <% unless change_details.empty? %>
-    <ul class="op-activity-list--item-details">
-      <% change_details.each do |detail| %>
-        <li class="op-activity-list--item-detail"><%= detail %></li>
-      <% end %>
-    </ul>
-  <% end %>
-</li>
+        header.with_column(mr: 1, classes: "ellipsis hidden-for-mobile") do
+          helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
+        end
+
+        header.with_column(mr: 1) do
+          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+            helpers.format_time(journal.created_at)
+          end
+        end
+      end
+
+      item_container.with_row(pl: 7, mt: 1) do
+        if content_changed?
+          link_to version_label, version_url,
+                  class: "spot-link",
+                  data: { turbo_frame: "_top" }
+        else
+          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { version_label }
+        end
+      end
+
+      unless change_details.empty?
+        item_container.with_row(pl: 7, mt: 1) do
+          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+            change_details.join(", ")
+          end
+        end
+      end
+    end
+  end
+%>

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -31,34 +31,62 @@
 
 <%=
   component_wrapper(class: "documents-versions-tab--item") do
-    flex_layout(align_items: :center, my: 2) do |row|
-      row.with_column(mr: 2) do
-        render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
-      end
+    concat(
+      flex_layout(align_items: :center, mt: 2, mb: 1) do |row|
+        row.with_column(mr: 2) do
+          render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
+        end
 
-      row.with_column(mr: 2, classes: "ellipsis hidden-for-mobile") do
-        helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
-      end
+        row.with_column(mr: 2, classes: "ellipsis hidden-for-mobile") do
+          helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
+        end
 
-      row.with_column(mr: 2) do
         if content_changed?
-          link_to format_time(journal.created_at), version_url,
-                  class: "spot-link",
-                  data: { turbo_frame: "_top" }
-        else
+          row.with_column(mr: 2) do
+            render(Primer::Beta::Button.new(
+              tag: :a,
+              href: version_url,
+              size: :small,
+              scheme: :default,
+              data: { turbo_frame: "_top" }
+            )) { I18n.t("documents.versions.view") }
+          end
+        end
+
+        row.with_column do
           render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
             format_time(journal.created_at)
           end
         end
       end
+    )
 
-      unless change_details.empty?
-        row.with_column do
-          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
-            change_details.join(", ")
+    simple_changes.each do |text|
+      concat(
+        flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
+          detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
+            ""
+          end
+          detail.with_column do
+            render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { text }
           end
         end
-      end
+      )
+    end
+
+    attribute_changes.each do |change|
+      concat(
+        flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
+          detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
+            ""
+          end
+          detail.with_column do
+            render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+              format_attribute_change(**change)
+            end
+          end
+        end
+      )
     end
   end
 %>

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -30,7 +30,10 @@
 %>
 
 <%=
-  component_wrapper(class: "documents-versions-tab--item") do
+  is_active = active_journal_id && active_journal_id == journal.id
+  wrapper_attrs = { id: "journal-#{journal.id}", class: "documents-versions-tab--item" }
+  wrapper_attrs[:style] = "background-color: var(--bgColor-accent-muted, #ddf4ff); border-radius: 4px;" if is_active
+  component_wrapper(**wrapper_attrs) do
     concat(
       flex_layout(align_items: :center, mt: 2, mb: 1) do |row|
         row.with_column(mr: 2) do

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -31,49 +31,29 @@
 
 <%=
   component_wrapper(class: "documents-versions-tab--item") do
-    flex_layout(
-      my: 2,
-      border: :left,
-      pl: 3,
-      classes: "work-packages-activities-tab-journals-item-component-details--journal-details-container"
-    ) do |item_container|
-      item_container.with_row(
-        flex_layout: true,
-        align_items: :center,
-        classes: "work-packages-activities-tab-journals-item-component-details--journal-details-header ellipsis"
-      ) do |header|
-        header.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--timeline-icon") do
-          render Primer::Beta::Octicon.new(icon: "history", size: :small, color: :subtle,
-                                          "aria-label": I18n.t("documents.versions.aria_version_entry"))
-        end
+    flex_layout(align_items: :center, my: 2) do |row|
+      row.with_column(mr: 2) do
+        render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
+      end
 
-        header.with_column(mr: 2) do
-          render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
-        end
+      row.with_column(mr: 2, classes: "ellipsis hidden-for-mobile") do
+        helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
+      end
 
-        header.with_column(mr: 1, classes: "ellipsis hidden-for-mobile") do
-          helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
-        end
-
-        header.with_column(mr: 1) do
+      row.with_column(mr: 2) do
+        if content_changed?
+          link_to format_time(journal.created_at), version_url,
+                  class: "spot-link",
+                  data: { turbo_frame: "_top" }
+        else
           render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
             format_time(journal.created_at)
           end
         end
       end
 
-      item_container.with_row(pl: 7, mt: 1) do
-        if content_changed?
-          link_to version_label, version_url,
-                  class: "spot-link",
-                  data: { turbo_frame: "_top" }
-        else
-          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { version_label }
-        end
-      end
-
       unless change_details.empty?
-        item_container.with_row(pl: 7, mt: 1) do
+        row.with_column do
           render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
             change_details.join(", ")
           end

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -57,7 +57,7 @@
 
         header.with_column(mr: 1) do
           render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
-            helpers.format_time(journal.created_at)
+            format_time(journal.created_at)
           end
         end
       end

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -34,62 +34,71 @@
   wrapper_attrs = { id: "journal-#{journal.id}", class: "documents-versions-tab--item" }
   wrapper_attrs[:style] = "background-color: var(--bgColor-accent-muted, #ddf4ff); border-radius: 4px;" if is_active
   component_wrapper(**wrapper_attrs) do
+    # Details container: margin-left: 19px + border-left mirrors WP activity timeline
     concat(
-      flex_layout(align_items: :center, mt: 2, mb: 1) do |row|
-        row.with_column(mr: 2) do
-          render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
-        end
+      content_tag(:div,
+                  style: "margin-left: 19px; border-left: var(--borderWidth-thin, 1px) solid var(--borderColor-default); min-height: 20px;") do
+        # Header row: margin-left: -14px pulls avatar back over the vertical line
+        concat(
+          content_tag(:div, style: "margin-left: -14px;") do
+            flex_layout(align_items: :center, mt: 2, mb: 1) do |row|
+              row.with_column(mr: 2) do
+                render Users::AvatarComponent.new(user: author, show_name: false, size: :mini)
+              end
 
-        row.with_column(mr: 2, classes: "ellipsis hidden-for-mobile") do
-          helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
-        end
+              row.with_column(mr: 2, classes: "ellipsis hidden-for-mobile") do
+                helpers.primer_link_to_user(author, scheme: :primary, font_weight: :bold)
+              end
 
-        if content_changed?
-          row.with_column(mr: 2) do
-            render(Primer::Beta::Button.new(
-              tag: :a,
-              href: version_url,
-              size: :small,
-              scheme: :default,
-              data: { turbo_frame: "_top" }
-            )) { I18n.t("documents.versions.view") }
+              if content_changed?
+                row.with_column(mr: 2) do
+                  render(Primer::Beta::Button.new(
+                    tag: :a,
+                    href: version_url,
+                    size: :small,
+                    scheme: :default,
+                    data: { turbo_frame: "_top" }
+                  )) { I18n.t("documents.versions.view") }
+                end
+              end
+
+              row.with_column do
+                render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+                  format_time(journal.created_at)
+                end
+              end
+            end
           end
+        )
+
+        simple_changes.each do |text|
+          concat(
+            flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
+              detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
+                ""
+              end
+              detail.with_column do
+                render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { text }
+              end
+            end
+          )
         end
 
-        row.with_column do
-          render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
-            format_time(journal.created_at)
-          end
+        attribute_changes.each do |change|
+          concat(
+            flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
+              detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
+                ""
+              end
+              detail.with_column do
+                render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
+                  format_attribute_change(**change)
+                end
+              end
+            end
+          )
         end
       end
     )
-
-    simple_changes.each do |text|
-      concat(
-        flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
-          detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
-            ""
-          end
-          detail.with_column do
-            render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) { text }
-          end
-        end
-      )
-    end
-
-    attribute_changes.each do |change|
-      concat(
-        flex_layout(align_items: :baseline, pl: 1, pb: 1) do |detail|
-          detail.with_column(mr: 2, classes: "work-packages-activities-tab-journals-item-component-details--journal-detail-stem-line") do
-            ""
-          end
-          detail.with_column do
-            render(Primer::Beta::Text.new(font_size: :small, color: :subtle)) do
-              format_attribute_change(**change)
-            end
-          end
-        end
-      )
-    end
   end
 %>

--- a/modules/documents/app/components/documents/versions_tab/item_component.html.erb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.html.erb
@@ -29,33 +29,36 @@
   ++#
 %>
 
-<% html_title(t(:label_document_plural), @document.title) %>
+<li class="op-activity-list--item">
+  <div class="op-activity-list--item-title">
+    <% if content_changed? %>
+      <%= link_to I18n.t("documents.versions.version_label", version: journal.version), version_url %>
+      <% if latest? %>
+        <span class="spot-caption">(<%= I18n.t("documents.versions.current") %>)</span>
+      <% end %>
+    <% else %>
+      <%= I18n.t("documents.versions.version_label", version: journal.version) %>
+    <% end %>
+  </div>
 
-<% if @document.collaborative? %>
-  <% if Setting.real_time_text_collaboration_enabled? %>
-    <%=
-      render(
-        Documents::ShowEditView::BlockNoteEditorComponent.new(
-          @document,
-          project: @project,
-          token_payload: @token_payload,
-          state: @state,
-          resource_url: @resource_url,
-          token_expires_in_seconds: @token_expires_in_seconds,
-          readonly: @readonly,
-          version_journal: @version_journal
-        )
+  <%=
+    render(
+      Activities::ItemSubtitleComponent.new(
+        user: author,
+        datetime: journal.created_at,
+        is_creation: journal.version == 1,
+        is_deletion: false,
+        is_work_package: false,
+        journable_type: "Document"
       )
-    %>
-  <% else %>
-    <%=
-      render(
-        Documents::ShowEditView::CollaborationDisabledNoticeComponent.new(
-          @document, project: @project, state: :show
-        )
-      )
-    %>
+    )
+  %>
+
+  <% unless change_details.empty? %>
+    <ul class="op-activity-list--item-details">
+      <% change_details.each do |detail| %>
+        <li class="op-activity-list--item-detail"><%= detail %></li>
+      <% end %>
+    </ul>
   <% end %>
-<% else %>
-  <%= render partial: "classic_show", locals: { document: @document, project: @project, attachments: @attachments, version_journal: @version_journal } %>
-<% end %>
+</li>

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -37,14 +37,18 @@ module Documents
 
       alias_method :journal, :model
 
-      options :document, :max_version
+      options :document, :max_version, active_journal_id: nil
 
       def author
         journal.user
       end
 
       def version_url
-        journal.version == max_version ? document_path(document) : document_path(document, version: journal.id)
+        if journal.version == max_version
+          document_path(document, tab: :versions)
+        else
+          document_path(document, version: journal.id, tab: :versions)
+        end
       end
 
       def content_changed?

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -37,7 +37,8 @@ module Documents
 
       alias_method :journal, :model
 
-      options :document, :max_version, active_journal_id: nil
+      options :document, :max_version
+      options active_journal_id: nil
 
       def author
         journal.user

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -56,7 +56,13 @@ module Documents
       def content_changed?
         journal.version == 1 ||
           journal.details.key?("content_binary") ||
-          journal.details.key?("description")
+          journal.details.key?("description") ||
+          restore_journal? ||
+          (document.collaborative? && journal.data.content_binary.present?)
+      end
+
+      def restore_journal?
+        journal.cause&.dig("type") == "document_version_restored"
       end
 
       def change_details

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -27,21 +27,49 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
 
 module Documents
-  module ShowEditView
-    class BlockNoteEditorComponent < ApplicationComponent
+  module VersionsTab
+    class ItemComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
 
-      alias_method :document, :model
+      alias_method :journal, :model
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
+      options :document, :max_version
 
-      private
+      def author
+        journal.user
+      end
 
-      def refresh_token_url
-        project_document_refresh_token_path(project, document)
+      def latest?
+        journal.version == max_version
+      end
+
+      def version_url
+        return document_path(document) if latest?
+
+        document_path(document, version: journal.id)
+      end
+
+      def content_changed?
+        journal.version == 1 ||
+          journal.details.key?("content_binary") ||
+          journal.details.key?("description")
+      end
+
+      def change_details
+        details = []
+
+        if journal.version == 1
+          details << I18n.t("documents.versions.created")
+        else
+          details << I18n.t("documents.versions.content_updated") if journal.details[:content_binary].present?
+          details << I18n.t("documents.versions.description_updated") if journal.details[:description].present?
+          details << I18n.t("documents.versions.title_updated") if journal.details[:title].present?
+          details << I18n.t("documents.versions.type_updated") if journal.details[:type_id].present?
+        end
+
+        details
       end
     end
   end

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -43,14 +43,8 @@ module Documents
         journal.user
       end
 
-      def latest?
-        journal.version == max_version
-      end
-
       def version_url
-        return document_path(document) if latest?
-
-        document_path(document, version: journal.id)
+        journal.version == max_version ? document_path(document) : document_path(document, version: journal.id)
       end
 
       def content_changed?
@@ -73,13 +67,8 @@ module Documents
         details << I18n.t("documents.versions.description_updated") if journal.details.key?("description")
         details << I18n.t("documents.versions.title_updated") if journal.details.key?("title")
         details << I18n.t("documents.versions.type_updated") if journal.details.key?("type_id")
+        details << I18n.t("documents.versions.restored") if restore_journal?
         details
-      end
-
-      def version_label
-        label = I18n.t("documents.versions.version_label", version: journal.version)
-        label += " (#{I18n.t('documents.versions.current')})" if latest?
-        label
       end
     end
   end

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -58,18 +58,20 @@ module Documents
       end
 
       def change_details
+        return [I18n.t("documents.versions.created")] if journal.version == 1
+
         details = []
-
-        if journal.version == 1
-          details << I18n.t("documents.versions.created")
-        else
-          details << I18n.t("documents.versions.content_updated") if journal.details[:content_binary].present?
-          details << I18n.t("documents.versions.description_updated") if journal.details[:description].present?
-          details << I18n.t("documents.versions.title_updated") if journal.details[:title].present?
-          details << I18n.t("documents.versions.type_updated") if journal.details[:type_id].present?
-        end
-
+        details << I18n.t("documents.versions.content_updated") if journal.details.key?("content_binary")
+        details << I18n.t("documents.versions.description_updated") if journal.details.key?("description")
+        details << I18n.t("documents.versions.title_updated") if journal.details.key?("title")
+        details << I18n.t("documents.versions.type_updated") if journal.details.key?("type_id")
         details
+      end
+
+      def version_label
+        label = I18n.t("documents.versions.version_label", version: journal.version)
+        label += " (#{I18n.t('documents.versions.current')})" if latest?
+        label
       end
     end
   end

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -59,16 +59,43 @@ module Documents
         journal.cause&.dig("type") == "document_version_restored"
       end
 
-      def change_details
+      # Simple text-only change descriptions (content, restored, etc.)
+      def simple_changes
         return [I18n.t("documents.versions.created")] if journal.version == 1
 
         details = []
         details << I18n.t("documents.versions.content_updated") if journal.details.key?("content_binary")
         details << I18n.t("documents.versions.description_updated") if journal.details.key?("description")
-        details << I18n.t("documents.versions.title_updated") if journal.details.key?("title")
-        details << I18n.t("documents.versions.type_updated") if journal.details.key?("type_id")
         details << I18n.t("documents.versions.restored") if restore_journal?
         details
+      end
+
+      # Structured attribute changes with old/new values for title and type
+      def attribute_changes
+        changes = []
+
+        if (title_vals = journal.details["title"])
+          changes << { label: Document.human_attribute_name(:title), old: title_vals.first, new_val: title_vals.last }
+        end
+
+        if (type_vals = journal.details["type_id"])
+          old_type = DocumentType.find_by(id: type_vals.first)
+          new_type = DocumentType.find_by(id: type_vals.last)
+          changes << { label: Document.human_attribute_name(:type_id), old: old_type&.name, new_val: new_type&.name }
+        end
+
+        changes
+      end
+
+      def format_attribute_change(label:, old:, new_val:)
+        label_html = content_tag(:strong, label)
+        if old.present? && new_val.present?
+          safe_join([label_html, " changed from ", content_tag(:em, old), " to ", content_tag(:em, new_val)])
+        elsif new_val.present?
+          safe_join([label_html, " set to ", content_tag(:em, new_val)])
+        elsif old.present?
+          safe_join([label_html, " deleted (", content_tag(:em, old), ")"])
+        end
       end
     end
   end

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -31,6 +31,7 @@
 module Documents
   module VersionsTab
     class ItemComponent < ApplicationComponent
+      include ApplicationHelper
       include OpPrimer::ComponentHelpers
       include OpTurbo::Streamable
 

--- a/modules/documents/app/components/documents/versions_tab/item_component.rb
+++ b/modules/documents/app/components/documents/versions_tab/item_component.rb
@@ -32,6 +32,7 @@ module Documents
   module VersionsTab
     class ItemComponent < ApplicationComponent
       include OpPrimer::ComponentHelpers
+      include OpTurbo::Streamable
 
       alias_method :journal, :model
 

--- a/modules/documents/app/controllers/documents/versions_controller.rb
+++ b/modules/documents/app/controllers/documents/versions_controller.rb
@@ -27,22 +27,44 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
 
 module Documents
-  module ShowEditView
-    class BlockNoteEditorComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
+  class VersionsController < ApplicationController
+    before_action :find_document
+    before_action :authorize
 
-      alias_method :document, :model
+    def index
+      @max_version = @document.journals.maximum(:version).to_i
+      journals_scope = @document.journals
+        .preload(:user, :data)
+        .order(version: :desc)
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
+      page = [params[:page].to_i, 1].max
+      per_page = page == 1 ? 20 : 50
 
-      private
+      # For pages after the first, offset by 20 + (page - 2) * 50
+      offset = page == 1 ? 0 : 20 + (page - 2) * 50
+      @journals = journals_scope.offset(offset).limit(per_page + 1)
 
-      def refresh_token_url
-        project_document_refresh_token_path(project, document)
+      @has_more = @journals.size > per_page
+      @journals = @journals.first(per_page)
+      @next_page = @has_more ? page + 1 : nil
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream
       end
+    end
+
+    private
+
+    def find_document
+      @document = Document.visible.find(params[:document_id])
+      @project = @document.project
+    end
+
+    def default_breadcrumb
+      @document.title
     end
   end
 end

--- a/modules/documents/app/controllers/documents/versions_controller.rb
+++ b/modules/documents/app/controllers/documents/versions_controller.rb
@@ -39,16 +39,30 @@ module Documents
         .preload(:user, :data)
         .reorder(version: :desc)
 
-      page = [params[:page].to_i, 1].max
-      per_page = page == 1 ? 20 : 50
+      scroll_to_id = params[:scroll_to].presence&.to_i
+      @scroll_to_id = scroll_to_id
 
-      # For pages after the first, offset by 20 + (page - 2) * 50
-      offset = page == 1 ? 0 : 20 + (page - 2) * 50
-      @journals = journals_scope.offset(offset).limit(per_page + 1)
-
-      @has_more = @journals.size > per_page
-      @journals = @journals.first(per_page)
-      @next_page = @has_more ? page + 1 : nil
+      if scroll_to_id
+        # Load enough items so the target journal is included (journals are ordered desc by version)
+        target_journal = @document.journals.find_by(id: scroll_to_id)
+        if target_journal
+          target_offset = @document.journals.where("version > ?", target_journal.version).count
+          load_count = [target_offset + 1, 20].max
+        else
+          load_count = 20
+        end
+        @journals = journals_scope.limit(load_count + 1)
+        @has_more = @journals.size > load_count
+        @journals = @journals.first(load_count)
+        @next_offset = load_count
+      else
+        offset = [params[:offset].to_i, 0].max
+        per_page = offset == 0 ? 20 : 50
+        @journals = journals_scope.offset(offset).limit(per_page + 1)
+        @has_more = @journals.size > per_page
+        @journals = @journals.first(per_page)
+        @next_offset = offset + per_page
+      end
 
       respond_to do |format|
         format.html

--- a/modules/documents/app/controllers/documents/versions_controller.rb
+++ b/modules/documents/app/controllers/documents/versions_controller.rb
@@ -37,7 +37,7 @@ module Documents
       @max_version = @document.journals.maximum(:version).to_i
       journals_scope = @document.journals
         .preload(:user, :data)
-        .order(version: :desc)
+        .reorder(version: :desc)
 
       page = [params[:page].to_i, 1].max
       per_page = page == 1 ? 20 : 50

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -58,9 +58,45 @@ class DocumentsController < ApplicationController
   def show
     @attachments = @document.attachments.order(Arel.sql("created_at DESC"))
 
+    load_version_journal if params[:version].present?
+
     if @document.collaborative? && Setting.real_time_text_collaboration_enabled?
-      setup_collaboration_context
+      setup_collaboration_context unless @version_journal
       derive_show_edit_state_from_params
+    end
+  end
+
+  def restore_version
+    journal = find_version_journal_for_manage
+    return unless journal
+
+    call = Documents::RestoreVersionService
+      .new(user: current_user, document: @document)
+      .call(journal:)
+
+    if call.success?
+      flash[:notice] = I18n.t("documents.versions.restore_success")
+      redirect_to document_path(@document)
+    else
+      flash[:error] = call.errors.full_messages.join(", ")
+      redirect_back_or_to document_path(@document)
+    end
+  end
+
+  def save_copy
+    journal = find_version_journal_for_manage
+    return unless journal
+
+    call = Documents::SaveCopyService
+      .new(user: current_user, document: @document)
+      .call(journal:)
+
+    if call.success?
+      flash[:notice] = I18n.t("documents.versions.save_copy_success")
+      redirect_to document_path(call.result)
+    else
+      flash[:error] = call.errors.full_messages.join(", ")
+      redirect_back_or_to document_path(@document)
     end
   end
 
@@ -235,5 +271,30 @@ class DocumentsController < ApplicationController
 
   def derive_show_edit_state_from_params
     @state = params[:state] == "edit" ? :edit : :show
+  end
+
+  def load_version_journal
+    journal = @document.journals.find_by(id: params[:version])
+    return unless journal
+
+    @version_journal = journal
+    @document.description = journal.data.description
+    @document.content_binary = journal.data.content_binary if @document.collaborative?
+    @readonly = true
+  end
+
+  def find_version_journal_for_manage
+    unless current_user.allowed_in_project?(:manage_documents, @project)
+      render_403
+      return nil
+    end
+
+    journal = @document.journals.find_by(id: params[:version_id])
+    unless journal
+      render_404
+      return nil
+    end
+
+    journal
   end
 end

--- a/modules/documents/app/controllers/documents_controller.rb
+++ b/modules/documents/app/controllers/documents_controller.rb
@@ -279,7 +279,10 @@ class DocumentsController < ApplicationController
 
     @version_journal = journal
     @document.description = journal.data.description
-    @document.content_binary = journal.data.content_binary if @document.collaborative?
+    if @document.collaborative?
+      @version_content_binary = journal.data.content_binary
+      @document.content_binary = @version_content_binary
+    end
     @readonly = true
   end
 

--- a/modules/documents/app/models/activities/document_activity_provider.rb
+++ b/modules/documents/app/models/activities/document_activity_provider.rb
@@ -33,10 +33,11 @@ class Activities::DocumentActivityProvider < Activities::BaseActivityProvider
                         permission: :view_documents
 
   def event_query_projection
+    journals = Journal.arel_table.name
     [
       activity_journal_projection_statement(:title, "document_title"),
       activity_journal_projection_statement(:project_id, "project_id"),
-      "MAX(#{Journal.arel_table.name}.version) OVER (PARTITION BY #{Journal.arel_table.name}.journable_id) AS journable_max_version"
+      Arel.sql("MAX(#{journals}.version) OVER (PARTITION BY #{journals}.journable_id) AS journable_max_version")
     ]
   end
 

--- a/modules/documents/app/models/activities/document_activity_provider.rb
+++ b/modules/documents/app/models/activities/document_activity_provider.rb
@@ -35,7 +35,8 @@ class Activities::DocumentActivityProvider < Activities::BaseActivityProvider
   def event_query_projection
     [
       activity_journal_projection_statement(:title, "document_title"),
-      activity_journal_projection_statement(:project_id, "project_id")
+      activity_journal_projection_statement(:project_id, "project_id"),
+      "MAX(#{Journal.arel_table.name}.version) OVER (PARTITION BY #{Journal.arel_table.name}.journable_id) AS journable_max_version"
     ]
   end
 
@@ -48,16 +49,24 @@ class Activities::DocumentActivityProvider < Activities::BaseActivityProvider
   end
 
   def event_path(event)
-    url_helpers.document_url(url_helper_parameter(event))
+    url_helpers.document_url(versioned_url_params(event))
   end
 
   def event_url(event)
-    url_helpers.document_url(url_helper_parameter(event))
+    url_helpers.document_url(versioned_url_params(event))
   end
 
   private
 
-  def url_helper_parameter(event)
-    event["journable_id"]
+  def versioned_url_params(event)
+    document_id = event["journable_id"]
+    journal_version = event["version"].to_i
+    max_version = event["journable_max_version"].to_i
+
+    if journal_version < max_version
+      { id: document_id, version: event["event_id"] }
+    else
+      document_id
+    end
   end
 end

--- a/modules/documents/app/models/document.rb
+++ b/modules/documents/app/models/document.rb
@@ -41,6 +41,9 @@ class Document < ApplicationRecord
                      add_permission: :manage_documents
 
   acts_as_journalized
+
+  attr_accessor :skip_journal_aggregation
+
   acts_as_event title: Proc.new { |o| "#{Document.model_name.human}: #{o.title}" },
                 url: Proc.new { |o| { controller: "/documents", action: "show", id: o.id } },
                 author: Proc.new { |o|

--- a/modules/documents/app/services/documents/restore_version_service.rb
+++ b/modules/documents/app/services/documents/restore_version_service.rb
@@ -39,6 +39,12 @@ module Documents
       attrs = { description: journal.data.description }
       attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
 
+      # Set a distinct cause so acts_as_journalized always creates a new journal
+      # entry rather than aggregating with the most recent one. Without this, the
+      # version that was current before restoring would be silently overwritten.
+      @document.journal_cause = CauseOfChange::Base.new("document_version_restored",
+                                                         "restored_journal_id" => journal.id)
+
       Documents::UpdateService
         .new(user: @user, model: @document)
         .call(attrs)

--- a/modules/documents/app/services/documents/restore_version_service.rb
+++ b/modules/documents/app/services/documents/restore_version_service.rb
@@ -39,9 +39,8 @@ module Documents
       attrs = { description: journal.data.description }
       attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
 
-      # Set a distinct cause so acts_as_journalized always creates a new journal
-      # entry rather than aggregating with the most recent one. Without this, the
-      # version that was current before restoring would be silently overwritten.
+      # Prevent aggregation so restore always appends a new journal entry.
+      @document.skip_journal_aggregation = true
       @document.journal_cause = CauseOfChange::Base.new("document_version_restored",
                                                          "restored_journal_id" => journal.id)
 

--- a/modules/documents/app/services/documents/restore_version_service.rb
+++ b/modules/documents/app/services/documents/restore_version_service.rb
@@ -36,7 +36,11 @@ module Documents
     end
 
     def call(journal:)
-      attrs = { description: journal.data.description }
+      attrs = {
+        title: journal.data.title,
+        description: journal.data.description,
+        type_id: journal.data.type_id
+      }
       attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
 
       # Prevent aggregation so restore always appends a new journal entry.

--- a/modules/documents/app/services/documents/restore_version_service.rb
+++ b/modules/documents/app/services/documents/restore_version_service.rb
@@ -27,22 +27,21 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
 
 module Documents
-  module ShowEditView
-    class BlockNoteEditorComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
+  class RestoreVersionService
+    def initialize(user:, document:)
+      @user = user
+      @document = document
+    end
 
-      alias_method :document, :model
+    def call(journal:)
+      attrs = { description: journal.data.description }
+      attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
-
-      private
-
-      def refresh_token_url
-        project_document_refresh_token_path(project, document)
-      end
+      Documents::UpdateService
+        .new(user: @user, model: @document)
+        .call(attrs)
     end
   end
 end

--- a/modules/documents/app/services/documents/save_copy_service.rb
+++ b/modules/documents/app/services/documents/save_copy_service.rb
@@ -27,21 +27,43 @@
 #
 # See COPYRIGHT and LICENSE files for more details.
 #++
-#
 
 module Documents
-  module ShowEditView
-    class BlockNoteEditorComponent < ApplicationComponent
-      include OpPrimer::ComponentHelpers
+  class SaveCopyService
+    def initialize(user:, document:)
+      @user = user
+      @document = document
+    end
 
-      alias_method :document, :model
+    def call(journal:)
+      attrs = {
+        title: "#{@document.title} (copy)",
+        description: journal.data.description,
+        project: @document.project,
+        type_id: @document.type_id,
+        kind: @document.kind
+      }
+      attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
 
-      options :project, :token_payload, :resource_url, :token_expires_in_seconds, :state, :readonly, :version_journal
+      result = Documents::CreateService
+        .new(user: @user)
+        .call(attrs)
 
-      private
+      copy_attachments(result.result) if result.success?
 
-      def refresh_token_url
-        project_document_refresh_token_path(project, document)
+      result
+    end
+
+    private
+
+    def copy_attachments(new_document)
+      @document.attachments.each do |source|
+        copy = source.copy
+        copy.container = new_document
+        copy.author = @user
+        copy.save!
+      rescue StandardError => e
+        Rails.logger.error("Failed to copy attachment #{source.id} to document #{new_document.id}: #{e.message}")
       end
     end
   end

--- a/modules/documents/app/services/documents/save_copy_service.rb
+++ b/modules/documents/app/services/documents/save_copy_service.rb
@@ -37,10 +37,10 @@ module Documents
 
     def call(journal:)
       attrs = {
-        title: "#{@document.title} (copy)",
+        title: "#{journal.data.title} (copy)",
         description: journal.data.description,
         project: @document.project,
-        type_id: @document.type_id,
+        type_id: journal.data.type_id,
         kind: @document.kind
       }
       attrs[:content_binary] = journal.data.content_binary if @document.collaborative?

--- a/modules/documents/app/views/documents/_classic_show.html.erb
+++ b/modules/documents/app/views/documents/_classic_show.html.erb
@@ -39,45 +39,58 @@
        document.title]
     )
 
-    if authorize_for(:documents, :edit)
-      header.with_action_button(
-        tag: :a,
-        scheme: :default,
-        mobile_icon: :pencil,
-        mobile_label: t(:button_edit),
-        size: :medium,
-        href: url_for({ controller: "/documents", action: "edit", id: document }),
-        aria: { label: t(:button_edit) },
-        title: t(:button_edit)
-      ) do |button|
-        button.with_leading_visual_icon(icon: :pencil)
-        t(:button_edit)
+    unless version_journal
+      if authorize_for(:documents, :edit)
+        header.with_action_button(
+          tag: :a,
+          scheme: :default,
+          mobile_icon: :pencil,
+          mobile_label: t(:button_edit),
+          size: :medium,
+          href: url_for({ controller: "/documents", action: "edit", id: document }),
+          aria: { label: t(:button_edit) },
+          title: t(:button_edit)
+        ) do |button|
+          button.with_leading_visual_icon(icon: :pencil)
+          t(:button_edit)
+        end
       end
-    end
-    if authorize_for(:documents, :destroy)
-      header.with_action_button(
-        tag: :a,
-        scheme: :danger,
-        mobile_icon: :trash,
-        mobile_label: t(:button_delete),
-        size: :medium,
-        href: url_for({ controller: "/documents", action: "destroy", id: document }),
-        aria: { label: I18n.t(:button_delete) },
-        data: {
-          turbo_confirm: I18n.t(:text_are_you_sure),
-          turbo_method: :delete
-        },
-        title: I18n.t(:button_delete)
-      ) do |button|
-        button.with_leading_visual_icon(icon: :trash)
-        t(:button_delete)
+      if authorize_for(:documents, :destroy)
+        header.with_action_button(
+          tag: :a,
+          scheme: :danger,
+          mobile_icon: :trash,
+          mobile_label: t(:button_delete),
+          size: :medium,
+          href: url_for({ controller: "/documents", action: "destroy", id: document }),
+          aria: { label: I18n.t(:button_delete) },
+          data: {
+            turbo_confirm: I18n.t(:text_are_you_sure),
+            turbo_method: :delete
+          },
+          title: I18n.t(:button_delete)
+        ) do |button|
+          button.with_leading_visual_icon(icon: :trash)
+          t(:button_delete)
+        end
       end
     end
   end
 %>
+
+<% if version_journal %>
+  <%= render Documents::ShowEditView::VersionBannerComponent.new(document, version_journal:, project:) %>
+<% end %>
 
 <div class="wiki op-uc-container">
   <%= format_text document.description, attachments: document.attachments %>
 </div>
 
 <%= list_attachments(api_v3_document_resource(document)) %>
+
+<div class="op-document-versions-section">
+  <h3 class="spot-subheader-small"><%= I18n.t("documents.versions.tab_title") %></h3>
+  <%= turbo_frame_tag(dom_id(document, :versions), src: document_versions_path(document), loading: :lazy) do %>
+    <%= tag.div(class: "loading-indicator -compact") %>
+  <% end %>
+</div>

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -44,7 +44,8 @@
           token_expires_in_seconds: @token_expires_in_seconds,
           readonly: @readonly,
           version_journal: @version_journal,
-          version_content_binary: @version_content_binary
+          version_content_binary: @version_content_binary,
+          tab_param: params[:tab]
         )
       )
     %>

--- a/modules/documents/app/views/documents/show.html.erb
+++ b/modules/documents/app/views/documents/show.html.erb
@@ -43,7 +43,8 @@
           resource_url: @resource_url,
           token_expires_in_seconds: @token_expires_in_seconds,
           readonly: @readonly,
-          version_journal: @version_journal
+          version_journal: @version_journal,
+          version_content_binary: @version_content_binary
         )
       )
     %>

--- a/modules/documents/app/views/documents/versions/index.html.erb
+++ b/modules/documents/app/views/documents/versions/index.html.erb
@@ -30,19 +30,24 @@
 %>
 
 <%= turbo_frame_tag dom_id(@document, :versions) do %>
-  <ul id="<%= dom_id(@document, :versions_list) %>"
-      class="op-activity-list"
-      data-controller="documents--versions-scroll"
-      data-documents--versions-scroll-target-id-value="<%= @scroll_to_id %>">
-    <% @journals.each do |journal| %>
-      <%= render Documents::VersionsTab::ItemComponent.new(
-            journal,
-            document: @document,
-            max_version: @max_version,
-            active_journal_id: @scroll_to_id
-          ) %>
-    <% end %>
-  </ul>
+  <div style="position: relative;">
+    <ul id="<%= dom_id(@document, :versions_list) %>"
+        class="op-activity-list"
+        style="position: relative; z-index: 10;"
+        data-controller="documents--versions-scroll"
+        data-documents--versions-scroll-target-id-value="<%= @scroll_to_id %>">
+      <% @journals.each do |journal| %>
+        <%= render Documents::VersionsTab::ItemComponent.new(
+              journal,
+              document: @document,
+              max_version: @max_version,
+              active_journal_id: @scroll_to_id
+            ) %>
+      <% end %>
+    </ul>
+
+    <div class="work-packages-activities-tab-journals-index-component--stem-connection"></div>
+  </div>
 
   <% if @has_more %>
     <div id="<%= dom_id(@document, :versions_load_more) %>">

--- a/modules/documents/app/views/documents/versions/index.html.erb
+++ b/modules/documents/app/views/documents/versions/index.html.erb
@@ -30,16 +30,24 @@
 %>
 
 <%= turbo_frame_tag dom_id(@document, :versions) do %>
-  <ul id="<%= dom_id(@document, :versions_list) %>" class="op-activity-list">
+  <ul id="<%= dom_id(@document, :versions_list) %>"
+      class="op-activity-list"
+      data-controller="documents--versions-scroll"
+      data-documents--versions-scroll-target-id-value="<%= @scroll_to_id %>">
     <% @journals.each do |journal| %>
-      <%= render Documents::VersionsTab::ItemComponent.new(journal, document: @document, max_version: @max_version) %>
+      <%= render Documents::VersionsTab::ItemComponent.new(
+            journal,
+            document: @document,
+            max_version: @max_version,
+            active_journal_id: @scroll_to_id
+          ) %>
     <% end %>
   </ul>
 
-  <% if @next_page %>
+  <% if @has_more %>
     <div id="<%= dom_id(@document, :versions_load_more) %>">
       <%= link_to I18n.t("documents.versions.load_more"),
-                  document_versions_path(@document, page: @next_page),
+                  document_versions_path(@document, offset: @next_offset),
                   data: { turbo_stream: true },
                   class: "button -secondary" %>
     </div>

--- a/modules/documents/app/views/documents/versions/index.html.erb
+++ b/modules/documents/app/views/documents/versions/index.html.erb
@@ -29,33 +29,19 @@
   ++#
 %>
 
-<% html_title(t(:label_document_plural), @document.title) %>
+<%= turbo_frame_tag dom_id(@document, :versions) do %>
+  <ul id="<%= dom_id(@document, :versions_list) %>" class="op-activity-list">
+    <% @journals.each do |journal| %>
+      <%= render Documents::VersionsTab::ItemComponent.new(journal, document: @document, max_version: @max_version) %>
+    <% end %>
+  </ul>
 
-<% if @document.collaborative? %>
-  <% if Setting.real_time_text_collaboration_enabled? %>
-    <%=
-      render(
-        Documents::ShowEditView::BlockNoteEditorComponent.new(
-          @document,
-          project: @project,
-          token_payload: @token_payload,
-          state: @state,
-          resource_url: @resource_url,
-          token_expires_in_seconds: @token_expires_in_seconds,
-          readonly: @readonly,
-          version_journal: @version_journal
-        )
-      )
-    %>
-  <% else %>
-    <%=
-      render(
-        Documents::ShowEditView::CollaborationDisabledNoticeComponent.new(
-          @document, project: @project, state: :show
-        )
-      )
-    %>
+  <% if @next_page %>
+    <div id="<%= dom_id(@document, :versions_load_more) %>">
+      <%= link_to I18n.t("documents.versions.load_more"),
+                  document_versions_path(@document, page: @next_page),
+                  data: { turbo_stream: true },
+                  class: "button -secondary" %>
+    </div>
   <% end %>
-<% else %>
-  <%= render partial: "classic_show", locals: { document: @document, project: @project, attachments: @attachments, version_journal: @version_journal } %>
 <% end %>

--- a/modules/documents/app/views/documents/versions/index.turbo_stream.erb
+++ b/modules/documents/app/views/documents/versions/index.turbo_stream.erb
@@ -35,11 +35,11 @@
   <% end %>
 <% end %>
 
-<% if @next_page %>
+<% if @has_more %>
   <%= turbo_stream.replace dom_id(@document, :versions_load_more) do %>
     <div id="<%= dom_id(@document, :versions_load_more) %>">
       <%= link_to I18n.t("documents.versions.load_more"),
-                  document_versions_path(@document, page: @next_page),
+                  document_versions_path(@document, offset: @next_offset),
                   data: { turbo_stream: true },
                   class: "button -secondary" %>
     </div>

--- a/modules/documents/app/views/documents/versions/index.turbo_stream.erb
+++ b/modules/documents/app/views/documents/versions/index.turbo_stream.erb
@@ -29,33 +29,21 @@
   ++#
 %>
 
-<% html_title(t(:label_document_plural), @document.title) %>
+<%= turbo_stream.append dom_id(@document, :versions_list) do %>
+  <% @journals.each do |journal| %>
+    <%= render Documents::VersionsTab::ItemComponent.new(journal, document: @document, max_version: @max_version) %>
+  <% end %>
+<% end %>
 
-<% if @document.collaborative? %>
-  <% if Setting.real_time_text_collaboration_enabled? %>
-    <%=
-      render(
-        Documents::ShowEditView::BlockNoteEditorComponent.new(
-          @document,
-          project: @project,
-          token_payload: @token_payload,
-          state: @state,
-          resource_url: @resource_url,
-          token_expires_in_seconds: @token_expires_in_seconds,
-          readonly: @readonly,
-          version_journal: @version_journal
-        )
-      )
-    %>
-  <% else %>
-    <%=
-      render(
-        Documents::ShowEditView::CollaborationDisabledNoticeComponent.new(
-          @document, project: @project, state: :show
-        )
-      )
-    %>
+<% if @next_page %>
+  <%= turbo_stream.replace dom_id(@document, :versions_load_more) do %>
+    <div id="<%= dom_id(@document, :versions_load_more) %>">
+      <%= link_to I18n.t("documents.versions.load_more"),
+                  document_versions_path(@document, page: @next_page),
+                  data: { turbo_stream: true },
+                  class: "button -secondary" %>
+    </div>
   <% end %>
 <% else %>
-  <%= render partial: "classic_show", locals: { document: @document, project: @project, attachments: @attachments, version_journal: @version_journal } %>
+  <%= turbo_stream.remove dom_id(@document, :versions_load_more) %>
 <% end %>

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       description_updated: "Description updated"
       title_updated: "Title updated"
       type_updated: "Type updated"
+      restored: "Restored from earlier version"
 
     page_header:
       heading: "All documents"

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
       restore_confirm: "Are you sure you want to restore this version? The current version will remain accessible via the version history."
       restore_success: "Document version has been restored successfully."
       save_copy_success: "A copy of this document version has been created."
+      aria_version_entry: "Version entry"
       created: "Document created"
       content_updated: "Content updated"
       description_updated: "Description updated"

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
       title_updated: "Title updated"
       type_updated: "Type updated"
       restored: "Restored from earlier version"
+      saved_at: "Saved"
 
     page_header:
       heading: "All documents"

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -58,6 +58,23 @@ en:
   enumeration_doc_categories: "Document categories"
 
   documents:
+    versions:
+      tab_title: "Versions"
+      version_label: "Version %{version}"
+      current: "current"
+      load_more: "Load more versions"
+      banner_text: "You are viewing an older version of this document, saved on %{datetime} by %{user}."
+      restore: "Restore this version"
+      save_copy: "Save as copy"
+      restore_confirm: "Are you sure you want to restore this version? The current version will remain accessible via the version history."
+      restore_success: "Document version has been restored successfully."
+      save_copy_success: "A copy of this document version has been created."
+      created: "Document created"
+      content_updated: "Content updated"
+      description_updated: "Description updated"
+      title_updated: "Title updated"
+      type_updated: "Type updated"
+
     page_header:
       heading: "All documents"
       action_menu:

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
       type_updated: "Type updated"
       restored: "Restored from earlier version"
       saved_at: "Saved"
+      view: "View"
 
     page_header:
       heading: "All documents"

--- a/modules/documents/config/routes.rb
+++ b/modules/documents/config/routes.rb
@@ -49,7 +49,11 @@ Rails.application.routes.draw do
       get :delete_dialog
       get :render_avatars, defaults: { format: :turbo_stream }
       get :render_last_saved_at, defaults: { format: :turbo_stream }
+      post :restore_version
+      post :save_copy
     end
+
+    resources :versions, only: [:index], controller: "documents/versions"
   end
 
   scope module: :documents do

--- a/modules/documents/db/migrate/20260606000000_add_type_id_to_document_journals.rb
+++ b/modules/documents/db/migrate/20260606000000_add_type_id_to_document_journals.rb
@@ -28,29 +28,22 @@
 # See COPYRIGHT and LICENSE files for more details.
 #++
 
-module Documents
-  class RestoreVersionService
-    def initialize(user:, document:)
-      @user = user
-      @document = document
-    end
+class AddTypeIdToDocumentJournals < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :document_journals, :type, foreign_key: { to_table: :document_types }, null: true
 
-    def call(journal:)
-      attrs = {
-        title: journal.data.title,
-        description: journal.data.description
-      }
-      attrs[:type_id] = journal.data.type_id if journal.data.type_id.present?
-      attrs[:content_binary] = journal.data.content_binary if @document.collaborative?
-
-      # Prevent aggregation so restore always appends a new journal entry.
-      @document.skip_journal_aggregation = true
-      @document.journal_cause = CauseOfChange::Base.new("document_version_restored",
-                                                         "restored_journal_id" => journal.id)
-
-      Documents::UpdateService
-        .new(user: @user, model: @document)
-        .call(attrs)
+    # Backfill type_id from the corresponding document's current type
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE document_journals
+          SET type_id = documents.type_id
+          FROM journals
+          JOIN documents ON documents.id = journals.journable_id
+          WHERE journals.data_type = 'Journal::DocumentJournal'
+            AND journals.data_id = document_journals.id
+        SQL
+      end
     end
   end
 end

--- a/modules/documents/lib/open_project/documents/engine.rb
+++ b/modules/documents/lib/open_project/documents/engine.rb
@@ -59,13 +59,15 @@ module OpenProject::Documents
                        render_avatars render_last_saved_at
                      ],
                      "documents/menus": %i[show],
-                     "documents/refresh_tokens": %i[create]
+                     "documents/refresh_tokens": %i[create],
+                     "documents/versions": %i[index]
                    },
                    permissible_on: :project
         permission :manage_documents,
                    {
                      documents: %i[
                        new create edit edit_title cancel_title_edit update update_title update_type delete_dialog destroy
+                       restore_version save_copy
                      ]
                    },
                    permissible_on: :project,


### PR DESCRIPTION
https://community.openproject.org/wp/STC-440

Implements version browsing, restore, and save-copy for both collaborative
(BlockNote/YDoc) and classic documents.

- Activity feed links to versioned document URLs (?version=<journal_id>)
  for non-latest journals; latest version keeps the canonical URL
- GET /documents/:id?version=<id> renders the document in read-only mode
  with a version banner showing author, timestamp, Restore and Save copy
  buttons (manage_documents required)
- POST /documents/:id/restore_version restores content_binary + description
  from the selected journal via UpdateService, creating a new journal entry
- POST /documents/:id/save_copy creates a new document with "(copy)" suffix,
  copying content + attachments via CreateService
- GET /documents/:document_id/versions renders a lazy-loaded versions tab
  (20 first, then 50 per page via Turbo Streams append)
- Versions tab shows all journals; only content-changing journals link to
  the versioned view; metadata-only changes are informational
- Versions tab added to both collaborative (BlockNote) and classic document
  views, reusing op-activity-list styles from the work package activity tab
- Title editing suppressed when viewing a historical version
- Hocuspocus provider not initialised in version view (readonly flag)
- Permission gates: view_documents for versions index,
  manage_documents for restore/save_copy

https://claude.ai/code/session_01EtGiEQ8opySbK9PcYMynx5