### PR TITLE
[STC-779] Fix Ctrl+Z (Undo) Does Not Work in the Document Editor

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^3.4.4",
         "@hocuspocus/server": "^3.4.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -3903,9 +3903,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.0",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
-      "integrity": "sha512-JKwG2P5RXM0JDED0AzDeiVoxuamHtzqLO5fp88EoFig+YXlPsedJHc90zjTDqCFRilwTDamCq3jjzdFvl42kCA==",
+      "version": "0.1.1",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^3.4.4",
     "@hocuspocus/server": "^3.4.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.1.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
         "openapi-explorer": "^2.4.793",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -19205,9 +19205,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.0",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
-      "integrity": "sha512-JKwG2P5RXM0JDED0AzDeiVoxuamHtzqLO5fp88EoFig+YXlPsedJHc90zjTDqCFRilwTDamCq3jjzdFvl42kCA==",
+      "version": "0.1.1",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",
@@ -37224,8 +37224,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
-      "integrity": "sha512-JKwG2P5RXM0JDED0AzDeiVoxuamHtzqLO5fp88EoFig+YXlPsedJHc90zjTDqCFRilwTDamCq3jjzdFvl42kCA==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
       "requires": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -158,7 +158,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.1.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.0/op-blocknote-extensions-0.1.0.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
     "openapi-explorer": "^2.4.793",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -88,9 +88,14 @@ class BlockNoteElement extends HTMLElement {
     this.reactRoot = createRoot(this.editorMount);
 
     this.renderCallback = (provider:HocuspocusProvider) => {
-      this.reactRoot?.render(
-        React.createElement(React.StrictMode, null, this.BlockNoteReactContainer(provider))
-      );
+      // Do NOT wrap in React.StrictMode. StrictMode's dev-mode double-mount causes
+      // BlockNoteView to destroy and recreate the ProseMirror view between the two mounts.
+      // y-prosemirror's `yUndoPlugin` destroys the Y.UndoManager on view-destroy (removing
+      // its `afterTransaction` handler from the Y.Doc), but the plugin's STATE retains the
+      // now-destroyed UndoManager reference. On the second mount the editor reuses the
+      // destroyed UndoManager, no `afterTransaction` handler is ever re-attached, no stack
+      // items are recorded, and Ctrl+Z becomes a no-op.
+      this.reactRoot?.render(this.BlockNoteReactContainer(provider));
     };
 
     LiveCollaborationManager.onReady(this.renderCallback);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -41,6 +41,7 @@ import {
   openProjectWorkPackageInlineSpec,
   workPackageSlashMenu,
   useOpBlockNoteExtensions,
+  PasteDeduplicateInstanceIdsExtension,
   useHashWpMenu,
 } from 'op-blocknote-extensions';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -119,7 +120,7 @@ export function OpBlockNoteEditor({
       // When external link capture is enabled, intercept clicks on external
       // links via a ProseMirror plugin and route through /external_redirect.
       ...(captureExternalLinks && {
-        extensions: [ExternalLinkCaptureExtension],
+        extensions: [PasteDeduplicateInstanceIdsExtension, ExternalLinkCaptureExtension],
       }),
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);

--- a/frontend/src/react/components/OpBlockNoteEditor.tsx
+++ b/frontend/src/react/components/OpBlockNoteEditor.tsx
@@ -124,7 +124,11 @@ export function OpBlockNoteEditor({
     };
   }, [hocuspocusProvider, doc, activeUser, localeDictionary, attachmentsEnabled, uploadFile, captureExternalLinks]);
 
-  const editor = useCreateBlockNote(editorParams, [activeUser]);
+  // Create the editor exactly once per mount. `useCreateBlockNote(options, deps)` uses `deps`
+  // as the sole `useMemo` key — `options` is intentionally NOT in deps. `[activeUser]` rebuilt
+  // the editor (wiping `Y.UndoManager` history) whenever a fresh `activeUser` reference
+  // reached this component, e.g. on Stimulus reconnect / Turbo morph.
+  const editor = useCreateBlockNote(editorParams, []);
   useOpBlockNoteExtensions(editor);
   type EditorType = typeof editor;
   const theme = useOpTheme();

--- a/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
+++ b/frontend/src/stimulus/controllers/dynamic/documents/init-yjs-provider.controller.ts
@@ -74,6 +74,17 @@ export default class extends Controller {
   connect():void {
     this.currentToken = this.tokenPayloadValue;
 
+    // If a provider for this document is already live, don't build a duplicate
+    // — adopt it. Stimulus can fire connect() a second time (HMR replay, Turbo
+    // morph, parent re-attach) without firing disconnect(); building a fresh
+    // Y.Doc + provider in that case would destroy the live one and wipe the
+    // editor's Y.UndoManager mid-session.
+    const existing = LiveCollaborationManager.getCurrentSessionFor(this.documentNameValue);
+    if (existing) {
+      this.ownedProvider = existing.provider;
+      return;
+    }
+
     const ydoc:Doc = new Y.Doc();
     const provider = new HocuspocusProvider({
       url: this.hocuspocusUrlValue,
@@ -87,7 +98,7 @@ export default class extends Controller {
       },
     });
 
-    LiveCollaborationManager.initializeYjsProvider(provider, ydoc);
+    LiveCollaborationManager.initializeYjsProvider(provider, ydoc, this.documentNameValue);
     this.ownedProvider = provider;
 
     if (this.refreshUrlValue && this.tokenExpiresInSecondsValue) {

--- a/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
+++ b/frontend/src/stimulus/helpers/live-collaboration-helpers.ts
@@ -36,21 +36,47 @@ type Listener = (provider:HocuspocusProvider) => void;
 class LiveCollaborationManagerClass {
   yjsProviderInstance:HocuspocusProvider|null = null;
   yjsDocInstance:Doc|null = null;
+  private currentDocumentName:string|null = null;
 
   private listeners:Listener[] = [];
 
   /**
-   * Initializes the YJS Provider
+   * Returns the active session for the given document, or null if none.
+   *
+   * Used by the init-yjs-provider Stimulus controller to detect that a
+   * provider for the same document is already live — letting it adopt the
+   * existing session instead of building a duplicate Y.Doc + provider pair.
+   * Stimulus can fire `connect()` a second time (HMR replay, Turbo morph)
+   * without firing `disconnect()`; without this check, the spurious re-init
+   * would tear down the live Y.Doc and wipe the editor's Y.UndoManager
+   * history mid-session.
+   */
+  getCurrentSessionFor(documentName:string):{provider:HocuspocusProvider; doc:Doc} | null {
+    if (this.yjsProviderInstance && this.yjsDocInstance && this.currentDocumentName === documentName) {
+      return { provider: this.yjsProviderInstance, doc: this.yjsDocInstance };
+    }
+    return null;
+  }
+
+  /**
+   * Initializes the YJS Provider for the given document.
+   *
+   * Callers SHOULD first check {@link getCurrentSessionFor} and adopt any
+   * existing session rather than calling this with a fresh provider, since
+   * this method unconditionally tears down the previous provider/doc.
+   *
    * @param provider The provider to use
    * @param doc The Y.Doc instance to use
+   * @param documentName Logical identifier of the document being edited
    * @returns void
    */
-  initializeYjsProvider(provider:HocuspocusProvider, doc:Doc) {
+  initializeYjsProvider(provider:HocuspocusProvider, doc:Doc, documentName:string) {
     this.destroyYjsProvider();
     this.destroyYjsDoc();
 
     this.yjsProviderInstance = provider;
     this.yjsDocInstance = doc;
+    this.currentDocumentName = documentName;
     this.listeners.forEach((listener) => listener(this.yjsProviderInstance!));
   }
 
@@ -82,6 +108,7 @@ class LiveCollaborationManagerClass {
   private destroy():void {
     this.destroyYjsProvider();
     this.destroyYjsDoc();
+    this.currentDocumentName = null;
 
     this.listeners = [];
   }

--- a/modules/documents/spec/features/block_note_editor_spec.rb
+++ b/modules/documents/spec/features/block_note_editor_spec.rb
@@ -182,6 +182,37 @@ RSpec.describe "BlockNote editor rendering", :js, :selenium, with_settings: { re
 
         editor.wait_for_autosave { document.reload.description&.include?("##{work_package.id}") }
       end
+
+      describe "CTRL-Z undo behavior" do
+        it "undoes typed text with CTRL-Z" do
+          visit document_path(document)
+          expect(page).to have_test_selector("blocknote-document-description")
+
+          editor.fill_in("X")
+          expect(editor.element).to have_text("X")
+
+          editor.undo
+
+          expect(editor.element).to have_no_text("X")
+        end
+
+        it "undoes an inline work package chip inserted via # notation with CTRL-Z" do
+          visit document_path(document)
+          expect(page).to have_test_selector("blocknote-document-description")
+
+          editor.element.send_keys("#tiger")
+          editor.wait_for_shadow_content("pet a tiger")
+          send_keys(:enter)
+          expect(editor.element).to have_no_text("#tiger") # chip replaced autocomplete text
+
+          expect(editor.element).to have_no_text("…") # chip finished loading
+          expect(editor.element).to have_text(/##{work_package.display_id}/)
+
+          editor.undo
+
+          expect(editor.element).to have_no_text(/##{work_package.display_id}/)
+        end
+      end
     end
   end
 end

--- a/spec/support/form_fields/primerized/block_note_editor_input.rb
+++ b/spec/support/form_fields/primerized/block_note_editor_input.rb
@@ -118,6 +118,27 @@ module FormFields
         end
       end
 
+      # Triggers undo in the editor by dispatching a synthetic Ctrl-Z keydown event
+      # directly to the shadow-DOM contenteditable element. Selenium's send_keys does
+      # not reliably deliver modifier-key chords to elements inside a shadow DOM, so
+      # we use execute_script instead. ProseMirror processes all keydown events on
+      # its editor div regardless of isTrusted.
+      def undo
+        page.execute_script(<<~JS)
+          var shadowRoot = #{shadow_root_query}
+          var element = shadowRoot.querySelector('div[role="textbox"]');
+          element.focus();
+          element.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'z',
+            code: 'KeyZ',
+            ctrlKey: true,
+            bubbles: true,
+            cancelable: true,
+            composed: true
+          }));
+        JS
+      end
+
       private
 
       # Attention: This only works with selenium, not with cuprite,


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/STC-779

# What are you trying to accomplish?
Fix CTRL-Z behaviour in documents

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
