### PR TITLE
Fix documents not working on exotic browsers

### DIFF
--- a/app/helpers/browser_helper.rb
+++ b/app/helpers/browser_helper.rb
@@ -60,11 +60,11 @@ module BrowserHelper
   ##
   # Browser specific classes for browser-specific fixes
   # or mobile detection
-  def browser_specific_classes
+  def browser_specific_classes # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
     [].tap do |classes|
       classes << "-browser-chrome" if browser.chrome? || browser.chromium_based?
       classes << "-browser-firefox" if browser.firefox?
-      classes << "-browser-safari" if browser.safari?
+      classes << "-browser-webkit" if browser.safari? || browser.epiphany?
       classes << "-browser-edge" if browser.edge?
 
       classes << "-browser-mobile" if browser.device.mobile?

--- a/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
+++ b/frontend/src/app/features/in-app-notifications/center/in-app-notification-center.component.sass
@@ -43,7 +43,7 @@
 
 
   :host
-    .-browser-safari &
+    .-browser-webkit &
       // Because of Safari's viewport bug, the address bar overlaps content with height: 100vh
       // Check #38082 before changing it
       height: 100%

--- a/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
+++ b/frontend/src/app/spot/styles/sass/components/modal-overlay.sass
@@ -10,7 +10,7 @@
   align-items: center
   display: none
 
-  .-browser-safari &
+  .-browser-webkit &
     // Again, iOS and Safari are being special. When the keyboard opens, that pushes the whole viewport to the top.
     // Thus, when using `top: 0` half of the modal is pushed out of the screen.
     // Instead, we only set `bottom: 0` and set the height to the app height which is set programmatically on every screen resize

--- a/frontend/src/elements/block-note-element.ts
+++ b/frontend/src/elements/block-note-element.ts
@@ -49,7 +49,7 @@ class BlockNoteElement extends HTMLElement {
     const shadowRoot = this.attachShadow({ mode: 'open' });
 
     this.editorRoot = document.createElement('div');
-    const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ') ?? [];
+    const browserSpecificClasses = this.getAttribute('browser-specific-classes')?.split(' ').filter(Boolean) ?? [];
     if (browserSpecificClasses.length > 0) {
       this.editorRoot.classList.add(...browserSpecificClasses);
     }

--- a/frontend/src/global_styles/content/_forms_mobile.sass
+++ b/frontend/src/global_styles/content/_forms_mobile.sass
@@ -62,7 +62,7 @@
   .form--field-inline-button
     width: auto !important
 
-  .-browser-safari,
+  .-browser-webkit,
   .-browser-chrome,
   .-browser-firefox
     // Special rule for mobile safari, chrome and firefox to prevent zooming into the text field

--- a/lib/primer/open_project/forms/block_note_editor.html.erb
+++ b/lib/primer/open_project/forms/block_note_editor.html.erb
@@ -41,7 +41,7 @@
       "attachments-collection-key": attachments_collection_key,
       "blocknote-stylesheet-url": blocknote_stylesheet_url,
       "shadow-dom-stylesheet-url": shadow_dom_stylesheet_url,
-      "browser-specific-classes": browser_specific_classes.join(" "),
+      "browser-specific-classes": browser_specific_classes.join(" ").presence,
       "data-test-selector": "blocknote-document-description"
     )
   )


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/STC-823

# What are you trying to accomplish?
Documents should not crash on exotic browsers (that would otherwise be perfectly able to render and use BlockNote).
I sometimes want to use Epiphany, because it is a webkit-based browser on linux, which means I can observe style-related problems which also occur in Safari locally on Linux.

The root cause was that browser_specific_classes in BrowserHelper only added classes for Chrome, Firefox, Safari, Edge, and mobile/Windows. Epiphany (WebKitGTK on Linux) didn't match any of those, so it returned []. The ERB template then rendered browser-specific-classes="", and "".split(' ') in JS produces [""] — one empty string — which passes the length > 0 guard and then classList.add("") throwed in WebKit.

## Screenshots

BEFORE
<img width="377" height="111" alt="Screenshot from 2026-06-08 19-05-20" src="https://github.com/user-attachments/assets/101c659a-f4c4-4b2b-9087-ee27ea034a30" />
<img width="706" height="104" alt="Screenshot from 2026-06-08 19-05-40" src="https://github.com/user-attachments/assets/9ade936d-bf35-4c99-81c7-4268f6a1dffe" />

I am not adding after Screenshots because there's no more error to see.

# What approach did you choose and why?
1. Fix the underlying issue of erroneous javascript when no browser specific class can be detected
2. Add epiphany to the check in app/helpers/browser_helper.rb  so I can see the WebKit CSS with it.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
