### PR TITLE
[DREAM-702] Status labels are cut off on desktop and mobile

### DIFF
--- a/app/components/work_packages/info_line_component.sass
+++ b/app/components/work_packages/info_line_component.sass
@@ -4,6 +4,9 @@
     @include text-shortener
     min-width: 25px
     max-width: 66%
+    // The label has a height of 18.5px. Half pixels are resolved differently by each OS/browser combination,
+    // resulting in cases where the bottom of the label was cut off
+    min-height: 19px
 
   &--id
     white-space: nowrap


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-702

# What are you trying to accomplish?
Set min-height for label to avoid it being cut off


