### PR TITLE
Implements GET /wiki_page_links

### DIFF
--- a/modules/wikis/app/models/queries/wikis/page_links/filter/wiki_page_link_type_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/filter/wiki_page_link_type_filter.rb
@@ -37,18 +37,20 @@ module Queries
 
           def type = :list
 
-          def name = :type
-
           def human_name
-            ::Wikis::PageLink.human_attribute_name(name)
+            ::Wikis::PageLink.human_attribute_name(:type)
           end
 
           def allowed_values
             API::V3::PageLinks::URN_PAGE_LINK_TYPE.invert.to_a
           end
 
+          def values=(values)
+            @values = Array(values).map { API::V3::PageLinks::URN_PAGE_LINK_TYPE.invert[it] }
+          end
+
           def where
-            where(type: values)
+            operator_strategy.sql_for_field(values, model.table_name, "type")
           end
         end
       end

--- a/modules/wikis/app/models/queries/wikis/page_links/filter/wiki_page_link_type_filter.rb
+++ b/modules/wikis/app/models/queries/wikis/page_links/filter/wiki_page_link_type_filter.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Queries
+  module Wikis
+    module PageLinks
+      module Filter
+        class WikiPageLinkTypeFilter < Filters::Base
+          self.model = ::Wikis::PageLink
+
+          def type = :list
+
+          def name = :type
+
+          def human_name
+            ::Wikis::PageLink.human_attribute_name(name)
+          end
+
+          def allowed_values
+            API::V3::PageLinks::URN_PAGE_LINK_TYPE.invert.to_a
+          end
+
+          def where
+            where(type: values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/wikis/lib/api/v3/page_links/page_links_api.rb
+++ b/modules/wikis/lib/api/v3/page_links/page_links_api.rb
@@ -32,6 +32,12 @@ module API
   module V3
     module PageLinks
       class PageLinksAPI < OpenProjectAPI
+        helpers do
+          def enrich_models_with_wiki_metadata(relation)
+            Wikis::PageLinkMetadataService.new(relation).call
+          end
+        end
+
         resources :wiki_page_links do
           post &::API::V3::PageLinks::CreateEndpoint.new(
             model: ::Wikis::RelationPageLink,
@@ -42,6 +48,28 @@ module API
             process_contract: ::Wikis::RelationPageLinks::CreateContract,
             render_representer: PageLinkCollectionRepresenter
           ).mount
+
+          get do
+            query = ParamsToQueryService.new(
+              ::Wikis::PageLink,
+              current_user,
+              query_class: ::Queries::Wikis::PageLinks::PageLinkQuery
+            ).call(params)
+
+            unless query.valid?
+              message = I18n.t("api_v3.errors.missing_or_malformed_parameter", parameter: "filters")
+              raise ::API::Errors::InvalidQuery.new(message)
+            end
+
+            relation = query.results.where(linkable: Authorization.work_packages(:view_work_packages, current_user))
+
+            PageLinkCollectionRepresenter.new(
+              enrich_models_with_wiki_metadata(relation).result,
+              per_page: params[:pageSize],
+              self_link: api_v3_paths.wiki_page_links,
+              current_user:
+            )
+          end
         end
       end
     end

--- a/modules/wikis/lib/open_project/wikis/engine.rb
+++ b/modules/wikis/lib/open_project/wikis/engine.rb
@@ -64,6 +64,7 @@ module OpenProject::Wikis
       # Registering queries and filters
       ::Queries::Register.register(::Queries::Wikis::PageLinks::PageLinkQuery) do
         filter ::Queries::Wikis::PageLinks::Filter::ProviderFilter
+        filter ::Queries::Wikis::PageLinks::Filter::WikiPageLinkTypeFilter
       end
     end
 

--- a/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
+++ b/modules/wikis/spec/requests/api/v3/page_links/page_links_api_spec.rb
@@ -34,18 +34,18 @@ require_module_spec_helper
 RSpec.describe "API v3 wiki page links resource", content_type: :json do
   include API::V3::Utilities::PathHelper
 
-  let(:work_package) { create(:work_package) }
-  let(:internal_wiki) { create(:internal_wiki_provider) }
-  let(:xwiki_provider) { create(:xwiki_provider) }
+  shared_let(:work_package) { create(:work_package) }
+  shared_let(:internal_wiki) { create(:internal_wiki_provider) }
+  shared_let(:xwiki_provider) { create(:xwiki_provider) }
 
-  let(:project) { work_package.project }
+  shared_let(:project) { work_package.project }
 
-  let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages manage_wiki_page_links) }) }
+  shared_let(:user) { create(:user, member_with_permissions: { project => %i(view_work_packages manage_wiki_page_links) }) }
 
-  let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: xwiki_provider, linkable: work_package) }
-  let(:inline_page_links) { create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
+  shared_let(:relation_page_links) { create_list(:relation_wiki_page_link, 3, provider: xwiki_provider, linkable: work_package) }
+  shared_let(:inline_page_links) { create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: work_package) }
 
-  let(:unrelated_page_links) do
+  shared_let(:unrelated_page_links) do
     create_list(:inline_wiki_page_link, 3, provider: internal_wiki, linkable: create(:work_package, project: project))
   end
 
@@ -75,6 +75,52 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
 
       it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
         let(:elements) { Wikis::PageLink.where(linkable: work_package, provider: internal_wiki).order(id: :desc).all }
+      end
+    end
+  end
+
+  describe "GET /api/v3/wiki_page_links" do
+    let(:unaccessible_links) { create_list(:relation_wiki_page_link, 2, provider: xwiki_provider) }
+    let(:path) { api_v3_paths.wiki_page_links }
+
+    context "with all preconditions met (happy path)" do
+      before do
+        unaccessible_links
+        get path
+      end
+
+      it_behaves_like "API V3 collection response", 9, 9, "WikiPageLink", "WikiPageLinkCollection" do
+        let(:elements) { Wikis::PageLink.where.not(id: unaccessible_links.pluck(:id)).order(id: :desc).all }
+      end
+    end
+
+    context "when filtered by provider" do
+      let(:filter) { [{ provider: { operator: "=", values: [internal_wiki.universal_identifier] } }] }
+
+      before { get "#{path}?filters=#{CGI.escape(filter.to_json)}" }
+
+      it_behaves_like "API V3 collection response", 6, 6, "WikiPageLink", "WikiPageLinkCollection" do
+        let(:elements) { Wikis::PageLink.where(provider: internal_wiki).order(id: :desc).all }
+      end
+    end
+
+    context "when filtered by link type" do
+      let(:filter) do
+        [{ wiki_page_link_type:
+             { operator: "=", values: [API::V3::PageLinks::URN_PAGE_LINK_TYPE["Wikis::RelationPageLink"]] } }]
+      end
+
+      before { get "#{path}?filters=#{CGI.escape(filter.to_json)}" }
+
+      it_behaves_like "API V3 collection response", 3, 3, "WikiPageLink", "WikiPageLinkCollection" do
+        let(:elements) { Wikis::RelationPageLink.where.not(id: unaccessible_links.pluck(:id)).order(id: :desc).all }
+      end
+
+      it "only returns the filtered type" do
+        json = MultiJson.load(last_response.body, symbolize_keys: true)
+
+        expect(json.dig(:_embedded, :elements))
+          .to all(include(wikiPageLinkType: API::V3::PageLinks::URN_PAGE_LINK_TYPE["Wikis::RelationPageLink"]))
       end
     end
   end
@@ -180,6 +226,7 @@ RSpec.describe "API v3 wiki page links resource", content_type: :json do
     allow(xwiki_class).to receive(:new).and_return(xwiki_query)
     stub_query_calls(inline_page_links, internal_query)
     stub_query_calls(relation_page_links, xwiki_query)
+    stub_query_calls(unrelated_page_links, internal_query)
   end
 
   def stub_query_calls(links, query)


### PR DESCRIPTION
Nothing too new on this.

I used the `Authorization` module to find out all work packages a user has access to, but that pretty much sums it.

This PR addresses [OP#73293](https://community.openproject.org/projects/XWI/work_packages/73293) and [OP#74408](https://community.openproject.org/projects/XWI/work_packages/74408)