### PR TITLE
[Dream-709] Highlighting of selecting WP does not work in notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.html
@@ -13,12 +13,12 @@
             class="op-ian-item"
             [class.op-ian-item_expanded]="records[0].expanded"
             [class.op-ian-item_read]="records[0].readIAN === true"
-            [class.op-ian-item_selected]="(selectedWorkPackage$ | async) === idFromLink(records[0]._links.resource.href)"
+            [class.op-ian-item_selected]="notificationMatchesSelectedWorkPackage(records[0], selectedWorkPackage$ | async)"
             [notification]="records[0]"
             [aggregatedNotifications]="records"
             attr.data-test-selector="op-ian-notification-item-{{records[0].id}}"
             [attr.data-qa-ian-read]="records[0].readIAN === true || undefined"
-            [attr.data-qa-ian-selected]="(selectedWorkPackage$ | async) === idFromLink(records[0]._links.resource.href)"
+            [attr.data-qa-ian-selected]="notificationMatchesSelectedWorkPackage(records[0], selectedWorkPackage$ | async)"
            />
         </cdk-virtual-scroll-viewport>
       } @else {

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.ts
@@ -153,7 +153,7 @@ export class InAppNotificationCenterComponent implements OnInit {
   protected readonly idFromLink = idFromLink;
 
   ngOnInit():void {
-    const facet = this.urlParams.get('facet') || 'unread';
+    const facet = this.urlParams.get('facet') ?? 'unread';
     this.storeService.setFacet(facet as 'unread'|'all');
     this.storeService.setFilters({
       filter: this.urlParams.get('filter'),
@@ -171,5 +171,13 @@ export class InAppNotificationCenterComponent implements OnInit {
     }
 
     return this.text.no_notification_for_filter;
+  }
+
+  notificationMatchesSelectedWorkPackage(notification:INotification, selected:string|null):boolean {
+    const href = notification._links.resource?.href;
+    const workPackageId = href ? idFromLink(href) : null;
+    const workPackage = workPackageId ? this.apiV3.work_packages.cache.current(workPackageId) : null;
+
+    return selected === workPackageId || selected === workPackage?.displayId;
   }
 }

--- a/spec/features/notifications/semantic_id_navigation_spec.rb
+++ b/spec/features/notifications/semantic_id_navigation_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Notification center uses displayId when navigating to the work p
     expect(page).to have_current_path(
       "/notifications/details/#{semantic_id}/activity"
     )
+    center.expect_item_selected(notification)
   end
 
   it "renders the notification's WP link with the semantic identifier in its href" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-709

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
Ensure notification center selection also matches the work package display ID when the details route uses a semantic identifier. 