### PR TITLE
Fix vertical content jumps in BlockNote editor

### DIFF
--- a/modules/documents/app/assets/stylesheets/_index.sass
+++ b/modules/documents/app/assets/stylesheets/_index.sass
@@ -4,7 +4,14 @@ $blocknote-max-width: 800px
   .ck-content
     min-height: 30vh
 
-.block-note-editor-container
+// BlockNote 0.51 stamps `.block-note-editor-container` (the className we
+// pass to <BlockNoteView>) onto BOTH its outer `.bn-container` wrapper AND
+// an inner wrapper without `.bn-container`. Without the `.bn-container`
+// requirement, the rules below cascade onto both elements — `gap: 10px`
+// and `flex-direction: column-reverse` get applied at two nesting levels,
+// which shows up as a few-pixel vertical layout jump whenever the side
+// menu / drag handle re-renders during selection.
+.block-note-editor-container.bn-container
   align-items: center
   position: relative
   display: flex


### PR DESCRIPTION
## Ticket

https://community.openproject.org/wp/STC-822

## Symptom

In the documents BlockNote editor: select a word, then move the mouse out of the content area toward the top of the editor → the content snaps a few pixels downward and back. Sometimes mouse clicks also "miss" — `mousedown` and `mouseup` land on different DOM nodes — because the layout is being recomputed mid-interaction.

## Cause

`<BlockNoteView>` in `@blocknote/mantine` ^0.51.3 stamps the `className` prop (`block-note-editor-container`) onto **two** elements:

```
<div class="bn-root bn-container … block-note-editor-container">    ← outer
  <div class="tiptap …">…</div>
  <div class="bn-root … block-note-editor-container">              ← inner (no .bn-container)
    <div class="undefined">…</div>
  </div>
</div>
```

The current selector in `modules/documents/app/assets/stylesheets/_index.sass`:

```sass
.block-note-editor-container
  display: flex
  flex-direction: column-reverse
  gap: 10px
  …
```

…matches **both** elements. Two `flex` layouts nested inside each other, each with `gap: 10px` and `column-reverse` — every time the side menu / drag handle plugin views re-render (which happens on selection change and on mouse-enter/leave events), both layout calcs run and the inner wrapper's gap shifts the visible content by a few pixels.

## Fix

Tighten the selector to `.block-note-editor-container.bn-container` so the rules only apply to the outer wrapper. The inner wrapper falls back to default styles (`display: block`, no gap), stops contributing to layout, and the jump disappears.

## Verified locally

Inspected the computed style of both elements on a real document:

| | `.bn-container` outer | inner wrapper |
| --- | --- | --- |
| Before fix | `display:flex; gap:10px; flex-direction:column-reverse` | `display:flex; gap:10px; flex-direction:column-reverse` |
| After fix | (unchanged) | `display:block; gap:normal; flex-direction:row` (browser defaults) |

Word-select + mouse-out no longer jumps. Mouse-down/mouseup hit the same node consistently.

## Why a separate PR

The undo bug (#23585 and the lib-side [opf/op-blocknote-extensions#149](https://github.com/opf/op-blocknote-extensions/pull/149)) and this CSS issue both showed up when `op-blocknote-extensions` was bumped to v0.1.0 (which brought along the BlockNote ^0.51.3 bump). They share root cause "BlockNote 0.51 changed DOM/plugin lifecycle", but the code surfaces are independent and the CSS fix can ship without waiting on the lib release.

## Merge checklist

- [ ] Test on Chrome, Firefox, Safari (the symptom may be UA-dependent in how aggressively the layout reflows)
- [ ] Confirm side menu / drag-handle positioning is still correct
- [ ] Confirm mobile layout (`_forms_mobile.sass` still references the un-tightened selector — left untouched intentionally since that font-size rule applies to `> .bn-editor` and isn't affected by the nesting issue)