### PR TITLE
hotfix making login page work again when using SAML with multiple certificates

### DIFF
--- a/modules/auth_saml/app/models/saml/provider/hash_builder.rb
+++ b/modules/auth_saml/app/models/saml/provider/hash_builder.rb
@@ -34,7 +34,7 @@ module Saml
           return {
             idp_cert_multi: {
               signing: certificates,
-              encryption: certificates
+              encryption: certificates.dup # evil hack to prevent breaking OpenProject::ConfidentialCache caching this value @todo fix this properly
             }
           }
         else


### PR DESCRIPTION
This is a hotfix for WP [#OP-19477](https://community.openproject.org/projects/OP/work_packages/OP-19477/activity)