### PR TITLE
Catch malformed filter parameters

### DIFF
--- a/app/services/api/v3/parse_query_params_service.rb
+++ b/app/services/api/v3/parse_query_params_service.rb
@@ -135,6 +135,10 @@ module API
       end
 
       def filter_from_params(filter)
+        unless filter.is_a?(Hash)
+          raise JSON::ParserError, "Filter must be a JSON object, got #{filter.class}"
+        end
+
         attribute = filter.keys.first # there should only be one attribute per filter
         operator =  filter[attribute]["operator"]
         values = Array(filter[attribute]["values"])

--- a/spec/services/api/v3/parse_query_params_service_spec.rb
+++ b/spec/services/api/v3/parse_query_params_service_spec.rb
@@ -285,6 +285,24 @@ RSpec.describe API::V3::ParseQueryParamsService,
             end
           end
         end
+
+        context "with a non-object filter element" do
+          let(:params) do
+            { filters: JSON::dump([["status", "=", "not a hash"]]) }
+          end
+
+          it "is not success" do
+            expect(subject)
+              .not_to be_success
+          end
+
+          it "returns the error" do
+            expect(subject.errors.messages[:base].length)
+              .to be(1)
+            expect(subject.errors.messages[:base][0])
+              .to include("Filter must be a JSON object, got Array")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-279

# What are you trying to accomplish?
When a malformed filter parameter is sent, we will respond with 400 Bad Request instead of crashing with a 500.

I could not find out which code segment or client was sending the malformed filter. Since it does not happen regularly, I suspect it was a user entering filters manually.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
