### PR TITLE
[Dream-709] Highlighting of selecting WP does not work in notification center

### DIFF
--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -192,7 +192,7 @@ export class IanCenterService extends UntilDestroyedMixin {
 
   public selectedNotification:INotification;
 
-  selectedWorkPackage$ = this.urlParams.pathMatching$(/\/details\/(\d+)/);
+  selectedWorkPackage$ = this.urlParams.pathMatching$(/\/details\/([^/?]+)/);
 
   constructor() {
     super();

--- a/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
+++ b/frontend/src/app/features/in-app-notifications/center/state/ian-center.service.ts
@@ -62,6 +62,9 @@ import { FrameElement } from '@hotwired/turbo';
 import { PathHelperService } from 'core-app/core/path-helper/path-helper.service';
 import { UrlParamsService } from 'core-app/core/navigation/url-params.service';
 import { IanBellService } from 'core-app/features/in-app-notifications/bell/state/ian-bell.service';
+import { WP_ID_URL_PATTERN } from 'core-app/shared/helpers/work-package-id-pattern';
+
+const DETAILS_URL_PATTERN = new RegExp(`/details/(${WP_ID_URL_PATTERN})(?:/|$)`);
 
 export interface INotificationPageQueryParameters {
   filter?:string|null;
@@ -192,7 +195,7 @@ export class IanCenterService extends UntilDestroyedMixin {
 
   public selectedNotification:INotification;
 
-  selectedWorkPackage$ = this.urlParams.pathMatching$(/\/details\/([^/?]+)/);
+  selectedWorkPackage$ = this.urlParams.pathMatching$(DETAILS_URL_PATTERN);
 
   constructor() {
     super();


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-709

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?

The selected work package route matcher previously only captured numeric IDs from `/details/:id`. Since semantic work package IDs can contain non-numeric characters, the notification center did not receive the selected work package value and could not mark the matching notification as selected.

The matcher now captures any route segment after `/details/`, allowing both numeric IDs and semantic IDs to be handled.
