### PR TITLE
[DREAM-707] Stabilize Angular track keys

### DIFF
--- a/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
+++ b/frontend/src/app/features/in-app-notifications/entry/actors-line/in-app-notification-actors-line.component.html
@@ -2,7 +2,7 @@
   [notification]="notification"
   />
 <div class="op-ian-actors--container">
-  @for (actor of actors | slice:0:3; track actor; let idx = $index; let last = $last) {
+  @for (actor of actors | slice:0:3; track actor.href; let idx = $index; let last = $last) {
     @if (last && actors.length > 1 && actors.length < 4) {
       <span textContent=" {{ text.and }} "></span>
     }

--- a/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
+++ b/frontend/src/app/features/team-planner/team-planner/add-work-packages/add-existing-pane.component.html
@@ -13,7 +13,7 @@
       #container
       class="op-add-existing-pane--results"
       >
-      @for (wp of currentWorkPackages$ | async; track wp) {
+      @for (wp of currentWorkPackages$ | async; track wp.href) {
         <wp-single-card [workPackage]="wp"
           [selectedWhenOpen]="true"
           [showInfoButton]="true"

--- a/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.html
+++ b/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.html
@@ -37,7 +37,7 @@
         [compareWith]="compareByHref"
         style="vertical-align: top;"
         >
-        @for (operator of availableOperators; track operator) {
+        @for (operator of availableOperators; track operator.href) {
           <option
             [textContent]="operator.name"
             [ngValue]="operator"

--- a/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.ts
+++ b/frontend/src/app/features/work-packages/components/filters/query-filter/query-filter.component.ts
@@ -30,9 +30,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, O
 import { I18nService } from 'core-app/core/i18n/i18n.service';
 import {
   compareByHref,
-  halHref,
 } from 'core-app/shared/helpers/angular/tracking-functions';
-import { BannersService } from 'core-app/core/enterprise/banners.service';
 import { WorkPackageViewFiltersService } from 'core-app/features/work-packages/routing/wp-view-base/view-services/wp-view-filters.service';
 import { SchemaCacheService } from 'core-app/core/schemas/schema-cache.service';
 import { CurrentProjectService } from 'core-app/core/current-project/current-project.service';

--- a/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-baseline/baseline/baseline.component.html
@@ -29,7 +29,7 @@
           <option [textContent]="text.drop_down_none_option"
             [selected]="!filterSelected"
           [value]="'-'"></option>
-          @for (availableValue of baselineAvailableValues; track availableValue) {
+          @for (availableValue of baselineAvailableValues; track availableValue.value) {
             <option
               [value]="availableValue.value"
               [selected]="availableValue.value === selectedFilter"
@@ -201,4 +201,3 @@
 } @else {
   <op-baseline-loading />
 }
-

--- a/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
+++ b/frontend/src/app/features/work-packages/components/wp-breadcrumb/wp-breadcrumb.html
@@ -8,7 +8,7 @@
         <li>
           <span>{{ hierarchyLabel }}: </span>
         </li>
-        @for (ancestor of workPackage.getAncestors(); track ancestor; let first = $first; let last = $last) {
+        @for (ancestor of workPackage.getAncestors(); track ancestor.href; let first = $first; let last = $last) {
           @if (!last) {
             <li
               class="op-wp-breadcrumb--ellipsed"

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relation-row/wp-relation-row.template.html
@@ -40,7 +40,7 @@
               opAutofocus
               (keydown.escape)="cancelRelationTypeEditOnEscape($event)"
               >
-              @for (relationType of availableRelationTypes; track relationType) {
+              @for (relationType of availableRelationTypes; track relationType.name) {
                 <option
                   [textContent]="relationType.label"
                   [ngValue]="relationType"

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relation-create.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-create/wp-relation-create.template.html
@@ -32,7 +32,7 @@
             role="listbox"
             [(ngModel)]="selectedRelationType"
             opAutofocus>
-            @for (type of relationTypes; track type) {
+            @for (type of relationTypes; track type.name) {
               <option
                 [textContent]="type.label"
               [value]="type.name"></option>

--- a/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
+++ b/frontend/src/app/features/work-packages/components/wp-relations/wp-relations-group/wp-relations-group.template.html
@@ -26,7 +26,7 @@
   <div
     class="relation-container"
     >
-    @for (relatedWorkPackage of relatedWorkPackages; track relatedWorkPackage) {
+    @for (relatedWorkPackage of relatedWorkPackages; track relatedWorkPackage.href) {
       <wp-relation-row [workPackage]="workPackage"
         [groupByWorkPackageType]="groupByWorkPackageType"
         [relatedWorkPackage]="relatedWorkPackage"

--- a/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view-tabs/files-tab/op-files-tab.component.html
@@ -22,7 +22,7 @@
     </section>
   }
 
-  @for (storage of projectStorages | async; track storage) {
+  @for (storage of projectStorages | async; track storage.id) {
     <section
       data-test-selector="op-tab-content--tab-section"
       class="op-tab-content--tab-section"

--- a/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-single-view/wp-single-view.component.html
@@ -145,7 +145,7 @@
         }
       </div>
     }
-    @for (storage of projectStorages | async; track storage) {
+    @for (storage of projectStorages | async; track storage.id) {
       <op-storage [resource]="workPackage"
         [projectStorage]="storage"
         [allowLinking]="true"

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/display-settings-tab.component.html
@@ -44,7 +44,7 @@
             id="selected_grouping"
             name="selected_grouping"
             class="form--select form--inline-select option-label--select">
-            @for (group of availableGroups; track group) {
+            @for (group of availableGroups; track group.href) {
               <option
                 [textContent]="group.name"
                 [selected]="currentGroup && currentGroup!.href === group.href"

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/sort-by-tab.component.html
@@ -32,7 +32,7 @@
   </div>
 
   @if (sortingMode === 'automatic') {
-    @for (sort of sortationObjects; track sort; let index = $index) {
+    @for (sort of sortationObjects; track $index; let index = $index) {
       <div class="form--row modal-sorting-row-{{index}}"
         >
         <div class="form--field -full-width">
@@ -57,7 +57,7 @@
                 <option [textContent]="emptyColumn.name"
                   [value]="emptyColumn.href"
                   [selected]="sort.column.href === null"></option>
-                @for (column of availableColumns; track column) {
+                @for (column of availableColumns; track column.href) {
                   <option
                     [textContent]="column.name"
                     [value]="column.href"></option>
@@ -68,7 +68,7 @@
         </div>
         <div class="form--field -full-width">
           <div class="form--field-container">
-            @for (availableDirection of availableDirections; track availableDirection) {
+            @for (availableDirection of availableDirections; track availableDirection.href) {
               <label class="option-label">
                 <input type="radio"
                   [(ngModel)]="sort.direction"

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/tabs/timelines-tab.component.html
@@ -59,7 +59,7 @@
                     id="modal-timelines-label-{{key}}"
                     (change)="updateLabels(key, $event.target.value)"
                     class="form--select">
-                    @for (column of availableAttributes; track column) {
+                    @for (column of availableAttributes; track column.id) {
                       <option
                         [textContent]="column.name"
                         [value]="column.id"

--- a/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.html
+++ b/frontend/src/app/features/work-packages/components/wp-table/configuration-modal/wp-table-configuration-relation-selector.html
@@ -7,7 +7,7 @@
       [(ngModel)]="selectedRelationFilter"
       (ngModelChange)="onRelationFilterSelected()"
       [compareWith]="compareRelationFilters">
-      @for (filter of availableRelationFilters; track filter) {
+      @for (filter of availableRelationFilters; track filter.id) {
         <option
           [textContent]="text[filter.id]"
           [ngValue]="filter">

--- a/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
+++ b/frontend/src/app/shared/components/attachments/attachment-list/attachment-list.component.html
@@ -2,7 +2,7 @@
   <ul
     class="spot-list spot-list_compact op-file-list"
     >
-    @for (attachment of attachments; track attachment; let i = $index) {
+    @for (attachment of attachments; track attachment.id; let i = $index) {
       <li
         op-attachment-list-item
         class="spot-list--item op-file-list--item"

--- a/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.html
+++ b/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.html
@@ -2,7 +2,7 @@
   <!-- Desktop Version -->
   <nav [attr.aria-label]="text.breadcrumb" class="hidden-for-mobile">
     <ol class="op-breadcrumbs--items">
-      @for (item of items; track item; let last = $last) {
+      @for (item of items; track trackBreadcrumbItem($index, item); let last = $last) {
         <li
           class="op-breadcrumbs--item"
           data-test-selector="op-breadcrumbs--item"

--- a/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.spec.ts
+++ b/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.spec.ts
@@ -1,0 +1,121 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { I18nService } from 'core-app/core/i18n/i18n.service';
+import { BreadcrumbItem, OpBreadcrumbsComponent } from './op-breadcrumbs.component';
+
+describe('OpBreadcrumbsComponent', () => {
+  let fixture:ComponentFixture<OpBreadcrumbsComponent>;
+  let component:OpBreadcrumbsComponent;
+
+  const i18nStub = { t: (_key:string) => 'Breadcrumb' };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        OpBreadcrumbsComponent,
+      ],
+      providers: [
+        { provide: I18nService, useValue: i18nStub },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OpBreadcrumbsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('reuses breadcrumb nodes for equivalent items with new object identities', () => {
+    component.items = [
+      { href: '/projects/sp', text: 'SP' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      { href: '/projects/sp/boards/48', text: 'Board 48' },
+    ];
+
+    fixture.detectChanges();
+
+    const originalItems = breadcrumbItems();
+
+    component.items = [
+      { href: '/projects/sp', text: 'SP' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      { href: '/projects/sp/boards/48', text: 'Board 48' },
+    ];
+
+    fixture.detectChanges();
+
+    const updatedItems = breadcrumbItems();
+
+    expect(updatedItems[0].nativeElement).toBe(originalItems[0].nativeElement);
+    expect(updatedItems[1].nativeElement).toBe(originalItems[1].nativeElement);
+    expect(updatedItems[2].nativeElement).toBe(originalItems[2].nativeElement);
+  });
+
+  it('keeps unchanged breadcrumb nodes when only the current item changes', () => {
+    component.items = [
+      { href: '/projects/sp', text: 'SP' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      'Old board name',
+    ];
+
+    fixture.detectChanges();
+
+    const originalItems = breadcrumbItems();
+
+    component.items = [
+      { href: '/projects/sp', text: 'SP' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      'New board name',
+    ];
+
+    fixture.detectChanges();
+
+    const updatedItems = breadcrumbItems();
+
+    expect(updatedItems[0].nativeElement).toBe(originalItems[0].nativeElement);
+    expect(updatedItems[1].nativeElement).toBe(originalItems[1].nativeElement);
+  });
+
+  it('keeps linked breadcrumb nodes when only the text changes', () => {
+    component.items = [
+      { href: '/projects/sp', text: 'Old project name' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      'Board 48',
+    ];
+
+    fixture.detectChanges();
+
+    const originalItems = breadcrumbItems();
+
+    component.items = [
+      { href: '/projects/sp', text: 'New project name' },
+      { href: '/projects/sp/boards', text: 'Boards' },
+      'Board 48',
+    ];
+
+    fixture.detectChanges();
+
+    const updatedItems = breadcrumbItems();
+
+    expect(updatedItems[0].nativeElement).toBe(originalItems[0].nativeElement);
+    expect(updatedItems[1].nativeElement).toBe(originalItems[1].nativeElement);
+    expect(updatedItems[2].nativeElement).toBe(originalItems[2].nativeElement);
+  });
+
+  it('builds stable tracking keys from breadcrumb values', () => {
+    const link:BreadcrumbLink = { href: '/projects/sp', text: 'SP' };
+
+    expect(component.trackBreadcrumbItem(1, link))
+      .toEqual('link:/projects/sp:1');
+    expect(component.trackBreadcrumbItem(2, 'Board 48'))
+      .toEqual('text:Board 48:2');
+  });
+
+  function breadcrumbItems() {
+    return fixture.debugElement.queryAll(By.css('[data-test-selector="op-breadcrumbs--item"]'));
+  }
+});
+
+type BreadcrumbLink = Extract<BreadcrumbItem, { href:string; text:string }>;

--- a/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.ts
+++ b/frontend/src/app/shared/components/breadcrumbs/op-breadcrumbs.component.ts
@@ -67,4 +67,12 @@ export class OpBreadcrumbsComponent {
   getHref(item:BreadcrumbItem):string | null {
     return this.isLink(item) ? item.href : null;
   }
+
+  trackBreadcrumbItem(index:number, item:BreadcrumbItem):string {
+    if (this.isLink(item)) {
+      return `link:${item.href}:${index}`;
+    }
+
+    return `text:${item}:${index}`;
+  }
 }

--- a/frontend/src/app/shared/components/grids/widgets/documents/documents.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/documents/documents.component.html
@@ -10,7 +10,7 @@
   @if (noEntries) {
     <op-no-results [title]="text.noResults" />
   }
-  @for (document of entries; track document) {
+  @for (document of entries; track document.id) {
     <h4 class="document-category-elements--header">
       <a [href]="documentPath(document)"
         [textContent]="document.title">

--- a/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
+++ b/frontend/src/app/shared/components/grids/widgets/time-entries/list/time-entries-list.component.html
@@ -59,7 +59,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  @for (item of rows; track item) {
+                  @for (item of rows; track item.entry?.id || 'sum:' + item.date) {
                     <tr class="time-entry">
                       @if (item.entry) {
                         <td class="activity"

--- a/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.html
+++ b/frontend/src/app/shared/components/modals/editor/macro-wp-button-modal/wp-button-macro.modal.html
@@ -28,7 +28,7 @@
               <option [textContent]="text.none"
                 [selected]="!selectedType"
               [value]=""></option>
-              @for (type of availableTypes; track type) {
+              @for (type of availableTypes; track type.href) {
                 <option
                   [textContent]="type.name"
                   [selected]="selectedType === type.name"

--- a/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
+++ b/frontend/src/app/shared/components/op-context-menu/op-context-menu.html
@@ -5,7 +5,7 @@
     role="menu"
     [attr.aria-label]="locals.label"
     [ngClass]="{'-empty': items.length === 0 }">
-    @for (item of items; track item) {
+    @for (item of items; track (item.href || item.linkText || item.ariaLabel || item.title || 'item') + ':' + $index) {
       @if (item.isHeader) {
         <li role="none">
           <span

--- a/frontend/src/app/shared/components/option-list/option-list.component.html
+++ b/frontend/src/app/shared/components/option-list/option-list.component.html
@@ -1,4 +1,4 @@
-@for (option of options; track option) {
+@for (option of options; track option.value) {
   <label
     [class]="getClassListForItem(option)"
     >

--- a/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
+++ b/frontend/src/app/shared/components/project-include/list/project-include-list.component.html
@@ -1,4 +1,4 @@
-@for (project of projects; track project) {
+@for (project of projects; track project.href) {
   <li
     class="spot-list--item op-project-include-list--item"
     data-test-selector="op-project-include-list--item"

--- a/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
+++ b/frontend/src/app/shared/components/storages/file-link-list-item/file-link-list-item.html
@@ -111,7 +111,7 @@
 
     @if (floatingActions.length > 0) {
       <div class="spot-list--item-floating-actions op-file-list--item-floating-actions hidden-for-mobile">
-        @for (action of floatingActions; track action) {
+        @for (action of floatingActions; track action.iconClass) {
           @if (!!action.href) {
             <a
               class="spot-link spot-link_octicon"

--- a/frontend/src/app/shared/components/storages/storage/storage.component.html
+++ b/frontend/src/app/shared/components/storages/storage/storage.component.html
@@ -21,7 +21,7 @@
     }
   </div>
 
-  @for (infoBox of storageErrors | async; track infoBox) {
+  @for (infoBox of storageErrors | async; track infoBox.header + ':' + infoBox.content) {
     <op-storage-information class="op-files-tab--storage-info-box"
       data-test-selector="op-storage--information"
       [content]="infoBox"

--- a/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab-inner.component.html
+++ b/frontend/src/app/shared/components/work-package-graphs/configuration-modal/tabs/settings-tab-inner.component.html
@@ -8,7 +8,7 @@
             [ngModelOptions]="{standalone: true}"
             id="selected_grouping"
             class="form--select">
-            @for (group of availableGroups; track group) {
+            @for (group of availableGroups; track group.href) {
               <option
                 [ngValue]="group"
               [textContent]="group.name"></option>
@@ -26,7 +26,7 @@
             [ngModelOptions]="{standalone: true}"
             id="selected_chart_type"
             class="form--select">
-            @for (type of availableChartTypes; track type) {
+            @for (type of availableChartTypes; track type.identifier) {
               <option
                 [ngValue]="type"
               [textContent]="type.label"></option>

--- a/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.template.html
+++ b/frontend/src/app/shared/components/work-package-graphs/overview/wp-overview-graph.template.html
@@ -1,6 +1,6 @@
 <select [(ngModel)]="groupBy"
   (ngModelChange)="setQueryProps()">
-  @for (option of availableGroupBy; track option) {
+  @for (option of availableGroupBy; track option.key) {
     <option [ngValue]="option.key">{{option.label}}</option>
   }
 </select>

--- a/frontend/src/app/spot/components/breadcrumbs/breadcrumbs.component.html
+++ b/frontend/src/app/spot/components/breadcrumbs/breadcrumbs.component.html
@@ -1,4 +1,4 @@
-@for (crumb of content.crumbs; track crumb; let i = $index, first = $first, last = $last) {
+@for (crumb of content.crumbs; track crumb.text + ':' + (crumb.icon || '') + ':' + $index; let i = $index, first = $first, last = $last) {
   @if ((first && !last) || i === content.crumbs.length - 2 || i === content.crumbs.length - 3) {
     <div
       class="spot-breadcrumbs--crumb"

--- a/frontend/src/app/spot/components/toggle/toggle.component.html
+++ b/frontend/src/app/spot/components/toggle/toggle.component.html
@@ -1,4 +1,4 @@
-@for (option of options; track option) {
+@for (option of options; track option.value) {
   <label
     [ngClass]="{ 'button': true, '-disabled': disabled, 'form--field-inline-button': true, '-active': value === option.value, 'spot-toggle--button': true }"
     data-test-selector="spot-toggle--option"

--- a/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/github_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -1,7 +1,7 @@
 <div class="git-actions-menu dropdown-relative dropdown -overflow-in-view dropdown-anchor-right">
   <h3 class="title">{{text.title}}</h3>
 
-  @for (snippet of snippets; track snippet) {
+  @for (snippet of snippets; track snippet.id) {
     <div class="copy-wrapper spot-form-field">
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>

--- a/modules/github_integration/frontend/module/pull-request/pull-request.component.html
+++ b/modules/github_integration/frontend/module/pull-request/pull-request.component.html
@@ -50,7 +50,7 @@
     [attr.aria-label]="text.label_actions"
     class='op-pull-request--checks'
     >
-    @for (checkRun of pullRequest._embedded.checkRuns; track checkRun) {
+    @for (checkRun of pullRequest._embedded.checkRuns; track checkRun.htmlUrl || checkRun.detailsUrl || checkRun.name) {
       <li class='op-pr-check'>
         <span class='op-pr-check--state-icon' [ngClass]="'op-pr-check--state-icon_' + checkRunState(checkRun)">
           <op-icon icon-classes="icon-{{ checkRunStateIcon(checkRun) }}"

--- a/modules/github_integration/frontend/module/tab-prs/tab-prs.component.html
+++ b/modules/github_integration/frontend/module/tab-prs/tab-prs.component.html
@@ -5,7 +5,7 @@
   ></p>
 }
 
-@for (pullRequest of (pullRequests$ | async); track pullRequest) {
+@for (pullRequest of (pullRequests$ | async); track pullRequest.id) {
   <op-github-pull-request [pullRequest]="pullRequest"
    />
 }

--- a/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
+++ b/modules/gitlab_integration/frontend/module/git-actions-menu/git-actions-menu.template.html
@@ -1,7 +1,7 @@
 <div class="git-actions-menu dropdown-relative dropdown -overflow-in-view dropdown-anchor-right">
   <h3 class="title">{{text.title}}</h3>
 
-  @for (snippet of snippets; track snippet) {
+  @for (snippet of snippets; track snippet.id) {
     <div class="copy-wrapper spot-form-field">
       <label class="spot-form-field--label-wrap">
         <div class="spot-form-field--label">{{ snippet.name }}</div>

--- a/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.template.html
+++ b/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.template.html
@@ -5,6 +5,6 @@
   ></p>
 }
 
-@for (gitlabIssue of gitlabIssues; track gitlabIssue) {
+@for (gitlabIssue of gitlabIssues; track gitlabIssue.id || gitlabIssue.htmlUrl) {
   <gitlab-issue [gitlabIssue]="gitlabIssue" />
 }

--- a/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.template.html
+++ b/modules/gitlab_integration/frontend/module/tab-mrs/tab-mrs.template.html
@@ -5,6 +5,6 @@
   ></p>
 }
 
-@for (mergeRequest of mergeRequests; track mergeRequest) {
+@for (mergeRequest of mergeRequests; track mergeRequest.id || mergeRequest.htmlUrl) {
   <gitlab-merge-request [mergeRequest]="mergeRequest" />
 }


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/DREAM-707


# What are you trying to accomplish?

Use stable scalar keys for Angular `@for` loops with rebuilt object values across breadcrumbs and related list templates to avoid DOM recreation warnings.


## Screenshots

no visual changes

# What approach did you choose?

This follows advice from the Angular documentation: [Why is track in @for blocks important?](https://angular.dev/guide/templates/control-flow#why-is-track-in-for-blocks-important)

# Merge checklist

- [X] Added/updated tests
- [X] Tested major browsers (Chrome, Firefox, Edge, ...)
