### PR TITLE
exclude turbo frame and stream from storage csp handling

### DIFF
--- a/modules/storages/lib/open_project/storages/append_storages_hosts_to_csp_hook.rb
+++ b/modules/storages/lib/open_project/storages/append_storages_hosts_to_csp_hook.rb
@@ -45,6 +45,8 @@ class OpenProject::Storages::AppendStoragesHostsToCspHook < OpenProject::Hook::L
   # places of OpenProject, and we want to be able to upload in all those places
   # (work packages module, BCF module, notification center, boards, ...).
   def application_controller_before_action(context)
+    return if turbo_frame_or_stream_request?(context[:request])
+
     storage_ids = ::Storages::ProjectStorage.where(
       project_id: Project.allowed_to(User.current, :manage_file_links)
     ).select(:storage_id)
@@ -56,5 +58,11 @@ class OpenProject::Storages::AppendStoragesHostsToCspHook < OpenProject::Hook::L
       # secure_headers gem provides this helper method to append to the current content security policy
       context[:controller].append_content_security_policy_directives(connect_src: storages_hosts)
     end
+  end
+
+  private
+
+  def turbo_frame_or_stream_request?(request)
+    request.headers&.key?("Turbo-Frame") || request.accept&.include?("text/vnd.turbo-stream.html")
   end
 end

--- a/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
+++ b/modules/storages/spec/lib/append_storages_hosts_to_csp_hook_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
   let(:storage) { create(:nextcloud_storage) }
   let(:project_storage) { create(:project_storage, project:, storage:) }
   let(:controller) { instance_double(ApplicationController) }
+  let(:request) do
+    instance_double(ActionDispatch::Request,
+                    headers: {},
+                    accept: [])
+  end
 
   before do
     storage
@@ -49,7 +54,7 @@ RSpec.describe OpenProject::Storages::AppendStoragesHostsToCspHook do
 
   def trigger_application_controller_before_action_hook
     hook_listener = described_class.instance
-    hook_listener.application_controller_before_action(controller:)
+    hook_listener.application_controller_before_action(controller:, request:)
   end
 
   shared_examples "content security policy directives" do

--- a/modules/storages/spec/requests/append_content_security_policy_spec.rb
+++ b/modules/storages/spec/requests/append_content_security_policy_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe "Appendix of default CSP for external file storage hosts" do
         csp = parse_csp(last_response.headers["Content-Security-Policy"])
         expect(csp["connect-src"]).to include(storage.host.chomp("/"))
       end
+
+      context "when doing a turbo frame request" do
+        it "does not append host to connect-src CSP" do
+          header("Turbo-Frame", "abc")
+          get "/"
+
+          csp = parse_csp(last_response.headers["Content-Security-Policy"])
+          expect(csp["connect-src"]).not_to include(storage.host.chomp("/"))
+        end
+      end
+
+      context "when doing a turbo stream request" do
+        it "does not append host to connect-src CSP" do
+          header("Accept", "text/vnd.turbo-stream.html")
+          get new_project_settings_project_storage_path(project)
+
+          csp = parse_csp(last_response.headers["Content-Security-Policy"])
+          expect(csp["connect-src"]).not_to include(storage.host.chomp("/"))
+        end
+      end
     end
 
     context "when not logged in" do


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/SSI-465

# What are you trying to accomplish?

Turbo frame and stream requests cannot change the CSP header of the original request defining the CSP. Because of this, fetching the information from the database is pointless and can just be avoided.

# Merge checklist

- [x] Added/updated tests