### PR TITLE
 [STC-779] Investigate Ctrl+Z (Undo) Does Not Work in the Document Editor Pull Preview

### DIFF
--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -82,9 +82,7 @@ class BlockNoteElement extends HTMLElement {
     this.reactRoot = createRoot(this.editorMount);
 
     this.renderCallback = (provider:HocuspocusProvider) => {
-      this.reactRoot?.render(
-        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
-      );
+      this.reactRoot?.render(this.BlockNoteReactContainer(provider));
     };
 
     LiveCollaborationManager.onReady(this.renderCallback);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -34,14 +34,14 @@ import { ExternalLinkCaptureExtension } from '../extensions/external-link-captur
 import { User } from '@blocknote/core/comments';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import { BlockNoteView } from '@blocknote/mantine';
-import { getDefaultReactSlashMenuItems, SuggestionMenuController, useCreateBlockNote } from '@blocknote/react';
+import { getDefaultReactSlashMenuItems, SuggestionMenuController } from '@blocknote/react';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import {
   initializeOpBlockNoteExtensions,
   openProjectWorkPackageBlockSpec,
   openProjectWorkPackageInlineSpec,
   workPackageSlashMenu,
-  useOpBlockNoteExtensions,
+  useOpBlockNote,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -124,8 +124,7 @@ export function OpBlockNoteEditor({
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 
-  const editor = useCreateBlockNote(editorParams, [activeUser]);
-  useOpBlockNoteExtensions(editor);
+  const editor = useOpBlockNote(editorParams, [activeUser]);
   type EditorType = typeof editor;
   const theme = useOpTheme();
 


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/STC/work_packages/STC-779

# What are you trying to accomplish?
Fix Ctrl+Z (undo) not working in the BlockNote editor after initialization.

# What approach did you choose and why?
Replace `useCreateBlockNote` + `useOpBlockNoteExtensions` with the new `useOpBlockNote` hook from `op-blocknote-extensions`. The hook internally wires up `DeduplicateInstanceIdsExtension` at editor creation time instead of registering it via `registerPlugin()` after the fact - which was causing ProseMirror to reset the history stack and breaking undo.

## Related PRs
- op-blocknote-extensions: https://github.com/opf/op-blocknote-extensions/pull/152

# Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)