### PR TITLE
Code Maintenance/STC-462: Fix slow "only changes" activity filter on work packages with long histories

### DIFF
--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -60,7 +60,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
     def attribute_data_changes_condition_sql
       <<~SQL.squish
         SELECT 1
-          FROM #{predecessor_lateral_sql}
+          FROM #{predecessor_lateral_sql} predecessor
           INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
           INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
           WHERE (#{data_changes_condition_sql})
@@ -95,11 +95,11 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
       )
     end
 
-    # The immediate predecessor journal, exposed as a `predecessor` relation for
-    # comparison. Seeking the highest version below the current one through the
-    # (journable_type, journable_id, version) index keeps this a single-row lookup
-    # per journal; versions are incremental but may have gaps, so the seek matches
-    # on `< version` rather than `version - 1`.
+    # The immediate predecessor journal, for comparison against the current one.
+    # Callers alias this as `predecessor`. Seeking the highest version below the
+    # current one through the (journable_type, journable_id, version) index keeps
+    # this a single-row lookup per journal; versions are incremental but may have
+    # gaps, so the seek matches on `< version` rather than `version - 1`.
     def predecessor_lateral_sql
       <<~SQL.squish
         LATERAL (
@@ -110,7 +110,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
             AND p.version < journals.version
           ORDER BY p.version DESC
           LIMIT 1
-        ) predecessor
+        )
       SQL
     end
 
@@ -158,7 +158,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
       <<~SQL.squish
         SELECT 1
           FROM #{table} curr
-          LEFT JOIN #{predecessor_lateral_sql} ON TRUE
+          LEFT JOIN #{predecessor_lateral_sql} predecessor ON TRUE
           LEFT JOIN #{table} pred
             ON pred.journal_id = predecessor.id
             AND #{join_conditions}
@@ -176,7 +176,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
 
       <<~SQL.squish
         SELECT 1
-          FROM #{predecessor_lateral_sql}
+          FROM #{predecessor_lateral_sql} predecessor
           INNER JOIN #{table} pred
             ON pred.journal_id = predecessor.id
           LEFT JOIN #{table} curr

--- a/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
+++ b/app/services/work_packages/activities_tab/paginator/journal_changes_filter.rb
@@ -60,13 +60,10 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
     def attribute_data_changes_condition_sql
       <<~SQL.squish
         SELECT 1
-          FROM journals predecessor
+          FROM #{predecessor_lateral_sql}
           INNER JOIN work_package_journals pred_data ON predecessor.data_id = pred_data.id
           INNER JOIN work_package_journals curr_data ON journals.data_id = curr_data.id
-          WHERE predecessor.journable_id = journals.journable_id
-            AND predecessor.journable_type = journals.journable_type
-            AND predecessor.version = (#{max_predecessor_version_sql})
-            AND (#{data_changes_condition_sql})
+          WHERE (#{data_changes_condition_sql})
       SQL
     end
 
@@ -98,15 +95,22 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
       )
     end
 
-    # Identify the immediate predecessor journal for comparison.
-    # NB: Journal versions are incremental but not guaranteed to be sequential.
-    def max_predecessor_version_sql
+    # The immediate predecessor journal, exposed as a `predecessor` relation for
+    # comparison. Seeking the highest version below the current one through the
+    # (journable_type, journable_id, version) index keeps this a single-row lookup
+    # per journal; versions are incremental but may have gaps, so the seek matches
+    # on `< version` rather than `version - 1`.
+    def predecessor_lateral_sql
       <<~SQL.squish
-        SELECT MAX(version)
-        FROM journals p2
-        WHERE p2.journable_id = journals.journable_id
-          AND p2.journable_type = journals.journable_type
-          AND p2.version < journals.version
+        LATERAL (
+          SELECT p.id, p.data_id
+          FROM journals p
+          WHERE p.journable_id = journals.journable_id
+            AND p.journable_type = journals.journable_type
+            AND p.version < journals.version
+          ORDER BY p.version DESC
+          LIMIT 1
+        ) predecessor
       SQL
     end
 
@@ -154,10 +158,7 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
       <<~SQL.squish
         SELECT 1
           FROM #{table} curr
-          LEFT JOIN journals predecessor
-            ON predecessor.journable_id = journals.journable_id
-            AND predecessor.journable_type = journals.journable_type
-            AND predecessor.version = (#{max_predecessor_version_sql})
+          LEFT JOIN #{predecessor_lateral_sql} ON TRUE
           LEFT JOIN #{table} pred
             ON pred.journal_id = predecessor.id
             AND #{join_conditions}
@@ -175,16 +176,13 @@ class WorkPackages::ActivitiesTab::Paginator::JournalChangesFilter
 
       <<~SQL.squish
         SELECT 1
-          FROM journals predecessor
+          FROM #{predecessor_lateral_sql}
           INNER JOIN #{table} pred
             ON pred.journal_id = predecessor.id
           LEFT JOIN #{table} curr
             ON curr.journal_id = journals.id
             AND #{join_conditions}
-          WHERE predecessor.journable_id = journals.journable_id
-            AND predecessor.journable_type = journals.journable_type
-            AND predecessor.version = (#{max_predecessor_version_sql})
-            AND curr.id IS NULL
+          WHERE curr.id IS NULL
       SQL
     end
   end


### PR DESCRIPTION
https://community.openproject.org/wp/STC-462

Follow-up to #23434 / #23506

## Issue

The work package activity tab's **"only changes"** filter got noticeably slow on work packages with long histories  - since we switched to db-level pagination, `pagy(:offset, …)` issues two statements per page: a `SELECT COUNT(*)` over the whole filtered set, then the `LIMIT/OFFSET` page.

See: https://qa.openproject-edge.com/wp/ACSMT-158

<details><summary>Statement 1 — Journal Count (885.1ms) </summary>

```sql
 SELECT COUNT(*)
  FROM journals
  WHERE journals.journable_id   = 10423
    AND journals.journable_type = 'WorkPackage'
    AND (
          version = 1
       OR (cause IS NOT NULL AND cause != '{}')
       OR EXISTS ( /* attribute/data changes  — predecessor seek ↓ */ )
       OR EXISTS ( /* attachment changes        */ )
       OR EXISTS ( /* custom field changes      */ )
       OR EXISTS ( /* file link changes         */ )
       OR ( journals.journable_type = 'Changeset'
            AND journals.journable_id IN (
                  SELECT changesets.id
                  FROM changesets
                  JOIN changesets_work_packages
                    ON changesets.id = changesets_work_packages.changeset_id
                  WHERE changesets_work_packages.work_package_id = 10423 ) )
        );
```

</details>

<details><summary>Statement 2 — Journal Load  (806.7ms) </summary>

```sql
SELECT journals.*
  FROM journals
  WHERE journals.journable_id   = 10423
    AND journals.journable_type = 'WorkPackage'
    AND ( /* …exactly the same OR-chain as above… */ )
  ORDER BY journals.created_at DESC, journals.id DESC
  LIMIT 20 OFFSET 0;
```

</details>

> [!TIP]
> [`pagy(:countless, ...)`](https://ddnexus.github.io/pagy/toolbox/paginators/countless/) could avoid the expensive `COUNT(*)` -  however that would [alter the activity tab current lazy page structure](https://github.com/opf/openproject/blob/dev/app/components/work_packages/activities_tab/journals/lazy_index_component.rb#L52-L58)- to only fetch the next page at a time, which might not be ideal for use cases where a user wants to jump between pages quickly.

## Fix

Replace a correlated `version = (SELECT MAX(version) WHERE version < current)` predicate - which forced Postgres into a per-journal sequential O(history) scan of the work package's entire history, with a `LATERAL (… ORDER BY version DESC LIMIT 1)` that index-seeks the predecessor through the existing unique `(journable_type, journable_id, version)` index.

Measured on a 701-journal work package:

| | count query cost | buffer pages touched (count) | cold first load |
|---|---|---|---|
| before | 81,499 | 3,265,916 | ~1,787 ms |
| after | 54,788 | 1,128,292 | ~781 ms |

_Every `EXISTS` branch locates the predecessor through the same index seek:_ 

 ```sql
  LATERAL (
    SELECT p.id, p.data_id
    FROM journals p
    WHERE p.journable_id   = journals.journable_id
      AND p.journable_type = journals.journable_type
      AND p.version < journals.version
    ORDER BY p.version DESC
    LIMIT 1
  ) predecessor
  ```
