### PR TITLE
[MEET-556] PATCH /api/v3/meetings/{id} - participants cannot be removed via _links.participants

### DIFF
--- a/modules/meeting/app/services/meetings/set_attributes_service.rb
+++ b/modules/meeting/app/services/meetings/set_attributes_service.rb
@@ -60,14 +60,26 @@ module Meetings
         model.participants.clear
         model.participants_attributes = participants_attributes
       else
-        model.participants_attributes = merge_with_existing_participants(participants_attributes)
+        replace_participants(participants_attributes)
       end
     end
 
-    def merge_with_existing_participants(participants_attributes)
-      existing_user_ids = model.participants.to_set { |p| p.user_id.to_i }
+    def replace_participants(participants_attributes)
+      incoming_user_ids = participants_attributes.to_set { |attrs| attrs[:user_id].to_i }
+      existing_participants = model.participants.index_by { |p| p.user_id.to_i }
 
-      participants_attributes.reject { |attrs| existing_user_ids.include?(attrs[:user_id].to_i) }
+      mark_removed_participants(incoming_user_ids, existing_participants)
+      model.participants_attributes = added_participant_attributes(participants_attributes, existing_participants)
+    end
+
+    def mark_removed_participants(incoming_user_ids, existing_participants)
+      existing_participants.each do |user_id, participant|
+        participant.mark_for_destruction unless incoming_user_ids.include?(user_id)
+      end
+    end
+
+    def added_participant_attributes(participants_attributes, existing_participants)
+      participants_attributes.reject { |attrs| existing_participants.key?(attrs[:user_id].to_i) }
     end
 
     def set_default_participant

--- a/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
+++ b/modules/meeting/spec/requests/api/v3/meetings/meetings_resource_spec.rb
@@ -303,6 +303,37 @@ RSpec.describe "API v3 Meeting resource", content_type: :json do
       end
     end
 
+    context "when sending a smaller list of participants to _links.participants" do
+      let(:participant_user) do
+        create(:user, member_with_permissions: { project => [:view_meetings] })
+      end
+      let(:other_participant_user) do
+        create(:user, member_with_permissions: { project => [:view_meetings] })
+      end
+
+      before do
+        create(:meeting_participant, meeting:, user: participant_user, invited: true)
+        create(:meeting_participant, meeting:, user: other_participant_user, invited: true)
+      end
+
+      it "removes unlisted participants" do
+        expect(meeting.participants.count).to eq(2)
+
+        body = {
+          lockVersion: meeting.lock_version,
+          _links: {
+            participants: [{ href: api_v3_paths.user(participant_user.id) }]
+          }
+        }.to_json
+
+        patch path, body
+
+        expect(last_response).to have_http_status(:ok)
+        expect(meeting.participants.reload.map(&:user_id)).to contain_exactly(participant_user.id)
+        expect(last_response.body).to have_json_size(1).at_path("_embedded/participants")
+      end
+    end
+
     context "without edit_meetings permission" do
       let(:permissions) { %i[view_meetings] }
 


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->
https://community.openproject.org/wp/MEET-556

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Allow removal of participants via the API

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->
Sending a list with fewer participants removes those not in the updated list

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
