### PR TITLE
do not try adding role to locked users for it will fail anyway

### DIFF
--- a/db/migrate/20250929070310_add_view_all_principals_permission_to_existing_roles.rb
+++ b/db/migrate/20250929070310_add_view_all_principals_permission_to_existing_roles.rb
@@ -86,6 +86,7 @@ class AddViewAllPrincipalsPermissionToExistingRoles < ActiveRecord::Migration[8.
     Member.joins(:principal, member_roles: :role)
           .where(member_roles: { roles: { id: project_roles_with_manage_members.pluck(:id) } })
           .where.not("users.type": "PlaceholderUser")
+          .not_locked
           .pluck(:user_id)
           .uniq
   end


### PR DESCRIPTION
Adapts the migration so that it doesn't try adding the global role to locked users since it's a waste of effort as the service call will fail with locked users. Also there is no point giving the role to locked users to begin with.