### PR TITLE
Chore: sort locale files alphabetically

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,1737 +28,10 @@
 
 ---
 en:
-  no_results_title_text: There is currently nothing to display.
-
-  activities:
-    index:
-      no_results_title_text: There has not been any activity for the project within this time frame.
-    work_packages:
-      activity_tab:
-        no_results_title_text: No activity to display
-        no_results_description_text: 'Choose "Show everything" to show all activity and comments'
-        label_activity_show_all: "Show everything"
-        label_activity_show_only_comments: "Show comments only"
-        label_activity_show_only_changes: "Show changes only"
-        label_sort_asc: "Newest at the bottom"
-        label_sort_desc: "Newest on top"
-        label_type_to_comment: "Add a comment. Type @ to notify people."
-        label_submit_comment: "Submit comment"
-        label_who: Who?
-        changed_on: "changed on"
-        created_on: "created this on"
-        changed: "changed"
-        created: "created"
-        commented: "commented"
-        internal_comment: Internal comment
-        internal_journal: Internal comments are visible to a limited group of members.
-        unsaved_changes_confirmation_message: You have unsaved changes. Are you sure you want to close the editor?
-        internal_comment_confirmation:
-          title: "Make this comment public?"
-          heading: "Make this comment public?"
-          description: "Your comment will be visible to anyone who can access this work package. Are you sure you want to do this?"
-          confirm_button_text: "Make public"
-
-  admin:
-    reserved_identifiers:
-      title: "Reserved project identifiers"
-      lede_html: "When a project's identifier is renamed, the previous identifier is kept reserved so that existing links and integrations keep working.<br>Here you can release reserved identifiers so that they may be used by other projects."
-      col_identifier: "Identifier"
-      col_project: "Project"
-      col_reserved: "Reserved"
-      not_available_in_semantic_mode: "Reserved project identifiers are only available in numeric identifier mode."
-      filter_label: "Search identifiers"
-      btn_release: "Release"
-      released_notice: 'Identifier "%{identifier}" has been released.'
-      identifier_not_found: "The reserved identifier could not be found. It may have already been released or the project may have been deleted. Please refresh the page."
-      dialog:
-        title: "Release identifier"
-        heading: 'Release "%{identifier}"?'
-        description: "Releasing this identifier cannot be undone. External links and integrations using it will stop resolving, and the name becomes available for any new project to claim."
-        checkbox_label: "I understand that this cannot be undone."
-        confirm_button: "Release identifier"
-      empty_heading: "No reserved identifiers"
-      reserved_ago: "%{time} ago"
-      empty_body: "When a project's identifier changes, the previous one will appear here so you can release it once it's safe to do so."
-    plugins:
-      no_results_title_text: There are currently no plugins installed.
-      no_results_content_text: See our integrations and plugins page for more information.
-    custom_styles:
-      color_theme: "Color theme"
-      color_theme_custom: "(Custom)"
-      tab_interface: "Interface"
-      tab_branding: "Branding"
-      tab_pdf_export_styles: "PDF export styles"
-      tab_pdf_export_font: "PDF export font"
-      fonts:
-        file_too_large: "is too large (maximum size is %{count} MB)."
-        file_is_invalid: "is not a valid TTF font file."
-      colors:
-        primary-button-color: "Primary button"
-        accent-color: "Accent"
-        header-bg-color: "Header background"
-        main-menu-bg-color: "Main menu background"
-        main-menu-bg-selected-background: "Main menu when selected"
-      custom_colors: "Custom colors"
-      manage_colors: "Edit color select options"
-      instructions:
-        primary-button-color: "Strong accent color, used for the most important button on a screen."
-        accent-color: "Color for links and other decently highlighted elements."
-        main-menu-bg-color: "Left side menu's background color."
-      theme_warning: Changing the theme will overwrite you custom style. The design will then be lost. Are you sure you want to continue?
-    enterprise:
-      delete_dialog:
-        title: "Delete enterprise token"
-        heading: "Delete this enterprise token?"
-        confirmation: "Are you sure you want to delete this Enterprise edition support token?"
-      create_dialog:
-        title: "Add Enterprise token"
-        type_token_text: "Your Enterprise token text"
-        token_placeholder: "Paste your Enterprise edition support token here"
-        token_caption: "To learn more about how to activate Enterprise edition check our [documentation](docs_url)."
-      add_token: "Upload an Enterprise edition support token"
-      replace_token: "Replace your current support token"
-      order: "Order Enterprise on-premises edition"
-      paste: "Paste your Enterprise edition support token"
-      required_for_feature: "This add-on is only available with an active Enterprise edition support token."
-      enterprise_link: "For more information, click here."
-      start_trial: "Start free trial"
-      book_now: "Book now"
-      get_quote: "Get a quote"
-      buttons:
-        upgrade: "Upgrade now"
-        contact: "Contact us for a demo"
-      status:
-        expired: "Expired"
-        expiring_soon: "Expiring soon"
-        in_grace_period: "In grace period"
-        invalid_domain: "Invalid domain"
-        not_active: "Not active"
-        trial: "Trial"
-    jemalloc_allocator: Jemalloc memory allocator
-    journal_aggregation:
-      caption: >
-        User actions on a work package (changing description, status, values, or writing comments) are grouped if performed within this period. It also controls notification and [webhook](webhook_link) delays.
-    import:
-      title: "Import"
-    jira:
-      title: "Jira Migrator"
-      description: "Use this tool to import data from your Jira instance. You can configure multiple Jira hosts and choose what to import in each import run."
-      errors:
-        cannot_delete_with_imports: "Cannot delete Jira host with existing imports"
-        custom_field_creation_failed: "Failed to create custom field '%{name}': %{message}"
-        semantic_identifiers_must_be_enabled:
-          title: "Project-based semantic identifiers must be enabled."
-          description: "Jira uses issue identifiers consisting of a project key and a sequence number (PRJ-123). OpenProject also supports it, but it needs to be enabled [here](link)."
-      blank:
-        title: "No Jira hosts configured yet"
-        description: "Configure a Jira host to start importing items from Jira to this OpenProject instance."
-      configuration:
-        title: "Jira configuration"
-        new: "New configuration"
-      banner:
-        title: "Beta - Try it out!"
-        description: "This Jira Migrator is currently in beta. We currently only support Jira Server/Data Center versions 10.x and 11.x. Cloud instances are not supported at this time."
-        contribution_callout: >
-          Please, help us improve the Jira Migrator with your feedback and private data donations. You can [join the development community](link) of the Jira Migrator.
-        supported_versions: ""
-      form:
-        fields:
-          name: "Name"
-          url: "Jira Server/Data Center URL"
-          personal_access_token: "Personal Access Token"
-        button_add: "Add configuration"
-        button_save: "Save configuration"
-        button_test: "Test configuration"
-        button_delete_token: "Delete token"
-        delete_token_confirm: "Are you sure you want to delete the token? This will disable the Jira connection."
-        label_testing: "Testing configuration..."
-      token_deleted: "Token was successfully deleted."
-      test:
-        success: "Successfully connected to %{server} (version %{version})"
-        failed: "Connection failed: Unable to retrieve server information"
-        error: "An unexpected error occurred while testing the connection"
-        connection_error: "Connection error: %{message}"
-        parse_error: "Failed to parse the response from the server. The server may not be a valid Jira instance."
-        api_error: "Jira API returned error status %{status}. Please check your Jira instance URL and API token."
-        token_error: "Invalid API token. Please check your credentials in the configuration."
-        missing_credentials: "Please provide both URL and Personal Access Token to test the connection"
-        invalid_url: "Please provide a valid URL"
-      client:
-        connection_error: "Failed to connect to Jira server: %{message}"
-        connection_timeout: "Connection to Jira server timed out: %{message}"
-        ssrf_blocked: >-
-          Connection blocked: the Jira host resolves to a private IP address. If your Jira instance
-          runs on an internal network, allow its IP via the OPENPROJECT_SSRF__PROTECTION__IP__ALLOWLIST
-          environment variable.
-        ssrf_block_doc_link: "Please see our [documentation](docs_url)."
-        ssl_error: "SSL error connecting to Jira server: %{message}"
-        parse_error: "Failed to parse Jira API response: %{message}"
-        api_error: "Jira API returned error status %{status}"
-        401_error: "Jira API returned a 401 error. Your authentication token may have expired or lack the required permissions. Please ensure the token belongs to a Jira administrator."
-        429_error: "Jira API returned a 429 error. It means token owner has been rate limited by the Jira instance. Please disable rate limiting for this user."
-      columns:
-        projects: "Projects"
-        last_change: "Last change"
-        added: "Added"
-        label_ago: "%{amount} ago"
-      run:
-        title: "Import run"
-        history: "History"
-        remove_error: "A Jira import run cannot be removed while it is running"
-        import_blocked_error: "Another Jira import run is currently in progress or awaiting review. Please complete or revert it before starting a new import."
-        project_identifier_taken: "You are trying to import a project with an already used identifier: %{taken_identifier}. Please update the project identifier in Jira then click on Retry."
-        blank:
-          title: "No import runs set up yet"
-          description: "Create an import run to start importing information from this Jira instance"
-        index:
-          description: "You can import different sets of data with each import run. It is possible to undo an import run immediately after in review mode but not after finalizing."
-          button_import_run: "Import run"
-          button_edit_configuration: "Edit configuration"
-        status:
-          initial: "Start"
-          instance_meta_fetching: "Fetching meta data"
-          instance_meta_error: "Error fetching meta data"
-          instance_meta_done: "Meta data fetched"
-          import_scope: "Select scope"
-          configuring: "Select scope"
-          projects_meta_fetching: "Fetching project data"
-          projects_meta_error: "Error fetching project data"
-          projects_meta_done: "Data gathered"
-          importing: "In progress"
-          import_error: "Error during import"
-          imported: "Review mode"
-          reverting: "Reverting"
-          revert_error: "Error during revert"
-          revert_cancelling: "Cancelling revert"
-          revert_cancelled: "Revert cancelled"
-          reverted: "Reverted"
-          finalizing: "Finalizing"
-          finalizing_error: "Error during finalizing"
-          finalizing_done: "Completed"
-        wizard:
-          button_retry: "Retry"
-          parts:
-            projects:
-              one: "1 project"
-              other: "%{count} projects"
-            issues:
-              one: "1 issue"
-              other: "%{count} issues"
-            work_packages:
-              one: "1 work package"
-              other: "%{count} work packages"
-            types:
-              one: "1 type"
-              other: "%{count} types"
-            statuses:
-              one: "1 status"
-              other: "%{count} statuses"
-            users:
-              one: "1 user"
-              other: "%{count} users"
-          groups:
-            fetch:
-              title: "Get base data"
-            groups_and_users:
-              title: "Groups and Users"
-            configuration:
-              title: "Configure import"
-            confirming:
-              title: "Confirm and import"
-            review:
-              title: "Review import"
-          sections:
-            fetch_data:
-              title: "Fetch instance meta data"
-              caption_done: "Completed"
-              description: "Check what data is available for import in the host Jira instance."
-              button_fetch: "Check available data"
-              label_progress: "Fetching data from Jira..."
-            groups_and_users:
-              title: "Groups and Users"
-            import_scope:
-              title: "Import scope"
-              caption: "Choose what you want to import into OpenProject"
-              caption_done: "Completed"
-              label_info: "Please note that this import tool is in beta and cannot import all types of data. Here is a summary of what the host Jira instance offers for import and what this tool is able to import right now."
-              description: "Select what data you want to import from the available data fetched from the host Jira instance."
-              label_supported_data: "Supported data"
-              label_coming_soon: "Coming soon (Q2 2026)"
-              label_coming_later: "Coming later"
-              label_available_server_data: "Available data on %{server_info}"
-              button_select_projects: "Select projects to import"
-              button_continue: "Continue"
-              label_import: "Select which projects you would like to import."
-              button_select: "Select projects"
-              label_selected_data: "Selected data for import"
-              label_progress: "Fetching data from Jira..."
-              elements:
-                relations: "Relations between issues"
-                project_ids: "Project identifiers"
-                issue_ids: "Issue identifiers"
-                sprints: "Sprint assignments"
-                workflows: "Project-level workflows"
-                schemes: "Schemas"
-                permissions: "Permissions"
-                projects: "Projects"
-                issues: "Issues"
-                issue_details: "Issue description, history, comments and attachments"
-                custom_fields: "A subset of custom fields"
-                users: "Involved users and groups"
-            confirm_import:
-              title: "Import data"
-              caption: "Review your import settings and start the import"
-              caption_done: "Completed"
-              label_available_data: "Data to be imported"
-              label_users_import_explanation: "Users that are involved in selected projects (group memberships included)"
-              button_start: "Start import"
-              description: "You are about to start an import run with the following settings."
-              label_progress: "Import in progress..."
-              label_import_data: "Currently importing"
-            import_result:
-              title: "Import run results"
-              caption: "Review import run or revert import"
-              info: "Import run was successful."
-              label_results: "Imported"
-              label_revert: "Revert import"
-              button_revert: "Revert import"
-              button_done: "Approve import"
-              preview_description: 'The imported data is currently in review mode. Click "Approve import" to make the import permanent or "Revert import" to undo all changes made in this import run.'
-              label_finalize_import: "Approve import"
-              label_finalizing: "Approving import..."
-              label_finalizing_done: "Import approved."
-              label_revert_progress: "Reverting import..."
-              label_reverted: "Import reverted."
-          select_dialog:
-            filter_projects: "Filter by text"
-          import_dialog:
-            title: "Please make sure you have a backup!"
-            confirm_button: "Start import"
-            description: >
-              Imports change your OpenProject configuration. After the import you will have the opportunity to review the changes.
-              While in review, you have an option to revert or approve the import. After approving the import reverting will no longer be possible.
-              Therefore, please, make sure that you have [a backup of your OpenProject instance](link) before proceeding.
-            confirm: "I understand and have a backup"
-          revert_dialog:
-            title: "Permanently revert this import?"
-            description: "This will delete all imported objects (including whole projects)."
-            confirm: "I understand that this reversion will delete data permanently"
-          finalize_dialog:
-            title: "Approve this import?"
-            description: "Once approved, this import can no longer be reverted. All imported data will become permanent."
-            confirm: "I understand that this action cannot be undone"
-            confirm_button: "Understood"
-          select_projects:
-            title: "Select projects"
-      user:
-        unknown_name: "Unknown"
-
-    mcp_configurations:
-      index:
-        description: "The model context protocol allows AI agents to provide its users with tools and resources exposed by this OpenProject instance. This feature is still in beta."
-        resources_heading: "Resources"
-        resources_description: "OpenProject implements the following resources. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP resources](docs_url)."
-        resources_submit: "Update resources"
-        tools_heading: "Tools"
-        tools_description: "OpenProject implements the following tools. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP tools](docs_url)."
-        tools_submit: "Update tools"
-      multi_update:
-        success: "MCP configurations were updated successfully."
-      server_form:
-        description_caption: "How the MCP server will be described to other applications who connect to it."
-        title_caption: "A short title shown to applications that connect to the MCP server."
-        tool_response_format: "Tool response format"
-        tool_response_format_content_only_label: "Content only"
-        tool_response_format_content_only_caption: >
-          Choose this if MCP clients connecting to this instance do not support structured content.
-          Tool responses will only contain plain text content and leave out the structured version.
-        tool_response_format_full_label: "Full"
-        tool_response_format_full_caption: >
-          The most compatible option. Tool responses will include both regular and structured content, allowing MCP clients to choose which format they want to read.
-          This may increase the number of tokens that the language model has to process, potentially increasing cost and decreasing performance.
-        tool_response_format_structured_only_label: "Structured content only"
-        tool_response_format_structured_only_caption: >
-          Choose this if you are certain that MCP clients connecting to this instance support structured content.
-          Tool responses will only include structured content and leave out its text representation.
-      update:
-        failure: "MCP configuration could not be updated."
-        success: "MCP configuration was updated successfully."
-    scim_clients:
-      authentication_methods:
-        sso: "JWT from identity provider"
-        oauth2_client: "OAuth 2.0 client credentials"
-        oauth2_token: "Static access token"
-      created_client_credentials_dialog_component:
-        title: "Client credentials created"
-        heading: "Client credentials have been generated"
-        one_time_hint: "This is the only time you will see the client secret. Make sure to copy it now."
-      created_token_dialog_component:
-        title: "Token created"
-        heading: "A token has been generated"
-        label_token: "Token"
-        one_time_hint: "This is the only time you will see this token. Make sure to copy it now."
-      delete_scim_client_dialog_component:
-        title: "Delete SCIM client"
-        heading: "Are you sure you want to delete this SCIM client?"
-        description: "Users managed by this SCIM client can no longer be updated by it."
-      edit:
-        label_delete_scim_client: "Delete SCIM client"
-      form:
-        auth_provider_description: "This is the service that users added by the SCIM provider will use to authenticate in OpenProject."
-        authentication_method_description_html: "This is how the SCIM client authenticates at OpenProject. Please ensure that OAuth tokens include the <code>scim_v2</code> scope."
-        description: "Please refer to our [documentation on configuring SCIM clients](docs_url) for more information on these configuration options."
-        jwt_sub_description: "For example, for Keycloak, this is the UUID of the service account  associated with the SCIM client. Consult [our documentation](docs_url) to learn how to find  the subject claim for your use case."
-        name_description: "Choose a name that will help other admins better understand why this client was configured."
-      index:
-        description: "SCIM clients configured here are able to interact with OpenProject SCIM server API to provision, update, and deprovision user accounts and groups."
-        label_create_button: "Add SCIM client"
-      new:
-        title: "New SCIM client"
-      revoke_static_token_dialog_component:
-        confirm_button: "Revoke"
-        title: "Revoke static token"
-        heading: "Are you sure you want to revoke this token?"
-        description: "The SCIM client that uses this token will no longer be able to access OpenProject's SCIM server API."
-      table_component:
-        blank_slate:
-          title: "No SCIM clients configured yet"
-          description: "Add clients to see them here"
-        user_count: "Users"
-      token_list_component:
-        description: "The tokens you generate here can be passed by a SCIM client to access the OpenProject SCIM API."
-        heading: "Tokens"
-        label_add_token: "Token"
-        label_aria_add_token: "Add token"
-      token_table_component:
-        blank_slate:
-          title: "No tokens have been created yet"
-          description: "You can create one now"
-        expired: "Expired on %{date}"
-        revoked: "Revoked on %{date}"
-        title: "Access token table"
-    settings:
-      new_project:
-        project_creation: "Project creation"
-        notification_text_default: >
-          <p>Hello,</p>
-          <p>A new project has been created: projectValue:name</p>
-          <p>Thank you</p>
-      work_packages_identifier:
-        page_header:
-          description: Choose between classic numerical work package IDs or semantic project-specific ones that prepend the project identifier to the work package ID.
-        banner:
-          existing_identifiers_notice: >
-            Existing identifiers for %{project_count} projects don't meet requirements for project-based semantic identifiers.
-            OpenProject can automatically update these so that they are valid as in the examples below.
-            Click on 'Convert identifiers' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
-        box_header:
-          table_title: Projects with identifiers to update
-          label_project: Project
-          label_previous_identifier: Previous identifier
-          label_autofixed_suggestion: Future identifier
-          label_example_work_package_id: Example work package ID
-        autofix_preview:
-          error_too_long: Has to be 10 characters or fewer
-          error_numerical: Cannot be purely numerical
-          error_does_not_start_with_letter: Must start with an uppercase letter
-          error_special_characters: Special characters not allowed
-          error_not_fully_uppercased: Must be uppercase
-          error_in_use: Already in use as another project's active handle
-          error_used_in_past: Reserved by another project's handle history
-          error_reserved_by_system: Reserved as a system keyword
-          error_unknown: Needs manual review
-          remaining_projects:
-            one: "... 1 more project"
-            other: "... %{count} more projects"
-        button_autofix: Convert identifiers
-        button_save: Convert identifiers
-        dialog:
-          title: Change work package identifiers
-          heading: Enable project-based work package IDs?
-          description: >
-            This will change IDs for all work packages in all projects in this instance.
-            Previous identifiers and URLs will continue to work.
-            This change will take some time to complete.
-          confirm_button: Change identifiers
-          checkbox_label: I understand that this will permanently change all work package IDs
-        success_banner: Successfully updated work package identifier format.
-        in_progress:
-          header_semantic: "Converting to project-based identifiers"
-          header_classic: "Converting to numeric identifiers"
-          footer_message: "Background conversion is in progress. You can safely leave this page."
-    workflows:
-      tabs:
-        default_transitions: "Default transitions"
-        user_author: "User is author"
-        user_assignee: "User is assignee"
-      status_button: "Status"
-      statuses_dialog:
-        title: "Statuses"
-        label: "Statuses enabled for this type"
-        caption: "Add or remove statuses you would like to associate with this type. Removing a status will also delete the workflow associated with it."
-      statuses_removal_dialog:
-        title: "Remove statuses"
-        heading:
-          one: "Remove 1 status?"
-          other: "Remove %{count} statuses?"
-        description: "Removing these statuses will make them unavailable to this type and delete existing workflows. Are you sure you want to proceed?"
-        confirm: "Remove"
-      leave_confirmation:
-        title: "Save changes before continuing?"
-        description: "You are about to leave this page but you have unsaved changes. Would you like to save them before continuing?"
-        ignore: "Ignore changes"
-        save: "Save changes and continue"
-      role_selector:
-        title: "Select roles"
-        label: "Role: %{role}"
-        no_role: "Select role"
-        roles:
-          one: "One role selected"
-          other: "%{count} roles selected"
-      blankslate:
-        title: "No status transitions configured"
-        description: "Add statuses to start configuring workflows for this role"
-    info:
-      database_deprecation_html: >
-        Starting with OpenProject 16.0, PostgreSQL 16 is required to use OpenProject.
-        Your installation will remain functional with your current database, but anticipate incompatability
-        in future releases.
-        <br/>
-        We have prepared [upgrade guides for all installation methods](upgrade_guide).
-        You can perform the upgrade ahead of the next release at any time by following the guides.
-
-  authentication:
-    login_and_registration: "Login and registration"
-
-  announcements:
-    show_until: Show until
-    is_active: currently displayed
-    is_inactive: currently not displayed
-
-  antivirus_scan:
-    not_processed_yet_message: "Downloading is blocked, as file was not scanned for viruses yet. Please try again later."
-    quarantined_message: "A virus was detected in file '%{filename}'. It has been quarantined and is not available for download."
-    deleted_message: "A virus was detected in file '%{filename}'. The file has been deleted."
-    deleted_by_admin: "The quarantined file '%{filename}' has been deleted by an administrator."
-    overridden_by_admin: "The quarantine for file '%{filename}' has been removed by %{user}. The file can now be acccessed."
-    quarantined_attachments:
-      container: "Container"
-      delete: "Delete the quarantined file"
-      title: "Quarantined attachments"
-      error_cannot_act_self: "Cannot perform actions on your own uploaded files."
-
-  attribute_help_texts:
-    caption: "This short version will be displayed as caption of the attribute."
-    note_public: "Any text and images you add to this field are publicly visible to all logged in users."
-    text_overview: "In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute."
-    show_preview: "Preview text"
-    add_new: "Add help text"
-    edit_field_name: "Edit help text for %{attribute_field_name}"
-
-  background_jobs:
-    status:
-      error_requeue: "Job experienced an error but is retrying. The error was: %{message}"
-      cancelled_due_to: "Job was cancelled due to error: %{message}"
-
-  ldap_auth_sources:
-    ldap_error: "LDAP-Error: %{error_message}"
-    ldap_auth_failed: "Could not authenticate at the LDAP-Server."
-    sync_failed: "Failed to synchronize from LDAP: %{message}."
-    back_to_index: "Click here to go back to the list of connection."
-    technical_warning: |
-      This LDAP form requires technical knowledge of your LDAP / Active Directory setup.
-      [Please visit our documentation for detailed instructions](docs_url).
-    attribute_texts:
-      name: Arbitrary name of the LDAP connection
-      host: LDAP host name or IP address
-      login_map: The attribute key in LDAP that is used to identify the unique user login. Usually, this will be `uid` or `samAccountName`.
-      generic_map: The attribute key in LDAP that is mapped to the OpenProject `%{attribute}` attribute
-      admin_map_html: "Optional: The attribute key in LDAP that <strong>if present</strong> marks the OpenProject user an admin. Leave empty when in doubt."
-      system_user_dn_html: |
-        Enter the DN of the system user used for read-only access.
-        <br>
-        Example: uid=openproject,ou=system,dc=example,dc=com
-      system_user_password: Enter the bind password of the system user
-      base_dn: |
-        Enter the Base DN of the subtree in LDAP you want OpenProject to look for users and groups.
-        OpenProject will filter for provided usernames in this subtree only.
-        Example: ou=users,dc=example,dc=com
-      filter_string: |
-        Add an optional RFC4515 filter to apply to the results returned for users filtered in the LDAP.
-        This can be used to restrict the set of users that are found by OpenProject for authentication and group synchronization.
-      filter_string_concat: |
-        OpenProject will always filter for the login attribute provided by the user to identify the record. If you provide a filter here,
-        it will be concatenated with an AND. By default, a catch-all (objectClass=*) will be used as a filter.
-      onthefly_register: |
-        If you check this box, OpenProject will automatically create new users from their LDAP entries
-        when they first authenticate with OpenProject.
-        Leave this unchecked to only allow existing accounts in OpenProject to authenticate through LDAP!
-
-    connection_encryption: "Connection encryption"
-    encryption_details: "LDAPS / STARTTLS options"
-    system_account: "System account"
-    system_account_legend: |
-      OpenProject requires read-only access through a system account to lookup users and groups in your LDAP tree.
-      Please specify the bind credentials for that system user in the following section.
-    ldap_details: "LDAP details"
-    user_settings: "Attribute mapping"
-    user_settings_legend: |
-      The following fields are related to how users are created in OpenProject from LDAP entries and
-      what LDAP attributes are used to define the attributes of an OpenProject user (attribute mapping).
-    tls_mode:
-      plain: "none"
-      simple_tls: "LDAPS"
-      start_tls: "STARTTLS"
-      plain_description: "Opens an unencrypted connection to the LDAP server. Not recommended for production."
-      simple_tls_description: "Use LDAPS. Requires a separate port on the LDAP server. This mode is often deprecated, we recommend using STARTTLS whenever possible."
-      start_tls_description: "Sends a STARTTLS command after connecting to the standard LDAP port. Recommended for encrypted connections."
-      section_more_info_link_html: >
-        This section concerns the connection security of this LDAP authentication source.
-        For more information, visit <a href="%{link}">the Net::LDAP documentation</a>.
-    tls_options:
-      verify_peer: "Verify SSL certificate"
-      verify_peer_description_html: >
-        Enables strict SSL verification of the certificate trusted chain.
-        <br>
-        <strong>Warning:</strong> Unchecking this option disables SSL verification of the LDAP server certificate.
-        This exposes your connection to Man in the Middle attacks.
-      tls_certificate_description: "If the LDAP server certificate is not in the trust sources of this system, you can add it manually here. Enter a PEM X509 certifiate string."
-  forums:
-    show:
-      no_results_title_text: There are currently no posts for the forum.
-
-  colors:
-    index:
-      no_results_title_text: There are currently no colors.
-      no_results_content_text: Create a new color
-      label_new_color: "New color"
-    new:
-      label_new_color: "New Color"
-    edit:
-      label_edit_color: "Edit Color"
-    form:
-      label_new_color: "New color"
-      label_edit_color: "Edit color"
-    label_no_color: "No color"
-    label_properties: "Properties"
-    label_really_delete_color: >
-      Are you sure, you want to delete the following color?
-      Types using this color will not be deleted.
-
-  custom_actions:
-    actions:
-      name: "Actions"
-      add: "Add action"
-      assigned_to:
-        executing_user_value: "(Assign to executing user)"
-    conditions: "Conditions"
-    plural: "Custom actions"
-    new: "New custom action"
-    edit: "Edit custom action %{name}"
-    execute: "Execute %{name}"
-
-  custom_fields:
-    admin:
-      custom_field_projects:
-        is_for_all_blank_slate:
-          heading: For all projects
-          description: This custom field is enabled in all projects since the "For all projects" option is checked. It cannot be deactivated for individual projects.
-      items:
-        actions: "Item actions"
-        blankslate:
-          root:
-            title: "Your list of items is empty"
-            description: "Start by adding items to the custom field of type hierarchy. Each item can be used to create a hierarchy bellow it. To navigate and create sub-items inside a hierarchy click on the created item."
-          item:
-            title: This item doesn't have any hierarchy level below
-            description: Add items to this list to create sub-items inside another one
-        delete_dialog:
-          title: "Delete custom field item"
-          heading: "Delete custom field item?"
-          description: "This action will irreversibly remove the item and all its sub-items. Any assigned values will be permanently deleted. If this field is required, removing items may cause existing work packages to become invalid."
-        placeholder:
-          label: "Item label"
-          short: "Short name"
-          weight: "Weight"
-      notice:
-        remember_items_and_projects: "Remember to set items and projects in the respective tabs for this custom field."
-      hierarchy:
-        subitems:
-          zero: no sub-items
-          one: 1 sub-item
-          other: "%{count} sub-items"
-      role_assignment:
-        title: Role Assignment
-        description: You can automatically grant a certain project role to any user assigned to this project attribute, regardless of that user’s original role in that project.
-        warning: Depending on the role selected below, the user assigned to this project attribute might gain significantly more permissions than they previously had, including the ability to add new members and elevate their role.
-        role_field_label: "Project Role"
-        role_field_caption: This project role will automatically be granted to any user assigned to this project attribute
-        review_hint: >
-          There are %{user_count} who are already assigned to this project attribute in various projects. They
-          might get additional permissions and be added to projects they did not previously have access to.
-        review_button: Review users and permissions
-        dialog:
-          title: "Overview of users and permissions"
-          change: Change
-          changes:
-            new_member: Will be added as a member
-            remove_member: Will be removed as a member
-            gain_and_lose_role: Will lose role ‘%{old_role}’ and gain role ‘%{new_role}’
-            gain_role: Will gain role ‘%{new_role}’
-            lose_role: Will lose role ‘%{old_role}’
-            no_change: No changes
-    text_add_new_custom_field: >
-      To add new custom fields to a project you first need to create them before
-      you can add them to this project.
-    is_enabled_globally: "Is enabled globally"
-    enabled_in_project: "Enabled in project"
-    contained_in_type: "Contained in type"
-    confirm_destroy_option: "Deleting an option will delete all of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
-    reorder_alphabetical: "Reorder values alphabetically"
-    reorder_confirmation: "Warning: The current order of available values as well as all unsaved values will be lost. Are you sure you want to continue?"
-    placeholder_version_select: "Work package or project selection is required first"
-    calculated_field_not_editable: "Non-editable attribute. This value is calculated automatically."
-    no_role_assigment: "No role assignment"
-    instructions:
-      is_required:
-        all: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new resources. Existing resources will not require a value when being updated."
-        project: "Required attributes need to be filled out by the user on project creation if the field is active ('For all projects' set or copying from a project/template in which the field is active). Existing projects will not require a value when being updated."
-      is_for_all:
-        all: "Mark the custom field as available in all existing and new projects."
-        project: "Mark the attribute as available in all existing and new projects."
-      multi_select:
-        all: "Allows the user to assign multiple values to this custom field."
-        project: "Allows the user to assign multiple values to this attribute."
-      searchable:
-        all: "Include the field values when using the global search functionality."
-        project: "Check to make this attribute available as a filter in project lists."
-      editable:
-        all: "Allow the field to be editable by users themselves."
-      admin_only:
-        all: "Check to make this custom field only visible to administrators. Users without admin rights will not be able to view or edit it."
-        project: "Check to make this attribute only visible to administrators. Users without admin rights will not be able to view or edit it."
-      is_filter:
-        all: >
-          Allow the custom field to be used in a filter in work package views.
-          Note that only with 'For all projects' selected, the custom field will show up in global views.
-      formula:
-        project: "Add numeric values or type / to search for an attribute or a mathematical operator."
-      regexp:
-        all: "eg. ^[A-Z0-9]+$"
-        project: "eg. ^[A-Z0-9]+$"
-      min_max:
-        all: "0 means no restriction"
-        project: "0 means no restriction"
-      has_comment:
-        project: "Allows the user to add a comment related to the project attribute when selecting the value in the project overview."
-
-    tab:
-      no_results_title_text: There are currently no custom fields.
-      no_results_content_text: Create a new custom field
-
-  calculated_values:
-    error_dialog:
-      title: "Error with Calculated value"
-    errors:
-      unknown: "An unknown error occurred. Please review the formula for this Calculated value."
-      mathematical: "The mathematical formula leads to an error. Please review the project calculation attribute and try again."
-      missing_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is empty.
-      disabled_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is disabled for the project.
-
-  concatenation:
-    single: "or"
-
-  danger_dialog:
-    confirmation_live_message_checked: "The button to proceed is now active."
-    confirmation_live_message_unchecked: "The button to proceed is now inactive. You need to tick the checkbox to continue."
-
-  departments:
-    edit: "Edit department"
-    add_user: "Add user"
-    add_department: "Add department"
-    blankslate:
-      heading: "Your organization has no departments"
-      description: >
-        Start by adding departments or users to the organization. Each department can be used to create
-        a hierarchy below it, to navigate and create sub-department inside a hierarchy click on the created item.
-      add_button: "Add"
-    detail_blankslate:
-      heading: "This department doesn’t have any hierarchy level below"
-      description: "Add departments or users to create sub-items inside another one."
-      add_button: "Add"
-    add_department_form:
-      name_label: "Department name"
-      name_placeholder: "Enter department name"
-    move_user_dialog:
-      title: "User already in a department"
-      heading: "Move user to this department?"
-      description: "%{user} is currently a member of %{from_department}. Moving them will remove them from that department."
-      confirm: "Move user"
-    context_menu:
-      add_sub_department: "Add sub-department"
-      add_user: "Add user"
-    flash:
-      user_added: "User was successfully added to the department."
-      user_removed: "User was successfully removed from the department."
-      department_created: "Department was successfully created."
-    errors:
-      move_user_failed: "Failed to move user between departments."
-
-  pagination:
-    label: "Pagination"
-    prev: "Previous"
-    prev_page: "Previous Page"
-    next: "Next"
-    next_page: "Next Page"
-    page: "Page %{number}"
-    page_with_more: "Page %{number}..."
-
-  mcp_configurations:
-    server_url_component:
-      caption: "The URL at which the OpenProject MCP server will be reachable. Required for setting up MCP clients."
-      label: "Server URL"
-
-  op_dry_validation:
-    or: "or"
-    errors:
-      unexpected_key: "is not allowed."
-      array?: "must be an array."
-      decimal?: "must be a decimal."
-      defined: "must not be defined."
-      eql?: "must be equal to %{left}."
-      filled?: "must be filled."
-      format?: "is in invalid format."
-      greater_or_equal_zero: "must be greater or equal to 0."
-      gteq?: "must be greater than or equal to %{num}."
-      hash?: "must be a hash."
-      included_in?:
-        arg:
-          default: "must be one of: %{list}."
-          range: "must be one of: %{list_left} - %{list_right}."
-      int?: "must be an integer."
-      key?: "is missing."
-      not_found: "not found."
-      respond_to?: "does not implement required method."
-      rules:
-        copy_workflow_from:
-          workflow_missing: "has no own workflow."
-        custom_field:
-          format_not_supported: "format '%{field_format}' is unsupported."
-        item:
-          root_item: "cannot be a root item."
-          not_persisted: "must be an already existing item."
-        label:
-          not_unique: "must be unique within the same hierarchy level."
-        short:
-          not_unique: "must be unique within the same hierarchy level."
-        parent:
-          not_descendant: "must be a descendant of the hierarchy root."
-      str?: "must be a string."
-      time?: "must be a time."
-      type?: "must be %{type}."
-      uri?: "is not a valid URI."
-    rules:
-      copy_workflow_from: "Type for workflow copy"
-      enabled: "Enabled"
-      depth: "Depth"
-      item: "Item"
-      label: "Label"
-      weight: "Weight"
-      short: "Short name"
-      parent: "Parent"
-      blueprint: "Pattern blueprint"
-
-  global_search:
-    title:
-      all_projects: 'Search for "%{search_term}" in all projects'
-      current_project: 'Search for "%{search_term}" in %{project_name}'
-      project_and_subprojects: 'Search for "%{search_term}" in %{project_name} and all subprojects'
-    placeholder: "Search in %{app_title}"
-    overwritten_tabs:
-      all: "All"
-      messages: "Forum"
-      wiki_pages: "Wiki"
-
-  groups:
-    edit:
-      synchronized_groups: "Synchronized groups"
-    index:
-      description: By grouping users together, you can add them as members to the same projects or assign the same global roles to them.
-    table_component:
-      blank_slate:
-        description: You can define named groups of users with specific permissions.
-        title: No groups set up yet
-      user_count: User count
-    users:
-      no_results_title_text: There are currently no users part of this group.
-    memberships:
-      no_results_title_text: There are currently no projects part of this group.
-    synchronized_groups:
-      blankslate:
-        action: Authentication settings
-        description: When this group is automatically synced with groups in external identity providers like OpenID, they will appear here. You can set this up in your Authentication settings.
-        title: No synchronized groups yet
-
-  incoming_mails:
-    ignore_filenames: >
-      Specify a list of names to ignore when processing attachments for incoming mails (e.g., signatures or icons).
-      Enter one filename per line.
-
-  portfolios:
-    index:
-      search:
-        label: Portfolio name filter
-        placeholder: Search portfolios
-      sub_items_html:
-        one: "<strong>1</strong> sub-item"
-        other: "<strong>%{count}</strong> sub-items"
-    lists:
-      active: "Active portfolios"
-      my: "My portfolios"
-      favorited: "Favorite portfolios"
-      archived: "Archived portfolios"
-
-  projects:
-    copy:
-      # Contains custom strings for options when copying a project that cannot be found elsewhere.
-      members: "Project members"
-      overviews: "Project overview"
-      queries: "Work packages: saved views"
-      wiki_page_attachments: "Wiki pages: attachments"
-      work_package_attachments: "Work packages: attachments"
-      work_package_categories: "Work packages: categories"
-      work_package_file_links: "Work packages: file links"
-      work_package_shares: "Work packages: shares"
-    create:
-      notification_email_subject: "Your project '%{project_name}' has been created"
-      complete_wizard_link: "Complete the %{artefact_name}"
-    delete:
-      scheduled: "Deletion has been scheduled and is performed in the background. You will be notified of the result."
-      schedule_failed: "Project cannot be deleted: %{errors}"
-      failed: "Deletion of project '%{name}' has failed"
-      failed_text: "The request to delete project '%{name}' has failed. The project was left archived."
-      completed: "Deletion of project '%{name}' completed"
-      completed_text: "The request to delete project '%{name}' has been completed."
-      completed_text_children: "Additionally, the following subprojects have been deleted:"
-    index:
-      open_as_gantt: "Open as Gantt view"
-      no_results_title_text: There are currently no projects
-      no_results_content_text: Create a new project
-      search:
-        label: Project name filter
-        placeholder: Search by project name
-    lists:
-      active: "Active projects"
-      my: "My projects"
-      favorited: "Favorite projects"
-      archived: "Archived projects"
-      shared: "Shared project lists"
-      my_lists: "My project lists"
-      new:
-        placeholder: "New project list"
-      delete_modal:
-        title: "Delete project list"
-        heading: "Delete this project list?"
-        text: "This action will not delete any project the list contains. Are you sure you want to delete this project list?"
-    settings:
-      header_details: Basic details
-      header_identifier: Identifier
-      header_status: Status
-      header_relations: Project relations
-      button_update_details: Update details
-      button_update_status_description: Update status description
-      button_update_parent_project: Update parent project
-      public_warning: >
-        This project is public.
-        Anyone who has access to this instance will be able to view and interact with this project depending on their role and associated permissions.
-        Sub-projects are not affected and have their own settings.
-      public_confirmation:
-        checkbox: "I understand that this will make the previously private content public"
-        title: "Make this project public?"
-        description: >
-          Anyone who has access to this instance will be able to view and interact with this project depending on their role and authentication settings.
-          Sub-projects are not affected and have their own settings.
-      private_confirmation:
-        checkbox: "I understand that this will make the previously public content private."
-        title: "Make this project private?"
-        description: >
-          The project will only be visible to project members depending on their role and associated permissions.
-          Sub-projects are not affected and have their own settings.
-      change_identifier: Change identifier
-      change_identifier_dialog_title: Change project identifier
-      change_identifier_format_hint_semantic: "Only uppercase letters (A–Z), numbers or underscores. Max 10 characters. Must start with a letter."
-      change_identifier_format_hint_legacy: "Only lowercase letters (a–z), numbers, dashes or underscores."
-      change_identifier_warning: >
-        This will permanently change identifiers and URLs of all work packages in this project.
-        The previous identifiers and URLs will nevertheless continue to work.
-      subitems:
-        template_section: >
-          Select templates to be used when creating new subitems.
-        project_template_label: "Template for projects"
-        project_template_caption: "Select a template project to be used as the default for new subitems of this type."
-        program_template_label: "Template for programs"
-        program_template_caption: "Select a template program to be used as the default for new subitems of this type."
-        no_template: "No predefined template"
-      template:
-        menu_title: "Template"
-        title: "Template settings"
-        enable_failed: "Failed to enable template mode."
-        members:
-          excluded_roles_label: "Roles to exclude when template is applied"
-          excluded_roles_caption: >
-            When creating a new project from this template, the roles selected above will be omitted.
-            This allows you to select which members will be excluded based on their project roles.
-            Users can then access the template for viewing purposes without being granted access to new projects created from it.
-      actions:
-        label_enable_all: "Enable all"
-        label_disable_all: "Disable all"
-      activities:
-        no_results_title_text: There are currently no activities available.
-      forums:
-        no_results_title_text: There are currently no forums for the project.
-        no_results_content_text: Create a new forum
-      categories:
-        no_results_title_text: There are currently no work package categories.
-        no_results_content_text: Create a new work package category
-      custom_fields:
-        no_results_title_text: There are currently no custom fields available.
-      life_cycle:
-        header:
-          title: "Project life cycle"
-          description_html: 'The active project phases define this project''s life cycle and are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a>. Enabled phases will be displayed in your <a href=%{overview_url} target="_blank">project overview</a>.'
-        non_defined: "No phases are currently defined."
-        section_header: "Phases"
-        step:
-          use_in_project: "Use %{step} in this project"
-        filter:
-          label: "Search project phase"
-      project_custom_fields:
-        header:
-          title: "Project attributes"
-          description_html:
-            'These project attributes will be displayed in your <a href=%{overview_url} target="_blank">project overview page</a> under their respective sections. You can enable or disable individual attributes.
-            Project attributes and sections are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a> by the administrator of the instance. '
-        filter:
-          label: "Search project attribute"
-        actions:
-          label_enable_single: "Active in this project, click to disable"
-          label_disable_single: "Inactive in this project, click to enable"
-          remove_from_project: "Remove from project"
-        is_for_all_blank_slate:
-          heading: For all projects
-          description: This project attribute is enabled in all projects since the "For all projects" option is checked. It cannot be deactivated for individual projects.
-        enabled_via_assignee_when_submitted_html: This project attribute cannot be disabled since it is set as <a href=%{pir_submission_url} target="_blank">assignee when submitted</a> for project initiation requests.
-      types:
-        no_results_title_text: There are currently no types available.
-        form:
-          enable_type_in_project: 'Enable type "%{type}"'
-      versions:
-        no_results_title_text: There are currently no versions for the project.
-        no_results_content_text: Create a new version
-        work_packages_graph: Work packages graph
-        show_work_packages: Show work packages
-      storage:
-        no_results_title_text: There is no additional recorded disk space consumed by this project.
-      work_package_priorities:
-        new_label: "New priority"
-      creation_wizard:
-        errors:
-          no_work_package_type: "Failed to enable project initiation request because it requires at least one active work package type and this project has none. Please add at least one work package type to this project."
-          no_status_when_submitted: "Failed to enable project initiation request because work package type %{type} requires at least one status associated with it. Please enable at least one status workflow for this work package type."
-        export:
-          description_attachment_export: "The generated artifact will be saved as a PDF attachment to the artifact work package."
-          description_file_link_export: "The artifact work package will have a file link to a PDF stored in an external file storage. Requires a working file storage with automatically-managed project folders for this project. At the moment only Nextcloud file storages are supported."
-          description_file_storage_selection: "Select which of the configured external file storages should be used."
-          external_file_storage: "External file storage"
-          label_artifact_export: "Artifact export"
-          label_attachment_export: "Save as work package file attachment"
-          label_file_link_export: "Upload file to external file storage and add file link to work package"
-          pdf_file_storage: "PDF file storage"
-          unavailable: "unavailable"
-        label_request_submission: "Request submission"
-        project_attributes_description: >
-          Select which project attributes should be included in the project initiation request.
-          This list only includes [project attributes](project_attributes_url) enabled for for this project.
-        enabled_because_required_html: This project attribute cannot be disabled for this project initiation request since it is defined as required. This can be changed in the <a href=%{admin_settings_url} target="_blank">administration settings</a> by the administrator of the instance.
-    status:
-      button_edit: Edit status
-    wizard:
-      sidebar_content_title: "Content"
-      sections: "Sections"
-      title: "Project initiation request"
-      no_help_text: "This attribute has no help text defined."
-      success: "Project attributes saved and artifact work package created successfully."
-      progress_label: "%{current} of %{total}"
-      create_artifact_work_package_error: "Failed to create artifact work package"
-      create_artifact_storage_error: "Failed to store artifact in file storage"
-  lists:
-    create:
-      success: "The modified list has been saved as a new list"
-      failure: "The modified list cannot be saved: %{errors}"
-    update:
-      success: "The modified list has been saved"
-      failure: "The modified list cannot be saved: %{errors}"
-    publish:
-      success: "The list has been made public"
-      failure: "The list cannot be made public: %{errors}"
-    unpublish:
-      success: "The list has been made private"
-      failure: "The list cannot be made private: %{errors}"
-    can_be_saved: "List modified:"
-    can_be_saved_as: "The modifications can only be saved in a new list:"
-
-  members:
-    index:
-      no_results_title_text: There are currently no members part of this project.
-      no_results_content_text: Add a member to the project
-    invite_by_mail: "Send invite to %{mail}"
-    send_invite_to: "Send invite to"
-    columns:
-      shared: "Shared"
-    filters:
-      all_shares: "All shares"
-    menu:
-      all: "All"
-      invited: "Invited"
-      locked: "Locked"
-      project_roles: "Project roles"
-      wp_shares: "Work package shares"
-      groups: "Groups"
-    delete_member_dialog:
-      title: "Remove member"
-      will_remove_the_users_role: "This will remove the user’s role from this project."
-      will_remove_the_groups_role: "This will remove the group role from this project."
-      however_work_packages_shared_with_user_html:
-        one: "However, %{shared_work_packages_link} has also been shared with this user."
-        other: "However, %{shared_work_packages_link} have also been shared with this user."
-      however_work_packages_shared_with_group_html:
-        one: "However, %{shared_work_packages_link} has also been shared with this group."
-        other: "However, %{shared_work_packages_link} have also been shared with this group."
-      remove_work_packages_shared_with_user_too: "A user that has been removed as member can still access shared work packages. Would you like to remove the shares too?"
-      remove_work_packages_shared_with_group_too: "A group that has been removed as member can still access shared work packages. Would you like to remove the shares too?"
-      will_not_affect_inherited_shares: "(This will not affect work packages shared with their group)."
-      can_remove_direct_but_not_shared_roles: "You can remove this user as a direct project member but a group they are in is also a member of this project, so they will continue being a member via the group."
-      also_work_packages_shared_with_user_html:
-        one: "Also, %{shared_work_packages_link} has been shared with this user."
-        other: "Also, %{shared_work_packages_link} have been shared with this user."
-      remove_project_membership_or_work_package_shares_too: "Do you want to remove just the user as a direct member (and keep the shares) or remove the work package shares too?"
-      will_remove_all_user_access_priveleges: "Deleting this member will remove all access privileges of the user to the project. The user will still exist as part of the instance."
-      will_remove_all_group_access_priveleges: "Deleting this member will remove all access privileges of the group to the project. The group will still exist as part of the instance."
-      cannot_delete_inherited_membership: "You cannot delete this member because they belong to a group that is itself a member of this project."
-      cannot_delete_inherited_membership_note_admin_html: "You can either remove the group as a member of the project or this specific member from the group in the %{administration_settings_link}."
-      cannot_delete_inherited_membership_note_non_admin: "You can either remove the group as a member of the project or contact your administrator to remove this specific member from the group."
-    delete_work_package_shares_dialog:
-      title: "Revoke work package shares"
-      shared_with_this_user_html:
-        one: "%{all_shared_work_packages_link} has been shared with this user."
-        other: "%{all_shared_work_packages_link} have been shared with this user."
-      shared_with_this_group_html:
-        one: "%{all_shared_work_packages_link} has been shared with this group."
-        other: "%{all_shared_work_packages_link} have been shared with this group."
-      shared_with_permission_html:
-        one: "Only %{shared_work_packages_link} has been shared with %{shared_role_name} permissions."
-        other: "Only %{shared_work_packages_link} have been shared with %{shared_role_name} permissions."
-      revoke_all_or_with_role: "Would you like to revoke access to all shared work packages, or only those with %{shared_role_name} permissions?"
-      will_not_affect_inherited_shares: "(This will not affect work packages shared with their group)."
-      cannot_remove_inherited: "The work packages shares shared via groups cannot be removed."
-      cannot_remove_inherited_with_role: "The work packages shares with role %{shared_role_name} are shared via groups and cannot be removed."
-      cannot_remove_inherited_note_admin_html: "You can either revoke the share to the group or remove this specific member from the group in the %{administration_settings_link}."
-      cannot_remove_inherited_note_non_admin: "You can either revoke the share to the group or contact your administrator to remove this specific member from the group."
-      will_revoke_directly_granted_access: "This action will revoke their access to all of them, but the work packages shared with a group."
-      will_revoke_access_to_all: "This action will revoke their access to all of them."
-
-  my:
-    access_token:
-      dialog:
-        token/api:
-          dialog_title: "Create new API token"
-          attention_text: "Treat API tokens like passwords. Anyone with this token will have access to information from this instance, share it only with trusted users."
-          dialog_body: "This token will allow third-party applications to communicate with your instance. To differentiate the new API token, please give it a name."
-          create_button: "Create"
-          name_label: "Token name"
-      created_dialog:
-        one_time_warning: "This is the only time you will see this token. Make sure to copy it now."
-        token/api:
-          title: "The API token has been generated"
-        token/rss:
-          title: "The RSS token has been generated"
-      failed_to_reset_token: "Failed to reset access token: %{error}"
-      failed_to_create_token: "Failed to create access token: %{error}"
-      failed_to_revoke_token: "Failed to revoke access token: %{error}"
-      notice_reset_token: "A new %{type} token has been generated. Your access token is:"
-      token_value_warning: "Note: This is the only time you will see this token, make sure to copy it now."
-      no_results_title_text: "There are currently no access tokens available."
-      notice_api_token_revoked: "The API token has been deleted. To create a new token please use the button in the API section."
-      notice_rss_token_revoked: "The RSS token has been deleted. To create a new token please use the link in the RSS section."
-      notice_ical_token_revoked: 'iCalendar token "%{token_name}" for calendar "%{calendar_name}" of project "%{project_name}" has been revoked. The iCalendar URL with this token is now invalid.'
-    password_confirmation_dialog:
-      confirmation_required: "You need to enter your account password to confirm this change."
-      title: "Confirm your password to continue"
-
-  news:
-    index:
-      no_results_title_text: There is currently no news to report.
-      no_results_content_text: Add a news item
-
-  roles:
-    edit:
-      default_for_new_projects_warning: >-
-        This role is configured as the default role given to non-admin users who create a project.
-        Do not remove the following permissions, otherwise project creators will be unable to complete
-        the setup of their newly created projects:
-    permissions:
-      section_check_all_label: "Assign all %{module} permissions"
-      section_uncheck_all_label: "Unassign all %{module} permissions"
-    report:
-      matrix_caption: "Permissions matrix for %{module} module"
-      matrix_checkbox_label: "Assign %{permission} permission to %{role} role"
-      matrix_check_all_label: "Assign all %{module} permissions to all roles"
-      matrix_uncheck_all_label: "Unassign all %{module} permissions from all roles"
-      matrix_check_uncheck_all_in_row_label_html: "Toggle <em>%{permission}</em> permission for all roles"
-      matrix_check_uncheck_all_in_col_label_html: "Toggle all %{module} permissions for <em>%{role}</em> role"
-
-  users:
-    force_password_change_hint: "The user must set a new password on their next login. Automatically enabled when sending credentials via email."
-    send_information_hint: "Emails the password in plain text. When checked, the user will be required to change their password on first login."
-    autologins:
-      prompt: "Stay logged in for %{num_days}"
-    sessions:
-      session_name: "%{browser_name} %{browser_version} on %{os_name}"
-      browser: "Browser"
-      expires: "Expires"
-      last_connection: "Last connection"
-      device: "Device / OS"
-      unknown_browser: "unknown browser"
-      unknown_os: "unknown operating system"
-      unknown: "(unknown)"
-      browser_session: "(Browser session)"
-      current: "Current (this device)"
-      title: "Session management"
-      instructions: "You are logged in to your account through the following devices. Revoke sessions that you do not recognise or from devices you do not control."
-      may_not_delete_current: "You cannot delete your current session."
-      deletion_warning: "Are you sure you want to revoke this session? You will be logged out on this device."
-    groups:
-      member_in_these_groups: "This user is currently a member of the following groups:"
-      no_results_title_text: This user is currently not a member in any group.
-      summary_with_more_html: Member of %{names} and %{count_link}.
-      more: "%{count} more"
-      summary_html: Member of %{names}.
-    memberships:
-      no_results_title_text: This user is currently not a member of a project.
-    open_profile: "Open profile"
-    invite_user_modal:
-      invite: "Invite"
-      title:
-        invite: "Invite user"
-        invite_to_project: "Invite %{type} to %{project}"
-        invite_principal_to_project: "Invite %{principal} to %{project}"
-      project:
-        label: "Project"
-        required: "Please select a project"
-        next_button: "Next"
-        no_results: "No projects were found"
-        no_invite_rights: "You are not allowed to invite members to this project"
-      type:
-        required: "Please select the type to be invited"
-        user:
-          title: "Invite user to %{project_name}"
-          description: "Permissions based on the assigned role in the selected project"
-        group:
-          title: "Invite group to %{project_name}"
-          description: "Permissions based on the assigned role in the selected project"
-        placeholder_user:
-          title: "Add placeholder user to %{project_name}"
-          title_no_ee: "Placeholder user (Enterprise edition only add-on)"
-          description: "Has no access to the project and no emails are sent out."
-
-        already_member_message: "Already a member of %{project}"
-      principal:
-        no_results_user: "No users were found"
-        invite_user: "Invite:"
-        no_results_placeholder: "No placeholders were found"
-        create_new_placeholder: "Create new placeholder:"
-        no_results_group: "No groups were found"
-        invite_to_project: "Invite to %{project_name}"
-        required:
-          user: "Please select a user"
-          placeholder: "Please select a placeholder"
-          group: "Please select a group"
-
-      role:
-        label: "Role in %{project}"
-        no_roles_found: "No roles were found"
-        description: >
-          This is the role that the user will receive when they join your project. The role defines which actions they are allowed to take and which information they are allowed to see.
-          [Learn more about roles and permissions.](docs_url)
-        required: "Please select a role"
-
-      message:
-        label: "Invitation message"
-        description: "We will send an email to the user, to which you can add a personal message here. An explanation for the invitation could be useful, or perhaps a bit of information regarding the project to help them get started."
-
-      summary:
-        next_button: "Send invitation"
-
-      success_message:
-        user: "The user can now log in to access %{project}. Meanwhile you can already plan with that user and assign work packages for instance."
-        placeholder_user: "The placeholder can now be used in %{project}. Meanwhile you can already plan with that user and assign work packages for instance."
-        group: "The group is now a part of %{project}. Meanwhile you can already plan with that group and assign work packages for instance."
-    working_hours:
-      current_schedule:
-        title: "Current schedule"
-        work_days: "Work days"
-        work_hours: "Work hours"
-        availability_factor: "Availability factor"
-        availability_subtitle: "Dedicated to project work"
-        effective_hours: "Effective work hours"
-        effective_subtitle: "Per week"
-        not_set: "Not set"
-      future:
-        title: "Future schedules"
-        description: "Plan working schedule changes ahead of time. Once the date arrives your working schedules will be updated automatically."
-        add_button: "Add future schedule"
-        blank_title: "No future schedules planned"
-        blank_description: "Create a future schedule to plan changes ahead of time"
-      history:
-        title: "Schedule history"
-        description: "View your past work schedules."
-        blank_title: "No schedule history yet"
-        blank_description: "Past schedule changes will appear here"
-      destroy:
-        confirm: "Are you sure you want to delete this working schedule?"
-      form:
-        title: "Plan a future work schedule"
-        title_current: "Edit current work schedule"
-        start_date: "Start date"
-        start_date_caption: "Select the date from when the new work schedule will be effective."
-        work_days: "Work days"
-        working_hours_label: "Working hours"
-        hours_mode_label: "Hours mode"
-        same_hours_mode: "Same hours per day"
-        individual_hours_mode: "Individual hours per day"
-        work_hours: "Work hours"
-        hours_per_day: "Hours per day"
-        per_day: "per day"
-        per_week: "per week"
-        total_work_hours: "Total work hours"
-        availability_description: "The availability factor represents the actual percentage of your working time dedicated to project tasks. This accounts for meetings, emails, administrative work, and other non-project activities."
-        availability_factor: "Availability factor"
-        availability_factor_caption: "Define the percentage of your working time dedicated to project work."
-        total_available_hours: "Total available work hours"
-        title_availability_factor: "Availability factor"
-        title_days_and_hours: "Days and hours"
-        title_future_dates: "Future dates"
-      table:
-        mobile_title: "Working schedules"
-        start_date: "Start date"
-        work_days: "Work days"
-        work_hours: "Work hours"
-        availability_factor: "Availability factor"
-        effective_work_hours: "Effective work hours"
-        work_days_count:
-          one: "1 working day"
-          other: "%{count} working days"
-  user_preferences:
-    disable_keyboard_shortcuts_caption: >
-      You can choose to disable default [keyboard shortcuts](docs_url) if you use a screen  reader or want to avoid accidentally triggering an action with a shortcut.
-  page:
-    text: "Text"
-  placeholder_users:
-    right_to_manage_members_missing: >
-      You are not allowed to delete the placeholder user.
-      You do not have the right to manage members for all projects that the placeholder user is a member of.
-    delete_tooltip: "Delete placeholder user"
-    deletion_info:
-      heading_html: "Delete placeholder user %{name}"
-      data_consequences: >
-        All occurrences of the placeholder user (e.g., as assignee, responsible or other user values)
-        will be reassigned to an account called "Deleted user".
-
-        As the data of every deleted account is reassigned to this account
-        it will not be possible to distinguish the data the user created from
-        the data of another deleted account.
-      irreversible: "This action is irreversible"
-      confirmation_html: "Enter the placeholder user name %{name} to confirm the deletion."
-  priorities:
-    edit:
-      priority_color_text: |
-        Click to assign or change the color of this priority.
-        It can be used for highlighting work packages in the table.
-    admin:
-      default:
-        caption: Making this priority default will override the previous default priority.
-
-  reactions:
-    action_title: "React"
-    add_reaction: "Add reaction"
-    react_with: "React with %{reaction}"
-    and_user: "and %{user}"
-    and_others:
-      one: and 1 other
-      other: and %{count} others
-    reaction_by: "%{reaction} by"
-
-  reportings:
-    index:
-      no_results_title_text: There are currently no status reportings.
-      no_results_content_text: Add a status reporting
-
-  statuses:
-    edit:
-      status_color_text: |
-        Click to assign or change the color of this status.
-        It is shown in the status button and can be used for highlighting work packages in the table.
-      status_default_text: |-
-        New work packages are by default set to this type. They cannot be read-only.
-      status_excluded_from_totals_text: |-
-        Check this option to exclude work packages with this status from totals of Work,
-        Remaining work, and % Complete in a hierarchy.
-      status_percent_complete_text_html: |-
-        In [status-based progress calculation mode](setting_url), the % Complete of a work
-        package is automatically set to this value when this status is selected.
-        Ignored in work-based mode.
-      status_readonly_html: |
-        Check this option to mark work packages with this status as read-only.
-        No attributes can be changed with the exception of the status.
-        <br>
-        <strong>Note</strong>: Inherited values (e.g., from children or relations) will still apply.
-    index:
-      no_results_title_text: There are currently no work package statuses.
-      no_results_content_text: Add a new status
-      headers:
-        is_default: "Default"
-        is_closed: "Closed"
-        is_readonly: "Read-only"
-        excluded_from_totals: "Excluded from totals"
-
-  themes:
-    dark: "Dark"
-    light: "Light"
-    sync_with_os: "Automatic (match OS color mode)"
-
-  types:
-    index:
-      no_results_title_text: There are currently no types.
-      no_results_content_text: Create a new type
-    edit:
-      form_configuration:
-        tab: "Form configuration"
-        label_group: "Section"
-        reset_to_defaults: "Reset form"
-        add_attribute_group: "Section"
-        add_query_group: "Related work packages table"
-        delete_group: "Delete section"
-        remove_attribute: "Remove from section"
-        drag_to_activate: "Drag fields from here to activate them"
-        drag_to_reorder: "Drag to reorder"
-        edit_query: "Edit query"
-        custom_field: "Custom field"
-        filter_inactive: "Filter attributes"
-        inactive_attributes_heading: "Inactive attributes"
-        no_inactive_attributes: "No inactive attributes"
-        blankslate_title: "No groups yet"
-        blankslate_description: "Add groups using the button above or drag attributes from the left panel."
-        group_actions: "Section actions"
-        rename_group: "Rename section"
-        confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
-        group_name_label: "Section name"
-        row_actions: "Row actions"
-        query_group_label: "Related work packages table"
-        empty_group_hint: "Drag attributes here"
-        invalid_attribute_groups: "The form configuration payload is invalid."
-        invalid_query: "The embedded query configuration is invalid."
-        not_found: "The requested form configuration item could not be found."
-        untitled_group: "Untitled group"
-        reset_title: "Reset form configuration"
-        confirm_reset: "Are you sure you want to reset the form configuration?"
-        builtin_field: "Built-in field"
-        reset_description: >
-          This will reset the attributes to their default group and disable ALL custom fields.
-      projects:
-        tab: Projects
-        enable_all: Enable for all projects
-        select_projects: Select projects
-        select_projects_description: Select the projects in which you would like to use this type.
-      settings:
-        tab: "Settings"
-        type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
-      subject_configuration:
-        tab: "Subject configuration"
-        manually_editable_subjects:
-          label: "Manually editable subjects"
-          caption: "Users can manually enter and edit work package subjects without restrictions."
-        automatically_generated_subjects:
-          label: "Automatically generated subjects"
-          caption: "Define a pattern using referenced attributes and text to automatically generate work package subjects. Users will not be able to manually edit subjects."
-        token:
-          label_with_context: "%{attribute_context}: %{attribute_label}"
-          context:
-            work_package: "Work package"
-            parent: "Parent"
-            project: "Project"
-        pattern:
-          label: "Subject pattern"
-          caption: Create patterns by adding text, or type "/" to search for [supported attributes](attributes_url).
-          insert_as_text: 'No attributes found. Add as text: "%{word}"'
-      export_configuration:
-        tab: "Generate PDF"
-        intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."
-        pdf_export_templates:
-          label: "PDF Export templates"
-          actions:
-            label_enable_all: "Enable all"
-            label_disable_all: "Disable all"
-
-  versions:
-    overview:
-      work_packages_in_archived_projects: "The version is shared with archived projects which still have work packages assigned to this version. These are counted, but will not appear in the linked views."
-      no_results_title_text: There are currently no work packages assigned to this version.
-
-  wiki:
-    page_not_editable_index: The requested page does not (yet) exist. You have been redirected to the index of all wiki pages.
-    no_results_title_text: There are currently no wiki pages.
-    print_hint: This will print the content of this wiki page without any navigation bars.
-
-    index:
-      no_results_content_text: Add a new wiki page
-
-  workflows:
-    copies:
-      form:
-        source_role_id:
-          label: "Source role"
-        target_role_ids:
-          label: "Target roles"
-        target_type_ids:
-          label: "Target types"
-        mode:
-          from_role:
-            label: "Copy to other roles"
-            caption: "Copy the current workflow to one or more roles inside the same work package type. If the selected role already has a workflow the current one will be overwritten."
-          from_type:
-            label: "Copy to another type"
-            caption: "Copy the current workflow to another work packages type. If the selected type already has a workflow the current one will be overwritten. This affects all roles."
-      from_roles:
-        create:
-          notice:
-            one: "Successfully copied workflow to '%{role_name}' role."
-            other: "Successfully copied workflow to %{count} roles."
-      from_types:
-        create:
-          notice:
-            one: "Successfully copied workflow to '%{type_name}' type."
-            other: "Successfully copied workflow to %{count} types."
-      new:
-        title: 'Copy workflow of "%{source_type}"'
-    form:
-      matrix_caption: "Workflow matrix"
-      matrix_caption_assignee: "Workflow matrix for assignee"
-      matrix_caption_author: "Workflow matrix for author"
-      matrix_checkbox_label: "Allow transition from %{old_status} to %{new_status}"
-      matrix_check_all_label: "Allow all transitions"
-      matrix_uncheck_all_label: "Disallow all transitions"
-      matrix_check_uncheck_all_in_row_label_html: "Toggle transitions from <em>%{old_status}</em> to all new statuses"
-      matrix_check_uncheck_all_in_col_label_html: "Toggle transitions from all old statuses to <em>%{new_status}</em>"
-    index:
-      type_filter:
-        label: "Filter by type name…"
-    page_headers:
-      index_component:
-        description: "Configure status transitions for each work package type."
-
-  work_flows:
-    index:
-      no_results_title_text: There are currently no workflows.
-
-  work_packages:
-    delete_dialog:
-      title: "Delete work package"
-      heading: "Permanently delete this work package?"
-      description: 'Are you sure you want to delete the work package "%{name}"?'
-      confirm_descendants_deletion: "I acknowledge that ALL descendants of this work package will be recursively removed."
-      cross_project_warning: "Work packages from the following projects will be deleted: %{projects}"
-    bulk_delete_dialog:
-      title: "Delete %{count} work packages"
-      heading: "Permanently delete these %{count} work packages?"
-      description: "The following work packages and all associated data will be permanently deleted:"
-      description_with_children: "The following work packages, including children and all associated data, will be permanently deleted:"
-      confirm_children_deletion: "I acknowledge that all selected work packages and their children will be permanently deleted."
-      cross_project_warning: "These work packages span multiple projects: %{projects}"
-      children_label: "The following children will also be deleted:"
-    datepicker_modal:
-      banner:
-        description:
-          automatic_mobile: "Start date derived."
-          click_on_show_relations_to_open_gantt: 'Click on "%{button_name}" for Gantt overview.'
-          manual_mobile: "Ignoring relations."
-          manual_gap_between_predecessors: "There is a gap between this and all predecessors."
-          manual_overlap_with_predecessors: "Overlaps with at least one predecessor."
-          manual_with_children: "This has child work packages but their start dates are ignored."
-        title:
-          automatic_mobile: "Automatically scheduled."
-          automatic_with_children: "The dates are determined by child work packages."
-          automatic_with_predecessor: "The start date is set by a predecessor."
-          manual_mobile: "Manually scheduled."
-          manually_scheduled: "Manually scheduled. Dates not affected by relations."
-      blankslate:
-        title: "No predecessors"
-        description: "To enable automatic scheduling, this work package needs to have at least one predecessor. It will then automatically be scheduled to start after the closest predecessor."
-      ignore_non_working_days:
-        title: "Working days only"
-      mode:
-        title: "Scheduling mode"
-        automatic: "Automatic"
-        manual: "Manual"
-      show_relations: "Show relations"
-      update_inputs_aria_live_message: "Date picker updated. %{message}"
-      tabs:
-        aria_label: "Datepicker tabs"
-        children: "Children"
-        dates: "Dates"
-        predecessors: "Predecessors"
-        successors: "Successors"
-        blankslate:
-          predecessors:
-            title: "No predecessors"
-            description: "This work package does not have any predecessors."
-          successors:
-            title: "No successors"
-            description: "This work package does not have any successors."
-          children:
-            title: "No children"
-            description: "This work package does not have any children."
-
-    x_descendants:
-      one: "One descendant work package"
-      other: "%{count} work package descendants"
-
-    bulk:
-      copy_failed: "The work packages could not be copied."
-      move_failed: "The work packages could not be moved."
-      could_not_be_saved: "The following work packages could not be saved:"
-      none_could_be_saved: "None of the %{total} work packages could be updated."
-      x_out_of_y_could_be_saved: "%{failing} out of the %{total} work packages could not be updated while %{success} could."
-      selected_because_descendants: "While %{selected} work packages were selected, in total %{total} work packages are affected which includes descendants."
-      descendant: "descendant of selected"
-
-    move:
-      no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
-      unsupported_for_multiple_projects: "Bulk move/copy is not supported for work packages from multiple projects"
-      current_type_not_available_in_target_project: >
-        The current type of the work package is not enabled in the target project.
-        Please enable the type in the target project if you'd like it to remain unchanged.
-        Otherwise, select an available type in the target project from the list.
-      bulk_current_type_not_available_in_target_project: >
-        The current types of the work packages aren't enabled in the target project.
-        Please enable the types in the target project if you'd like them to remain unchanged.
-        Otherwise, select an available type in the target project from the list.
-    sharing:
-      missing_workflow_warning:
-        title: "Workflow missing for work package sharing"
-        message: "No workflow is configured for the 'Work package editor' role. Without a workflow, the shared with user cannot alter the status of the work package. Workflows can be copied. Select a source type (e.g. 'Task') and source role (e.g. 'Member'). Then select the target types. To start with, you could select all the types as targets. Finally, select the 'Work package editor' role as the target and press 'Copy'. After having thus created the defaults, fine tune the workflows as you do for every other role."
-        link_message: "Configure the workflows in the administration."
-
-    summary:
-      reports:
-        category:
-          no_results_title_text: There are currently no categories available.
-        assigned_to:
-          no_results_title_text: There are currently no members part of this project.
-        responsible:
-          no_results_title_text: There are currently no members part of this project.
-        author:
-          no_results_title_text: There are currently no members part of this project.
-        priority:
-          no_results_title_text: There are currently no priorities available.
-        type:
-          no_results_title_text: There are currently no types available.
-        version:
-          no_results_title_text: There are currently no versions available.
-
-  work_package_relations_tab:
-    index:
-      action_bar_title: "Add relations to other work packages to create a link between them."
-      no_results_title_text: There are currently no relations available.
-      blankslate_heading: "No relations"
-      blankslate_description: "This work package does not have any relations yet."
-    label_add_child_button: "Child"
-    label_add_x: "Add %{x}"
-    label_edit_x: "Edit %{x}"
-    label_add_description: "Add description"
-    lag:
-      subject: "Lag"
-      caption: |-
-        The minimum number of working days to keep in between the two work packages.
-        It can also be negative.
-    relations:
-      label_new_child_created: "New work package created and added as a child"
-      label_relates_singular: "related to"
-      label_relates_plural: "related to"
-      label_relates_to_singular: "related to"
-      label_relates_to_plural: "related to"
-      relates_description: "Creates a visible link between the two work packages with no additional effect"
-      relates_to_description: "Creates a visible link between the two work packages with no additional effect"
-      label_precedes_singular: "successor (after)"
-      label_precedes_plural: "successors (after)"
-      precedes_description: "The related work package necessarily needs to start after this one finishes"
-      label_follows_singular: "predecessor (before)"
-      label_follows_plural: "predecessors (before)"
-      follows_description: "The related work package necessarily needs to finish before this one can start"
-      label_child_singular: "child"
-      label_child_plural: "children"
-      new_child: "Create new child"
-      new_child_description: "Creates a related work package as a sub-item of the current (parent) work package"
-      child: "Child"
-      child_description: "Makes the related work package a sub-item of the current (parent) work package"
-      parent: "Parent"
-      parent_description: "Makes the related work package a parent of the current (child) work package"
-      label_closest: "Closest"
-      label_blocks_singular: "blocks"
-      label_blocks_plural: "blocks"
-      blocks_description: "The related work package cannot be closed until this one is closed first"
-      label_blocked_singular: "blocked by"
-      label_blocked_plural: "blocked by"
-      label_blocked_by_singular: "blocked by"
-      label_blocked__by_plural: "blocked by"
-      blocked_description: "This work package cannot be closed until the related one is closed first"
-      blocked_by_description: "This work package cannot be closed until the related one is closed first"
-      label_duplicates_singular: "duplicates"
-      label_duplicates_plural: "duplicates"
-      duplicates_description: "This is a copy of the related work package"
-      label_duplicated_singular: "duplicated by"
-      label_duplicated_plural: "duplicated by"
-      label_duplicated_by_singular: "duplicated by"
-      label_duplicated_by_plural: "duplicated by"
-      duplicated_by_description: "The related work package is a copy of this"
-      duplicated_description: "The related work package is a copy of this"
-      label_includes_singular: "includes"
-      label_includes_plural: "includes"
-      includes_description: "Marks the related work package as including this one with no additional effect"
-      label_partof_singular: "part of"
-      label_partof_plural: "part of"
-      label_part_of_singular: "part of"
-      label_part_of_plural: "part of"
-      partof_description: "Marks the related work package as being part of this one with no additional effect"
-      part_of_description: "Marks the related work package as being part of this one with no additional effect"
-      label_requires_singular: "requires"
-      label_requires_plural: "requires"
-      requires_description: "Marks the related work package as a requirement to this one"
-      label_required_singular: "required by"
-      label_required_plural: "required by"
-      required_description: "Marks this work package as being a requirement to the related one"
-
-      label_parent_singular: "parent"
-      label_parent_plural: "parent"
-      label_other_relations: "Other relations"
-      ghost_relation_title: "Related work package"
-      ghost_relation_description: "This is not visible to you due to permissions."
-
-  label_invitation: Invitation
   account:
+    auth_source_login_html: Please login as <em>%{login}</em> to activate your account.
     delete: "Delete account"
     delete_confirmation: "Are you sure you want to delete the account?"
-    deletion_pending: "Account has been scheduled for deletion. Note that this process takes place in the background. It might take a few moments until the user is fully deleted."
     deletion_info:
       data_consequences:
         other: "All user-specific data will be deleted. The user's activity in shared views such as work packages and meetings will not be deleted but instead be associated with a generic 'Deleted user' that cannot be linked to the original account."
@@ -1767,6 +40,7 @@ en:
       login_consequences:
         other: "This account will immediately be removed from the system and the user will no longer be able to log in with their credentials."
         self: "Your account will immediately be removed from the system and you will no longer be able to log in using your credentials."
+    deletion_pending: "Account has been scheduled for deletion. Note that this process takes place in the background. It might take a few moments until the user is fully deleted."
     error_inactive_activation_by_mail: >
       Your account has not yet been activated.
       To activate your account, click on the link that was emailed to you.
@@ -1780,10 +54,9 @@ en:
       User registration is limited for the Single sign-on provider '%{name}'. Please ask an administrator to activate the
       account for you or change the self registration limit for this provider.
     login_with_auth_provider: "or sign in with your existing account"
-    signup_with_auth_provider: "or sign up using"
-    auth_source_login_html: Please login as <em>%{login}</em> to activate your account.
     omniauth_login: Please login to activate your account.
 
+    signup_with_auth_provider: "or sign up using"
   actionview_instancetag_blank_option: "Please select"
 
   activemodel:
@@ -1793,18 +66,6 @@ en:
 
   activerecord:
     attributes:
-      work_package_semantic_alias:
-        identifier: "Identifier"
-        work_package: "Work package"
-      jira_import:
-        projects: "Projects"
-      "import/jira":
-        name: "Jira instance name"
-        url: "Jira instance URL"
-        personal_access_token: "Personal access token"
-      "import/jira_open_project_reference":
-        jira: "Jira"
-        jira_import: "Jira Migrator"
       announcements:
         show_until: "Display until"
       attachment:
@@ -1818,92 +79,109 @@ en:
         filesize: "Size"
       attribute_help_text:
         attribute_name: "Attribute"
-        help_text: "Help text"
         caption: "Caption"
+        help_text: "Help text"
       auth_provider:
         scim_clients: "SCIM clients"
       calculated_value_error:
-        error_code: "Error code"
         customized_id: "Customized ID"
         customized_type: "Customized type"
+        error_code: "Error code"
       capability:
         context: "Context"
       changeset:
         repository: "Repository"
       comment:
-        commented: "Commented" # an object that this comment belongs to
+        commented: "Commented"  # an object that this comment belongs to
       custom_action:
         actions: "Actions"
       custom_field:
+        admin_only: "Admin-only"
         allow_non_open_versions: "Allow non-open versions"
+        content_right_to_left: "Right-to-Left content"
         default_value: "Default value"
         editable: "Editable"
         field_format: "Format"
         formula: "Formula"
+        has_comment: "Add a comment text field"
         is_filter: "Used as a filter"
         is_for_all: "For all projects"
         is_required: "Required"
         max_length: "Maximum length"
         min_length: "Minimum length"
-        content_right_to_left: "Right-to-Left content"
         multi_value: "Allow multi-select"
         possible_values: "Possible values"
         regexp: "Regular expression"
         searchable: "Searchable"
-        admin_only: "Admin-only"
-        has_comment: "Add a comment text field"
       custom_value:
         value: "Value"
       design_color:
         variable: "Variable"
       doorkeeper/application:
-        uid: "Client ID"
-        secret: "Client secret"
-        owner: "Owner"
         builtin: "Builtin"
-        enabled: "Active"
-        redirect_uri: "Redirect URI"
         client_credentials_user_id: "Client Credentials User ID"
-        scopes: "Scopes"
         confidential: "Confidential"
+        enabled: "Active"
+        owner: "Owner"
+        redirect_uri: "Redirect URI"
+        scopes: "Scopes"
+        secret: "Client secret"
+        uid: "Client ID"
       emoji_reaction:
         reactable: "Reacted on"
       enterprise_token:
+        active_user_count_restriction: "Active users"
+        encoded_token: "Enterprise support token"
+        plan: "Plan"
         starts_at: "Valid since"
         subscriber: "Subscriber"
         subscription: "Subscription"
-        plan: "Plan"
-        encoded_token: "Enterprise support token"
-        active_user_count_restriction: "Active users"
       enterprise_trial:
         company: "Company"
       favorite:
         favorited: "Item"
       grids/grid:
+        column_count: "Number of columns"
         page: "Page"
         row_count: "Number of rows"
-        column_count: "Number of columns"
         widgets: "Widgets"
+      group:
+        group_users: "Group users"
+        identity_url: "Identity URL"
+        organizational_unit: "Organizational unit"
+        parent: "Parent group"
+      group_detail:
+        organizational_unit: "Organizational unit"
+        parent: "Parent group"
+      "import/jira":
+        name: "Jira instance name"
+        personal_access_token: "Personal access token"
+        url: "Jira instance URL"
+      "import/jira_open_project_reference":
+        jira: "Jira"
+        jira_import: "Jira Migrator"
+      jira_import:
+        projects: "Projects"
       journal:
-        notes: "Notes"
         cause_type: "Cause type"
+        notes: "Notes"
       ldap_auth_source:
         account: "Account"
+        admin: "Administrator"
         attr_firstname: "Firstname attribute"
         attr_lastname: "Lastname attribute"
         attr_login: "Username attribute"
         attr_mail: "Email attribute"
-        filter_string: "Filter string"
-        admin: "Administrator"
         base_dn: "Base DN"
+        filter_string: "Filter string"
         host: "Host"
         onthefly: "Automatic user creation"
         port: "Port"
         tls_certificate_string: "LDAP server SSL certificate"
       mcp_configuration:
+        description: Description
         enabled: Enabled
         title: Title
-        description: Description
       member:
         blocked: "Blocked"
         roles: "Roles"
@@ -1912,101 +190,118 @@ en:
         resource: "Resource"
       oauth_client:
         client: "Client ID"
+      ordered_persisted_query_entity:
+        entity: "Entity"
+        persisted_query: "Persisted query"
+        position: "Position"
+      persisted_query:
+        filters: "Filters"
+        name: "Name"
+        orders: "Orders"
+        selects: "Selects"
+        views: "Views"
+      persisted_view:
+        name: "Name"
+        parent: "Parent view"
+        public: "Public"
+        query: "Query"
       project:
         active_value:
-          true: "unarchived"
           false: "archived"
+          true: "unarchived"
         attribute_groups: "Attribute Groups"
         description: "Description"
         enabled_modules: "Enabled modules"
         identifier: "Identifier"
         latest_activity_at: "Latest activity at"
         parent: "Subproject of"
-        project_creation_wizard_enabled: "Project initiation request"
-        public_value:
-          title: "Visibility"
-          true: "public"
-          false: "private"
-        queries: "Queries"
-        status_code: "Status"
-        status_explanation: "Status description"
-        status_codes:
-          not_started: "Not started"
-          on_track: "On track"
-          at_risk: "At risk"
-          off_track: "Off track"
-          finished: "Finished"
-          discontinued: "Discontinued"
         project_creation_wizard_assignee_custom_field: "Assignee when submitted"
+        project_creation_wizard_enabled: "Project initiation request"
         project_creation_wizard_notification_text: "Notification text"
         project_creation_wizard_send_confirmation_email: "Confirmation email"
         project_creation_wizard_status_when_submitted: "Status when submitted"
         project_creation_wizard_work_package_comment: "Work package comment"
         project_creation_wizard_work_package_type: "Work package type"
+        public_value:
+          false: "private"
+          title: "Visibility"
+          true: "public"
+        queries: "Queries"
+        status_code: "Status"
+        status_codes:
+          at_risk: "At risk"
+          discontinued: "Discontinued"
+          finished: "Finished"
+          not_started: "Not started"
+          off_track: "Off track"
+          on_track: "On track"
+        status_explanation: "Status description"
         template: "Template"
         templated: "Template project"
         templated_value:
-          true: "marked as template"
           false: "unmarked as template"
+          true: "marked as template"
         types: "Types"
         versions: "Versions"
         work_packages: "Work Packages"
-        workspace_type: "Workspace type"
-      project_custom_field:
-        custom_field_section: Section
-      subproject_template_assignment:
         workspace_type: "Workspace type"
       project/phase:
         date_range: "Date range"
         definition: "Definition"
         duration: "Duration"
+        finish_date: "Finish date"
         start_date: "Start date"
         start_date_caption: "Follows the previous phase."
-        finish_date: "Finish date"
       project/phase_definition:
-        name: "Name"
         color: "Color"
-        start_gate: "Start phase gate"
-        start_gate_name: "Start phase gate name"
         finish_gate: "Finish phase gate"
         finish_gate_name: "Finish phase gate name"
+        name: "Name"
+        start_gate: "Start phase gate"
+        start_gate_name: "Start phase gate name"
+      project_custom_field:
+        custom_field_section: Section
       query:
-        sums: "Sums"
-        columns: "Columns"
-        column_names: "Columns"
-        relations_to_type_column: "Relations to %{type}"
-        relations_of_type_column: "%{type} relations"
         child_work_packages: "Child work packages"
-        group_by: "Group results by"
-        sort_by: "Sort results by"
+        column_names: "Columns"
+        columns: "Columns"
+        display_representation: "Display mode"
         filters: "Filters"
+        group_by: "Group results by"
+        hidden: "Hidden"
+        highlighted_attributes: "Highlighted attributes"
+        highlighting_mode: "Highlight mode"
+        include_subprojects: "Include subprojects"
+        manual_sorting: "Manual sort order"
+        ordered_work_packages: "Work packages order"
+        relations_of_type_column: "%{type} relations"
+        relations_to_type_column: "Relations to %{type}"
+        results: "Results"
+        show_hierarchies: "Display mode"
+        sort_by: "Sort results by"
+        sort_criteria: "Sort criteria"
+        starred: "Favorite"
+        sums: "Sums"
         timeline_labels: "Timeline labels"
         timeline_visible: "Show Gantt chart"
         timeline_zoom_level: "Gantt chart zoom level"
         timestamps: "Baseline timestamps"
-        sort_criteria: "Sort criteria"
-        highlighted_attributes: "Highlighted attributes"
-        highlighting_mode: "Highlight mode"
-        display_representation: "Display mode"
-        show_hierarchies: "Display mode"
-        starred: "Favorite"
-        hidden: "Hidden"
-        manual_sorting: "Manual sort order"
-        ordered_work_packages: "Work packages order"
-        include_subprojects: "Include subprojects"
-        results: "Results"
       relation:
-        lag: "Lag"
         from: "Related work package"
-        to: "Related work package"
+        lag: "Lag"
         relation_type: "Relation type"
+        to: "Related work package"
       reminder:
-        remindable: "Reminded object"
         remind_at: "Remind at"
         remind_at_date: "Date"
         remind_at_time: "Time"
+        remindable: "Reminded object"
       reminder_notification:
         notification: "Notification"
+      remote_identity:
+        auth_source: "Auth Source"
+        integration: "Integration"
+        user: "User"
       repository:
         url: "URL"
       role:
@@ -2015,107 +310,106 @@ en:
         authentication_method: "Authentication method"
         jwt_sub: "Subject claim"
       status:
+        default_done_ratio: "% Complete"
+        excluded_from_totals: "Exclude from calculation of totals in hierarchy"
         is_closed: "Work package closed"
         is_readonly: "Work package read-only"
-        excluded_from_totals: "Exclude from calculation of totals in hierarchy"
-        default_done_ratio: "% Complete"
-      token/named:
-        token_name: "Token name"
-      token/ical:
-        calendar: "Calendar"
-        ical_token_query_assignment: "Query assignment"
+      subproject_template_assignment:
+        workspace_type: "Workspace type"
       time_entry:
         activity: "Activity"
         hours: "Hours"
+        ongoing: "Ongoing"
         spent_on: "Date"
         type: "Type"
-        ongoing: "Ongoing"
+      token/ical:
+        calendar: "Calendar"
+        ical_token_query_assignment: "Query assignment"
+      token/named:
+        token_name: "Token name"
       type:
-        description: "Default text for description"
         attribute_groups: "Form configuration"
-        is_in_roadmap: "Displayed in roadmap by default"
-        is_default: "Activated for new projects by default"
-        is_milestone: "Is milestone"
         color: "Color"
+        description: "Default text for description"
+        is_default: "Activated for new projects by default"
+        is_in_roadmap: "Displayed in roadmap by default"
+        is_milestone: "Is milestone"
         patterns: "Patterns"
-      remote_identity:
-        auth_source: "Auth Source"
-        integration: "Integration"
-        user: "User"
       user:
         admin: "Administrator"
         auth_source: "Authentication source"
-        ldap_auth_source: "LDAP connection"
-        identity_url: "Identity URL"
+        consented_at: "Consented at"
         current_password: "Current password"
+        failed_login_count: "Failed login attempts"
+        first_login: "First login"
+        first_name: "First name"
         force_password_change: "Enforce password change on next login"
+        identity_url: "Identity URL"
         language: "Language"
         last_login_on: "Last login"
-        failed_login_count: "Failed login attempts"
-        first_name: "First name"
         last_name: "Last name"
-        first_login: "First login"
+        ldap_auth_source: "LDAP connection"
         new_password: "New password"
         password_confirmation: "Confirmation"
-        consented_at: "Consented at"
-      group:
-        identity_url: "Identity URL"
-        parent: "Parent group"
-        organizational_unit: "Organizational unit"
-        group_users: "Group users"
-      group_detail:
-        parent: "Parent group"
-        organizational_unit: "Organizational unit"
+      user_card_view:
+        card_size: "Card size"
+        columns_per_row: "Columns per row"
+
+        secondary_info: "Secondary info"
+        show_email: "Show email"
+        show_status_badge: "Show status badge"
+        tag_limit: "Tag limit"
+        tag_source: "Tag source"
+      user_non_working_time:
+        end_date: "End date"
+        start_date: "Start date"
       user_preference:
-        header_look_and_feel: "Look and feel"
-        header_alerts: "Alerts"
-        button_update_look_and_feel: "Update look and feel"
-        button_update_alerts: "Update alerts"
-        button_update_user_information: "Update profile"
-        comments_sorting: "Display work package activity sorted by"
-        disable_keyboard_shortcuts: "Disable keyboard shortcuts"
-        dismissed_enterprise_banners: "Hidden enterprise banners"
-        impaired: "Accessibility mode"
         auto_hide_popups: "Automatically hide success banners"
         auto_hide_popups_caption: "When enabled, the green success banners will automatically disappear after 5 seconds."
-        warn_on_leaving_unsaved: "Warn me when leaving a work package with unsaved changes"
-        increase_theme_contrast: "Increase theme contrast"
+        button_update_alerts: "Update alerts"
+        button_update_look_and_feel: "Update look and feel"
+        button_update_user_information: "Update profile"
+        comments_sorting: "Display work package activity sorted by"
+        daily_reminders: "Daily reminders"
+        disable_keyboard_shortcuts: "Disable keyboard shortcuts"
+        dismissed_enterprise_banners: "Hidden enterprise banners"
+        force_dark_theme_contrast: "Force high-contrast when in Dark mode"
+        force_dark_theme_contrast_caption: "Uses the high-contrast version of Dark mode when automatic color mode is selected."
+        force_light_theme_contrast: "Force high-contrast when in Light mode"
+        force_light_theme_contrast_caption: "Uses the high-contrast version of Light mode when automatic color mode is selected."
+        header_alerts: "Alerts"
+        header_look_and_feel: "Look and feel"
+        impaired: "Accessibility mode"
         increase_contrast: "Increase contrast"
         increase_contrast_caption: "Enables high-contrast mode for the chosen colour mode."
-        force_light_theme_contrast: "Force high-contrast when in Light mode"
-        force_dark_theme_contrast: "Force high-contrast when in Dark mode"
-        force_light_theme_contrast_caption: "Uses the high-contrast version of Light mode when automatic color mode is selected."
-        force_dark_theme_contrast_caption: "Uses the high-contrast version of Dark mode when automatic color mode is selected."
+        increase_theme_contrast: "Increase theme contrast"
+        mode_guideline: "Some modes will overwrite custom theme colors for accessibility and legibility. Please select Light mode for full custom theme support."
         theme: "Color mode"
         time_zone: "Time zone"
-        mode_guideline: "Some modes will overwrite custom theme colors for accessibility and legibility. Please select Light mode for full custom theme support."
-        daily_reminders: "Daily reminders"
+        warn_on_leaving_unsaved: "Warn me when leaving a work package with unsaved changes"
         workdays: "Working days"
-      users/invitation/form_model:
-        principal_type: "Invitation type"
-        id_or_email: "Name or email address"
-      user_non_working_time:
-        start_date: "Start date"
-        end_date: "End date"
       user_working_hours:
-        valid_from: "Valid from"
-        monday: "Monday"
-        monday_hours: "Monday hours"
-        tuesday: "Tuesday"
-        tuesday_hours: "Tuesday hours"
-        wednesday: "Wednesday"
-        wednesday_hours: "Wednesday hours"
-        thursday: "Thursday"
-        thursday_hours: "Thursday hours"
+        availability_factor: "Availability factor"
+        days: "Working days"
         friday: "Friday"
         friday_hours: "Friday hours"
+        monday: "Monday"
+        monday_hours: "Monday hours"
         saturday: "Saturday"
         saturday_hours: "Saturday hours"
+        shared_hours: "Work hours"
         sunday: "Sunday"
         sunday_hours: "Sunday hours"
-        availability_factor: "Availability factor"
-        shared_hours: "Work hours"
-        days: "Working days"
+        thursday: "Thursday"
+        thursday_hours: "Thursday hours"
+        tuesday: "Tuesday"
+        tuesday_hours: "Tuesday hours"
+        valid_from: "Valid from"
+        wednesday: "Wednesday"
+        wednesday_hours: "Wednesday hours"
+      users/invitation/form_model:
+        id_or_email: "Name or email address"
+        principal_type: "Invitation type"
       version:
         effective_date: "Finish date"
         sharing: "Sharing"
@@ -2126,25 +420,25 @@ en:
         redirect_existing_links: "Redirect existing links"
         text: "Page content"
       work_package:
-        ancestor: "Descendants of" # used for filtering of work packages that are descendants of a given work package
-        begin_insertion: "Begin of the insertion"
+        ancestor: "Descendants of"  # used for filtering of work packages that are descendants of a given work package
         begin_deletion: "Begin of the deletion"
+        begin_insertion: "Begin of the insertion"
         children: "Subelements"
         derived_done_ratio: "Total % complete"
         derived_remaining_hours: "Total remaining work"
         derived_remaining_time: "Total remaining work"
         done_ratio: "% Complete"
         duration: "Duration"
-        end_insertion: "End of the insertion"
         end_deletion: "End of the deletion"
+        end_insertion: "End of the insertion"
         identifier: "Identifier"
         ignore_non_working_days: "Ignore non working days"
         include_non_working_days:
-          title: "Working days"
           false: "working days only"
+          title: "Working days"
           true: "include non-working days"
         journal_internal: Internal Journal
-        notify: "Notify" # used in custom actions
+        notify: "Notify"  # used in custom actions
         parent: "Parent"
         parent_issue: "Parent"
         parent_work_package: "Parent"
@@ -2154,9 +448,9 @@ en:
         relatable: "Relatable to"
         remaining_hours: "Remaining work"
         remaining_time: "Remaining work"
+        schedule_manually: "Manual scheduling"
         sequence_number: "Sequence number"
         shared_with_users: "Shared with"
-        schedule_manually: "Manual scheduling"
         spent_hours: "Spent time"
         spent_time: "Spent time"
         subproject: "Subproject"
@@ -2164,36 +458,15 @@ en:
         type: "Type"
         version: "Version"
         watcher: "Watcher"
-      ordered_persisted_query_entity:
-        persisted_query: "Persisted query"
-        entity: "Entity"
-        position: "Position"
-      persisted_query:
-        name: "Name"
-        views: "Views"
-        filters: "Filters"
-        orders: "Orders"
-        selects: "Selects"
-      persisted_view:
-        name: "Name"
-        query: "Query"
-        parent: "Parent view"
-        public: "Public"
-      user_card_view:
-        secondary_info: "Secondary info"
-        show_status_badge: "Show status badge"
-        show_email: "Show email"
-        tag_source: "Tag source"
-        tag_limit: "Tag limit"
-        card_size: "Card size"
-        columns_per_row: "Columns per row"
-
+      work_package_semantic_alias:
+        identifier: "Identifier"
+        work_package: "Work package"
     errors:
       messages:
         accepted: "must be accepted."
         after: "must be after %{date}."
-        after_today: "must be in the future."
         after_or_equal_to: "must be after or equal to %{date}."
+        after_today: "must be in the future."
         before: "must be before %{date}."
         before_or_equal_to: "must be before or equal to %{date}."
         blank: "can't be blank."
@@ -2205,14 +478,14 @@ en:
         could_not_be_copied: "%{dependency} could not be (fully) copied."
         datetime_must_be_in_future: "must be in the future."
         does_not_exist: "does not exist."
-        error_enterprise_only: "%{action} is only available in the OpenProject Enterprise edition."
-        error_unauthorized: "may not be accessed."
-        error_readonly: "was attempted to be written but is not writable."
-        error_conflict: "Information has been updated by at least one other user in the meantime."
-        error_not_found: "not found."
         email: "is not a valid email address."
         empty: "can't be empty."
         enterprise_plan_required: "requires at least the %{plan_name}."
+        error_conflict: "Information has been updated by at least one other user in the meantime."
+        error_enterprise_only: "%{action} is only available in the OpenProject Enterprise edition."
+        error_not_found: "not found."
+        error_readonly: "was attempted to be written but is not writable."
+        error_unauthorized: "may not be accessed."
         even: "must be even."
         exclusion: "is reserved."
         feature_disabled: is not available.
@@ -2234,26 +507,26 @@ en:
         invalid_url_scheme: "is not a supported protocol (allowed: %{allowed_schemes})."
         is_for_all_cannot_modify: "is for all projects and can therefore not be modified."
         less_than_or_equal_to: "must be less than or equal to %{count}."
-        not_available: "is not available due to a system configuration."
-        not_before_start_date: "must not be before the start date."
-        not_deletable: "cannot be deleted."
-        not_editable: "cannot be edited because it is already in effect."
-        not_current_user: "is not the current user."
-        not_found: "not found."
         not_a_date: "is not a valid date."
         not_a_datetime: "is not a valid date time."
         not_a_number: "is not a number."
         not_allowed: "is invalid because of missing permissions."
-        not_json: "is not parseable as JSON."
-        not_json_object: "is not a JSON object."
         not_an_integer: "is not an integer."
         not_an_iso_date: "is not a valid date. Required format: YYYY-MM-DD."
+        not_available: "is not available due to a system configuration."
+        not_before_start_date: "must not be before the start date."
+        not_current_user: "is not the current user."
+        not_deletable: "cannot be deleted."
+        not_editable: "cannot be edited because it is already in effect."
+        not_found: "not found."
+        not_json: "is not parseable as JSON."
+        not_json_object: "is not a JSON object."
         not_same_project: "doesn't belong to the same project."
         odd: "must be odd."
         overlapping_range: "overlaps with an existing non-working day range."
-        regex_match_failed: "does not match the regular expression %{expression}."
         regex_invalid: "could not be validated with the associated regular expression."
         regex_list_invalid: "Lines %{invalid_lines} could not be parsed as regular expression."
+        regex_match_failed: "does not match the regular expression %{expression}."
         smaller_than_or_equal_to_max_length: "must be smaller than or equal to maximum length."
         ssrf_filtered: "violates the SSRF policy of this OpenProject instance."
         system_wide_non_working_day_exists: "conflicts with an existing system-wide non-working day for this date."
@@ -2271,199 +544,210 @@ en:
         user_already_in_department: "User %{user_id} is already a member of department %{department_id}."
         wrong_length: "is the wrong length (should be %{count} characters)."
       models:
-        group:
-          attributes:
-            parent_id:
-              circular_dependency: "would create a circular group hierarchy."
-              organizational_unit_mismatch: "must have the same organizational unit setting as the group."
-        ldap_auth_source:
-          attributes:
-            tls_certificate_string:
-              invalid_certificate: "The provided SSL certificate is invalid: %{additional_message}"
-              format: "%{message}"
         attachment:
           attributes:
             content_type:
               blank: "The content type of the file cannot be blank."
-              not_allowlisted: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
               format: "%{message}"
+              not_allowlisted: "The file was rejected by an automatic filter. '%{value}' is not allowed for upload."
         capability:
           context:
             global: "Global"
           query:
             filters:
               minimum: "need to include at least one filter for principal, context or id with the '=' operator."
+        custom_actions:
+          empty: "(%{name}) value can't be empty."
+          format: "%{message}"
+          greater_than_or_equal_to: "(%{name}) must be greater than or equal to %{count}."
+          inclusion: "(%{name}) value is not set to one of the allowed values."
+          not_an_integer: "(%{name}) is not an integer."
+          not_logged_in: "(%{name}) value cannot be set because you are not logged in."
+          only_one_allowed: "(%{name}) only one value is allowed."
+          smaller_than_or_equal_to: "(%{name}) must be smaller than or equal to %{count}."
         custom_field:
           at_least_one_custom_option: "At least one option needs to be available."
+          attributes:
+            formula:
+              blank: "Formula can't be blank."
+              format: "%{message}"
+              invalid: "Formula is invalid."
+              invalid_characters: "Only numeric values, mathematical operators and project attributes of type integer, float, calculated value and weighted list are allowed."
+              not_allowed_custom_fields_referenced: "The attribute %{custom_fields} cannot be used because it leads to a circular reference; one attribute depends on the other."
+            required:
+              cannot_be_true: "cannot be set to true."
           previous_custom_field_recalculation_unprocessed: "The recalculation of previous changes for this custom field have not been applied yet, please try again in a few minutes."
           referenced_in_other_fields_html:
             one: "%{name} is used in project attribute calculation %{links}."
             other: "%{name} is used in project attribute calculations: %{links}."
-          attributes:
-            formula:
-              blank: "Formula can't be blank."
-              invalid: "Formula is invalid."
-              invalid_characters: "Only numeric values, mathematical operators and project attributes of type integer, float, calculated value and weighted list are allowed."
-              not_allowed_custom_fields_referenced: "The attribute %{custom_fields} cannot be used because it leads to a circular reference; one attribute depends on the other."
-              format: "%{message}"
-            required:
-              cannot_be_true: "cannot be set to true."
         custom_fields_project:
           attributes:
             project_ids:
               blank: "Please select a project."
-        custom_actions:
-          only_one_allowed: "(%{name}) only one value is allowed."
-          empty: "(%{name}) value can't be empty."
-          inclusion: "(%{name}) value is not set to one of the allowed values."
-          not_logged_in: "(%{name}) value cannot be set because you are not logged in."
-          not_an_integer: "(%{name}) is not an integer."
-          smaller_than_or_equal_to: "(%{name}) must be smaller than or equal to %{count}."
-          greater_than_or_equal_to: "(%{name}) must be greater than or equal to %{count}."
-          format: "%{message}"
         doorkeeper/application:
           attributes:
             redirect_uri:
+              forbidden_uri: "is forbidden by the server."
               fragment_present: "cannot contain a fragment."
               invalid_uri: "must be a valid URI."
               relative_uri: "must be an absolute URI."
               secured_uri: 'is not providing a "Secure Context". Either use HTTPS or a loopback address, such as localhost.'
-              forbidden_uri: "is forbidden by the server."
             scopes:
               not_match_configured: "doesn't match available scopes."
+        enterprise_token:
+          already_added: "This token has already been added."
+          only_one_trial: "Only one trial token can be active. Please delete the previous trial token before adding another."
+          unreadable: "can't be read. Are you sure it is a support token?"
         enterprise_trial:
           already_used: "was already used to create a trial."
           failed_to_create: "Trial could not be created (%{status})"
           general_consent: "Please accept the terms and conditions."
-        enterprise_token:
-          only_one_trial: "Only one trial token can be active. Please delete the previous trial token before adding another."
-          unreadable: "can't be read. Are you sure it is a support token?"
-          already_added: "This token has already been added."
         favorite:
           already_favorited: "has already been favorited."
         grids/grid:
-          overlaps: "overlap."
-          outside: "is outside of the grid."
           end_before_start: "end value needs to be larger than the start value."
+          outside: "is outside of the grid."
+          overlaps: "overlap."
+        group:
+          attributes:
+            parent_id:
+              circular_dependency: "would create a circular group hierarchy."
+              organizational_unit_mismatch: "must have the same organizational unit setting as the group."
         ical_token_query_assignment:
           attributes:
             name:
               blank: "is mandatory. Please select a name."
               not_unique: "is already in use. Please select another name."
+        jira:
+          invalid_protocol: "Please provide a valid protocol (http or https)"
+        ldap_auth_source:
+          attributes:
+            tls_certificate_string:
+              format: "%{message}"
+              invalid_certificate: "The provided SSL certificate is invalid: %{additional_message}"
         meeting:
           error_conflict: "Unable to save because the meeting was updated by someone else in the meantime. Please reload the page."
+        member:
+          attributes:
+            principal:
+              unassignable: "cannot be assigned to a project."
+            roles:
+              more_than_one: "has more than one role."
+              ungrantable: "has an unassignable role."
+          principal_blank: "Please choose at least one user or group."
+          role_blank: "need to be assigned."
         message:
           cannot_move_message_to_forum_of_different_project: "A message cannot be moved to a forum of a different project."
+        non_working_day:
+          attributes:
+            date:
+              format: "%{message}"
+              taken: "A non-working day already exists for %{value}."
         notifications:
           at_least_one_channel: "At least one channel for sending notifications needs to be specified."
           attributes:
-            read_ian:
-              read_on_creation: "cannot be set to true on notification creation."
             mail_reminder_sent:
               set_on_creation: "cannot be set to true on notification creation."
+            read_ian:
+              read_on_creation: "cannot be set to true on notification creation."
             reason:
               no_notification_reason: "cannot be blank as IAN is chosen as a channel."
             reason_mail_digest:
               no_notification_reason: "cannot be blank as mail digest is chosen as a channel."
-        non_working_day:
-          attributes:
-            date:
-              taken: "A non-working day already exists for %{value}."
-              format: "%{message}"
         parse_schema_filter_params_service:
           attributes:
             base:
-              unsupported_operator: "The operator is not supported."
-              invalid_values: "A value is invalid."
               id_filter_required: "An 'id' filter is required."
+              invalid_values: "A value is invalid."
+              unsupported_operator: "The operator is not supported."
         project:
           archived_ancestor: "The project has an archived ancestor."
-          foreign_wps_reference_version: "Work packages in non descendant projects reference versions of the project or its descendants."
-          cannot_be_assigned_to_artifact_work_package: "The chosen user is not allowed to be assigned to work packages."
           attributes:
             base:
               archive_permission_missing_on_subprojects: "You do not have the permissions required to archive all sub-projects. Please contact an administrator."
               project_initiation_request_disabled: "Project initiation request is disabled. It must be enabled to create the artifact work package."
-            types:
-              in_use_by_work_packages: "still in use by work packages: %{types}"
-            identifier:
-              must_start_with_letter: "must start with a letter"
-              no_special_characters: "may only contain uppercase letters, numbers, and underscores"
             enabled_modules:
               dependency_missing: "The module '%{dependency}' needs to be enabled as well since the module '%{module}' depends on it."
               format: "%{message}"
+            identifier:
+              must_start_with_letter: "must start with a letter"
+              no_special_characters: "may only contain uppercase letters, numbers, and underscores"
+            types:
+              in_use_by_work_packages: "still in use by work packages: %{types}"
+          cannot_be_assigned_to_artifact_work_package: "The chosen user is not allowed to be assigned to work packages."
+          foreign_wps_reference_version: "Work packages in non descendant projects reference versions of the project or its descendants."
+        project/phase:
+          attributes:
+            finish_date:
+              must_be_after_start_date: "must be after the start date."
+            start_date:
+              must_be_before_finish_date: "must be before the finish date."
+              non_continuous_dates: "can't be earlier than the previous phase's end date."
+          cannot_be_a_non_working_day: "can't be a non-working day."
         project_custom_field_project_mapping:
           attributes:
             project_ids:
               blank: "Please select a project."
-        project/phase:
-          attributes:
-            start_date:
-              must_be_before_finish_date: "must be before the finish date."
-              non_continuous_dates: "can't be earlier than the previous phase's end date."
-            finish_date:
-              must_be_after_start_date: "must be after the start date."
-          cannot_be_a_non_working_day: "can't be a non-working day."
-        query:
-          attributes:
-            public:
-              error_unauthorized: "- The user has no permission to create public views."
-            group_by:
-              invalid: "Can't group by: %{value}"
-              format: "%{message}"
-            column_names:
-              invalid: "Invalid query column: %{value}"
-              format: "%{message}"
-            sort_criteria:
-              invalid: "Can't sort by column: %{value}"
-              format: "%{message}"
-            timestamps:
-              invalid: "Timestamps contain invalid values: %{values}"
-              forbidden: "Timestamps contain forbidden values: %{values}"
-              format: "%{message}"
-            selects:
-              name_not_included: "The 'Name' column needs to be included"
-              nonexistent: "The column '%{column}' does not exist."
-              format: "%{message}"
-          group_by_hierarchies_exclusive: "is mutually exclusive with group by '%{group_by}'. You cannot activate both."
-          can_only_be_modified_by_owner: "The query can only be modified by its owner."
-          need_permission_to_modify_public_query: "You cannot modify a public query."
-          filters:
-            custom_fields:
-              inexistent: "There is no custom field for the filter."
         queries/filters/base:
           attributes:
             values:
-              inclusion: "filter has invalid values."
               format: "%{message}"
+              inclusion: "filter has invalid values."
         queries/principals/filters/internal_mentionable_on_work_package_filter:
           attributes:
             values:
               single_value_requirement: "must be a single work package"
+        query:
+          attributes:
+            column_names:
+              format: "%{message}"
+              invalid: "Invalid query column: %{value}"
+            group_by:
+              format: "%{message}"
+              invalid: "Can't group by: %{value}"
+            public:
+              error_unauthorized: "- The user has no permission to create public views."
+            selects:
+              format: "%{message}"
+              name_not_included: "The 'Name' column needs to be included"
+              nonexistent: "The column '%{column}' does not exist."
+            sort_criteria:
+              format: "%{message}"
+              invalid: "Can't sort by column: %{value}"
+            timestamps:
+              forbidden: "Timestamps contain forbidden values: %{values}"
+              format: "%{message}"
+              invalid: "Timestamps contain invalid values: %{values}"
+          can_only_be_modified_by_owner: "The query can only be modified by its owner."
+          filters:
+            custom_fields:
+              inexistent: "There is no custom field for the filter."
+          group_by_hierarchies_exclusive: "is mutually exclusive with group by '%{group_by}'. You cannot activate both."
+          need_permission_to_modify_public_query: "You cannot modify a public query."
         relation:
-          typed_dag:
-            circular_dependency: "The relationship creates a circle of relationships."
           attributes:
             base:
               error_not_deletable: "This relation cannot be deleted because you do not have edit permissions for the selected work package."
               error_not_editable: "This relation cannot be edited because you do not have edit permissions for the selected work package."
-            to_id:
-              format: "The selected work package %{message}"
-              error_not_found: "could not be found."
-              error_readonly: "cannot be changed for existing relations."
-              error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
             from_id:
-              format: "The selected work package %{message}"
               error_not_found: "could not be found."
-              error_readonly: "cannot be changed for existing relations."
               error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
+              error_readonly: "cannot be changed for existing relations."
+              format: "The selected work package %{message}"
+            to_id:
+              error_not_found: "could not be found."
+              error_not_manageable: "cannot be added because you do not have edit permissions for the selected work package."
+              error_readonly: "cannot be changed for existing relations."
+              format: "The selected work package %{message}"
+          typed_dag:
+            circular_dependency: "The relationship creates a circle of relationships."
         repository:
-          not_available: "SCM vendor is not available"
-          not_whitelisted: "is not allowed by the configuration."
           invalid_url: "is not a valid repository URL or path."
           must_not_be_ssh: "must not be an SSH url."
           must_not_point_to_openproject_directory: "must not point to an OpenProject-managed repository directory."
           no_directory: "is not a directory."
+          not_available: "SCM vendor is not available"
+          not_whitelisted: "is not allowed by the configuration."
         role:
           attributes:
             permissions:
@@ -2471,11 +755,11 @@ en:
         setting:
           attributes:
             base:
-              working_days_are_missing: "At least one day of the week must be defined as a working day."
-              previous_working_day_changes_unprocessed: "The previous changes to the working days configuration have not been applied yet."
-              hours_per_day_are_missing: "The number of hours per day must be defined."
               durations_are_not_positive_numbers: "The durations must be positive numbers."
+              hours_per_day_are_missing: "The number of hours per day must be defined."
               hours_per_day_is_out_of_bounds: "Hours per day can't be more than 24"
+              previous_working_day_changes_unprocessed: "The previous changes to the working days configuration have not been applied yet."
+              working_days_are_missing: "At least one day of the week must be defined as a working day."
         status:
           attributes:
             default_done_ratio:
@@ -2485,144 +769,132 @@ en:
           attributes:
             hours:
               day_limit: "is too high as a maximum of 24 hours can be logged per date."
-        user_preference:
+        token/named:
           attributes:
-            pause_reminders:
-              invalid_range: "can only be a valid date range."
-            daily_reminders:
-              full_hour: "can only be configured to be delivered at a full hour."
-            notification_settings:
-              only_one_global_setting: "There must only be one global notification setting."
-              email_alerts_global: "The email notification settings can only be set globally."
+            token_name:
+              blank: "Please provide a token name"
               format: "%{message}"
-              wrong_date: "Wrong value for Start date, Due date, or Overdue."
-        watcher:
-          attributes:
-            user_id:
-              not_allowed_to_view: "is not allowed to view this resource."
-              locked: "is locked."
-        wiki_page:
-          error_conflict: "The wiki page has been updated by someone else while you were editing it."
-          attributes:
-            slug:
-              undeducible: "cannot be deduced from the title '%{title}'."
-        work_package:
-          is_not_a_valid_target_for_time_entries: "Work package #%{id} is not a valid target for reassigning the time entries."
-          attributes:
-            id:
-              format: "%{message}"
-              cannot_add_child_because_of_lack_of_permission: "Cannot add child because you don't have permissions to edit the selected work package."
-              blank: "ID can't be blank."
-            identifier:
-              semantic_identifier_incomplete: "and sequence_number must both be set at the same time."
-            assigned_to:
-              format: "%{message}"
-            done_ratio:
-              does_not_match_work_and_remaining_work: "does not match Work and Remaining work"
-              cannot_be_set_when_work_is_zero: "cannot be set when Work is 0h"
-              must_be_set_when_remaining_work_is_set: "required when Remaining work is set."
-              must_be_set_when_work_and_remaining_work_are_set: "required when Work and Remaining work are set."
-              inclusion: "must be between 0 and 100."
-            due_date:
-              not_start_date: "is not on start date, although this is required for milestones."
-              cannot_be_null: "can not be set to null as start date and duration are known."
-            duration:
-              larger_than_dates: "is larger than the interval between the start and the finish date."
-              smaller_than_dates: "is smaller than the interval between the start and the finish date."
-              not_available_for_milestones: "is not available for milestone typed work packages."
-              cannot_be_null: "can not be set to null as start date and finish date are known."
-              not_an_integer: "is not a valid duration."
-            parent:
-              cannot_be_milestone: "cannot be a milestone."
-              cannot_be_self_assigned: "cannot be assigned to itself."
-              cannot_be_in_another_project: "cannot be in another project."
-              not_a_valid_parent: "is invalid."
-            schedule_manually:
-              cannot_be_automatically_scheduled: "cannot be set to false (automatically scheduled) as it has no predecessors or children."
-            start_date:
-              violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
-              cannot_be_null: "can not be set to null as finish date and duration are known."
-            status_id:
-              status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
-              status_invalid_in_type: "is invalid because the current status does not exist in this type."
-            type:
-              cannot_be_milestone_due_to_children: "cannot be a milestone because this work package has children."
-            priority_id:
-              only_active_priorities_allowed: "needs to be active."
-            category:
-              only_same_project_categories_allowed: "The category of a work package must be within the same project as the work package."
-              does_not_exist: "The specified category does not exist."
-            estimated_hours:
-              not_a_number: "is not a valid duration."
-              cant_be_inferior_to_remaining_work: "cannot be lower than Remaining work."
-              must_be_set_when_remaining_work_and_percent_complete_are_set: "required when Remaining work and % Complete are set."
-            remaining_hours:
-              not_a_number: "is not a valid duration."
-              cant_exceed_work: "cannot be higher than Work."
-              must_be_set_when_work_is_set: "required when Work is set."
-              must_be_set_when_work_and_percent_complete_are_set: "required when Work and % Complete are set."
-              must_be_set_to_zero_hours_when_work_is_set_and_percent_complete_is_100p:
-                >-
-                must be 0h when Work is set and % Complete is 100%.
-              must_be_empty_when_work_is_empty_and_percent_complete_is_100p: >-
-                must be empty when Work is empty and % Complete is 100%.
-          readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
+              in_use: "This token name is already in use, please select a different one"
         type:
           attributes:
             attribute_groups:
               attribute_unknown: "Invalid work package attribute used."
               attribute_unknown_name: "Invalid work package attribute used: %{attribute}"
               duplicate_group: "The group name '%{group}' is used more than once. Group names must be unique."
-              query_invalid: "The embedded query '%{group}' is invalid: %{details}"
               group_without_name: "Group name can't be blank."
+              query_invalid: "The embedded query '%{group}' is invalid: %{details}"
             patterns:
               invalid_tokens: "One or more attributes inside the field are not valid. Please, fix the attributes before saving."
         user:
           attributes:
             base:
-              user_limit_reached: "User limit reached. No more accounts can be created on the current plan."
               one_must_be_active: "Admin User cannot be locked/removed. At least one admin must be active."
-            password_confirmation:
-              confirmation: "Password confirmation does not match password."
-              format: "%{message}"
+              user_limit_reached: "User limit reached. No more accounts can be created on the current plan."
             password:
-              requirements_not_met: "Must include characters of the following types: %{rules}"
               lowercase: "lowercase (e.g. 'a')"
-              uppercase: "uppercase (e.g. 'A')"
-              numeric: "numeric (e.g. '1')"
-              special: "special (e.g. '%')"
-              reused:
-                one: "has been used before. Please choose one that is different from your last one."
-                other: "has been used before. Please choose one that is different from your last %{count}."
               match:
                 confirm: "Confirm new password."
                 description: "'Password confirmation' should match the input in the 'New password' field."
+              numeric: "numeric (e.g. '1')"
+              requirements_not_met: "Must include characters of the following types: %{rules}"
+              reused:
+                one: "has been used before. Please choose one that is different from your last one."
+                other: "has been used before. Please choose one that is different from your last %{count}."
+              special: "special (e.g. '%')"
+              uppercase: "uppercase (e.g. 'A')"
+            password_confirmation:
+              confirmation: "Password confirmation does not match password."
+              format: "%{message}"
             status:
               invalid_on_create: "is not a valid status for new users."
+        user_preference:
+          attributes:
+            daily_reminders:
+              full_hour: "can only be configured to be delivered at a full hour."
+            notification_settings:
+              email_alerts_global: "The email notification settings can only be set globally."
+              format: "%{message}"
+              only_one_global_setting: "There must only be one global notification setting."
+              wrong_date: "Wrong value for Start date, Due date, or Overdue."
+            pause_reminders:
+              invalid_range: "can only be a valid date range."
         user_working_hours:
           attributes:
             days:
               no_working_day: "At least one day needs to be configured as a working day."
-        member:
-          principal_blank: "Please choose at least one user or group."
-          role_blank: "need to be assigned."
-          attributes:
-            roles:
-              ungrantable: "has an unassignable role."
-              more_than_one: "has more than one role."
-            principal:
-              unassignable: "cannot be assigned to a project."
         version:
           undeletable_archived_projects: "The version cannot be deleted as it has work packages attached to it."
           undeletable_work_packages_attached: "The version cannot be deleted as it has work packages attached to it."
-        token/named:
+        watcher:
           attributes:
-            token_name:
-              blank: "Please provide a token name"
-              in_use: "This token name is already in use, please select a different one"
+            user_id:
+              locked: "is locked."
+              not_allowed_to_view: "is not allowed to view this resource."
+        wiki_page:
+          attributes:
+            slug:
+              undeducible: "cannot be deduced from the title '%{title}'."
+          error_conflict: "The wiki page has been updated by someone else while you were editing it."
+        work_package:
+          attributes:
+            assigned_to:
               format: "%{message}"
-        jira:
-          invalid_protocol: "Please provide a valid protocol (http or https)"
+            category:
+              does_not_exist: "The specified category does not exist."
+              only_same_project_categories_allowed: "The category of a work package must be within the same project as the work package."
+            done_ratio:
+              cannot_be_set_when_work_is_zero: "cannot be set when Work is 0h"
+              does_not_match_work_and_remaining_work: "does not match Work and Remaining work"
+              inclusion: "must be between 0 and 100."
+              must_be_set_when_remaining_work_is_set: "required when Remaining work is set."
+              must_be_set_when_work_and_remaining_work_are_set: "required when Work and Remaining work are set."
+            due_date:
+              cannot_be_null: "can not be set to null as start date and duration are known."
+              not_start_date: "is not on start date, although this is required for milestones."
+            duration:
+              cannot_be_null: "can not be set to null as start date and finish date are known."
+              larger_than_dates: "is larger than the interval between the start and the finish date."
+              not_an_integer: "is not a valid duration."
+              not_available_for_milestones: "is not available for milestone typed work packages."
+              smaller_than_dates: "is smaller than the interval between the start and the finish date."
+            estimated_hours:
+              cant_be_inferior_to_remaining_work: "cannot be lower than Remaining work."
+              must_be_set_when_remaining_work_and_percent_complete_are_set: "required when Remaining work and % Complete are set."
+              not_a_number: "is not a valid duration."
+            id:
+              blank: "ID can't be blank."
+              cannot_add_child_because_of_lack_of_permission: "Cannot add child because you don't have permissions to edit the selected work package."
+              format: "%{message}"
+            identifier:
+              semantic_identifier_incomplete: "and sequence_number must both be set at the same time."
+            parent:
+              cannot_be_in_another_project: "cannot be in another project."
+              cannot_be_milestone: "cannot be a milestone."
+              cannot_be_self_assigned: "cannot be assigned to itself."
+              not_a_valid_parent: "is invalid."
+            priority_id:
+              only_active_priorities_allowed: "needs to be active."
+            remaining_hours:
+              cant_exceed_work: "cannot be higher than Work."
+              must_be_empty_when_work_is_empty_and_percent_complete_is_100p: >-
+                must be empty when Work is empty and % Complete is 100%.
+              must_be_set_to_zero_hours_when_work_is_set_and_percent_complete_is_100p: >-
+                must be 0h when Work is set and % Complete is 100%.
+              must_be_set_when_work_and_percent_complete_are_set: "required when Work and % Complete are set."
+              must_be_set_when_work_is_set: "required when Work is set."
+              not_a_number: "is not a valid duration."
+            schedule_manually:
+              cannot_be_automatically_scheduled: "cannot be set to false (automatically scheduled) as it has no predecessors or children."
+            start_date:
+              cannot_be_null: "can not be set to null as finish date and duration are known."
+              violates_relationships: "can only be set to %{soonest_start} or later so as not to violate the work package's relationships."
+            status_id:
+              status_invalid_in_type: "is invalid because the current status does not exist in this type."
+              status_transition_invalid: "is invalid because no valid transition exists from old to new status for the current user's roles."
+            type:
+              cannot_be_milestone_due_to_children: "cannot be a milestone because this work package has children."
+          is_not_a_valid_target_for_time_entries: "Work package #%{id} is not a valid target for reassigning the time entries."
+          readonly_status: "The work package is in a readonly status so its attributes cannot be changed."
       template:
         body: "Please check the following fields:"
         header:
@@ -2653,6 +925,9 @@ en:
       issue_priority:
         one: "Priority"
         other: "Priorities"
+      jira:
+        one: "Jira"
+        other: "Jira"
       meeting_participant: "Meeting participant"
       member: "Member"
       message: "Message"
@@ -2675,9 +950,6 @@ en:
       scim_client:
         one: "SCIM client"
         other: "SCIM clients"
-      jira:
-        one: "Jira"
-        other: "Jira"
       status: "Work package status"
       token/api:
         one: Access token
@@ -2690,53 +962,41 @@ en:
         other: "Types"
       user: "User"
       version: "Version"
-      workflow: "Workflow"
-      work_package: "Work package"
       wiki: "Wiki"
       wiki_page: "Wiki page"
 
-  errors:
-    header_invalid_fields:
-      one: "There was a problem with the following field:"
-      other: "There were problems with the following fields:"
-    header_additional_invalid_fields:
-      one: "Additionally, there was a problem with the following field:"
-      other: "Additionally, there were problems with the following fields:"
-    field_erroneous_label: "This field is invalid: %{full_errors}\nPlease enter a valid value."
-    messages:
-      must_be_template: "must be template"
-      unsupported_storage_type: "is not a supported storage type."
-      storage_error: "There was an error with the storage connection."
-      invalid_input: "The input is invalid."
-      invalid_child_for_parent: "is not allowed as a parent for this view type."
+      work_package: "Work package"
+      workflow: "Workflow"
+  activities:
+    index:
+      no_results_title_text: There has not been any activity for the project within this time frame.
+    work_packages:
+      activity_tab:
+        changed: "changed"
+        changed_on: "changed on"
+        commented: "commented"
+        created: "created"
+        created_on: "created this on"
+        internal_comment: Internal comment
+        internal_comment_confirmation:
+          confirm_button_text: "Make public"
 
+          description: "Your comment will be visible to anyone who can access this work package. Are you sure you want to do this?"
+          heading: "Make this comment public?"
+          title: "Make this comment public?"
+        internal_journal: Internal comments are visible to a limited group of members.
+        label_activity_show_all: "Show everything"
+        label_activity_show_only_changes: "Show changes only"
+        label_activity_show_only_comments: "Show comments only"
+        label_sort_asc: "Newest at the bottom"
+        label_sort_desc: "Newest on top"
+        label_submit_comment: "Submit comment"
+        label_type_to_comment: "Add a comment. Type @ to notify people."
+        label_who: Who?
+        no_results_description_text: 'Choose "Show everything" to show all activity and comments'
+        no_results_title_text: No activity to display
+        unsaved_changes_confirmation_message: You have unsaved changes. Are you sure you want to close the editor?
   activity:
-    item:
-      created_by_on: "created by %{user} on %{datetime}"
-      created_by_on_time_entry: "time logged by %{user} on %{datetime}"
-      created_on: "created on %{datetime}"
-      created_on_time_entry: "time logged on %{datetime}"
-      updated_by_on: "updated by %{user} on %{datetime}"
-      updated_by_on_time_entry: "logged time updated by %{user} on %{datetime}"
-      updated_on: "updated on %{datetime}"
-      updated_on_time_entry: "logged time updated on %{datetime}"
-      deleted_on: "deleted on %{datetime}"
-      deleted_by_on: "deleted by %{user} on %{datetime}"
-      added_on: "added on %{datetime}"
-      added_by_on: "added by %{user} on %{datetime}"
-      removed_on: "removed on %{datetime}"
-      removed_by_on: "removed by %{user} on %{datetime}"
-      parent_without_of: "Subproject"
-      parent_no_longer: "No longer subproject of"
-      time_entry:
-        hour:
-          one: "%{count} hour"
-          other: "%{count} hours"
-        hour_html:
-          one: "<i>%{count} hour</i>"
-          other: "<i>%{count} hours</i>"
-        updated: "changed from %{old_value} to %{value}"
-        logged_for: "Logged for"
     filter:
       changeset: "Changesets"
       message: "Forums"
@@ -2746,6 +1006,32 @@ en:
       time_entry: "Spent time"
       wiki_edit: "Wiki"
       work_package: "Work packages"
+    item:
+      added_by_on: "added by %{user} on %{datetime}"
+      added_on: "added on %{datetime}"
+      created_by_on: "created by %{user} on %{datetime}"
+      created_by_on_time_entry: "time logged by %{user} on %{datetime}"
+      created_on: "created on %{datetime}"
+      created_on_time_entry: "time logged on %{datetime}"
+      deleted_by_on: "deleted by %{user} on %{datetime}"
+      deleted_on: "deleted on %{datetime}"
+      parent_no_longer: "No longer subproject of"
+      parent_without_of: "Subproject"
+      removed_by_on: "removed by %{user} on %{datetime}"
+      removed_on: "removed on %{datetime}"
+      time_entry:
+        hour:
+          one: "%{count} hour"
+          other: "%{count} hours"
+        hour_html:
+          one: "<i>%{count} hour</i>"
+          other: "<i>%{count} hours</i>"
+        logged_for: "Logged for"
+        updated: "changed from %{old_value} to %{value}"
+      updated_by_on: "updated by %{user} on %{datetime}"
+      updated_by_on_time_entry: "logged time updated by %{user} on %{datetime}"
+      updated_on: "updated on %{datetime}"
+      updated_on_time_entry: "logged time updated on %{datetime}"
     project_phase:
       activated: "activated"
       added_date: "set to %{date}"
@@ -2756,102 +1042,665 @@ en:
       phase_and_one_gate: "%{phase_message}. %{gate_message}"
       removed_date: "date deleted %{date}"
 
-  # common attributes of all models
-  attributes:
+  admin:
+    custom_styles:
+      color_theme: "Color theme"
+      color_theme_custom: "(Custom)"
+      colors:
+        accent-color: "Accent"
+        header-bg-color: "Header background"
+        main-menu-bg-color: "Main menu background"
+        main-menu-bg-selected-background: "Main menu when selected"
+        primary-button-color: "Primary button"
+      custom_colors: "Custom colors"
+      fonts:
+        file_is_invalid: "is not a valid TTF font file."
+        file_too_large: "is too large (maximum size is %{count} MB)."
+      instructions:
+        accent-color: "Color for links and other decently highlighted elements."
+        main-menu-bg-color: "Left side menu's background color."
+        primary-button-color: "Strong accent color, used for the most important button on a screen."
+      manage_colors: "Edit color select options"
+      tab_branding: "Branding"
+      tab_interface: "Interface"
+      tab_pdf_export_font: "PDF export font"
+      tab_pdf_export_styles: "PDF export styles"
+      theme_warning: Changing the theme will overwrite you custom style. The design will then be lost. Are you sure you want to continue?
+    enterprise:
+      add_token: "Upload an Enterprise edition support token"
+      book_now: "Book now"
+      buttons:
+        contact: "Contact us for a demo"
+        upgrade: "Upgrade now"
+      create_dialog:
+        title: "Add Enterprise token"
+        token_caption: "To learn more about how to activate Enterprise edition check our [documentation](docs_url)."
+        token_placeholder: "Paste your Enterprise edition support token here"
+        type_token_text: "Your Enterprise token text"
+      delete_dialog:
+        confirmation: "Are you sure you want to delete this Enterprise edition support token?"
+        heading: "Delete this enterprise token?"
+        title: "Delete enterprise token"
+      enterprise_link: "For more information, click here."
+      get_quote: "Get a quote"
+      order: "Order Enterprise on-premises edition"
+      paste: "Paste your Enterprise edition support token"
+      replace_token: "Replace your current support token"
+      required_for_feature: "This add-on is only available with an active Enterprise edition support token."
+      start_trial: "Start free trial"
+      status:
+        expired: "Expired"
+        expiring_soon: "Expiring soon"
+        in_grace_period: "In grace period"
+        invalid_domain: "Invalid domain"
+        not_active: "Not active"
+        trial: "Trial"
+    import:
+      title: "Import"
+    info:
+      database_deprecation_html: >
+        Starting with OpenProject 16.0, PostgreSQL 16 is required to use OpenProject.
+        Your installation will remain functional with your current database, but anticipate incompatability
+        in future releases.
+        <br/>
+        We have prepared [upgrade guides for all installation methods](upgrade_guide).
+        You can perform the upgrade ahead of the next release at any time by following the guides.
+
+    jemalloc_allocator: Jemalloc memory allocator
+    jira:
+      banner:
+        contribution_callout: >
+          Please, help us improve the Jira Migrator with your feedback and private data donations. You can [join the development community](link) of the Jira Migrator.
+        description: "This Jira Migrator is currently in beta. We currently only support Jira Server/Data Center versions 10.x and 11.x. Cloud instances are not supported at this time."
+        supported_versions: ""
+        title: "Beta - Try it out!"
+      blank:
+        description: "Configure a Jira host to start importing items from Jira to this OpenProject instance."
+        title: "No Jira hosts configured yet"
+      client:
+        401_error: "Jira API returned a 401 error. Your authentication token may have expired or lack the required permissions. Please ensure the token belongs to a Jira administrator."
+        429_error: "Jira API returned a 429 error. It means token owner has been rate limited by the Jira instance. Please disable rate limiting for this user."
+        api_error: "Jira API returned error status %{status}"
+        connection_error: "Failed to connect to Jira server: %{message}"
+        connection_timeout: "Connection to Jira server timed out: %{message}"
+        parse_error: "Failed to parse Jira API response: %{message}"
+        ssl_error: "SSL error connecting to Jira server: %{message}"
+        ssrf_block_doc_link: "Please see our [documentation](docs_url)."
+        ssrf_blocked: >-
+          Connection blocked: the Jira host resolves to a private IP address. If your Jira instance
+          runs on an internal network, allow its IP via the OPENPROJECT_SSRF__PROTECTION__IP__ALLOWLIST
+          environment variable.
+      columns:
+        added: "Added"
+        label_ago: "%{amount} ago"
+        last_change: "Last change"
+        projects: "Projects"
+      configuration:
+        new: "New configuration"
+        title: "Jira configuration"
+      description: "Use this tool to import data from your Jira instance. You can configure multiple Jira hosts and choose what to import in each import run."
+      errors:
+        cannot_delete_with_imports: "Cannot delete Jira host with existing imports"
+        custom_field_creation_failed: "Failed to create custom field '%{name}': %{message}"
+        semantic_identifiers_must_be_enabled:
+          description: "Jira uses issue identifiers consisting of a project key and a sequence number (PRJ-123). OpenProject also supports it, but it needs to be enabled [here](link)."
+          title: "Project-based semantic identifiers must be enabled."
+      form:
+        button_add: "Add configuration"
+        button_delete_token: "Delete token"
+        button_save: "Save configuration"
+        button_test: "Test configuration"
+        delete_token_confirm: "Are you sure you want to delete the token? This will disable the Jira connection."
+        fields:
+          name: "Name"
+          personal_access_token: "Personal Access Token"
+          url: "Jira Server/Data Center URL"
+        label_testing: "Testing configuration..."
+      run:
+        blank:
+          description: "Create an import run to start importing information from this Jira instance"
+          title: "No import runs set up yet"
+        history: "History"
+        import_blocked_error: "Another Jira import run is currently in progress or awaiting review. Please complete or revert it before starting a new import."
+        index:
+          button_edit_configuration: "Edit configuration"
+          button_import_run: "Import run"
+          description: "You can import different sets of data with each import run. It is possible to undo an import run immediately after in review mode but not after finalizing."
+        project_identifier_taken: "You are trying to import a project with an already used identifier: %{taken_identifier}. Please update the project identifier in Jira then click on Retry."
+        remove_error: "A Jira import run cannot be removed while it is running"
+        status:
+          configuring: "Select scope"
+          finalizing: "Finalizing"
+          finalizing_done: "Completed"
+          finalizing_error: "Error during finalizing"
+          import_error: "Error during import"
+          import_scope: "Select scope"
+          imported: "Review mode"
+          importing: "In progress"
+          initial: "Start"
+          instance_meta_done: "Meta data fetched"
+          instance_meta_error: "Error fetching meta data"
+          instance_meta_fetching: "Fetching meta data"
+          projects_meta_done: "Data gathered"
+          projects_meta_error: "Error fetching project data"
+          projects_meta_fetching: "Fetching project data"
+          revert_cancelled: "Revert cancelled"
+          revert_cancelling: "Cancelling revert"
+          revert_error: "Error during revert"
+          reverted: "Reverted"
+          reverting: "Reverting"
+        title: "Import run"
+        wizard:
+          button_retry: "Retry"
+          finalize_dialog:
+            confirm: "I understand that this action cannot be undone"
+            confirm_button: "Understood"
+            description: "Once approved, this import can no longer be reverted. All imported data will become permanent."
+            title: "Approve this import?"
+          groups:
+            configuration:
+              title: "Configure import"
+            confirming:
+              title: "Confirm and import"
+            fetch:
+              title: "Get base data"
+            groups_and_users:
+              title: "Groups and Users"
+            review:
+              title: "Review import"
+          import_dialog:
+            confirm: "I understand and have a backup"
+            confirm_button: "Start import"
+            description: >
+              Imports change your OpenProject configuration. After the import you will have the opportunity to review the changes.
+              While in review, you have an option to revert or approve the import. After approving the import reverting will no longer be possible.
+              Therefore, please, make sure that you have [a backup of your OpenProject instance](link) before proceeding.
+            title: "Please make sure you have a backup!"
+          parts:
+            issues:
+              one: "1 issue"
+              other: "%{count} issues"
+            projects:
+              one: "1 project"
+              other: "%{count} projects"
+            statuses:
+              one: "1 status"
+              other: "%{count} statuses"
+            types:
+              one: "1 type"
+              other: "%{count} types"
+            users:
+              one: "1 user"
+              other: "%{count} users"
+            work_packages:
+              one: "1 work package"
+              other: "%{count} work packages"
+          revert_dialog:
+            confirm: "I understand that this reversion will delete data permanently"
+            description: "This will delete all imported objects (including whole projects)."
+            title: "Permanently revert this import?"
+          sections:
+            confirm_import:
+              button_start: "Start import"
+              caption: "Review your import settings and start the import"
+              caption_done: "Completed"
+              description: "You are about to start an import run with the following settings."
+              label_available_data: "Data to be imported"
+              label_import_data: "Currently importing"
+              label_progress: "Import in progress..."
+              label_users_import_explanation: "Users that are involved in selected projects (group memberships included)"
+              title: "Import data"
+            fetch_data:
+              button_fetch: "Check available data"
+              caption_done: "Completed"
+              description: "Check what data is available for import in the host Jira instance."
+              label_progress: "Fetching data from Jira..."
+              title: "Fetch instance meta data"
+            groups_and_users:
+              title: "Groups and Users"
+            import_result:
+              button_done: "Approve import"
+              button_revert: "Revert import"
+              caption: "Review import run or revert import"
+              info: "Import run was successful."
+              label_finalize_import: "Approve import"
+              label_finalizing: "Approving import..."
+              label_finalizing_done: "Import approved."
+              label_results: "Imported"
+              label_revert: "Revert import"
+              label_revert_progress: "Reverting import..."
+              label_reverted: "Import reverted."
+              preview_description: 'The imported data is currently in review mode. Click "Approve import" to make the import permanent or "Revert import" to undo all changes made in this import run.'
+              title: "Import run results"
+            import_scope:
+              button_continue: "Continue"
+              button_select: "Select projects"
+              button_select_projects: "Select projects to import"
+              caption: "Choose what you want to import into OpenProject"
+              caption_done: "Completed"
+              description: "Select what data you want to import from the available data fetched from the host Jira instance."
+              elements:
+                custom_fields: "A subset of custom fields"
+                issue_details: "Issue description, history, comments and attachments"
+                issue_ids: "Issue identifiers"
+                issues: "Issues"
+                permissions: "Permissions"
+                project_ids: "Project identifiers"
+                projects: "Projects"
+                relations: "Relations between issues"
+                schemes: "Schemas"
+                sprints: "Sprint assignments"
+                users: "Involved users and groups"
+                workflows: "Project-level workflows"
+              label_available_server_data: "Available data on %{server_info}"
+              label_coming_later: "Coming later"
+              label_coming_soon: "Coming soon (Q2 2026)"
+              label_import: "Select which projects you would like to import."
+              label_info: "Please note that this import tool is in beta and cannot import all types of data. Here is a summary of what the host Jira instance offers for import and what this tool is able to import right now."
+              label_progress: "Fetching data from Jira..."
+              label_selected_data: "Selected data for import"
+              label_supported_data: "Supported data"
+              title: "Import scope"
+          select_dialog:
+            filter_projects: "Filter by text"
+          select_projects:
+            title: "Select projects"
+      test:
+        api_error: "Jira API returned error status %{status}. Please check your Jira instance URL and API token."
+        connection_error: "Connection error: %{message}"
+        error: "An unexpected error occurred while testing the connection"
+        failed: "Connection failed: Unable to retrieve server information"
+        invalid_url: "Please provide a valid URL"
+        missing_credentials: "Please provide both URL and Personal Access Token to test the connection"
+        parse_error: "Failed to parse the response from the server. The server may not be a valid Jira instance."
+        success: "Successfully connected to %{server} (version %{version})"
+        token_error: "Invalid API token. Please check your credentials in the configuration."
+      title: "Jira Migrator"
+      token_deleted: "Token was successfully deleted."
+      user:
+        unknown_name: "Unknown"
+
+    journal_aggregation:
+      caption: >
+        User actions on a work package (changing description, status, values, or writing comments) are grouped if performed within this period. It also controls notification and [webhook](webhook_link) delays.
+    mcp_configurations:
+      index:
+        description: "The model context protocol allows AI agents to provide its users with tools and resources exposed by this OpenProject instance. This feature is still in beta."
+        resources_description: "OpenProject implements the following resources. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP resources](docs_url)."
+        resources_heading: "Resources"
+        resources_submit: "Update resources"
+        tools_description: "OpenProject implements the following tools. Each can be enabled, renamed and described as you want. For more information, please refer to the [documentation on MCP tools](docs_url)."
+        tools_heading: "Tools"
+        tools_submit: "Update tools"
+      multi_update:
+        success: "MCP configurations were updated successfully."
+      server_form:
+        description_caption: "How the MCP server will be described to other applications who connect to it."
+        title_caption: "A short title shown to applications that connect to the MCP server."
+        tool_response_format: "Tool response format"
+        tool_response_format_content_only_caption: >
+          Choose this if MCP clients connecting to this instance do not support structured content.
+          Tool responses will only contain plain text content and leave out the structured version.
+        tool_response_format_content_only_label: "Content only"
+        tool_response_format_full_caption: >
+          The most compatible option. Tool responses will include both regular and structured content, allowing MCP clients to choose which format they want to read.
+          This may increase the number of tokens that the language model has to process, potentially increasing cost and decreasing performance.
+        tool_response_format_full_label: "Full"
+        tool_response_format_structured_only_caption: >
+          Choose this if you are certain that MCP clients connecting to this instance support structured content.
+          Tool responses will only include structured content and leave out its text representation.
+        tool_response_format_structured_only_label: "Structured content only"
+      update:
+        failure: "MCP configuration could not be updated."
+        success: "MCP configuration was updated successfully."
+    plugins:
+      no_results_content_text: See our integrations and plugins page for more information.
+      no_results_title_text: There are currently no plugins installed.
+    reserved_identifiers:
+      btn_release: "Release"
+      col_identifier: "Identifier"
+      col_project: "Project"
+      col_reserved: "Reserved"
+      dialog:
+        checkbox_label: "I understand that this cannot be undone."
+        confirm_button: "Release identifier"
+        description: "Releasing this identifier cannot be undone. External links and integrations using it will stop resolving, and the name becomes available for any new project to claim."
+        heading: 'Release "%{identifier}"?'
+        title: "Release identifier"
+      empty_body: "When a project's identifier changes, the previous one will appear here so you can release it once it's safe to do so."
+      empty_heading: "No reserved identifiers"
+      filter_label: "Search identifiers"
+      identifier_not_found: "The reserved identifier could not be found. It may have already been released or the project may have been deleted. Please refresh the page."
+      lede_html: "When a project's identifier is renamed, the previous identifier is kept reserved so that existing links and integrations keep working.<br>Here you can release reserved identifiers so that they may be used by other projects."
+      not_available_in_semantic_mode: "Reserved project identifiers are only available in numeric identifier mode."
+      released_notice: 'Identifier "%{identifier}" has been released.'
+      reserved_ago: "%{time} ago"
+      title: "Reserved project identifiers"
+    scim_clients:
+      authentication_methods:
+        oauth2_client: "OAuth 2.0 client credentials"
+        oauth2_token: "Static access token"
+        sso: "JWT from identity provider"
+      created_client_credentials_dialog_component:
+        heading: "Client credentials have been generated"
+        one_time_hint: "This is the only time you will see the client secret. Make sure to copy it now."
+        title: "Client credentials created"
+      created_token_dialog_component:
+        heading: "A token has been generated"
+        label_token: "Token"
+        one_time_hint: "This is the only time you will see this token. Make sure to copy it now."
+        title: "Token created"
+      delete_scim_client_dialog_component:
+        description: "Users managed by this SCIM client can no longer be updated by it."
+        heading: "Are you sure you want to delete this SCIM client?"
+        title: "Delete SCIM client"
+      edit:
+        label_delete_scim_client: "Delete SCIM client"
+      form:
+        auth_provider_description: "This is the service that users added by the SCIM provider will use to authenticate in OpenProject."
+        authentication_method_description_html: "This is how the SCIM client authenticates at OpenProject. Please ensure that OAuth tokens include the <code>scim_v2</code> scope."
+        description: "Please refer to our [documentation on configuring SCIM clients](docs_url) for more information on these configuration options."
+        jwt_sub_description: "For example, for Keycloak, this is the UUID of the service account  associated with the SCIM client. Consult [our documentation](docs_url) to learn how to find  the subject claim for your use case."
+        name_description: "Choose a name that will help other admins better understand why this client was configured."
+      index:
+        description: "SCIM clients configured here are able to interact with OpenProject SCIM server API to provision, update, and deprovision user accounts and groups."
+        label_create_button: "Add SCIM client"
+      new:
+        title: "New SCIM client"
+      revoke_static_token_dialog_component:
+        confirm_button: "Revoke"
+        description: "The SCIM client that uses this token will no longer be able to access OpenProject's SCIM server API."
+        heading: "Are you sure you want to revoke this token?"
+        title: "Revoke static token"
+      table_component:
+        blank_slate:
+          description: "Add clients to see them here"
+          title: "No SCIM clients configured yet"
+        user_count: "Users"
+      token_list_component:
+        description: "The tokens you generate here can be passed by a SCIM client to access the OpenProject SCIM API."
+        heading: "Tokens"
+        label_add_token: "Token"
+        label_aria_add_token: "Add token"
+      token_table_component:
+        blank_slate:
+          description: "You can create one now"
+          title: "No tokens have been created yet"
+        expired: "Expired on %{date}"
+        revoked: "Revoked on %{date}"
+        title: "Access token table"
+    settings:
+      new_project:
+        notification_text_default: >
+          <p>Hello,</p>
+          <p>A new project has been created: projectValue:name</p>
+          <p>Thank you</p>
+        project_creation: "Project creation"
+      work_packages_identifier:
+        autofix_preview:
+          error_does_not_start_with_letter: Must start with an uppercase letter
+          error_in_use: Already in use as another project's active handle
+          error_not_fully_uppercased: Must be uppercase
+          error_numerical: Cannot be purely numerical
+          error_reserved_by_system: Reserved as a system keyword
+          error_special_characters: Special characters not allowed
+          error_too_long: Has to be 10 characters or fewer
+          error_unknown: Needs manual review
+          error_used_in_past: Reserved by another project's handle history
+          remaining_projects:
+            one: "... 1 more project"
+            other: "... %{count} more projects"
+        banner:
+          existing_identifiers_notice: >
+            Existing identifiers for %{project_count} projects don't meet requirements for project-based semantic identifiers.
+            OpenProject can automatically update these so that they are valid as in the examples below.
+            Click on 'Convert identifiers' to update identifiers for all projects in this manner and enable project-based semantic identifiers.
+        box_header:
+          label_autofixed_suggestion: Future identifier
+          label_example_work_package_id: Example work package ID
+          label_previous_identifier: Previous identifier
+          label_project: Project
+          table_title: Projects with identifiers to update
+        button_autofix: Convert identifiers
+        button_save: Convert identifiers
+        dialog:
+          checkbox_label: I understand that this will permanently change all work package IDs
+          confirm_button: Change identifiers
+          description: >
+            This will change IDs for all work packages in all projects in this instance.
+            Previous identifiers and URLs will continue to work.
+            This change will take some time to complete.
+          heading: Enable project-based work package IDs?
+          title: Change work package identifiers
+        in_progress:
+          footer_message: "Background conversion is in progress. You can safely leave this page."
+          header_classic: "Converting to numeric identifiers"
+          header_semantic: "Converting to project-based identifiers"
+        page_header:
+          description: Choose between classic numerical work package IDs or semantic project-specific ones that prepend the project identifier to the work package ID.
+        success_banner: Successfully updated work package identifier format.
+    workflows:
+      blankslate:
+        description: "Add statuses to start configuring workflows for this role"
+        title: "No status transitions configured"
+      leave_confirmation:
+        description: "You are about to leave this page but you have unsaved changes. Would you like to save them before continuing?"
+        ignore: "Ignore changes"
+        save: "Save changes and continue"
+        title: "Save changes before continuing?"
+      role_selector:
+        label: "Role: %{role}"
+        no_role: "Select role"
+        roles:
+          one: "One role selected"
+          other: "%{count} roles selected"
+        title: "Select roles"
+      status_button: "Status"
+      statuses_dialog:
+        caption: "Add or remove statuses you would like to associate with this type. Removing a status will also delete the workflow associated with it."
+        label: "Statuses enabled for this type"
+        title: "Statuses"
+      statuses_removal_dialog:
+        confirm: "Remove"
+        description: "Removing these statuses will make them unavailable to this type and delete existing workflows. Are you sure you want to proceed?"
+        heading:
+          one: "Remove 1 status?"
+          other: "Remove %{count} statuses?"
+        title: "Remove statuses"
+      tabs:
+        default_transitions: "Default transitions"
+        user_assignee: "User is assignee"
+        user_author: "User is author"
+  announcements:
+    is_active: currently displayed
+    is_inactive: currently not displayed
+
+    show_until: Show until
+  antivirus_scan:
+    deleted_by_admin: "The quarantined file '%{filename}' has been deleted by an administrator."
+    deleted_message: "A virus was detected in file '%{filename}'. The file has been deleted."
+    not_processed_yet_message: "Downloading is blocked, as file was not scanned for viruses yet. Please try again later."
+    overridden_by_admin: "The quarantine for file '%{filename}' has been removed by %{user}. The file can now be acccessed."
+    quarantined_attachments:
+      container: "Container"
+      delete: "Delete the quarantined file"
+      error_cannot_act_self: "Cannot perform actions on your own uploaded files."
+
+      title: "Quarantined attachments"
+    quarantined_message: "A virus was detected in file '%{filename}'. It has been quarantined and is not available for download."
+  api_v3:
+    attributes:
+      property: "Property"
+    errors:
+      bad_request:
+        emoji_reactions_activity_type_not_supported: "This activity type does not support emoji reactions."
+        invalid_link: "The link under key '%{key}' is not valid."
+        links_not_an_object: "_links must be a JSON object."
+      code_400: "Bad request: %{message}"
+      code_401: "You need to be authenticated to access this resource."
+      code_401_wrong_credentials: "You did not provide the correct credentials."
+      code_403: "You are not authorized to access this resource."
+      code_404: "The requested resource could not be found."
+      code_409: "Could not update the resource because of conflicting modifications."
+      code_429: "Too many requests. Please try again later."
+      code_500: "An internal error has occurred."
+      code_500_missing_enterprise_token: "The request can not be handled due to invalid or missing Enterprise token."
+      code_500_outbound_request_failure: "An outbound request to another resource has failed with status code %{status_code}."
+      conflict:
+        multiple_reminders_not_allowed: |-
+          You can only set one reminder at a time for a work package. Please delete or update the existing reminder.
+      eprops:
+        invalid_gzip: "is invalid gzip: %{message}"
+        invalid_json: "is invalid json: %{message}"
+
+      expected:
+        date: "YYYY-MM-DD (ISO 8601 date only)"
+        datetime: "YYYY-MM-DDThh:mm:ss[.lll][+hh:mm] (any compatible ISO 8601 datetime)"
+        duration: "ISO 8601 duration"
+      invalid_content_type: "Expected CONTENT-TYPE to be '%{content_type}' but got '%{actual}'."
+      invalid_format: "Invalid format for property '%{property}': Expected format like '%{expected_format}', but got '%{actual}'."
+      invalid_json: "The request could not be parsed as JSON."
+      invalid_relation: "The relation is invalid."
+      invalid_resource: "For property '%{property}' a link like '%{expected}' is expected, but got '%{actual}'."
+      invalid_signal:
+        embed: "The requested embedding of %{invalid} is not supported. Supported embeddings are %{supported}."
+        select: "The requested select of %{invalid} is not supported. Supported selects are %{supported}."
+      invalid_user_status_transition: "The current user account status does not allow this operation."
+      missing_content_type: "not specified"
+      missing_or_malformed_parameter: "The query parameter '%{parameter}' is missing or malformed."
+      missing_property: "Missing property '%{property}'."
+      missing_request_body: "There was no request body."
+      multipart_body_error: "The request body did not contain the expected multipart parts."
+      multiple_errors: "Multiple field constraints have been violated."
+      not_found:
+        reminder: "The reminder you are looking for cannot be found or has been deleted."
+        work_package: "The work package you are looking for cannot be found or has been deleted."
+      render:
+        context_not_parsable: "The context provided is not a link to a resource."
+        context_object_not_found: "Cannot find the resource given as the context."
+        unsupported_context: "The resource given is not supported as context."
+      unable_to_create_attachment: "The attachment could not be created"
+      unable_to_create_attachment_permissions: "The attachment could not be saved due to lacking file system permissions"
+      user:
+        name_readonly: "The name attribute is read-only. Changes can be written through the attributes firstname and lastname."
+      validation:
+        due_date: "Finish date cannot be set on parent work packages."
+        invalid_user_assigned_to_work_package: "The chosen user is not allowed to be '%{property}' for this work package."
+        start_date: "Start date cannot be set on parent work packages."
+    resources:
+      schema: "Schema"
+
+    undisclosed:
+      ancestor: Undisclosed - The ancestor is invisible because of lacking permissions.
+      definingProject: Undisclosed - The project is invisible because of lacking permissions.
+      definingWorkspace: Undisclosed - The workspace is invisible because of lacking permissions.
+      parent: Undisclosed - The parent is invisible because of lacking permissions.
+      project: Undisclosed - The project is invisible because of lacking permissions.
+      workPackage: Undisclosed - The work package is invisible because of lacking permissions.
+
+  attribute_help_texts:
+    add_new: "Add help text"
+    caption: "This short version will be displayed as caption of the attribute."
+    edit_field_name: "Edit help text for %{attribute_field_name}"
+
+    note_public: "Any text and images you add to this field are publicly visible to all logged in users."
+    show_preview: "Preview text"
+    text_overview: "In this view, you can create custom help texts for attributes view. When defined, these texts can be shown by clicking the help icon next to its belonging attribute."
+  attributes:  # common attributes of all models
+    action: "Action"
     active: "Active"
+    actor: "Actor"
+    api_key: "API key"
     assigned_to: "Assignee"
     assignee: "Assignee"
     attachments: "Attachments"
-    actor: "Actor"
-    action: "Action"
-    api_key: "API key"
     author: "Author"
     avatar: "Avatar"
     base: "General Error:"
     body: "Body"
     category: "Category"
+    color: "Color"
     comment: "Comment"
     comments: "Comment"
     content: "Content"
-    color: "Color"
-    creator: "Creator"
     created_at: "Created on"
+    creator: "Creator"
     custom_field: "Custom field"
     custom_options: "Possible values"
     custom_values: "Custom fields"
     date: "Date"
     dates_interval: "Date range"
     default_columns: "Default columns"
-    description: "Description"
     derived_due_date: "Derived finish date"
     derived_estimated_hours: "Total work"
     derived_start_date: "Derived start date"
+    description: "Description"
     direction: "Direction"
     display_sums: "Display Sums"
     domain: "Domain"
     due_date: "Finish date"
-    estimated_hours: "Work"
-    estimated_time: "Work"
     email: "Email"
     entity_type: "Entity"
+    estimated_hours: "Work"
+    estimated_time: "Work"
     expires_at: "Expires on"
-    firstname: "First name"
     filter: "Filter"
+    firstname: "First name"
     group: "Group"
     groups: "Groups"
     hexcode: "Hex code"
     id: "ID"
     is_default: "Default value"
     is_for_all: "For all projects"
-    public: "Public"
-    principal: "User or group"
     # kept for backwards compatibility
     issue: "Work package"
     journal: "Journal"
     journal_notes: "Comment"
     lastname: "Last name"
-    login: "Username"
     lock_version: "Lock version"
+    login: "Username"
     mail: "Email"
     name: "Name"
     note: "Note"
     notes: "Notes"
     number: "Number"
-    options: "Options"
     operator: "Operator"
+    options: "Options"
     password: "Password"
+    principal: "User or group"
     priority: "Priority"
     project: "Project"
     project_ids: "Project IDs"
     project_phase: "Project phase"
     project_phase_definition: "Project phase"
+    public: "Public"
     reason: "Reason"
-    responsible: "Accountable"
-    required: "Required"
     recipient: "Recipient"
+    required: "Required"
+    responsible: "Accountable"
     role: "Role"
     roles: "Roles"
     search: "Search"
+    slug: "Slug"
     sprint: "Sprint"
     start_date: "Start date"
-    status: "Status"
     state: "State"
+    status: "Status"
     subject: "Subject"
-    slug: "Slug"
     summary: "Summary"
     template: "Template"
-    time_zone: "Time zone"
     text: "Text"
+    time_zone: "Time zone"
     title: "Title"
     type: "Type"
     typeahead: "Autocomplete"
     uid: "Unique identifier"
+    unit: "Unit"
     updated_at: "Updated on"
     updated_on: "Updated on"
     uploader: "Uploader"
     user: "User"
     username: "Username"
-    unit: "Unit"
     value: "Value"
     values: "Values"
     version: "Version"
@@ -2859,7 +1708,21 @@ en:
     work_package: "Work package"
     work_package_id: "Work package"
 
+  authentication:
+    login_and_registration: "Login and registration"
+
+  background_jobs:
+    status:
+      cancelled_due_to: "Job was cancelled due to error: %{message}"
+
+      error_requeue: "Job experienced an error but is retrying. The error was: %{message}"
   backup:
+    error:
+      backup_pending: There is already a backup pending.
+      invalid_token: Invalid or missing backup token
+      limit_reached: You can only do %{limit} backups per day.
+
+      token_cooldown: The backup token will be valid in %{hours} hours.
     failed: "Backup failed"
     label_backup_token: "Backup token"
     label_create_token: "Create backup token"
@@ -2869,8 +1732,8 @@ en:
     reset_token:
       action_create: Create
       action_reset: Reset
-      heading_reset: "Reset backup token"
       heading_create: "Create backup token"
+      heading_reset: "Reset backup token"
       implications: >
         Enabling backups will allow any user with the required permissions and this backup token
         to download a backup containing all data of this OpenProject installation.
@@ -2881,31 +1744,28 @@ en:
         You can delete the backup token to disable backups for this user.
       verification_html: >
         Enter %{word} to confirm you want to %{action} the backup token.
-      verification_word_reset: reset
       verification_word_create: create
+      verification_word_reset: reset
       warning: >
         When you create a new token you will only be allowed to request a backup after
         24 hours. This is a safety measure. After that you can request a backup any time using that token.
     text_token_deleted: Backup token deleted. Backups are now disabled.
-    error:
-      invalid_token: Invalid or missing backup token
-      token_cooldown: The backup token will be valid in %{hours} hours.
-      backup_pending: There is already a backup pending.
-      limit_reached: You can only do %{limit} backups per day.
-
   button_actions: "Actions"
   button_add: "Add"
   button_add_comment: "Add comment"
   button_add_item_above: "Add item above"
   button_add_item_below: "Add item below"
-  button_add_sub_item: "Add sub-item"
   button_add_member: Add member
+  button_add_menu_entry: "Add menu item"
+  button_add_non_working_time: "Time off"
+  button_add_sub_item: "Add sub-item"
   button_add_watcher: "Add watcher"
   button_annotate: "Annotate"
   button_apply: "Apply"
   button_apply_changes: "Apply changes"
   button_archive: "Archive"
   button_back: "Back"
+  button_buy_now: "Buy now"
   button_cancel: "Cancel"
   button_change: "Change"
   button_change_parent_page: "Change parent page"
@@ -2915,26 +1775,29 @@ en:
   button_click_to_reveal: "Click to reveal"
   button_close: "Close"
   button_collapse_all: "Collapse all"
-  button_confirm: "Confirm"
-  button_configure: "Configure"
-  button_continue: "Continue"
   button_complete: "Complete"
+  button_configure: "Configure"
+  button_configure_menu_entry: "Configure menu item"
+  button_confirm: "Confirm"
+  button_continue: "Continue"
   button_copy: "Copy"
-  button_copy_to_clipboard: "Copy to clipboard"
   button_copy_link_to_clipboard: "Copy link to clipboard"
+  button_copy_to_clipboard: "Copy to clipboard"
   button_create: "Create"
   button_create_and_continue: "Create and continue"
   button_decline: "Decline"
   button_delete: "Delete"
+  button_delete_menu_entry: "Delete menu item"
   button_delete_permanently: "Delete permanently"
   button_delete_watcher: "Delete watcher %{name}"
-  button_download: "Download"
   button_disable: "Disable"
+  button_download: "Download"
   button_duplicate: "Duplicate"
   button_duplicate_and_follow: "Duplicate and follow"
   button_edit: "Edit"
-  button_enable: "Enable"
   button_edit_associated_wikipage: "Edit associated wiki page: %{page_title}"
+  button_edit_non_working_time: "Edit time off"
+  button_enable: "Enable"
   button_expand_all: "Expand all"
   button_favorite: "Add to favorites"
   button_filter: "Filter"
@@ -2943,19 +1806,28 @@ en:
   button_list: "List"
   button_lock: "Lock"
   button_login: "Sign in"
+  button_manage_menu_entry: "Configure menu item"
+  button_manage_roles: "Manage roles"
   button_move: "Move"
   button_move_and_follow: "Move and follow"
   button_next: "Next"
   button_print: "Print"
+  button_publish: "Make public"
   button_quote: "Quote"
   button_remove: Remove
+  button_remove_member: "Remove member"
+  button_remove_member_and_shares: "Remove member and shares"
   button_remove_permanently: "Remove permanently"
   button_remove_reminder: "Remove reminder"
   button_rename: "Rename"
   button_replace: "Replace"
-  button_revoke: "Revoke"
   button_reply: "Reply"
   button_reset: "Reset"
+  button_revoke: "Revoke"
+  button_revoke_access: "Revoke access"
+  button_revoke_all: "Revoke all"
+  button_revoke_only: "Revoke only %{shared_role_name}"
+  button_revoke_work_package_shares: "Revoke work package shares"
   button_rollback: "Rollback to this version"
   button_save: "Save"
   button_save_as: "Save as"
@@ -2968,117 +1840,225 @@ en:
   button_test: "Test"
   button_unarchive: "Unarchive"
   button_uncheck_all: "Uncheck all"
-  button_unlock: "Unlock"
   button_unfavorite: "Remove from favorites"
+  button_unlock: "Unlock"
+  button_unpublish: "Make private"
+
   button_unwatch: "Unwatch"
   button_update: "Update"
   button_upgrade: "Upgrade"
-  button_buy_now: "Buy now"
   button_upload: "Upload"
   button_view: "View"
-  button_watch: "Watch"
-  button_manage_menu_entry: "Configure menu item"
-  button_add_menu_entry: "Add menu item"
-  button_configure_menu_entry: "Configure menu item"
-  button_delete_menu_entry: "Delete menu item"
   button_view_shared_work_packages: "View shared work packages"
-  button_manage_roles: "Manage roles"
-  button_remove_member: "Remove member"
-  button_remove_member_and_shares: "Remove member and shares"
-  button_revoke_work_package_shares: "Revoke work package shares"
-  button_revoke_access: "Revoke access"
-  button_revoke_all: "Revoke all"
-  button_revoke_only: "Revoke only %{shared_role_name}"
-  button_publish: "Make public"
-  button_unpublish: "Make private"
+  button_watch: "Watch"
+  calculated_values:
+    error_dialog:
+      title: "Error with Calculated value"
+    errors:
+      disabled_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is disabled for the project.
+
+      mathematical: "The mathematical formula leads to an error. Please review the project calculation attribute and try again."
+      missing_value: The attribute "%{custom_field_name}" is required by this Calculated value, but is empty.
+      unknown: "An unknown error occurred. Please review the formula for this Calculated value."
+  colors:
+    edit:
+      label_edit_color: "Edit Color"
+    form:
+      label_edit_color: "Edit color"
+      label_new_color: "New color"
+    index:
+      label_new_color: "New color"
+      no_results_content_text: Create a new color
+      no_results_title_text: There are currently no colors.
+    label_no_color: "No color"
+    label_properties: "Properties"
+    label_really_delete_color: >
+      Are you sure, you want to delete the following color?
+      Types using this color will not be deleted.
+
+    new:
+      label_new_color: "New Color"
+  concatenation:
+    single: "or"
 
   consent:
     checkbox_label: I have noted and do consent to the above.
-    failure_message: Consent failed, cannot proceed.
-    title: User Consent
-    decline_warning_message: You have declined to consent and have been logged out.
-    user_has_consented: The user gave their consent to your [configured consent information text](consent_settings).
-    not_yet_consented: The user has not yet given their consent to your [configured consent information text](consent_settings). They will be reminded the next time they log in.
     contact_mail_instructions: Define the mail address that users can reach a data controller to perform data change or removal requests.
-    contact_your_administrator: Please contact your administrator if you want to have your account deleted.
     contact_this_mail_address: Please contact %{mail_address} if you want to have your account deleted.
+    contact_your_administrator: Please contact your administrator if you want to have your account deleted.
+    decline_warning_message: You have declined to consent and have been logged out.
+    failure_message: Consent failed, cannot proceed.
+    not_yet_consented: The user has not yet given their consent to your [configured consent information text](consent_settings). They will be reminded the next time they log in.
     text_update_consent_time: Check this box to force users to consent again. Enable when you have changed the legal aspect of the consent information above.
+    title: User Consent
     update_consent_last_time: "Last update of consent: %{update_time}"
 
+    user_has_consented: The user gave their consent to your [configured consent information text](consent_settings).
   copy_project:
-    title: 'Copy project "%{source_project_name}"'
-    started: 'Started to copy project "%{source_project_name}" to "%{target_project_name}". You will be informed by mail as soon as "%{target_project_name}" is available.'
-    failed: "Cannot copy project %{source_project_name}"
-    failed_internal: "Copying failed due to an internal error."
-    succeeded: "Created project %{target_project_name}"
-    errors: "Error"
-    project_custom_fields: "Custom fields on project"
-    x_objects_of_this_type:
-      zero: "No objects of this type"
-      one: "One object of this type"
-      other: "%{count} objects of this type"
-    text:
-      failed: 'Could not copy project "%{source_project_name}" to project "%{target_project_name}".'
-      succeeded: 'Copied project "%{source_project_name}" to "%{target_project_name}".'
-    source_project_label: "Project copied"
     copy_options:
       dependencies_label: "Copy from project"
 
-  create_project:
-    attributes_heading: "Fill in this mandatory information to work on your projects."
-    template_label: "Use template"
-    template_heading: "Select a project template to work with the most common project management methods, or create a project from scratch."
-    copy_options:
-      dependencies_label: "Copy from template"
-    blank_template:
-      label: "Blank project"
-      description: Start from scratch. Manually add project attributes, members and modules.
-    blank_description: No description provided.
-
+    errors: "Error"
+    failed: "Cannot copy project %{source_project_name}"
+    failed_internal: "Copying failed due to an internal error."
+    project_custom_fields: "Custom fields on project"
+    source_project_label: "Project copied"
+    started: 'Started to copy project "%{source_project_name}" to "%{target_project_name}". You will be informed by mail as soon as "%{target_project_name}" is available.'
+    succeeded: "Created project %{target_project_name}"
+    text:
+      failed: 'Could not copy project "%{source_project_name}" to project "%{target_project_name}".'
+      succeeded: 'Copied project "%{source_project_name}" to "%{target_project_name}".'
+    title: 'Copy project "%{source_project_name}"'
+    x_objects_of_this_type:
+      one: "One object of this type"
+      other: "%{count} objects of this type"
+      zero: "No objects of this type"
   create_portfolio:
-    template_heading: "Select a portfolio template to work with the most common project management methods, or create a portfolio from scratch."
     blank_template:
-      label: "Blank portfolio"
       description: Start from scratch. Manually add portfolio attributes, members and modules.
 
+      label: "Blank portfolio"
+    template_heading: "Select a portfolio template to work with the most common project management methods, or create a portfolio from scratch."
   create_program:
-    template_heading: "Select a program template to work with the most common project management methods, or create a program from scratch."
     blank_template:
-      label: "Blank program"
       description: Start from scratch. Manually add program attributes, members and modules.
 
+      label: "Blank program"
+    template_heading: "Select a program template to work with the most common project management methods, or create a program from scratch."
+  create_project:
+    attributes_heading: "Fill in this mandatory information to work on your projects."
+    blank_description: No description provided.
+
+    blank_template:
+      description: Start from scratch. Manually add project attributes, members and modules.
+      label: "Blank project"
+    copy_options:
+      dependencies_label: "Copy from template"
+    template_heading: "Select a project template to work with the most common project management methods, or create a project from scratch."
+    template_label: "Use template"
   create_wiki_page: "Create new wiki page"
   create_wiki_page_button: "Wiki page"
 
+  custom_actions:
+    actions:
+      add: "Add action"
+      assigned_to:
+        executing_user_value: "(Assign to executing user)"
+      name: "Actions"
+    conditions: "Conditions"
+    edit: "Edit custom action %{name}"
+    execute: "Execute %{name}"
+
+    new: "New custom action"
+    plural: "Custom actions"
+  custom_fields:
+    admin:
+      custom_field_projects:
+        is_for_all_blank_slate:
+          description: This custom field is enabled in all projects since the "For all projects" option is checked. It cannot be deactivated for individual projects.
+          heading: For all projects
+      hierarchy:
+        subitems:
+          one: 1 sub-item
+          other: "%{count} sub-items"
+          zero: no sub-items
+      items:
+        actions: "Item actions"
+        blankslate:
+          item:
+            description: Add items to this list to create sub-items inside another one
+            title: This item doesn't have any hierarchy level below
+          root:
+            description: "Start by adding items to the custom field of type hierarchy. Each item can be used to create a hierarchy bellow it. To navigate and create sub-items inside a hierarchy click on the created item."
+            title: "Your list of items is empty"
+        delete_dialog:
+          description: "This action will irreversibly remove the item and all its sub-items. Any assigned values will be permanently deleted. If this field is required, removing items may cause existing work packages to become invalid."
+          heading: "Delete custom field item?"
+          title: "Delete custom field item"
+        placeholder:
+          label: "Item label"
+          short: "Short name"
+          weight: "Weight"
+      notice:
+        remember_items_and_projects: "Remember to set items and projects in the respective tabs for this custom field."
+      role_assignment:
+        description: You can automatically grant a certain project role to any user assigned to this project attribute, regardless of that user’s original role in that project.
+        dialog:
+          change: Change
+          changes:
+            gain_and_lose_role: Will lose role ‘%{old_role}’ and gain role ‘%{new_role}’
+            gain_role: Will gain role ‘%{new_role}’
+            lose_role: Will lose role ‘%{old_role}’
+            new_member: Will be added as a member
+            no_change: No changes
+            remove_member: Will be removed as a member
+          title: "Overview of users and permissions"
+        review_button: Review users and permissions
+        review_hint: >
+          There are %{user_count} who are already assigned to this project attribute in various projects. They
+          might get additional permissions and be added to projects they did not previously have access to.
+        role_field_caption: This project role will automatically be granted to any user assigned to this project attribute
+        role_field_label: "Project Role"
+        title: Role Assignment
+        warning: Depending on the role selected below, the user assigned to this project attribute might gain significantly more permissions than they previously had, including the ability to add new members and elevate their role.
+    calculated_field_not_editable: "Non-editable attribute. This value is calculated automatically."
+    confirm_destroy_option: "Deleting an option will delete all of its occurrences (e.g. in work packages). Are you sure you want to delete it?"
+    contained_in_type: "Contained in type"
+    enabled_in_project: "Enabled in project"
+    instructions:
+      admin_only:
+        all: "Check to make this custom field only visible to administrators. Users without admin rights will not be able to view or edit it."
+        project: "Check to make this attribute only visible to administrators. Users without admin rights will not be able to view or edit it."
+      editable:
+        all: "Allow the field to be editable by users themselves."
+      formula:
+        project: "Add numeric values or type / to search for an attribute or a mathematical operator."
+      has_comment:
+        project: "Allows the user to add a comment related to the project attribute when selecting the value in the project overview."
+
+      is_filter:
+        all: >
+          Allow the custom field to be used in a filter in work package views.
+          Note that only with 'For all projects' selected, the custom field will show up in global views.
+      is_for_all:
+        all: "Mark the custom field as available in all existing and new projects."
+        project: "Mark the attribute as available in all existing and new projects."
+      is_required:
+        all: "Mark the custom field as required. This will make it mandatory to fill in the field when creating new resources. Existing resources will not require a value when being updated."
+        project: "Required attributes need to be filled out by the user on project creation if the field is active ('For all projects' set or copying from a project/template in which the field is active). Existing projects will not require a value when being updated."
+      min_max:
+        all: "0 means no restriction"
+        project: "0 means no restriction"
+      multi_select:
+        all: "Allows the user to assign multiple values to this custom field."
+        project: "Allows the user to assign multiple values to this attribute."
+      regexp:
+        all: "eg. ^[A-Z0-9]+$"
+        project: "eg. ^[A-Z0-9]+$"
+      searchable:
+        all: "Include the field values when using the global search functionality."
+        project: "Check to make this attribute available as a filter in project lists."
+    is_enabled_globally: "Is enabled globally"
+    no_role_assigment: "No role assignment"
+    placeholder_version_select: "Work package or project selection is required first"
+    reorder_alphabetical: "Reorder values alphabetically"
+    reorder_confirmation: "Warning: The current order of available values as well as all unsaved values will be lost. Are you sure you want to continue?"
+    tab:
+      no_results_content_text: Create a new custom field
+
+      no_results_title_text: There are currently no custom fields.
+    text_add_new_custom_field: >
+      To add new custom fields to a project you first need to create them before
+      you can add them to this project.
+  danger_dialog:
+    confirmation_live_message_checked: "The button to proceed is now active."
+    confirmation_live_message_unchecked: "The button to proceed is now inactive. You need to tick the checkbox to continue."
+
   date:
     abbr_day_names: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-    abbr_month_names:
-      [
-        ~,
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-      ]
+    abbr_month_names: [null, "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
     abbr_week: "Wk"
-    day_names:
-      [
-        "Sunday",
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-      ]
+    day_names: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
     formats:
       # Use the strftime parameters for formats.
       # When no format has been given, it uses default.
@@ -3087,22 +2067,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     # Don't forget the nil at the beginning; there's no such thing as a 0th month
-    month_names:
-      [
-        ~,
-        "January",
-        "February",
-        "March",
-        "April",
-        "May",
-        "June",
-        "July",
-        "August",
-        "September",
-        "October",
-        "November",
-        "December",
-      ]
+    month_names: [null, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
     # Used in date_select and datetime_select.
     order:
       - :year
@@ -3136,44 +2101,76 @@ en:
       x_days:
         one: "1 day"
         other: "%{count} days"
-      x_minutes:
-        one: "1 minute"
-        other: "%{count} minutes"
-      x_minutes_abbreviated:
-        one: "1 min"
-        other: "%{count} mins"
       x_hours:
         one: "1 hour"
         other: "%{count} hours"
       x_hours_abbreviated:
         one: "1 hr"
         other: "%{count} hrs"
-      x_weeks:
-        one: "1 week"
-        other: "%{count} weeks"
+      x_minutes:
+        one: "1 minute"
+        other: "%{count} minutes"
+      x_minutes_abbreviated:
+        one: "1 min"
+        other: "%{count} mins"
       x_months:
         one: "1 month"
         other: "%{count} months"
-      x_years:
-        one: "1 year"
-        other: "%{count} years"
       x_seconds:
         one: "1 second"
         other: "%{count} seconds"
       x_seconds_abbreviated:
         one: "1 s"
         other: "%{count} s"
+      x_weeks:
+        one: "1 week"
+        other: "%{count} weeks"
+      x_years:
+        one: "1 year"
+        other: "%{count} years"
     units:
-      minute_abbreviated:
-        one: "min"
-        other: "mins"
-      hour:
-        one: "hour"
-        other: "hours"
       day:
         one: "day"
         other: "days"
 
+      hour:
+        one: "hour"
+        other: "hours"
+      minute_abbreviated:
+        one: "min"
+        other: "mins"
+  departments:
+    add_department: "Add department"
+    add_department_form:
+      name_label: "Department name"
+      name_placeholder: "Enter department name"
+    add_user: "Add user"
+    blankslate:
+      add_button: "Add"
+      description: >
+        Start by adding departments or users to the organization. Each department can be used to create
+        a hierarchy below it, to navigate and create sub-department inside a hierarchy click on the created item.
+      heading: "Your organization has no departments"
+    context_menu:
+      add_sub_department: "Add sub-department"
+      add_user: "Add user"
+    detail_blankslate:
+      add_button: "Add"
+      description: "Add departments or users to create sub-items inside another one."
+      heading: "This department doesn’t have any hierarchy level below"
+    edit: "Edit department"
+    errors:
+      move_user_failed: "Failed to move user between departments."
+
+    flash:
+      department_created: "Department was successfully created."
+      user_added: "User was successfully added to the department."
+      user_removed: "User was successfully removed from the department."
+    move_user_dialog:
+      confirm: "Move user"
+      description: "%{user} is currently a member of %{from_department}. Moving them will remove them from that department."
+      heading: "Move user to this department?"
+      title: "User already in a department"
   description_active: "Active?"
   description_attachment_toggle: "Show/Hide attachments"
   description_autocomplete: >
@@ -3182,6 +2179,7 @@ en:
     using the arrow up and arrow down key and select it with tab or
     enter. Alternatively you can enter the work package number directly.
   description_available_columns: "Available Columns"
+  description_category_reassign: "Choose category"
   description_choose_project: "Projects"
   description_compare_from: "Compare from"
   description_compare_to: "Compare to"
@@ -3192,7 +2190,6 @@ en:
   description_enter_text: "Enter text"
   description_filter: "Filter"
   description_filter_toggle: "Show/Hide filter"
-  description_category_reassign: "Choose category"
   description_message_content: "Message content"
   description_my_project: "You are member"
   description_notes: "Notes"
@@ -3206,17 +2203,53 @@ en:
   description_sub_work_package: "Sub work package of current"
   description_toc_toggle: "Show/Hide table of contents"
   description_wiki_subpages_reassign: "Choose new parent page"
-
   # Text direction: Left-to-Right (ltr) or Right-to-Left (rtl)
   direction: ltr
 
+  doorkeeper:
+    access_token_url: "Access token URL"
+
+    auth_url: "Auth URL"
+    errors:
+      messages:
+        access_denied: "The resource owner or authorization server denied the request."
+        admin_authenticator_not_configured: "Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured."
+        credential_flow_not_configured: "Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured."
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+        invalid_client: "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
+        invalid_code_challenge_method: "The code challenge method must be plain or S256."
+        invalid_grant: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        invalid_request:
+          missing_param: "Missing required parameter: %{value}."
+          request_not_authorized: "Request need to be authorized. Required parameter for authorizing request is missing or invalid."
+          unknown: "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
+        invalid_scope: "The requested scope is invalid, unknown, or malformed."
+        invalid_token:
+          expired: "The access token expired"
+          revoked: "The access token was revoked"
+          unknown: "The access token is invalid"
+        resource_owner_authenticator_not_configured: "Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured."
+        revoke:
+          unauthorized: "You are not authorized to revoke this token."
+
+        server_error: "The authorization server encountered an unexpected condition which prevented it from fulfilling the request."
+        temporarily_unavailable: "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
+        unauthorized_client: "The client is not authorized to perform this request using this method."
+        unsupported_grant_type: "The authorization grant type is not supported by the authorization server."
+
+        unsupported_response_mode: "The authorization server does not support this response mode."
+        unsupported_response_type: "The authorization server does not support this response type."
+    pre_authorization:
+      status: "Pre-authorization"
   ee:
     features:
       baseline_comparison: Baseline Comparisons
       board_view: Advanced Boards
       calculated_values: Calculated values
       capture_external_links: Capture External Links
-      internal_comments: Internal Comments
       custom_actions: Custom Actions
       custom_field_hierarchies: Hierarchies
       customize_life_cycle: Customize Life Cycle
@@ -3224,6 +2257,7 @@ en:
       define_custom_style: Custom theme and logo
       edit_attribute_groups: Edit Attribute Groups
       gantt_pdf_export: Gantt PDF Export
+      internal_comments: Internal Comments
       ldap_groups: LDAP users and group sync
       mcp_server: Model Context Protocol (MCP)
       meeting_templates: Reusable meeting templates
@@ -3242,21 +2276,35 @@ en:
       work_package_query_relation_columns: Work Package Query Relation Columns
       work_package_sharing: Share work packages with external users
       work_package_subject_generation: Work Package Subject Generation
+    teaser:
+      description_html: "You have access to all %{trial_plan} features."
+      title:
+        one: "One day left of %{trial_plan} trial token"
+        other: "%{count} days left of %{trial_plan} trial token"
+    trial:
+      already_retrieved: >
+        Your trial enterprise token was already retrieved. Please check your emails for the token being attached.
+        Please reach out to our support team if you need a new one.
+      confirmation_info: >
+        We sent you an email on %{date} to %{email} with all the information to start the free trial of OpenProject Enterprise.
+        Please check your inbox and click the confirmation link provided to start your 14-day free trial.
+      confirmation_subline: >
+        Please, check your inbox and follow the steps to start your 14-day free trial.
+      consent: "I agree with the [terms of service](tos_url) and the [privacy policy](privacy_url)."
+
+      domain_caption: The token will be valid for your currently configured host name.
+      not_found: "You have requested a trial token, but that request is no longer available. Please try again."
+      receive_newsletter: "I want to receive the OpenProject [newsletter](newsletter_url)."
+      request_again: "Request again"
+      resend_action: "Resend confirmation email"
+      successfully_saved: "Your trial enterprise token has been successfully retrieved."
+      token_sent: "Trial token requested"
+      wait_for_confirmation: "We sent you an email to confirm your address in order to retrieve a trial token."
+      welcome_description: "Get a quick overview of project management and team collaboration with OpenProject Enterprise edition."
+      welcome_title: "Quick feature overview"
     upsell:
-      buy_now_button: "Buy now"
-      plans_title: "Enterprise plans"
-      title: "Enterprise add-on"
-      plan_title: "Enterprise %{plan} add-on"
-      plan_name: "%{plan} enterprise plan"
-      trial_text: "This feature is included in your active Enterprise trial."
-      plan_text_html: "Available starting with the %{plan_name}."
-      unlimited: "Unlimited"
       already_have_token: >
         Already have a token? Add it using the button below to upgrade to the booked Enterprise plan.
-      hide_banner: "Hide this banner"
-      homescreen_description: >
-        Enterprise plans extend the Community edition of OpenProject with additional [Enterprise add-ons](enterprise_url) and professional support, ideal for organizations running OpenProject in a mission-critical environment.
-      homescreen_subline: By upgrading, you will also be supporting an open source project.
       baseline_comparison:
         description: Highlight changes made to this list since any point in the past.
       benefits:
@@ -3270,200 +2318,209 @@ en:
         professional_support: "Professional support"
         professional_support_text: "Get reliable, high-touch support from senior support engineers with expert knowledge about running OpenProject in business-critical environments."
 
-      work_package_subject_generation:
-        description: "Create automatically generated subjects using referenced attributes and text."
-      customize_life_cycle:
-        description: "Create and organize different project phases than the ones provided by PM2 project cycle planning."
+      buy_now_button: "Buy now"
+      calculated_values:
+        description: "Calculated values allow you to create a mathematical formula based attribute using numeric values and other project attributes and custom fields."
       capture_external_links:
         description: "Prevent social engineering attacks by capturing and warning about external links before users visit them."
-      work_package_query_relation_columns:
-        description: "Need to see relations or child elements in the work package list?"
+      custom_actions:
+        description: "Custom actions are one-click shortcuts to a set of pre-defined actions that you can make available on certain work packages based on status, role, type or project."
+        title: "Custom actions"
+      custom_field_hierarchies:
+        description: "Hierarchy custom fields allow organizing hierarchical structures in work packages and projects by making use of multi-level select lists."
+      customize_life_cycle:
+        description: "Create and organize different project phases than the ones provided by PM2 project cycle planning."
+      date_alerts:
+        description: "With date alerts, you will be notified of upcoming start or finish dates so that you never miss or forget an important deadline."
+      define_custom_style:
+        description: Customize your OpenProject installation with your own logo and colors.
+        more_info: "Note: the used logo will be publicly accessible."
+        title: "Custom color theme and logo"
       edit_attribute_groups:
         description: "Customize form configuration with these additional add-ons:"
         features:
           groups: "Add new attribute sections"
-          rename: "Rename attribute sections"
           related: "Add a table of related work packages"
-      readonly_work_packages:
-        description: "Mark work packages as read-only for specific statuses."
-      custom_field_hierarchies:
-        description: "Hierarchy custom fields allow organizing hierarchical structures in work packages and projects by making use of multi-level select lists."
-      date_alerts:
-        description: "With date alerts, you will be notified of upcoming start or finish dates so that you never miss or forget an important deadline."
-      weighted_item_lists:
-        description: "Weighted item lists allow you to create a list with underlying numeric values associated."
-      work_package_sharing:
-        description: "Share work packages with users who are not members of the project."
-      project_list_sharing:
-        description: "Share project lists with individual users."
-      calculated_values:
-        description: "Calculated values allow you to create a mathematical formula based attribute using numeric values and other project attributes and custom fields."
-      define_custom_style:
-        title: "Custom color theme and logo"
-        more_info: "Note: the used logo will be publicly accessible."
-        description: Customize your OpenProject installation with your own logo and colors.
-      custom_actions:
-        title: "Custom actions"
-        description: "Custom actions are one-click shortcuts to a set of pre-defined actions that you can make available on certain work packages based on status, role, type or project."
+          rename: "Rename attribute sections"
+      hide_banner: "Hide this banner"
+      homescreen_description: >
+        Enterprise plans extend the Community edition of OpenProject with additional [Enterprise add-ons](enterprise_url) and professional support, ideal for organizations running OpenProject in a mission-critical environment.
+      homescreen_subline: By upgrading, you will also be supporting an open source project.
+      internal_comments:
+        description: "Internal comments allow an internal team to communicate amongst themselves privately. These are only visible to certain project roles and will never be visible publicly."
+        title: Internal comments
+      internal_comments_inline:
+        description: " "
+        title: "Write internal comments only a small group can see"
       mcp_server:
         description: "Bring OpenProject into your AI workflows with a secure MCP server."
       meeting_templates:
         description: "Define meeting templates with a set agenda structure and save time by reusing them when creating new meetings."
       nextcloud_sso:
-        title: "Single Sign-On for Nextcloud Storage"
         description: "Enable seamless and secure authentication for your Nextcloud storage with Single Sign-On. Simplify access management and enhance user convenience."
-      scim_api:
-        title: "SCIM clients"
-        description: "Automate user management in OpenProject by seamlessly integrating external identity services like Microsoft Entra or Keycloak through our SCIM Server API. Available starting with the Enterprise corporate plan."
-      sso_auth_providers:
-        title: "Single Sign-On (SSO)"
-        description: "Enable users to log in via external SSO providers using SAML or OpenID Connect for seamless access and integration with existing identity systems."
-      virus_scanning:
-        description: "Ensure uploaded files in OpenProject are scanned for viruses before being accessible by other users."
-      project_creation_wizard:
-        description: "Generate a step-by-step wizard to help project managers fill out a project initiation request."
+        title: "Single Sign-On for Nextcloud Storage"
       placeholder_users:
-        title: Placeholder users
         description: >
           Placeholder users are a way to assign work packages to users who are not part of your project.
           They can be useful in a range of scenarios; for example, if you need to track tasks for a resource that is not yet named or available,
           or if you don’t want to give that person access to OpenProject but still want to track tasks assigned to them.
-      internal_comments:
-        title: Internal comments
-        description: "Internal comments allow an internal team to communicate amongst themselves privately. These are only visible to certain project roles and will never be visible publicly."
-      internal_comments_inline:
-        title: "Write internal comments only a small group can see"
-        description: " "
+        title: Placeholder users
+      plan_name: "%{plan} enterprise plan"
+      plan_text_html: "Available starting with the %{plan_name}."
+      plan_title: "Enterprise %{plan} add-on"
+      plans_title: "Enterprise plans"
       portfolio_management:
         description: Align your projects to your strategic goals by organizing them into portfolios and programs.
-    teaser:
-      title:
-        one: "One day left of %{trial_plan} trial token"
-        other: "%{count} days left of %{trial_plan} trial token"
-      description_html: "You have access to all %{trial_plan} features."
-    trial:
-      not_found: "You have requested a trial token, but that request is no longer available. Please try again."
-      wait_for_confirmation: "We sent you an email to confirm your address in order to retrieve a trial token."
-      already_retrieved: >
-        Your trial enterprise token was already retrieved. Please check your emails for the token being attached.
-        Please reach out to our support team if you need a new one.
-      successfully_saved: "Your trial enterprise token has been successfully retrieved."
-      token_sent: "Trial token requested"
-      request_again: "Request again"
-      resend_action: "Resend confirmation email"
-      welcome_title: "Quick feature overview"
-      welcome_description: "Get a quick overview of project management and team collaboration with OpenProject Enterprise edition."
-      confirmation_info: >
-        We sent you an email on %{date} to %{email} with all the information to start the free trial of OpenProject Enterprise.
-        Please check your inbox and click the confirmation link provided to start your 14-day free trial.
-      confirmation_subline: >
-        Please, check your inbox and follow the steps to start your 14-day free trial.
-      domain_caption: The token will be valid for your currently configured host name.
-      receive_newsletter: "I want to receive the OpenProject [newsletter](newsletter_url)."
-      consent: "I agree with the [terms of service](tos_url) and the [privacy policy](privacy_url)."
-
+      project_creation_wizard:
+        description: "Generate a step-by-step wizard to help project managers fill out a project initiation request."
+      project_list_sharing:
+        description: "Share project lists with individual users."
+      readonly_work_packages:
+        description: "Mark work packages as read-only for specific statuses."
+      scim_api:
+        description: "Automate user management in OpenProject by seamlessly integrating external identity services like Microsoft Entra or Keycloak through our SCIM Server API. Available starting with the Enterprise corporate plan."
+        title: "SCIM clients"
+      sso_auth_providers:
+        description: "Enable users to log in via external SSO providers using SAML or OpenID Connect for seamless access and integration with existing identity systems."
+        title: "Single Sign-On (SSO)"
+      title: "Enterprise add-on"
+      trial_text: "This feature is included in your active Enterprise trial."
+      unlimited: "Unlimited"
+      virus_scanning:
+        description: "Ensure uploaded files in OpenProject are scanned for viruses before being accessible by other users."
+      weighted_item_lists:
+        description: "Weighted item lists allow you to create a list with underlying numeric values associated."
+      work_package_query_relation_columns:
+        description: "Need to see relations or child elements in the work package list?"
+      work_package_sharing:
+        description: "Share work packages with users who are not members of the project."
+      work_package_subject_generation:
+        description: "Create automatically generated subjects using referenced attributes and text."
   email_calendar_updates:
-    state:
-      disabled: "Disabled."
-      enabled: "Enabled."
     button:
       disabled: "Enable"
       enabled: "Disable"
 
-  enumeration_activities: "Time tracking activities"
-  enumeration_work_package_priorities: "Work package priorities"
-  enumeration_reported_project_statuses: "Reported status"
-  enumeration_caption_order_changed: "Order successfully changed."
-  enumeration_could_not_be_moved: "Enumeration could not be moved."
+    state:
+      disabled: "Disabled."
+      enabled: "Enabled."
+  enterprise_plans:
+    legacy_enterprise: "Enterprise Plan"
 
   enterprise_trials:
     dialog_component:
       title: Enterprise Trial
 
+  enumeration_activities: "Time tracking activities"
+  enumeration_caption_order_changed: "Order successfully changed."
+  enumeration_could_not_be_moved: "Enumeration could not be moved."
+
+  enumeration_reported_project_statuses: "Reported status"
+  enumeration_work_package_priorities: "Work package priorities"
+  error_attribute_not_highlightable: "Attribute(s) not highlightable: %{attributes}"
+
   error_auth_source_sso_failed: "Single Sign-On (SSO) for user '%{value}' failed"
   error_can_not_archive_project: "This project cannot be archived: %{errors}"
-  error_can_not_delete_entry: "Unable to delete entry"
   error_can_not_delete_custom_field: "Unable to delete custom field"
+  error_can_not_delete_entry: "Unable to delete entry"
   error_can_not_delete_in_use_archived_undisclosed: "There are also work packages in archived projects. You need to ask an administrator to perform the deletion to see which projects are affected."
   error_can_not_delete_in_use_archived_work_packages: "There are also work packages in archived projects. You need to reactivate the following projects first, before you can change the attribute of the respective work packages: %{archived_projects_urls}"
+  error_can_not_delete_standard_type: "Standard types cannot be deleted."
   error_can_not_delete_type:
     explanation: 'This type contains work packages and cannot be deleted. You can see all affected work packages in <a target="_blank" href="%{url}">this view</a>.'
-  error_can_not_delete_standard_type: "Standard types cannot be deleted."
+  error_can_not_find_all_resources: "Could not find all related resources to this request."
   error_can_not_invite_user: "Failed to send invitation to user."
   error_can_not_remove_role: "This role is in use and cannot be deleted."
   error_can_not_reopen_work_package_on_closed_version: "A work package assigned to a closed version cannot be reopened"
-  error_can_not_find_all_resources: "Could not find all related resources to this request."
   error_can_not_unarchive_project: "This project cannot be unarchived: %{errors}"
   error_check_user_and_role: "Please choose a user and a role."
   error_code: "Error %{code}"
   error_color_could_not_be_saved: "Color could not be saved"
   error_cookie_missing: "The OpenProject cookie is missing. Please ensure that cookies are enabled, as this application will not properly function without."
   error_custom_option_not_found: "Option does not exist."
-  error_enterprise_plan_needed: "You need the %{plan} enterprise plan to perform this action."
   error_enterprise_activation_user_limit: "Your account could not be activated (user limit reached). Please contact your administrator to gain access."
+  error_enterprise_plan_needed: "You need the %{plan} enterprise plan to perform this action."
   error_enterprise_token_invalid_domain: "The Enterprise edition is not active. Your Enterprise token's domain (%{actual}) does not match the system's host name (%{expected})."
+  error_external_authentication_failed_message: "An error occurred during external authentication: %{message}"
   error_failed_to_delete_entry: "Failed to delete this entry."
   error_in_dependent: "Error attempting to alter dependent object: %{dependent_class} #%{related_id} - %{related_subject}: %{error}"
   error_in_new_dependent: "Error attempting to create dependent object: %{dependent_class} - %{related_subject}: %{error}"
   error_invalid_selected_value: "Invalid selected value."
   error_journal_attribute_not_present: "Journal does not contain attribute %{attribute}."
-  error_pdf_export_too_many_columns: "Too many columns selected for the PDF export. Please reduce the number of columns."
-  error_pdf_date_range_too_long: "The selected work package date range exceeds the allowable PDF export limit. Please condense the range to a maximum of %{years} years."
-  error_pdf_failed_to_export: "The PDF export could not be saved: %{error}"
-  error_token_authenticity: "Unable to verify Cross-Site Request Forgery token. Did you try to submit data on multiple browsers or tabs? Please close all tabs and try again."
-  error_reminder_not_found: "The reminder was not found or was already notified about."
-  error_work_package_not_found_in_project: "The work package was not found or does not belong to this project"
-  error_work_package_id_not_found: "The work package was not found."
-  error_must_be_project_member: "must be project member"
-  error_migrations_are_pending: "Your OpenProject installation has pending database migrations. You have likely missed running the migrations on your last upgrade. Please check the upgrade guide to properly upgrade your installation."
-  error_migrations_visit_upgrade_guides: "Please visit our upgrade guide documentation"
-  error_no_default_work_package_status: 'No default work package status is defined. Please check your configuration (Go to "Administration -> Work package statuses").'
-  error_no_type_in_project: "No type is associated to this project. Please check the Project settings."
-  error_omniauth_registration_timed_out: "The registration via an external authentication provider timed out. Please try again."
-  error_omniauth_invalid_auth: "The authentication information returned from the identity provider was invalid. Please contact your administrator for further help."
-  error_password_change_failed: "An error occurred when trying to change the password."
-  error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
-  error_scm_not_found: "The entry or revision was not found in the repository."
-  error_type_could_not_be_saved: "Type could not be saved"
-  error_unable_delete_status: "The work package status cannot be deleted since it is used by at least one work package."
-  error_unable_delete_default_status: "Unable to delete the default work package status. Please select another default work package status before deleting the current one."
-  error_unable_to_connect: "Unable to connect (%{value})"
-  error_unable_delete_wiki: "Unable to delete the wiki page."
-  error_unable_update_wiki: "Unable to update the wiki page."
-  error_workflow_copy_source: "Please select a source type or role"
-  error_workflow_copy_target: "Please select target type(s) and role(s)"
   error_menu_item_not_created: Menu item could not be added
   error_menu_item_not_saved: Menu item could not be saved
+  error_migrations_are_pending: "Your OpenProject installation has pending database migrations. You have likely missed running the migrations on your last upgrade. Please check the upgrade guide to properly upgrade your installation."
+  error_migrations_visit_upgrade_guides: "Please visit our upgrade guide documentation"
+  error_must_be_project_member: "must be project member"
+  error_no_default_work_package_status: 'No default work package status is defined. Please check your configuration (Go to "Administration -> Work package statuses").'
+  error_no_type_in_project: "No type is associated to this project. Please check the Project settings."
+  error_omniauth_invalid_auth: "The authentication information returned from the identity provider was invalid. Please contact your administrator for further help."
+  error_omniauth_registration_timed_out: "The registration via an external authentication provider timed out. Please try again."
+  error_password_change_failed: "An error occurred when trying to change the password."
+  error_pdf_date_range_too_long: "The selected work package date range exceeds the allowable PDF export limit. Please condense the range to a maximum of %{years} years."
+  error_pdf_export_too_many_columns: "Too many columns selected for the PDF export. Please reduce the number of columns."
+  error_pdf_failed_to_export: "The PDF export could not be saved: %{error}"
+  error_reminder_not_found: "The reminder was not found or was already notified about."
+  error_scm_command_failed: "An error occurred when trying to access the repository: %{value}"
+  error_scm_not_found: "The entry or revision was not found in the repository."
+  error_token_authenticity: "Unable to verify Cross-Site Request Forgery token. Did you try to submit data on multiple browsers or tabs? Please close all tabs and try again."
+  error_type_could_not_be_saved: "Type could not be saved"
+  error_unable_delete_default_status: "Unable to delete the default work package status. Please select another default work package status before deleting the current one."
+  error_unable_delete_status: "The work package status cannot be deleted since it is used by at least one work package."
+  error_unable_delete_wiki: "Unable to delete the wiki page."
+  error_unable_to_connect: "Unable to connect (%{value})"
+  error_unable_update_wiki: "Unable to update the wiki page."
   error_wiki_root_menu_item_conflict: >
     Can't rename "%{old_name}" to "%{new_name}" due to a conflict in the resulting menu item
     with the existing menu item "%{existing_caption}" (%{existing_identifier}).
 
-  error_external_authentication_failed_message: "An error occurred during external authentication: %{message}"
-  error_attribute_not_highlightable: "Attribute(s) not highlightable: %{attributes}"
+  error_work_package_id_not_found: "The work package was not found."
+  error_work_package_not_found_in_project: "The work package was not found or does not belong to this project"
+  error_workflow_copy_source: "Please select a source type or role"
+  error_workflow_copy_target: "Please select target type(s) and role(s)"
+  errors:
+    field_erroneous_label: "This field is invalid: %{full_errors}\nPlease enter a valid value."
+    header_additional_invalid_fields:
+      one: "Additionally, there was a problem with the following field:"
+      other: "Additionally, there were problems with the following fields:"
+    header_invalid_fields:
+      one: "There was a problem with the following field:"
+      other: "There were problems with the following fields:"
+    messages:
+      invalid_child_for_parent: "is not allowed as a parent for this view type."
 
+      invalid_input: "The input is invalid."
+      must_be_template: "must be template"
+      storage_error: "There was an error with the storage connection."
+      unsupported_storage_type: "is not a supported storage type."
   events:
     changeset: "Changeset edited"
     message: Message edited
     news: News
-    project_details: "Project details edited"
     project: "Project edited"
+    project_details: "Project details edited"
     projects: "Project edited"
     reply: Replied
     time_entry: "Timelog edited"
-    wiki_page: "Wiki page edited"
-    work_package_closed: "Work Package closed"
-    work_package_edit: "Work Package edited"
-    work_package_note: "Work Package note added"
     title:
       project_html: "Project: %{name}"
       subproject_html: "Subproject: %{name}"
 
+    wiki_page: "Wiki page edited"
+    work_package_closed: "Work Package closed"
+    work_package_edit: "Work Package edited"
+    work_package_note: "Work Package note added"
   export:
+    demo:
+      button_text: Generate Demo PDF
+      footer: "Generated by OpenProject"
+      heading: "Demo PDF"
     dialog:
-      title: "Export"
-      submit: "Export"
-      save_export_settings:
-        label: "Save settings"
+      columns:
+        input_caption_report: "By default all attributes added as columns in the work package list are selected. Long text fields are not available in the attribute table, but can be displayed below it."
+        input_caption_required: "It is not possible to export the view without any column. Please add at least one column."
+        input_caption_table: "By default all attributes added as columns in the work package list are selected. Long text fields are not available in table based exports."
+        input_label_report: "Add columns to attribute table"
       format:
         label: "File format"
         options:
@@ -3473,126 +2530,95 @@ en:
             label: "PDF"
           xls:
             label: "XLS"
-      columns:
-        input_label_report: "Add columns to attribute table"
-        input_caption_report: "By default all attributes added as columns in the work package list are selected. Long text fields are not available in the attribute table, but can be displayed below it."
-        input_caption_table: "By default all attributes added as columns in the work package list are selected. Long text fields are not available in table based exports."
-        input_caption_required: "It is not possible to export the view without any column. Please add at least one column."
       pdf:
-        export_type:
-          label: "PDF export type"
-          options:
-            table:
-              label: "Table"
-              caption: "Export the work packages list in a table with the desired columns."
-            report:
-              label: "Report"
-              caption: "Export the work package on a detailed report of all work packages in the list."
-            gantt:
-              label: "Gantt chart"
-              caption: "Export the work packages list in a Gantt diagram view."
-        include_images:
-          label: "Include images"
-          caption: "Exclude images to reduce the size of the PDF export."
-        gantt_zoom_levels:
-          label: "Zoom levels"
-          caption: "Select what is the zoom level for dates displayed in the chart."
-          options:
-            days: "Days"
-            weeks: "Weeks"
-            months: "Months"
-            quarters: "Quarters"
         column_width:
           label: "Table column width"
           options:
-            narrow: "Narrow"
             medium: "Medium"
-            wide: "Wide"
+            narrow: "Narrow"
             very_wide: "Very wide"
-        paper_size:
-          label: "Paper size"
-          caption: "Depending on the chart size more than one page might be exported."
+            wide: "Wide"
+        export_type:
+          label: "PDF export type"
+          options:
+            gantt:
+              caption: "Export the work packages list in a Gantt diagram view."
+              label: "Gantt chart"
+            report:
+              caption: "Export the work package on a detailed report of all work packages in the list."
+              label: "Report"
+            table:
+              caption: "Export the work packages list in a table with the desired columns."
+              label: "Table"
+        gantt_zoom_levels:
+          caption: "Select what is the zoom level for dates displayed in the chart."
+          label: "Zoom levels"
+          options:
+            days: "Days"
+            months: "Months"
+            quarters: "Quarters"
+            weeks: "Weeks"
+        include_images:
+          caption: "Exclude images to reduce the size of the PDF export."
+          label: "Include images"
         long_text_fields:
+          drag_area_label: "Manage long text fields"
           input_caption: "By default all long text fields are selected."
           input_label: "Add long text fields"
           input_placeholder: "Search for long text fields"
-          drag_area_label: "Manage long text fields"
+        paper_size:
+          caption: "Depending on the chart size more than one page might be exported."
+          label: "Paper size"
+      save_export_settings:
+        label: "Save settings"
+      submit: "Export"
+      title: "Export"
       xls:
-        include_relations:
-          label: "Include relations"
-          caption: "This option will create a duplicate of each work package for every relation this has with another work package."
         include_descriptions:
-          label: "Include descriptions"
           caption: "This option will add a description column in raw format."
-    your_work_packages_export: "Work packages are being exported"
-    your_projects_export: "Projects are being exported"
-    succeeded: "Export completed"
-    failed: "An error has occurred while trying to export the work packages: %{message}"
-    demo:
-      heading: "Demo PDF"
-      footer: "Generated by OpenProject"
-      button_text: Generate Demo PDF
+          label: "Include descriptions"
+        include_relations:
+          caption: "This option will create a duplicate of each work package for every relation this has with another work package."
+          label: "Include relations"
     errors:
       embedded_table_with_too_many_columns: "This embedded work package table could not fit on the page, please reduce the number of columns."
+    failed: "An error has occurred while trying to export the work packages: %{message}"
     format:
       atom: "Atom"
       csv: "CSV"
       pdf: "PDF"
-      pdf_overview_table: "PDF Table"
-      pdf_report_with_images: "PDF Report with images"
-      pdf_report: "PDF Report"
       pdf_gantt: "PDF Gantt"
+      pdf_overview_table: "PDF Table"
+      pdf_report: "PDF Report"
+      pdf_report_with_images: "PDF Report with images"
     image:
       omitted: "Image not exported."
     macro:
-      error: "Macro error, %{message}"
       attribute_not_found: "attribute not found: %{attribute}"
+      error: "Macro error, %{message}"
       model_not_found: "invalid attribute model: %{model}"
-      resource_not_found: "resource not found: %{resource}"
       nested_rich_text_unsupported: "Nested rich text embedding currently not supported in export"
+      resource_not_found: "resource not found: %{resource}"
+    succeeded: "Export completed"
     units:
-      hours: h
       days: d
-  pdf_generator:
-    page_nr_footer: "Page %{page} of %{total}"
-    template_attributes:
-      label: "Attributes and description"
-      caption: All the attributes present in the current form configuration using the default template.
-    template_contract:
-      label: "Contract"
-      caption: Work package details formatted to the standard German contract form.
-    dialog:
-      title: Generate PDF
-      submit: Download
-      templates:
-        label: "Template"
-        none_enabled: "No template has been enabled for this work package type"
-      footer_center:
-        label: Footer text
-        caption: This text will appear on every page at the center of the footer.
-      footer_right:
-        label: Footer text
-        caption: This text will appear on every page at the right of the footer.
-      hyphenation:
-        label: Hyphenation
-        caption: Break line between words for better layout and justification.
-      hyphenation_language:
-        label: Language and hyphenation
-      page_orientation:
-        label: Page orientation
-        caption: Select the orientation of the pages in the PDF document.
-        options:
-          portrait: Portrait
-          landscape: Landscape
+      hours: h
+    your_projects_export: "Projects are being exported"
+    your_work_packages_export: "Work packages are being exported"
+  external_link_warning:
+    continue_button: "Continue to external website"
+    continue_message: "Are you sure you want to proceed to the following external link?"
+    title: "Leaving OpenProject"
+    warning_message: "You are about to leave OpenProject and visit an external website. Please be aware that external websites are not under our control and may have different privacy and security policies."
   extraction:
     available:
-      pdftotext: "Pdftotext available (optional)"
-      unrtf: "Unrtf available (optional)"
       catdoc: "Catdoc available (optional)"
-      xls2csv: "Xls2csv available (optional)"
       catppt: "Catppt available (optional)"
+      pdftotext: "Pdftotext available (optional)"
       tesseract: "Tesseract available (optional)"
 
+      unrtf: "Unrtf available (optional)"
+      xls2csv: "Xls2csv available (optional)"
   filterable_tree_view:
     filter_mode:
       all: "All"
@@ -3601,31 +2627,62 @@ en:
     include_sub_items: "Include sub-items"
     no_results_text: "No results"
 
-  header:
-    project_select_component:
-      all_projects: "All projects"
-      favorites: "Favorites"
-      leave_project: "Leave project"
-      title: "Projects"
-
-  toggle_switch:
-    label_on: "On"
-    label_off: "Off"
+  forums:
+    show:
+      no_results_title_text: There are currently no posts for the forum.
 
   general_csv_decimal_separator: "."
   general_csv_encoding: "UTF-8"
   general_csv_separator: ","
   general_first_day_of_week: "7"
   general_pdf_encoding: "ISO-8859-1"
-  general_text_no: "no"
-  general_text_yes: "yes"
   general_text_No: "No"
   general_text_Yes: "Yes"
-  general_text_true: "true"
   general_text_false: "false"
 
+  general_text_no: "no"
+  general_text_true: "true"
+  general_text_yes: "yes"
+  global_search:
+    overwritten_tabs:
+      all: "All"
+      messages: "Forum"
+      wiki_pages: "Wiki"
+
+    placeholder: "Search in %{app_title}"
+    title:
+      all_projects: 'Search for "%{search_term}" in all projects'
+      current_project: 'Search for "%{search_term}" in %{project_name}'
+      project_and_subprojects: 'Search for "%{search_term}" in %{project_name} and all subprojects'
+  groups:
+    edit:
+      synchronized_groups: "Synchronized groups"
+    index:
+      description: By grouping users together, you can add them as members to the same projects or assign the same global roles to them.
+    memberships:
+      no_results_title_text: There are currently no projects part of this group.
+    synchronized_groups:
+      blankslate:
+        action: Authentication settings
+        description: When this group is automatically synced with groups in external identity providers like OpenID, they will appear here. You can set this up in your Authentication settings.
+        title: No synchronized groups yet
+
+    table_component:
+      blank_slate:
+        description: You can define named groups of users with specific permissions.
+        title: No groups set up yet
+      user_count: User count
+    users:
+      no_results_title_text: There are currently no users part of this group.
   gui_validation_error: "1 error"
   gui_validation_error_plural: "%{count} errors"
+
+  header:
+    project_select_component:
+      all_projects: "All projects"
+      favorites: "Favorites"
+      leave_project: "Leave project"
+      title: "Projects"
 
   health_reports:
     common:
@@ -3648,26 +2705,27 @@ en:
         skipped: Skipped
         warning: Warning
 
+  help_texts:
+    views:
+      favoured: "Mark this view as favourite and add to the saved views sidebar on the left."
+      project: >
+        %{plural} are always attached to a project.
+        You can only select projects here where the %{plural} module is active.
+        After creating a %{singular} you can add work packages from other projects to it.
+      public: "Publish this view, allowing other users to access your view. Users with the 'Manage public views' permission can modify or remove public query. This does not affect the visibility of work package results in that view and depending on their permissions, users may see different results."
   homescreen:
     additional:
-      projects: "Newest visible projects in this instance."
-      no_visible_projects: "There are no visible projects in this instance."
       favorite_projects:
         no_results: "You have no favorite projects"
         no_results_subtext: "Add one or multiple projects as favorite through their overview or in a project list."
+      no_visible_projects: "There are no visible projects in this instance."
+      projects: "Newest visible projects in this instance."
       users: "Newest registered users in this instance."
     blocks:
       community: "OpenProject community"
-      upsell:
-        title: "Upgrade to Enterprise edition"
       new_features:
-        header: "Read about new features and product updates."
-        learn_about: "Learn more about all new features"
-        missing: "There are no highlighted features yet."
         # We need to include the version to invalidate outdated translations in other locales
         "17_5":
-          new_features_title: >
-            The release contains various new features and improvements, such as:
           new_features_list:
             line_0: "Project-based work package identifiers for clearer references."
             line_1: Jira Migrator support for Jira identifiers, due dates, and more.
@@ -3677,61 +2735,57 @@ en:
             line_5: More flexible meeting schedules and reduced email notification noise.
             line_6: Nested groups for organizational structures and inherited permissions.
             line_7: Improved administration interfaces for workflows, users, and type configuration.
+          new_features_title: >
+            The release contains various new features and improvements, such as:
+        header: "Read about new features and product updates."
+        learn_about: "Learn more about all new features"
+        missing: "There are no highlighted features yet."
+      upsell:
+        title: "Upgrade to Enterprise edition"
     links:
-      upgrade_enterprise_edition: "Upgrade to Enterprise edition"
-      postgres_migration: "Migrating your installation to PostgreSQL"
-      user_guides: "User guides"
-      faq: "FAQ"
-      impressum: "Legal notice"
-      glossary: "Glossary"
-      shortcuts: "Shortcuts"
       blog: "OpenProject blog"
+      faq: "FAQ"
       forums: "Community forum"
-      security_alerts: "Security alerts"
+      glossary: "Glossary"
+      impressum: "Legal notice"
       newsletter: "Newsletter"
+
+      postgres_migration: "Migrating your installation to PostgreSQL"
+      security_alerts: "Security alerts"
+      shortcuts: "Shortcuts"
+      upgrade_enterprise_edition: "Upgrade to Enterprise edition"
+      user_guides: "User guides"
+  http:
+    request:
+      failed_authorization: "The server side request failed authorizing itself."
+      missing_authorization: "The server side request failed due to missing authorization information."
+    response:
+      unexpected: "Unexpected response received."
 
   image_conversion:
     imagemagick: "Imagemagick"
 
-  journals:
-    changes_retracted: "The changes were retracted."
+  incoming_mails:
+    ignore_filenames: >
+      Specify a list of names to ignore when processing attachments for incoming mails (e.g., signatures or icons).
+      Enter one filename per line.
 
-    caused_changes:
-      budget_deleted: "Budget has been deleted"
-      dates_changed: "Dates changed"
-      default_attribute_written: "Read-only attributes written"
-      import: "Imported"
-      progress_mode_changed_to_status_based: "Progress calculation updated"
-      status_changed: "Status '%{status_name}'"
-      system_update: "OpenProject system update:"
-      work_package_duplicate_closed: "Duplicate work package updated:"
-      total_percent_complete_mode_changed_to_work_weighted_average: "Calculation of % Complete totals now weighted by Work."
-      total_percent_complete_mode_changed_to_simple_average: "Calculation of % Complete totals now based on a simple average of only % Complete values."
+  instructions_after_error_link: "You can try to sign in again by clicking [here](signin_url). If the error persists, ask your admin for help."
+
+  instructions_after_logout_link: "You can sign in again by clicking [here](signin_url)."
+  instructions_after_registration_link: "You can sign in as soon as your account has been activated by clicking [here](signin_url)."
+  journals:
     cause_descriptions:
-      import:
-        header: "changes by %{author}"
-        field_changed: "%{field} changed from %{old_value} to %{new_value}"
-        field_set: "%{field} set to %{value}"
-        field_removed: "%{field} removed"
-        field_updated: "%{field} updated"
-        deleted_with_diff: "%{field} deleted (%{link})"
-        changed_with_diff: "%{field} changed (%{link})"
-        set_with_diff: "%{field} set (%{link})"
-      work_package_predecessor_changed_times: by changes to predecessor %{link}
-      work_package_parent_changed_times: by changes to parent %{link}
-      work_package_children_changed_times: by changes to child %{link}
-      work_package_related_changed_times: by changes to related %{link}
-      work_package_duplicate_closed: The status was automatically updated by the duplicated work package %{link}
-      unaccessable_work_package_changed: by changes to a related work package
       budget_deleted: Budget has been deleted
-      working_days_changed:
-        changed: "by changes to working days (%{changes})"
-        days:
-          working: "%{day} is now working"
-          non_working: "%{day} is now non-working"
-        dates:
-          working: "%{date} is now working"
-          non_working: "%{date} is now non-working"
+      import:
+        changed_with_diff: "%{field} changed (%{link})"
+        deleted_with_diff: "%{field} deleted (%{link})"
+        field_changed: "%{field} changed from %{old_value} to %{new_value}"
+        field_removed: "%{field} removed"
+        field_set: "%{field} set to %{value}"
+        field_updated: "%{field} updated"
+        header: "changes by %{author}"
+        set_with_diff: "%{field} set (%{link})"
       progress_mode_changed_to_status_based: Progress calculation mode set to status-based
       status_excluded_from_totals_set_to_false_message: now included in hierarchy totals
       status_excluded_from_totals_set_to_true_message: now excluded from hierarchy totals
@@ -3740,219 +2794,58 @@ en:
         file_links_journal: >
           From now on, activity related to file links (files stored in external storages) will appear here in the
           Activity tab. The following represent activity concerning links that already existed:
-        progress_calculation_adjusted_from_disabled_mode: >-
-          Progress calculation automatically <a href="%{href}" target="_blank">set to work-based mode and adjusted with version update</a>.
         progress_calculation_adjusted: >-
           Progress calculation automatically <a href="%{href}" target="_blank">adjusted with version update</a>.
+        progress_calculation_adjusted_from_disabled_mode: >-
+          Progress calculation automatically <a href="%{href}" target="_blank">set to work-based mode and adjusted with version update</a>.
         scheduling_mode_adjusted: >-
           Scheduling mode automatically adjusted with version update.
+        sprint_migration: "Version '%{version_name}' has been copied as a sprint."
         totals_removed_from_childless_work_packages: >-
           Work and progress totals automatically removed for non-parent work packages with <a href="%{href}" target="_blank">version update</a>.
           This is a maintenance task and can be safely ignored.
-        sprint_migration: "Version '%{version_name}' has been copied as a sprint."
-      total_percent_complete_mode_changed_to_work_weighted_average: >-
-        Child work packages without Work are ignored.
       total_percent_complete_mode_changed_to_simple_average: >-
         Work values of child work packages are ignored.
-  links:
-    configuration_guide: "Configuration guide"
-    get_in_touch: "You have questions? Get in touch with us."
-
-  instructions_after_registration_link: "You can sign in as soon as your account has been activated by clicking [here](signin_url)."
-  instructions_after_logout_link: "You can sign in again by clicking [here](signin_url)."
-  instructions_after_error_link: "You can try to sign in again by clicking [here](signin_url). If the error persists, ask your admin for help."
-
-  menus:
-    admin:
-      ai: "Artificial Intelligence (AI)"
-      aggregation: "Aggregation"
-      api_and_webhooks: "API and webhooks"
-      mail_notification: "Email notifications"
-      mails_and_notifications: "Emails and notifications"
-      mcp_configurations: "Model Context Protocol (MCP)"
-    quick_add:
-      label: "Add…"
-
-  my_account:
-    notifications_and_email:
-      title: "Notification and email"
-      tabs:
-        notifications: "Notification settings"
-        email_reminders: "Email reminders"
-    access_tokens:
-      description: "Provider tokens are issued by OpenProject, allowing other applications to access it. Client tokens are issued by other applications, allowing OpenProject to access them."
-      no_results:
-        title: "No access tokens to display"
-        description: "All of them have been disabled. They can be re-enabled in the administration menu."
-      access_tokens: "Access tokens"
-      headers:
-        action: "Action"
-        expiration: "Expires"
-      indefinite_expiration: "Never"
-      simple_revoke_confirmation: "Are you sure you want to revoke this token?"
-      tabs:
-        client:
-          title: "Client tokens"
-        provider:
-          title: "Provider tokens"
-      token/api:
-        blank_description: "There is no API token yet. You can create one using the button below."
-        blank_title: "No API token"
-        title: "API"
-        table_title: "API tokens"
-        text_hint: "API tokens allow third-party applications to communicate with this OpenProject instance via REST APIs."
-        static_token_name: "API token"
-        disabled_text: "API tokens are not enabled by the administrator. Please contact your administrator to use this feature."
-        add_button: "API token"
-      ical:
-        blank_description: "To add an iCalendar token, subscribe to a new or existing calendar from within the Calendar module of a project. You must have the necessary permissions."
-        blank_title: "No iCalendar token"
-        title: "iCalendar"
-        table_title: "iCalendar tokens"
-        text_hint_link: "iCalendar tokens allow users to [subscribe to OpenProject calendars](docs_url) and view up-to-date work package information from external clients."
-        disabled_text: "iCalendar subscriptions are not enabled by the administrator. Please contact your administrator to use this feature."
-      oauth_application:
-        active_tokens: "Active tokens"
-        blank_description: "There is no third-party application access configured and active for you."
-        blank_title: "No OAuth application token"
-        last_refreshed_at: "Last refreshed at"
-        title: "OAuth"
-        table_title: "OAuth application tokens"
-        text_hint: "OAuth application tokens allow third-party applications to connect with this OpenProject instance."
-      oauth_client:
-        blank_description: "There are no OAuth client tokens yet."
-        blank_title: "No OAuth client tokens"
-        failed: "An error occurred and the token couldn't be removed. Please try again later."
-        integration_type: "Integration type"
-        table_title: "OAuth client tokens"
-        text_hint: "OAuth client tokens allow this OpenProject instance to connect with external applications, such as file storages."
-        title: "OAuth"
-        remove_token: "Do you really want to remove this token? You will need to login again on %{integration}."
-        removed: "OAuth client token successfully removed"
-        unknown_integration: "Unknown"
-      token/rss:
-        add_button: "RSS token"
-        blank_description: "There is no RSS token yet. You can create one using the button below."
-        blank_title: "No RSS token"
-        title: "RSS"
-        table_title: "RSS tokens"
-        text_hint: "RSS tokens allow users to keep up with the latest changes in this OpenProject instance via an external RSS reader."
-        static_token_name: "RSS token"
-        disabled_text: "RSS tokens are not enabled by the administrator. Please contact your administrator to use this feature."
-      storages:
-        unknown_storage: "Unknown storage"
-    email_reminders:
-      immediate_reminders:
-        title: "Send me an email reminder"
-        mentioned: "Notify me when I am mentioned"
-        personal_reminder: "Notify me for personal reminders"
-      daily_reminders:
-        title: "Send me daily email reminders for unread notifications"
-        description: "You will receive these reminders only for unread notifications and only at hours you specify. Until you configure a time zone for your account, the times will be interpreted to be in UTC."
-        enabled: "Enable daily email reminders"
-        add_time: "Add time"
-        remove_time: "Remove time"
-        time_slot_label: "Reminder time (UTC)"
-      workdays:
-        title: "Receive email reminders on these days"
-        submit_button: "Update reminder days"
-      pause_reminders:
-        title: "Pause email notifications"
-        enabled: "Temporarily pause daily email reminders"
-        date_range: "Pause period"
-      email_alerts:
-        title: "Email alerts for other items that are not work packages"
-        description: "Notifications today are limited to work packages. You can choose to continue receiving email alerts for these events until they are included in notifications."
-        news_added: "News added"
-        news_commented: "Comment on a news item"
-        document_added: "Document added"
-        forum_messages: "Forum message posted"
-        wiki_page_added: "Wiki page added"
-        wiki_page_updated: "Wiki page updated"
-        membership_added: "Membership added"
-        membership_updated: "Membership updated"
-        submit_button: "Update alerts"
-    notifications:
-      participating:
-        title: "Participating"
-        description: "Notifications for all activities in work packages you are involved in (assignee, accountable or watcher)."
-        submit_button: "Update preferences"
-        mentioned: "Mentioned"
-        watched: "Watching"
-        assignee: "Assignee"
-        responsible: "Accountable"
-        shared: "Shared with me"
-      date_alerts:
-        title: "Date alerts"
-        description: "Automatic notifications when important dates are approaching for open work packages you are involved in (assignee, accountable or watcher)."
-        submit_button: "Update date alerts"
-        start_date: "Start date"
-        due_date: "Finish date"
-        overdue: "Overdue"
-        times:
-          same_day: "On the same day"
-          one_day_before: "1 day before"
-          three_days_before: "3 days before"
-          seven_days_before: "7 days before"
-          one_day_after: "1 day after"
-          three_days_after: "3 days after"
-          seven_days_after: "7 days after"
-      non_participating:
-        title: "Non-participating"
-        description: "Additional notifications for activities in all projects."
-        submit_button: "Update preferences"
-        work_package_created: "New work packages"
-        work_package_commented: "All new comments"
-        work_package_processed: "All status changes"
-        work_package_prioritized: "All priority changes"
-        work_package_scheduled: "All date changes"
-      project_specific_settings:
-        title: "Project-specific notification settings"
-        description: "These project-specific settings override default settings above."
-        add_button: "Add project-specific notifications"
-        dialog_title: "Add project-specific notifications"
-        list_header: "Projects with specific notifications"
-
-  notifications:
-    reasons:
-      assigned: "Assignee"
-      dateAlert: "Date alert"
-      mentioned: "Mentioned"
-      responsible: "Accountable"
-      shared: "Shared"
-      watched: "Watcher"
-      reminder: "Reminder"
-    facets:
-      unread: "Unread"
-      unread_title: "Show unread"
-      all: "All"
-      all_title: "Show all"
-    menu:
-      by_project: "Unread by project"
-      by_reason: "Reason"
-      inbox: "Inbox"
-    send_notifications: "Send notifications for this action"
-    work_packages:
-      subject:
-        created: "The work package was created."
-        assigned: "You have been assigned to %{work_package}"
-        subscribed: "You subscribed to %{work_package}"
-        mentioned: "You have been mentioned in %{work_package}"
-        responsible: "You have become accountable for %{work_package}"
-        watched: "You are watching %{work_package}"
-    query:
-      invalid_filter: "Invalid notification filter"
+      total_percent_complete_mode_changed_to_work_weighted_average: >-
+        Child work packages without Work are ignored.
+      unaccessable_work_package_changed: by changes to a related work package
+      work_package_children_changed_times: by changes to child %{link}
+      work_package_duplicate_closed: The status was automatically updated by the duplicated work package %{link}
+      work_package_parent_changed_times: by changes to parent %{link}
+      work_package_predecessor_changed_times: by changes to predecessor %{link}
+      work_package_related_changed_times: by changes to related %{link}
+      working_days_changed:
+        changed: "by changes to working days (%{changes})"
+        dates:
+          non_working: "%{date} is now non-working"
+          working: "%{date} is now working"
+        days:
+          non_working: "%{day} is now non-working"
+          working: "%{day} is now working"
+    caused_changes:
+      budget_deleted: "Budget has been deleted"
+      dates_changed: "Dates changed"
+      default_attribute_written: "Read-only attributes written"
+      import: "Imported"
+      progress_mode_changed_to_status_based: "Progress calculation updated"
+      status_changed: "Status '%{status_name}'"
+      system_update: "OpenProject system update:"
+      total_percent_complete_mode_changed_to_simple_average: "Calculation of % Complete totals now based on a simple average of only % Complete values."
+      total_percent_complete_mode_changed_to_work_weighted_average: "Calculation of % Complete totals now weighted by Work."
+      work_package_duplicate_closed: "Duplicate work package updated:"
+    changes_retracted: "The changes were retracted."
 
   label_accessibility: "Accessibility"
   label_account: "Account"
   label_actions: "Actions"
-  label_active: "Active"
   label_activate_user: "Activate user"
+  label_active: "Active"
   label_active_in_new_projects: "Active in new projects"
   label_activity: "Activity"
-  label_add_edit_translations: "Add and edit translations"
   label_add_another_file: "Add another file"
+  label_add_column: "Add column"
   label_add_columns: "Add selected columns"
+  label_add_edit_translations: "Add and edit translations"
   label_add_note: "Add a note"
   label_add_projects: "Add projects"
   label_add_related_work_packages: "Add related work packages"
@@ -3964,31 +2857,21 @@ en:
   label_additional_workflow_transitions_for_assignee: "Additional transitions allowed when the user is the assignee"
   label_additional_workflow_transitions_for_author: "Additional transitions allowed when the user is the author"
   label_administration: "Administration"
-  label_interface_colors: "Interface colors"
-  label_interface_colors_description: "These colors control how the application looks. If you modify them the theme will automatically be changed to Custom theme, but we can’t assure the compliance of the accessibility contrast minimums (WCAG 2.1). "
   label_age: "Age"
   label_ago: "days ago"
   label_all: "all"
-  label_all_uppercase: "All"
-  label_all_time: "all time"
-  label_all_words: "All words"
   label_all_open_wps: "All open"
+  label_all_time: "all time"
+  label_all_uppercase: "All"
+  label_all_words: "All words"
   label_always_visible: "Always displayed"
-  label_announcement: "Announcement"
   label_angular: "AngularJS"
-  label_app_modules: "%{app_title} modules"
+  label_announcement: "Announcement"
   label_api_access_key: "API access key"
   label_api_access_key_created_on: "API access key created %{value} ago"
   label_api_access_key_type: "API"
-  label_auto_option: "(auto)"
-  label_ical_access_key_type: "iCalendar"
-  label_ical_access_key_description: 'iCalendar token "%{token_name}" for "%{calendar_name}" in "%{project_name}"'
-  label_ical_access_key_not_present: "iCalendar token(s) not present."
-  label_ical_access_key_generation_hint: "Automatically generated when subscribing to a calendar."
-  label_ical_access_key_latest: "latest"
-  label_ical_access_key_revoke: "Revoke"
-  label_integrations: "Integrations"
-  label_add_column: "Add column"
+  label_api_doc: "API documentation"
+  label_app_modules: "%{app_title} modules"
   label_applied_status: "Applied status"
   label_archive_project: "Archive project"
   label_ascending: "Ascending"
@@ -3996,12 +2879,10 @@ en:
   label_associated_revisions: "Associated revisions"
   label_attachment_plural: "Attachments"
   label_attribute: "Attribute"
-  label_attribute_plural: "Attributes"
-  label_ldap_auth_source_new: "New LDAP connection"
-  label_ldap_auth_source: "LDAP connection"
-  label_ldap_auth_source_plural: "LDAP connections"
   label_attribute_expand_text: "The complete text for '%{attribute}'"
+  label_attribute_plural: "Attributes"
   label_authentication: "Authentication"
+  label_auto_option: "(auto)"
   label_available_custom_fields_projects: "Available custom fields projects"
   label_available_global_roles: "Available global roles"
   label_available_project_attributes: "Available project attributes"
@@ -4011,7 +2892,6 @@ en:
   label_available_project_work_package_categories: "Available work package categories"
   label_available_project_work_package_types: "Available work package types"
   label_available_projects: "Available projects"
-  label_api_doc: "API documentation"
   label_backup: "Backup"
   label_backup_code: "Backup code"
   label_basic_details: "Basic details"
@@ -4019,30 +2899,19 @@ en:
   label_blocked_by: "blocked by"
   label_blocks: "blocks"
   label_blog: "Blog"
-  label_forums_locked: "Locked"
-  label_forum_new: "New forum"
-  label_forum_plural: "Forums"
-  label_forum_sticky: "Sticky"
-  label_boolean: "Boolean"
   label_board_plural: "Boards"
+  label_boolean: "Boolean"
   label_branch: "Branch"
   label_browse: "Browse"
   label_builtin: "Built-in"
   label_bulk_edit_selected_work_packages: "Bulk edit selected work packages"
   label_bundled: "(Bundled)"
-  label_calendar: "Calendar"
-  label_calendars_and_dates: "Calendars and dates"
-  label_calendar_show: "Show Calendar"
-  label_category: "Category"
-  label_completed: Completed
-  label_committed_at_html: "%{committed_revision_link} at %{date}"
-  label_committed_link: "committed revision %{revision_identifier}"
-  label_consent_settings: "User Consent"
-  label_wiki_menu_item: Wiki menu item
-  label_select_main_menu_item: Select new main menu item
-  label_required_disk_storage: "Required disk storage"
-  label_send_invitation: Send invitation
   label_calculated_value: "Calculated value"
+  label_calendar: "Calendar"
+  label_calendar_show: "Show Calendar"
+  label_calendar_subscriptions: "Calendar subscriptions"
+  label_calendars_and_dates: "Calendars and dates"
+  label_category: "Category"
   label_change_parent: "Change parent"
   label_change_plural: "Changes"
   label_change_properties: "Change properties"
@@ -4053,71 +2922,99 @@ en:
   label_changeset: "Changeset"
   label_changeset_id: "Changeset ID"
   label_changeset_plural: "Changesets"
-  label_checked: "checked"
   label_check_uncheck_all_in_column: "Check/Uncheck all in column"
   label_check_uncheck_all_in_row: "Check/Uncheck all in row"
+  label_checked: "checked"
   label_child_element: "Child element"
   label_choices: "Choices"
   label_close_versions: "Close completed versions"
+  label_closed: "closed"
   label_closed_work_packages: "closed"
   label_collapse: "Collapse"
   label_collapsed_click_to_show: "Collapsed. Click to show"
-  label_configuration: configuration
+  label_color_plural: "Colors"
+  label_columns: "Columns"
   label_comment_add: "Add a comment"
   label_comment_added: "Comment added"
   label_comment_delete: "Delete comments"
   label_comment_plural: "Comments"
   label_commits_per_author: "Commits per author"
   label_commits_per_month: "Commits per month"
+  label_committed_at_html: "%{committed_revision_link} at %{date}"
+  label_committed_link: "committed revision %{revision_identifier}"
+  label_completed: Completed
+  label_configuration: configuration
   label_confirmation: "Confirmation"
+  label_consent_settings: "User Consent"
   label_contains: "contains"
-  label_starts_with: "starts with"
   label_content: "Content"
-  label_color_plural: "Colors"
+  label_continued_from_previous_year: "continued from previous year"
+  label_continues_into_next_year: "continues into next year"
   label_copied: "copied"
+  label_copy_project: "Copy project"
   label_copy_same_as_target: "Same as target"
   label_copy_source: "Source"
   label_copy_target: "Target"
   label_copy_workflow_from: "Copy workflow from"
-  label_copy_workflow_from_type: "Copy to another type"
   label_copy_workflow_from_role: "Copy to other roles"
-  label_copy_project: "Copy project"
-  label_core_version: "Core version"
+  label_copy_workflow_from_type: "Copy to another type"
   label_core_build: "Core build"
+  label_core_version: "Core version"
   label_created_by: "Created by %{user}"
   label_current_status: "Current status"
   label_current_version: "Current version"
+  label_custom_comment: "%{name} comment"
+  label_custom_export_cover: "Custom export cover background"
+  label_custom_export_cover_overlay: "Custom export cover background overlay"
+  label_custom_export_cover_text_color: "Text color"
+  label_custom_export_font_bold: "Bold"
+  label_custom_export_font_bold_italic: "Bold Italic"
+  label_custom_export_font_instructions: >
+    Upload and manage custom TrueType (.ttf) fonts used in your PDF exports.
+    For best results, use matching files from the same font family. If no font is provided, the default NotoSans font will be used.
+  label_custom_export_font_italic: "Italic"
+  label_custom_export_font_regular: "Regular"
+  label_custom_export_footer: "Custom export footer image"
+  label_custom_export_images_instructions: >
+    Upload and manage custom image files used in your PDF exports.
+  label_custom_export_logo: "Custom export logo"
+  label_custom_favicon: "Custom favicon"
   label_custom_field_add_no_type: "Add this field to a work package type"
+  label_custom_field_default_type: "Empty type"
   label_custom_field_new: "New custom field"
   label_custom_field_plural: "Custom fields"
-  label_custom_field_default_type: "Empty type"
+  label_custom_logo: "Custom logo desktop"
+  label_custom_logo_mobile: "Custom logo mobile"
+  label_custom_pdf_export_settings: "Custom PDF export settings"
   label_custom_style: "Design"
   label_custom_style_description: "Choose how OpenProject looks to you with themes, select your default colors to use in the app and how exports look like."
+  label_custom_touch_icon: "Custom touch icon"
   label_dashboard: "Dashboard"
   label_database_version: "PostgreSQL version"
   label_date: "Date"
-  label_dates: "Dates"
   label_date_and_time: "Date and time"
   label_date_format: "Date format"
   label_date_from: "From"
   label_date_from_to: "From %{start} to %{end}"
   label_date_to: "To"
+  label_dates: "Dates"
   label_day_plural: "days"
   label_default: "Default"
-  label_delete_user: "Delete user"
-  label_delete_project: "Delete project"
+  label_defaults: "Defaults"
   label_delete: "Delete"
+  label_delete_project: "Delete project"
+  label_delete_user: "Delete user"
   label_deleted: "deleted"
   label_deleted_custom_field: "(deleted custom field)"
   label_deleted_custom_item: "(deleted item)"
   label_deleted_custom_option: "(deleted option)"
-  label_empty_element: "(empty)"
-  label_go_back: "Go back one menu level"
-  label_go_forward: "Open %{module} sub-menu"
-  label_missing_or_hidden_custom_option: "(missing value or lacking permissions to access)"
+  label_departments: "Organization"
+  label_departments_description_html: >
+    Define your company’s structure by creating departments and sub-departments in a hierarchical way. This allows you
+    to reflect reporting lines and maintain a clear, structured overview of your organization within OpenProject. You
+    can also import an existing organization structure through [LDAP group synchronisation](ldap_docs_article).
   label_descending: "Descending"
   label_details: "Details"
-  label_defaults: "Defaults"
   label_development_roadmap: "Development roadmap"
   label_diff: "diff"
   label_diff_inline: "inline"
@@ -4131,39 +3028,38 @@ en:
   label_download: "%{count} Download"
   label_download_plural: "%{count} Downloads"
   label_downloads_abbr: "D/L"
-  label_duplicated_by: "duplicated by"
   label_duplicate: "duplicate"
+  label_duplicated_by: "duplicated by"
   label_duplicates: "duplicates"
   label_edit: "Edit"
   label_edit_x: "Edit: %{x}"
-  label_view_x: "View: %{x}"
+  label_empty_element: "(empty)"
   label_enable_multi_select: "Toggle multiselect"
+  label_enabled_project_activities: "Enabled time tracking activities"
   label_enabled_project_custom_fields: "Enabled custom fields"
   label_enabled_project_modules: "Enabled modules"
-  label_enabled_project_activities: "Enabled time tracking activities"
+  label_end_date: "Finish date"
   label_end_to_end: "end to end"
   label_end_to_start: "end to start"
-  label_enumeration_new: "New enumeration value"
-  label_enumeration_value: "Enumeration value"
-  label_enumerations: "Enumerations"
   label_enterprise: "Enterprise"
   label_enterprise_active_users: "%{current}/%{limit} booked active users"
   label_enterprise_edition: "Enterprise edition"
   label_enterprise_support: "Enterprise support"
+  label_enumeration_new: "New enumeration value"
+  label_enumeration_value: "Enumeration value"
+  label_enumerations: "Enumerations"
   label_environment: "Environment"
-  label_estimates_and_progress: "Estimates and progress"
   label_equals: "is"
   label_equals_with_descendants: "is any with descendants"
+  label_estimates_and_progress: "Estimates and progress"
   label_everywhere: "everywhere"
   label_example: "Example"
-  label_experimental: "Experimental"
-  label_i_am_member: "I am member"
-  label_ifc_viewer: "Ifc Viewer"
-  label_ifc_model_plural: "Ifc Models"
-  label_import: "Import"
-  label_export_to: "Also available in:"
   label_expand: "Expand"
   label_expanded_click_to_collapse: "Expanded. Click to collapse"
+  label_experimental: "Experimental"
+  label_export_plural: "Exports"
+  label_export_to: "Also available in:"
+  label_external_links: "External links"
   label_f_hour: "%{value} hour"
   label_f_hour_plural: "%{value} hours"
   label_favorite: "Favorite"
@@ -4174,8 +3070,8 @@ en:
   label_file_plural: "Files"
   label_filter: "Filters"
   label_filter_add: "Add filter"
-  label_filter_by: "Filter by"
   label_filter_any_name_attribute: "Name attributes"
+  label_filter_by: "Filter by"
   label_filter_plural: "Filters"
   label_filters_toggle: "Show/hide filters"
   label_float: "Float"
@@ -4183,68 +3079,77 @@ en:
   label_follows: "follows"
   label_form_configuration: "Form configuration"
   label_formula: "Formula"
+  label_forum_new: "New forum"
+  label_forum_plural: "Forums"
+  label_forum_sticky: "Sticky"
+  label_forums_locked: "Locked"
   label_gantt_chart: "Gantt chart"
   label_gantt_chart_plural: "Gantt charts"
   label_general: "General"
   label_generate_key: "Generate a key"
-  label_global_modules: "Global modules"
-  label_global_roles: "Global roles"
   label_git_path: "Path to .git directory"
+  label_global: "Global"
+  label_global_modules: "Global modules"
+  label_global_role: "Global role"
+  label_global_roles: "Global roles"
+  label_go_back: "Go back one menu level"
+  label_go_forward: "Open %{module} sub-menu"
   label_greater_or_equal: ">="
-  label_group_by: "Group by"
-  label_group_new: "New group"
   label_group: "Group"
+  label_group_by: "Group by"
   label_group_named: "Group %{name}"
+  label_group_new: "New group"
   label_group_plural: "Groups"
   label_help: "Help"
   label_here: here
   label_hide: "Hide"
-  label_history: "History"
   label_hierarchy: "Hierarchy"
   label_hierarchy_leaf: "Hierarchy leaf"
+  label_history: "History"
   label_home: "Home"
-  label_subject_or_id: "Subject or ID"
-  label_calendar_subscriptions: "Calendar subscriptions"
+  label_i_am_member: "I am member"
+  label_ical_access_key_description: 'iCalendar token "%{token_name}" for "%{calendar_name}" in "%{project_name}"'
+  label_ical_access_key_generation_hint: "Automatically generated when subscribing to a calendar."
+  label_ical_access_key_latest: "latest"
+  label_ical_access_key_not_present: "iCalendar token(s) not present."
+  label_ical_access_key_revoke: "Revoke"
+  label_ical_access_key_type: "iCalendar"
   label_identifier: "Identifiers"
-  label_project_identifier: "Project identifier"
+  label_ifc_model_plural: "Ifc Models"
+  label_ifc_viewer: "Ifc Viewer"
+  label_import: "Import"
   label_in: "in"
   label_in_less_than: "in less than"
   label_in_more_than: "in more than"
   label_inactive: "Inactive"
-  label_incoming_emails: "Incoming emails"
-  label_includes: "includes"
-  label_incomplete: Incomplete
   label_include_sub_projects: Include sub-projects
+  label_includes: "includes"
+  label_incoming_emails: "Incoming emails"
+  label_incomplete: Incomplete
   label_index_by_date: "Index by date"
   label_index_by_title: "Index by title"
   label_information: "Information"
   label_information_plural: "Information"
   label_installation_guides: "Installation guides"
   label_integer: "Integer"
+  label_integrations: "Integrations"
   label_interface: "Interface"
+  label_interface_colors: "Interface colors"
+  label_interface_colors_description: "These colors control how the application looks. If you modify them the theme will automatically be changed to Custom theme, but we can’t assure the compliance of the accessibility contrast minimums (WCAG 2.1). "
   label_internal: "Internal"
   label_introduction_video: "Getting started video"
+  label_invitation: Invitation
   label_invite_user: "Invite user"
   label_item: "Item"
   label_item_plural: "Items"
-  label_weighted_item_list: "Weighted item list"
-  label_share: "Share"
-  label_share_project_list: "Share project list"
-  label_share_work_package: "Share work package"
-  label_show_all_registered_users: "Show all registered users"
-  label_show_less: "Show less"
-  label_show_more: "Show more"
+  label_jira_import: "Jira Migrator"
   label_journal: "Journal"
   label_journal_diff: "Description Comparison"
-  label_language: "Language"
-  label_languages: "Languages"
-  label_export_plural: "Exports"
-  label_external_links: "External links"
-  label_locale: "Language and region"
   label_jump_to_a_project: "Jump to a project..."
-  label_jira_import: "Jira Migrator"
   label_keyword_plural: "Keywords"
+  label_language: "Language"
   label_language_based: "Based on user's language"
+  label_languages: "Languages"
   label_last_activity: "Last activity"
   label_last_change_on: "Last change on"
   label_last_changes: "last %{count} changes"
@@ -4254,57 +3159,43 @@ en:
   label_last_week: "last week"
   label_latest_revision: "Latest revision"
   label_latest_revision_plural: "Latest revisions"
+  label_ldap_auth_source: "LDAP connection"
+  label_ldap_auth_source_new: "New LDAP connection"
+  label_ldap_auth_source_plural: "LDAP connections"
   label_ldap_authentication: "LDAP authentication"
   label_learn_more: "Learn more"
   label_less_or_equal: "<="
   label_less_than_ago: "less than days ago"
+  label_life_cycle_step_plural: "Project life cycle"
   label_link_url: "Link (URL)"
   label_list: "List"
   label_loading: "Loading..."
-  label_locked: "locked"
+  label_locale: "Language and region"
   label_lock_user: "Lock user"
+  label_locked: "locked"
   label_logged_as: "Logged in as"
   label_login: "Sign in"
-  label_custom_comment: "%{name} comment"
-  label_custom_logo: "Custom logo desktop"
-  label_custom_logo_mobile: "Custom logo mobile"
-  label_custom_export_logo: "Custom export logo"
-  label_custom_export_cover: "Custom export cover background"
-  label_custom_export_footer: "Custom export footer image"
-  label_custom_export_font_regular: "Regular"
-  label_custom_export_font_bold: "Bold"
-  label_custom_export_font_italic: "Italic"
-  label_custom_export_font_bold_italic: "Bold Italic"
-  label_custom_export_cover_overlay: "Custom export cover background overlay"
-  label_custom_export_cover_text_color: "Text color"
-  label_custom_pdf_export_settings: "Custom PDF export settings"
-  label_custom_favicon: "Custom favicon"
-  label_custom_touch_icon: "Custom touch icon"
-  label_departments: "Organization"
-  label_departments_description_html: >
-    Define your company’s structure by creating departments and sub-departments in a hierarchical way. This allows you
-    to reflect reporting lines and maintain a clear, structured overview of your organization within OpenProject. You
-    can also import an existing organization structure through [LDAP group synchronisation](ldap_docs_article).
   label_logout: "Sign out"
-  label_mapping_for: "Mapping for: %{attribute}"
   label_main_menu: "Side Menu"
   label_manage: "Manage"
   label_manage_groups: "Manage groups"
   label_managed_repositories_vendor: "Managed %{vendor} repositories"
+  label_mapping_for: "Mapping for: %{attribute}"
   label_mathematical_operators: "Mathematical operators"
   label_max_size: "Maximum size"
   label_me: "me"
-  label_member_new: "New member"
   label_member_all_admin: "(All roles due to admin status)"
+  label_member_new: "New member"
   label_member_plural: "Members"
-  label_membership_plural: "Memberships"
+  label_member_role: "Project role"
   label_membership_added: "Member added"
+  label_membership_plural: "Memberships"
   label_membership_updated: "Member updated"
   label_menu: "Menu"
   label_menu_badge:
-    pre_alpha: "pre-alpha"
     alpha: "alpha"
     beta: "beta"
+    pre_alpha: "pre-alpha"
   label_menu_item_name: "Name of menu item"
   label_message: "Message"
   label_message_last: "Last message"
@@ -4315,10 +3206,12 @@ en:
   label_minute_plural: "minutes"
   label_missing_api_access_key: "Missing API access key"
   label_missing_feeds_access_key: "Missing RSS access key"
+  label_missing_or_hidden_custom_option: "(missing value or lacking permissions to access)"
   label_modification: "%{count} change"
   label_modified: "modified"
   label_module_plural: "Modules"
   label_modules: "Modules"
+  label_modules_and_plugins: "Modules and Plugins"
   label_months_from: "months from"
   label_more: "More"
   label_more_information: "More information"
@@ -4327,8 +3220,8 @@ en:
   label_move_column_right: "Move column right"
   label_move_work_package: "Move work package"
   label_my_account: "Account settings"
-  label_my_activity: "My activity"
   label_my_account_data: "My account data"
+  label_my_activity: "My activity"
   label_my_avatar: "My avatar"
   label_my_queries: "My custom queries"
   label_name: "Name"
@@ -4336,13 +3229,13 @@ en:
   label_new: "New"
   label_new_features: "New features"
   label_new_statuses_allowed: "New statuses allowed"
-  label_news_singular: "News"
   label_news_added: "News added"
   label_news_comment_added: "Comment added to a news"
+  label_news_edit: "Edit news"
   label_news_latest: "Latest news"
   label_news_new: "Add news"
-  label_news_edit: "Edit news"
   label_news_plural: "News"
+  label_news_singular: "News"
   label_news_view_all: "View all news"
   label_next: "Next"
   label_next_week: "Next week"
@@ -4350,31 +3243,35 @@ en:
   label_no_change_option: "(No change)"
   label_no_data: "No data to display"
   label_no_due_date: "no finish date"
-  label_no_start_date: "no start date"
-  label_no_parent_page: "No parent page"
   label_no_parent_group: "(No parent group)"
-  label_notification_center_plural: "Notifications"
-  label_nothing_display: "Nothing to display"
+  label_no_parent_page: "No parent page"
+  label_no_start_date: "no start date"
   label_nobody: "nobody"
-  label_not_configured: "Not configured"
-  label_not_found: "not found"
+  label_non_working_days: "Availability calendar"
+  label_non_working_days_summary: "Summary"
+  label_non_working_days_with_count: "Non-working days (%{count})"
+  label_non_working_times_summary: "%{year} summary"
+  label_non_working_times_with_count: "%{year} time off (%{count})"
   label_none: "none"
   label_none_parentheses: "(none)"
+  label_not_changeable: "(not changeable)"
+  label_not_configured: "Not configured"
   label_not_contains: "doesn't contain"
   label_not_equals: "is not"
-  label_life_cycle_step_plural: "Project life cycle"
+  label_not_found: "not found"
+  label_nothing_display: "Nothing to display"
+  label_notification_center_plural: "Notifications"
   label_on: "on"
-  label_operator_all: "is not empty"
-  label_operator_none: "is empty"
-  label_operator_equals_or: "is (OR)"
-  label_operator_equals_all: "is (AND)"
-  label_operator_shared_with_user_any: "any"
   label_open: "open"
-  label_closed: "closed"
   label_open_menu: "Open menu"
   label_open_work_packages: "open"
   label_open_work_packages_plural: "open"
   label_openproject_website: "OpenProject website"
+  label_operator_all: "is not empty"
+  label_operator_equals_all: "is (AND)"
+  label_operator_equals_or: "is (OR)"
+  label_operator_none: "is empty"
+  label_operator_shared_with_user_any: "any"
   label_optional_description: "Description"
   label_options: "Options"
   label_other: "Other"
@@ -4386,17 +3283,18 @@ en:
     This will also inherit all memberships, including permissions of the parent group.
   label_part_of: "part of"
   label_password_lost: "Forgot your password?"
-  label_password_rule_lowercase: "Lowercase"
-  label_password_rule_numeric: "Numeric Characters"
-  label_password_rule_special: "Special Characters"
-  label_password_rule_uppercase: "Uppercase"
   label_password_requirement_lowercase: "Must contain at least one lowercase character."
   label_password_requirement_numeric: "Must contain at least one numeric character."
   label_password_requirement_special: "Must contain at least one special character."
   label_password_requirement_uppercase: "Must contain at least one uppercase character."
+  label_password_rule_lowercase: "Lowercase"
+  label_password_rule_numeric: "Numeric Characters"
+  label_password_rule_special: "Special Characters"
+  label_password_rule_uppercase: "Uppercase"
   label_path_encoding: "Path encoding"
-  label_per_page: "Per page:"
   label_people: "People"
+  label_per_page: "Per page:"
+  label_percent_complete: "% Complete"
   label_permissions: "Permissions"
   label_permissions_report: "Permissions report"
   label_personalize_page: "Personalize this page"
@@ -4406,8 +3304,9 @@ en:
   label_planning: "Planning"
   label_please_login: "Please log in"
   label_plugins: "Plugins"
+  label_portfolio: "Portfolio"
+  label_portfolio_new: "New portfolio"
   label_portfolio_plural: "Portfolios"
-  label_modules_and_plugins: "Modules and Plugins"
   label_precedes: "precedes"
   label_preferences: "Preferences"
   label_preview: "Preview"
@@ -4420,38 +3319,36 @@ en:
   label_privacy_policy: "Data privacy and security policy"
   label_product_version: "Product version"
   label_profile: "Profile"
-  label_percent_complete: "% Complete"
+  label_program: "Program"
+  label_program_new: "New program"
   label_progress_tracking: "Progress tracking"
   label_project: "Project"
   label_project_activity: "Project activity"
-  label_project_attribute_plural: "Project attributes"
   label_project_attribute_manage_link: "Manage project attributes"
-  label_project_count: "Total number of projects"
+  label_project_attribute_plural: "Project attributes"
+  label_project_attributes_plural: "Project attributes"
+  label_project_attributes_settings: "Project attributes settings"
   label_project_copy_notifications: "Send email notifications during the project copy"
+  label_project_count: "Total number of projects"
+  label_project_custom_field_plural: "Project attributes"
+  label_project_default_type: "Allow empty type"
+  label_project_hide_details: "Hide project details"
+  label_project_hierarchy: "Project hierarchy"
+  label_project_identifier: "Project identifier"
   label_project_initiation_export_pdf: "Export PDF for %{project_creation_name}"
   label_project_latest: "Latest projects"
-  label_project_default_type: "Allow empty type"
-  label_project_hierarchy: "Project hierarchy"
+  label_project_life_cycle: "Project life cycle"
+  label_project_list_plural: "Project lists"
   label_project_mappings: "Projects"
   label_project_new: "New project"
   label_project_plural: "Projects"
-  label_project_list_plural: "Project lists"
-  label_reserved_identifiers: "Reserved project identifiers"
-  label_project_life_cycle: "Project life cycle"
-  label_project_attributes_plural: "Project attributes"
-  label_project_custom_field_plural: "Project attributes"
   label_project_settings: "Project settings"
-  label_project_attributes_settings: "Project attributes settings"
+  label_project_show_details: "Show project details"
   label_project_storage_plural: "File storages"
   label_project_storage_project_folder: "File storages: Project folders"
-  label_projects_disk_usage_information: "%{count} projects using %{used_disk_space} disk space"
   label_project_view_all: "View all projects"
-  label_project_show_details: "Show project details"
-  label_project_hide_details: "Hide project details"
-  label_portfolio: "Portfolio"
-  label_portfolio_new: "New portfolio"
-  label_program: "Program"
-  label_program_new: "New program"
+  label_projects_disk_usage_information: "%{count} projects using %{used_disk_space} disk space"
+  label_projects_menu: "Projects"
   label_public_projects: "Public projects"
   label_query_new: "New query"
   label_query_plural: "Custom queries"
@@ -4481,66 +3378,80 @@ en:
   label_reporting: "Reporting"
   label_reporting_plural: "Reportings"
   label_repository: "Repository"
+  label_repository_plural: "Repositories"
   label_repository_remove: "Remove repository"
   label_repository_root: "Repository root"
-  label_repository_plural: "Repositories"
   label_request_submission: "Request submission"
   label_required: "required"
+  label_required_disk_storage: "Required disk storage"
   label_requires: "requires"
+  label_reserved_identifiers: "Reserved project identifiers"
   label_result_plural: "Results"
   label_revision: "Revision"
   label_revision_id: "Revision %{value}"
   label_revision_plural: "Revisions"
   label_roadmap: "Roadmap"
-  label_roadmap_edit: "Edit roadmap %{name}"
   label_roadmap_due_in: "Due in %{value}"
+  label_roadmap_edit: "Edit roadmap %{name}"
   label_roadmap_no_work_packages: "No work packages for this version"
   label_roadmap_overdue: "%{value} late"
   label_role_and_permissions: "Roles and permissions"
-  label_role_new: "New role"
   label_role_grantable: "Grantable role"
-  label_role_plural: "Roles"
   label_role_missing_permissions: "%{role} (missing required permissions)"
+  label_role_new: "New role"
+  label_role_plural: "Roles"
   label_role_search: "Assign role to new members"
+  label_role_type: "Type"
+  label_schedule_and_availability: "Schedule and availability"
   label_scm: "SCM"
   label_scroll_left: "Scroll left"
   label_scroll_right: "Scroll right"
   label_search: "Search"
   label_search_by_name: "Search by name"
+  label_seeded_from_env_warning: This record has been created through a setting environment variable. It is not editable through UI.
+  label_select_main_menu_item: Select new main menu item
   label_send_information: "Send new credentials to the user"
+  label_send_invitation: Send invitation
   label_send_test_email: "Send a test email"
   label_session: "Session"
   label_setting_plural: "Settings"
-  label_system_settings: "System settings"
+  label_share: "Share"
+  label_share_project_list: "Share project list"
+  label_share_work_package: "Share work package"
+  label_show_all_registered_users: "Show all registered users"
   label_show_completed_versions: "Show completed versions"
-  label_columns: "Columns"
+  label_show_less: "Show less"
+  label_show_more: "Show more"
   label_sort: "Sort"
   label_sort_ascending: "Sort ascending"
   label_sort_by: "Sort by %{value}"
-  label_sorted_by: "sorted by %{value}"
   label_sort_descending: "Sort descending"
   label_sort_higher: "Move up"
   label_sort_highest: "Move to top"
   label_sort_lower: "Move down"
   label_sort_lowest: "Move to bottom"
+  label_sorted_by: "sorted by %{value}"
   label_spent_time: "Spent time"
   label_start_to_end: "start to end"
   label_start_to_start: "start to start"
+  label_starts_with: "starts with"
   label_statistics: "Statistics"
   label_status: "Status"
   label_status_plural: "Statuses"
-  label_storage_free_space: "Remaining disk space"
-  label_storage_used_space: "Used disk space"
-  label_storage_group: "Storage filesystem %{identifier}"
   label_storage_for: "Encompasses storage for"
+  label_storage_free_space: "Remaining disk space"
+  label_storage_group: "Storage filesystem %{identifier}"
+  label_storage_used_space: "Used disk space"
   label_string: "Text"
+  label_subitems: "Subitems"
+  label_subject_or_id: "Subject or ID"
   label_subproject: "Subproject"
   label_subproject_new: "New subproject"
   label_subproject_plural: "Subprojects"
-  label_subitems: "Subitems"
   label_subtask_plural: "Subtasks"
   label_summary: "Summary"
   label_system: "System"
+  label_system_settings: "System settings"
   label_system_storage: "Storage information"
   label_table_of_contents: "Table of contents"
   label_tag: "Tag"
@@ -4552,19 +3463,21 @@ en:
   label_this_week: "this week"
   label_this_year: "this year"
   label_time: "Time"
-  label_time_entry_plural: "Spent time"
   label_time_entry_activity_plural: "Spent time activities"
+  label_time_entry_plural: "Spent time"
   label_title: "Title"
-  label_projects_menu: "Projects"
   label_today: "today"
+  label_today_as_date: "Select today as date."
+  label_today_as_due_date: "Select today as finish date."
+  label_today_as_start_date: "Select today as start date."
   label_today_capitalized: "Today"
   label_token_version: "Token Version"
-  label_today_as_start_date: "Select today as start date."
-  label_today_as_due_date: "Select today as finish date."
-  label_today_as_date: "Select today as date."
   label_top_menu: "Top Menu"
   label_topic_plural: "Topics"
   label_total: "Total"
+  label_total_days_off: "Total days off"
+  label_total_global_non_working_days: "Global non-working days"
+  label_total_user_non_working_times: "Personal non-working days"
   label_type_new: "New type"
   label_type_plural: "Types"
   label_ui: "User Interface"
@@ -4576,19 +3489,19 @@ en:
   label_used_by_types: "Used by types"
   label_used_in_projects: "Used in projects"
   label_user: "User"
-  label_user_and_permission: "Users and permissions"
-  label_user_named: "User %{name}"
   label_user_activity_html: "%{value}'s activity"
+  label_user_and_permission: "Users and permissions"
   label_user_anonymous: "Anonymous"
   label_user_menu: "User menu"
+  label_user_named: "User %{name}"
   label_user_new: "New user"
   label_user_plural: "Users"
   label_user_search: "Search for user"
   label_user_settings: "User settings"
   label_users_settings: "Users settings"
   label_value_x: "Value: %{x}"
-  label_version_new: "New version"
   label_version_edit: "Edit version"
+  label_version_new: "New version"
   label_version_plural: "Versions"
   label_version_sharing_descendants: "With subprojects"
   label_version_sharing_hierarchy: "With project hierarchy"
@@ -4599,48 +3512,53 @@ en:
   label_view_all_revisions: "View all revisions"
   label_view_diff: "View differences"
   label_view_revisions: "View revisions"
+  label_view_x: "View: %{x}"
   label_watched_work_packages: "Watched work packages"
-  label_what_is_this: "What is this?"
   label_week: "Week"
+  label_weighted_item_list: "Weighted item list"
+  label_what_is_this: "What is this?"
   label_widget: "Widget"
   label_widget_new: "New widget"
   label_wiki_content_added: "Wiki page added"
   label_wiki_content_updated: "Wiki page updated"
-  label_wiki_toc: "Table of Contents"
-  label_wiki_toc_empty: "Table of Contents is empty as no headings are present."
   label_wiki_dont_show_menu_item: "Do not show this wikipage in project navigation"
   label_wiki_edit: "Wiki edit"
   label_wiki_edit_plural: "Wiki edits"
-  label_wiki_page_attachments: "Wiki page attachments"
-  label_wiki_page_id: "Wiki page ID"
+  label_wiki_menu_item: Wiki menu item
   label_wiki_navigation: "Wiki navigation"
   label_wiki_page: "Wiki page"
+  label_wiki_page_attachments: "Wiki page attachments"
+  label_wiki_page_id: "Wiki page ID"
   label_wiki_page_plural: "Wiki pages"
   label_wiki_show_index_page_link: "Show submenu item 'Table of Contents'"
   label_wiki_show_menu_item: "Show as menu item in project navigation"
   label_wiki_show_new_page_link: "Show submenu item 'Create new child page'"
   label_wiki_start: "Start page"
+  label_wiki_toc: "Table of Contents"
+  label_wiki_toc_empty: "Table of Contents is empty as no headings are present."
   label_work: "Work"
   label_work_package: "Work package"
   label_work_package_attachments: "Work package attachments"
   label_work_package_category_new: "New category"
   label_work_package_category_plural: "Work package categories"
   label_work_package_comments: "Work package comments"
+  label_work_package_edit: "Edit work package %{name}"
   label_work_package_hierarchy: "Work package hierarchy"
   label_work_package_new: "New work package"
-  label_work_package_edit: "Edit work package %{name}"
   label_work_package_plural: "Work packages"
   label_work_package_status: "Work package status"
   label_work_package_status_new: "New status"
   label_work_package_status_plural: "Work package statuses"
-  label_work_package_types: "Work package types"
   label_work_package_tracking: "Work package tracking"
+  label_work_package_types: "Work package types"
   label_work_package_view_all: "View all work packages"
   label_workflow: "Workflow"
   label_workflow_copy: "Copy workflow"
   label_workflow_plural: "Workflows"
   label_workflow_summary: "Summary"
+  label_working_days: "Working days"
   label_working_days_and_hours: "Working days and hours"
+  label_working_hours: "Work schedule"
   label_x_closed_work_packages_abbr:
     one: "1 closed"
     other: "%{count} closed"
@@ -4649,89 +3567,152 @@ en:
     one: "1 comment"
     other: "%{count} comments"
     zero: "no comments"
-  label_x_items:
-    one: "1 item"
-    other: "%{count} items"
-    zero: "no items"
-  label_x_open_work_packages_abbr:
-    one: "1 open"
-    other: "%{count} open"
-    zero: "0 open"
-  label_x_work_packages:
-    one: "1 work package"
-    other: "%{count} work packages"
-    zero: "No work packages"
-  label_x_projects:
-    one: "1 project"
-    other: "%{count} projects"
-    zero: "no projects"
+  label_x_days:
+    one: "1 day"
+    other: "%{count} days"
   label_x_files:
     one: "1 file"
     other: "%{count} files"
     zero: "no files"
-  label_x_days:
-    one: "1 day"
-    other: "%{count} days"
+  label_x_items:
+    one: "1 item"
+    other: "%{count} items"
+    zero: "no items"
+  label_x_items_selected:
+    one: "One item selected"
+    other: "%{count} items selected"
+  label_x_open_work_packages_abbr:
+    one: "1 open"
+    other: "%{count} open"
+    zero: "0 open"
+  label_x_projects:
+    one: "1 project"
+    other: "%{count} projects"
+    zero: "no projects"
+  label_x_work_packages:
+    one: "1 work package"
+    other: "%{count} work packages"
+    zero: "No work packages"
   label_x_working_days:
     one: "1 working day"
     other: "%{count} working days"
   label_x_working_days_time_off:
     one: "Time off: 1 working day"
     other: "Time off: %{count} working days"
-  label_x_items_selected:
-    one: "One item selected"
-    other: "%{count} items selected"
   label_yesterday: "yesterday"
   label_zen_mode: "Zen mode"
-  label_role_type: "Type"
-  label_member_role: "Project role"
-  label_global_role: "Global role"
-  label_not_changeable: "(not changeable)"
-  label_global: "Global"
-  label_seeded_from_env_warning: This record has been created through a setting environment variable. It is not editable through UI.
-  label_schedule_and_availability: "Schedule and availability"
-  label_working_hours: "Work schedule"
-  label_non_working_days: "Availability calendar"
-  label_non_working_days_with_count: "Non-working days (%{count})"
-  label_non_working_days_summary: "Summary"
-  button_add_non_working_time: "Time off"
-  button_edit_non_working_time: "Edit time off"
-  label_continued_from_previous_year: "continued from previous year"
-  label_continues_into_next_year: "continues into next year"
-  label_end_date: "Finish date"
-  label_working_days: "Working days"
-  label_non_working_times_with_count: "%{year} time off (%{count})"
-  label_non_working_times_summary: "%{year} summary"
-  label_total_user_non_working_times: "Personal non-working days"
-  label_total_global_non_working_days: "Global non-working days"
-  label_total_days_off: "Total days off"
+  ldap_auth_sources:
+    attribute_texts:
+      admin_map_html: "Optional: The attribute key in LDAP that <strong>if present</strong> marks the OpenProject user an admin. Leave empty when in doubt."
+      base_dn: |
+        Enter the Base DN of the subtree in LDAP you want OpenProject to look for users and groups.
+        OpenProject will filter for provided usernames in this subtree only.
+        Example: ou=users,dc=example,dc=com
+      filter_string: |
+        Add an optional RFC4515 filter to apply to the results returned for users filtered in the LDAP.
+        This can be used to restrict the set of users that are found by OpenProject for authentication and group synchronization.
+      filter_string_concat: |
+        OpenProject will always filter for the login attribute provided by the user to identify the record. If you provide a filter here,
+        it will be concatenated with an AND. By default, a catch-all (objectClass=*) will be used as a filter.
+      generic_map: The attribute key in LDAP that is mapped to the OpenProject `%{attribute}` attribute
+      host: LDAP host name or IP address
+      login_map: The attribute key in LDAP that is used to identify the unique user login. Usually, this will be `uid` or `samAccountName`.
+      name: Arbitrary name of the LDAP connection
+      onthefly_register: |
+        If you check this box, OpenProject will automatically create new users from their LDAP entries
+        when they first authenticate with OpenProject.
+        Leave this unchecked to only allow existing accounts in OpenProject to authenticate through LDAP!
+
+      system_user_dn_html: |
+        Enter the DN of the system user used for read-only access.
+        <br>
+        Example: uid=openproject,ou=system,dc=example,dc=com
+      system_user_password: Enter the bind password of the system user
+    back_to_index: "Click here to go back to the list of connection."
+    connection_encryption: "Connection encryption"
+    encryption_details: "LDAPS / STARTTLS options"
+    ldap_auth_failed: "Could not authenticate at the LDAP-Server."
+    ldap_details: "LDAP details"
+    ldap_error: "LDAP-Error: %{error_message}"
+    sync_failed: "Failed to synchronize from LDAP: %{message}."
+    system_account: "System account"
+    system_account_legend: |
+      OpenProject requires read-only access through a system account to lookup users and groups in your LDAP tree.
+      Please specify the bind credentials for that system user in the following section.
+    technical_warning: |
+      This LDAP form requires technical knowledge of your LDAP / Active Directory setup.
+      [Please visit our documentation for detailed instructions](docs_url).
+    tls_mode:
+      plain: "none"
+      plain_description: "Opens an unencrypted connection to the LDAP server. Not recommended for production."
+      section_more_info_link_html: >
+        This section concerns the connection security of this LDAP authentication source.
+        For more information, visit <a href="%{link}">the Net::LDAP documentation</a>.
+      simple_tls: "LDAPS"
+      simple_tls_description: "Use LDAPS. Requires a separate port on the LDAP server. This mode is often deprecated, we recommend using STARTTLS whenever possible."
+      start_tls: "STARTTLS"
+      start_tls_description: "Sends a STARTTLS command after connecting to the standard LDAP port. Recommended for encrypted connections."
+    tls_options:
+      tls_certificate_description: "If the LDAP server certificate is not in the trust sources of this system, you can add it manually here. Enter a PEM X509 certifiate string."
+      verify_peer: "Verify SSL certificate"
+      verify_peer_description_html: >
+        Enables strict SSL verification of the certificate trusted chain.
+        <br>
+        <strong>Warning:</strong> Unchecking this option disables SSL verification of the LDAP server certificate.
+        This exposes your connection to Man in the Middle attacks.
+    user_settings: "Attribute mapping"
+    user_settings_legend: |
+      The following fields are related to how users are created in OpenProject from LDAP entries and
+      what LDAP attributes are used to define the attributes of an OpenProject user (attribute mapping).
+  link: link
+
+  links:
+    configuration_guide: "Configuration guide"
+    get_in_touch: "You have questions? Get in touch with us."
+
+  lists:
+    can_be_saved: "List modified:"
+    can_be_saved_as: "The modifications can only be saved in a new list:"
+
+    create:
+      failure: "The modified list cannot be saved: %{errors}"
+      success: "The modified list has been saved as a new list"
+    publish:
+      failure: "The list cannot be made public: %{errors}"
+      success: "The list has been made public"
+    unpublish:
+      failure: "The list cannot be made private: %{errors}"
+      success: "The list has been made private"
+    update:
+      failure: "The modified list cannot be saved: %{errors}"
+      success: "The modified list has been saved"
   macro_execution_error: "Error executing the macro %{macro_name}"
   macro_unavailable: "Macro %{macro_name} cannot be displayed."
   macro_unknown: "Unknown or unsupported macro."
   macros:
-    placeholder: "[Placeholder] Macro %{macro_name}"
+    create_work_package_link:
+      errors:
+        invalid_type: "No type found with name '%{type}' in project '%{project}'."
+        no_project_context: "Calling create_work_package_link macro from outside project context."
+      link_name: "New work package"
+      link_name_type: "New %{type_name}"
     errors:
       missing_or_invalid_parameter: "Missing or invalid macro parameter."
-    legacy_warning:
-      timeline: "This legacy timeline macro has been removed and is no longer available. You can replace the functionality with an embedded table macro."
     include_wiki_page:
       removed: "The macro does no longer exist."
+    legacy_warning:
+      timeline: "This legacy timeline macro has been removed and is no longer available. You can replace the functionality with an embedded table macro."
+    placeholder: "[Placeholder] Macro %{macro_name}"
     wiki_child_pages:
       errors:
         page_not_found: "Cannot find the wiki page '%{name}'."
-    create_work_package_link:
-      errors:
-        no_project_context: "Calling create_work_package_link macro from outside project context."
-        invalid_type: "No type found with name '%{type}' in project '%{project}'."
-      link_name: "New work package"
-      link_name_type: "New %{type_name}"
   mail:
     actions: "Actions"
     digests:
-      including_mention_singular: "including a mention"
       including_mention_plural: "including %{number_mentioned} mentions"
-      unread_notification_singular: "1 unread notification"
+      including_mention_singular: "including a mention"
       unread_notification_plural: "%{number_unread} unread notifications"
+      unread_notification_singular: "1 unread notification"
       you_have: "You have"
     logo_alt_text: "Logo"
     mention:
@@ -4740,8 +3721,51 @@ en:
       center: "To notification center"
       see_in_center: "See comment in notification center"
       settings: "Change email settings"
+    reminder_notifications:
+      heading: "You have a new reminder"
+      note: "Note: “%{note}”"
+      subject: "Reminder: %{note}"
     salutation: "Hello %{user},"
     salutation_full_name: "Full name"
+    sharing:
+      work_packages:
+        allowed_actions_html: "You have the following permissions on this work package: %{allowed_actions}. This can change depending on your project role and permissions."
+        create_account: "To access this work package, you will need to create and activate an account on %{instance}."
+        enterprise_text: "Share work packages with users who are not members of the project."
+        open_work_package: "Open work package"
+        subject: "Work package %{id} was shared with you"
+        summary:
+          group: "%{user} shared a work package with the group %{group} you are a member of"
+          user: "%{user} shared a work package with you with %{role_rights} rights"
+    storages:
+      health:
+        email_notification_settings: "Storage email notification settings"
+        healthy:
+          solved_at: "solved at"
+          subject: 'Storage "%{name}" is now healthy!'
+          summary: "The problem with your %{storage_name} storage integration is now solved"
+        plaintext:
+          healthy:
+            details: "For more details or to make any necessary amendments, you can visit your storage configuration"
+            error-solved-on: "Solved On"
+            recommendation: "We will continue monitoring the system to ensure it remains in good health. In case of any discrepancies, we will notify you."
+            summary: 'Good news! The status of your storage, %{storage_name}, is currently displaying as "Healthy".'
+          storage: "Storage"
+          unhealthy:
+            error-details: "Error Details"
+            error-message: "Error Message"
+            error-occurred-on: "Occurred On"
+            recommendation: "We recommend heading over to the storage configuration page to address this issue"
+            summary: 'The status of your storage, %{storage_name}, is currently displaying as "Error". We''ve detected an issue that might require your attention.'
+            unsubscribe: "If you would no longer like to receive these notifications, you can unsubscribe at any time. To unsubscribe, please follow the instructions on this page"
+        see_storage_settings: "See storage settings"
+        unhealthy:
+          since: "since"
+          subject: 'Storage "%{name}" is unhealthy!'
+          summary: "There is a problem with your %{storage_name} storage integration"
+          troubleshooting:
+            link_text: "troubleshooting documentation"
+            text: "For more information, check file storages"
     work_packages:
       created_at: "Created at %{timestamp} by %{user} "
       login_to_see_all: "Log in to see all notifications."
@@ -4752,92 +3776,73 @@ en:
         other: "There are %{count} more work packages with notifications."
       open_in_browser: "Open in browser"
       reason:
-        watched: "Watched"
         assigned: "Assigned"
-        responsible: "Accountable"
+        date_alert_due_date: "Date alert"
+        date_alert_start_date: "Date alert"
         mentioned: "Mentioned"
+        prefix: "Received because of the notification setting: %{reason}"
+        reminder: "Reminder"
+        responsible: "Accountable"
         shared: "Shared"
         subscribed: "all"
-        prefix: "Received because of the notification setting: %{reason}"
-        date_alert_start_date: "Date alert"
-        date_alert_due_date: "Date alert"
-        reminder: "Reminder"
+        watched: "Watched"
       see_all: "See all"
       updated_at: "Updated at %{timestamp} by %{user}"
-    reminder_notifications:
-      subject: "Reminder: %{note}"
-      heading: "You have a new reminder"
-      note: "Note: “%{note}”"
-    sharing:
-      work_packages:
-        allowed_actions_html: "You have the following permissions on this work package: %{allowed_actions}. This can change depending on your project role and permissions."
-        create_account: "To access this work package, you will need to create and activate an account on %{instance}."
-        open_work_package: "Open work package"
-        subject: "Work package %{id} was shared with you"
-        enterprise_text: "Share work packages with users who are not members of the project."
-        summary:
-          user: "%{user} shared a work package with you with %{role_rights} rights"
-          group: "%{user} shared a work package with the group %{group} you are a member of"
-    storages:
-      health:
-        plaintext:
-          storage: "Storage"
-          healthy:
-            summary: 'Good news! The status of your storage, %{storage_name}, is currently displaying as "Healthy".'
-            error-solved-on: "Solved On"
-            recommendation: "We will continue monitoring the system to ensure it remains in good health. In case of any discrepancies, we will notify you."
-            details: "For more details or to make any necessary amendments, you can visit your storage configuration"
-          unhealthy:
-            summary: 'The status of your storage, %{storage_name}, is currently displaying as "Error". We''ve detected an issue that might require your attention.'
-            error-details: "Error Details"
-            error-message: "Error Message"
-            error-occurred-on: "Occurred On"
-            recommendation: "We recommend heading over to the storage configuration page to address this issue"
-            unsubscribe: "If you would no longer like to receive these notifications, you can unsubscribe at any time. To unsubscribe, please follow the instructions on this page"
-        email_notification_settings: "Storage email notification settings"
-        see_storage_settings: "See storage settings"
-        healthy:
-          subject: 'Storage "%{name}" is now healthy!'
-          solved_at: "solved at"
-          summary: "The problem with your %{storage_name} storage integration is now solved"
-        unhealthy:
-          subject: 'Storage "%{name}" is unhealthy!'
-          since: "since"
-          summary: "There is a problem with your %{storage_name} storage integration"
-          troubleshooting:
-            text: "For more information, check file storages"
-            link_text: "troubleshooting documentation"
   mail_body_account_activation_request: "A new user (%{value}) has registered. The account is pending your approval:"
   mail_body_account_information: "Your account information"
   mail_body_account_information_external: "You can use your %{value} account to log in."
   mail_body_backup_ready: "Your requested backup is ready. You can download it here:"
+  mail_body_backup_token_info: The previous token is no longer valid.
   mail_body_backup_token_reset_admin_info: The backup token for user '%{user}' has been reset.
   mail_body_backup_token_reset_user_info: Your backup token has been reset.
-  mail_body_backup_token_info: The previous token is no longer valid.
-  mail_body_backup_waiting_period: The new token will be enabled in %{hours} hours.
   mail_body_backup_token_warning: If this wasn't you, login to OpenProject immediately and reset it again.
+  mail_body_backup_waiting_period: The new token will be enabled in %{hours} hours.
+  mail_body_group_reminder: '%{count} work package(s) that are assigned to group "%{group}" are due in the next %{days} days:'
   mail_body_incoming_email_error: The email you sent to OpenProject could not be processed.
   mail_body_incoming_email_error_in_reply_to: "At %{received_at} %{from_email} wrote"
   mail_body_incoming_email_error_logs: "Logs"
   mail_body_lost_password: "To change your password, click on the following link:"
-  mail_password_change_not_possible:
-    title: "Password change not possible"
-    body: "Your account at %{app_title} is connected to an external authentication provider (%{name})."
-    subtext: "Passwords for external account cannot be changed in the application. Please use the lost password functionality of your authentication provider."
   mail_body_register: "Welcome to %{app_title}. Please activate your account by clicking on this link:"
+  mail_body_register_closing: "Your OpenProject team"
+  mail_body_register_ending: "Stay connected! Kind regards,"
   mail_body_register_header_title: "Project member invitation email"
-  mail_body_register_user: "Dear %{name}, "
   mail_body_register_links_html: |
     Please feel free to browse our youtube channel (%{youtube_link}) where we provide a webinar (%{webinar_link})
     and “Get started” videos (%{get_started_link}) to make your first steps in OpenProject as easy as possible.
     <br />
     If you have any further questions, consult our documentation (%{documentation_link}) or contact your administrator.
-  mail_body_register_closing: "Your OpenProject team"
-  mail_body_register_ending: "Stay connected! Kind regards,"
+  mail_body_register_user: "Dear %{name}, "
   mail_body_reminder: "%{count} work package(s) that are assigned to you are due in the next %{days} days:"
-  mail_body_group_reminder: '%{count} work package(s) that are assigned to group "%{group}" are due in the next %{days} days:'
   mail_body_wiki_page_added: "The '%{id}' wiki page has been added by %{author}."
   mail_body_wiki_page_updated: "The '%{id}' wiki page has been updated by %{author}."
+  mail_member_added_project:
+    body:
+      added_by:
+        with_message: "%{user} added you as a member to the project '%{project}' writing:"
+        without_message: "%{user} added you as a member to the project '%{project}'."
+      roles: "You have the following roles:"
+
+    subject: "%{project} - You have been added as a member"
+  mail_member_updated_global:
+    body:
+      roles: "You now have the following roles:"
+
+      updated_by:
+        with_message: "%{user} updated the roles you have globally writing:"
+        without_message: "%{user} updated the roles you have globally."
+    subject: "Your global permissions have been updated"
+  mail_member_updated_project:
+    body:
+      roles: "You now have the following roles:"
+
+      updated_by:
+        with_message: "%{user} updated the roles you have in the project '%{project}' writing:"
+        without_message: "%{user} updated the roles you have in the project '%{project}'."
+    subject: "%{project} - Your roles have been updated"
+  mail_password_change_not_possible:
+    body: "Your account at %{app_title} is connected to an external authentication provider (%{name})."
+    subtext: "Passwords for external account cannot be changed in the application. Please use the lost password functionality of your authentication provider."
+    title: "Password change not possible"
   mail_subject_account_activation_request: "%{value} account activation request"
   mail_subject_backup_ready: "Your backup is ready"
   mail_subject_backup_token_reset: "Backup token reset"
@@ -4847,125 +3852,387 @@ en:
   mail_subject_wiki_content_added: "'%{id}' wiki page has been added"
   mail_subject_wiki_content_updated: "'%{id}' wiki page has been updated"
 
-  mail_member_added_project:
-    subject: "%{project} - You have been added as a member"
-    body:
-      added_by:
-        without_message: "%{user} added you as a member to the project '%{project}'."
-        with_message: "%{user} added you as a member to the project '%{project}' writing:"
-      roles: "You have the following roles:"
-
-  mail_member_updated_project:
-    subject: "%{project} - Your roles have been updated"
-    body:
-      updated_by:
-        without_message: "%{user} updated the roles you have in the project '%{project}'."
-        with_message: "%{user} updated the roles you have in the project '%{project}' writing:"
-      roles: "You now have the following roles:"
-
-  mail_member_updated_global:
-    subject: "Your global permissions have been updated"
-    body:
-      updated_by:
-        without_message: "%{user} updated the roles you have globally."
-        with_message: "%{user} updated the roles you have globally writing:"
-      roles: "You now have the following roles:"
-
   mail_user_activation_limit_reached:
-    subject: User activation limit reached
     message_html: |
       A new user (%{email}) tried to create an account on an OpenProject environment that you manage (%{host}).
       The user cannot activate their account since the user limit has been reached.
     steps:
-      a: "Upgrade your payment plan ([here](upgrade_url))" # here turned into a link
-      b: "Lock or delete an existing user ([here](users_url))" # here turned into a link
+      a: "Upgrade your payment plan ([here](upgrade_url))"  # here turned into a link
+      b: "Lock or delete an existing user ([here](users_url))"  # here turned into a link
       label: "To allow the user to sign in you can either: "
 
+    subject: User activation limit reached
+  mcp_configurations:
+    server_url_component:
+      caption: "The URL at which the OpenProject MCP server will be reachable. Required for setting up MCP clients."
+      label: "Server URL"
+
+  members:
+    columns:
+      shared: "Shared"
+    delete_member_dialog:
+      also_work_packages_shared_with_user_html:
+        one: "Also, %{shared_work_packages_link} has been shared with this user."
+        other: "Also, %{shared_work_packages_link} have been shared with this user."
+      can_remove_direct_but_not_shared_roles: "You can remove this user as a direct project member but a group they are in is also a member of this project, so they will continue being a member via the group."
+      cannot_delete_inherited_membership: "You cannot delete this member because they belong to a group that is itself a member of this project."
+      cannot_delete_inherited_membership_note_admin_html: "You can either remove the group as a member of the project or this specific member from the group in the %{administration_settings_link}."
+      cannot_delete_inherited_membership_note_non_admin: "You can either remove the group as a member of the project or contact your administrator to remove this specific member from the group."
+      however_work_packages_shared_with_group_html:
+        one: "However, %{shared_work_packages_link} has also been shared with this group."
+        other: "However, %{shared_work_packages_link} have also been shared with this group."
+      however_work_packages_shared_with_user_html:
+        one: "However, %{shared_work_packages_link} has also been shared with this user."
+        other: "However, %{shared_work_packages_link} have also been shared with this user."
+      remove_project_membership_or_work_package_shares_too: "Do you want to remove just the user as a direct member (and keep the shares) or remove the work package shares too?"
+      remove_work_packages_shared_with_group_too: "A group that has been removed as member can still access shared work packages. Would you like to remove the shares too?"
+      remove_work_packages_shared_with_user_too: "A user that has been removed as member can still access shared work packages. Would you like to remove the shares too?"
+      title: "Remove member"
+      will_not_affect_inherited_shares: "(This will not affect work packages shared with their group)."
+      will_remove_all_group_access_priveleges: "Deleting this member will remove all access privileges of the group to the project. The group will still exist as part of the instance."
+      will_remove_all_user_access_priveleges: "Deleting this member will remove all access privileges of the user to the project. The user will still exist as part of the instance."
+      will_remove_the_groups_role: "This will remove the group role from this project."
+      will_remove_the_users_role: "This will remove the user’s role from this project."
+    delete_work_package_shares_dialog:
+      cannot_remove_inherited: "The work packages shares shared via groups cannot be removed."
+      cannot_remove_inherited_note_admin_html: "You can either revoke the share to the group or remove this specific member from the group in the %{administration_settings_link}."
+      cannot_remove_inherited_note_non_admin: "You can either revoke the share to the group or contact your administrator to remove this specific member from the group."
+      cannot_remove_inherited_with_role: "The work packages shares with role %{shared_role_name} are shared via groups and cannot be removed."
+      revoke_all_or_with_role: "Would you like to revoke access to all shared work packages, or only those with %{shared_role_name} permissions?"
+      shared_with_permission_html:
+        one: "Only %{shared_work_packages_link} has been shared with %{shared_role_name} permissions."
+        other: "Only %{shared_work_packages_link} have been shared with %{shared_role_name} permissions."
+      shared_with_this_group_html:
+        one: "%{all_shared_work_packages_link} has been shared with this group."
+        other: "%{all_shared_work_packages_link} have been shared with this group."
+      shared_with_this_user_html:
+        one: "%{all_shared_work_packages_link} has been shared with this user."
+        other: "%{all_shared_work_packages_link} have been shared with this user."
+      title: "Revoke work package shares"
+      will_not_affect_inherited_shares: "(This will not affect work packages shared with their group)."
+      will_revoke_access_to_all: "This action will revoke their access to all of them."
+
+      will_revoke_directly_granted_access: "This action will revoke their access to all of them, but the work packages shared with a group."
+    filters:
+      all_shares: "All shares"
+    index:
+      no_results_content_text: Add a member to the project
+      no_results_title_text: There are currently no members part of this project.
+    invite_by_mail: "Send invite to %{mail}"
+    menu:
+      all: "All"
+      groups: "Groups"
+      invited: "Invited"
+      locked: "Locked"
+      project_roles: "Project roles"
+      wp_shares: "Work package shares"
+    send_invite_to: "Send invite to"
+  menu_item: "Menu item"
+  menu_item_setting: "Visibility"
+
+  menus:
+    admin:
+      aggregation: "Aggregation"
+      ai: "Artificial Intelligence (AI)"
+      api_and_webhooks: "API and webhooks"
+      mail_notification: "Email notifications"
+      mails_and_notifications: "Emails and notifications"
+      mcp_configurations: "Model Context Protocol (MCP)"
+    quick_add:
+      label: "Add…"
+
   more_actions: "More functions"
+
+  my:
+    access_token:
+      created_dialog:
+        one_time_warning: "This is the only time you will see this token. Make sure to copy it now."
+        token/api:
+          title: "The API token has been generated"
+        token/rss:
+          title: "The RSS token has been generated"
+      dialog:
+        token/api:
+          attention_text: "Treat API tokens like passwords. Anyone with this token will have access to information from this instance, share it only with trusted users."
+          create_button: "Create"
+          dialog_body: "This token will allow third-party applications to communicate with your instance. To differentiate the new API token, please give it a name."
+          dialog_title: "Create new API token"
+          name_label: "Token name"
+      failed_to_create_token: "Failed to create access token: %{error}"
+      failed_to_reset_token: "Failed to reset access token: %{error}"
+      failed_to_revoke_token: "Failed to revoke access token: %{error}"
+      no_results_title_text: "There are currently no access tokens available."
+      notice_api_token_revoked: "The API token has been deleted. To create a new token please use the button in the API section."
+      notice_ical_token_revoked: 'iCalendar token "%{token_name}" for calendar "%{calendar_name}" of project "%{project_name}" has been revoked. The iCalendar URL with this token is now invalid.'
+      notice_reset_token: "A new %{type} token has been generated. Your access token is:"
+      notice_rss_token_revoked: "The RSS token has been deleted. To create a new token please use the link in the RSS section."
+      token_value_warning: "Note: This is the only time you will see this token, make sure to copy it now."
+    password_confirmation_dialog:
+      confirmation_required: "You need to enter your account password to confirm this change."
+      title: "Confirm your password to continue"
+
+  my_account:
+    access_tokens:
+      access_tokens: "Access tokens"
+      description: "Provider tokens are issued by OpenProject, allowing other applications to access it. Client tokens are issued by other applications, allowing OpenProject to access them."
+      headers:
+        action: "Action"
+        expiration: "Expires"
+      ical:
+        blank_description: "To add an iCalendar token, subscribe to a new or existing calendar from within the Calendar module of a project. You must have the necessary permissions."
+        blank_title: "No iCalendar token"
+        disabled_text: "iCalendar subscriptions are not enabled by the administrator. Please contact your administrator to use this feature."
+        table_title: "iCalendar tokens"
+        text_hint_link: "iCalendar tokens allow users to [subscribe to OpenProject calendars](docs_url) and view up-to-date work package information from external clients."
+        title: "iCalendar"
+      indefinite_expiration: "Never"
+      no_results:
+        description: "All of them have been disabled. They can be re-enabled in the administration menu."
+        title: "No access tokens to display"
+      oauth_application:
+        active_tokens: "Active tokens"
+        blank_description: "There is no third-party application access configured and active for you."
+        blank_title: "No OAuth application token"
+        last_refreshed_at: "Last refreshed at"
+        table_title: "OAuth application tokens"
+        text_hint: "OAuth application tokens allow third-party applications to connect with this OpenProject instance."
+        title: "OAuth"
+      oauth_client:
+        blank_description: "There are no OAuth client tokens yet."
+        blank_title: "No OAuth client tokens"
+        failed: "An error occurred and the token couldn't be removed. Please try again later."
+        integration_type: "Integration type"
+        remove_token: "Do you really want to remove this token? You will need to login again on %{integration}."
+        removed: "OAuth client token successfully removed"
+        table_title: "OAuth client tokens"
+        text_hint: "OAuth client tokens allow this OpenProject instance to connect with external applications, such as file storages."
+        title: "OAuth"
+        unknown_integration: "Unknown"
+      simple_revoke_confirmation: "Are you sure you want to revoke this token?"
+      storages:
+        unknown_storage: "Unknown storage"
+      tabs:
+        client:
+          title: "Client tokens"
+        provider:
+          title: "Provider tokens"
+      token/api:
+        add_button: "API token"
+        blank_description: "There is no API token yet. You can create one using the button below."
+        blank_title: "No API token"
+        disabled_text: "API tokens are not enabled by the administrator. Please contact your administrator to use this feature."
+        static_token_name: "API token"
+        table_title: "API tokens"
+        text_hint: "API tokens allow third-party applications to communicate with this OpenProject instance via REST APIs."
+        title: "API"
+      token/rss:
+        add_button: "RSS token"
+        blank_description: "There is no RSS token yet. You can create one using the button below."
+        blank_title: "No RSS token"
+        disabled_text: "RSS tokens are not enabled by the administrator. Please contact your administrator to use this feature."
+        static_token_name: "RSS token"
+        table_title: "RSS tokens"
+        text_hint: "RSS tokens allow users to keep up with the latest changes in this OpenProject instance via an external RSS reader."
+        title: "RSS"
+    email_reminders:
+      daily_reminders:
+        add_time: "Add time"
+        description: "You will receive these reminders only for unread notifications and only at hours you specify. Until you configure a time zone for your account, the times will be interpreted to be in UTC."
+        enabled: "Enable daily email reminders"
+        remove_time: "Remove time"
+        time_slot_label: "Reminder time (UTC)"
+        title: "Send me daily email reminders for unread notifications"
+      email_alerts:
+        description: "Notifications today are limited to work packages. You can choose to continue receiving email alerts for these events until they are included in notifications."
+        document_added: "Document added"
+        forum_messages: "Forum message posted"
+        membership_added: "Membership added"
+        membership_updated: "Membership updated"
+        news_added: "News added"
+        news_commented: "Comment on a news item"
+        submit_button: "Update alerts"
+        title: "Email alerts for other items that are not work packages"
+        wiki_page_added: "Wiki page added"
+        wiki_page_updated: "Wiki page updated"
+      immediate_reminders:
+        mentioned: "Notify me when I am mentioned"
+        personal_reminder: "Notify me for personal reminders"
+        title: "Send me an email reminder"
+      pause_reminders:
+        date_range: "Pause period"
+        enabled: "Temporarily pause daily email reminders"
+        title: "Pause email notifications"
+      workdays:
+        submit_button: "Update reminder days"
+        title: "Receive email reminders on these days"
+    notifications:
+      date_alerts:
+        description: "Automatic notifications when important dates are approaching for open work packages you are involved in (assignee, accountable or watcher)."
+        due_date: "Finish date"
+        overdue: "Overdue"
+        start_date: "Start date"
+        submit_button: "Update date alerts"
+        times:
+          one_day_after: "1 day after"
+          one_day_before: "1 day before"
+          same_day: "On the same day"
+          seven_days_after: "7 days after"
+          seven_days_before: "7 days before"
+          three_days_after: "3 days after"
+          three_days_before: "3 days before"
+        title: "Date alerts"
+      non_participating:
+        description: "Additional notifications for activities in all projects."
+        submit_button: "Update preferences"
+        title: "Non-participating"
+        work_package_commented: "All new comments"
+        work_package_created: "New work packages"
+        work_package_prioritized: "All priority changes"
+        work_package_processed: "All status changes"
+        work_package_scheduled: "All date changes"
+      participating:
+        assignee: "Assignee"
+        description: "Notifications for all activities in work packages you are involved in (assignee, accountable or watcher)."
+        mentioned: "Mentioned"
+        responsible: "Accountable"
+        shared: "Shared with me"
+        submit_button: "Update preferences"
+        title: "Participating"
+        watched: "Watching"
+      project_specific_settings:
+        add_button: "Add project-specific notifications"
+        description: "These project-specific settings override default settings above."
+        dialog_title: "Add project-specific notifications"
+        list_header: "Projects with specific notifications"
+
+        title: "Project-specific notification settings"
+    notifications_and_email:
+      tabs:
+        email_reminders: "Email reminders"
+        notifications: "Notification settings"
+      title: "Notification and email"
+  news:
+    index:
+      no_results_content_text: Add a news item
+
+      no_results_title_text: There is currently no news to report.
+  no_results_title_text: There is currently nothing to display.
 
   noscript_description: "You need to activate JavaScript in order to use OpenProject!"
   noscript_heading: "JavaScript disabled"
   noscript_learn_more: "Learn more"
 
+  note: Note
+  note_password_login_disabled_link: "Password login has been disabled through a [configuration setting](configuration_url)."
+  nothing_to_preview: "Nothing to preview"
+
   notice_accessibility_mode: The accessibility mode can be enabled in your [account settings](url).
   notice_account_activated: "Your account has been activated. You can now log in."
   notice_account_already_activated: The account has already been activated.
-  notice_account_invalid_token: Invalid activation token
   notice_account_invalid_credentials: "Invalid user or password"
   notice_account_invalid_credentials_or_blocked: "Invalid user or password or the account is blocked due to multiple failed login attempts. If so, it will be unblocked automatically in a short time."
+  notice_account_invalid_token: Invalid activation token
   notice_account_lost_email_sent: "An email with instructions to choose a new password has been sent to you."
   notice_account_new_password_forced: "A new password is required."
+  notice_account_other_session_expired: "All other sessions tied to your account have been invalidated."
   notice_account_password_expired: "Your password expired after %{days} days. Please set a new one."
   notice_account_password_updated: "Password was successfully updated."
   notice_account_pending: "Your account was created and is now pending administrator approval."
   notice_account_register_done: "Account was successfully created. To activate your account, click on the link that was emailed to you."
+  notice_account_registered_and_logged_in: "Welcome, your account has been activated. You are logged in now."
   notice_account_unknown_email: "Unknown user."
   notice_account_update_failed: "Account setting could not be saved. Please have a look at your account page."
   notice_account_updated: "Account was successfully updated."
-  notice_account_other_session_expired: "All other sessions tied to your account have been invalidated."
   notice_account_wrong_password: "Wrong password"
-  notice_account_registered_and_logged_in: "Welcome, your account has been activated. You are logged in now."
   notice_activation_failed: The account could not be activated.
+  notice_attachment_migration_wiki_page: >
+    This page was generated automatically during the update of OpenProject.
+    It contains all attachments previously associated with the %{container_type} "%{container_name}".
+  notice_auth_stage_error: "Authentication stage '%{stage}' failed."
   notice_auth_stage_verification_error: "Could not verify stage '%{stage}'."
   notice_auth_stage_wrong_stage: "Expected to finish authentication stage '%{expected}', but '%{actual}' returned."
-  notice_auth_stage_error: "Authentication stage '%{stage}' failed."
+  notice_automatic_set_of_standard_type: "Set standard type automatically."
+  notice_bad_request: "Bad Request."
   notice_can_t_change_password: "This account uses an external authentication source. Impossible to change the password."
   notice_custom_options_deleted: "Option '%{option_value}' and its %{num_deleted} occurrences were deleted."
-  notice_email_error: "An error occurred while sending mail (%{value})"
-  notice_email_sent: "An email was sent to %{value}"
-  notice_failed_to_save_work_packages: "Failed to save %{count} work package(s) on %{total} selected: %{ids}."
-  notice_failed_to_save_members: "Failed to save member(s): %{errors}."
   notice_deletion_scheduled: "The deletion has been scheduled and is performed asynchronously."
 
+  notice_email_error: "An error occurred while sending mail (%{value})"
+  notice_email_sent: "An email was sent to %{value}"
+  notice_failed_to_save_members: "Failed to save member(s): %{errors}."
+  notice_failed_to_save_work_packages: "Failed to save %{count} work package(s) on %{total} selected: %{ids}."
   notice_file_not_found: "The page you were trying to access doesn't exist or has been removed."
   notice_forced_logout: "You have been automatically logged out after %{ttl_time} minutes of inactivity."
   notice_internal_server_error: "An error occurred on the page you were trying to access. If you continue to experience problems please contact your %{app_title} administrator for assistance."
   notice_locking_conflict: "Information has been updated by at least one other user in the meantime."
+  notice_locking_conflict_action_button: "Discard changes and reload"
   notice_locking_conflict_additional_information: "The update(s) came from %{users}."
+  notice_locking_conflict_danger: "Could not save your changes because of conflicting modifications. To not lose your edits, copy them locally and reload to view the updated version."
   notice_locking_conflict_reload_page: "Please reload the page, review the changes and reapply your updates."
   notice_locking_conflict_warning: "This page has been updated by someone else. To not lose your edits, copy them locally and reload to view the updated version."
-  notice_locking_conflict_danger: "Could not save your changes because of conflicting modifications. To not lose your edits, copy them locally and reload to view the updated version."
-  notice_locking_conflict_action_button: "Discard changes and reload"
+  notice_logged_out: "You have been logged out."
   notice_member_added: Added %{name} to the project.
-  notice_members_added: Added %{number} users to the project.
-  notice_member_removed: "Removed %{user} from project."
   notice_member_deleted: "%{user} has been removed from the project and deleted."
+  notice_member_removed: "Removed %{user} from project."
+  notice_members_added: Added %{number} users to the project.
   notice_no_principals_found: "No results found."
-  notice_bad_request: "Bad Request."
   notice_not_authorized: "You are not authorized to access this page."
   notice_not_authorized_archived_project: "The project you're trying to access has been archived."
-  notice_requires_enterprise_token: "Enterprise token missing or doesn't allow access to this page."
+  notice_parent_item_not_found: "Parent item not found."
   notice_password_confirmation_failed: "The entered password is not correct."
   notice_principals_found_multiple: "There are %{number} results found. \n Tab to focus the first result."
   notice_principals_found_single: "There is one result. \n Tab to focus it."
-  notice_parent_item_not_found: "Parent item not found."
+  notice_project_cannot_update_custom_fields: "You cannot update the project's available custom fields. The project is invalid: %{errors}"
   notice_project_not_deleted: "The project wasn't deleted."
   notice_project_not_found: "Project not found."
+  notice_requires_enterprise_token: "Enterprise token missing or doesn't allow access to this page."
   notice_smtp_address_unsafe_env_hint: "SMTP address %{address} is not safe. Please add it to the whitelist using the %{env_name} environment variable."
+  notice_successful_cancel: "Successful cancellation."
   notice_successful_connection: "Successful connection."
   notice_successful_create: "Successful creation."
   notice_successful_delete: "Successful deletion."
-  notice_successful_cancel: "Successful cancellation."
   notice_successful_update: "Successful update."
-  notice_unsuccessful_create: "Creation failed."
-  notice_unsuccessful_create_with_reason: "Creation failed: %{reason}"
-  notice_unsuccessful_update: "Update failed."
-  notice_unsuccessful_update_with_reason: "Update failed: %{reason}"
   notice_successful_update_custom_fields_added_to_project: |
     Successful update. The custom fields of the activated types are automatically activated
     on the work package form. <a href="%{url}" target="_blank">See more</a>.
   notice_to_many_principals_to_display: "There are too many results.\nNarrow down the search by typing in the name of the new member (or group)."
-  notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
+  notice_unsuccessful_create: "Creation failed."
+  notice_unsuccessful_create_with_reason: "Creation failed: %{reason}"
+  notice_unsuccessful_update: "Update failed."
+  notice_unsuccessful_update_with_reason: "Update failed: %{reason}"
   notice_user_invitation_resent: An invitation has been sent to %{email}.
-  present_access_key_value: "Your %{key_name} is: %{value}"
-  notice_automatic_set_of_standard_type: "Set standard type automatically."
-  notice_logged_out: "You have been logged out."
+  notice_user_missing_authentication_method: User has yet to choose a password or another way to sign in.
   notice_wont_delete_auth_source: The LDAP connection cannot be deleted as long as there are still users using it.
-  notice_project_cannot_update_custom_fields: "You cannot update the project's available custom fields. The project is invalid: %{errors}"
-  notice_attachment_migration_wiki_page: >
-    This page was generated automatically during the update of OpenProject.
-    It contains all attachments previously associated with the %{container_type} "%{container_name}".
+  notifications:
+    facets:
+      all: "All"
+      all_title: "Show all"
+      unread: "Unread"
+      unread_title: "Show unread"
+    menu:
+      by_project: "Unread by project"
+      by_reason: "Reason"
+      inbox: "Inbox"
+    query:
+      invalid_filter: "Invalid notification filter"
 
+    reasons:
+      assigned: "Assignee"
+      dateAlert: "Date alert"
+      mentioned: "Mentioned"
+      reminder: "Reminder"
+      responsible: "Accountable"
+      shared: "Shared"
+      watched: "Watcher"
+    send_notifications: "Send notifications for this action"
+    work_packages:
+      subject:
+        assigned: "You have been assigned to %{work_package}"
+        created: "The work package was created."
+        mentioned: "You have been mentioned in %{work_package}"
+        responsible: "You have become accountable for %{work_package}"
+        subscribed: "You subscribed to %{work_package}"
+        watched: "You are watching %{work_package}"
   # Default format for numbers
   number:
     format:
@@ -4987,12 +4254,176 @@ en:
           mb: "MB"
           tb: "TB"
 
+  oauth:
+    application:
+      builtin: Built-in instance application
+      client_credentials: "Client credentials"
+      confidential: Confidential
+      default_scopes: "(Default scopes)"
+      instructions:
+        client_credential_user_id: "Optional user ID to impersonate when clients use this application. Leave empty to allow public access only"
+        confidential: "Check if the application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are assumed non-confidential."
+        default_scopes: ""
+        enabled: "Enable this application, allowing users to perform authorization grants with it."
+        name: "The name of your application. This will be displayed to other users upon authorization."
+        redirect_uri_html: >
+          The allowed URLs authorized users can be redirected to. One entry per line.
+          <br/>
+          If you're registering a desktop application, use the following URL.
+        register_intro: "If you are developing an OAuth API client application for OpenProject, you can register it using this form for all users to use."
+        scopes: "Check the scopes you want the application to grant access to. If no scope is checked, api_v3 is assumed."
+      named: "OAuth application '%{name}'"
+      new: "New OAuth application"
+      non_confidential: Non confidential
+      plural: "OAuth applications"
+      scopes: "Scopes"
+      singular: "OAuth application"
+    authorization_dialog:
+      authorize: "Authorize"
+      cancel: "Cancel and deny authorization."
+      prompt_html: "Authorize <strong>%{application_name}</strong> to use your account <em>%{login}</em>?"
+      title: "Authorize %{application_name}"
+      wants_to_access_html: >
+        This application requests access to your OpenProject account.
+        <br/>
+        <strong>It has requested the following permissions:</strong>
+    authorization_error: "An authorization error has occurred."
+    client_credentials: "User used for Client credentials"
+    client_credentials_impersonation_html: >
+      By default, OpenProject provides OAuth 2.0 authorization via %{authorization_code_flow_link}.
+      You can optionally enable %{client_credentials_flow_link}, but you must provide a user on whose behalf requests will be performed.
+    client_credentials_impersonation_set_to: "Client credentials user set to"
+    client_credentials_impersonation_warning: "Note: Clients using the 'Client credentials' flow in this application will have the rights of this user"
+    client_id: "Client ID"
+    client_secret_notice: >
+      This is the only time we can print the client secret, please note it down and keep it secure.
+      It should be treated as a password and cannot be retrieved by OpenProject at a later time.
+    confirm_revoke_my_application:
+      one: "Do you really want to remove this application? This will revoke one token active for it."
+      other: "Do you really want to remove this application? This will revoke %{count} tokens active for it."
+    empty_application_lists: No OAuth applications have been registered.
+    flows:
+      authorization_code: "Authorization code flow"
+      client_credentials: "Client credentials flow"
+    grants:
+      created_date: "Approved on"
+      none_given: "No OAuth applications have been granted access to your user account."
+      scopes: "Permissions"
+      successful_application_revocation: "Revocation of application %{application_name} successful."
+    header:
+      builtin_applications: Built-in OAuth applications
+      other_applications: Other OAuth applications
+    my_registered_applications: "Registered OAuth applications"
+
+    scopes:
+      api_v3: "Full API v3 access"
+      api_v3_text: "Application will receive full read & write access to the OpenProject API v3 to perform actions on your behalf."
+  oauth_client:
+    errors:
+      oauth_authorization_code_grant_had_errors: "OAuth2 Authorization grant unsuccessful"
+      oauth_client_not_found: "OAuth2 client not found in 'callback' endpoint (redirect_uri)."
+      oauth_client_not_found_explanation: >
+        This error appears after you have updated the client_id and client_secret
+        in OpenProject, but haven't updated the 'Return URI' field in the OAuth2 provider.
+      oauth_code_not_present: "OAuth2 'code' not found in 'callback' endpoint (redirect_uri)."
+      oauth_code_not_present_explanation: >
+        This error appears if you have selected the wrong response_type
+        in the OAuth2 provider. Response_type should be 'code' or similar.
+      oauth_issue_contact_admin: "OAuth2 reported an error. Please contact your system administrator."
+      oauth_reported: "OAuth2 provider reported"
+      oauth_returned_error: "OAuth2 returned an error"
+      oauth_returned_http_error: "OAuth2 returned a network error"
+      oauth_returned_json_error: "OAuth2 returned a JSON error"
+      oauth_returned_standard_error: "OAuth2 returned an internal error"
+      oauth_state_not_present: "OAuth2 'state' not found in 'callback' endpoint (redirect_uri)."
+      oauth_state_not_present_explanation: >
+        The 'state' is used to indicate to OpenProject where to continue
+        after a successful OAuth2 authorization.
+        A missing 'state' is an internal error that may appear during setup.
+        Please contact your system administrator.
+      rack_oauth2:
+        client_secret_invalid: "Client secret is invalid (client_secret_invalid)"
+        invalid_client: "The OAuth2 Authorization Server doesn't recognize OpenProject (invalid_client)."
+        invalid_grant: "The OAuth2 Authorization Server asks you to reauthorize (invalid_grant)."
+        invalid_request: >
+          OAuth2 Authorization Server responded with 'invalid_request'.
+          This error appears if you try to authorize multiple times or in case of technical issues.
+        invalid_response: "OAuth2 Authorization Server provided an invalid response (invalid_response)"
+        invalid_scope: "You are not allowed to access the requested resource (invalid_scope)."
+
+        unauthorized_client: "The OAuth2 Authorization Server rejects the grant type (unauthorized_client)"
+        unsupported_grant_type: "The OAuth2 Authorization Server asks you to reauthorize (unsupported_grant_type)."
+      refresh_token_called_without_existing_token: >
+        Internal error: Called refresh_token without a previously existing token.
+      refresh_token_updated_failed: "Error during update of OAuthClientToken"
+      wrong_token_type_returned: "OAuth2 returned a wrong type of token, expecting AccessToken::Bearer"
+    labels:
+      label_oauth_integration: "OAuth2 integration"
+      label_redirect_uri: "Redirect URI"
+      label_refresh_token: "Refresh token"
+      label_request_token: "Request token"
+    urn_connection_status:
+      connected: "Connected"
+      error: "Error"
+      failed_authorization: "Authorization failed"
+      not_connected: "Not connected"
   onboarding:
     heading_getting_started: "Get an overview"
-    text_getting_started_description: "Get a quick overview of project management and team collaboration with OpenProject. You can restart this video from the help menu."
-    welcome: "Welcome to %{app_title}"
     select_language: "Please select your language"
 
+    text_getting_started_description: "Get a quick overview of project management and team collaboration with OpenProject. You can restart this video from the help menu."
+    welcome: "Welcome to %{app_title}"
+  op_dry_validation:
+    errors:
+      array?: "must be an array."
+      decimal?: "must be a decimal."
+      defined: "must not be defined."
+      eql?: "must be equal to %{left}."
+      filled?: "must be filled."
+      format?: "is in invalid format."
+      greater_or_equal_zero: "must be greater or equal to 0."
+      gteq?: "must be greater than or equal to %{num}."
+      hash?: "must be a hash."
+      included_in?:
+        arg:
+          default: "must be one of: %{list}."
+          range: "must be one of: %{list_left} - %{list_right}."
+      int?: "must be an integer."
+      key?: "is missing."
+      not_found: "not found."
+      respond_to?: "does not implement required method."
+      rules:
+        copy_workflow_from:
+          workflow_missing: "has no own workflow."
+        custom_field:
+          format_not_supported: "format '%{field_format}' is unsupported."
+        item:
+          not_persisted: "must be an already existing item."
+          root_item: "cannot be a root item."
+        label:
+          not_unique: "must be unique within the same hierarchy level."
+        parent:
+          not_descendant: "must be a descendant of the hierarchy root."
+        short:
+          not_unique: "must be unique within the same hierarchy level."
+      str?: "must be a string."
+      time?: "must be a time."
+      type?: "must be %{type}."
+      unexpected_key: "is not allowed."
+      uri?: "is not a valid URI."
+    or: "or"
+    rules:
+      blueprint: "Pattern blueprint"
+
+      copy_workflow_from: "Type for workflow copy"
+      depth: "Depth"
+      enabled: "Enabled"
+      item: "Item"
+      label: "Label"
+      parent: "Parent"
+      short: "Short name"
+      weight: "Weight"
+  open_link_in_a_new_tab: "Open link in a new tab"
   open_project:
     common:
       work_package_card_component:
@@ -5003,21 +4434,60 @@ en:
         parent: "Parent"
         undisclosed: "Undisclosed"
 
-  permission_add_work_package_comments: "Add comments"
-  permission_add_work_packages: "Add work packages"
+  page:
+    text: "Text"
+  pagination:
+    label: "Pagination"
+    next: "Next"
+    next_page: "Next Page"
+    page: "Page %{number}"
+    page_with_more: "Page %{number}..."
+
+    prev: "Previous"
+    prev_page: "Previous Page"
+  pdf_generator:
+    dialog:
+      footer_center:
+        caption: This text will appear on every page at the center of the footer.
+        label: Footer text
+      footer_right:
+        caption: This text will appear on every page at the right of the footer.
+        label: Footer text
+      hyphenation:
+        caption: Break line between words for better layout and justification.
+        label: Hyphenation
+      hyphenation_language:
+        label: Language and hyphenation
+      page_orientation:
+        caption: Select the orientation of the pages in the PDF document.
+        label: Page orientation
+        options:
+          landscape: Landscape
+          portrait: Portrait
+      submit: Download
+      templates:
+        label: "Template"
+        none_enabled: "No template has been enabled for this work package type"
+      title: Generate PDF
+    page_nr_footer: "Page %{page} of %{total}"
+    template_attributes:
+      caption: All the attributes present in the current form configuration using the default template.
+      label: "Attributes and description"
+    template_contract:
+      caption: Work package details formatted to the standard German contract form.
+      label: "Contract"
+  permission_add_internal_comments: "Write internal comments"
   permission_add_messages: "Post messages"
-  permission_add_project: "Create projects"
   permission_add_portfolios: "Create portfolios"
   permission_add_programs: "Create programs"
+  permission_add_project: "Create projects"
+  permission_add_subprojects: "Create subprojects"
   permission_add_work_package_attachments: "Add attachments"
   permission_add_work_package_attachments_explanation: "Allows adding attachments without Edit work packages permission"
-  permission_add_internal_comments: "Write internal comments"
-  permission_archive_project: "Archive project"
-  permission_create_user: "Create users"
-  permission_manage_user: "Edit users"
-  permission_manage_placeholder_user: "Create, edit, and delete placeholder users"
-  permission_add_subprojects: "Create subprojects"
+  permission_add_work_package_comments: "Add comments"
   permission_add_work_package_watchers: "Add watchers"
+  permission_add_work_packages: "Add work packages"
+  permission_archive_project: "Archive project"
   permission_assign_versions: "Assign versions"
   permission_browse_repository: "Read-only access to repository (browse and checkout)"
   permission_change_work_package_status: "Change work package status"
@@ -5028,31 +4498,37 @@ en:
   permission_copy_projects_explanation: "In template projects, this permission has a secondary function, it allows the creation of new projects derived from the template."
   permission_copy_work_packages: "Duplicate work packages"
   permission_create_backup: "Create backups"
-  permission_delete_work_package_watchers: "Delete watchers"
-  permission_delete_work_packages: "Delete work packages"
+  permission_create_user: "Create users"
   permission_delete_messages: "Delete messages"
   permission_delete_own_messages: "Delete own messages"
   permission_delete_reportings: "Delete reportings"
   permission_delete_timelines: "Delete timelines"
-  permission_edit_work_package_comments: "Moderate comments"
-  permission_edit_work_package_comments_explanation: "Caution: Users with this permission are able to edit anyone's comment."
-  permission_edit_work_packages: "Edit work packages"
+  permission_delete_work_package_watchers: "Delete watchers"
+  permission_delete_work_packages: "Delete work packages"
+  permission_edit_attribute_help_texts: "Edit attribute help texts"
   permission_edit_messages: "Edit messages"
-  permission_edit_own_internal_comments: "Edit own internal comments"
-  permission_edit_own_work_package_comments: "Edit own comments"
-  permission_edit_own_messages: "Edit own messages"
-  permission_edit_own_time_entries: "Edit own time logs"
   permission_edit_others_internal_comments: "Moderate internal comments"
   permission_edit_others_internal_comments_explanation: "Caution: Users with this permission are able to edit other users' internal comments."
+  permission_edit_own_internal_comments: "Edit own internal comments"
+  permission_edit_own_messages: "Edit own messages"
+  permission_edit_own_time_entries: "Edit own time logs"
+  permission_edit_own_work_package_comments: "Edit own comments"
   permission_edit_project: "Edit project"
   permission_edit_project_attributes: "Edit project attributes"
   permission_edit_project_phases: "Edit project phases"
+  permission_edit_project_query: "Edit project query"
+
   permission_edit_reportings: "Edit reportings"
   permission_edit_time_entries: "Edit time logs for other users"
   permission_edit_timelines: "Edit timelines"
   permission_edit_wiki_pages: "Edit wiki pages"
-  permission_export_work_packages: "Export work packages"
+  permission_edit_work_package_comments: "Moderate comments"
+  permission_edit_work_package_comments_explanation: "Caution: Users with this permission are able to edit anyone's comment."
+  permission_edit_work_packages: "Edit work packages"
   permission_export_projects: "Export projects"
+  permission_export_work_packages: "Export work packages"
+  permission_header_for_project_module_work_package_tracking: "Work packages and Gantt charts"
+
   permission_invite_members_by_email: "Invite members by email"
   permission_invite_members_by_email_explanation: >
     Allows users to invite new members by email.
@@ -5060,48 +4536,55 @@ en:
     Depends on the permission to manage members
   permission_log_own_time: "Log own time"
   permission_log_time: "Log time for other users"
-  permission_manage_forums: "Manage forums"
   permission_manage_categories: "Manage work package categories"
   permission_manage_dashboards: "Manage dashboards"
-  permission_manage_work_package_relations: "Manage work package relations"
+  permission_manage_forums: "Manage forums"
   permission_manage_members: "Manage members"
   permission_manage_news: "Manage news"
-  permission_manage_project_activities: "Manage project activities"
-  permission_manage_public_queries: "Manage public views"
-  permission_manage_repository: "Manage repository"
-  permission_manage_subtasks: "Manage work package hierarchies"
-  permission_manage_versions: "Manage versions"
-  permission_manage_wiki: "Manage wiki"
+  permission_manage_own_reminders: "Create own reminders"
   permission_manage_own_working_times: "Manage own working times"
   permission_manage_own_working_times_explanation: >
     Allows users to manage their own working times, and personal non-working days.
+  permission_manage_placeholder_user: "Create, edit, and delete placeholder users"
+  permission_manage_project_activities: "Manage project activities"
+  permission_manage_public_bcf_queries: "Manage public BCF queries"
+  permission_manage_public_project_queries: "Manage public project lists"
+  permission_manage_public_queries: "Manage public views"
+  permission_manage_repository: "Manage repository"
+  permission_manage_subtasks: "Manage work package hierarchies"
+  permission_manage_types: "Select types"
+  permission_manage_user: "Edit users"
+  permission_manage_versions: "Manage versions"
+  permission_manage_wiki: "Manage wiki"
+  permission_manage_work_package_relations: "Manage work package relations"
   permission_manage_working_times: "Manage working times for all users"
   permission_manage_working_times_explanation: >
     Allows users to manage working times for all users, including personal non-working days.
   permission_move_work_packages: "Move work packages"
+  permission_save_bcf_queries: "Save BCF queries"
   permission_save_queries: "Save views"
   permission_search_project: "Search project"
   permission_select_custom_fields: "Select custom fields"
   permission_select_project_custom_fields: "Select project attributes"
+  permission_select_project_modules: "Select project modules"
   permission_select_project_phases: "Select project phases"
   permission_select_project_phases_explanation: "Activate/Deactivate the phases in a project. Enables the user to select the life cycle appropriate for the project as inactive phases will not be visible in the project overview page nor the project list."
-  permission_select_project_modules: "Select project modules"
   permission_share_work_packages: "Share work packages"
-  permission_manage_types: "Select types"
-  permission_manage_own_reminders: "Create own reminders"
   permission_view_all_principals: "View all users and groups"
   permission_view_all_principals_explanation: >
     Allows users to see all users and groups in the system, even if they are not members of any joined projects or groups.
-  permission_view_project: "View projects"
   permission_view_changesets: "View repository revisions in OpenProject"
-  permission_view_internal_comments: "View internal comments"
   permission_view_commit_author_statistics: "View commit author statistics"
   permission_view_dashboards: "View dashboards"
-  permission_view_work_package_watchers: "View watchers list"
-  permission_view_work_packages: "View work packages"
+  permission_view_internal_comments: "View internal comments"
+  permission_view_members: "View members"
   permission_view_messages: "View messages"
   permission_view_news: "View news"
-  permission_view_members: "View members"
+  permission_view_project: "View projects"
+  permission_view_project_activity: "View project activity"
+  permission_view_project_attributes: "View project attributes"
+  permission_view_project_phases: "View project phases"
+  permission_view_project_query: "View project query"
   permission_view_reportings: "View reportings"
   permission_view_shared_work_packages: "View work package shares"
   permission_view_time_entries: "View spent time"
@@ -5109,79 +4592,300 @@ en:
   permission_view_user_email: "View users' mail addresses"
   permission_view_wiki_edits: "View wiki history"
   permission_view_wiki_pages: "View wiki"
+  permission_view_work_package_watchers: "View watchers list"
+  permission_view_work_packages: "View work packages"
   permission_work_package_assigned: "Become assignee/responsible"
   permission_work_package_assigned_explanation: "Work packages can be assigned to users and groups in possession of this role in the respective project"
-  permission_view_project_activity: "View project activity"
-  permission_view_project_attributes: "View project attributes"
-  permission_view_project_phases: "View project phases"
-  permission_save_bcf_queries: "Save BCF queries"
-  permission_manage_public_bcf_queries: "Manage public BCF queries"
-  permission_edit_attribute_help_texts: "Edit attribute help texts"
-  permission_manage_public_project_queries: "Manage public project lists"
-  permission_view_project_query: "View project query"
-  permission_edit_project_query: "Edit project query"
+  placeholder_users:
+    delete_tooltip: "Delete placeholder user"
+    deletion_info:
+      confirmation_html: "Enter the placeholder user name %{name} to confirm the deletion."
+      data_consequences: >
+        All occurrences of the placeholder user (e.g., as assignee, responsible or other user values)
+        will be reassigned to an account called "Deleted user".
 
+        As the data of every deleted account is reassigned to this account
+        it will not be possible to distinguish the data the user created from
+        the data of another deleted account.
+      heading_html: "Delete placeholder user %{name}"
+      irreversible: "This action is irreversible"
+    right_to_manage_members_missing: >
+      You are not allowed to delete the placeholder user.
+      You do not have the right to manage members for all projects that the placeholder user is a member of.
   placeholders:
     default: "-"
     templated_hint: Automatically generated through type %{type}
 
+  plugin_openproject_auth_plugins:
+    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
+    name: "OpenProject Auth Plugins"
+  plugin_openproject_auth_saml:
+    description: "Adds the OmniAuth SAML provider to OpenProject"
+
+    name: "OmniAuth SAML / Single-Sign On"
   portfolio:
     count:
-      zero: "0 portfolios"
       one: "1 portfolio"
       other: "%{count} portfolios"
 
+      zero: "0 portfolios"
+  portfolios:
+    index:
+      search:
+        label: Portfolio name filter
+        placeholder: Search portfolios
+      sub_items_html:
+        one: "<strong>1</strong> sub-item"
+        other: "<strong>%{count}</strong> sub-items"
+    lists:
+      active: "Active portfolios"
+      archived: "Archived portfolios"
+
+      favorited: "Favorite portfolios"
+      my: "My portfolios"
+  present_access_key_value: "Your %{key_name} is: %{value}"
+  priorities:
+    admin:
+      default:
+        caption: Making this priority default will override the previous default priority.
+
+    edit:
+      priority_color_text: |
+        Click to assign or change the color of this priority.
+        It can be used for highlighting work packages in the table.
   program:
     count:
-      zero: "0 programs"
       one: "1 program"
       other: "%{count} programs"
 
+      zero: "0 programs"
   project:
     archive:
-      title: "Archive project"
-      are_you_sure: "Are you sure you want to archive the project '%{name}'?"
       archived: "Archived"
+      are_you_sure: "Are you sure you want to archive the project '%{name}'?"
+      title: "Archive project"
     count:
-      zero: "0 projects"
       one: "1 project"
       other: "%{count} projects"
+      zero: "0 projects"
     destroy:
-      title: "Delete project"
-      heading: "Permanently delete this project?"
       confirmation_message_for_subprojects_html:
-        zero: >
-          You are about to permanently delete all data relating to project <strong>%{name}</strong>.
         one: >
           You are about to permanently delete all data relating to project <strong>%{name}</strong> and this subproject:
         other: >
           You are about to permanently delete all data relating to project <strong>%{name}</strong> and these subprojects:
+        zero: >
+          You are about to permanently delete all data relating to project <strong>%{name}</strong>.
+      heading: "Permanently delete this project?"
+      title: "Delete project"
     filters:
       project_phase: "Project phase: %{phase}"
       project_phase_any: "Project phase: Any"
       project_phase_gate: "Project phase gate: %{gate}"
     identifier:
+      title: Change the project's identifier
       warning_one: Members of the project will have to relocate the project's repositories.
       warning_two: Existing links to the project will no longer work.
-      title: Change the project's identifier
     not_available: "Project N/A"
     template:
-      copying_title: "Applying template"
       copying: >
         Your project is being created from the selected template project.
         You will be notified by mail as soon as the project is available.
-      use_template: "Use template"
+      copying_title: "Applying template"
       make_template: "Set as template"
       remove_from_templates: "Remove from templates"
 
+      use_template: "Use template"
   project_module_activity: "Activity"
   project_module_forums: "Forums"
-  project_module_work_package_tracking: "Work packages"
   project_module_news: "News"
   project_module_repository: "Repository"
   project_module_wiki: "Wiki"
-  permission_header_for_project_module_work_package_tracking: "Work packages and Gantt charts"
+  project_module_work_package_tracking: "Work packages"
+  projects:
+    copy:
+      # Contains custom strings for options when copying a project that cannot be found elsewhere.
+      members: "Project members"
+      overviews: "Project overview"
+      queries: "Work packages: saved views"
+      wiki_page_attachments: "Wiki pages: attachments"
+      work_package_attachments: "Work packages: attachments"
+      work_package_categories: "Work packages: categories"
+      work_package_file_links: "Work packages: file links"
+      work_package_shares: "Work packages: shares"
+    create:
+      complete_wizard_link: "Complete the %{artefact_name}"
+      notification_email_subject: "Your project '%{project_name}' has been created"
+    delete:
+      completed: "Deletion of project '%{name}' completed"
+      completed_text: "The request to delete project '%{name}' has been completed."
+      completed_text_children: "Additionally, the following subprojects have been deleted:"
+      failed: "Deletion of project '%{name}' has failed"
+      failed_text: "The request to delete project '%{name}' has failed. The project was left archived."
+      schedule_failed: "Project cannot be deleted: %{errors}"
+      scheduled: "Deletion has been scheduled and is performed in the background. You will be notified of the result."
+    index:
+      no_results_content_text: Create a new project
+      no_results_title_text: There are currently no projects
+      open_as_gantt: "Open as Gantt view"
+      search:
+        label: Project name filter
+        placeholder: Search by project name
+    lists:
+      active: "Active projects"
+      archived: "Archived projects"
+      delete_modal:
+        heading: "Delete this project list?"
+        text: "This action will not delete any project the list contains. Are you sure you want to delete this project list?"
+        title: "Delete project list"
+      favorited: "Favorite projects"
+      my: "My projects"
+      my_lists: "My project lists"
+      new:
+        placeholder: "New project list"
+      shared: "Shared project lists"
+    settings:
+      actions:
+        label_disable_all: "Disable all"
+        label_enable_all: "Enable all"
+      activities:
+        no_results_title_text: There are currently no activities available.
+      button_update_details: Update details
+      button_update_parent_project: Update parent project
+      button_update_status_description: Update status description
+      categories:
+        no_results_content_text: Create a new work package category
+        no_results_title_text: There are currently no work package categories.
+      change_identifier: Change identifier
+      change_identifier_dialog_title: Change project identifier
+      change_identifier_format_hint_legacy: "Only lowercase letters (a–z), numbers, dashes or underscores."
+      change_identifier_format_hint_semantic: "Only uppercase letters (A–Z), numbers or underscores. Max 10 characters. Must start with a letter."
+      change_identifier_warning: >
+        This will permanently change identifiers and URLs of all work packages in this project.
+        The previous identifiers and URLs will nevertheless continue to work.
+      creation_wizard:
+        enabled_because_required_html: This project attribute cannot be disabled for this project initiation request since it is defined as required. This can be changed in the <a href=%{admin_settings_url} target="_blank">administration settings</a> by the administrator of the instance.
+        errors:
+          no_status_when_submitted: "Failed to enable project initiation request because work package type %{type} requires at least one status associated with it. Please enable at least one status workflow for this work package type."
+          no_work_package_type: "Failed to enable project initiation request because it requires at least one active work package type and this project has none. Please add at least one work package type to this project."
+        export:
+          description_attachment_export: "The generated artifact will be saved as a PDF attachment to the artifact work package."
+          description_file_link_export: "The artifact work package will have a file link to a PDF stored in an external file storage. Requires a working file storage with automatically-managed project folders for this project. At the moment only Nextcloud file storages are supported."
+          description_file_storage_selection: "Select which of the configured external file storages should be used."
+          external_file_storage: "External file storage"
+          label_artifact_export: "Artifact export"
+          label_attachment_export: "Save as work package file attachment"
+          label_file_link_export: "Upload file to external file storage and add file link to work package"
+          pdf_file_storage: "PDF file storage"
+          unavailable: "unavailable"
+        label_request_submission: "Request submission"
+        project_attributes_description: >
+          Select which project attributes should be included in the project initiation request.
+          This list only includes [project attributes](project_attributes_url) enabled for for this project.
+      custom_fields:
+        no_results_title_text: There are currently no custom fields available.
+      forums:
+        no_results_content_text: Create a new forum
+        no_results_title_text: There are currently no forums for the project.
+      header_details: Basic details
+      header_identifier: Identifier
+      header_relations: Project relations
+      header_status: Status
+      life_cycle:
+        filter:
+          label: "Search project phase"
+        header:
+          description_html: 'The active project phases define this project''s life cycle and are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a>. Enabled phases will be displayed in your <a href=%{overview_url} target="_blank">project overview</a>.'
+          title: "Project life cycle"
+        non_defined: "No phases are currently defined."
+        section_header: "Phases"
+        step:
+          use_in_project: "Use %{step} in this project"
+      private_confirmation:
+        checkbox: "I understand that this will make the previously public content private."
+        description: >
+          The project will only be visible to project members depending on their role and associated permissions.
+          Sub-projects are not affected and have their own settings.
+        title: "Make this project private?"
+      project_custom_fields:
+        actions:
+          label_disable_single: "Inactive in this project, click to enable"
+          label_enable_single: "Active in this project, click to disable"
+          remove_from_project: "Remove from project"
+        enabled_via_assignee_when_submitted_html: This project attribute cannot be disabled since it is set as <a href=%{pir_submission_url} target="_blank">assignee when submitted</a> for project initiation requests.
+        filter:
+          label: "Search project attribute"
+        header:
+          description_html: 'These project attributes will be displayed in your <a href=%{overview_url} target="_blank">project overview page</a> under their respective sections. You can enable or disable individual attributes. Project attributes and sections are defined in the <a href=%{admin_settings_url} target="_blank">administration settings</a> by the administrator of the instance. '
+          title: "Project attributes"
+        is_for_all_blank_slate:
+          description: This project attribute is enabled in all projects since the "For all projects" option is checked. It cannot be deactivated for individual projects.
+          heading: For all projects
+      public_confirmation:
+        checkbox: "I understand that this will make the previously private content public"
+        description: >
+          Anyone who has access to this instance will be able to view and interact with this project depending on their role and authentication settings.
+          Sub-projects are not affected and have their own settings.
+        title: "Make this project public?"
+      public_warning: >
+        This project is public.
+        Anyone who has access to this instance will be able to view and interact with this project depending on their role and associated permissions.
+        Sub-projects are not affected and have their own settings.
+      storage:
+        no_results_title_text: There is no additional recorded disk space consumed by this project.
+      subitems:
+        no_template: "No predefined template"
+        program_template_caption: "Select a template program to be used as the default for new subitems of this type."
+        program_template_label: "Template for programs"
+        project_template_caption: "Select a template project to be used as the default for new subitems of this type."
+        project_template_label: "Template for projects"
+        template_section: >
+          Select templates to be used when creating new subitems.
+      template:
+        enable_failed: "Failed to enable template mode."
+        members:
+          excluded_roles_caption: >
+            When creating a new project from this template, the roles selected above will be omitted.
+            This allows you to select which members will be excluded based on their project roles.
+            Users can then access the template for viewing purposes without being granted access to new projects created from it.
+          excluded_roles_label: "Roles to exclude when template is applied"
+        menu_title: "Template"
+        title: "Template settings"
+      types:
+        form:
+          enable_type_in_project: 'Enable type "%{type}"'
+        no_results_title_text: There are currently no types available.
+      versions:
+        no_results_content_text: Create a new version
+        no_results_title_text: There are currently no versions for the project.
+        show_work_packages: Show work packages
+        work_packages_graph: Work packages graph
+      work_package_priorities:
+        new_label: "New priority"
+    status:
+      button_edit: Edit status
+    wizard:
+      create_artifact_storage_error: "Failed to store artifact in file storage"
+      create_artifact_work_package_error: "Failed to create artifact work package"
+      no_help_text: "This attribute has no help text defined."
+      progress_label: "%{current} of %{total}"
+      sections: "Sections"
+      sidebar_content_title: "Content"
+      success: "Project attributes saved and artifact work package created successfully."
+      title: "Project initiation request"
+  queries:
+    apply_filter: Apply preconfigured filter
+    configure_view:
+      columns:
+        drag_area_label: "Manage and reorder columns"
+        input_label: "Add columns"
+        input_placeholder: "Select a column"
+      heading: Configure view
+      sort_by:
+        automatic:
+          description: "Order the %{plural} by one or more sorting criteria. You will lose the previous sorting."
 
+          heading: "Automatic"
   query:
     attribute_and_direction: "%{attribute} (%{direction})"
 
@@ -5194,21 +4898,35 @@ en:
     member_of_group: "Assignee's group"
     name_or_identifier: "Name or identifier"
     only_subproject_id: "Only subproject"
-    shared_with_user: "Shared with users"
     shared_with_me: "Shared with me"
+    shared_with_user: "Shared with users"
     subproject_id: "Including subproject"
 
+  reactions:
+    action_title: "React"
+    add_reaction: "Add reaction"
+    and_others:
+      one: and 1 other
+      other: and %{count} others
+    and_user: "and %{user}"
+    react_with: "React with %{reaction}"
+    reaction_by: "%{reaction} by"
+
+  reportings:
+    index:
+      no_results_content_text: Add a status reporting
+
+      no_results_title_text: There are currently no status reportings.
   repositories:
     at_identifier: "at %{identifier}"
     atom_revision_feed: "Atom revision feed"
     autofetch_information: "Check this if you want repositories to be updated automatically when accessing the repository module page.\nThis encompasses the retrieval of commits from the repository and refreshing the required disk storage."
     checkout:
       access:
-        readwrite: "Read + Write"
-        read: "Read-only"
         none: "No checkout access, you may only view the repository through this application."
+        read: "Read-only"
+        readwrite: "Read + Write"
       access_permission: "Your permissions on this repository"
-      url: "Checkout URL"
       base_url_text: "The base URL to use for generating checkout URLs (e.g., https://myserver.example.org/repos/).\nNote: The base URL is only used for rewriting checkout URLs in managed repositories. Other repositories are not altered."
       default_instructions:
         git: |-
@@ -5219,9 +4937,10 @@ en:
           Please consult the documentation of Subversion if you need more information on the checkout procedure and available clients.
       enable_instructions_text: "Displays checkout instructions defined below on all repository-related pages."
       instructions: "Checkout instructions"
+      not_available: "Checkout instructions are not defined for this repository. Ask your administrator to enable them for this repository in the system settings."
       show_instructions: "Display checkout instructions"
       text_instructions: "This text is displayed alongside the checkout URL for guidance on how to check out the repository."
-      not_available: "Checkout instructions are not defined for this repository. Ask your administrator to enable them for this repository in the system settings."
+      url: "Checkout URL"
     create_managed_delay: "Please note: The repository is managed, it is created asynchronously on the disk and will be available shortly."
     create_successful: "The repository has been registered."
     delete_sucessful: "The repository has been deleted."
@@ -5237,21 +4956,21 @@ en:
       title_not_managed: "Remove the linked %{repository_type}?"
     errors:
       build_failed: "Unable to create the repository with the selected configuration. %{reason}"
-      managed_delete: "Unable to delete the managed repository."
-      managed_delete_local: "Unable to delete the local repository on filesystem at '%{path}': %{error_message}"
-      empty_repository: "The repository exists, but is empty. It does not contain any revisions yet."
-      exists_on_filesystem: "The repository directory already exists in the filesystem."
-      filesystem_access_failed: "An error occurred while accessing the repository in the filesystem: %{message}"
-      not_manageable: "This repository vendor cannot be managed by OpenProject."
-      path_permission_failed: "An error occurred trying to create the following path: %{path}. Please ensure that OpenProject may write to that folder."
-      unauthorized: "You're not authorized to access the repository or the credentials are invalid."
-      unavailable: "The repository is unavailable."
-      exception_title: "Cannot access the repository: %{message}"
       disabled_or_unknown_type: "The selected type %{type} is disabled or no longer available for the SCM vendor %{vendor}."
       disabled_or_unknown_vendor: "The SCM vendor %{vendor} is disabled or no longer available."
+      empty_repository: "The repository exists, but is empty. It does not contain any revisions yet."
+      exception_title: "Cannot access the repository: %{message}"
+      exists_on_filesystem: "The repository directory already exists in the filesystem."
+      filesystem_access_failed: "An error occurred while accessing the repository in the filesystem: %{message}"
+      managed_delete: "Unable to delete the managed repository."
+      managed_delete_local: "Unable to delete the local repository on filesystem at '%{path}': %{error_message}"
+      not_manageable: "This repository vendor cannot be managed by OpenProject."
+      path_permission_failed: "An error occurred trying to create the following path: %{path}. Please ensure that OpenProject may write to that folder."
       remote_call_failed: "Calling the managed remote failed with message '%{message}' (Code: %{code})"
       remote_invalid_response: "Received an invalid response from the managed remote."
       remote_save_failed: "Could not save the repository with the parameters retrieved from the remote."
+      unauthorized: "You're not authorized to access the repository or the credentials are invalid."
+      unavailable: "The repository is unavailable."
     git:
       instructions:
         managed_url: "This is the URL of the managed (local) Git repository."
@@ -5260,9 +4979,9 @@ en:
           You can also use remote repositories which are cloned to a local copy by
           using a value starting with http(s):// or file://.
         path_encoding: "Override Git path encoding (Default: UTF-8)"
+      local_introduction: "If you have an existing local Git repository, you can link it with OpenProject to access it from within the application."
       local_title: "Link existing local Git repository"
       local_url: "Local URL"
-      local_introduction: "If you have an existing local Git repository, you can link it with OpenProject to access it from within the application."
       managed_introduction: "Let OpenProject create and integrate a local Git repository automatically."
       managed_title: "Git repository integrated into OpenProject"
       managed_url: "Managed URL"
@@ -5272,62 +4991,68 @@ en:
     managed_remote: "Managed repositories for this vendor are handled remotely."
     managed_remote_note: "Information on the URL and path of this repository is not available prior to its creation."
     managed_url: "Managed URL"
-    settings:
-      automatic_managed_repos_disabled: "Disable automatic creation"
-      automatic_managed_repos: "Automatic creation of managed repositories"
-      automatic_managed_repos_text: "By setting a vendor here, newly created projects will automatically receive a managed repository of this vendor."
-    scm_vendor: "Source control management system"
+    named_repository: "%{vendor_name} repository"
     scm_type: "Repository type"
     scm_types:
-      local: "Link existing local repository"
       existing: "Link existing repository"
+      local: "Link existing local repository"
       managed: "Create new repository in OpenProject"
+    scm_vendor: "Source control management system"
+    settings:
+      automatic_managed_repos: "Automatic creation of managed repositories"
+      automatic_managed_repos_disabled: "Disable automatic creation"
+      automatic_managed_repos_text: "By setting a vendor here, newly created projects will automatically receive a managed repository of this vendor."
     storage:
       not_available: "Disk storage consumption is not available for this repository."
-      update_timeout: "Keep the last required disk space information for a repository for N minutes.\nAs counting the required disk space of a repository may be costly, increase this value to reduce performance impact."
       oauth_application_details_html: "The client secret value will not be accessible again after you close this window. Please copy these values into the Nextcloud OpenProject Integration settings:"
       oauth_application_details_link_text: "Go to settings page"
       setup_documentation_details: "If you need help configuring a new file storage please check the documentation: "
       setup_documentation_details_link_text: "File storages setup"
       show_warning_details: "To use this file storage remember to activate the module and the specific storage in the project settings of each desired project."
+      update_timeout: "Keep the last required disk space information for a repository for N minutes.\nAs counting the required disk space of a repository may be costly, increase this value to reduce performance impact."
     subversion:
-      existing_title: "Existing Subversion repository"
       existing_introduction: "If you have an existing Subversion repository, you can link it with OpenProject to access it from within the application."
+      existing_title: "Existing Subversion repository"
       existing_url: "Existing URL"
       instructions:
         managed_url: "This is the URL of the managed (local) Subversion repository."
         url: "Enter the repository URL. This may either target a local repository (starting with %{local_proto} ), or a remote repository.\nThe following URL schemes are supported:"
-      managed_title: "Subversion repository integrated into OpenProject"
       managed_introduction: "Let OpenProject create and integrate a local Subversion repository automatically."
+      managed_title: "Subversion repository integrated into OpenProject"
       managed_url: "Managed URL"
       password: "Repository Password"
       username: "Repository username"
     truncated: "Sorry, we had to truncate this directory to %{limit} files. %{truncated} entries were omitted from the list."
-    named_repository: "%{vendor_name} repository"
     update_settings_successful: "The settings have been successfully saved."
     url: "URL to repository"
     warnings:
       cannot_annotate: "This file cannot be annotated."
 
+  roles:
+    edit:
+      default_for_new_projects_warning: >-
+        This role is configured as the default role given to non-admin users who create a project.
+        Do not remove the following permissions, otherwise project creators will be unable to complete
+        the setup of their newly created projects:
+    permissions:
+      section_check_all_label: "Assign all %{module} permissions"
+      section_uncheck_all_label: "Unassign all %{module} permissions"
+    report:
+      matrix_caption: "Permissions matrix for %{module} module"
+      matrix_check_all_label: "Assign all %{module} permissions to all roles"
+      matrix_check_uncheck_all_in_col_label_html: "Toggle all %{module} permissions for <em>%{role}</em> role"
+
+      matrix_check_uncheck_all_in_row_label_html: "Toggle <em>%{permission}</em> permission for all roles"
+      matrix_checkbox_label: "Assign %{permission} permission to %{role} role"
+      matrix_uncheck_all_label: "Unassign all %{module} permissions from all roles"
   scheduling:
-    manual: "set to Manual"
     automatic: "set to Automatic"
 
+    manual: "set to Manual"
   search_input_placeholder: "Search ..."
 
-  setting_allowed_link_protocols: "Allowed link protocols"
-  setting_allowed_link_protocols_text_html: >-
-    Allow these protocols to be rendered as links in work package descriptions, long text fields and comments.
-    For example, %{tel_code} or %{element_code}. Enter one protocol per line.
-    <br/>
-    Protocols %{http_code}, %{https_code}, and %{mailto_code} are always allowed.
-  setting_capture_external_links: "Capture external links"
-  setting_capture_external_links_text: >
-    When enabled, all external links in formatted text will redirect through a warning page
-    before leaving the application. This helps protect users from potentially malicious external websites.
-  setting_capture_external_links_require_login: "Require users to be logged in"
-  setting_capture_external_links_require_login_text: >
-    When enabled, users wanting to click on external links need to be logged in before being able to continue.
+  setting_accessibility_mode_for_anonymous: "Enable accessibility mode for anonymous users"
+  setting_activity_days_default: "Days displayed on project activity"
   setting_after_first_login_redirect_url: "First login redirect"
   setting_after_first_login_redirect_url_text_html: >
     Set a path to redirect users after their first login. If empty, redirects to the home page for the onboarding tour.
@@ -5338,31 +5063,25 @@ en:
     Set a default path to redirect users after login, if no back link was provided. Redirects to home page if not set.
     <br/>
     Example: %{example_code}
-  setting_apiv3_cors_title: "Cross-Origin Resource Sharing (CORS)"
+  setting_allowed_link_protocols: "Allowed link protocols"
+  setting_allowed_link_protocols_text_html: >-
+    Allow these protocols to be rendered as links in work package descriptions, long text fields and comments.
+    For example, %{tel_code} or %{element_code}. Enter one protocol per line.
+    <br/>
+    Protocols %{http_code}, %{https_code}, and %{mailto_code} are always allowed.
+  setting_antivirus_scan_action: "Infected file action"
+  setting_antivirus_scan_mode: "Scan mode"
+  setting_api_tokens_enabled: "Enable API tokens"
+  setting_api_tokens_enabled_caption: >
+    Decide whether users can create personal API tokens in their account settings. These tokens can be used to access the different
+    APIs of OpenProject, such as APIv3 and MCP.
   setting_apiv3_cors_enabled: "Enable CORS"
   setting_apiv3_cors_origins: "API V3 Cross-Origin Resource Sharing (CORS) allowed origins"
   setting_apiv3_cors_origins_instructions_html: >
     If CORS is enabled, these are the origins that are allowed to access OpenProject API.
     <br/>
     Please check the [Documentation on the Origin header](docs_url) on how to specify the expected values.
-  setting_apiv3_write_readonly_attributes: "Write access to read-only attributes"
-  setting_apiv3_write_readonly_attributes_instructions: >
-    If enabled, the API will allow administrators to write static read-only attributes during creation,
-    such as createdAt and author.
-  setting_apiv3_write_readonly_attributes_warning: >
-    This setting has a use-case for e.g., importing data, but allows
-    administrators to impersonate the creation of items as other users. All creation requests are being
-    logged however with the true author.
-  setting_apiv3_write_readonly_attributes_additional_html: >
-    For more information on attributes and supported resources, please see the [API documentation](api_documentation_link).
-  setting_apiv3_max_page_size: "Maximum API page size"
-  setting_apiv3_max_page_size_instructions: >
-    Set the maximum page size the API will respond with.
-    It will not be possible to perform API requests that return more values on a single page.
-  setting_apiv3_max_page_size_warning: >
-    Please only change this value if you are sure why you need it.
-    Setting to a high value will result in significant performance impacts, while a value lower than the per page options
-    will cause errors in paginated views.
+  setting_apiv3_cors_title: "Cross-Origin Resource Sharing (CORS)"
   setting_apiv3_docs: "Documentation"
   setting_apiv3_docs_enabled: "Enable docs page"
   setting_apiv3_docs_enabled_instructions_html: >
@@ -5372,32 +5091,28 @@ en:
     Please be aware that enabling the API docs on a production system may expose sensitive information
     or result in accidental loss of data when not being careful.
     We recommend to only enable this setting for development purposes.
-  setting_attachment_whitelist: "Attachment upload whitelist"
-  setting_email_delivery_method: "Email delivery method"
-  setting_emails_salutation: "Address user in emails with"
-  setting_oauth_allow_remapping_of_existing_users: "Allow remapping of existing users"
-  setting_sendmail_location: "Location of the sendmail executable"
-  setting_sendmail_arguments: "Arguments for sendmail"
-  setting_smtp_enable_starttls_auto: "Automatically use STARTTLS if available"
-  setting_smtp_ssl: "Use SSL connection"
-  setting_smtp_address: "SMTP server"
-  setting_smtp_port: "SMTP port"
-  setting_smtp_authentication: "SMTP authentication"
-  setting_smtp_user_name: "SMTP username"
-  setting_smtp_password: "SMTP password"
-  setting_smtp_domain: "SMTP HELO domain"
-  setting_activity_days_default: "Days displayed on project activity"
-  setting_api_tokens_enabled: "Enable API tokens"
-  setting_api_tokens_enabled_caption: >
-    Decide whether users can create personal API tokens in their account settings. These tokens can be used to access the different
-    APIs of OpenProject, such as APIv3 and MCP.
+  setting_apiv3_max_page_size: "Maximum API page size"
+  setting_apiv3_max_page_size_instructions: >
+    Set the maximum page size the API will respond with.
+    It will not be possible to perform API requests that return more values on a single page.
+  setting_apiv3_max_page_size_warning: >
+    Please only change this value if you are sure why you need it.
+    Setting to a high value will result in significant performance impacts, while a value lower than the per page options
+    will cause errors in paginated views.
+  setting_apiv3_write_readonly_attributes: "Write access to read-only attributes"
+  setting_apiv3_write_readonly_attributes_additional_html: >
+    For more information on attributes and supported resources, please see the [API documentation](api_documentation_link).
+  setting_apiv3_write_readonly_attributes_instructions: >
+    If enabled, the API will allow administrators to write static read-only attributes during creation,
+    such as createdAt and author.
+  setting_apiv3_write_readonly_attributes_warning: >
+    This setting has a use-case for e.g., importing data, but allows
+    administrators to impersonate the creation of items as other users. All creation requests are being
+    logged however with the true author.
   setting_app_subtitle: "Application subtitle"
   setting_app_title: "Application title"
-  setting_organization_name: "Organization name"
   setting_attachment_max_size: "Attachment max. size"
-  setting_show_work_package_attachments: "Show attachments in the files tab by default"
-  setting_antivirus_scan_mode: "Scan mode"
-  setting_antivirus_scan_action: "Infected file action"
+  setting_attachment_whitelist: "Attachment upload whitelist"
   setting_autofetch_changesets: "Autofetch repository changes"
   setting_autologin: "Autologin"
   setting_available_languages: "Available languages"
@@ -5405,17 +5120,25 @@ en:
   setting_brute_force_block_after_failed_logins: "Block user after this number of failed login attempts"
   setting_brute_force_block_minutes: "Time the user is blocked for"
   setting_cache_formatted_text: "Cache formatted text"
-  setting_use_wysiwyg_description: "Select to enable CKEditor5 WYSIWYG editor for all users by default. CKEditor has limited functionality for GFM Markdown."
+  setting_capture_external_links: "Capture external links"
+  setting_capture_external_links_require_login: "Require users to be logged in"
+  setting_capture_external_links_require_login_text: >
+    When enabled, users wanting to click on external links need to be logged in before being able to continue.
+  setting_capture_external_links_text: >
+    When enabled, all external links in formatted text will redirect through a warning page
+    before leaving the application. This helps protect users from potentially malicious external websites.
+  setting_collaborative_editing_hocuspocus_secret: "Hocuspocus server secret"
+  setting_collaborative_editing_hocuspocus_url: "Hocuspocus server URL"
   setting_column_options: "Default work package lists columns"
   setting_commit_fix_keywords: "Fixing keywords"
   setting_commit_logs_encoding: "Commit messages encoding"
   setting_commit_logtime_activity_id: "Activity for logged time"
   setting_commit_logtime_enabled: "Enable time logging"
   setting_commit_ref_keywords: "Referencing keywords"
-  setting_consent_time: "Consent time"
+  setting_consent_decline_mail: "Consent contact mail address"
   setting_consent_info: "Consent information text"
   setting_consent_required: "Consent required"
-  setting_consent_decline_mail: "Consent contact mail address"
+  setting_consent_time: "Consent time"
   setting_cross_project_work_package_relations: "Allow cross-project work package relations"
   setting_csv_escape_formulas: "Escape formulas in CSV exports"
   setting_csv_escape_formulas_text: >
@@ -5424,56 +5147,36 @@ en:
     formula injection when exported files are opened in spreadsheet applications such as Excel.
     This comes at the downside of modifying the string values inside the CSV,
     so you may want to disable this if downstream tools require the exact, unescaped cell values.
-  setting_first_week_of_year: "First week in year contains"
   setting_date_format: "Date"
   setting_default_language: "Default language"
   setting_default_projects_modules: "Default enabled modules for new projects"
   setting_default_projects_public: "New projects are public by default"
-  setting_disable_password_login: "Disable password authentication"
   setting_diff_max_lines_displayed: "Max number of diff lines displayed"
-  setting_omniauth_direct_login_provider: "Direct login SSO provider"
+  setting_disable_password_login: "Disable password authentication"
   setting_display_subprojects_work_packages: "Display subprojects work packages on main projects by default"
   setting_duration_format: "Duration format"
-  setting_duration_format_hours_only: "Hours only"
   setting_duration_format_days_and_hours: "Days and hours"
+  setting_duration_format_hours_only: "Hours only"
   setting_duration_format_instructions: "This defines how Work, Remaining work, and Time spent durations are displayed."
+  setting_email_delivery_method: "Email delivery method"
+  setting_email_login: "Use email as login"
   setting_emails_footer: "Emails footer"
   setting_emails_header: "Emails header"
-  setting_email_login: "Use email as login"
-  setting_enabled_scm: "Enabled SCM"
+  setting_emails_salutation: "Address user in emails with"
   setting_enabled_projects_columns: "Columns in a projects list displayed by default"
+  setting_enabled_scm: "Enabled SCM"
   setting_feeds_enabled: "Enable Feeds"
-  setting_ical_enabled: "Enable iCalendar subscriptions"
   setting_feeds_limit: "Feed content limit"
   setting_file_max_size_displayed: "Max size of text files displayed inline"
+  setting_first_week_of_year: "First week in year contains"
   setting_host_name: "Host name"
-  setting_collaborative_editing_hocuspocus_url: "Hocuspocus server URL"
-  setting_collaborative_editing_hocuspocus_secret: "Hocuspocus server secret"
   setting_hours_per_day: "Hours per day"
   setting_hours_per_day_explanation: >-
     This defines what is considered a "day" when displaying duration in days and hours
     (for example, if a day is 8 hours, 32 hours would be 4 days).
+  setting_ical_enabled: "Enable iCalendar subscriptions"
   setting_invitation_expiration_days: "Activation email expires after"
   setting_invitation_expiration_days_caption: "Number of days after which the activation email expires."
-  setting_work_package_done_ratio: "Progress calculation mode"
-  setting_work_package_done_ratio_field: "Work-based"
-  setting_work_package_done_ratio_field_caption_html: >-
-    <i>% Complete</i> can be freely set to any value.
-    If you optionally enter a value for <i>Work</i>, <i>Remaining work</i> will automatically be derived.
-  setting_work_package_done_ratio_status: "Status-based"
-  setting_work_package_done_ratio_status_caption_html: >-
-    Each status has a <i>% Complete</i> value associated with it.
-    Changing status will change <i>% Complete</i>.
-  setting_work_package_done_ratio_explanation_html: >
-    In <b>work-based</b> mode, % Complete can be freely set to any value.
-    If you optionally enter a value for Work, Remaining work will automatically be derived.
-    In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
-  setting_work_package_properties: "Work package properties"
-  setting_work_package_startdate_is_adddate: "Use current date as start date for new work packages"
-  setting_work_packages_projects_export_limit: "Work packages / Projects export limit"
-  setting_work_packages_projects_export_limit_text: >
-    Maximum number of work packages or projects that can be included in a single
-    export. Larger exports are truncated to this limit.
   setting_journal_aggregation_time_minutes: "Aggregation period"
   setting_log_requesting_user: "Log user login, name, and mail address for all requests"
   setting_login_required: "Authentication required"
@@ -5482,15 +5185,18 @@ en:
   setting_lost_password_caption: "When checked, allow users to reset their own passwords."
   setting_mail_from: "Emission email address"
   setting_mail_handler_api_key: "API key"
-  setting_mail_handler_body_delimiters: "Truncate emails after one of these lines"
   setting_mail_handler_body_delimiter_regex: "Truncate emails matching this regex"
+  setting_mail_handler_body_delimiters: "Truncate emails after one of these lines"
   setting_mail_handler_ignore_filenames: "Ignored mail attachments"
+  setting_new_project_notification_text: "Notification text"
+  setting_new_project_send_confirmation_email: "Send notification to author when creating a new project"
   setting_new_project_user_role_id: "Role given to a non-admin user who creates a project"
   setting_new_project_user_role_id_caption: >
     Only roles that include the permissions to edit project attributes and to manage members are listed,
     so that the creator can complete the project setup.
-  setting_new_project_send_confirmation_email: "Send notification to author when creating a new project"
-  setting_new_project_notification_text: "Notification text"
+  setting_oauth_allow_remapping_of_existing_users: "Allow remapping of existing users"
+  setting_omniauth_direct_login_provider: "Direct login SSO provider"
+  setting_organization_name: "Organization name"
   setting_password_active_rules: "Password requirements"
   setting_password_count_former_banned: "Number of most recently used passwords banned for reuse"
   setting_password_days_valid: "Number of days, after which to enforce a password change"
@@ -5504,32 +5210,21 @@ en:
   setting_percent_complete_on_status_closed_set_100p_caption: >-
     A closed work package is considered complete.
   setting_plain_text_mail: "Plain text mail (no HTML)"
-  setting_protocol: "Protocol"
   setting_project_gantt_query: "Project portfolio Gantt view"
   setting_project_gantt_query_text: "You can modify the query that is used to display Gantt chart from the project overview page."
-  setting_security_badge_displayed: "Display security badge"
+  setting_protocol: "Protocol"
   setting_registration_footer: "Registration footer"
   setting_registration_footer_caption: "This text is displayed in the footer of the registration page. Use the HTML editor to format the text for each selected language."
   setting_repositories_automatic_managed_vendor: "Automatic repository vendor type"
   setting_repositories_encodings: "Repositories encodings"
-  setting_repository_storage_cache_minutes: "Repository disk size cache"
-  setting_repository_checkout_display: "Show checkout instructions"
   setting_repository_checkout_base_url: "Checkout base URL"
+  setting_repository_checkout_display: "Show checkout instructions"
   setting_repository_checkout_text: "Checkout instruction text"
   setting_repository_log_display_limit: "Maximum number of revisions displayed on file log"
+  setting_repository_storage_cache_minutes: "Repository disk size cache"
   setting_repository_truncate_at: "Maximum number of files displayed in the repository browser"
+  setting_security_badge_displayed: "Display security badge"
   setting_self_registration: "Self-registration"
-  setting_self_registration_caption: >
-    Choose the self-registration mechanism for users. Be careful with the setting you choose, as some
-    options allow users to activate their own accounts to this instance.
-  setting_self_registration_warning: >
-    The user will be able to activate their own accounts.
-    Please note that this will give them access to all public projects and their content.
-    Please make sure that no sensitive or private data is exposed in public projects.
-  setting_self_registration_disabled: "Disabled"
-  setting_self_registration_disabled_caption: >
-    No accounts can be registered on their own. Only administrators and users with the global permission
-    to create new users are able to create new accounts.
   setting_self_registration_activation_by_email: "Account activation by email"
   setting_self_registration_activation_by_email_caption: >
     Users can register on their own and activate their account after confirming their email address.
@@ -5538,86 +5233,86 @@ en:
   setting_self_registration_automatic_activation_caption: >
     Users can register on their own. Their accounts are immediately active without further action.
     Administrators have no moderation control over the activation process.
+  setting_self_registration_caption: >
+    Choose the self-registration mechanism for users. Be careful with the setting you choose, as some
+    options allow users to activate their own accounts to this instance.
+  setting_self_registration_disabled: "Disabled"
+  setting_self_registration_disabled_caption: >
+    No accounts can be registered on their own. Only administrators and users with the global permission
+    to create new users are able to create new accounts.
   setting_self_registration_manual_activation: "Manual account activation"
   setting_self_registration_manual_activation_caption: >
     Users can register on their own. Their accounts are in a pending state until an administrator
     or user with the global permission to create or manage users activates them.
+  setting_self_registration_warning: >
+    The user will be able to activate their own accounts.
+    Please note that this will give them access to all public projects and their content.
+    Please make sure that no sensitive or private data is exposed in public projects.
+  setting_sendmail_arguments: "Arguments for sendmail"
+  setting_sendmail_location: "Location of the sendmail executable"
   setting_session_ttl: "Session expiration time after inactivity"
-  setting_session_ttl_hint: "Value below 5 works like disabled"
   setting_session_ttl_enabled: "Session expires"
+  setting_session_ttl_hint: "Value below 5 works like disabled"
+  setting_show_work_package_attachments: "Show attachments in the files tab by default"
+  setting_smtp_address: "SMTP server"
+  setting_smtp_authentication: "SMTP authentication"
+  setting_smtp_domain: "SMTP HELO domain"
+  setting_smtp_enable_starttls_auto: "Automatically use STARTTLS if available"
+  setting_smtp_password: "SMTP password"
+  setting_smtp_port: "SMTP port"
+  setting_smtp_ssl: "Use SSL connection"
+  setting_smtp_user_name: "SMTP username"
   setting_start_of_week: "Week starts on"
-  setting_sys_api_enabled: "Enable repository management web service"
   setting_sys_api_description: "The repository management web service provides integration and user authorization for accessing repositories."
+  setting_sys_api_enabled: "Enable repository management web service"
   setting_time_format: "Time"
   setting_total_percent_complete_mode: "Calculation of % Complete hierarchy totals"
+  setting_total_percent_complete_mode_simple_average: "Simple average"
+  setting_total_percent_complete_mode_simple_average_caption_html: >-
+    <i>Work</i> is ignored and the <i>total % Complete</i> will be a simple average of <i>% Complete</i> values of work packages in the hierarchy.
   setting_total_percent_complete_mode_work_weighted_average: "Weighted by work"
   setting_total_percent_complete_mode_work_weighted_average_caption_html: >-
     The <i>total % Complete</i> will be weighted against the <i>Work</i> of each work package in the hierarchy.
     Work packages without <i>Work</i> will be ignored.
-  setting_total_percent_complete_mode_simple_average: "Simple average"
-  setting_total_percent_complete_mode_simple_average_caption_html: >-
-    <i>Work</i> is ignored and the <i>total % Complete</i> will be a simple average of <i>% Complete</i> values of work packages in the hierarchy.
-  setting_accessibility_mode_for_anonymous: "Enable accessibility mode for anonymous users"
-  setting_user_format: "Users name format"
+  setting_use_wysiwyg_description: "Select to enable CKEditor5 WYSIWYG editor for all users by default. CKEditor has limited functionality for GFM Markdown."
   setting_user_default_timezone: "Users default time zone"
+  setting_user_format: "Users name format"
   setting_users_deletable_by_admins: "User accounts deletable by admins"
   setting_users_deletable_by_self: "Users allowed to delete their accounts"
+  setting_welcome_on_homescreen: "Display welcome block on homescreen"
   setting_welcome_text: "Welcome block text"
   setting_welcome_title: "Welcome block title"
-  setting_welcome_on_homescreen: "Display welcome block on homescreen"
+  setting_work_package_done_ratio: "Progress calculation mode"
+  setting_work_package_done_ratio_explanation_html: >
+    In <b>work-based</b> mode, % Complete can be freely set to any value.
+    If you optionally enter a value for Work, Remaining work will automatically be derived.
+    In <b>status-based</b> mode, each status has a % Complete value associated with it. Changing status will change % Complete.
+  setting_work_package_done_ratio_field: "Work-based"
+  setting_work_package_done_ratio_field_caption_html: >-
+    <i>% Complete</i> can be freely set to any value.
+    If you optionally enter a value for <i>Work</i>, <i>Remaining work</i> will automatically be derived.
+  setting_work_package_done_ratio_status: "Status-based"
+  setting_work_package_done_ratio_status_caption_html: >-
+    Each status has a <i>% Complete</i> value associated with it.
+    Changing status will change <i>% Complete</i>.
+  setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"
+  setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
+  setting_work_package_properties: "Work package properties"
+  setting_work_package_startdate_is_adddate: "Use current date as start date for new work packages"
   setting_work_packages_identifier_classic: Instance-wide numerical sequence (default)
   setting_work_packages_identifier_classic_caption: "Every work package gets a sequential number starting with 1 (for example, #1234). The numbers are unique within the instance and remain the same even if work packages are moved between projects."
   setting_work_packages_identifier_semantic: "Project-based semantic identifiers (Beta)"
   setting_work_packages_identifier_semantic_caption: "Every project has a unique project identifier prefixed to a number (for example, PROJ-11). The numbering of each project starts at 1. If a work package is moved to another project, a new identifier is generated but the old one will continue to function."
-  setting_work_package_list_default_highlighting_mode: "Default highlighting mode"
-  setting_work_package_list_default_highlighted_attributes: "Default inline highlighted attributes"
+  setting_work_packages_projects_export_limit: "Work packages / Projects export limit"
+  setting_work_packages_projects_export_limit_text: >
+    Maximum number of work packages or projects that can be included in a single
+    export. Larger exports are truncated to this limit.
   setting_working_days: "Working days"
 
   settings:
-    errors:
-      not_writable: "The setting is not writable and can only be changed by a sysadmin."
-      failed_to_update: "Setting '%{name}' could not be updated: %{message}"
-    authentication:
-      login: "Login"
-      registration: "Registration"
-      sso: "Single Sign-On (SSO)"
-      omniauth_direct_login_hint_html: >
-        If this option is active, login requests will redirect to the configured omniauth provider.
-        The login dropdown and sign-in page will be disabled.
-        <br/>
-        <strong>Note:</strong> Unless you also disable password logins, with this option enabled,
-        users can still log in internally by visiting the <code>%{internal_path}</code> login page.
-      remapping_existing_users_hint: >
-        If enabled, allows any configured identity provider to login existing users based on their username,
-        even if the user never signed in through that provider before. This can be useful when migrating the OpenProject instance
-        to a new SSO provider, but is not recommended when using a provider that is not trusted by all users of your instance.
-    attachments:
-      whitelist_text_html: >
-        Define a list of valid file extensions and/or mime types for uploaded files.
-        <br/>
-        Enter file extensions (e.g., <code>%{ext_example}</code>) or mime types (e.g., <code>%{mime_example}</code>).
-        <br/>
-        Leave empty to allow any file type to be uploaded.
-        Multiple values allowed (one line for each value).
-      show_work_package_attachments: >
-        Deactivating this option will hide the attachments list on the work packages files tab for new projects. The
-        files attached in the description of a work package will still be uploaded in the internal attachments storage.
     antivirus:
-      title: "Virus scanning"
-      clamav_ping_failed: "Failed to connect the the ClamAV daemon. Double-check the configuration and try again."
-      remaining_quarantined_files_html: >
-        Virus scanning has been disbled. %{file_count} remain in quarantine.
-        To review quarantined files, please visit this link: %{link}
-      remaining_scan_complete_html: >
-        Remaining files have been scanned. There are %{file_count} in quarantine.
-        You are being redirected to the quarantine page. Use this page to delete or override quarantined files.
-      remaining_rescanned_files: >
-        Virus scanning has been enabled successfully.
-        There are %{file_count} that were uploaded previously and still need to be scanned.
-        This process has been scheduled in the background. The files will remain accessible during the scan.
       actions:
         delete: "Delete the file"
-        quarantine: "Quarantine the file"
         instructions_html: >
           Select the action to perform for files on which a virus has been detected:
           <br/>
@@ -5625,9 +5320,11 @@ en:
           <li><strong>%{quarantine_option}</strong>: Quarantine the file, preventing users from accessing it. Administrators can review and delete quarantined files in the administration.</li>
           <li><strong>%{delete_option}</strong>: Delete the file immediately.</li>
           </ul>
+        quarantine: "Quarantine the file"
+      clamav_ping_failed: "Failed to connect the the ClamAV daemon. Double-check the configuration and try again."
       modes:
-        clamav_socket_html: Enter the socket to the clamd daemon, e.g., %{example}
         clamav_host_html: Enter the hostname and port to the clamd daemon separated by colon. e.g., %{example}
+        clamav_socket_html: Enter the socket to the clamd daemon, e.g., %{example}
         description_html: >
           Select the mode in which the antivirus scanner integration should operate.
           <br/>
@@ -5636,6 +5333,42 @@ en:
           <li><strong>%{socket_option}</strong>: You have set up ClamAV on the same server as OpenProject and the scan daemon clamd is running in the background</li>
           <li><strong>%{host_option}</strong>: You are streaming files to an external virus scanning host.</li>
           </ul>
+      remaining_quarantined_files_html: >
+        Virus scanning has been disbled. %{file_count} remain in quarantine.
+        To review quarantined files, please visit this link: %{link}
+      remaining_rescanned_files: >
+        Virus scanning has been enabled successfully.
+        There are %{file_count} that were uploaded previously and still need to be scanned.
+        This process has been scheduled in the background. The files will remain accessible during the scan.
+      remaining_scan_complete_html: >
+        Remaining files have been scanned. There are %{file_count} in quarantine.
+        You are being redirected to the quarantine page. Use this page to delete or override quarantined files.
+      title: "Virus scanning"
+    attachments:
+      show_work_package_attachments: >
+        Deactivating this option will hide the attachments list on the work packages files tab for new projects. The
+        files attached in the description of a work package will still be uploaded in the internal attachments storage.
+      whitelist_text_html: >
+        Define a list of valid file extensions and/or mime types for uploaded files.
+        <br/>
+        Enter file extensions (e.g., <code>%{ext_example}</code>) or mime types (e.g., <code>%{mime_example}</code>).
+        <br/>
+        Leave empty to allow any file type to be uploaded.
+        Multiple values allowed (one line for each value).
+    authentication:
+      login: "Login"
+      omniauth_direct_login_hint_html: >
+        If this option is active, login requests will redirect to the configured omniauth provider.
+        The login dropdown and sign-in page will be disabled.
+        <br/>
+        <strong>Note:</strong> Unless you also disable password logins, with this option enabled,
+        users can still log in internally by visiting the <code>%{internal_path}</code> login page.
+      registration: "Registration"
+      remapping_existing_users_hint: >
+        If enabled, allows any configured identity provider to login existing users based on their username,
+        even if the user never signed in through that provider before. This can be useful when migrating the OpenProject instance
+        to a new SSO provider, but is not recommended when using a provider that is not trusted by all users of your instance.
+      sso: "Single Sign-On (SSO)"
     brute_force_prevention: "Automated user blocking"
     date_format:
       first_date_of_week_and_year_set: >
@@ -5645,119 +5378,122 @@ en:
         Select the date of January that is contained in the first week of the year.
         This value together with first day of the week determines the total number of weeks in a year.
         For more information, please see our <a href="%{link}" target="_blank">documentation</a> on this topic.
+    errors:
+      failed_to_update: "Setting '%{name}' could not be updated: %{message}"
+      not_writable: "The setting is not writable and can only be changed by a sysadmin."
     experimental:
+      feature_flags: Feature flags
       save_confirmation: Caution! Risk of data loss! Only activate experimental features if you do not mind breaking your OpenProject installation and losing all of its data.
       warning_toast: Feature flags are settings that activate features that are still under development. They shall only be used for testing purposes. They shall never be activated on OpenProject installations holding important data. These features will very likely corrupt your data. Use them at your own risk.
-      feature_flags: Feature flags
     general: "General"
     highlighting:
       mode_long:
         inline: "Highlight attribute(s) inline"
         none: "No highlighting"
+        priority: "Entire row by Priority"
         status: "Entire row by Status"
         type: "Entire row by Type"
-        priority: "Entire row by Priority"
     icalendar:
       enable_subscriptions_text_html: Allows users with the necessary permissions to subscribe to OpenProject calendars and access work package information via an external calendar client. <strong>Note:</strong> Please read about <a href="%{link}" target="_blank">iCalendar subscriptions</a> to understand potential security risks before enabling this.
     language_name_being_default: "%{language_name} (default)"
     notifications:
-      events_explanation: "Governs for which event an email is sent out. Work packages are excluded from this list as the notifications for them can be configured specifically for every user."
       delay_minutes_explanation: "Email sending can be delayed to allow users with configured in app notification to confirm the notification within the application before a mail is sent out. Users who read a notification within the application will not receive an email for the already read notification."
+      events_explanation: "Governs for which event an email is sent out. Work packages are excluded from this list as the notifications for them can be configured specifically for every user."
     other: "Other"
     passwords: "Passwords"
     project_attributes:
+      edit:
+        description: "Changes to this project attribute will be reflected in all projects where it is enabled. Required attributes cannot be disabled on a per-project basis."
       heading: "Project attributes"
+      heading_description: "These project attributes appear in the overview page of each project. You can add new attributes, group them into sections and re-order them as you please. These attributes can be enabled or disabled but not re-ordered at a project level."
+      label_edit_section: "Edit title"
       label_for_all_projects: "All projects"
       label_new_attribute: "Project attribute"
       label_new_section: "Section"
-      label_edit_section: "Edit title"
-      label_section_actions: "Section actions"
-      heading_description: "These project attributes appear in the overview page of each project. You can add new attributes, group them into sections and re-order them as you please. These attributes can be enabled or disabled but not re-ordered at a project level."
-      label_project_custom_field_actions: "Project attribute actions"
       label_no_project_custom_fields: "No project attributes defined in this section"
-      edit:
-        description: "Changes to this project attribute will be reflected in all projects where it is enabled. Required attributes cannot be disabled on a per-project basis."
+      label_project_custom_field_actions: "Project attribute actions"
+      label_section_actions: "Section actions"
       new:
-        heading: "New attribute"
         description: "Changes to this project attribute will be reflected in all projects where it is enabled. Required attributes cannot be disabled on a per-project basis."
+        heading: "New attribute"
       sections:
         display_representation:
           overview:
             label: "Project attribute shown in:"
             main_area:
-              label: "Main area"
               description: "Add all the project attributes as individual widgets in the main section of the project overview."
+              label: "Main area"
             side_panel:
-              label: "Side panel"
               description: "Add all the project attributes in a section inside the right side panel in the project overview."
+              label: "Side panel"
     project_initiation_request:
+      blankslate:
+        description: "OpenProject can generate a step-by-step wizard to help project managers fill out a project initiation request. You can choose which project attributes should be included and what to do with the output document. Enable it here to start configuring the wizard."
+        title: "Initiation request not enabled"
+      disable_dialog:
+        checkbox_message: "I understand that this action is not reversible"
+        confirmation_message: "The initiation request wizard will no longer be available to new projects based on this template. Project managers and project owners will need to manually configure and fill out the relevant information in the Project overview."
+        heading: "Disable this project initiation request?"
+        title: "Disable project initiation request"
       header_description: >
         OpenProject can generate a step-by-step wizard to help project managers fill out a project initiation request.
         You can choose which project attributes should be included and create a PDF artifact as a result.
-      status:
-        submitted: "%{wizard_name} has been submitted"
-        submitted_description: "Click the button below to go to the work package for the submission process."
-        submitted_button: "Open submission request"
-        not_completed: "%{wizard_name} not yet completed"
-        not_completed_description: "Provide the necessary information by filling the attributes and get the project started."
-      wizard_status_button:
-        project_initiation_request: "Open project initiation request"
-        project_creation_wizard: "Open project creation wizard"
-        project_mandate: "Open project mandate"
-      blankslate:
-        title: "Initiation request not enabled"
-        description: "OpenProject can generate a step-by-step wizard to help project managers fill out a project initiation request. You can choose which project attributes should be included and what to do with the output document. Enable it here to start configuring the wizard."
-      disable_dialog:
-        title: "Disable project initiation request"
-        heading: "Disable this project initiation request?"
-        confirmation_message: "The initiation request wizard will no longer be available to new projects based on this template. Project managers and project owners will need to manually configure and fill out the relevant information in the Project overview."
-        checkbox_message: "I understand that this action is not reversible"
       name:
         artifact_name: "Artifact name"
         artifact_name_caption: "Choose the name for this artifact that your project management framework recommends."
         options:
-          project_initiation_request: "Project initiation request"
           project_creation_wizard: "Project creation wizard"
+          project_initiation_request: "Project initiation request"
           project_mandate: "Project mandate"
+      status:
+        not_completed: "%{wizard_name} not yet completed"
+        not_completed_description: "Provide the necessary information by filling the attributes and get the project started."
+        submitted: "%{wizard_name} has been submitted"
+        submitted_button: "Open submission request"
+        submitted_description: "Click the button below to go to the work package for the submission process."
       submission:
+        assignee: "Assignee when submitted"
+        assignee_caption_html: "The user or group assigned to this project attribute will also become the assignee of the new work package. This list includes active project attributes of type <i>User</i> only."
+        confirmation_email_default: "Hello,\n\nYou submitted a project initiation request for **%{project_name}**. It is now awaiting review.\nClick the link below to access the work package with your request."
+        confirmation_email_text: "Confirmation email text"
+        description: "When a user submits a project initiation request, a new work package will be created with the request artifact attached as a PDF file. The settings below define the type, status and assignee for this new work package."
         description_template: >
           **This work package was automatically created upon completion of the %{wizard_name} workflow.**
 
           A PDF artifact containing all submitted information has been generated and attached to this work package for reference and audit purposes.
 
           If you need to update or re-run the initiation steps, you can reopen the wizard at any time by using the link below:
-        description: "When a user submits a project initiation request, a new work package will be created with the request artifact attached as a PDF file. The settings below define the type, status and assignee for this new work package."
-        work_package_type: "Work package type"
-        work_package_type_caption: "The work package type that should be used to store the completed artifact."
+        send_confirmation_email: "Send confirmation email to the user who submitted the project initiation request"
         status_when_submitted: "Status when submitted"
         status_when_submitted_caption: "The status the generated work package will transition to once the request is submitted."
-        send_confirmation_email: "Send confirmation email to the user who submitted the project initiation request"
-        assignee: "Assignee when submitted"
-        assignee_caption_html: "The user or group assigned to this project attribute will also become the assignee of the new work package. This list includes active project attributes of type <i>User</i> only."
-        confirmation_email_text: "Confirmation email text"
-        confirmation_email_default: "Hello,\n\nYou submitted a project initiation request for **%{project_name}**. It is now awaiting review.\nClick the link below to access the work package with your request."
         work_package_comment: "Work package comment"
         work_package_comment_caption: "The assignee selected above will automatically be @mentioned in the comment."
         work_package_comment_default: "A project initiation request for **%{project_name}** was submitted and is awaiting review."
+        work_package_type: "Work package type"
+        work_package_type_caption: "The work package type that should be used to store the completed artifact."
+      wizard_status_button:
+        project_creation_wizard: "Open project creation wizard"
+        project_initiation_request: "Open project initiation request"
+        project_mandate: "Open project mandate"
     project_phase_definitions:
+      both_gate: "Start and finish gate"
+      filter:
+        label: "Search project phase"
+      finish_gate: "Finish gate"
+      finish_gate_caption: "Add a gate with the end date of the phase"
       heading: "Project life cycle"
       heading_description: "Project life cycle defines the project phases that can be used for your project planning and will appear in the overview page of each project. These attributes can be enabled or disabled but not re-ordered at a project level."
       label_add: "Add"
       label_add_description: "Add project phase definition"
-      filter:
-        label: "Search project phase"
-      section_header: "Phases"
-      non_defined: "No phases are currently defined."
-      phase_gates: "Phase gates"
       new:
         description: "Changes to this project phase will be reflected in all projects where it is enabled."
         heading: "New phase"
-      both_gate: "Start and finish gate"
       no_gate: "No gate"
+      non_defined: "No phases are currently defined."
+      phase_gates: "Phase gates"
+      section_header: "Phases"
       start_gate: "Start gate"
       start_gate_caption: "Add a gate with the start date of the phase"
-      finish_gate: "Finish gate"
-      finish_gate_caption: "Add a gate with the end date of the phase"
     projects:
       missing_dependencies: "Project module %{module} was checked which depends on %{dependencies}. You need to check these dependencies as well."
       section_new_projects: "Settings for new projects"
@@ -5765,14 +5501,9 @@ en:
     session: "Session"
     user:
       default_preferences: "Default preferences"
-      display_format: "Display format"
       deletion: "Deletion"
-    working_days:
-      section_work_week: "Work week"
-      section_holidays_and_closures: "Holidays and closures"
+      display_format: "Display format"
     work_packages:
-      work_package_identifier: "Work package identifiers"
-      not_allowed_text: "You do not have the necessary permissions to view this page."
       activities:
         enable_internal_comments: "Enable internal comments"
         helper_text_html: >
@@ -5780,54 +5511,163 @@ en:
           These are only visible to selected roles that have the necessary permissions and will not be visible publicly.
           [Click here to learn more](docs_url)
 
-  text_formatting:
-    markdown: "Markdown"
-    plain: "Plain text"
-
+      not_allowed_text: "You do not have the necessary permissions to view this page."
+      work_package_identifier: "Work package identifiers"
+    working_days:
+      section_holidays_and_closures: "Holidays and closures"
+      section_work_week: "Work week"
+  sharing:
+    count:
+      one: "1 user"
+      other: "%{count} users"
+      zero: "0 users"
+    denied: "You don't have permissions to share %{entities}."
+    filter:
+      group: "Group"
+      not_project_group: "Not project group"
+      not_project_member: "Not project member"
+      project_group: "Project group"
+      project_member: "Project member"
+      role: "Role"
+      type: "Type"
+      user: "User"
+    label_search: "Search for users to invite"
+    label_search_placeholder: "Search by user or email address"
+    label_toggle_all: "Toggle all shares"
+    project_queries:
+      access_warning: "Users will only see the projects they have access to. Sharing project lists does not impact individual project permissions."
+      blank_state:
+        private:
+          description: "This project list has not been shared with anyone yet. Only you can access this list."
+          header: "Not shared: Private"
+        public:
+          description: "Everyone can view this project list. You can also add individual users with extra permissions."
+          header: "Shared with everyone"
+      permissions:
+        edit: "Edit"
+        edit_description: "Can view, share and edit this project list."
+        view: "View"
+        view_description: "Can view this project list."
+      public_flag:
+        caption: "Everyone can view this project list. Those with global edit permissions can modify it."
+        label: "Share with everyone at %{instance_name}"
+      publishing_denied: "You do not have permission to make project lists public."
+      upsell:
+        message: "Sharing project lists with individual users is an enterprise add-on."
+      user_details:
+        can_manage_public_lists: "Can edit due to global permissions"
+        can_view_because_public: "Can already view because list is shared with everyone"
+        owner: "List owner"
+    remove: "Remove"
+    share: "Share"
+    text_empty_search_description: "There are no users with the current filter criteria."
+    text_empty_search_header: "We couldn't find any matching results."
+    text_empty_state_description: "The %{entity} has not been shared with anyone yet."
+    text_empty_state_header: "Not shared"
+    text_user_limit_reached: "Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this %{entity}."
+    text_user_limit_reached_admins: 'Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to add more users.'
+    user_details:
+      additional_privileges_group: "Might have additional privileges (as group member)"
+      additional_privileges_project: "Might have additional privileges (as project member)"
+      additional_privileges_project_or_group: "Might have additional privileges (as project or group member)"
+      invite_resent: "Invite has been resent"
+      invited: "Invite sent. "
+      locked: "Locked user"
+      not_project_group: "Group (shared with all members)"
+      not_project_member: "Not a project member"
+      project_group: "Group members might have additional privileges (as project members)"
+      resend_invite: "Resend."
+    warning_locked_user: "The user %{user} is locked and cannot be shared with"
+    warning_no_selected_user: "Please select users to share this %{entity} with"
+    warning_user_limit_reached: >
+      Adding additional users will exceed the current limit.
+      Please contact an administrator to increase the user limit to ensure external users are able to access this %{entity}.
+    warning_user_limit_reached_admin_html: >
+      Adding additional users will exceed the current limit.
+      Please [upgrade your plan](upgrade_url) to be able to ensure external users are able to access this %{entity}.
   status_active: "active"
   status_archived: "archived"
   status_blocked: "blocked"
+  status_deleted: deleted
   status_invited: invited
   status_locked: locked
   status_registered: registered
-  status_deleted: deleted
+  statuses:
+    edit:
+      status_color_text: |
+        Click to assign or change the color of this status.
+        It is shown in the status button and can be used for highlighting work packages in the table.
+      status_default_text: |-
+        New work packages are by default set to this type. They cannot be read-only.
+      status_excluded_from_totals_text: |-
+        Check this option to exclude work packages with this status from totals of Work,
+        Remaining work, and % Complete in a hierarchy.
+      status_percent_complete_text_html: |-
+        In [status-based progress calculation mode](setting_url), the % Complete of a work
+        package is automatically set to this value when this status is selected.
+        Ignored in work-based mode.
+      status_readonly_html: |
+        Check this option to mark work packages with this status as read-only.
+        No attributes can be changed with the exception of the status.
+        <br>
+        <strong>Note</strong>: Inherited values (e.g., from children or relations) will still apply.
+    index:
+      headers:
+        excluded_from_totals: "Excluded from totals"
 
+        is_closed: "Closed"
+        is_default: "Default"
+        is_readonly: "Read-only"
+      no_results_content_text: Add a new status
+      no_results_title_text: There are currently no work package statuses.
   # Used in array.to_sentence.
   support:
     array:
       sentence_connector: "and"
       skip_last_comma: "false"
 
-  text_accessibility_hint: "The accessibility mode is designed for users who are blind, motorically handicaped or have a bad eyesight. For the latter focused elements are specially highlighted. Please notice, that the Backlogs module is not available in this mode."
   text_access_token_hint: "Access tokens allow you to grant external applications access to resources in OpenProject."
+  text_accessibility_hint: "The accessibility mode is designed for users who are blind, motorically handicaped or have a bad eyesight. For the latter focused elements are specially highlighted. Please notice, that the Backlogs module is not available in this mode."
   text_analyze: "Further analyze: %{subject}"
   text_are_you_sure: "Are you sure?"
-  open_link_in_a_new_tab: "Open link in a new tab"
   text_are_you_sure_continue: "Are you sure you want to continue?"
   text_are_you_sure_with_children: "Delete work package and all child work packages?"
   text_are_you_sure_with_project_custom_fields: "Deleting this attribute will also delete its values in all projects. Are you sure you want to do this?"
   text_are_you_sure_with_project_life_cycle_step: "Deleting this phase will also delete its usages in all projects. Are you sure you want to do this?"
   text_assign_to_project: "Assign to the project"
-  text_form_configuration: >
-    You can customize which fields will be displayed in work package forms.
-    You can freely group the fields to reflect the needs for your domain.
-  text_form_configuration_required_attribute: "Attribute is marked required and thus always shown"
   text_caracters_maximum: "%{count} characters maximum."
   text_caracters_minimum: "Must be at least %{count} characters long."
   text_comma_separated: "Multiple values allowed (comma separated)."
   text_comment_wiki_page: "Comment to wiki page: %{page}"
-  text_custom_field_possible_values_info: "One line for each value"
+  text_custom_export_cover_instructions: >
+    This is the image that appears in the background of a cover page in your PDF exports.
+    It needs to be an about 800px width by 500px height sized PNG or JPEG image file.
+  text_custom_export_font_bold_instructions: >
+    This is the font file for bold text. It needs to be in TTF format.
+  text_custom_export_font_bold_italic_instructions: >
+    This is the font file for bold and italic text. It needs to be in TTF format.
+  text_custom_export_font_italic_instructions: >
+    This is the font file for italic text. It needs to be in TTF format.
+  text_custom_export_font_regular_instructions: >
+    This is the font file for regular text. It needs to be in TTF format and is required.
+  text_custom_export_footer_instructions: >
+    PDF exports will include a graphical element positioned to the left of the footer.
+    This image must be a PNG or JPEG file with approximately 200 pixels in width.
+  text_custom_export_logo_instructions: >
+    This is the logo that appears in your PDF exports.
+    It needs to be a PNG or JPEG image file.
+    A black or colored logo on transparent or white background is recommended.
+  text_custom_favicon_instructions: >
+    This is the tiny icon that appears in your browser window/tab next to the
+    page's title.
+    It needs to be a squared 32 by 32 pixels sized PNG image file with a transparent background.
   text_custom_field_hint_activate_per_project: >
     When using custom fields: Keep in mind that custom fields need to be
     activated per project, too.
   text_custom_field_hint_activate_per_project_and_type: >
     Custom fields need to be activated per work
     package type and per project.
-  text_project_custom_field_html: >
-    The Enterprise edition will add these additional add-ons for projects' custom fields: <br>
-    <ul>
-      <li><b>Add custom fields for projects to your Project list to create a project portfolio view</b></li>
-    </ul>
+  text_custom_field_possible_values_info: "One line for each value"
   text_custom_logo_instructions: >
     The logo automatically scales to fit the header.
     For best results, upload a white logo on a transparent 130×47px image.
@@ -5836,33 +5676,6 @@ en:
     The logo automatically scales to fit the header.
     For best results, upload a white logo on a transparent 130×33px image.
     You can add as much spacing inside that image as you like.
-  text_custom_export_logo_instructions: >
-    This is the logo that appears in your PDF exports.
-    It needs to be a PNG or JPEG image file.
-    A black or colored logo on transparent or white background is recommended.
-  text_custom_export_cover_instructions: >
-    This is the image that appears in the background of a cover page in your PDF exports.
-    It needs to be an about 800px width by 500px height sized PNG or JPEG image file.
-  text_custom_export_footer_instructions: >
-    PDF exports will include a graphical element positioned to the left of the footer.
-    This image must be a PNG or JPEG file with approximately 200 pixels in width.
-  label_custom_export_font_instructions: >
-    Upload and manage custom TrueType (.ttf) fonts used in your PDF exports.
-    For best results, use matching files from the same font family. If no font is provided, the default NotoSans font will be used.
-  label_custom_export_images_instructions: >
-    Upload and manage custom image files used in your PDF exports.
-  text_custom_export_font_regular_instructions: >
-    This is the font file for regular text. It needs to be in TTF format and is required.
-  text_custom_export_font_bold_instructions: >
-    This is the font file for bold text. It needs to be in TTF format.
-  text_custom_export_font_italic_instructions: >
-    This is the font file for italic text. It needs to be in TTF format.
-  text_custom_export_font_bold_italic_instructions: >
-    This is the font file for bold and italic text. It needs to be in TTF format.
-  text_custom_favicon_instructions: >
-    This is the tiny icon that appears in your browser window/tab next to the
-    page's title.
-    It needs to be a squared 32 by 32 pixels sized PNG image file with a transparent background.
   text_custom_touch_icon_instructions: >
     This is the icon that appears in your mobile or tablet when you place a
     bookmark on your homescreen.
@@ -5873,70 +5686,76 @@ en:
   text_default_administrator_account_changed: "Default administrator account changed"
   text_default_encoding: "Default: UTF-8"
   text_destroy: "Delete"
-  text_destroy_with_associated: "There are additional objects associated with the work package(s) that are to be deleted. Those objects are of the following types:"
   text_destroy_what_to_do: "What do you want to do?"
+  text_destroy_with_associated: "There are additional objects associated with the work package(s) that are to be deleted. Those objects are of the following types:"
   text_diff_truncated: "... This diff was truncated because it exceeds the maximum size that can be displayed."
   text_email_delivery_not_configured: "Email delivery is not configured, and notifications are disabled.\nConfigure your SMTP server to enable them."
   text_enumeration_category_reassign_to: "Reassign them to this value:"
   text_enumeration_destroy_question: "%{count} objects are assigned to this value."
   text_file_repository_writable: "Attachments directory writable"
+  text_form_configuration: >
+    You can customize which fields will be displayed in work package forms.
+    You can freely group the fields to reflect the needs for your domain.
+  text_form_configuration_required_attribute: "Attribute is marked required and thus always shown"
+  text_formatting:
+    markdown: "Markdown"
+    plain: "Plain text"
+
   text_git_repo_example: "a bare and local repository (e.g. /gitrepo, c:\\gitrepo)"
   text_hint_date_format: "Enter a date in the form of YYYY-MM-DD. Other formats may be changed to an unwanted date."
   text_hint_disable_with_0: "Note: Disable with 0"
   text_hours_between: "Between %{min} and %{max} hours."
-  text_work_package_added: "Work package %{id} has been reported by %{author}."
-  text_work_package_category_destroy_assignments: "Remove category assignments"
-  text_work_package_category_destroy_question: "Some work packages (%{count}) are assigned to this category. What do you want to do?"
-  text_work_package_category_reassign_to: "Reassign work packages to this category"
-  text_work_package_updated: "Work package %{id} has been updated by %{author}."
-  text_work_package_watcher_added: "You have been added as a watcher to Work package %{id} by %{watcher_changer}."
-  text_work_package_watcher_removed: "You have been removed from watchers of Work package %{id} by %{watcher_changer}."
-  text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
-  text_work_packages_ref_in_commit_messages: "Referencing and fixing work packages in commit messages"
   text_journal_added: "%{label} %{value} added"
   text_journal_attachment_added: "%{label} %{value} added as attachment"
   text_journal_attachment_deleted: "%{label} %{old} removed as attachment"
-  text_journal_changed_plain: "%{label} changed from %{old} %{linebreak}to %{new}"
   text_journal_changed_no_detail: "%{label} updated"
+  text_journal_changed_plain: "%{label} changed from %{old} %{linebreak}to %{new}"
   text_journal_changed_with_diff: "%{label} changed (%{link})"
   text_journal_deleted: "%{label} deleted (%{old})"
   text_journal_deleted_subproject: "%{label} %{old}"
   text_journal_deleted_with_diff: "%{label} deleted (%{link})"
   text_journal_file_link_added: "%{label} link to %{value} (%{storage}) added"
   text_journal_file_link_deleted: "%{label} link to %{old} (%{storage}) removed"
+  text_journal_label_value: "%{label} %{value}"
   text_journal_of: "%{label} %{value}"
   text_journal_set_to: "%{label} set to %{value}"
   text_journal_set_with_diff: "%{label} set (%{link})"
-  text_journal_label_value: "%{label} %{value}"
   text_latest_note: "The latest comment is: %{note}"
   text_length_between: "Length between %{min} and %{max} characters."
   text_line_separated: "Multiple values allowed (one line for each value)."
   text_load_default_configuration: "Load the default configuration"
-  text_no_roles_defined: There are no roles defined.
   text_no_access_tokens_configurable: "There are no access tokens which can be configured."
   text_no_configuration_data: "Roles, types, work package statuses and workflow have not been configured yet.\nIt is highly recommended to load the default configuration. You will be able to modify it once loaded."
   text_no_notes: "There are no comments available for this work package."
-  text_notice_too_many_values_are_inperformant: "Note: Displaying more than 100 items per page can increase the page load time."
+  text_no_roles_defined: There are no roles defined.
   text_notice_security_badge_displayed_html: >
     Note: if enabled, this will display a badge with your installation status in the <a href="%{information_panel_path}">%{information_panel_label}</a> administration panel,
     and on the home page. It is displayed to administrators only.
     <br/>
     The badge will check your current OpenProject version against the official OpenProject release database to alert you of any updates or known vulnerabilities.
     For more information on what the check provides, what data is needed to provide available updates, and how to disable this check, please visit <a href="%{more_info_url}">the configuration documentation</a>.
+  text_notice_too_many_values_are_inperformant: "Note: Displaying more than 100 items per page can increase the page load time."
   text_own_membership_delete_confirmation: "You are about to remove some or all of your permissions and may no longer be able to edit this project after that.\nAre you sure you want to continue?"
   text_permanent_delete_confirmation_checkbox_label: "I understand that this deletion cannot be reversed"
   text_permanent_remove_confirmation_checkbox_label: "I understand that this removal cannot be reversed"
   text_plugin_assets_writable: "Plugin assets directory writable"
   text_powered_by: "Powered by %{link}"
-  text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter."
+  text_project_custom_field_html: >
+    The Enterprise edition will add these additional add-ons for projects' custom fields: <br>
+    <ul>
+      <li><b>Add custom fields for projects to your Project list to create a project portfolio view</b></li>
+    </ul>
   text_project_identifier_description: 'The project identifier is prepended to all work package IDs. If the identifier is "PROJ" for example, the work package identifier will be "PROJ-12" or "PROJ-246".'
-  text_project_identifier_url_description: "The project identifier is included in the URL of the project."
-  text_project_identifier_handle_format: "Must start with a letter and contain only uppercase letters, numbers, and underscores (max 10 characters)."
   text_project_identifier_format: "Must start with a lowercase letter. Only lowercase letters (a-z), numbers, dashes and underscores are allowed."
+  text_project_identifier_handle_format: "Must start with a letter and contain only uppercase letters, numbers, and underscores (max 10 characters)."
+  text_project_identifier_info: "Only lower case letters (a-z), numbers, dashes and underscores are allowed, must start with a lower case letter."
+  text_project_identifier_url_description: "The project identifier is included in the URL of the project."
   text_reassign: "Reassign to work package:"
   text_regexp_multiline: 'The regex is applied in a multi-line mode. e.g., ^---\s+'
   text_rename_wiki_page: "Rename wiki page"
   text_repository_usernames_mapping: "Select or update the OpenProject user mapped to each username found in the repository log.\nUsers with the same OpenProject and repository username or email are automatically mapped."
+  text_setup_mail_configuration: "Configure your email provider"
+
   text_status_changed_by_changeset: "Applied in changeset %{value}."
   text_table_difference_description: "In this table the single %{entries} are shown. You can view the difference between any two entries by first selecting the according checkboxes in the table. When clicking on the button below the table the differences are shown."
   text_time_logged_by_changeset: "Applied in changeset %{value}."
@@ -5947,7 +5766,6 @@ en:
   text_unallowed_characters: "Unallowed characters"
   text_user_invited: The user has been invited and is pending registration.
   text_user_wrote: "%{value} wrote:"
-  text_wrote: "wrote"
   text_warn_on_leaving_unsaved: "The work package contains unsaved text that will be lost if you leave this page."
   text_what_did_you_change_click_to_add_comment: "What did you change? Click to add comment"
   text_wiki_destroy_confirmation: "Are you sure you want to delete this wiki and all its content?"
@@ -5955,19 +5773,24 @@ en:
   text_wiki_page_destroy_question: "This page has %{descendants} child page(s) and descendant(s). What do you want to do?"
   text_wiki_page_nullify_children: "Keep child pages as root pages"
   text_wiki_page_reassign_children: "Reassign child pages to this parent page"
+  text_work_package_added: "Work package %{id} has been reported by %{author}."
+  text_work_package_category_destroy_assignments: "Remove category assignments"
+  text_work_package_category_destroy_question: "Some work packages (%{count}) are assigned to this category. What do you want to do?"
+  text_work_package_category_reassign_to: "Reassign work packages to this category"
+  text_work_package_updated: "Work package %{id} has been updated by %{author}."
+  text_work_package_watcher_added: "You have been added as a watcher to Work package %{id} by %{watcher_changer}."
+  text_work_package_watcher_removed: "You have been removed from watchers of Work package %{id} by %{watcher_changer}."
+  text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
+  text_work_packages_ref_in_commit_messages: "Referencing and fixing work packages in commit messages"
   text_workflow_edit: "Select a role and a type to edit the workflow"
+  text_wrote: "wrote"
   text_zoom_in: "Zoom in"
   text_zoom_out: "Zoom out"
-  text_setup_mail_configuration: "Configure your email provider"
+  themes:
+    dark: "Dark"
+    light: "Light"
+    sync_with_os: "Automatic (match OS color mode)"
 
-  help_texts:
-    views:
-      project: >
-        %{plural} are always attached to a project.
-        You can only select projects here where the %{plural} module is active.
-        After creating a %{singular} you can add work packages from other projects to it.
-      public: "Publish this view, allowing other users to access your view. Users with the 'Manage public views' permission can modify or remove public query. This does not affect the visibility of work package results in that view and depending on their permissions, users may see different results."
-      favoured: "Mark this view as favourite and add to the saved views sidebar on the left."
   time:
     am: "am"
     formats:
@@ -5978,20 +5801,20 @@ en:
     pm: "pm"
 
   timeframe:
-    show: "Show timeframe"
     end: "to"
+    show: "Show timeframe"
     start: "from"
 
-  title_remove_and_delete_user: Remove the invited user from the project and delete him/her.
   title_enterprise_upgrade: "Upgrade to unlock more users."
 
-  tooltip_user_default_timezone: >
-    The default time zone for new users. Can be changed in a user's settings.
-  tooltip_resend_invitation: >
-    Sends another invitation email with a fresh token in
-    case the old one expired or the user did not get the original email.
-    Can also be used for active users to choose a new authentication method.
-    When used with active users their status will be changed to 'invited'.
+  title_remove_and_delete_user: Remove the invited user from the project and delete him/her.
+  toggle_switch:
+    label_off: "Off"
+
+    label_on: "On"
+  token:
+    hashed_token:
+      display_value_placeholder: "***"
 
   tooltip:
     setting_email_login: >
@@ -5999,19 +5822,14 @@ en:
       Instead their given email address will serve as the login.
       An administrator may still change the login separately.
 
-  queries:
-    apply_filter: Apply preconfigured filter
-    configure_view:
-      heading: Configure view
-      columns:
-        input_label: "Add columns"
-        input_placeholder: "Select a column"
-        drag_area_label: "Manage and reorder columns"
-      sort_by:
-        automatic:
-          heading: "Automatic"
-          description: "Order the %{plural} by one or more sorting criteria. You will lose the previous sorting."
+  tooltip_resend_invitation: >
+    Sends another invitation email with a fresh token in
+    case the old one expired or the user did not get the original email.
+    Can also be used for active users to choose a new authentication method.
+    When used with active users their status will be changed to 'invited'.
 
+  tooltip_user_default_timezone: >
+    The default time zone for new users. Can be changed in a user's settings.
   top_menu:
     additional_resources: "Additional resources"
     getting_started: "Getting started"
@@ -6019,27 +5837,108 @@ en:
 
   total_progress: "Total progress"
 
+  types:
+    edit:
+      export_configuration:
+        intro: "Select which templates from those that are available you would like to enable for this type. The template determines the design and attributes visible in the exported PDF of a work package using this type. The first template on the list is selected by default."
+        pdf_export_templates:
+          actions:
+            label_disable_all: "Disable all"
+
+            label_enable_all: "Enable all"
+          label: "PDF Export templates"
+        tab: "Generate PDF"
+      form_configuration:
+        add_attribute_group: "Section"
+        add_query_group: "Related work packages table"
+        blankslate_description: "Add groups using the button above or drag attributes from the left panel."
+        blankslate_title: "No groups yet"
+        builtin_field: "Built-in field"
+        confirm_delete_group: "Are you sure you want to delete this section? This action cannot be automatically reversed."
+        confirm_reset: "Are you sure you want to reset the form configuration?"
+        custom_field: "Custom field"
+        delete_group: "Delete section"
+        drag_to_activate: "Drag fields from here to activate them"
+        drag_to_reorder: "Drag to reorder"
+        edit_query: "Edit query"
+        empty_group_hint: "Drag attributes here"
+        filter_inactive: "Filter attributes"
+        group_actions: "Section actions"
+        group_name_label: "Section name"
+        inactive_attributes_heading: "Inactive attributes"
+        invalid_attribute_groups: "The form configuration payload is invalid."
+        invalid_query: "The embedded query configuration is invalid."
+        label_group: "Section"
+        no_inactive_attributes: "No inactive attributes"
+        not_found: "The requested form configuration item could not be found."
+        query_group_label: "Related work packages table"
+        remove_attribute: "Remove from section"
+        rename_group: "Rename section"
+        reset_description: >
+          This will reset the attributes to their default group and disable ALL custom fields.
+        reset_title: "Reset form configuration"
+        reset_to_defaults: "Reset form"
+        row_actions: "Row actions"
+        tab: "Form configuration"
+        untitled_group: "Untitled group"
+      projects:
+        enable_all: Enable for all projects
+        select_projects: Select projects
+        select_projects_description: Select the projects in which you would like to use this type.
+        tab: Projects
+      settings:
+        tab: "Settings"
+        type_color_text: The selected color distinguishes different types in Gantt charts or work packages tables. It is therefore recommended to use a strong color.
+      subject_configuration:
+        automatically_generated_subjects:
+          caption: "Define a pattern using referenced attributes and text to automatically generate work package subjects. Users will not be able to manually edit subjects."
+          label: "Automatically generated subjects"
+        manually_editable_subjects:
+          caption: "Users can manually enter and edit work package subjects without restrictions."
+          label: "Manually editable subjects"
+        pattern:
+          caption: Create patterns by adding text, or type "/" to search for [supported attributes](attributes_url).
+          insert_as_text: 'No attributes found. Add as text: "%{word}"'
+          label: "Subject pattern"
+        tab: "Subject configuration"
+        token:
+          context:
+            parent: "Parent"
+            project: "Project"
+            work_package: "Work package"
+          label_with_context: "%{attribute_context}: %{attribute_label}"
+    index:
+      no_results_content_text: Create a new type
+      no_results_title_text: There are currently no types.
+  unsupported_browser:
+    close_warning: "Ignore this warning."
+
+    message: "You may run into errors and degraded experience on this page."
+    title: "Your browser is outdated and unsupported."
+    update_message: "Please update your browser."
   user:
-    all: "all"
-    active: "active"
     activate: "Activate"
     activate_and_reset_failed_logins: "Activate and reset failed logins"
+    active: "active"
+    all: "all"
+    assign_random_password: "Assign random password (sent to user via email)"
     authentication_provider: "Authentication Provider"
-    identity_url_text: "The internal unique identifier provided by the authentication provider."
     authentication_settings_disabled_due_to_external_authentication: >
       This user authenticates via an external authentication provider, so there is no password
       in OpenProject to be changed.
     authorization_rejected: "You are not allowed to sign in."
-    assign_random_password: "Assign random password (sent to user via email)"
     blocked: "locked temporarily"
     blocked_num_failed_logins:
       one: "locked temporarily (one failed login attempt)"
       other: "locked temporarily (%{count} failed login attempts)"
     confirm_status_change: "You are about to change the status of '%{name}'. Are you sure you want to continue?"
     deleted: "Deleted user"
-    error_status_change_self: "You cannot change your own user status."
     error_admin_change_on_non_admin: "Only administrators can change the status of administrator users."
+    error_cannot_delete_user: "User cannot be deleted"
+
     error_status_change_failed: "Changing the user status failed due to the following errors: %{errors}"
+    error_status_change_self: "You cannot change your own user status."
+    identity_url_text: "The internal unique identifier provided by the authentication provider."
     invite: Invite user via email
     invited: invited
     lock: "Lock permanently"
@@ -6048,26 +5947,188 @@ en:
     password_change_unsupported: Change of password is not supported.
     registered: "registered"
     reset_failed_logins: "Reset failed logins"
-    status_user_and_brute_force: "%{user} and %{brute_force}"
     status_change: "Status change"
+    status_user_and_brute_force: "%{user} and %{brute_force}"
     text_change_disabled_for_provider_login: "The name and email is set by your login provider and can thus not be changed."
     unlock: "Unlock"
     unlock_and_reset_failed_logins: "Unlock and reset failed logins"
-    error_cannot_delete_user: "User cannot be deleted"
+  user_preferences:
+    disable_keyboard_shortcuts_caption: >
+      You can choose to disable default [keyboard shortcuts](docs_url) if you use a screen  reader or want to avoid accidentally triggering an action with a shortcut.
+  users:
+    autologins:
+      prompt: "Stay logged in for %{num_days}"
+    force_password_change_hint: "The user must set a new password on their next login. Automatically enabled when sending credentials via email."
+    groups:
+      member_in_these_groups: "This user is currently a member of the following groups:"
+      more: "%{count} more"
+      no_results_title_text: This user is currently not a member in any group.
+      summary_html: Member of %{names}.
+      summary_with_more_html: Member of %{names} and %{count_link}.
+    invite_user_modal:
+      invite: "Invite"
+      message:
+        description: "We will send an email to the user, to which you can add a personal message here. An explanation for the invitation could be useful, or perhaps a bit of information regarding the project to help them get started."
 
+        label: "Invitation message"
+      principal:
+        create_new_placeholder: "Create new placeholder:"
+        invite_to_project: "Invite to %{project_name}"
+        invite_user: "Invite:"
+        no_results_group: "No groups were found"
+        no_results_placeholder: "No placeholders were found"
+        no_results_user: "No users were found"
+        required:
+          group: "Please select a group"
+
+          placeholder: "Please select a placeholder"
+          user: "Please select a user"
+      project:
+        label: "Project"
+        next_button: "Next"
+        no_invite_rights: "You are not allowed to invite members to this project"
+        no_results: "No projects were found"
+        required: "Please select a project"
+      role:
+        description: >
+          This is the role that the user will receive when they join your project. The role defines which actions they are allowed to take and which information they are allowed to see.
+          [Learn more about roles and permissions.](docs_url)
+        label: "Role in %{project}"
+        no_roles_found: "No roles were found"
+        required: "Please select a role"
+
+      success_message:
+        group: "The group is now a part of %{project}. Meanwhile you can already plan with that group and assign work packages for instance."
+        placeholder_user: "The placeholder can now be used in %{project}. Meanwhile you can already plan with that user and assign work packages for instance."
+        user: "The user can now log in to access %{project}. Meanwhile you can already plan with that user and assign work packages for instance."
+      summary:
+        next_button: "Send invitation"
+
+      title:
+        invite: "Invite user"
+        invite_principal_to_project: "Invite %{principal} to %{project}"
+        invite_to_project: "Invite %{type} to %{project}"
+      type:
+        already_member_message: "Already a member of %{project}"
+        group:
+          description: "Permissions based on the assigned role in the selected project"
+          title: "Invite group to %{project_name}"
+        placeholder_user:
+          description: "Has no access to the project and no emails are sent out."
+
+          title: "Add placeholder user to %{project_name}"
+          title_no_ee: "Placeholder user (Enterprise edition only add-on)"
+        required: "Please select the type to be invited"
+        user:
+          description: "Permissions based on the assigned role in the selected project"
+          title: "Invite user to %{project_name}"
+    memberships:
+      no_results_title_text: This user is currently not a member of a project.
+    open_profile: "Open profile"
+    send_information_hint: "Emails the password in plain text. When checked, the user will be required to change their password on first login."
+    sessions:
+      browser: "Browser"
+      browser_session: "(Browser session)"
+      current: "Current (this device)"
+      deletion_warning: "Are you sure you want to revoke this session? You will be logged out on this device."
+      device: "Device / OS"
+      expires: "Expires"
+      instructions: "You are logged in to your account through the following devices. Revoke sessions that you do not recognise or from devices you do not control."
+      last_connection: "Last connection"
+      may_not_delete_current: "You cannot delete your current session."
+      session_name: "%{browser_name} %{browser_version} on %{os_name}"
+      title: "Session management"
+      unknown: "(unknown)"
+      unknown_browser: "unknown browser"
+      unknown_os: "unknown operating system"
+    working_hours:
+      current_schedule:
+        availability_factor: "Availability factor"
+        availability_subtitle: "Dedicated to project work"
+        effective_hours: "Effective work hours"
+        effective_subtitle: "Per week"
+        not_set: "Not set"
+        title: "Current schedule"
+        work_days: "Work days"
+        work_hours: "Work hours"
+      destroy:
+        confirm: "Are you sure you want to delete this working schedule?"
+      form:
+        availability_description: "The availability factor represents the actual percentage of your working time dedicated to project tasks. This accounts for meetings, emails, administrative work, and other non-project activities."
+        availability_factor: "Availability factor"
+        availability_factor_caption: "Define the percentage of your working time dedicated to project work."
+        hours_mode_label: "Hours mode"
+        hours_per_day: "Hours per day"
+        individual_hours_mode: "Individual hours per day"
+        per_day: "per day"
+        per_week: "per week"
+        same_hours_mode: "Same hours per day"
+        start_date: "Start date"
+        start_date_caption: "Select the date from when the new work schedule will be effective."
+        title: "Plan a future work schedule"
+        title_availability_factor: "Availability factor"
+        title_current: "Edit current work schedule"
+        title_days_and_hours: "Days and hours"
+        title_future_dates: "Future dates"
+        total_available_hours: "Total available work hours"
+        total_work_hours: "Total work hours"
+        work_days: "Work days"
+        work_hours: "Work hours"
+        working_hours_label: "Working hours"
+      future:
+        add_button: "Add future schedule"
+        blank_description: "Create a future schedule to plan changes ahead of time"
+        blank_title: "No future schedules planned"
+        description: "Plan working schedule changes ahead of time. Once the date arrives your working schedules will be updated automatically."
+        title: "Future schedules"
+      history:
+        blank_description: "Past schedule changes will appear here"
+        blank_title: "No schedule history yet"
+        description: "View your past work schedules."
+        title: "Schedule history"
+      table:
+        availability_factor: "Availability factor"
+        effective_work_hours: "Effective work hours"
+        mobile_title: "Working schedules"
+        start_date: "Start date"
+        work_days: "Work days"
+        work_days_count:
+          one: "1 working day"
+          other: "%{count} working days"
+        work_hours: "Work hours"
   version_status_closed: "closed"
   version_status_locked: "locked"
   version_status_open: "open"
 
-  note: Note
-  note_password_login_disabled_link: "Password login has been disabled through a [configuration setting](configuration_url)."
+  versions:
+    overview:
+      no_results_title_text: There are currently no work packages assigned to this version.
+
+      work_packages_in_archived_projects: "The version is shared with archived projects which still have work packages assigned to this version. These are counted, but will not appear in the linked views."
   warning: Warning
   warning_attachments_not_saved: "%{count} file(s) could not be saved."
+  warning_bar:
+    hostname_mismatch:
+      text_html: >
+        Your application is running with its host name setting set to <code>%{set_hostname}</code>, but the request
+        is a <code>%{actual_hostname}</code> hostname.
+        This will result in errors! Go to <a href="%{setting_path}">System settings</a> and change the "Host name" setting to correct this.
+
+      title: "Hostname setting mismatch"
+    https_mismatch:
+      text_html: >
+        Your application is running with HTTPS mode set to <code>%{set_protocol}</code>, but the request
+        is an <code>%{actual_protocol}</code> request.
+        This will result in errors! You will need to set the following configuration value: <code>%{setting_value}</code>.
+        Please see <a href="%{more_info_path}">the installation documentation</a> on how to set this configuration.
+      title: "HTTPS mode setup mismatch"
   warning_imminent_user_limit_html: >
     You invited more users than are supported by your current plan.
     Invited users may not be able to join your OpenProject environment.
     Please [upgrade your plan](upgrade_url) or block existing
     users in order to allow invited and registered users to join.
+  warning_protocol_mismatch_html: >
+
   warning_registration_token_expired: |
     The activation email has expired. We sent you a new one to %{email}.
     Please click the link inside of it to activate your account.
@@ -6080,45 +6141,40 @@ en:
   warning_user_limit_reached_instructions: >
     You reached your user limit (%{current}/%{max} active users).
     Please contact sales@openproject.com to upgrade your Enterprise edition plan and add additional users.
-  warning_protocol_mismatch_html: >
+  wiki:
+    index:
+      no_results_content_text: Add a new wiki page
 
-  warning_bar:
-    https_mismatch:
-      title: "HTTPS mode setup mismatch"
-      text_html: >
-        Your application is running with HTTPS mode set to <code>%{set_protocol}</code>, but the request
-        is an <code>%{actual_protocol}</code> request.
-        This will result in errors! You will need to set the following configuration value: <code>%{setting_value}</code>.
-        Please see <a href="%{more_info_path}">the installation documentation</a> on how to set this configuration.
-    hostname_mismatch:
-      title: "Hostname setting mismatch"
-      text_html: >
-        Your application is running with its host name setting set to <code>%{set_hostname}</code>, but the request
-        is a <code>%{actual_hostname}</code> hostname.
-        This will result in errors! Go to <a href="%{setting_path}">System settings</a> and change the "Host name" setting to correct this.
+    no_results_title_text: There are currently no wiki pages.
+    page_not_editable_index: The requested page does not (yet) exist. You have been redirected to the index of all wiki pages.
+    print_hint: This will print the content of this wiki page without any navigation bars.
 
-  menu_item: "Menu item"
-  menu_item_setting: "Visibility"
-
+  wiki_menu_item_delete_not_permitted: The wiki menu item of the only wiki page cannot be deleted.
   wiki_menu_item_for: 'Menu item for wikipage "%{title}"'
-  wiki_menu_item_setting: "Visibility"
   wiki_menu_item_new_main_item_explanation: >
     You are deleting the only main wiki menu item. You now have to choose a wiki page for which a new main item will be generated.
     To delete the wiki the wiki module can be deactivated by project administrators.
-  wiki_menu_item_delete_not_permitted: The wiki menu item of the only wiki page cannot be deleted.
+  wiki_menu_item_setting: "Visibility"
+  work_flows:
+    index:
+      no_results_title_text: There are currently no workflows.
+
   # TODO: merge with work_packages top level key
   work_package:
-    updated_automatically_by_child_changes: |
-      _Updated automatically by changing values within child work package %{child}_
     destroy:
       info: "Deleting the work package is an irreversible action."
       title: "Delete the work package"
+    permissions:
+      comment: "Comment"
+      comment_description: "Can view and comment this work package."
+      comment_verb: "comment"
+      edit: "Edit"
+      edit_description: "Can view, comment and edit this work package."
+      edit_verb: "edit"
+      view: "View"
+      view_description: "Can view this work package."
+      view_verb: "view"
     progress:
-      label_note: "Note:"
-      modal:
-        work_based_help_text: "Each field is automatically calculated from the two others when possible."
-        status_based_help_text: "% Complete is set by work package status."
-        migration_warning_text: "In work-based progress calculation mode, % Complete cannot be manually set and is tied to Work. The existing value has been kept but cannot be edited. Please input Work first."
       derivation_hints:
         done_ratio:
           cleared_because_remaining_work_is_empty: "Cleared because Remaining work is empty."
@@ -6129,388 +6185,279 @@ en:
           derived: "Derived from Remaining work and % Complete."
           same_as_remaining_work: "Set to same value as Remaining work."
         remaining_hours:
-          cleared_because_work_is_empty: "Cleared because Work is empty."
           cleared_because_percent_complete_is_empty: "Cleared because % Complete is empty."
+          cleared_because_work_is_empty: "Cleared because Work is empty."
           decreased_by_delta_like_work: "Decreased by %{delta}, matching the reduction in Work."
           derived: "Derived from Work and % Complete."
           increased_by_delta_like_work: "Increased by %{delta}, matching the increase in Work."
           same_as_work: "Set to same value as Work."
-    permissions:
-      comment: "Comment"
-      comment_verb: "comment"
-      comment_description: "Can view and comment this work package."
-      edit: "Edit"
-      edit_verb: "edit"
-      edit_description: "Can view, comment and edit this work package."
-      view: "View"
-      view_verb: "view"
-      view_description: "Can view this work package."
+      label_note: "Note:"
+      modal:
+        migration_warning_text: "In work-based progress calculation mode, % Complete cannot be manually set and is tied to Work. The existing value has been kept but cannot be edited. Please input Work first."
+        status_based_help_text: "% Complete is set by work package status."
+        work_based_help_text: "Each field is automatically calculated from the two others when possible."
     reminders:
+      create_success_message_html: "Reminder set successfully. You will receive a notification for this work package %{reminder_time}."
       label_remind_at: "Date"
       note_placeholder: "Why are you setting this reminder?"
-      create_success_message_html: "Reminder set successfully. You will receive a notification for this work package %{reminder_time}."
-      success_update_message: "Reminder updated successfully."
       success_deletion_message: "Reminder deleted successfully."
-  sharing:
-    count:
-      zero: "0 users"
-      one: "1 user"
-      other: "%{count} users"
-    filter:
-      project_member: "Project member"
-      not_project_member: "Not project member"
-      project_group: "Project group"
-      not_project_group: "Not project group"
-      user: "User"
-      group: "Group"
-      role: "Role"
-      type: "Type"
-    denied: "You don't have permissions to share %{entities}."
-    label_search: "Search for users to invite"
-    label_search_placeholder: "Search by user or email address"
-    label_toggle_all: "Toggle all shares"
-    remove: "Remove"
-    share: "Share"
-    text_empty_search_description: "There are no users with the current filter criteria."
-    text_empty_search_header: "We couldn't find any matching results."
-    text_empty_state_description: "The %{entity} has not been shared with anyone yet."
-    text_empty_state_header: "Not shared"
-    text_user_limit_reached: "Adding additional users will exceed the current limit. Please contact an administrator to increase the user limit to ensure external users are able to access this %{entity}."
-    text_user_limit_reached_admins: 'Adding additional users will exceed the current limit. Please <a href="%{upgrade_url}">upgrade your plan</a> to be able to add more users.'
-    warning_user_limit_reached: >
-      Adding additional users will exceed the current limit.
-      Please contact an administrator to increase the user limit to ensure external users are able to access this %{entity}.
-    warning_user_limit_reached_admin_html: >
-      Adding additional users will exceed the current limit.
-      Please [upgrade your plan](upgrade_url) to be able to ensure external users are able to access this %{entity}.
-    warning_no_selected_user: "Please select users to share this %{entity} with"
-    warning_locked_user: "The user %{user} is locked and cannot be shared with"
-    user_details:
-      locked: "Locked user"
-      invited: "Invite sent. "
-      resend_invite: "Resend."
-      invite_resent: "Invite has been resent"
-      not_project_member: "Not a project member"
-      project_group: "Group members might have additional privileges (as project members)"
-      not_project_group: "Group (shared with all members)"
-      additional_privileges_project: "Might have additional privileges (as project member)"
-      additional_privileges_group: "Might have additional privileges (as group member)"
-      additional_privileges_project_or_group: "Might have additional privileges (as project or group member)"
-    project_queries:
-      publishing_denied: "You do not have permission to make project lists public."
-      access_warning: "Users will only see the projects they have access to. Sharing project lists does not impact individual project permissions."
-      user_details:
-        owner: "List owner"
-        can_view_because_public: "Can already view because list is shared with everyone"
-        can_manage_public_lists: "Can edit due to global permissions"
-      public_flag:
-        label: "Share with everyone at %{instance_name}"
-        caption: "Everyone can view this project list. Those with global edit permissions can modify it."
-      blank_state:
-        public:
-          header: "Shared with everyone"
-          description: "Everyone can view this project list. You can also add individual users with extra permissions."
-        private:
-          header: "Not shared: Private"
-          description: "This project list has not been shared with anyone yet. Only you can access this list."
-      permissions:
-        view: "View"
-        view_description: "Can view this project list."
-        edit: "Edit"
-        edit_description: "Can view, share and edit this project list."
-      upsell:
-        message: "Sharing project lists with individual users is an enterprise add-on."
+      success_update_message: "Reminder updated successfully."
+    updated_automatically_by_child_changes: |
+      _Updated automatically by changing values within child work package %{child}_
+  work_package_relations_tab:
+    index:
+      action_bar_title: "Add relations to other work packages to create a link between them."
+      blankslate_description: "This work package does not have any relations yet."
+      blankslate_heading: "No relations"
+      no_results_title_text: There are currently no relations available.
+    label_add_child_button: "Child"
+    label_add_description: "Add description"
+    label_add_x: "Add %{x}"
+    label_edit_x: "Edit %{x}"
+    lag:
+      caption: |-
+        The minimum number of working days to keep in between the two work packages.
+        It can also be negative.
+      subject: "Lag"
+    relations:
+      blocked_by_description: "This work package cannot be closed until the related one is closed first"
+      blocked_description: "This work package cannot be closed until the related one is closed first"
+      blocks_description: "The related work package cannot be closed until this one is closed first"
+      child: "Child"
+      child_description: "Makes the related work package a sub-item of the current (parent) work package"
+      duplicated_by_description: "The related work package is a copy of this"
+      duplicated_description: "The related work package is a copy of this"
+      duplicates_description: "This is a copy of the related work package"
+      follows_description: "The related work package necessarily needs to finish before this one can start"
+      ghost_relation_description: "This is not visible to you due to permissions."
+
+      ghost_relation_title: "Related work package"
+      includes_description: "Marks the related work package as including this one with no additional effect"
+      label_blocked__by_plural: "blocked by"
+      label_blocked_by_singular: "blocked by"
+      label_blocked_plural: "blocked by"
+      label_blocked_singular: "blocked by"
+      label_blocks_plural: "blocks"
+      label_blocks_singular: "blocks"
+      label_child_plural: "children"
+      label_child_singular: "child"
+      label_closest: "Closest"
+      label_duplicated_by_plural: "duplicated by"
+      label_duplicated_by_singular: "duplicated by"
+      label_duplicated_plural: "duplicated by"
+      label_duplicated_singular: "duplicated by"
+      label_duplicates_plural: "duplicates"
+      label_duplicates_singular: "duplicates"
+      label_follows_plural: "predecessors (before)"
+      label_follows_singular: "predecessor (before)"
+      label_includes_plural: "includes"
+      label_includes_singular: "includes"
+      label_new_child_created: "New work package created and added as a child"
+      label_other_relations: "Other relations"
+      label_parent_plural: "parent"
+      label_parent_singular: "parent"
+      label_part_of_plural: "part of"
+      label_part_of_singular: "part of"
+      label_partof_plural: "part of"
+      label_partof_singular: "part of"
+      label_precedes_plural: "successors (after)"
+      label_precedes_singular: "successor (after)"
+      label_relates_plural: "related to"
+      label_relates_singular: "related to"
+      label_relates_to_plural: "related to"
+      label_relates_to_singular: "related to"
+      label_required_plural: "required by"
+      label_required_singular: "required by"
+      label_requires_plural: "requires"
+      label_requires_singular: "requires"
+      new_child: "Create new child"
+      new_child_description: "Creates a related work package as a sub-item of the current (parent) work package"
+      parent: "Parent"
+      parent_description: "Makes the related work package a parent of the current (child) work package"
+      part_of_description: "Marks the related work package as being part of this one with no additional effect"
+      partof_description: "Marks the related work package as being part of this one with no additional effect"
+      precedes_description: "The related work package necessarily needs to start after this one finishes"
+      relates_description: "Creates a visible link between the two work packages with no additional effect"
+      relates_to_description: "Creates a visible link between the two work packages with no additional effect"
+      required_description: "Marks this work package as being a requirement to the related one"
+
+      requires_description: "Marks the related work package as a requirement to this one"
+  work_packages:
+    bulk:
+      copy_failed: "The work packages could not be copied."
+      could_not_be_saved: "The following work packages could not be saved:"
+      descendant: "descendant of selected"
+
+      move_failed: "The work packages could not be moved."
+      none_could_be_saved: "None of the %{total} work packages could be updated."
+      selected_because_descendants: "While %{selected} work packages were selected, in total %{total} work packages are affected which includes descendants."
+      x_out_of_y_could_be_saved: "%{failing} out of the %{total} work packages could not be updated while %{success} could."
+    bulk_delete_dialog:
+      children_label: "The following children will also be deleted:"
+      confirm_children_deletion: "I acknowledge that all selected work packages and their children will be permanently deleted."
+      cross_project_warning: "These work packages span multiple projects: %{projects}"
+      description: "The following work packages and all associated data will be permanently deleted:"
+      description_with_children: "The following work packages, including children and all associated data, will be permanently deleted:"
+      heading: "Permanently delete these %{count} work packages?"
+      title: "Delete %{count} work packages"
+    datepicker_modal:
+      banner:
+        description:
+          automatic_mobile: "Start date derived."
+          click_on_show_relations_to_open_gantt: 'Click on "%{button_name}" for Gantt overview.'
+          manual_gap_between_predecessors: "There is a gap between this and all predecessors."
+          manual_mobile: "Ignoring relations."
+          manual_overlap_with_predecessors: "Overlaps with at least one predecessor."
+          manual_with_children: "This has child work packages but their start dates are ignored."
+        title:
+          automatic_mobile: "Automatically scheduled."
+          automatic_with_children: "The dates are determined by child work packages."
+          automatic_with_predecessor: "The start date is set by a predecessor."
+          manual_mobile: "Manually scheduled."
+          manually_scheduled: "Manually scheduled. Dates not affected by relations."
+      blankslate:
+        description: "To enable automatic scheduling, this work package needs to have at least one predecessor. It will then automatically be scheduled to start after the closest predecessor."
+        title: "No predecessors"
+      ignore_non_working_days:
+        title: "Working days only"
+      mode:
+        automatic: "Automatic"
+        manual: "Manual"
+        title: "Scheduling mode"
+      show_relations: "Show relations"
+      tabs:
+        aria_label: "Datepicker tabs"
+        blankslate:
+          children:
+            description: "This work package does not have any children."
+
+            title: "No children"
+          predecessors:
+            description: "This work package does not have any predecessors."
+            title: "No predecessors"
+          successors:
+            description: "This work package does not have any successors."
+            title: "No successors"
+        children: "Children"
+        dates: "Dates"
+        predecessors: "Predecessors"
+        successors: "Successors"
+      update_inputs_aria_live_message: "Date picker updated. %{message}"
+    delete_dialog:
+      confirm_descendants_deletion: "I acknowledge that ALL descendants of this work package will be recursively removed."
+      cross_project_warning: "Work packages from the following projects will be deleted: %{projects}"
+      description: 'Are you sure you want to delete the work package "%{name}"?'
+      heading: "Permanently delete this work package?"
+      title: "Delete work package"
+    move:
+      bulk_current_type_not_available_in_target_project: >
+        The current types of the work packages aren't enabled in the target project.
+        Please enable the types in the target project if you'd like them to remain unchanged.
+        Otherwise, select an available type in the target project from the list.
+      current_type_not_available_in_target_project: >
+        The current type of the work package is not enabled in the target project.
+        Please enable the type in the target project if you'd like it to remain unchanged.
+        Otherwise, select an available type in the target project from the list.
+      no_common_statuses_exists: "There is no status available for all selected work packages. Their status cannot be changed."
+      unsupported_for_multiple_projects: "Bulk move/copy is not supported for work packages from multiple projects"
+    sharing:
+      missing_workflow_warning:
+        link_message: "Configure the workflows in the administration."
+
+        message: "No workflow is configured for the 'Work package editor' role. Without a workflow, the shared with user cannot alter the status of the work package. Workflows can be copied. Select a source type (e.g. 'Task') and source role (e.g. 'Member'). Then select the target types. To start with, you could select all the types as targets. Finally, select the 'Work package editor' role as the target and press 'Copy'. After having thus created the defaults, fine tune the workflows as you do for every other role."
+        title: "Workflow missing for work package sharing"
+    summary:
+      reports:
+        assigned_to:
+          no_results_title_text: There are currently no members part of this project.
+        author:
+          no_results_title_text: There are currently no members part of this project.
+        category:
+          no_results_title_text: There are currently no categories available.
+        priority:
+          no_results_title_text: There are currently no priorities available.
+        responsible:
+          no_results_title_text: There are currently no members part of this project.
+        type:
+          no_results_title_text: There are currently no types available.
+        version:
+          no_results_title_text: There are currently no versions available.
+
+    x_descendants:
+      one: "One descendant work package"
+      other: "%{count} work package descendants"
+
+  workflows:
+    copies:
+      form:
+        mode:
+          from_role:
+            caption: "Copy the current workflow to one or more roles inside the same work package type. If the selected role already has a workflow the current one will be overwritten."
+            label: "Copy to other roles"
+          from_type:
+            caption: "Copy the current workflow to another work packages type. If the selected type already has a workflow the current one will be overwritten. This affects all roles."
+            label: "Copy to another type"
+        source_role_id:
+          label: "Source role"
+        target_role_ids:
+          label: "Target roles"
+        target_type_ids:
+          label: "Target types"
+      from_roles:
+        create:
+          notice:
+            one: "Successfully copied workflow to '%{role_name}' role."
+            other: "Successfully copied workflow to %{count} roles."
+      from_types:
+        create:
+          notice:
+            one: "Successfully copied workflow to '%{type_name}' type."
+            other: "Successfully copied workflow to %{count} types."
+      new:
+        title: 'Copy workflow of "%{source_type}"'
+    form:
+      matrix_caption: "Workflow matrix"
+      matrix_caption_assignee: "Workflow matrix for assignee"
+      matrix_caption_author: "Workflow matrix for author"
+      matrix_check_all_label: "Allow all transitions"
+      matrix_check_uncheck_all_in_col_label_html: "Toggle transitions from all old statuses to <em>%{new_status}</em>"
+      matrix_check_uncheck_all_in_row_label_html: "Toggle transitions from <em>%{old_status}</em> to all new statuses"
+      matrix_checkbox_label: "Allow transition from %{old_status} to %{new_status}"
+      matrix_uncheck_all_label: "Disallow all transitions"
+    index:
+      type_filter:
+        label: "Filter by type name…"
+    page_headers:
+      index_component:
+        description: "Configure status transitions for each work package type."
+
   working_days:
+    change_button: "Change working days"
+    dialog:
+      confirm_button: "Save and reschedule"
+      description: >
+        Changing which days of the week are considered working days or non-working days
+        can affect the start and finish days of all work packages and life cycles in all projects in this instance.
+      heading: "Change the working days?"
+      removed_title: "You will remove the following days from the non-working days list:"
+      title: "Change working days"
+      warning: >
+        The changes might take some time to take effect. You will be notified when all relevant work
+        packages and project life cycles have been updated.
     info: >
       Days that are not selected are skipped when scheduling work packages and project life cycles (and not included in the day count).
       These can be overridden at a work-package level.
     instance_wide_info: >
       Dates added to the list below are considered non-working and skipped when scheduling work packages.
-    change_button: "Change working days"
+    journal_note:
+      changed: _**Working days** changed (%{changes})._
+      dates:
+        non_working: "%{date} is now non-working"
+        working: "%{date} is now working"
+      days:
+        non_working: "%{day} is now non-working"
+        working: "%{day} is now working"
     warning: >
       Changing which days of the week are considered working days or non-working days
       can affect the start and finish days of all work packages and life cycles in all projects in this instance.
-    dialog:
-      title: "Change working days"
-      description: >
-        Changing which days of the week are considered working days or non-working days
-        can affect the start and finish days of all work packages and life cycles in all projects in this instance.
-      removed_title: "You will remove the following days from the non-working days list:"
-      warning: >
-        The changes might take some time to take effect. You will be notified when all relevant work
-        packages and project life cycles have been updated.
-      heading: "Change the working days?"
-      confirm_button: "Save and reschedule"
-    journal_note:
-      changed: _**Working days** changed (%{changes})._
-      days:
-        working: "%{day} is now working"
-        non_working: "%{day} is now non-working"
-      dates:
-        working: "%{date} is now working"
-        non_working: "%{date} is now non-working"
-  nothing_to_preview: "Nothing to preview"
-
-  api_v3:
-    attributes:
-      property: "Property"
-    errors:
-      code_400: "Bad request: %{message}"
-      code_401: "You need to be authenticated to access this resource."
-      code_401_wrong_credentials: "You did not provide the correct credentials."
-      code_403: "You are not authorized to access this resource."
-      code_404: "The requested resource could not be found."
-      code_409: "Could not update the resource because of conflicting modifications."
-      code_429: "Too many requests. Please try again later."
-      code_500: "An internal error has occurred."
-      code_500_outbound_request_failure: "An outbound request to another resource has failed with status code %{status_code}."
-      code_500_missing_enterprise_token: "The request can not be handled due to invalid or missing Enterprise token."
-      bad_request:
-        emoji_reactions_activity_type_not_supported: "This activity type does not support emoji reactions."
-        invalid_link: "The link under key '%{key}' is not valid."
-        links_not_an_object: "_links must be a JSON object."
-      conflict:
-        multiple_reminders_not_allowed: |-
-          You can only set one reminder at a time for a work package. Please delete or update the existing reminder.
-      not_found:
-        work_package: "The work package you are looking for cannot be found or has been deleted."
-        reminder: "The reminder you are looking for cannot be found or has been deleted."
-      expected:
-        date: "YYYY-MM-DD (ISO 8601 date only)"
-        datetime: "YYYY-MM-DDThh:mm:ss[.lll][+hh:mm] (any compatible ISO 8601 datetime)"
-        duration: "ISO 8601 duration"
-      invalid_content_type: "Expected CONTENT-TYPE to be '%{content_type}' but got '%{actual}'."
-      invalid_format: "Invalid format for property '%{property}': Expected format like '%{expected_format}', but got '%{actual}'."
-      invalid_json: "The request could not be parsed as JSON."
-      invalid_relation: "The relation is invalid."
-      invalid_resource: "For property '%{property}' a link like '%{expected}' is expected, but got '%{actual}'."
-      invalid_signal:
-        embed: "The requested embedding of %{invalid} is not supported. Supported embeddings are %{supported}."
-        select: "The requested select of %{invalid} is not supported. Supported selects are %{supported}."
-      invalid_user_status_transition: "The current user account status does not allow this operation."
-      missing_content_type: "not specified"
-      missing_property: "Missing property '%{property}'."
-      missing_request_body: "There was no request body."
-      missing_or_malformed_parameter: "The query parameter '%{parameter}' is missing or malformed."
-      multipart_body_error: "The request body did not contain the expected multipart parts."
-      multiple_errors: "Multiple field constraints have been violated."
-      unable_to_create_attachment: "The attachment could not be created"
-      unable_to_create_attachment_permissions: "The attachment could not be saved due to lacking file system permissions"
-      user:
-        name_readonly: "The name attribute is read-only. Changes can be written through the attributes firstname and lastname."
-      render:
-        context_not_parsable: "The context provided is not a link to a resource."
-        unsupported_context: "The resource given is not supported as context."
-        context_object_not_found: "Cannot find the resource given as the context."
-      validation:
-        due_date: "Finish date cannot be set on parent work packages."
-        invalid_user_assigned_to_work_package: "The chosen user is not allowed to be '%{property}' for this work package."
-        start_date: "Start date cannot be set on parent work packages."
-      eprops:
-        invalid_gzip: "is invalid gzip: %{message}"
-        invalid_json: "is invalid json: %{message}"
-
-    resources:
-      schema: "Schema"
-
-    undisclosed:
-      parent: Undisclosed - The parent is invisible because of lacking permissions.
-      project: Undisclosed - The project is invisible because of lacking permissions.
-      ancestor: Undisclosed - The ancestor is invisible because of lacking permissions.
-      definingProject: Undisclosed - The project is invisible because of lacking permissions.
-      definingWorkspace: Undisclosed - The workspace is invisible because of lacking permissions.
-      workPackage: Undisclosed - The work package is invisible because of lacking permissions.
-
-  doorkeeper:
-    pre_authorization:
-      status: "Pre-authorization"
-    auth_url: "Auth URL"
-    access_token_url: "Access token URL"
-
-    errors:
-      messages:
-        # Common error messages
-        invalid_request:
-          unknown: "The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed."
-          missing_param: "Missing required parameter: %{value}."
-          request_not_authorized: "Request need to be authorized. Required parameter for authorizing request is missing or invalid."
-        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
-        unauthorized_client: "The client is not authorized to perform this request using this method."
-        access_denied: "The resource owner or authorization server denied the request."
-        invalid_scope: "The requested scope is invalid, unknown, or malformed."
-        invalid_code_challenge_method: "The code challenge method must be plain or S256."
-        server_error: "The authorization server encountered an unexpected condition which prevented it from fulfilling the request."
-        temporarily_unavailable: "The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server."
-
-        # Configuration error messages
-        credential_flow_not_configured: "Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured."
-        resource_owner_authenticator_not_configured: "Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured."
-        admin_authenticator_not_configured: "Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured."
-
-        # Access grant errors
-        unsupported_response_type: "The authorization server does not support this response type."
-        unsupported_response_mode: "The authorization server does not support this response mode."
-
-        # Access token errors
-        invalid_client: "Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method."
-        invalid_grant: "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
-        unsupported_grant_type: "The authorization grant type is not supported by the authorization server."
-
-        invalid_token:
-          revoked: "The access token was revoked"
-          expired: "The access token expired"
-          unknown: "The access token is invalid"
-        revoke:
-          unauthorized: "You are not authorized to revoke this token."
-
-        forbidden_token:
-          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
-
-  unsupported_browser:
-    title: "Your browser is outdated and unsupported."
-    message: "You may run into errors and degraded experience on this page."
-    update_message: "Please update your browser."
-    close_warning: "Ignore this warning."
-
-  oauth:
-    application:
-      builtin: Built-in instance application
-      confidential: Confidential
-      singular: "OAuth application"
-      scopes: "Scopes"
-      client_credentials: "Client credentials"
-      plural: "OAuth applications"
-      named: "OAuth application '%{name}'"
-      new: "New OAuth application"
-      non_confidential: Non confidential
-      default_scopes: "(Default scopes)"
-      instructions:
-        enabled: "Enable this application, allowing users to perform authorization grants with it."
-        name: "The name of your application. This will be displayed to other users upon authorization."
-        redirect_uri_html: >
-          The allowed URLs authorized users can be redirected to. One entry per line.
-          <br/>
-          If you're registering a desktop application, use the following URL.
-        confidential: "Check if the application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are assumed non-confidential."
-        scopes: "Check the scopes you want the application to grant access to. If no scope is checked, api_v3 is assumed."
-        client_credential_user_id: "Optional user ID to impersonate when clients use this application. Leave empty to allow public access only"
-        register_intro: "If you are developing an OAuth API client application for OpenProject, you can register it using this form for all users to use."
-        default_scopes: ""
-    header:
-      builtin_applications: Built-in OAuth applications
-      other_applications: Other OAuth applications
-    empty_application_lists: No OAuth applications have been registered.
-    client_id: "Client ID"
-    client_secret_notice: >
-      This is the only time we can print the client secret, please note it down and keep it secure.
-      It should be treated as a password and cannot be retrieved by OpenProject at a later time.
-    authorization_dialog:
-      authorize: "Authorize"
-      cancel: "Cancel and deny authorization."
-      prompt_html: "Authorize <strong>%{application_name}</strong> to use your account <em>%{login}</em>?"
-      title: "Authorize %{application_name}"
-      wants_to_access_html: >
-        This application requests access to your OpenProject account.
-        <br/>
-        <strong>It has requested the following permissions:</strong>
-    scopes:
-      api_v3: "Full API v3 access"
-      api_v3_text: "Application will receive full read & write access to the OpenProject API v3 to perform actions on your behalf."
-    grants:
-      created_date: "Approved on"
-      scopes: "Permissions"
-      successful_application_revocation: "Revocation of application %{application_name} successful."
-      none_given: "No OAuth applications have been granted access to your user account."
-    flows:
-      authorization_code: "Authorization code flow"
-      client_credentials: "Client credentials flow"
-    client_credentials: "User used for Client credentials"
-    client_credentials_impersonation_set_to: "Client credentials user set to"
-    client_credentials_impersonation_warning: "Note: Clients using the 'Client credentials' flow in this application will have the rights of this user"
-    client_credentials_impersonation_html: >
-      By default, OpenProject provides OAuth 2.0 authorization via %{authorization_code_flow_link}.
-      You can optionally enable %{client_credentials_flow_link}, but you must provide a user on whose behalf requests will be performed.
-    confirm_revoke_my_application:
-      one: "Do you really want to remove this application? This will revoke one token active for it."
-      other: "Do you really want to remove this application? This will revoke %{count} tokens active for it."
-    authorization_error: "An authorization error has occurred."
-    my_registered_applications: "Registered OAuth applications"
-
-  oauth_client:
-    urn_connection_status:
-      connected: "Connected"
-      error: "Error"
-      failed_authorization: "Authorization failed"
-      not_connected: "Not connected"
-    labels:
-      label_oauth_integration: "OAuth2 integration"
-      label_redirect_uri: "Redirect URI"
-      label_request_token: "Request token"
-      label_refresh_token: "Refresh token"
-    errors:
-      oauth_authorization_code_grant_had_errors: "OAuth2 Authorization grant unsuccessful"
-      oauth_reported: "OAuth2 provider reported"
-      oauth_returned_error: "OAuth2 returned an error"
-      oauth_returned_json_error: "OAuth2 returned a JSON error"
-      oauth_returned_http_error: "OAuth2 returned a network error"
-      oauth_returned_standard_error: "OAuth2 returned an internal error"
-      wrong_token_type_returned: "OAuth2 returned a wrong type of token, expecting AccessToken::Bearer"
-      oauth_issue_contact_admin: "OAuth2 reported an error. Please contact your system administrator."
-      oauth_client_not_found: "OAuth2 client not found in 'callback' endpoint (redirect_uri)."
-      refresh_token_called_without_existing_token: >
-        Internal error: Called refresh_token without a previously existing token.
-      refresh_token_updated_failed: "Error during update of OAuthClientToken"
-      oauth_client_not_found_explanation: >
-        This error appears after you have updated the client_id and client_secret
-        in OpenProject, but haven't updated the 'Return URI' field in the OAuth2 provider.
-      oauth_code_not_present: "OAuth2 'code' not found in 'callback' endpoint (redirect_uri)."
-      oauth_code_not_present_explanation: >
-        This error appears if you have selected the wrong response_type
-        in the OAuth2 provider. Response_type should be 'code' or similar.
-      oauth_state_not_present: "OAuth2 'state' not found in 'callback' endpoint (redirect_uri)."
-      oauth_state_not_present_explanation: >
-        The 'state' is used to indicate to OpenProject where to continue
-        after a successful OAuth2 authorization.
-        A missing 'state' is an internal error that may appear during setup.
-        Please contact your system administrator.
-      rack_oauth2:
-        client_secret_invalid: "Client secret is invalid (client_secret_invalid)"
-        invalid_request: >
-          OAuth2 Authorization Server responded with 'invalid_request'.
-          This error appears if you try to authorize multiple times or in case of technical issues.
-        invalid_response: "OAuth2 Authorization Server provided an invalid response (invalid_response)"
-        invalid_grant: "The OAuth2 Authorization Server asks you to reauthorize (invalid_grant)."
-        invalid_client: "The OAuth2 Authorization Server doesn't recognize OpenProject (invalid_client)."
-        unauthorized_client: "The OAuth2 Authorization Server rejects the grant type (unauthorized_client)"
-        unsupported_grant_type: "The OAuth2 Authorization Server asks you to reauthorize (unsupported_grant_type)."
-        invalid_scope: "You are not allowed to access the requested resource (invalid_scope)."
-
-  http:
-    request:
-      failed_authorization: "The server side request failed authorizing itself."
-      missing_authorization: "The server side request failed due to missing authorization information."
-    response:
-      unexpected: "Unexpected response received."
-
   you: you
-  link: link
-
-  plugin_openproject_auth_plugins:
-    name: "OpenProject Auth Plugins"
-    description: "Integration of OmniAuth strategy providers for authentication in OpenProject."
-  plugin_openproject_auth_saml:
-    name: "OmniAuth SAML / Single-Sign On"
-    description: "Adds the OmniAuth SAML provider to OpenProject"
-
-  enterprise_plans:
-    legacy_enterprise: "Enterprise Plan"
-
-  token:
-    hashed_token:
-      display_value_placeholder: "***"
-
-  external_link_warning:
-    title: "Leaving OpenProject"
-    warning_message: "You are about to leave OpenProject and visit an external website. Please be aware that external websites are not under our control and may have different privacy and security policies."
-    continue_message: "Are you sure you want to proceed to the following external link?"
-    continue_button: "Continue to external website"

--- a/config/locales/js-en.yml
+++ b/config/locales/js-en.yml
@@ -29,6 +29,29 @@
 ---
 en:
   js:
+    admin:
+      type_form:
+        edit_query: "Edit query"
+
+      work_packages_settings:
+        warning_progress_calculation_mode_change_from_field_to_status_html: >-
+          Changing progress calculation mode from work-based to status-based will result
+          in all existing <i>% Complete</i> values to be lost and replaced with values
+          associated with each status. Existing values for <i>Remaining work</i> may
+          also be recalculated to reflect this change. This action is not reversible.
+        warning_progress_calculation_mode_change_from_status_to_field_html: >-
+          Changing progress calculation mode from status-based to work-based will make
+          the <i>% Complete</i> field freely editable. If you optionally enter values
+          for <i>Work</i> or <i>Remaining work</i>, they will also be linked to <i>% Complete</i>.
+          Changing <i>Remaining work</i> can then update <i>% Complete</i>.
+      working_days:
+        add_non_working_day: "Non-working day"
+        already_added_error: "A non-working day for this date exists already. There can only be one non-working day created for each unique date."
+
+        calendar:
+          empty_state_description: 'No specific non-working days are defined for this year. Click on "+ Non-working day" below to add a date.'
+          empty_state_header: "Non-working days"
+          new_date: "(new)"
     ajax:
       hide: "Hide"
       loading: "Loading…"
@@ -50,290 +73,391 @@ en:
       type_to_search: "Type to search"
 
     autocomplete_select:
+      active: "Active %{label} %{name}"
+
       placeholder:
         multi: 'Add "%{name}"'
         single: 'Select "%{name}"'
       remove: "Remove %{name}"
-      active: "Active %{label} %{name}"
+    autocompleter:
+      notFoundText: "No items found"
+      placeholder: "Type to search"
+      project:
+        placeholder: "Select project"
 
+      search: "Search"
     backup:
-      attachments_disabled: Attachments may not be included since they exceed the maximum overall size allowed.
-        You can change this via the configuration (requires a server restart).
+      attachments_disabled: Attachments may not be included since they exceed the maximum overall size allowed. You can change this via the configuration (requires a server restart).
+      download_backup: Download backup
+      include_attachments: Include attachments
       info: >
         You can trigger a backup here. The process can take some time depending on the amount
         of data (especially attachments) you have. You will receive an email once it's ready.
+      last_backup: Last backup
+      last_backup_from: Last backup from
       note: >
         A new backup will override any previous one. Only a limited number of backups per day
         can be requested.
-      last_backup: Last backup
-      last_backup_from: Last backup from
-      title: Backup OpenProject
       options: Options
-      include_attachments: Include attachments
-      download_backup: Download backup
       request_backup: Request backup
 
-    close_popup_title: "Close popup"
-    close_filter_title: "Close filter"
-    close_form_title: "Close form"
-
-    button_add_watcher: "Add watcher"
+      title: Backup OpenProject
+    baseline:
+      apply: "Apply"
+      clear: "Clear"
+      drop_down:
+        a_specific_date: "a specific date"
+        between_two_specific_dates: "between two specific dates"
+        last_month: "last month"
+        last_week: "last week"
+        last_working_day: "last working day"
+        none: "-"
+        yesterday: "yesterday"
+      from: "From"
+      header_description: "Highlight changes made to this list since any point in the past."
+      help_description: "Reference time zone for the baseline."
+      icon_tooltip:
+        added: "Added to view within the comparison time period"
+        changed: "Maintained with modifications"
+        removed: "Removed from view within the comparison time period"
+      legends:
+        changes_between: "Changes between"
+        changes_since: "Changes since"
+        in_your_timezone: "In your local timezone:"
+        maintained_with_changes: "Maintained with changes"
+        no_longer_meets_filter_criteria: "No longer meets filter criteria"
+        now_meets_filter_criteria: "Now meets filter criteria"
+      show_changes_since: "Show changes since"
+      time: "Time"
+      time_description: "In your local time: %{datetime}"
+      to: "To"
+      toggle_title: "Baseline"
+    breadcrumb: "Breadcrumb"
     button_add: "Add"
+    button_add_watcher: "Add watcher"
+    button_advanced_filter: "Advanced filter"
     button_back: "Back"
     button_back_to_list_view: "Back to list view"
     button_cancel: "Cancel"
-    button_close: "Close"
     button_change_project: "Move to another project"
     button_check_all: "Check all"
+    button_close: "Close"
+    button_close_details: "Close details view"
+    button_collapse_all: "Collapse all"
     button_configure-form: "Configure form"
     button_confirm: "Confirm"
     button_continue: "Continue"
     button_copy: "Copy"
-    button_copy_to_clipboard: "Copy to clipboard"
     button_copy_link_to_clipboard: "Copy link to clipboard"
+    button_copy_to_clipboard: "Copy to clipboard"
     button_copy_to_other_project: "Duplicate in another project"
+    button_create: "Create"
+
     button_custom-fields: "Custom fields"
     button_delete: "Delete"
     button_delete_watcher: "Delete watcher"
     button_details_view: "Details view"
     button_duplicate: "Duplicate"
     button_edit: "Edit"
-    button_filter: "Filter"
-    button_collapse_all: "Collapse all"
     button_expand_all: "Expand all"
-    button_advanced_filter: "Advanced filter"
+    button_export-atom: "Download Atom"
+    button_filter: "Filter"
+    button_generate_pdf: "Generate PDF"
     button_list_view: "List view"
-    button_show_view: "Fullscreen view"
     button_log_time: "Log time"
-    button_start_timer: "Start timer"
-    button_stop_timer: "Stop timer"
     button_more: "More"
-    button_open_details: "Open details view"
-    button_close_details: "Close details view"
-    button_open_fullscreen: "Open fullscreen view"
-    button_show_cards: "Show card view"
-    button_show_list: "Show list view"
-    button_show_table: "Show table view"
-    button_show_gantt: "Show Gantt view"
-    button_show_fullscreen: "Show fullscreen view"
     button_more_actions: "More actions"
+    button_open_details: "Open details view"
+    button_open_fullscreen: "Open fullscreen view"
     button_quote: "Quote"
     button_save: "Save"
     button_settings: "Settings"
+    button_show_cards: "Show card view"
+    button_show_fullscreen: "Show fullscreen view"
+    button_show_gantt: "Show Gantt view"
+    button_show_list: "Show list view"
+    button_show_table: "Show table view"
+    button_show_view: "Fullscreen view"
+    button_start_timer: "Start timer"
+    button_stop_timer: "Stop timer"
     button_uncheck_all: "Uncheck all"
     button_update: "Update"
-    button_export-atom: "Download Atom"
-    button_generate_pdf: "Generate PDF"
-    button_create: "Create"
+    caption_rate_history: "Rate history"
 
     card:
       add_new: "Add new card"
       highlighting:
-        inline: "Highlight inline:"
         entire_card_by: "Entire card by"
+        inline: "Highlight inline:"
       remove_from_list: "Remove card from list"
 
-    caption_rate_history: "Rate history"
+    chart:
+      axis_criteria: "Axis criteria"
+      errors:
+        could_not_load: "The data to display the graph could not be loaded. The necessary permissions may be lacking."
 
+      modal_title: "Work package graph configuration"
+      tabs:
+        dataset: "Dataset %{number}"
+        graph_settings: "General"
+      type: "Chart type"
+      types:
+        bar: "Bar"
+        doughnut: "Doughnut"
+        horizontal_bar: "Horizontal bar"
+        line: "Line"
+        pie: "Pie"
+        polar_area: "Polar area"
+        radar: "Radar"
     clipboard:
       browser_error: "Your browser doesn't support copying to clipboard. Please copy it manually: %{content}"
       copied_successful: "Successfully copied to clipboard!"
 
-    chart:
-      type: "Chart type"
-      axis_criteria: "Axis criteria"
-      modal_title: "Work package graph configuration"
-      types:
-        line: "Line"
-        horizontal_bar: "Horizontal bar"
-        bar: "Bar"
-        pie: "Pie"
-        doughnut: "Doughnut"
-        radar: "Radar"
-        polar_area: "Polar area"
-      tabs:
-        graph_settings: "General"
-        dataset: "Dataset %{number}"
-      errors:
-        could_not_load: "The data to display the graph could not be loaded. The necessary permissions may be lacking."
+    close_filter_title: "Close filter"
+    close_form_title: "Close form"
 
+    close_popup_title: "Close popup"
+    custom_actions:
+      date:
+        current_date: "Current date"
+
+        specific: "on"
     description_available_columns: "Available Columns"
     description_current_position: "You are here: "
     description_select_work_package: "Select work package #%{id}"
     description_subwork_package: "Child of work package #%{id}"
     editor:
-      revisions: "Show local modifications"
-      no_revisions: "No local modifications found"
-      preview: "Toggle preview mode"
-      source_code: "Toggle Markdown source mode"
-      error_saving_failed: "Saving the document failed with the following error: %{error}"
       ckeditor_error: "An error occurred within CKEditor"
-      mode:
-        manual: "Switch to Markdown source"
-        wysiwyg: "Switch to WYSIWYG editor"
+      error_saving_failed: "Saving the document failed with the following error: %{error}"
       macro:
-        error: "Cannot expand macro: %{message}"
         attribute_reference:
-          macro_help_tooltip: "This text segment is being dynamically rendered by a macro."
-          not_found: "Requested resource could not be found"
-          nested_macro: "This macro is recursively referencing %{model} %{id}."
           invalid_attribute: "The selected attribute '%{name}' does not exist."
+          macro_help_tooltip: "This text segment is being dynamically rendered by a macro."
+          nested_macro: "This macro is recursively referencing %{model} %{id}."
+          not_found: "Requested resource could not be found"
         child_pages:
           button: "Links to child pages"
-          include_parent: "Include parent"
-          text: "[Placeholder] Links to child pages of"
-          page: "Wiki page"
-          this_page: "this page"
           hint: |
             Leave this field empty to list all child pages of the current page. If you want to reference a different page, provide its title or slug.
+          include_parent: "Include parent"
+          page: "Wiki page"
+          text: "[Placeholder] Links to child pages of"
+          this_page: "this page"
         code_block:
           button: "Insert code snippet"
-          title: "Insert / edit Code snippet"
           language: "Formatting language"
           language_hint: "Enter the formatting language that will be used for highlighting (if supported)."
+          title: "Insert / edit Code snippet"
         dropdown:
-          macros: "Macros"
           chose_macro: "Choose macro"
+          macros: "Macros"
+        embedded_calendar:
+          text: "[Placeholder] Embedded calendar"
+
+        embedded_table:
+          button: "Embed work package table"
+          text: "[Placeholder] Embedded work package table"
+        error: "Cannot expand macro: %{message}"
         toc: "Table of contents"
         toolbar_help: "Click to select widget and show the toolbar. Double-click to edit widget"
         wiki_page_include:
           button: "Include content of another wiki page"
-          text: "[Placeholder] Included wiki page of"
-          page: "Wiki page"
-          not_set: "(Page not yet set)"
           hint: |
             Include the content of another wiki page by specifying its title or slug.
             You can include the wiki page of another project by separating them with a colon like the following example.
+          not_set: "(Page not yet set)"
+          page: "Wiki page"
+          text: "[Placeholder] Included wiki page of"
         work_package_button:
           button: "Insert create work package button"
-          type: "Work package type"
           button_style: "Use button style"
           button_style_hint: "Optional: Check to make macro appear as a button, not as a link."
-          without_type: "Create work package"
+          type: "Work package type"
           with_type: "Create work package (Type: %{typename})"
-        embedded_table:
-          button: "Embed work package table"
-          text: "[Placeholder] Embedded work package table"
-        embedded_calendar:
-          text: "[Placeholder] Embedded calendar"
-
-    admin:
-      type_form:
-        edit_query: "Edit query"
-
-      working_days:
-        calendar:
-          empty_state_header: "Non-working days"
-          empty_state_description: 'No specific non-working days are defined for this year. Click on "+ Non-working day" below to add a date.'
-          new_date: "(new)"
-        add_non_working_day: "Non-working day"
-        already_added_error: "A non-working day for this date exists already. There can only be one non-working day created for each unique date."
-
-      work_packages_settings:
-        warning_progress_calculation_mode_change_from_status_to_field_html: >-
-          Changing progress calculation mode from status-based to work-based will make
-          the <i>% Complete</i> field freely editable. If you optionally enter values
-          for <i>Work</i> or <i>Remaining work</i>, they will also be linked to <i>% Complete</i>.
-          Changing <i>Remaining work</i> can then update <i>% Complete</i>.
-        warning_progress_calculation_mode_change_from_field_to_status_html: >-
-          Changing progress calculation mode from work-based to status-based will result
-          in all existing <i>% Complete</i> values to be lost and replaced with values
-          associated with each status. Existing values for <i>Remaining work</i> may
-          also be recalculated to reflect this change. This action is not reversible.
-    custom_actions:
-      date:
-        specific: "on"
-        current_date: "Current date"
-
-    error:
-      internal: "An internal error has occurred."
-      cannot_save_changes_with_message: "Cannot save your changes due to the following error: %{error}"
-      query_saving: "The view could not be saved."
-      embedded_table_loading: "The embedded view could not be loaded: %{message}"
+          without_type: "Create work package"
+      mode:
+        manual: "Switch to Markdown source"
+        wysiwyg: "Switch to WYSIWYG editor"
+      no_revisions: "No local modifications found"
+      preview: "Toggle preview mode"
+      revisions: "Show local modifications"
+      source_code: "Toggle Markdown source mode"
     enumeration_activities: "Activities (time tracking)"
     enumeration_doc_categories: "Document categories"
     enumeration_work_package_priorities: "Work package priorities"
+    error:
+      cannot_save_changes_with_message: "Cannot save your changes due to the following error: %{error}"
+      embedded_table_loading: "The embedded view could not be loaded: %{message}"
+      internal: "An internal error has occurred."
+      query_saving: "The view could not be saved."
+    error_attachment_upload: "File failed to upload: %{error}"
+    error_attachment_upload_permission: "You don't have the permission to upload files on this resource."
+
+    error_could_not_resolve_user_name: "Couldn't resolve user name"
+    error_could_not_resolve_version_name: "Couldn't resolve version name"
+    exclusion_info:
+      modal:
+        content: >-
+          The status '%{status_name}' has been configured to be excluded from hierarchy
+          totals of Work, Remaining work, and % Complete. The totals do not take
+          this value into account.
+
+        title: "Status excluded from hierarchy totals"
+    favorite_projects:
+      no_results: "You have no favorite projects"
+      no_results_subtext: "Add one or multiple projects as favorite through their overview or in a project list."
+
+    field_value_enter_prompt: "Enter a value for '%{field}'"
+
     filter:
-      more_values_not_shown: "There are %{total} more results, search to filter results."
       description:
-        text_open_filter: "Open this filter with 'ALT' and arrow keys."
         text_close_filter: "To select an entry leave the focus for example by pressing enter. To leave without filter select the first (empty) entry."
+        text_open_filter: "Open this filter with 'ALT' and arrow keys."
+      more_values_not_shown: "There are %{total} more results, search to filter results."
       noneElement: "(none)"
-      time_zone_converted:
-        two_values: "%{from} - %{to} in your local time."
-        only_start: "From %{from} in your local time."
-        only_end: "Till %{to} in your local time."
-      value_spacer: "-"
       sorting:
         criteria:
           one: "First sorting criteria"
-          two: "Second sorting criteria"
           three: "Third sorting criteria"
 
-    gantt_chart:
-      label: "Gantt chart"
-      quarter_label: "Q%{quarter_number}"
-      labels:
-        title: "Label configuration"
-        bar: "Bar labels"
-        left: "Left"
-        right: "Right"
-        farRight: "Far right"
-        description: >
-          Select the attributes you want to be shown in the respective positions of the Gantt chart at all times.
-          Note that when hovering over an element, its date labels will be shown instead of these attributes.
+          two: "Second sorting criteria"
+      time_zone_converted:
+        only_end: "Till %{to} in your local time."
+        only_start: "From %{from} in your local time."
+        two_values: "%{from} - %{to} in your local time."
+      value_spacer: "-"
+    forms:
+      advanced_settings: "Advanced settings"
 
+      load_error_message: "There was an error loading the form"
+      submit_success_message: "The form was successfully submitted"
+      validation_error_message: "Please fix the errors present in the form"
+    gantt_chart:
       button_activate: "Show Gantt chart"
       button_deactivate: "Hide Gantt chart"
       filter:
         noneSelection: "(none)"
+      label: "Gantt chart"
+      labels:
+        bar: "Bar labels"
+        description: >
+          Select the attributes you want to be shown in the respective positions of the Gantt chart at all times.
+          Note that when hovering over an element, its date labels will be shown instead of these attributes.
+
+        farRight: "Far right"
+        left: "Left"
+        right: "Right"
+        title: "Label configuration"
+      quarter_label: "Q%{quarter_number}"
       selection_mode:
         notification: "Click on any highlighted work package to create the relation. Press escape to cancel."
       zoom:
-        in: "Zoom in"
-        out: "Zoom out"
         auto: "Auto zoom"
         days: "Days"
-        weeks: "Weeks"
-        months: "Months"
-        quarters: "Quarters"
-        years: "Years"
         description: >
           Select the initial zoom level that should be shown when autozoom is not available.
 
-    general_text_no: "no"
-    general_text_yes: "yes"
+        in: "Zoom in"
+        months: "Months"
+        out: "Zoom out"
+        quarters: "Quarters"
+        weeks: "Weeks"
+        years: "Years"
     general_text_No: "No"
     general_text_Yes: "Yes"
 
+    general_text_no: "no"
+    general_text_yes: "yes"
+    global_search:
+      all_projects: "In all projects"
+      close_search: "Close search"
+      current_project: "In this project"
+      current_project_and_all_descendants: "In this project + subprojects"
+      direct_hit_available: "Work package with exact ID found. Press Enter to open it."
+      items_available: "%{count} items available"
+      recently_viewed: "Recently viewed"
+      search_placeholder_expanded: "Search work packages by subject, project, type, status or ID"
+      title:
+        all_projects: "all projects"
+        project_and_subprojects: "and all subprojects"
+        search_for: "Search for"
+
     hal:
       error:
-        update_conflict_refresh: "Click here to refresh the resource and update to the newest version."
         edit_prohibited: "Editing %{attribute} is blocked for this resource. Either this attribute is derived from relations (e.g, children) or otherwise not configurable."
         format:
           date: "%{attribute} is no valid date - YYYY-MM-DD expected."
         general: "An error has occurred."
 
+        update_conflict_refresh: "Click here to refresh the resource and update to the newest version."
+    help_texts:
+      show_modal: "Show help text"
+
     ical_sharing_modal:
-      title: "Subscribe to calendar"
-      inital_setup_error_message: "An error occured while fetching data."
-      description: "You can use the URL (iCalendar) to subscribe to this calendar in an external client and view up-to-date work package information from there."
-      warning: "Please don't share this URL with other users. Anyone with this link will be able to view work package details without an account or password."
-      token_name_label: "Where will you be using this?"
-      token_name_placeholder: 'Type a name, e.g. "Phone"'
-      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="%{myAccessTokensUrl}" target="_blank">access tokens</a> list.'
       copy_url_label: "Copy URL"
+      description: "You can use the URL (iCalendar) to subscribe to this calendar in an external client and view up-to-date work package information from there."
       ical_generation_error_text: "An error occured while generating the calendar URL."
+      inital_setup_error_message: "An error occured while fetching data."
       success_message: 'The URL "%{name}" was successfully copied to your clipboard. Paste it in your calendar client to complete the subscription.'
 
+      title: "Subscribe to calendar"
+      token_name_description_text: 'If you subscribe to this calendar from multiple devices, this name will help you distinguish between them in your <a href="%{myAccessTokensUrl}" target="_blank">access tokens</a> list.'
+      token_name_label: "Where will you be using this?"
+      token_name_placeholder: 'Type a name, e.g. "Phone"'
+      warning: "Please don't share this URL with other users. Anyone with this link will be able to view work package details without an account or password."
+    include_projects:
+      apply: "Apply"
+      clear_selection: "Clear selection"
+      include_subprojects: "Include all sub-projects"
+      no_results: "No project matches your search criteria."
+      search_placeholder: "Search projects..."
+      selected_filter:
+        all: "All projects"
+        selected: "Only selected"
+      title: "Projects"
+      toggle_title: "Include projects"
+      tooltip:
+        current_project: "This is the current project you are in."
+        does_not_match_search: "Project does not match the search criteria."
+        include_all_selected: "Project already included since Include all sub-projects is enabled."
+    include_workspaces:
+      types:
+        portfolio: "Portfolio"
+        program: "Program"
+    inplace:
+      btn_preview_disable: "Disable preview"
+      btn_preview_enable: "Preview"
+      button_cancel: "%{attribute}: Cancel"
+      button_cancel_all: "Cancel"
+      button_edit: "%{attribute}: Edit"
+      button_save: "%{attribute}: Save"
+      button_save_all: "Save"
+      clear_value_label: "-"
+      errors:
+        maxlength: "%{field} cannot contain more than %{maxLength} digit(s)"
+        messages_on_field: "This field is invalid: %{messages}"
+
+        minlength: "%{field} cannot contain less than %{minLength} digit(s)"
+        number: "%{field} is not a valid number"
+        required: "%{field} cannot be empty"
+      link_formatting_help: "Text formatting help"
+      null_value_label: "No value"
+    invalid_job_response: "Invalid response from server."
+
+    invite_user_modal:
+      invite: "Invite"
+      placeholder_add_tag: "Create placeholder user"
+
     label_activate: "Activate"
-    label_assignee: "Assignee"
-    label_assignee_alt_text: "This work package is assigned to %{name}"
+    label_activity_show_all: "Show all activities"
+    label_activity_show_only_comments: "Show activities with comments only"
+    label_add_attachments: "Attach files"
     label_add_column_after: "Add column after"
     label_add_column_before: "Add column before"
     label_add_columns: "Add columns"
     label_add_comment: "Add comment"
     label_add_comment_title: "Comment and type @ to notify other people"
+    label_add_description: "Add a description for %{file}"
     label_add_row_after: "Add row after"
     label_add_row_before: "Add row before"
     label_add_selected_columns: "Add selected columns"
@@ -346,6 +470,9 @@ en:
     label_all_work_packages: "all work packages"
     label_and: "and"
     label_ascending: "Ascending"
+    label_assignee: "Assignee"
+    label_assignee_alt_text: "This work package is assigned to %{name}"
+    label_attachments: Attachments
     label_author: "Author: %{user}"
     label_avatar: "Avatar"
     label_between: "between"
@@ -353,42 +480,52 @@ en:
     label_board_locked: "Locked"
     label_board_plural: "Boards"
     label_board_sticky: "Sticky"
+    label_cancel_comment: "Cancel comment"
     label_change: "Change"
+    label_children_derived_duration: "Work package's children derived duration"
+    label_closed_work_packages: "closed"
+    label_collapse: "Collapse"
+    label_collapse_all: "Collapse all"
+    label_collapse_text: "Collapse text"
+    label_collapsed: "collapsed"
+    label_columns: "Columns"
+    label_comment: "Comment"
+    label_contains: "contains"
     label_create: "Create"
     label_create_work_package: "Create new work package"
     label_created_by: "Created by"
+    label_created_on: "created on"
     label_current: "current"
+    label_custom_queries: "Private"
     label_date: "Date"
     label_date_with_format: "Enter the %{date_attribute} using the following format: %{format}"
     label_deactivate: "Deactivate"
+    label_default_queries: "Default"
     label_descending: "Descending"
     label_description: "Description"
     label_details: "Details"
     label_display: "Display"
-    label_cancel_comment: "Cancel comment"
-    label_closed_work_packages: "closed"
-    label_collapse: "Collapse"
-    label_collapsed: "collapsed"
-    label_collapse_all: "Collapse all"
-    label_collapse_text: "Collapse text"
-    label_comment: "Comment"
-    label_contains: "contains"
-    label_created_on: "created on"
+    label_drop_files: "Drop files here to attach files."
+    label_drop_folders_hint: You cannot upload folders as an attachment. Please select single files.
+    label_drop_or_click_files: "Drop files here or click to attach files."
     label_edit_comment: "Edit this comment"
     label_edit_status: "Edit the status of the work package"
     label_email: "Email"
     label_equals: "is"
     label_expand: "Expand"
-    label_expanded: "expanded"
     label_expand_all: "Expand all"
-    label_expand_text: "Show full text"
     label_expand_project_menu: "Expand project menu"
+    label_expand_text: "Show full text"
+    label_expanded: "expanded"
     label_export: "Export"
     label_export_preparing: "The export is being prepared and will be downloaded shortly."
     label_favorites: "Favorites"
     label_filename: "File"
+    label_files_to_upload: "These files will be uploaded:"
     label_filesize: "Size"
+    label_formattable_attachment_hint: "Attach and link files by dropping on this field, or pasting from the clipboard."
     label_general: "General"
+    label_global_queries: "Public"
     label_greater_or_equal: ">="
     label_group: "Group"
     label_group_by: "Group by"
@@ -396,15 +533,15 @@ en:
     label_hide_attributes: "Show less"
     label_hide_column: "Hide column"
     label_hide_project_menu: "Collapse project menu"
+    label_import: "Import"
     label_in: "in"
     label_in_less_than: "in less than"
     label_in_more_than: "in more than"
     label_incoming_emails: "Incoming emails"
     label_information_plural: "Information"
     label_invalid: "Invalid"
-    label_import: "Import"
-    label_latest_activity: "Latest activity"
     label_last_updated_on: "Last updated on"
+    label_latest_activity: "Latest activity"
     label_learn_more_link: "Learn more"
     label_less_or_equal: "<="
     label_less_than_ago: "less than days ago"
@@ -414,38 +551,44 @@ en:
     label_me: "me"
     label_meeting_agenda: "Agenda"
     label_meeting_minutes: "Minutes"
-    label_more_than_ago: "more than days ago"
     label_moderate_comment: "Moderate comment"
+    label_more_than_ago: "more than days ago"
     label_next: "Next"
     label_no_color: "No color"
     label_no_data: "No data to display"
+    label_no_date: "no date"
     label_no_due_date: "no finish date"
     label_no_start_date: "no start date"
-    label_no_date: "no date"
     label_no_value: "No value"
     label_none: "none"
     label_not_contains: "doesn't contain"
     label_not_equals: "is not"
     label_on: "on"
-    label_open_menu: "Open menu"
     label_open_context_menu: "Open context menu"
+    label_open_menu: "Open menu"
     label_open_work_packages: "open"
     label_password: "Password"
-    label_previous: "Previous"
     label_per_page: "Per page:"
     label_please_wait: "Please wait"
+    label_press_enter_to_save: "Press enter to save."
+    label_previous: "Previous"
     label_project: "Project"
     label_project_plural: "Projects"
-    label_visibility_settings: "Visibility settings"
+    label_public_query: "Public"
     label_quote_comment: "Quote this comment"
     label_recent: "Recent"
-    label_reset: "Reset"
+    label_rejected_files: "These files cannot be uploaded:"
+    label_rejected_files_reason: "These files cannot be uploaded as their size is greater than %{maximumFilesize}"
     label_remove: "Remove"
+    label_remove_all_files: Delete all files
     label_remove_column: "Remove column"
     label_remove_columns: "Remove selected columns"
+    label_remove_file: "Delete %{fileName}"
     label_remove_row: "Remove row"
+    label_remove_watcher: "Remove watcher %{name}"
     label_report: "Report"
     label_repository_plural: "Repositories"
+    label_reset: "Reset"
     label_resize_project_menu: "Resize project menu"
     label_save_as: "Save as"
     label_search_columns: "Search a column"
@@ -454,176 +597,180 @@ en:
     label_show_attributes: "Show all attributes"
     label_show_in_menu: "Show view in menu"
     label_sort_by: "Sort by"
-    label_sorted_by: "sorted by"
     label_sort_higher: "Move up"
     label_sort_lower: "Move down"
+    label_sorted_by: "sorted by"
     label_sorting: "Sorting"
     label_spent_time: "Spent time"
     label_star_query: "Favorited"
-    label_press_enter_to_save: "Press enter to save."
-    label_public_query: "Public"
+    label_starred_queries: "Favorite"
+    label_subject: "Subject"
     label_sum: "Sum"
     label_sum_for: "Sum for"
-    label_total_sum: "Total sum"
-    label_subject: "Subject"
     label_this_week: "this week"
-    label_today: "Today"
     label_time_entry_plural: "Spent time"
-    label_up: "Up"
-    label_user_plural: "Users"
-    label_activity_show_only_comments: "Show activities with comments only"
-    label_activity_show_all: "Show all activities"
-    label_total_progress: "%{percent}% Total progress"
+    label_today: "Today"
     label_total_amount: "Total: %{amount}"
+    label_total_progress: "%{percent}% Total progress"
+    label_total_sum: "Total sum"
+    label_unwatch: "Unwatch"
+    label_unwatch_work_package: "Unwatch work package"
+    label_up: "Up"
     label_updated_on: "updated on"
+    label_upload_counter: "%{done} of %{count} files finished"
+    label_upload_notification: "Uploading files..."
+    label_uploaded_by: "Uploaded by"
+    label_user_plural: "Users"
+    label_validation_error: "The work package could not be saved due to the following errors:"
     label_value_derived_from_children: "(value derived from children)"
-    label_children_derived_duration: "Work package's children derived duration"
+    label_version_plural: "Versions"
+    label_view_has_changed: "This view has unsaved changes. Click to save them."
+
+    label_visibility_settings: "Visibility settings"
+    label_wait: "Please wait for configuration..."
     label_warning: "Warning"
-    label_work_package: "Work package"
-    label_work_package_parent: "Parent work package"
-    label_work_package_plural: "Work packages"
     label_watch: "Watch"
     label_watch_work_package: "Watch work package"
     label_watcher_added_successfully: "Watcher successfully added!"
     label_watcher_deleted_successfully: "Watcher successfully deleted!"
-    label_work_package_details_you_are_here: "You are on the %{tab} tab for %{type} %{subject}."
+    label_work_package: "Work package"
     label_work_package_context_menu: "Work package context menu"
-    label_unwatch: "Unwatch"
-    label_unwatch_work_package: "Unwatch work package"
-    label_uploaded_by: "Uploaded by"
-    label_default_queries: "Default"
-    label_starred_queries: "Favorite"
-    label_global_queries: "Public"
-    label_custom_queries: "Private"
-    label_columns: "Columns"
-    label_attachments: Attachments
-    label_drop_files: "Drop files here to attach files."
-    label_drop_or_click_files: "Drop files here or click to attach files."
-    label_drop_folders_hint: You cannot upload folders as an attachment. Please select single files.
-    label_add_attachments: "Attach files"
-    label_formattable_attachment_hint: "Attach and link files by dropping on this field, or pasting from the clipboard."
-    label_remove_file: "Delete %{fileName}"
-    label_remove_watcher: "Remove watcher %{name}"
-    label_remove_all_files: Delete all files
-    label_add_description: "Add a description for %{file}"
-    label_upload_notification: "Uploading files..."
+    label_work_package_details_you_are_here: "You are on the %{tab} tab for %{type} %{subject}."
+    label_work_package_parent: "Parent work package"
+    label_work_package_plural: "Work packages"
     label_work_package_upload_notification: "Uploading files for Work package #%{id}: %{subject}"
     label_wp_id_added_by: "#%{id} added by %{author}"
-    label_files_to_upload: "These files will be uploaded:"
-    label_rejected_files: "These files cannot be uploaded:"
-    label_rejected_files_reason: "These files cannot be uploaded as their size is greater than %{maximumFilesize}"
-    label_wait: "Please wait for configuration..."
-    label_upload_counter: "%{done} of %{count} files finished"
-    label_validation_error: "The work package could not be saved due to the following errors:"
-    label_version_plural: "Versions"
-    label_view_has_changed: "This view has unsaved changes. Click to save them."
+    modals:
+      button_apply: "Apply"
+      button_cancel: "Cancel"
+      button_delete: "Delete"
+      button_save: "Save"
+      button_submit: "Submit"
+      destroy_time_entry:
+        text: "Are you sure you want to delete the following time entry?"
 
-    help_texts:
-      show_modal: "Show help text"
-
-    onboarding:
-      buttons:
-        skip: "Skip"
-        next: "Next"
-        got_it: "Got it"
-      steps:
-        help_menu: "The Help (?) menu provides <b>additional help resources</b>. Here you can find a user guide, helpful how-to videos and more. <br> Enjoy your work with OpenProject!"
-        members: "Invite new <b>members</b> to join your project."
-        quick_add_button: "Click on the plus (+) icon in the header navigation to <b>create a new project</b> or to <b>invite coworkers</b>."
-        sidebar_arrow: "Use the return arrow in the top left corner to return to the project’s <b>main menu</b>."
-        welcome: "Take a three-minute introduction tour to learn the most <b>important features</b>. <br> We recommend completing the steps until the end. You can restart the tour any time."
-        wiki: "Within the <b>wiki</b> you can document and share knowledge together with your team."
-        boards:
-          overview: "Select <b>boards</b> to shift the view and manage your project using the agile boards view."
-          lists_kanban: "Here you can create multiple lists (columns) within your board. This feature allows you to create a <b>Kanban board</b>, for example."
-          lists_basic: "Here you can create multiple lists (columns) within your agile board."
-          add: "Click on the plus (+) icon to <b>create a new card</b> or <b>add an existing card</b> to the list on the board."
-          drag: "Drag and drop your cards within a given list to reorder them, or to move them to another list. <br> You can click the info (i) icon in the upper right-hand corner or double-click a card to open its details."
-        wp:
-          toggler: "Now let's have a look at the <b>work package</b> section, which gives you a more detailed view of your work."
-          list: "This <b>work</b> package overview provides a list of all the work in your project, such as tasks, milestones, phases, and more. <br> Work packages can be created and edited directly from this view. To access the details of a particular work package, simply double-click its row."
-          full_view: "The <b>work package details</b> view provides all the relevant information pertaining to a given work package, such as its description, status, priority, activities, dependencies, and comments."
-          back_button: "Use the return arrow in the top left corner to exit and return to the work package list."
-          create_button: "The <b>+ Create</b> button will add a new work package to your project."
-          gantt_menu: "Create project schedules and timelines effortlessly using the Gantt chart module."
-          timeline: "Here you can <b>edit your project plan</b>, create new work packages, such as tasks, milestones, phases, and more, as well as <b>add dependencies</b>. All team members can see and update the latest plan at any time."
-        team_planner:
-          overview: "The team planner lets you visually assign tasks to team members and get an overview of who is working on what."
-          calendar: "The weekly or biweekly planning board displays all work packages assigned to your team members."
-          add_assignee: "To get started, add assignees to the team planner."
-          add_existing: "Search for existing work packages and drag them to the team planner to instantly assign them to a team member and define start and end dates."
-          card: "Drag work packages horizontally to move them backwards or forwards in time, drag the edges to change start and end dates and even drag them vertically to a different row to assign them to another member."
-
+        title: "Confirm deletion of time entry"
+      form_submit:
+        text: "Are you sure you want to perform this action?"
+        title: "Confirm to continue"
+      label_delete_page: "Delete current page"
+      label_name: "Name"
+    no_job_id: "No job ID returned from server."
+    notice_bad_request: "Bad Request."
+    notice_job_started: "job started."
+    notice_no_results_to_display: "No visible results to display."
+    notice_successful_create: "Successful creation."
+    notice_successful_delete: "Successful deletion."
+    notice_successful_update: "Successful update."
     notifications:
-      title: "Notifications"
-      no_unread: "No unread notifications"
-      reasons:
-        mentioned: "Mentioned"
-        watched: "Watcher"
-        assigned: "Assignee"
-        # The enum value is named 'responsible' in the database and that is what is transported through the API
-        # up to the frontend.
-        responsible: "Accountable"
-        created: "Created"
-        scheduled: "Scheduled"
-        commented: "Commented"
-        processed: "Processed"
-        prioritized: "Prioritized"
-        dateAlert: "Date alert"
-        shared: "Shared"
-        reminder: "Reminder"
+      center:
+        and_more_users:
+          one: "and 1 other"
+          other: "and %{count} others"
+        empty_state:
+          no_notification: "Looks like you are all caught up."
+          no_notification_for_filter: "Looks like you are all caught up for this filter."
+          no_notification_with_current_filter: "Looks like you are all caught up for %{filter} filter."
+          no_notification_with_current_project_filter: "Looks like you are all caught up with the selected project."
+          no_selection: "Click on a notification to view all activity details."
+        label_actor_and: "and"
+        mark_all_read: "Mark all as read"
+        mark_all_read_confirmation: "This will mark all notifications in this view as read. Are you sure you want to do this?"
+        mark_as_read: "Mark as read"
+        new_notifications:
+          link_text: "Click here to load them."
+          message: "There are new notifications."
+        no_results:
+          at_all: "New notifications will appear here when there is activity that concerns you."
+          with_current_filter: "There are no notifications in this view at the moment"
+        text_update_date_by: "%{date} by"
+        total_count_warning: "Showing the %{newest_count} most recent notifications. %{more_count} more are not displayed."
       date_alerts:
         milestone_date: "Milestone date"
         overdue: "Overdue"
         overdue_since: "for %{difference_in_days}."
-        property_today: "is today."
         property_is: "is in %{difference_in_days}."
-        property_was: "was %{difference_in_days} ago."
         property_is_deleted: "is deleted."
-      center:
-        label_actor_and: "and"
-        and_more_users:
-          one: "and 1 other"
-          other: "and %{count} others"
-        no_results:
-          at_all: "New notifications will appear here when there is activity that concerns you."
-          with_current_filter: "There are no notifications in this view at the moment"
-        mark_all_read: "Mark all as read"
-        mark_as_read: "Mark as read"
-        mark_all_read_confirmation: "This will mark all notifications in this view as read. Are you sure you want to do this?"
-        text_update_date_by: "%{date} by"
-        total_count_warning: "Showing the %{newest_count} most recent notifications. %{more_count} more are not displayed."
-        empty_state:
-          no_notification: "Looks like you are all caught up."
-          no_notification_with_current_project_filter: "Looks like you are all caught up with the selected project."
-          no_notification_with_current_filter: "Looks like you are all caught up for %{filter} filter."
-          no_notification_for_filter: "Looks like you are all caught up for this filter."
-          no_selection: "Click on a notification to view all activity details."
-        new_notifications:
-          message: "There are new notifications."
-          link_text: "Click here to load them."
+        property_today: "is today."
+        property_was: "was %{difference_in_days} ago."
+      no_unread: "No unread notifications"
+      reasons:
+        assigned: "Assignee"
+        commented: "Commented"
+        created: "Created"
+        dateAlert: "Date alert"
+        mentioned: "Mentioned"
+        prioritized: "Prioritized"
+        processed: "Processed"
+        reminder: "Reminder"
+        # The enum value is named 'responsible' in the database and that is what is transported through the API
+        # up to the frontend.
+        responsible: "Accountable"
+        scheduled: "Scheduled"
+        shared: "Shared"
+        watched: "Watcher"
       reminders:
         note: "Note: “%{note}”"
       settings:
         change_notification_settings: 'You can modify your <a target="_blank" href="%{url}">notification settings</a> to ensure you never miss an important update.'
         title: "Notification settings"
 
+      title: "Notifications"
+    onboarding:
+      buttons:
+        got_it: "Got it"
+        next: "Next"
+        skip: "Skip"
+      steps:
+        boards:
+          add: "Click on the plus (+) icon to <b>create a new card</b> or <b>add an existing card</b> to the list on the board."
+          drag: "Drag and drop your cards within a given list to reorder them, or to move them to another list. <br> You can click the info (i) icon in the upper right-hand corner or double-click a card to open its details."
+          lists_basic: "Here you can create multiple lists (columns) within your agile board."
+          lists_kanban: "Here you can create multiple lists (columns) within your board. This feature allows you to create a <b>Kanban board</b>, for example."
+          overview: "Select <b>boards</b> to shift the view and manage your project using the agile boards view."
+        help_menu: "The Help (?) menu provides <b>additional help resources</b>. Here you can find a user guide, helpful how-to videos and more. <br> Enjoy your work with OpenProject!"
+        members: "Invite new <b>members</b> to join your project."
+        quick_add_button: "Click on the plus (+) icon in the header navigation to <b>create a new project</b> or to <b>invite coworkers</b>."
+        sidebar_arrow: "Use the return arrow in the top left corner to return to the project’s <b>main menu</b>."
+        team_planner:
+          add_assignee: "To get started, add assignees to the team planner."
+          add_existing: "Search for existing work packages and drag them to the team planner to instantly assign them to a team member and define start and end dates."
+          calendar: "The weekly or biweekly planning board displays all work packages assigned to your team members."
+          card: "Drag work packages horizontally to move them backwards or forwards in time, drag the edges to change start and end dates and even drag them vertically to a different row to assign them to another member."
+
+          overview: "The team planner lets you visually assign tasks to team members and get an overview of who is working on what."
+        welcome: "Take a three-minute introduction tour to learn the most <b>important features</b>. <br> We recommend completing the steps until the end. You can restart the tour any time."
+        wiki: "Within the <b>wiki</b> you can document and share knowledge together with your team."
+        wp:
+          back_button: "Use the return arrow in the top left corner to exit and return to the work package list."
+          create_button: "The <b>+ Create</b> button will add a new work package to your project."
+          full_view: "The <b>work package details</b> view provides all the relevant information pertaining to a given work package, such as its description, status, priority, activities, dependencies, and comments."
+          gantt_menu: "Create project schedules and timelines effortlessly using the Gantt chart module."
+          list: "This <b>work</b> package overview provides a list of all the work in your project, such as tasks, milestones, phases, and more. <br> Work packages can be created and edited directly from this view. To access the details of a particular work package, simply double-click its row."
+          timeline: "Here you can <b>edit your project plan</b>, create new work packages, such as tasks, milestones, phases, and more, as well as <b>add dependencies</b>. All team members can see and update the latest plan at any time."
+          toggler: "Now let's have a look at the <b>work package</b> section, which gives you a more detailed view of your work."
+    open_project_storage_modal:
+      waiting_subtitle:
+        network_off: "There is a network problem."
+        network_on: "Network is back. We are trying."
+      waiting_title:
+        timeout: "Timeout"
     pagination:
       no_other_page: "You are on the only page."
-      pages_skipped: "Pages skipped."
       page_navigation: "Pagination navigation"
-      per_page_navigation: 'Items per page selection'
       pages:
         page_number: Page %{number}
         show_per_page: Show %{number} per page
 
+      pages_skipped: "Pages skipped."
+      per_page_navigation: 'Items per page selection'
     placeholders:
       default: "-"
-      subject: "Enter subject here"
-      selection: "Please select"
       description: "Description: Click to edit..."
       relation_description: "Click to add description for this relation"
 
+      selection: "Please select"
+      subject: "Enter subject here"
     project:
       autocompleter:
         label: "Project autocompletion"
@@ -634,229 +781,291 @@ en:
         Please choose a project to create the work package in to see all attributes.
         You can only select projects which have the type above activated.
 
-    text_are_you_sure: "Are you sure?"
-    text_are_you_sure_to_cancel: "You have unsaved changes on this page. Are you sure you want to discard them?"
-    breadcrumb: "Breadcrumb"
-    text_data_lost: "All entered data will be lost."
-    text_user_wrote: "%{value} wrote:"
-
-    time_entry:
-      work_package_required: "Requires selecting a work package first."
-      title: "Log time"
-      tracking: "Time tracking"
-      stop: "Stop"
-
-    timer:
-      start_new_timer: "Start new timer"
-      timer_already_running: "To start a new timer, you must first stop the current timer:"
-      timer_already_stopped: "No active timer for this work package, have you stopped it in another window?"
-      tracking_time: "Tracking time"
-      button_stop: "Stop current timer"
-
-    two_factor_authentication:
-      label_two_factor_authentication: "Two-factor authentication"
-
-    watchers:
-      label_loading: loading watchers...
-      label_error_loading: An error occurred while loading the watchers
-      label_search_watchers: Search watchers
-      label_add: Add watchers
-      label_discard: Discard selection
-      typeahead_placeholder: Search for possible watchers
-
-    relation_labels:
-      parent: "Parent"
-      child: "Child"
-      children: "Children"
-      relates: "Related To"
-      duplicates: "Duplicates"
-      duplicated: "Duplicated by"
-      blocks: "Blocks"
-      blocked: "Blocked by"
-      precedes: "Precedes"
-      follows: "Follows"
-      includes: "Includes"
-      partof: "Part of"
-      requires: "Requires"
-      required: "Required by"
-
-      relation_type: "relation type"
-
-    relations_hierarchy:
-      parent_headline: "Parent"
-      hierarchy_headline: "Hierarchy"
-      children_headline: "Children"
-
-    relation_buttons:
-      set_parent: "Set parent"
-      change_parent: "Change parent"
-      remove_parent: "Remove parent"
-      hierarchy_indent: "Indent hierarchy"
-      hierarchy_outdent: "Outdent hierarchy"
-      group_by_wp_type: "Group by work package type"
-      group_by_relation_type: "Group by relation type"
-      add_parent: "Add existing parent"
-      add_new_child: "Create new child"
-      create_new: "Create new"
-      add_existing: "Add existing"
-      add_existing_child: "Add child"
-      remove_child: "Remove child"
-      add_new_relation: "Create new relation"
-      add_existing_relation: "Add existing relation"
-      update_description: "Set or update description of this relation"
-      toggle_description: "Toggle relation description"
-      update_relation: "Click to change the relation type"
-      show_relations: "Show relations"
-      add_predecessor: "Add predecessor"
-      add_successor: "Add successor"
-      remove: "Remove relation"
-      save: "Save relation"
-      abort: "Abort"
-
-    relations_autocomplete:
-      placeholder: "Type to search"
-      parent_placeholder: "Choose new parent or press escape to cancel."
-
-    autocompleter:
-      placeholder: "Type to search"
-      notFoundText: "No items found"
-      search: "Search"
-      project:
-        placeholder: "Select project"
-
-    repositories:
-      select_tag: "Select tag"
-      select_branch: "Select branch"
-
-    field_value_enter_prompt: "Enter a value for '%{field}'"
-
     project_menu_details: "Details"
 
+    projects:
+      identifier_suggestion:
+        loading: "Loading suggestion..."
+        set_name_first: "Please set the name first."
+    relation_buttons:
+      abort: "Abort"
+
+      add_existing: "Add existing"
+      add_existing_child: "Add child"
+      add_existing_relation: "Add existing relation"
+      add_new_child: "Create new child"
+      add_new_relation: "Create new relation"
+      add_parent: "Add existing parent"
+      add_predecessor: "Add predecessor"
+      add_successor: "Add successor"
+      change_parent: "Change parent"
+      create_new: "Create new"
+      group_by_relation_type: "Group by relation type"
+      group_by_wp_type: "Group by work package type"
+      hierarchy_indent: "Indent hierarchy"
+      hierarchy_outdent: "Outdent hierarchy"
+      remove: "Remove relation"
+      remove_child: "Remove child"
+      remove_parent: "Remove parent"
+      save: "Save relation"
+      set_parent: "Set parent"
+      show_relations: "Show relations"
+      toggle_description: "Toggle relation description"
+      update_description: "Set or update description of this relation"
+      update_relation: "Click to change the relation type"
+    relation_labels:
+      blocked: "Blocked by"
+      blocks: "Blocks"
+      child: "Child"
+      children: "Children"
+      duplicated: "Duplicated by"
+      duplicates: "Duplicates"
+      follows: "Follows"
+      includes: "Includes"
+      parent: "Parent"
+      partof: "Part of"
+      precedes: "Precedes"
+      relates: "Related To"
+      relation_type: "relation type"
+
+      required: "Required by"
+
+      requires: "Requires"
+    relations:
+      empty: No relation exists
+      remove: Remove relation
+    relations_autocomplete:
+      parent_placeholder: "Choose new parent or press escape to cancel."
+
+      placeholder: "Type to search"
+    relations_hierarchy:
+      children_headline: "Children"
+
+      hierarchy_headline: "Hierarchy"
+      parent_headline: "Parent"
+    repositories:
+      select_branch: "Select branch"
+
+      select_tag: "Select tag"
+    sharing:
+      selected_count: "%{count} selected"
+      selection:
+        mixed: "Mixed"
+      share: "Share"
     sort:
-      sorted_asc: "Ascending sort applied, "
-      sorted_dsc: "Descending sort applied, "
-      sorted_no: "No sort applied, "
-      sorting_disabled: "sorting is disabled"
       activate_asc: "activate to apply an ascending sort"
       activate_dsc: "activate to apply a descending sort"
       activate_no: "activate to remove the sort"
 
-    text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
+      sorted_asc: "Ascending sort applied, "
+      sorted_dsc: "Descending sort applied, "
+      sorted_no: "No sort applied, "
+      sorting_disabled: "sorting is disabled"
+    spot:
+      drop_modal:
+        close: "Close modal"
+        focus_grab: "This is a focus anchor for modals. Press shift+tab to go back to the modal trigger element."
+      filter_chip:
+        remove: "Remove"
+    text_are_you_sure: "Are you sure?"
+    text_are_you_sure_to_cancel: "You have unsaved changes on this page. Are you sure you want to discard them?"
+    text_data_lost: "All entered data will be lost."
     text_query_destroy_confirmation: "Are you sure you want to delete the selected view?"
+    text_user_wrote: "%{value} wrote:"
+
+    text_work_packages_destroy_confirmation: "Are you sure you want to delete the selected work package(s)?"
+    time_entry:
+      stop: "Stop"
+
+      title: "Log time"
+      tracking: "Time tracking"
+      work_package_required: "Requires selecting a work package first."
+    timer:
+      button_stop: "Stop current timer"
+
+      start_new_timer: "Start new timer"
+      timer_already_running: "To start a new timer, you must first stop the current timer:"
+      timer_already_stopped: "No active timer for this work package, have you stopped it in another window?"
+      tracking_time: "Tracking time"
     tl_toolbar:
-      zooms: "Zoom level"
       outlines: "Hierarchy level"
+      zooms: "Zoom level"
+    toolbar:
+      filter: "Filter"
+      search_query_label: "Search saved views"
+      settings:
+        columns: "Columns"
+        configure_view: "Configure view"
+        delete: "Delete"
+        display_hierarchy: "Display hierarchy"
+        display_sums: "Display sums"
+        export: "Export"
+        group_by: "Group by"
+        hide_hierarchy: "Hide hierarchy"
+        hide_sums: "Hide sums"
+        page_settings: "Rename view"
+        save: "Save"
+        save_as: "Save as"
+        share_calendar: "Subscribe to calendar"
+        sort_by: "Sort by"
+        visibility_settings: "Visibility settings"
+      unselected_title: "Work package"
+    two_factor_authentication:
+      label_two_factor_authentication: "Two-factor authentication"
+
+    units:
+      child_work_packages:
+        one: "one child work package"
+        other: "%{count} work package children"
+      day:
+        one: "1 day"
+        other: "%{count} days"
+        zero: "0 days"
+      hour:
+        one: "1 h"
+        other: "%{count} h"
+        zero: "0 h"
+      hour_string: "%{hours} h"
+      word:
+        one: "1 word"
+        other: "%{count} words"
+      workPackage:
+        one: "work package"
+        other: "work packages"
     upsell:
       ee_only: "Enterprise edition add-on"
+    views:
+      card: "Cards"
+      list: "Table"
+      timeline: "Gantt"
+
+    watchers:
+      label_add: Add watchers
+      label_discard: Discard selection
+      label_error_loading: An error occurred while loading the watchers
+      label_loading: loading watchers...
+      label_search_watchers: Search watchers
+      typeahead_placeholder: Search for possible watchers
+
     wiki_formatting:
-      strong: "Strong"
-      italic: "Italic"
-      underline: "Underline"
-      deleted: "Deleted"
       code: "Inline Code"
+      deleted: "Deleted"
       heading1: "Heading 1"
       heading2: "Heading 2"
       heading3: "Heading 3"
-      unordered_list: "Unordered List"
-      ordered_list: "Ordered List"
-      quote: "Quote"
-      unquote: "Unquote"
-      preformatted_text: "Preformatted Text"
-      wiki_link: "Link to a Wiki page"
       image: "Image"
-    sharing:
-      share: "Share"
-      selected_count: "%{count} selected"
-      selection:
-        mixed: "Mixed"
+      italic: "Italic"
+      ordered_list: "Ordered List"
+      preformatted_text: "Preformatted Text"
+      quote: "Quote"
+      strong: "Strong"
+      underline: "Underline"
+      unordered_list: "Unordered List"
+      unquote: "Unquote"
+      wiki_link: "Link to a Wiki page"
     work_packages:
+      baseline:
+        addition_label: "Added to view within the comparison time period"
+        column_incompatible: "This column does not show changes in Baseline mode."
+        modification_label: "Modified within the comparison time period"
+        removal_label: "Removed from view within the comparison time period"
       bulk_actions:
-        edit: "Bulk edit"
         delete: "Bulk delete"
         duplicate: "Bulk duplicate"
+        edit: "Bulk edit"
         move: "Bulk change of project"
       button_clear: "Clear"
       comment_added: "The comment was successfully added."
       comment_send_failed: "An error has occurred. Could not submit the comment."
       comment_updated: "The comment was successfully updated."
       confirm_edit_cancel: "Are you sure you want to cancel editing the work package?"
-      description_filter: "Filter"
+      create:
+        button: "Create"
+        header: "New %{type}"
+        header_no_type: "New work package (Type not yet set)"
+        header_with_parent: "New %{type} (Child of %{parent_type} #%{id})"
+        title: "New work package"
+      default_queries:
+        all_open: "All open"
+        assigned_to_me: "Assigned to me"
+        created_by_me: "Created by me"
+        latest_activity: "Latest activity"
+        manually_sorted: "New manually sorted query"
+        overdue: "Overdue"
+        recently_created: "Recently created"
+        shared_with_me: "Shared with me"
+        shared_with_users: "Shared with users"
+        summary: "Summary"
       description_enter_text: "Enter text"
+      description_filter: "Filter"
       description_options_hide: "Hide options"
       description_options_show: "Show options"
+      duplicate:
+        title: "Duplicate work package"
       edit_attribute: "%{attribute} - Edit"
+      faulty_query:
+        description: Your view is erroneous and could not be processed.
+        title: Work packages could not be loaded.
+      filters:
+        baseline_incompatible: "This filter attribute is not taken into consideration in Baseline mode."
+        baseline_warning: "Baseline mode is on but some of your active filters are not included in the comparison."
+        title: "Filter work packages"
+      hierarchy:
+        children_collapsed: "Hierarchy level %{level}, collapsed. Click to show the filtered children"
+        children_expanded: "Hierarchy level %{level}, expanded. Click to collapse the filtered children"
+        hide: "Hide hierarchy mode"
+        leaf: "Work package leaf at level %{level}."
+        show: "Show hierarchy mode"
+        toggle_button: "Click to toggle hierarchy mode."
+      inline_create:
+        title: "Click here to add a new work package to this list"
+      jump_marks:
+        content: "Jump to content"
+        label_content: "Click here to skip over the menu and go to the content"
+        label_pagination: "Click here to skip over the work packages table and go to pagination"
+        pagination: "Jump to table pagination"
       key_value: "%{key}: %{value}"
-      label_enable_multi_select: "Enable multiselect"
+      label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
       label_disable_multi_select: "Disable multiselect"
+      label_enable_multi_select: "Enable multiselect"
       label_filter_add: "Add filter"
       label_filter_by_text: "Filter by text"
       label_options: "Options"
-      label_column_multiselect: "Combined dropdown field: Select with arrow keys, confirm selection with enter, delete with backspace"
+      limited_results: Only %{count} work packages can be shown in manual sorting mode. Please reduce the results by filtering, or switch to automatic sorting.
       message_error_during_bulk_delete: An error occurred while trying to delete work packages.
       message_successful_bulk_delete: Successfully deleted work packages.
       message_successful_show_in_fullscreen: "Click here to open this work package in fullscreen view."
       message_view_spent_time: "Show spent time for this work package"
       message_work_package_read_only: "Work package is locked in this status. No attribute other than status can be altered."
       message_work_package_status_blocked: "Work package status is not writable due to closed status and closed version being assigned."
+      no_results:
+        description: Either none have been created or all work packages are filtered out.
+        title: No work packages to display.
       placeholder_filter_by_text: "Subject, description, comments, ..."
+      placeholders:
+        date: "Select date"
+        default: "-"
       progress:
         title: "Work estimates and progress"
-      baseline:
-        addition_label: "Added to view within the comparison time period"
-        removal_label: "Removed from view within the comparison time period"
-        modification_label: "Modified within the comparison time period"
-        column_incompatible: "This column does not show changes in Baseline mode."
-      filters:
-        title: "Filter work packages"
-        baseline_incompatible: "This filter attribute is not taken into consideration in Baseline mode."
-        baseline_warning: "Baseline mode is on but some of your active filters are not included in the comparison."
-      inline_create:
-        title: "Click here to add a new work package to this list"
-      create:
-        title: "New work package"
-        header: "New %{type}"
-        header_no_type: "New work package (Type not yet set)"
-        header_with_parent: "New %{type} (Child of %{parent_type} #%{id})"
-        button: "Create"
-      duplicate:
-        title: "Duplicate work package"
-      hierarchy:
-        show: "Show hierarchy mode"
-        hide: "Hide hierarchy mode"
-        toggle_button: "Click to toggle hierarchy mode."
-        leaf: "Work package leaf at level %{level}."
-        children_collapsed: "Hierarchy level %{level}, collapsed. Click to show the filtered children"
-        children_expanded: "Hierarchy level %{level}, expanded. Click to collapse the filtered children"
-      faulty_query:
-        title: Work packages could not be loaded.
-        description: Your view is erroneous and could not be processed.
-      no_results:
-        title: No work packages to display.
-        description: Either none have been created or all work packages are filtered out.
-      limited_results: Only %{count} work packages can be shown in manual sorting mode. Please reduce the results by filtering, or switch to automatic sorting.
-      property_groups:
-        details: "Details"
-        people: "People"
-        estimatesAndTime: "Estimates & Time"
-        other: "Other"
       properties:
         assignee: "Assignee"
         author: "Author"
+        category: "Category"
         createdAt: "Created on"
-        description: "Description"
         date: "Date"
-        percentComplete: "% Complete"
-        percentCompleteAlternative: "Progress"
+        description: "Description"
         dueDate: "Finish date"
         duration: "Duration"
-        spentTime: "Spent time"
-        category: "Category"
+        percentComplete: "% Complete"
+        percentCompleteAlternative: "Progress"
         percentageDone: "Percentage done"
         priority: "Priority"
         projectName: "Project"
+        remainingTime: "Remaining work"
         remainingWork: "Remaining work"
         remainingWorkAlternative: "Remaining hours"
         responsible: "Responsible"
+        spentTime: "Spent time"
         startDate: "Start date"
         status: "Status"
         subject: "Subject"
@@ -864,315 +1073,105 @@ en:
         title: "Title"
         type: "Type"
         updatedAt: "Updated on"
-        versionName: "Version"
         version: "Version"
+        versionName: "Version"
         work: "Work"
         workAlternative: "Estimated time"
-        remainingTime: "Remaining work"
-      default_queries:
-        manually_sorted: "New manually sorted query"
-        latest_activity: "Latest activity"
-        created_by_me: "Created by me"
-        assigned_to_me: "Assigned to me"
-        recently_created: "Recently created"
-        all_open: "All open"
-        overdue: "Overdue"
-        summary: "Summary"
-        shared_with_users: "Shared with users"
-        shared_with_me: "Shared with me"
-      jump_marks:
-        pagination: "Jump to table pagination"
-        label_pagination: "Click here to skip over the work packages table and go to pagination"
-        content: "Jump to content"
-        label_content: "Click here to skip over the menu and go to the content"
-      placeholders:
-        default: "-"
-        date: "Select date"
+      property_groups:
+        details: "Details"
+        estimatesAndTime: "Estimates & Time"
+        other: "Other"
+        people: "People"
       query:
+        click_to_edit_query_name: "Click to edit title of this view."
         column_names: "Columns"
-        group_by: "Group results by"
+        confirm_edit_cancel: "Are you sure you want to cancel editing the name of this view? Title will be set back to previous value."
+        display_sums: "Display Sums"
+        errors:
+          duplicate_query_title: "Name of this view already exists. Change anyway?"
+          not_found: "There is no such view"
+          unretrievable_query: "Unable to retrieve view from URL"
+        filters: "Filters"
         group: "Group by"
+        group_by: "Group results by"
         group_by_disabled_by_hierarchy: "Group by is disabled due to the hierarchy mode being active."
+        hide_column: "Hide column"
         hierarchy_disabled_by_group_by: "Hierarchy mode is disabled due to results being grouped by %{column}."
-        sort_ascending: "Sort ascending"
-        sort_descending: "Sort descending"
+        insert_columns: "Insert columns"
         move_column_left: "Move column left"
         move_column_right: "Move column right"
-        hide_column: "Hide column"
-        insert_columns: "Insert columns"
-        filters: "Filters"
-        display_sums: "Display Sums"
-        confirm_edit_cancel: "Are you sure you want to cancel editing the name of this view? Title will be set back to previous value."
-        click_to_edit_query_name: "Click to edit title of this view."
-        rename_query_placeholder: "Name of this view"
-        star_text: "Mark this view as favorite and add to the saved views sidebar on the left."
         public_text: >
           Publish this view, allowing other users to access your view. Users with the 'Manage public views' permission can modify or remove public query.
           This does not affect the visibility of work package results in that view and depending on their permissions, users may see different results.
-        errors:
-          unretrievable_query: "Unable to retrieve view from URL"
-          not_found: "There is no such view"
-          duplicate_query_title: "Name of this view already exists. Change anyway?"
+        rename_query_placeholder: "Name of this view"
+        sort_ascending: "Sort ascending"
+        sort_descending: "Sort descending"
+        star_text: "Mark this view as favorite and add to the saved views sidebar on the left."
         text_no_results: "No matching views were found."
       reminders:
         button_label: "Set reminder"
-        title:
-          new: "Set a reminder"
-          edit: "Edit reminder"
-        subtitle: "You will receive a notification for this work package at the chosen time."
         presets:
-          tomorrow: "Tomorrow"
-          three_days: "In 3 days"
-          week: "In a week"
-          month: "In a month"
           custom: "At a particular date/time"
+          month: "In a month"
+          three_days: "In 3 days"
+          tomorrow: "Tomorrow"
+          week: "In a week"
+        subtitle: "You will receive a notification for this work package at the chosen time."
+        title:
+          edit: "Edit reminder"
+          new: "Set a reminder"
       scheduling:
         is_parent: "The dates of this work package are automatically deduced from its children. Activate 'Manual scheduling' to set the dates."
         is_switched_from_manual_to_automatic: "The dates of this work package may need to be recalculated after switching from manual to automatic scheduling due to relationships with other work packages."
       sharing:
-        title: "Share work package"
         show_all_users: "Show all users with whom the work package has been shared with"
+        title: "Share work package"
       table:
         configure_button: "Configure work package table"
         summary: "Table with rows of work package and columns of work package attributes."
         text_inline_edit: "Most cells of this table are buttons that activate inline-editing functionality of that attribute."
-        text_sort_hint: "With the links in the table headers you can sort, group, reorder, remove and add table columns."
         text_select_hint: "Select boxes should be opened with 'ALT' and arrow keys."
+        text_sort_hint: "With the links in the table headers you can sort, group, reorder, remove and add table columns."
       table_configuration:
         button: "Configure this work package table"
         choose_display_mode: "Display work packages as"
-        modal_title: "Work package table configuration"
-        embedded_tab_disabled: "This configuration tab is not available for the embedded view you are editing."
+        columns_help_text: "Use the input field above to add columns to your table view. You can drag and drop the columns to reorder them."
         default: "default"
-        display_settings: "Display settings"
         default_mode: "Flat list"
-        hierarchy_mode: "Hierarchy"
-        hierarchy_hint: "All filtered table results will be augmented with their ancestors. Hierarchies can be expanded and collapsed."
+        display_settings: "Display settings"
         display_sums_hint: "Display sums of all summable attributes in a row below the table results."
-        show_timeline_hint: "Show an interactive gantt chart on the right side of the table. You can change its width by dragging the divider between table and gantt chart."
+        embedded_tab_disabled: "This configuration tab is not available for the embedded view you are editing."
+        hierarchy_hint: "All filtered table results will be augmented with their ancestors. Hierarchies can be expanded and collapsed."
+        hierarchy_mode: "Hierarchy"
         highlighting: "Highlighting"
         highlighting_mode:
           description: "Highlight with color"
-          none: "No highlighting"
+          entire_row_by: "Entire row by"
           inline: "Highlighted attribute(s)"
           inline_all: "All attributes"
-          entire_row_by: "Entire row by"
-          status: "Status"
+          none: "No highlighting"
           priority: "Priority"
+          status: "Status"
           type: "Type"
-        sorting_mode:
-          description: "Chose the mode to sort your Work packages:"
-          automatic: "Automatic"
-          manually: "Manually"
-          warning: "You will lose your previous sorting when activating the automatic sorting mode."
-        columns_help_text: "Use the input field above to add columns to your table view. You can drag and drop the columns to reorder them."
+        modal_title: "Work package table configuration"
         relation_filters:
           filter_work_packages_by_relation_type: "Filter work packages by relation type"
+        show_timeline_hint: "Show an interactive gantt chart on the right side of the table. You can change its width by dragging the divider between table and gantt chart."
+        sorting_mode:
+          automatic: "Automatic"
+          description: "Chose the mode to sort your Work packages:"
+          manually: "Manually"
+          warning: "You will lose your previous sorting when activating the automatic sorting mode."
       tabs:
-        overview: Overview
         activity: Activity
+        files: Files
+        overview: Overview
         relations: Relations
         watchers: Watchers
-        files: Files
       time_relative:
         days: "days"
-        weeks: "weeks"
         months: "months"
-    toolbar:
-      settings:
-        configure_view: "Configure view"
-        columns: "Columns"
-        sort_by: "Sort by"
-        group_by: "Group by"
-        display_sums: "Display sums"
-        display_hierarchy: "Display hierarchy"
-        hide_hierarchy: "Hide hierarchy"
-        hide_sums: "Hide sums"
-        save: "Save"
-        save_as: "Save as"
-        export: "Export"
-        visibility_settings: "Visibility settings"
-        share_calendar: "Subscribe to calendar"
-        page_settings: "Rename view"
-        delete: "Delete"
-      filter: "Filter"
-      unselected_title: "Work package"
-      search_query_label: "Search saved views"
-    modals:
-      label_name: "Name"
-      label_delete_page: "Delete current page"
-      button_apply: "Apply"
-      button_save: "Save"
-      button_submit: "Submit"
-      button_cancel: "Cancel"
-      button_delete: "Delete"
-      form_submit:
-        title: "Confirm to continue"
-        text: "Are you sure you want to perform this action?"
-      destroy_time_entry:
-        title: "Confirm deletion of time entry"
-        text: "Are you sure you want to delete the following time entry?"
-
-    notice_no_results_to_display: "No visible results to display."
-    notice_successful_create: "Successful creation."
-    notice_successful_delete: "Successful deletion."
-    notice_successful_update: "Successful update."
-    notice_job_started: "job started."
-    no_job_id: "No job ID returned from server."
-    invalid_job_response: "Invalid response from server."
-
-    notice_bad_request: "Bad Request."
-    relations:
-      empty: No relation exists
-      remove: Remove relation
-    inplace:
-      button_edit: "%{attribute}: Edit"
-      button_save: "%{attribute}: Save"
-      button_cancel: "%{attribute}: Cancel"
-      button_save_all: "Save"
-      button_cancel_all: "Cancel"
-      link_formatting_help: "Text formatting help"
-      btn_preview_enable: "Preview"
-      btn_preview_disable: "Disable preview"
-      null_value_label: "No value"
-      clear_value_label: "-"
-      errors:
-        required: "%{field} cannot be empty"
-        number: "%{field} is not a valid number"
-        maxlength: "%{field} cannot contain more than %{maxLength} digit(s)"
-        minlength: "%{field} cannot contain less than %{minLength} digit(s)"
-        messages_on_field: "This field is invalid: %{messages}"
-
-    error_could_not_resolve_version_name: "Couldn't resolve version name"
-    error_could_not_resolve_user_name: "Couldn't resolve user name"
-    error_attachment_upload: "File failed to upload: %{error}"
-    error_attachment_upload_permission: "You don't have the permission to upload files on this resource."
-
-    units:
-      workPackage:
-        one: "work package"
-        other: "work packages"
-      child_work_packages:
-        one: "one child work package"
-        other: "%{count} work package children"
-      hour_string: "%{hours} h"
-      hour:
-        one: "1 h"
-        other: "%{count} h"
-        zero: "0 h"
-      day:
-        one: "1 day"
-        other: "%{count} days"
-        zero: "0 days"
-      word:
-        one: "1 word"
-        other: "%{count} words"
+        weeks: "weeks"
     zen_mode:
       button_activate: "Activate zen mode"
       button_deactivate: "Deactivate zen mode"
-    global_search:
-      all_projects: "In all projects"
-      close_search: "Close search"
-      items_available: "%{count} items available"
-      direct_hit_available: "Work package with exact ID found. Press Enter to open it."
-      current_project_and_all_descendants: "In this project + subprojects"
-      current_project: "In this project"
-      recently_viewed: "Recently viewed"
-      search_placeholder_expanded: "Search work packages by subject, project, type, status or ID"
-      title:
-        all_projects: "all projects"
-        project_and_subprojects: "and all subprojects"
-        search_for: "Search for"
-
-    views:
-      card: "Cards"
-      list: "Table"
-      timeline: "Gantt"
-
-    invite_user_modal:
-      invite: "Invite"
-      placeholder_add_tag: "Create placeholder user"
-
-    exclusion_info:
-      modal:
-        title: "Status excluded from hierarchy totals"
-        content: >-
-          The status '%{status_name}' has been configured to be excluded from hierarchy
-          totals of Work, Remaining work, and % Complete. The totals do not take
-          this value into account.
-
-    favorite_projects:
-      no_results: "You have no favorite projects"
-      no_results_subtext: "Add one or multiple projects as favorite through their overview or in a project list."
-
-    include_projects:
-      toggle_title: "Include projects"
-      title: "Projects"
-      clear_selection: "Clear selection"
-      apply: "Apply"
-      selected_filter:
-        all: "All projects"
-        selected: "Only selected"
-      search_placeholder: "Search projects..."
-      include_subprojects: "Include all sub-projects"
-      tooltip:
-        include_all_selected: "Project already included since Include all sub-projects is enabled."
-        current_project: "This is the current project you are in."
-        does_not_match_search: "Project does not match the search criteria."
-      no_results: "No project matches your search criteria."
-    include_workspaces:
-      types:
-        program: "Program"
-        portfolio: "Portfolio"
-    baseline:
-      toggle_title: "Baseline"
-      clear: "Clear"
-      apply: "Apply"
-      header_description: "Highlight changes made to this list since any point in the past."
-      show_changes_since: "Show changes since"
-      help_description: "Reference time zone for the baseline."
-      time_description: "In your local time: %{datetime}"
-      time: "Time"
-      from: "From"
-      to: "To"
-      drop_down:
-        none: "-"
-        yesterday: "yesterday"
-        last_working_day: "last working day"
-        last_week: "last week"
-        last_month: "last month"
-        a_specific_date: "a specific date"
-        between_two_specific_dates: "between two specific dates"
-      legends:
-        changes_since: "Changes since"
-        changes_between: "Changes between"
-        now_meets_filter_criteria: "Now meets filter criteria"
-        no_longer_meets_filter_criteria: "No longer meets filter criteria"
-        maintained_with_changes: "Maintained with changes"
-        in_your_timezone: "In your local timezone:"
-      icon_tooltip:
-        added: "Added to view within the comparison time period"
-        removed: "Removed from view within the comparison time period"
-        changed: "Maintained with modifications"
-    forms:
-      submit_success_message: "The form was successfully submitted"
-      load_error_message: "There was an error loading the form"
-      validation_error_message: "Please fix the errors present in the form"
-      advanced_settings: "Advanced settings"
-
-    spot:
-      filter_chip:
-        remove: "Remove"
-      drop_modal:
-        focus_grab: "This is a focus anchor for modals. Press shift+tab to go back to the modal trigger element."
-        close: "Close modal"
-    open_project_storage_modal:
-      waiting_title:
-        timeout: "Timeout"
-      waiting_subtitle:
-        network_off: "There is a network problem."
-        network_on: "Network is back. We are trying."
-    projects:
-      identifier_suggestion:
-        loading: "Loading suggestion..."
-        set_name_first: "Please set the name first."

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,3 +31,8 @@ pre-commit:
       files: git diff --name-only --staged
       glob: "{Gemfile.lock,frontend/package.json}"
       run: script/check_same_primer_view_components_version_everywhere
+    sort-locales:
+      files: git diff --name-only --staged
+      glob: "**/config/locales/{en,js-en}.yml"
+      run: python3 script/i18n/sort_locales.py {files}
+      stage_fixed: true

--- a/modules/auth_saml/config/locales/en.yml
+++ b/modules/auth_saml/config/locales/en.yml
@@ -3,150 +3,93 @@ en:
   activerecord:
     attributes:
       saml/provider:
-        display_name: Name
-        identifier: Identifier
-        secret: Secret
-        scope: Scope
         assertion_consumer_service_url: ACS (Assertion consumer service) URL
-        limit_self_registration: Limit self registration
-        sp_entity_id: Service entity ID
-        metadata_url: Identity provider metadata URL
-        name_identifier_format: Name identifier format
-        idp_entity_id: Identity provider entity ID
-        idp_sso_service_url: Identity provider login endpoint
-        idp_slo_service_url: Identity provider logout endpoint
-        idp_cert: Public certificate of identity provider
         authn_requests_signed: Sign SAML AuthnRequests
-        want_assertions_signed: Require signed responses
-        want_assertions_encrypted: Require encrypted responses
         certificate: Certificate used by OpenProject for SAML requests
-        private_key: Corresponding private key for OpenProject SAML requests
-        signature_method: Signature algorithm
         digest_method: Digest algorithm
+        display_name: Name
         format: "Format"
         icon: "Custom icon"
+        identifier: Identifier
+        idp_cert: Public certificate of identity provider
+        idp_entity_id: Identity provider entity ID
+        idp_slo_service_url: Identity provider logout endpoint
+        idp_sso_service_url: Identity provider login endpoint
+        limit_self_registration: Limit self registration
+        metadata_url: Identity provider metadata URL
+        name_identifier_format: Name identifier format
+        private_key: Corresponding private key for OpenProject SAML requests
+        scope: Scope
+        secret: Secret
+        signature_method: Signature algorithm
+        sp_entity_id: Service entity ID
+        want_assertions_encrypted: Require encrypted responses
+        want_assertions_signed: Require signed responses
     errors:
       models:
         saml/provider:
+          certificate_expired: "is expired and can no longer be used."
           invalid_certificate: "is not a valid PEM-formatted certificate: %{additional_message}"
           invalid_private_key: "is not a valid PEM-formatted private key: %{additional_message}"
-          certificate_expired: "is expired and can no longer be used."
           unmatched_private_key: "does not belong to the given certificate"
   saml:
-    menu_title: SAML providers
-    delete_title: Delete SAML provider
     delete_heading: Delete this SAML provider?
+    delete_title: Delete SAML provider
     info:
-      title: "SAML Protocol Configuration Parameters"
       description: >
         Use these parameters to configure your identity provider connection to OpenProject.
-    metadata_parser:
-      success: "Successfully updated the configuration using the identity provider metadata."
-      invalid_url: "Provided metadata URL is invalid. Provide a HTTP(s) URL."
-      error: "Failed to retrieve the identity provider metadata: %{error}"
-      federation_metadata: >
-        The metadata URL points to a federation aggregate (many identity providers).
-        Use your institution's direct metadata URL, or enter your institution's IdP entity ID in the metadata form and try again.
-      metadata_too_large: "The metadata file exceeds the maximum allowed size."
-    providers:
-      label_empty_title: "No SAML providers configured yet."
-      label_empty_description: "Add a provider to see them here."
-      label_automatic_configuration: Automatic configuration
-      label_metadata: Metadata
-      label_metadata_endpoint: OpenProject metadata endpoint
-      label_openproject_information: OpenProject information
-      label_configuration_details: "Identity provider endpoints and certificates"
-      label_configuration_encryption: "Signatures and Encryption"
-      label_add_new: New SAML identity provider
-      label_edit: Edit SAML identity provider %{name}
-      label_uid: Internal user id
-      label_mapping: Mapping
-      label_requested_attribute_for: "Requested attribute for: %{attribute}"
-
-      no_results_table: No SAML identity providers have been defined yet.
-      notice_created: A new SAML identity provider was successfully created.
-      plural: SAML identity providers
-      singular: SAML identity provider
-      requested_attributes: Requested attributes
-      attribute_mapping: Attribute mapping
-      attribute_mapping_text: >
-        The following fields control which attributes provided by the SAML identity provider
-        are used to provide user attributes in OpenProject
-      metadata:
-        dialog: "This is the URL where the OpenProject SAML metadata is available. Optionally use it to configure your identity provider:"
-      upsell:
-        title: "Single Sign-On (SSO) with SAML"
-        description: Connect OpenProject to a SAML identity provider
-      request_attributes:
-        title: 'Requested attributes'
-        legend: >
-          These attributes are added to the SAML XML metadata to signify to the identify provider which attributes OpenProject requires.
-          You may still need to explicitly configure your identity provider to send these attributes. Please refer to your IdP's documentation.
-        name: 'Requested attribute key'
-        format: 'Attribute format'
-      section_headers:
-        configuration: "Primary configuration"
-        attributes: "Attributes"
-      section_texts:
-        display_name: "Configure the display name of the SAML provider."
-        metadata: "Pre-fill configuration using a metadata URL or by pasting metadata XML"
-        metadata_form: "If your identity provider has a metadata endpoint or XML download, add it below to pre-fill the configuration."
-        metadata_form_banner: "Editing the metadata may override existing values in other sections. "
-        configuration: "Configure the endpoint URLs for the identity provider, certificates, and further SAML options."
-        configuration_metadata: "This information has been pre-filled using the supplied metadata. In most cases, they do not require editing."
-        encryption: "Configure assertion signatures and encryption for SAML requests and responses."
-        encryption_form: "You may optionally want to encrypt the assertion response, or have requests from OpenProject signed."
-        mapping: "Manually adjust the mapping between the SAML response and user attributes in OpenProject."
-        requested_attributes: "Define the set of attributes to be requested in the SAML request sent to your identity provider."
-      seeded_from_env: "This provider was seeded from the environment configuration. It cannot be edited."
-    settings:
-      metadata_none: "I don't have metadata"
-      metadata_url: "Metadata URL"
-      metadata_xml: "Metadata XML"
+      title: "SAML Protocol Configuration Parameters"
     instructions:
-      documentation_link: >
-        Please refer to our [documentation on configuring SAML providers](docs_url) for more information on these configuration options.
+      authn_requests_signed: >
+        If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
+      certificate: >
+        Enter the X509 PEM-formatted certificate used by OpenProject for signing SAML requests.
+      digest_method: >
+        Select the digest algorithm to use for the SAML request signature performed by OpenProject (Default: %{default_option}).
       display_name: >
         The name of the provider. This will be displayed as the login button and in the list of providers.
-      metadata_none: >
-        Your identity provider does not have a metadata endpoint or XML download option. You can configure it manually.
-      metadata_url: >
-        Your identity provider provides a metadata URL.
-      idp_entity_id: >
-        Optional: Useful when the metadata URL points to a federation aggregate with a lot of entries.
-        Enter the entity ID of your institution's identity provider. Leave blank for single-entity metadata URLs.
-      metadata_xml: >
-        Your identity provider provides a metadata XML download.
-      limit_self_registration: >
-        If enabled users can only register using this provider if the self registration setting allows for it.
-      sp_entity_id: >
-        The entity ID of the service provider (SP). Sometimes also referred to as Audience. This is the unique client identifier of the OpenProject instance.
-      idp_sso_service_url: >
-        The URL of the identity provider login endpoint.
-      idp_slo_service_url: >
-        The URL of the identity provider logout endpoint.
+      documentation_link: >
+        Please refer to our [documentation on configuring SAML providers](docs_url) for more information on these configuration options.
+      icon: >
+        Optionally provide a public URL to an icon graphic that will be displayed next to the provider name.
       idp_cert: >
         Enter the X509 PEM-formatted public certificate of the identity provider.
         You can enter multiple certificates by separating them with a newline.
-      name_identifier_format: >
-        Set the name identifier format to be used for the SAML assertion.
-      sp_metadata_endpoint: >
-        This is the URL where the OpenProject SAML metadata is available.
-        Optionally use it to configure your identity provider.
+      idp_entity_id: >
+        Optional: Useful when the metadata URL points to a federation aggregate with a lot of entries.
+        Enter the entity ID of your institution's identity provider. Leave blank for single-entity metadata URLs.
+      idp_slo_service_url: >
+        The URL of the identity provider logout endpoint.
+      idp_sso_service_url: >
+        The URL of the identity provider login endpoint.
+      limit_self_registration: >
+        If enabled users can only register using this provider if the self registration setting allows for it.
       mapping: >
         Configure the mapping between the SAML response and user attributes in OpenProject.
         You can configure multiple attribute names to look for. OpenProject will choose the first available attribute
         from the SAML response.
-      mapping_login: >
-        SAML attributes from the response used for the login.
-      mapping_mail: >
-        SAML attributes from the response used for the email of the user.
       mapping_firstname: >
         SAML attributes from the response used for the given name.
       mapping_lastname: >
         SAML attributes from the response used for the last name.
+      mapping_login: >
+        SAML attributes from the response used for the login.
+      mapping_mail: >
+        SAML attributes from the response used for the email of the user.
       mapping_uid: >
         SAML attribute to use for the internal user ID. Leave empty to use the name_id attribute instead
+      metadata_for_idp: >
+        This information might be requested by your SAML identity provider.
+      metadata_none: >
+        Your identity provider does not have a metadata endpoint or XML download option. You can configure it manually.
+      metadata_url: >
+        Your identity provider provides a metadata URL.
+      metadata_xml: >
+        Your identity provider provides a metadata XML download.
+      name_identifier_format: >
+        Set the name identifier format to be used for the SAML assertion.
+      private_key: >
+        Enter the X509 PEM-formatted private key for the above certificate. This needs to be an RSA private key.
       request_uid: >
         SAML attribute to request for the internal user ID. By default, the name_id will be used for this field.
       requested_attributes: >
@@ -154,22 +97,79 @@ en:
       requested_format: >
         The format of the requested attribute. This is used to specify the format of the attribute in the SAML request.
         Please see [documentation on configuring requested attributes](docs_url) for more information.
-      authn_requests_signed: >
-        If checked, OpenProject will sign the SAML AuthnRequest. You will have to provide a signing certificate and private key using the fields below.
+      signature_method: >
+        Select the signature algorithm to use for the SAML request signature performed by OpenProject (Default: %{default_option}).
+      sp_entity_id: >
+        The entity ID of the service provider (SP). Sometimes also referred to as Audience. This is the unique client identifier of the OpenProject instance.
+      sp_metadata_endpoint: >
+        This is the URL where the OpenProject SAML metadata is available.
+        Optionally use it to configure your identity provider.
+      want_assertions_encrypted: >
+        If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
       want_assertions_signed: >
         If checked, OpenProject will required signed responses from the identity provider using its own certificate keypair.
         OpenProject will verify the signature against the certificate from the basic configuration section.
-      want_assertions_encrypted: >
-        If enabled, require the identity provider to encrypt the assertion response using the certificate pair that you provide.
-      certificate: >
-        Enter the X509 PEM-formatted certificate used by OpenProject for signing SAML requests.
-      private_key: >
-        Enter the X509 PEM-formatted private key for the above certificate. This needs to be an RSA private key.
-      signature_method: >
-        Select the signature algorithm to use for the SAML request signature performed by OpenProject (Default: %{default_option}).
-      digest_method: >
-        Select the digest algorithm to use for the SAML request signature performed by OpenProject (Default: %{default_option}).
-      icon: >
-        Optionally provide a public URL to an icon graphic that will be displayed next to the provider name.
-      metadata_for_idp: >
-        This information might be requested by your SAML identity provider.
+    menu_title: SAML providers
+    metadata_parser:
+      error: "Failed to retrieve the identity provider metadata: %{error}"
+      federation_metadata: >
+        The metadata URL points to a federation aggregate (many identity providers).
+        Use your institution's direct metadata URL, or enter your institution's IdP entity ID in the metadata form and try again.
+      invalid_url: "Provided metadata URL is invalid. Provide a HTTP(s) URL."
+      metadata_too_large: "The metadata file exceeds the maximum allowed size."
+      success: "Successfully updated the configuration using the identity provider metadata."
+    providers:
+      attribute_mapping: Attribute mapping
+      attribute_mapping_text: >
+        The following fields control which attributes provided by the SAML identity provider
+        are used to provide user attributes in OpenProject
+      label_add_new: New SAML identity provider
+      label_automatic_configuration: Automatic configuration
+      label_configuration_details: "Identity provider endpoints and certificates"
+      label_configuration_encryption: "Signatures and Encryption"
+      label_edit: Edit SAML identity provider %{name}
+      label_empty_description: "Add a provider to see them here."
+      label_empty_title: "No SAML providers configured yet."
+      label_mapping: Mapping
+      label_metadata: Metadata
+      label_metadata_endpoint: OpenProject metadata endpoint
+      label_openproject_information: OpenProject information
+      label_requested_attribute_for: "Requested attribute for: %{attribute}"
+
+      label_uid: Internal user id
+      metadata:
+        dialog: "This is the URL where the OpenProject SAML metadata is available. Optionally use it to configure your identity provider:"
+      no_results_table: No SAML identity providers have been defined yet.
+      notice_created: A new SAML identity provider was successfully created.
+      plural: SAML identity providers
+      request_attributes:
+        format: 'Attribute format'
+        legend: >
+          These attributes are added to the SAML XML metadata to signify to the identify provider which attributes OpenProject requires.
+          You may still need to explicitly configure your identity provider to send these attributes. Please refer to your IdP's documentation.
+        name: 'Requested attribute key'
+        title: 'Requested attributes'
+      requested_attributes: Requested attributes
+      section_headers:
+        attributes: "Attributes"
+        configuration: "Primary configuration"
+      section_texts:
+        configuration: "Configure the endpoint URLs for the identity provider, certificates, and further SAML options."
+        configuration_metadata: "This information has been pre-filled using the supplied metadata. In most cases, they do not require editing."
+        display_name: "Configure the display name of the SAML provider."
+        encryption: "Configure assertion signatures and encryption for SAML requests and responses."
+        encryption_form: "You may optionally want to encrypt the assertion response, or have requests from OpenProject signed."
+        mapping: "Manually adjust the mapping between the SAML response and user attributes in OpenProject."
+        metadata: "Pre-fill configuration using a metadata URL or by pasting metadata XML"
+        metadata_form: "If your identity provider has a metadata endpoint or XML download, add it below to pre-fill the configuration."
+        metadata_form_banner: "Editing the metadata may override existing values in other sections. "
+        requested_attributes: "Define the set of attributes to be requested in the SAML request sent to your identity provider."
+      seeded_from_env: "This provider was seeded from the environment configuration. It cannot be edited."
+      singular: SAML identity provider
+      upsell:
+        description: Connect OpenProject to a SAML identity provider
+        title: "Single Sign-On (SSO) with SAML"
+    settings:
+      metadata_none: "I don't have metadata"
+      metadata_url: "Metadata URL"
+      metadata_xml: "Metadata XML"

--- a/modules/avatars/config/locales/en.yml
+++ b/modules/avatars/config/locales/en.yml
@@ -1,44 +1,44 @@
 # English strings go here
 ---
 en:
+  are_you_sure_delete_avatar: "Are you sure you want to delete your avatar?"
+  avatar_deleted: "Avatar deleted successfully."
+  avatars:
+    label_avatar: "Avatar"
+    label_current_avatar: 'Current avatar'
+    label_gravatar: 'Gravatar'
+    label_local_avatar: 'Custom avatar'
+    settings:
+      enable_gravatars: 'Enable user gravatars'
+      enable_local_avatars: 'Enable user custom avatars'
+      gravatar_default: "Default Gravatar image"
+    text_change_gravatar_html: 'To change or add the Gravatar for your mail address, go to %{gravatar_url}.'
+    text_current_avatar: |
+      The following image shows the current avatar.
+    text_local_avatar_over_gravatar: |
+      If you set one, this custom avatar is used in precedence over the gravatar above.
+    text_upload_instructions: |
+      Upload your own custom avatar of 128 by 128 pixels. Larger files will be resized and cropped to match.
+      A preview of your avatar will be shown before uploading, once you selected an image.
+    text_your_current_gravatar: |
+      OpenProject uses your gravatar if you registered one, or a default image or icon if one exists.
+      The current gravatar is as follows:
+    text_your_local_avatar: |
+      OpenProject allows you to upload your own custom avatar.
+  empty_file_error: "Please upload a valid image (jpg, png, gif)"
+
+  error_image_size: "The image is too large."
+  error_image_upload: "Error saving the image."
+  label_avatar: "Avatar"
+  label_avatar_plural: "Avatars"
+  label_choose_avatar: "Choose Avatar from file"
+  label_current_avatar: "Current Avatar"
+  message_avatar_uploaded: "Avatar changed successfully."
   plugin_openproject_avatars:
-    name: "Avatars"
     description: >-
       This plugin allows OpenProject users to upload a picture to be used as an avatar or use
       registered images from Gravatar.
 
-  label_avatar: "Avatar"
-  label_avatar_plural: "Avatars"
-  label_current_avatar: "Current Avatar"
-  label_choose_avatar: "Choose Avatar from file"
-  message_avatar_uploaded: "Avatar changed successfully."
-  error_image_upload: "Error saving the image."
-  error_image_size: "The image is too large."
-  are_you_sure_delete_avatar: "Are you sure you want to delete your avatar?"
-  avatar_deleted: "Avatar deleted successfully."
+    name: "Avatars"
   unable_to_delete_avatar: "Avatar could not be deleted."
   wrong_file_format: "Allowed formats are jpg, png, gif"
-  empty_file_error: "Please upload a valid image (jpg, png, gif)"
-
-  avatars:
-    label_avatar: "Avatar"
-    label_gravatar: 'Gravatar'
-    label_current_avatar: 'Current avatar'
-    label_local_avatar: 'Custom avatar'
-    text_current_avatar: |
-      The following image shows the current avatar.
-    text_upload_instructions: |
-      Upload your own custom avatar of 128 by 128 pixels. Larger files will be resized and cropped to match.
-      A preview of your avatar will be shown before uploading, once you selected an image.
-    text_change_gravatar_html: 'To change or add the Gravatar for your mail address, go to %{gravatar_url}.'
-    text_your_local_avatar: |
-      OpenProject allows you to upload your own custom avatar.
-    text_local_avatar_over_gravatar: |
-      If you set one, this custom avatar is used in precedence over the gravatar above.
-    text_your_current_gravatar: |
-      OpenProject uses your gravatar if you registered one, or a default image or icon if one exists.
-      The current gravatar is as follows:
-    settings:
-      enable_gravatars: 'Enable user gravatars'
-      gravatar_default: "Default Gravatar image"
-      enable_local_avatars: 'Enable user custom avatars'

--- a/modules/avatars/config/locales/js-en.yml
+++ b/modules/avatars/config/locales/js-en.yml
@@ -2,15 +2,15 @@
 ---
 en:
   js:
-    label_preview: 'Preview'
-    button_update: 'Update'
     avatars:
+      empty_file_error: "Please upload a valid image (jpg, png, gif)"
+      error_image_too_large: "Image is too large."
       label_choose_avatar: "Choose Avatar from file"
-      uploading_avatar: "Uploading your avatar."
       text_upload_instructions: |
         Upload your own custom avatar of 128 by 128 pixels. Larger files will be resized and cropped to match.
         A preview of your avatar will be shown before uploading, once you selected an image.
 
-      error_image_too_large: "Image is too large."
+      uploading_avatar: "Uploading your avatar."
       wrong_file_format: "Allowed formats are jpg, png, gif"
-      empty_file_error: "Please upload a valid image (jpg, png, gif)"
+    button_update: 'Update'
+    label_preview: 'Preview'

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -28,15 +28,11 @@
 
 ---
 en:
-  plugin_openproject_backlogs:
-    name: "OpenProject Backlogs"
-    description: "This module adds features enabling agile teams to work with OpenProject in Scrum projects."
-
   activerecord:
     attributes:
       project:
-        sprint_sharing: "Sprint sharing"
         backlog_excluded_types: "Excluded work package types"
+        sprint_sharing: "Sprint sharing"
         statuses_considered_closed: "Statuses considered closed"
       sprint:
         duration: "Duration"
@@ -45,9 +41,9 @@ en:
         name: "Sprint name"
         sharing: "Sharing"
         statuses:
-          in_planning: "In planning"
           active: "Active"
           completed: "Completed"
+          in_planning: "In planning"
         work_packages: "Work packages"
       work_package:
         backlog_bucket: "Backlog Bucket"
@@ -58,87 +54,87 @@ en:
 
     errors:
       messages:
+        dates_required: "Start and finish dates are required in order to start the sprint."
         must_be_in_planning: "must be in planning to start."
         only_one_active_sprint_allowed: "only one active sprint is allowed per project."
-        dates_required: "Start and finish dates are required in order to start the sprint."
       models:
         project:
-          receiving_sprints: "is receiving shared sprints. Own sprints cannot be created."
           attributes:
             sprint_sharing:
               share_all_projects_already_taken: "cannot be set because project \"%{name}\" is already sharing with all projects."
               share_all_projects_already_taken_anonymous: "cannot be set because another project is already sharing with all projects."
+          receiving_sprints: "is receiving shared sprints. Own sprints cannot be created."
         sprint:
           attributes:
             base:
+              format: "%{message}"
               unfinished_work_packages:
                 one: "There is one work package that was not completed in this sprint."
                 other: "There are %{count} work packages that were not completed in this sprint."
-              format: "%{message}"
             status:
               not_active: "is not active so it cannot be closed."
         work_package:
-          backlog_bucket_xor_sprint: "cannot be assigned to both a sprint and a backlog bucket."
           attributes:
             backlog_bucket:
               backlog_bucket_from_another_project: "must belong to the same project as the work package."
             blocks_ids:
               can_only_contain_work_packages_of_current_sprint: "can only contain IDs of work packages in the current sprint."
               must_block_at_least_one_work_package: "must contain the ID of at least one ticket."
-            version_id:
-              task_version_must_be_the_same_as_story_version: "must be the same as the parent story's version."
             sprint:
               not_assignable: "is not assignable since it is either not shared with the project or already finished."
               not_eligible_for_moving: "is not an active sprint in the project which holds the sprint the work package is moved out of."
 
+            version_id:
+              task_version_must_be_the_same_as_story_version: "must be the same as the parent story's version."
+          backlog_bucket_xor_sprint: "cannot be assigned to both a sprint and a backlog bucket."
     models:
       sprint: "Sprint"
 
   backlogs:
     administration_blankslate:
-      title: "Backlog admin settings are evolving"
       text: "We are currently redesigning the Backlogs module. Admin settings for sprints and backlogs will be visible here in the near future. Project-level settings remain available."
 
-    bucket_destroy_modal_component:
-      title: "Delete backlog bucket?"
-      details: "The backlog bucket '%{name}' will be deleted and all work packages will be moved to the backlog inbox. No work package will be deleted."
-
+      title: "Backlog admin settings are evolving"
     bucket_component:
-      blankslate_title: "Backlog bucket is empty"
-      blankslate_description: "Drag items here to add them."
-      label_actions: "Backlog bucket actions"
       action_menu:
-        edit_backlog_bucket: "Edit backlog bucket"
         delete_backlog_bucket: "Delete backlog bucket"
 
+        edit_backlog_bucket: "Edit backlog bucket"
+      blankslate_description: "Drag items here to add them."
+      blankslate_title: "Backlog bucket is empty"
+      label_actions: "Backlog bucket actions"
+    bucket_destroy_modal_component:
+      details: "The backlog bucket '%{name}' will be deleted and all work packages will be moved to the backlog inbox. No work package will be deleted."
+
+      title: "Delete backlog bucket?"
     burndown_chart:
       show:
-        blankslate_title: "No burndown data available"
         blankslate_description: "Set start and end date for the sprint to generate a burndown chart."
 
+        blankslate_title: "No burndown data available"
     excluded_work_package_types_caption: >
       Choose which work package types to hide from the backlog. Items of the selected types will not appear in the backlog automatically,
       keeping it focused on the work that matters to your team.
       For example, types like Epics or Milestones that are managed at a higher level can be hidden to keep the backlog focused on actionable items.
     finish_sprint_dialog_component:
-      title: "There are work in progress items"
-      body: "%{message} What would you like to do with these?"
-      legend: "Action for unfinished work packages"
       actions:
-        move_to_top_of_backlog: "Move them to the top of the backlog"
         move_to_bottom_of_backlog: "Move them to the bottom of the backlog"
         move_to_sprint: "Move them to another sprint"
-      select_sprint_label: "Select sprint"
+        move_to_top_of_backlog: "Move them to the top of the backlog"
+      body: "%{message} What would you like to do with these?"
       button_complete_sprint: "Complete sprint"
 
+      legend: "Action for unfinished work packages"
+      select_sprint_label: "Select sprint"
+      title: "There are work in progress items"
     inbox_component:
-      title: "Inbox"
-      blankslate_title: "Backlog inbox is empty"
       blankslate_description: "All open work packages in this project will automatically appear here."
+      blankslate_title: "Backlog inbox is empty"
       show_more:
         one: "Show 1 more item"
         other: "Show %{count} more items"
 
+      title: "Inbox"
     label_burndown_chart: "Burndown chart"
     label_is_done_status: "Status %{status_name} means done"
     label_sprint_board: "Sprint board"
@@ -147,9 +143,9 @@ en:
       title: "Move to backlog bucket"
 
     move_to_sprint_dialog_component:
-      title: "Move to sprint"
       label_sprint: "Sprint"
 
+      title: "Move to sprint"
     points_label:
       one: "point"
       other: "points"
@@ -163,50 +159,50 @@ en:
     show_burndown_chart: "Burndown chart"
 
     sprint_component:
-      blankslate_title: "%{name} is empty"
-      blankslate_description: "No items planned yet. Drag items here to add them."
-      label_actions: "Sprint actions"
-      label_start_sprint: "Start sprint"
-      label_complete_sprint: "Complete sprint"
-      start_sprint_disabled_reason_active_sprint: "Another sprint is already active."
-      start_sprint_disabled_reason_missing_dates: "Start and finish dates are required in order to start the sprint."
       action_menu:
-        edit_sprint: "Edit sprint"
         add_work_package: "Add work package"
 
+        edit_sprint: "Edit sprint"
+      blankslate_description: "No items planned yet. Drag items here to add them."
+      blankslate_title: "%{name} is empty"
+      label_actions: "Sprint actions"
+      label_complete_sprint: "Complete sprint"
+      label_start_sprint: "Start sprint"
+      start_sprint_disabled_reason_active_sprint: "Another sprint is already active."
+      start_sprint_disabled_reason_missing_dates: "Start and finish dates are required in order to start the sprint."
     sprints_component:
       blankslate:
-        title: "No sprints present yet"
-        settings_link_text: "project settings"
-        receive_and_manage_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
-        receive_description_text: "This project receives shared sprints from a different project, but none are available right now."
         create_and_manage_description_html: "To start planning your sprint, create one here or go to the %{settings_link} to receive sprints from a different project."
         create_description_text: "To start planning your sprint, create one here."
         manage_description_html: "To start planning your sprint, go to the %{settings_link} to receive sprints from a different project."
         no_actions_description_text: "No sprints are available for this project yet."
 
-    story_points:
-      one: "%{count} story point"
-      other: "%{count} story points"
+        receive_and_manage_description_html: "This project receives sprints from a different project. Manage this in the %{settings_link}."
+        receive_description_text: "This project receives shared sprints from a different project, but none are available right now."
+        settings_link_text: "project settings"
+        title: "No sprints present yet"
     statuses_considered_closed_caption: >
       Choose the statuses that represent a closed or finished state in your workflow.
       These will be treated as the "Closed" state across reporting (e.g. burndown) and sprint planning.
       For example, statuses like Done, Resolved, or Won't Fix may all represent a closed work item in your process.
+    stories:
+      update_service:
+        ambiguous_target: "target_id and direction cannot both be present."
+        invalid_direction: "direction must be one of: higher, highest, lower, lowest."
+
+        invalid_target_type: "target_type must be one of: backlog_bucket:<backlog_bucket_id>, sprint:<sprint_id>, inbox."
+        missing_target: "target_id or direction must be present."
+    story_points:
+      one: "%{count} story point"
+      other: "%{count} story points"
     types_and_statuses: "Types and statuses"
 
     unassigned: "Unassigned"
 
     user_preference:
-      header_backlogs: "Backlogs module"
       button_update_backlogs: "Update backlogs module"
 
-    stories:
-      update_service:
-        missing_target: "target_id or direction must be present."
-        ambiguous_target: "target_id and direction cannot both be present."
-        invalid_target_type: "target_type must be one of: backlog_bucket:<backlog_bucket_id>, sprint:<sprint_id>, inbox."
-        invalid_direction: "direction must be one of: higher, highest, lower, lowest."
-
+      header_backlogs: "Backlogs module"
     work_package_card_menu_component:
       action_menu:
         copy_url_to_clipboard: "Copy URL to clipboard"
@@ -231,24 +227,24 @@ en:
 
   label_all_sprints: "All sprints"
   label_backlog: "Backlog"
-  label_backlogs: "Backlogs"
   label_backlog_and_sprints: "Backlog and sprints"
   label_backlog_bucket_edit: "Edit backlog bucket"
   label_backlog_bucket_new: "New backlog bucket"
+  label_backlogs: "Backlogs"
   label_burndown_chart: "Burndown chart"
   label_inbox: "Inbox"
-  label_sprint_board: "Sprint board"
   label_points_burn_down: "Down"
   label_points_burn_up: "Up"
+  label_sprint_board: "Sprint board"
   label_sprint_edit: "Edit sprint"
   label_sprint_new: "New sprint"
   label_task_board: "Task board"
-  notice_successful_start: "The sprint was started."
   notice_successful_finish: "The sprint was completed."
-  notice_unsuccessful_start: "The sprint could not be started."
-  notice_unsuccessful_start_with_reason: "The sprint could not be started: %{reason}"
+  notice_successful_start: "The sprint was started."
   notice_unsuccessful_finish: "The sprint could not be completed."
   notice_unsuccessful_finish_with_reason: "The sprint could not be completed: %{reason}"
+  notice_unsuccessful_start: "The sprint could not be started."
+  notice_unsuccessful_start_with_reason: "The sprint could not be started: %{reason}"
   notice_work_package_invisible_after_move: >
     The work package was moved to %{backlog} but is not visible because its type or status is excluded from the backlog.
   permission_create_sprints: "Create sprints"
@@ -261,6 +257,10 @@ en:
   permission_start_complete_sprint: "Start/complete sprint"
   permission_view_sprints: "View sprints"
 
+  plugin_openproject_backlogs:
+    description: "This module adds features enabling agile teams to work with OpenProject in Scrum projects."
+
+    name: "OpenProject Backlogs"
   project_module_backlogs: "Backlogs"
 
   projects:
@@ -268,21 +268,21 @@ en:
       backlog_sharing:
         options:
           no_sharing:
-            label: "Don't share"
             caption: "Sprints created in this project will only be available and visible to this project. They will also not be visible to subprojects."
+            label: "Don't share"
           receive_shared:
-            label: "Receive shared sprints"
             caption: "This project can only use sprints shared by other projects."
+            label: "Receive shared sprints"
             warning: "This project can only use sprints shared by other projects. Unused sprints created in this project in the past, will no longer be visible."
           share_all_projects:
-            label: "All projects"
             caption: "Sprints created in this project will be available to all projects in this instance. If you select this option, it will no longer be available to other projects."
             disabled_caption: "Option not available since project \"%{name}\" is currently sharing with all projects and only one project can do this."
             disabled_caption_anonymous: "Option not available since another project is currently sharing with all projects and only one project can do this."
+            label: "All projects"
           share_subprojects:
-            label: "Subprojects"
             caption: "Sprints created in this project will be available to all subprojects of the current project."
             info: "Sharing a sprint will share the name, status and the start and finish dates in all projects. These cannot be modified in projects that receive and use these sprints."
+            label: "Subprojects"
         sprint_sharing: Share sprints
 
       backlogs:

--- a/modules/backlogs/config/locales/js-en.yml
+++ b/modules/backlogs/config/locales/js-en.yml
@@ -29,9 +29,9 @@
 ---
 en:
   js:
-    work_packages:
-      properties:
-        storyPoints: "Story Points"
     burndown:
       day: "Day"
       points: "Points"
+    work_packages:
+      properties:
+        storyPoints: "Story Points"

--- a/modules/bim/config/locales/en.yml
+++ b/modules/bim/config/locales/en.yml
@@ -1,117 +1,22 @@
 # English strings go here for Rails i18n
 ---
 en:
-  plugin_openproject_bim:
-    name: "OpenProject BIM and BCF functionality"
-    description: "This OpenProject plugin introduces BIM and BCF functionality."
-
-  bim:
-    label_bim: 'BIM'
-    error_direct_upload_failed: 'Direct upload failed.'
-
-  bcf:
-    label_bcf: 'BCF'
-    label_imported_failed: 'Failed imports of BCF topics'
-    label_imported_successfully: 'Successfully imported BCF topics'
-    label_bcf_issue_associated: "BCF issue associated"
-    issues: "Issues"
-    recommended: 'recommended'
-    not_recommended: 'not recommended'
-    no_viewpoints: 'No viewpoints'
-    new_badge: "New"
-    exceptions:
-      file_invalid: "BCF file invalid"
-
-    x_bcf_issues:
-      zero: 'No BCF issues'
-      one: 'One BCF issue'
-      other: '%{count} BCF issues'
-
-    bcf_xml:
-      xml_file: 'BCF XML File'
-      import_title: 'Import'
-      export: 'Export'
-      import_update_comment: '(Updated in BCF import)'
-      import_failed: 'Cannot import BCF file: %{error}'
-      import_failed_unsupported_bcf_version: 'Failed to read the BCF file: The BCF version is not supported. Please ensure the version is at least %{minimal_version} or higher.'
-      import_successful: 'Imported %{count} BCF issues'
-      import_canceled: 'BCF-XML import canceled.'
-      type_not_active: "The issue type is not activated for this project."
-
-      import:
-        num_issues_found: '%{x_bcf_issues} are contained in the BCF-XML file, their details are listed below.'
-        button_prepare: 'Prepare import'
-        button_perform_import: 'Confirm import'
-        button_proceed: 'Proceed with import'
-        button_back_to_list: 'Back to list'
-        no_permission_to_add_members: 'You do not have sufficient permissions to add them as members to the project.'
-        contact_project_admin: 'Contact your project admin to add them as members and start this import again.'
-        continue_anyways: 'Do you want to proceed and finish the import anyways?'
-        description: "Provide a BCF-XML v2.1 file to import into this project. You can examine its contents before performing the import."
-        invalid_types_found: 'Invalid topic type names found'
-        invalid_statuses_found: 'Invalid status names found'
-        invalid_priorities_found: 'Invalid priority names found'
-        invalid_emails_found: 'Invalid email addresses found'
-        unknown_emails_found: 'Unknown email addresses found'
-        unknown_property: 'Unknown property'
-        non_members_found: 'Non project members found'
-        import_types_as: 'Set all these types to'
-        import_statuses_as: 'Set all these statuses to'
-        import_priorities_as: 'Set all these priorities to'
-        invite_as_members_with_role: 'Invite them as members to the project "%{project}" with role'
-        add_as_members_with_role: 'Add them as members to the project "%{project}" with role'
-        no_type_provided: 'No type provided'
-        no_status_provided: 'No status provided'
-        no_priority_provided: 'No priority provided'
-        perform_description: "Do you want to import or update the issues listed above?"
-        replace_with_system_user: 'Replace them with "System" user'
-        import_as_system_user: 'Import them as "System" user.'
-        what_to_do: "What do you want to do?"
-        work_package_has_newer_changes: "Outdated! This topic was not updated as the latest changes on the server were newer than the \"ModifiedDate\" of the imported topic. However, comments to the topic were imported."
-        bcf_file_not_found: "Failed to locate BCF file. Please start the upload process again."
-
-  export:
-    format:
-      bcf: "BCF-XML"
-  attributes:
-    bcf_thumbnail: "BCF snapshot"
-
-  project_module_bcf: "BCF"
-  project_module_bim: "BCF"
-  permission_view_linked_issues: "View BCF issues"
-  permission_manage_bcf: "Import and manage BCF issues"
-  permission_manage_bcf_explanation: |
-    Allows managing BCF issues, including bulk import and updates.
-    BCF import maps file metadata to project resources and can create or update work packages
-    and comments using author and timestamp values from the imported file, effectively acting on behalf of users.
-  permission_delete_bcf: "Delete BCF issues"
-
-  oauth:
-    scopes:
-      bcf_v2_1: "Full access to the BCF v2.1 API"
-      bcf_v2_1_text: "Application will receive full read & write access to the OpenProject BCF API v2.1 to perform actions on your behalf."
-
   activerecord:
-    models:
-      bim/ifc_models/ifc_model: "IFC model"
     attributes:
-      bim/ifc_models/ifc_model:
-        ifc_attachment: "IFC file"
-        is_default: "Default model"
-        attachments: "IFC file"
       bim/bcf/issue:
         bcf_comment: "BCF comment"
         bim_snippet: "BIM snippet"
         reference_links: "Reference links"
         stage: "Stage"
         viewpoint: "Viewpoint"
+      bim/ifc_models/ifc_model:
+        attachments: "IFC file"
+        ifc_attachment: "IFC file"
+        is_default: "Default model"
     errors:
       models:
-        bim/ifc_models/ifc_model:
-          attributes:
-            base:
-              ifc_attachment_missing: "No ifc file attached."
-              invalid_ifc_file: "The provided file is not a valid IFC file."
+        bim/bcf/issue:
+          uuid_already_taken: "Can't import this BCF issue as there already is another with the same GUID. Could it be that this BCF issue had already been imported into a different project?"
         bim/bcf/viewpoint:
           bitmaps_not_writable: "bitmaps is not writable as it is not yet implemented."
           index_not_integer: "index is not an integer."
@@ -122,37 +27,132 @@ en:
           invalid_perspective_camera: "perspective_camera is invalid."
           mismatching_guid: "The guid in the json_viewpoint does not match the model's guid."
           no_json: "Is not a well structured json."
-          snapshot_type_unsupported: "snapshot_type needs to be either 'png' or 'jpg'."
           snapshot_data_blank: "snapshot_data needs to be provided."
+          snapshot_type_unsupported: "snapshot_type needs to be either 'png' or 'jpg'."
           unsupported_key: "An unsupported json property is included."
-        bim/bcf/issue:
-          uuid_already_taken: "Can't import this BCF issue as there already is another with the same GUID. Could it be that this BCF issue had already been imported into a different project?"
-  ifc_models:
-    label_ifc_models: 'IFC models'
-    label_new_ifc_model: 'New IFC model'
-    label_show_defaults: 'Show defaults'
-    label_default_ifc_models: 'Default IFC models'
-    label_edit_defaults: 'Edit defaults'
-    no_defaults_warning:
-      title: 'No IFC model was set as default for this project.'
-      check_1: 'Check that you have uploaded at least one IFC model.'
-      check_2: 'Check that at least one IFC model is set to "Default".'
-    no_results: "No IFC models have been uploaded in this project."
-    conversion_status:
-      label: 'Processing?'
-      pending: 'Pending'
-      processing: 'Processing'
-      completed: 'Completed'
-      error: 'Error'
-    processing_notice:
-      processing_default: 'The following default IFC models are still being processed and are thus not available, yet:'
-    flash_messages:
-      upload_successful: 'Upload succeeded. It will now get processed and will be ready to use in a couple of minutes.'
-    conversion:
-      missing_commands: "The following IFC converter commands are missing on this system: %{names}"
-  project_module_ifc_models: "IFC models"
-  permission_view_ifc_models: "View IFC models"
-  permission_manage_ifc_models: "Import and manage IFC models"
+        bim/ifc_models/ifc_model:
+          attributes:
+            base:
+              ifc_attachment_missing: "No ifc file attached."
+              invalid_ifc_file: "The provided file is not a valid IFC file."
+    models:
+      bim/ifc_models/ifc_model: "IFC model"
+  attributes:
+    bcf_thumbnail: "BCF snapshot"
+
+  bcf:
+    bcf_xml:
+      export: 'Export'
+      import:
+        add_as_members_with_role: 'Add them as members to the project "%{project}" with role'
+        bcf_file_not_found: "Failed to locate BCF file. Please start the upload process again."
+
+        button_back_to_list: 'Back to list'
+        button_perform_import: 'Confirm import'
+        button_prepare: 'Prepare import'
+        button_proceed: 'Proceed with import'
+        contact_project_admin: 'Contact your project admin to add them as members and start this import again.'
+        continue_anyways: 'Do you want to proceed and finish the import anyways?'
+        description: "Provide a BCF-XML v2.1 file to import into this project. You can examine its contents before performing the import."
+        import_as_system_user: 'Import them as "System" user.'
+        import_priorities_as: 'Set all these priorities to'
+        import_statuses_as: 'Set all these statuses to'
+        import_types_as: 'Set all these types to'
+        invalid_emails_found: 'Invalid email addresses found'
+        invalid_priorities_found: 'Invalid priority names found'
+        invalid_statuses_found: 'Invalid status names found'
+        invalid_types_found: 'Invalid topic type names found'
+        invite_as_members_with_role: 'Invite them as members to the project "%{project}" with role'
+        no_permission_to_add_members: 'You do not have sufficient permissions to add them as members to the project.'
+        no_priority_provided: 'No priority provided'
+        no_status_provided: 'No status provided'
+        no_type_provided: 'No type provided'
+        non_members_found: 'Non project members found'
+        num_issues_found: '%{x_bcf_issues} are contained in the BCF-XML file, their details are listed below.'
+        perform_description: "Do you want to import or update the issues listed above?"
+        replace_with_system_user: 'Replace them with "System" user'
+        unknown_emails_found: 'Unknown email addresses found'
+        unknown_property: 'Unknown property'
+        what_to_do: "What do you want to do?"
+        work_package_has_newer_changes: "Outdated! This topic was not updated as the latest changes on the server were newer than the \"ModifiedDate\" of the imported topic. However, comments to the topic were imported."
+      import_canceled: 'BCF-XML import canceled.'
+      import_failed: 'Cannot import BCF file: %{error}'
+      import_failed_unsupported_bcf_version: 'Failed to read the BCF file: The BCF version is not supported. Please ensure the version is at least %{minimal_version} or higher.'
+      import_successful: 'Imported %{count} BCF issues'
+      import_title: 'Import'
+      import_update_comment: '(Updated in BCF import)'
+      type_not_active: "The issue type is not activated for this project."
+
+      xml_file: 'BCF XML File'
+    exceptions:
+      file_invalid: "BCF file invalid"
+
+    issues: "Issues"
+    label_bcf: 'BCF'
+    label_bcf_issue_associated: "BCF issue associated"
+    label_imported_failed: 'Failed imports of BCF topics'
+    label_imported_successfully: 'Successfully imported BCF topics'
+    new_badge: "New"
+    no_viewpoints: 'No viewpoints'
+    not_recommended: 'not recommended'
+    recommended: 'recommended'
+    x_bcf_issues:
+      one: 'One BCF issue'
+      other: '%{count} BCF issues'
+
+      zero: 'No BCF issues'
+  bim:
+    error_direct_upload_failed: 'Direct upload failed.'
+
+    label_bim: 'BIM'
+  export:
+    format:
+      bcf: "BCF-XML"
   extraction:
     available:
       ifc_convert: "IFC conversion pipeline available"
+  ifc_models:
+    conversion:
+      missing_commands: "The following IFC converter commands are missing on this system: %{names}"
+    conversion_status:
+      completed: 'Completed'
+      error: 'Error'
+      label: 'Processing?'
+      pending: 'Pending'
+      processing: 'Processing'
+    flash_messages:
+      upload_successful: 'Upload succeeded. It will now get processed and will be ready to use in a couple of minutes.'
+    label_default_ifc_models: 'Default IFC models'
+    label_edit_defaults: 'Edit defaults'
+    label_ifc_models: 'IFC models'
+    label_new_ifc_model: 'New IFC model'
+    label_show_defaults: 'Show defaults'
+    no_defaults_warning:
+      check_1: 'Check that you have uploaded at least one IFC model.'
+      check_2: 'Check that at least one IFC model is set to "Default".'
+      title: 'No IFC model was set as default for this project.'
+    no_results: "No IFC models have been uploaded in this project."
+    processing_notice:
+      processing_default: 'The following default IFC models are still being processed and are thus not available, yet:'
+  oauth:
+    scopes:
+      bcf_v2_1: "Full access to the BCF v2.1 API"
+      bcf_v2_1_text: "Application will receive full read & write access to the OpenProject BCF API v2.1 to perform actions on your behalf."
+
+  permission_delete_bcf: "Delete BCF issues"
+
+  permission_manage_bcf: "Import and manage BCF issues"
+  permission_manage_bcf_explanation: |
+    Allows managing BCF issues, including bulk import and updates.
+    BCF import maps file metadata to project resources and can create or update work packages
+    and comments using author and timestamp values from the imported file, effectively acting on behalf of users.
+  permission_manage_ifc_models: "Import and manage IFC models"
+  permission_view_ifc_models: "View IFC models"
+  permission_view_linked_issues: "View BCF issues"
+  plugin_openproject_bim:
+    description: "This OpenProject plugin introduces BIM and BCF functionality."
+
+    name: "OpenProject BIM and BCF functionality"
+  project_module_bcf: "BCF"
+  project_module_bim: "BCF"
+  project_module_ifc_models: "IFC models"

--- a/modules/bim/config/locales/js-en.yml
+++ b/modules/bim/config/locales/js-en.yml
@@ -3,28 +3,28 @@
 en:
   js:
     bcf:
-      label_bcf: 'BCF'
-      import: 'Import'
-      import_bcf_xml_file: 'Import BCF XML file (BCF version 2.1)'
+      add_viewpoint: 'Add viewpoint'
+      delete_viewpoint: 'Delete viewpoint'
       export: 'Export'
       export_bcf_xml_file: 'Export BCF XML file (BCF version 2.1)'
-      viewpoint: 'Viewpoint'
-      add_viewpoint: 'Add viewpoint'
-      show_viewpoint: 'Show viewpoint'
-      delete_viewpoint: 'Delete viewpoint'
+      import: 'Import'
+      import_bcf_xml_file: 'Import BCF XML file (BCF version 2.1)'
+      label_bcf: 'BCF'
       management: 'BCF management'
       refresh: 'Refresh'
       refresh_work_package: 'Refresh work package'
+      show_viewpoint: 'Show viewpoint'
+      viewpoint: 'Viewpoint'
     ifc_models:
       empty_warning: "This project does not yet have any IFC models."
-      use_this_link_to_manage: "Use this link to upload and manage your IFC models"
       keyboard_input_disabled: "Viewer does not have keyboard controls. Click on the viewer to give keyboard control to the viewer."
       models:
         ifc_models: 'IFC models'
+      use_this_link_to_manage: "Use this link to upload and manage your IFC models"
       views:
-        viewer: 'Viewer'
         split: 'Viewer and table'
         split_cards: 'Viewer and cards'
+        viewer: 'Viewer'
     revit:
       revit_add_in: "Revit Add-In"
       revit_add_in_settings: "Revit Add-In settings"

--- a/modules/boards/config/locales/en.yml
+++ b/modules/boards/config/locales/en.yml
@@ -1,48 +1,47 @@
 # English strings go here
 ---
 en:
-  plugin_openproject_boards:
-    name: "OpenProject Boards"
-    description: "Provides board views."
-
-  permission_show_board_views: "View boards"
-  permission_manage_board_views: "Manage boards"
-  project_module_board_view: "Boards"
-
-  ee:
-    upsell:
-      board_view:
-        description: 'Would you like to automate your workflows with Boards? Advanced boards are an Enterprise add-on. Please upgrade to a paid plan.'
   boards:
-    label_board: "Board"
-    label_boards: "Boards"
-    label_create_new_board: "Create new board"
-    label_board_type: "Board type"
-    board_types:
-      free: Basic
-      action: "Action board (%{attribute})"
     board_type_attributes:
       assignee: Assignee
+      basic: Basic
       status: Kanban
-      version: Version
       subproject: Subproject
       subtasks: Parent-child
-      basic: Basic
+      version: Version
     board_type_descriptions:
+      assignee: >
+        Board with automated columns based on assigned users.
+        Ideal for dispatching work packages.
       basic: >
         Start from scratch with a blank board.
         Manually add cards and columns to this board.
       status: >
         Basic kanban style board with columns for status such as To Do, In Progress, Done.
-      assignee: >
-        Board with automated columns based on assigned users.
-        Ideal for dispatching work packages.
-      version: >
-        Board with automated columns based on the version attribute.
-        Ideal for planning product development.
       subproject: >
         Board with automated columns for subprojects.
         Dragging work packages to other lists updates the (sub-)project accordingly.
       subtasks: >
         Board with automated columns for sub-elements.
         Dragging work packages to other lists updates the parent accordingly.
+      version: >
+        Board with automated columns based on the version attribute.
+        Ideal for planning product development.
+    board_types:
+      action: "Action board (%{attribute})"
+      free: Basic
+    label_board: "Board"
+    label_board_type: "Board type"
+    label_boards: "Boards"
+    label_create_new_board: "Create new board"
+  ee:
+    upsell:
+      board_view:
+        description: 'Would you like to automate your workflows with Boards? Advanced boards are an Enterprise add-on. Please upgrade to a paid plan.'
+  permission_manage_board_views: "Manage boards"
+  permission_show_board_views: "View boards"
+  plugin_openproject_boards:
+    description: "Provides board views."
+
+    name: "OpenProject Boards"
+  project_module_board_view: "Boards"

--- a/modules/boards/config/locales/js-en.yml
+++ b/modules/boards/config/locales/js-en.yml
@@ -7,91 +7,91 @@ en:
         description: 'Would you like to automate your workflows with Boards? Advanced boards are an Enterprise add-on. Please upgrade to a paid plan.'
   js:
     boards:
-      create_new: 'Create new board'
-      label_unnamed_board: 'Unnamed board'
-      label_unnamed_list: 'Unnamed list'
-      label_board_type: 'Board type'
-      lists:
-        delete: 'Delete list'
-
-      version:
-        is_locked: 'Version is locked. No items can be added to this version.'
-        is_closed: 'Version is closed. No items can be added to this version.'
-        close_version: 'Close version'
-        open_version: 'Open version'
-        lock_version: 'Lock version'
-        unlock_version: 'Unlock version'
-        edit_version: 'Edit version'
-        show_version: 'Show version'
-        locked: 'Locked'
-        closed: 'Closed'
-
-      new_board: 'New board'
-      add_list: 'Add list to board'
       add_card: 'Add card'
-      error_attribute_not_writable: "Cannot move the work package, %{attribute} is not writable."
-      error_loading_the_list: "Error loading the list: %{error_message}"
-      error_permission_missing: "The permission to create public queries is missing"
-      error_cannot_move_into_self: "You can not move a work package into its own column."
-      text_hidden_list_warning: "Not all lists are displayed because you lack the permission. Contact your admin for more information."
-      click_to_remove_list: "Click to remove this list"
+      add_list: 'Add list to board'
+      add_list_modal:
+        labels:
+          assignee: Select user to add as a new assignee list
+          status: Select status to add as a new list
+          subproject: Select subproject to add as a new list
+          subtasks: Select work package to add as a new list
+          version: Select version to add as a new list
+        warning:
+          add_members: <a href="%{link}">Add a new member to this project</a> to select users again.
+          assignee: There isn't any member matched with your filter value.  <br>
+          no_member: This project currently does not have any members that can be added.  <br>
+          status: |
+            There is currently no status available. <br>
+            Either there are none or they have all already been added to the board.
       board_type:
-        text: 'Board type'
-        free: 'basic'
-        select_board_type: 'Please choose the type of board you need.'
-        free_text: >
-          Start from scratch with a blank board.
-          Manually add cards and columns to this board.
         action: 'Action board'
         action_by_attribute: 'Action board (%{attribute})'
         action_text: >
           A board with filtered lists on %{attribute} attribute. Moving work packages to other lists
           will update their attribute.
+        action_text_assignee: >
+          Board with automated columns based on assigned users.
+          Ideal for dispatching work packages.
+        action_text_status: >
+          Basic kanban style board with columns for status such as To Do, In Progress, Done.
         action_text_subprojects: >
           Board with automated columns for subprojects.
           Dragging work packages to other lists updates the (sub-)project accordingly.
         action_text_subtasks: >
           Board with automated columns for sub-elements.
           Dragging work packages to other lists updates the parent accordingly.
-        action_text_status: >
-          Basic kanban style board with columns for status such as To Do, In Progress, Done.
-        action_text_assignee: >
-          Board with automated columns based on assigned users.
-          Ideal for dispatching work packages.
         action_text_version: >
           Board with automated columns based on the version attribute.
           Ideal for planning product development.
         action_type:
           assignee: assignee
           status: status
-          version: version
           subproject: subproject
           subtasks: parent-child
+          version: version
         board_type_title:
           assignee: Assignee
+          basic: Basic
           status: Status
-          version: Version
           subproject: Subproject
           subtasks: Parent-child
-          basic: Basic
+          version: Version
+        free: 'basic'
+        free_text: >
+          Start from scratch with a blank board.
+          Manually add cards and columns to this board.
         select_attribute: "Action attribute"
 
-      add_list_modal:
-        labels:
-          assignee: Select user to add as a new assignee list
-          status: Select status to add as a new list
-          version: Select version to add as a new list
-          subproject: Select subproject to add as a new list
-          subtasks: Select work package to add as a new list
-        warning:
-          status: |
-            There is currently no status available. <br>
-            Either there are none or they have all already been added to the board.
-          assignee: There isn't any member matched with your filter value.  <br>
-          no_member: This project currently does not have any members that can be added.  <br>
-          add_members: <a href="%{link}">Add a new member to this project</a> to select users again.
+        select_board_type: 'Please choose the type of board you need.'
+        text: 'Board type'
+      click_to_remove_list: "Click to remove this list"
       configuration_modal:
-        title: 'Configure this board'
         display_settings:
           card_mode: "Display as cards"
           table_mode: "Display as table"
+        title: 'Configure this board'
+      create_new: 'Create new board'
+      error_attribute_not_writable: "Cannot move the work package, %{attribute} is not writable."
+      error_cannot_move_into_self: "You can not move a work package into its own column."
+      error_loading_the_list: "Error loading the list: %{error_message}"
+      error_permission_missing: "The permission to create public queries is missing"
+      label_board_type: 'Board type'
+      label_unnamed_board: 'Unnamed board'
+      label_unnamed_list: 'Unnamed list'
+      lists:
+        delete: 'Delete list'
+
+      new_board: 'New board'
+      text_hidden_list_warning: "Not all lists are displayed because you lack the permission. Contact your admin for more information."
+      version:
+        close_version: 'Close version'
+        closed: 'Closed'
+
+        edit_version: 'Edit version'
+        is_closed: 'Version is closed. No items can be added to this version.'
+        is_locked: 'Version is locked. No items can be added to this version.'
+        lock_version: 'Lock version'
+        locked: 'Locked'
+        open_version: 'Open version'
+        show_version: 'Show version'
+        unlock_version: 'Unlock version'

--- a/modules/budgets/config/locales/en.yml
+++ b/modules/budgets/config/locales/en.yml
@@ -28,25 +28,22 @@
 
 ---
 en:
-  plugin_budgets_engine:
-    name: "Budgets"
-
   activerecord:
     attributes:
       budget:
         author: "Author"
         available: "Available"
+        base_amount: "Base amount"
         budget: "Planned"
         budget_ratio: "Spent (ratio)"
         description: "Description"
+        labor_budget: "Planned labor costs"
+        labor_budget_items: "Planned labor costs"
+        material_budget: "Planned unit costs"
         spent: "Spent"
         status: "Status"
         subject: "Subject"
         type: "Cost type"
-        labor_budget: "Planned labor costs"
-        labor_budget_items: "Planned labor costs"
-        material_budget: "Planned unit costs"
-        base_amount: "Base amount"
       work_package:
         budget_subject: "Budget title"
     errors:
@@ -67,8 +64,45 @@ en:
   attributes:
     budget: "Budget"
 
-  button_add_budget_item: "Add planned costs"
+  budgets:
+    widgets:
+      budget_by_cost_type:
+        blankslate:
+          description: "Get an overview of your budgets and costs to efficiently track the health status of your project"
+          heading: "Start project controlling"
+        blankslate_zero:
+          description: "Add details about your planned budget to see data here"
+          heading: "Budget details missing"
+        count_caption:
+          one: "Data aggregated from %{count} budget"
+          other: "Data aggregated from %{count} budgets"
+          zero: "No budget data."
+        count_caption_with_subitems:
+          portfolio:
+            one: "Data aggregated from %{count} budget included in this portfolio and its subitems."
+            other: "Data aggregated from %{count} budgets included in this portfolio and its subitems."
+            zero: "No budget data."
+          program:
+            one: "Data aggregated from %{count} budget included in this program and its subitems."
+            other: "Data aggregated from %{count} budgets included in this program and its subitems."
+            zero: "No budget data."
+          project:
+            one: "Data aggregated from %{count} budget included in this project and its subitems."
+            other: "Data aggregated from %{count} budgets included in this project and its subitems."
+            zero: "No budget data."
+        title: "Budget by cost type"
+        view_details: "View budget details"
+
+      budget_totals:
+        remaining_budget: "Remaining budget"
+        spent_budget: "Spent budget"
+        title: "Budget totals"
+        total_actual_costs: "Total actual costs"
+        total_planned_budget: "Total planned budget"
+  budgets_title: "Budgets"
+
   button_add_budget: "Add budget"
+  button_add_budget_item: "Add planned costs"
   button_add_cost_type: "Add cost type"
   button_cancel_edit_budget: "Cancel editing budget"
   button_cancel_edit_costs: "Cancel editing costs"
@@ -76,43 +110,6 @@ en:
   caption_labor: "Labor"
   caption_labor_costs: "Actual labor costs"
   caption_material_costs: "Actual unit costs"
-  budgets_title: "Budgets"
-
-  budgets:
-    widgets:
-      budget_totals:
-        title: "Budget totals"
-        remaining_budget: "Remaining budget"
-        spent_budget: "Spent budget"
-        total_actual_costs: "Total actual costs"
-        total_planned_budget: "Total planned budget"
-      budget_by_cost_type:
-        title: "Budget by cost type"
-        blankslate:
-          heading: "Start project controlling"
-          description: "Get an overview of your budgets and costs to efficiently track the health status of your project"
-        blankslate_zero:
-          heading: "Budget details missing"
-          description: "Add details about your planned budget to see data here"
-        count_caption:
-          zero: "No budget data."
-          one: "Data aggregated from %{count} budget"
-          other: "Data aggregated from %{count} budgets"
-        count_caption_with_subitems:
-          project:
-            zero: "No budget data."
-            one: "Data aggregated from %{count} budget included in this project and its subitems."
-            other: "Data aggregated from %{count} budgets included in this project and its subitems."
-          program:
-            zero: "No budget data."
-            one: "Data aggregated from %{count} budget included in this program and its subitems."
-            other: "Data aggregated from %{count} budgets included in this program and its subitems."
-          portfolio:
-            zero: "No budget data."
-            one: "Data aggregated from %{count} budget included in this portfolio and its subitems."
-            other: "Data aggregated from %{count} budgets included in this portfolio and its subitems."
-        view_details: "View budget details"
-
   events:
     budget: "Budget edited"
 
@@ -122,26 +119,29 @@ en:
 
   label_budget: "Budget"
   label_budget_available: "Budget available"
+  label_budget_details: "Budget details"
+
   label_budget_id: "Budget #%{id}"
   label_budget_new: "New budget"
   label_budget_planned: "Budget planned"
   label_budget_plural: "Budgets"
   label_budget_spent: "Budget spent"
   label_budget_spent_ratio: "Budget spent ratio"
+  label_budget_totals: "Totals"
   label_deliverable: "Budget"
   label_example_placeholder: "e.g., %{decimal}"
   label_view_all_budgets: "View all budgets"
   label_yes: "Yes"
-  label_budget_totals: "Totals"
-  label_budget_details: "Budget details"
-
   notice_budget_conflict: "Work packages must be of the same project."
   notice_no_budgets_available: "No budgets available."
 
   permission_edit_budgets: "Edit budgets"
   permission_view_budgets: "View budgets"
+  plugin_budgets_engine:
+    name: "Budgets"
+
   project_module_budgets: "Budgets"
 
-  text_budget_reassign_to: "Reassign them to this budget:"
   text_budget_delete: "Delete the budget from all work packages"
   text_budget_destroy_assigned_wp: "There are %{count} work packages assigned to this budget. What do you want to do?"
+  text_budget_reassign_to: "Reassign them to this budget:"

--- a/modules/calendar/config/locales/en.yml
+++ b/modules/calendar/config/locales/en.yml
@@ -1,14 +1,14 @@
 # English strings go here
 ---
 en:
-  plugin_openproject_calendar:
-    name: "OpenProject Calendar"
-    description: "Provides calendar views."
-
   label_calendar: "Calendar"
   label_calendar_plural: "Calendars"
   label_new_calendar: "New calendar"
-  permission_view_calendar: "View calendars"
   permission_manage_calendars: "Manage calendars"
   permission_share_calendars: "Subscribe to iCalendars"
+  permission_view_calendar: "View calendars"
+  plugin_openproject_calendar:
+    description: "Provides calendar views."
+
+    name: "OpenProject Calendar"
   project_module_calendar_view: "Calendars"

--- a/modules/calendar/config/locales/js-en.yml
+++ b/modules/calendar/config/locales/js-en.yml
@@ -4,7 +4,7 @@ en:
   js:
     calendar:
       create_new: 'Create new calendar'
+      label_calendar_plural: 'Calendars'
       title: 'Calendar'
       too_many: 'There are %{count} work packages in total, but only %{max} can be shown.'
       unsaved_title: 'Unnamed calendar'
-      label_calendar_plural: 'Calendars'

--- a/modules/costs/config/locales/en.yml
+++ b/modules/costs/config/locales/en.yml
@@ -28,27 +28,42 @@
 
 ---
 en:
-  plugin_costs:
-    name: "Time and costs"
-    description: "This module adds features for planning and tracking costs of projects."
-
   activerecord:
     attributes:
       cost_entry:
-        work_package: "Work package"
+        entity: Logged for
+        entity_gid: Logged for
+        entity_id: Logged for
+        logged_by: "Logged by"
         overridden_costs: "Overridden costs"
         spent: "Spent"
         spent_on: "Date"
-        logged_by: "Logged by"
-        entity: Logged for
-        entity_id: Logged for
-        entity_gid: Logged for
+        work_package: "Work package"
       cost_type:
-        unit: "Unit name"
-        unit_plural: "Pluralized unit name"
         default: "Cost type by default"
         for_all_projects: "For all projects"
         rates: "Rates"
+        unit: "Unit name"
+        unit_plural: "Pluralized unit name"
+      rate:
+        rate: "Rate"
+      time_entry:
+        activity: Activity
+        comments: Comment
+        end_time: Finish time
+        entity: Logged for
+        entity_gid: Logged for
+        entity_id: Logged for
+        hours: Hours
+        project: Project
+        spent_on: Date
+        start_time: Start time
+        subject: Subject
+        time: Time
+        user: User
+        work_package: Work package
+      user:
+        default_rates: "Default rates"
       work_package:
         costs_by_type: "Spent units"
         labor_costs: "Labor costs"
@@ -56,73 +71,61 @@ en:
         overall_costs: "Overall costs"
         spent_costs: "Spent costs"
         spent_units: "Spent units"
-      rate:
-        rate: "Rate"
-      user:
-        default_rates: "Default rates"
-      time_entry:
-        project: Project
-        user: User
-        work_package: Work package
-        subject: Subject
-        hours: Hours
-        comments: Comment
-        activity: Activity
-        spent_on: Date
-        start_time: Start time
-        end_time: Finish time
-        time: Time
-        entity: Logged for
-        entity_id: Logged for
-        entity_gid: Logged for
+    errors:
+      models:
+        cost_types_project:
+          attributes:
+            project_ids:
+              blank: "Please select a project."
+        time_entry:
+          cannot_log_for_this_work_package: "Cannot log time for this work package."
+          duplicate_ongoing: "An ongoing time entry already exists for this user."
+          invalid_time: "must be between 00:00 and 23:59."
+        work_package:
+          is_not_a_valid_target_for_cost_entries: "Work package #%{id} is not a valid target for reassigning the cost entries."
+          nullify_is_not_valid_for_cost_entries: "Cost entries can not be assigned to a project."
     models:
-      time_entry:
-        one: "Time entry"
-        other: "Time entries"
       cost_entry:
         one: "Cost entry"
         other: "Cost entries"
       cost_type:
         one: "Cost type"
         other: "Cost types"
+      rate: "Rate"
+      time_entry:
+        one: "Time entry"
+        other: "Time entries"
       time_entry_activity:
         one: "Time tracking activity"
         other: "Time tracking activities"
-      rate: "Rate"
+  api_v3:
     errors:
-      models:
-        time_entry:
-          invalid_time: "must be between 00:00 and 23:59."
-          cannot_log_for_this_work_package: "Cannot log time for this work package."
-          duplicate_ongoing: "An ongoing time entry already exists for this user."
-        work_package:
-          is_not_a_valid_target_for_cost_entries: "Work package #%{id} is not a valid target for reassigning the cost entries."
-          nullify_is_not_valid_for_cost_entries: "Cost entries can not be assigned to a project."
-        cost_types_project:
-          attributes:
-            project_ids:
-              blank: "Please select a project."
+      validation:
+        start_time_different_date: "Date part of startTime (%{start_time}) must be the same as the spentOn (%{spent_on}) date."
+
   attributes:
     comment: "Comment"
     cost_type: "Cost type"
     costs: "Costs"
     current_rate: "Current rate"
+    fixed_date: "Fixed date"
+
     hours: "Hours"
     units: "Units"
     valid_from: "Valid from"
-    fixed_date: "Fixed date"
-
+  button_add_activity: "Activity"
   button_add_rate: "Add rate"
+  button_add_time_entry: "Log time"
   button_log_costs: "Log unit costs"
   button_log_time: "Log"
-  button_add_activity: "Activity"
-  button_add_time_entry: "Log time"
   button_stop_timer: "Stop timer"
 
   caption_booked_on_project: "Booked on project"
   caption_default: "Default"
   caption_default_rate_history_for: "Default rate history for %{user}"
   caption_locked_on: "Locked on"
+  caption_log_time_dialog: "Log time"
+
   caption_materials: "Units"
   caption_rate_history: "Rate history"
   caption_rate_history_for: "Rate history for %{user}"
@@ -130,23 +133,63 @@ en:
   caption_save_rate: "Save rate"
   caption_set_rate: "Set current rate"
   caption_show_locked: "Show locked types"
-  caption_log_time_dialog: "Log time"
+  cost_types:
+    admin:
+      columns:
+        active_projects: "Active projects"
+      cost_type_projects:
+        for_all_projects_blank_slate:
+          description: "Uncheck \"For all projects\" on the details tab to limit this cost type to specific projects."
+          heading: "This cost type is enabled in all projects"
+        no_projects:
+          description: "Add projects so this cost type can be used in them."
+          heading: "No projects assigned"
+      rates:
+        title: "Rate history"
+    errors:
+      no_cost_types_available: "No cost types are available in this project. Please contact an administrator."
+    settings:
+      cost_types:
+        for_all_projects_hint: "This cost type is enabled in all projects."
 
-  description_date_for_new_rate: "Date for new rate"
+        heading: "Cost types"
+        none_active: "No cost types are currently active in this project."
+      time_and_costs: "Time & Costs"
+  costs:
+    widgets:
+      actual_costs:
+        blankslate:
+          action: "Log time"
+          description: "Get an overview of your costs and logged time to monitor progress of your project. Make sure that work packages are associated with the correct budget."
+          heading: "Start tracking your time and costs"
+        title: "Actual costs by month"
+        view_details: "View actual costs details"
+
   description_costs_settings: "Define the desired format for the costs in all projects."
+  description_date_for_new_rate: "Date for new rate"
   description_time_settings: "Define which fields are mandatory to fill when logging time in all projects."
 
+  ee:
+    features:
+      time_entry_time_restrictions: Require exact time tracking
+    upsell:
+      time_entry_time_restrictions:
+        description: "Improve your time tracking by requiring exact start and finish times when logging time."
   group_by_others: "not in any group"
 
+  label_available_cost_types_projects: "Available cost types projects"
   label_between: "between"
+  label_cost: "Cost"
   label_cost_filter_add: "Add cost entry filter"
-  label_costlog: "Logged unit costs"
   label_cost_plural: "Costs"
   label_cost_type_plural: "Cost types"
   label_cost_type_specific: "Cost type #%{id}: %{name}"
+  label_costlog: "Logged unit costs"
+  label_costs: "Costs"
   label_costs_per_page: "Costs per page"
   label_current_default_rate: "Current default rate"
   label_date_on: "on"
+  label_day: "Day"
   label_deleted_cost_types: "Deleted cost types"
   label_display_cost_entries: "Display unit costs"
   label_display_time_entries: "Display reported hours"
@@ -158,61 +201,56 @@ en:
   label_group_by_add: "Add grouping field"
   label_hourly_rate: "Hourly rate"
   label_include_deleted: "Include deleted"
-  label_work_package_filter_add: "Add work package filter"
   label_kind: "Type"
   label_less_or_equal: "<="
+  label_list: "List"
   label_log_costs: "Log unit costs"
-  label_new_time_entry_activity: "New time entry activity"
-  label_time_entry_activity_form_description: "Changes to this time entry activity will be reflected in all projects where it is enabled."
-  label_no: "No"
-  label_option_plural: "Options"
-  label_overall_costs: "Overall costs"
-  label_rate: "Rate"
-  label_rate_plural: "Rates"
-  label_status_finished: "Finished"
-  label_show: "Show"
-  label_units: "Cost units"
-  label_user: "User"
-  label_until: "until"
-  label_valid_from: "Valid from"
-  label_yes: "Yes"
-  label_time: "Time"
-  label_cost: "Cost"
-  label_costs: "Costs"
   label_mandatory_fields: "Mandatory fields"
+  label_month: "Month"
   label_my_time_tracking: "My time tracking"
-  label_no_time: "No time tracked"
+  label_new_time_entry_activity: "New time entry activity"
   label_next_day: "Next day"
+  label_next_month: "Next month"
   label_next_week: "Next week"
   label_next_workweek: "Next work week"
-  label_next_month: "Next month"
+  label_no: "No"
+  label_no_time: "No time tracked"
+  label_option_plural: "Options"
+  label_overall_costs: "Overall costs"
   label_previous_day: "Previous day"
-  label_previous_workweek: "Previous work week"
-  label_previous_week: "Previous week"
   label_previous_month: "Previous month"
+  label_previous_week: "Previous week"
+  label_previous_workweek: "Previous work week"
+  label_rate: "Rate"
+  label_rate_plural: "Rates"
+  label_show: "Show"
   label_specific_day: "Day %{day}"
   label_specific_month: "Month %{month}"
-  label_list: "List"
-  label_month: "Month"
-  label_workweek: "Work week"
-  label_day: "Day"
-  label_today_capitalized: "Today"
-  label_view_mode_switcher: "Change view"
+  label_status_finished: "Finished"
+  label_time: "Time"
+  label_time_entry_activity_form_description: "Changes to this time entry activity will be reflected in all projects where it is enabled."
   label_timer_since: "Started at %{time}"
 
-  placeholder_activity_select_work_package_first: Work package selection is required first
-
-  notice_something_wrong: "Something went wrong. Please try again."
-  notice_successful_restore: "Successful restore."
-  notice_successful_lock: "Locked successfully."
+  label_today_capitalized: "Today"
+  label_units: "Cost units"
+  label_until: "until"
+  label_user: "User"
+  label_valid_from: "Valid from"
+  label_view_mode_switcher: "Change view"
+  label_work_package_filter_add: "Add work package filter"
+  label_workweek: "Work week"
+  label_yes: "Yes"
   notice_cost_logged_successfully: "Unit cost logged successfully."
   notice_different_time_zones: "This user has a different time zone (%{tz}). Time will be logged using their time zone."
-  notice_time_entry_update_failed: "Failed to update time entry. Errors: %{errors}"
+  notice_something_wrong: "Something went wrong. Please try again."
+  notice_successful_lock: "Locked successfully."
+  notice_successful_restore: "Successful restore."
   notice_time_entry_delete_failed: "Failed to delete time entry. Errors: %{errors}"
 
+  notice_time_entry_update_failed: "Failed to update time entry. Errors: %{errors}"
   permission_edit_cost_entries: "Edit booked unit costs"
-  permission_edit_own_cost_entries: "Edit own booked unit costs"
   permission_edit_hourly_rates: "Edit hourly rates"
+  permission_edit_own_cost_entries: "Edit own booked unit costs"
   permission_edit_own_hourly_rate: "Edit own hourly rates"
   permission_edit_rates: "Edit rates"
   permission_log_costs: "Book unit costs"
@@ -224,19 +262,25 @@ en:
   permission_view_own_hourly_rate: "View own hourly rate"
   permission_view_own_time_entries: "View own spent time"
 
+  placeholder_activity_select_work_package_first: Work package selection is required first
+
+  plugin_costs:
+    description: "This module adds features for planning and tracking costs of projects."
+
+    name: "Time and costs"
   project_module_costs: "Time and costs"
 
   setting_allow_tracking_start_and_end_times: "Allow start and finish times"
+  setting_allow_tracking_start_and_end_times_caption: "Enables entering start and finish times when logging time."
   setting_costs_currency: "Currency"
   setting_costs_currency_caption: "This is the unit of currency. It can be a three-letter ISO code like EUR, USD or JPY or a symbol like €, $ or ¥."
   setting_costs_currency_format: "Currency format"
   setting_costs_currency_format_prefix: "Before the number (e.g. EUR 100)"
   setting_costs_currency_format_suffix: "After the number (e.g. 100 EUR)"
   setting_enforce_tracking_start_and_end_times: "Require start and finish times"
-  setting_enforce_without_allow: "Requiring start and finish times is not possible without allowing them"
-  setting_allow_tracking_start_and_end_times_caption: "Enables entering start and finish times when logging time."
   setting_enforce_tracking_start_and_end_times_caption: "Makes entering start and finish times mandatory when logging time."
 
+  setting_enforce_without_allow: "Requiring start and finish times is not possible without allowing them"
   text_assign_time_and_cost_entries_to_project: "Assign reported hours and costs to the project"
   text_destroy_cost_entries_question: "%{cost_entries} were reported on the work packages you are about to delete. What do you want to do ?"
   text_destroy_time_and_cost_entries: "Delete reported hours and costs"
@@ -244,55 +288,10 @@ en:
   text_reassign_time_and_cost_entries: "Reassign reported hours and costs to this work package:"
   text_warning_hidden_elements: "Some entries may have been excluded from the aggregation."
 
-  week: "week"
-
   total_times:
-    workweek: "Workweek Total: %{hours}"
-    week: "Week Total: %{hours}"
-    month: "Month Total: %{hours}"
     day: "Day Total: %{hours}"
 
-  api_v3:
-    errors:
-      validation:
-        start_time_different_date: "Date part of startTime (%{start_time}) must be the same as the spentOn (%{spent_on}) date."
-
-  label_available_cost_types_projects: "Available cost types projects"
-  cost_types:
-    errors:
-      no_cost_types_available: "No cost types are available in this project. Please contact an administrator."
-    admin:
-      columns:
-        active_projects: "Active projects"
-      cost_type_projects:
-        for_all_projects_blank_slate:
-          heading: "This cost type is enabled in all projects"
-          description: "Uncheck \"For all projects\" on the details tab to limit this cost type to specific projects."
-        no_projects:
-          heading: "No projects assigned"
-          description: "Add projects so this cost type can be used in them."
-      rates:
-        title: "Rate history"
-    settings:
-      time_and_costs: "Time & Costs"
-      cost_types:
-        heading: "Cost types"
-        none_active: "No cost types are currently active in this project."
-        for_all_projects_hint: "This cost type is enabled in all projects."
-
-  costs:
-    widgets:
-      actual_costs:
-        title: "Actual costs by month"
-        blankslate:
-          heading: "Start tracking your time and costs"
-          description: "Get an overview of your costs and logged time to monitor progress of your project. Make sure that work packages are associated with the correct budget."
-          action: "Log time"
-        view_details: "View actual costs details"
-
-  ee:
-    features:
-      time_entry_time_restrictions: Require exact time tracking
-    upsell:
-      time_entry_time_restrictions:
-        description: "Improve your time tracking by requiring exact start and finish times when logging time."
+    month: "Month Total: %{hours}"
+    week: "Week Total: %{hours}"
+    workweek: "Workweek Total: %{hours}"
+  week: "week"

--- a/modules/costs/config/locales/js-en.yml
+++ b/modules/costs/config/locales/js-en.yml
@@ -29,15 +29,15 @@
 ---
 en:
   js:
-    text_are_you_sure: "Are you sure?"
-    myTimeTracking:
-      noSpecificTime: "No specific time"
-    work_packages:
-      property_groups:
-        costs: "Costs"
-      properties:
-        overallCosts: "Overall costs"
-        spentUnits: "Spent units"
     button_log_costs: "Log unit costs"
     label_hour: "hour"
     label_hours: "hours"
+    myTimeTracking:
+      noSpecificTime: "No specific time"
+    text_are_you_sure: "Are you sure?"
+    work_packages:
+      properties:
+        overallCosts: "Overall costs"
+        spentUnits: "Spent units"
+      property_groups:
+        costs: "Costs"

--- a/modules/documents/config/locales/en.yml
+++ b/modules/documents/config/locales/en.yml
@@ -28,14 +28,12 @@
 
 ---
 en:
-  plugin_openproject_documents:
-    name: "OpenProject Documents"
-    description: "An OpenProject plugin to allow creation of documents in projects."
-
-  attributes:
-    collaborative_editing_hocuspocus_url: "Hocuspocus server URL"
-
   activerecord:
+    attributes:
+      document:
+        content_binary: "Content binary"
+        title: "Title"
+
     errors:
       models:
         document_type:
@@ -43,150 +41,152 @@ en:
     models:
       document: "Document"
       documents: "Documents"
-    attributes:
-      document:
-        content_binary: "Content binary"
-        title: "Title"
-
   activity:
     filter:
       document: "Documents"
 
+  attributes:
+    collaborative_editing_hocuspocus_url: "Hocuspocus server URL"
+
   default_doc_category_tech: "Technical documentation"
   default_doc_category_user: "User documentation"
 
-  enumeration_doc_categories: "Document categories"
-
   documents:
+    active_editors: "Active editors"
+    active_editors_count:
+      one: "1 active editor"
+      other: "%{count} active editors"
+
+    admin:
+      collaboration_settings:
+        banner:
+          none_writable: These values are configured via environment variables and cannot be edited here.
+          some_unwritable: Some values are configured via environment variables and cannot be edited here.
+        hocuspocus_server: Hocuspocus server
+
+        hocuspocus_server_secret:
+          caption: "Paste the secret provided by the Hocuspocus server."
+          label: "Client secret"
+        hocuspocus_server_url:
+          caption: "The WebSocket address of a working Hocuspocus server."
+          invalid_scheme: "Must use a WebSocket protocol (ws:// or wss://)."
+          label: "Hocuspocus server URL"
+        page_header:
+          description: |-
+            When enabled, real-time collaboration allows multiple users to edit a document at the same time.
+            It requires a working %{hocuspocus_server_link} to function.
+      disable_text_collaboration_dialog:
+        confirmation_checkbox_message: I understand that I might permanently lose data
+        confirmation_message: |-
+          All existing documents may become inaccessible. Please only do this if you are certain you want to disable
+          real-time collaboration and the BlockNote editor in this instance.
+        heading: Disable real-time collaboration?
+        success: Real-time collaboration has been disabled.
+
+        title: Disable real-time collaboration
+      enable_text_collaboration:
+        description: |-
+          Once enabled, multiple users will be able to work together on a document at the same time.
+          All new documents will be based on a new editor (BlockNote) and will require a working connection to a
+          Hocuspocus server.
+        heading: Real-time collaboration is not enabled
+        primary_action: Enable real-time collaboration
+        success: Real-time collaboration has been enabled.
+
+    delete_dialog:
+      confirmation_message_html: "This will permanently delete this document and all file attachments. Are you sure you want to do this?"
+
+      heading: "Delete this document?"
+      title: "Delete document"
+    delete_document_type_dialog:
+      at_least_one_type_required:
+        heading: Cannot delete the last document type
+        message: There must always be at least one document type configured. Create another one first if you want to delete this one.
+
+        title: Cannot delete document type
+      confirmation_message: |-
+        The type "%{type_name}" is currently unused. Deleting this type will have no effect on existing documents.
+      heading: Delete this document type?
+      reassign_message:
+        one: The type "%{type_name}" is currently being used in %{document_count} document. Please select which type to reassign them to.
+        other: The type "%{type_name}" is currently being used in %{document_count} documents. Please select which type to reassign them to.
+      select_reassign_to_label: Reassign documents to
+      title: Delete document type
+    document_categories_deprecation_notice:
+      description: |-
+        Your existing file categories have been converted to document types with the introduction of the new Documents module.
+        All existing documents have also been migrated to these new types.
+      heading: File categories are now called 'Document types'
+      primary_action: Configure document types
+      secondary_action: Learn more about the Documents module
+
+    document_type_actions: "Document type actions"
+
+    documents_list_blank_slate:
+      description: "There are no documents in this view. You can click the button below to add one."
+
+      heading: "There are no documents yet"
+    index_page:
+      label_legacy: "Legacy"
+
+      name: "Name"
+      type: "Type"
+      updated_at: "Last edited"
+    info_line:
+      connection_restored: "You are now back online."
+
+      currently_offline: "You are currently offline."
+    label_attachment_author: "Attachment author"
+    label_categories: "Categories"
+    last_updated_at: "Last saved %{time}."
+
+    menu:
+      all: "All documents"
+      collaboration_settings: "Real-time collaboration"
+
+      types: "Types"
+    new_category: "New category"
+    new_type: "New type"
+
     page_header:
-      heading: "All documents"
       action_menu:
         document_actions: "Document actions"
         edit_title: "Edit title"
+
+      heading: "All documents"
+    show_edit_view:
+      connection_error_notice:
+        action: Try again
+        description_server_unavailable: |-
+          Unable to open document because the real-time text collaboration server is unreachable.
+          Please contact the administrator if the problem persists.
+      tabs: "Document tabs"
 
     subheader:
       filter:
         label: "Document name filter"
         placeholder: "Type here to search document names"
 
-    documents_list_blank_slate:
-      heading: "There are no documents yet"
-      description: "There are no documents in this view. You can click the button below to add one."
-
-    document_categories_deprecation_notice:
-      heading: File categories are now called 'Document types'
-      description: |-
-        Your existing file categories have been converted to document types with the introduction of the new Documents module.
-        All existing documents have also been migrated to these new types.
-      primary_action: Configure document types
-      secondary_action: Learn more about the Documents module
-
-    document_type_actions: "Document type actions"
-
     text_collaboration_disabled_notice:
       description: |-
         Unable to open document because real-time text collaboration is disabled.
         Please contact your administrator to enable real-time text collaboration if you want to access this document.
 
-    show_edit_view:
-      connection_error_notice:
-        description_server_unavailable: |-
-          Unable to open document because the real-time text collaboration server is unreachable.
-          Please contact the administrator if the problem persists.
-        action: Try again
-      tabs: "Document tabs"
-
-    index_page:
-      name: "Name"
-      type: "Type"
-      updated_at: "Last edited"
-      label_legacy: "Legacy"
-
-    menu:
-      all: "All documents"
-      types: "Types"
-      collaboration_settings: "Real-time collaboration"
-
-    last_updated_at: "Last saved %{time}."
-
-    info_line:
-      currently_offline: "You are currently offline."
-      connection_restored: "You are now back online."
-
-    active_editors: "Active editors"
-    active_editors_count:
-      one: "1 active editor"
-      other: "%{count} active editors"
-
-    label_attachment_author: "Attachment author"
-    label_categories: "Categories"
-    new_category: "New category"
-    new_type: "New type"
-
-    delete_dialog:
-      title: "Delete document"
-      heading: "Delete this document?"
-      confirmation_message_html: "This will permanently delete this document and all file attachments. Are you sure you want to do this?"
-
-    delete_document_type_dialog:
-      title: Delete document type
-      heading: Delete this document type?
-      confirmation_message: |-
-        The type "%{type_name}" is currently unused. Deleting this type will have no effect on existing documents.
-      select_reassign_to_label: Reassign documents to
-      reassign_message:
-        one: The type "%{type_name}" is currently being used in %{document_count} document. Please select which type to reassign them to.
-        other: The type "%{type_name}" is currently being used in %{document_count} documents. Please select which type to reassign them to.
-      at_least_one_type_required:
-        title: Cannot delete document type
-        heading: Cannot delete the last document type
-        message: There must always be at least one document type configured. Create another one first if you want to delete this one.
-
-    admin:
-      collaboration_settings:
-        page_header:
-          description: |-
-            When enabled, real-time collaboration allows multiple users to edit a document at the same time.
-            It requires a working %{hocuspocus_server_link} to function.
-        banner:
-          none_writable: These values are configured via environment variables and cannot be edited here.
-          some_unwritable: Some values are configured via environment variables and cannot be edited here.
-        hocuspocus_server_url:
-          label: "Hocuspocus server URL"
-          caption: "The WebSocket address of a working Hocuspocus server."
-          invalid_scheme: "Must use a WebSocket protocol (ws:// or wss://)."
-        hocuspocus_server_secret:
-          label: "Client secret"
-          caption: "Paste the secret provided by the Hocuspocus server."
-        hocuspocus_server: Hocuspocus server
-
-      enable_text_collaboration:
-        heading: Real-time collaboration is not enabled
-        description: |-
-          Once enabled, multiple users will be able to work together on a document at the same time.
-          All new documents will be based on a new editor (BlockNote) and will require a working connection to a
-          Hocuspocus server.
-        primary_action: Enable real-time collaboration
-        success: Real-time collaboration has been enabled.
-
-      disable_text_collaboration_dialog:
-        title: Disable real-time collaboration
-        heading: Disable real-time collaboration?
-        confirmation_message: |-
-          All existing documents may become inaccessible. Please only do this if you are certain you want to disable
-          real-time collaboration and the BlockNote editor in this instance.
-        confirmation_checkbox_message: I understand that I might permanently lose data
-        success: Real-time collaboration has been disabled.
+  enumeration_doc_categories: "Document categories"
 
   label_document_added: "Document added"
+  label_document_category: "Category"
+  label_document_description: "Description"
   label_document_new: "New document"
   label_document_plural: "Documents"
-  label_documents: "Documents"
   label_document_title: "Title"
-  label_document_description: "Description"
-  label_document_category: "Category"
   label_document_type: "Type"
 
+  label_documents: "Documents"
   permission_manage_documents: "Manage documents"
   permission_view_documents: "View documents"
+  plugin_openproject_documents:
+    description: "An OpenProject plugin to allow creation of documents in projects."
+
+    name: "OpenProject Documents"
   project_module_documents: "Documents"

--- a/modules/gantt/config/locales/js-en.yml
+++ b/modules/gantt/config/locales/js-en.yml
@@ -2,6 +2,6 @@
 en:
   js:
     work_packages:
-      label_gantt_chart_plural: "Gantt charts"
       default_queries:
         milestones: 'Milestones'
+      label_gantt_chart_plural: "Gantt charts"

--- a/modules/github_integration/config/locales/en.yml
+++ b/modules/github_integration/config/locales/en.yml
@@ -30,51 +30,51 @@
 en:
   attributes:
     additions_count: "Number of additions"
-    deletions_count: "Number of deletions"
+    changed_files_count: "Changed files"
     comments_count: "Comments count"
-    github_html_url: "Pull Request URL"
-    github_app_owner_avatar_url: "Owner avatar URL"
-    review_comments_count: "Review comments count"
+    deletions_count: "Number of deletions"
     github: "GitHub identifer"
+    github_app_owner_avatar_url: "Owner avatar URL"
     github_avatar_url: "Avatar URL"
-    github_updated_at: "Updated at"
+    github_html_url: "Pull Request URL"
     github_login: "GitHub login"
+    github_updated_at: "Updated at"
     host: "Host"
     labels: "Labels"
     repository: "Repository"
-    changed_files_count: "Changed files"
+    review_comments_count: "Review comments count"
   button_add_deploy_target: Add deploy target
   label_deploy_target: Deploy target
   label_deploy_target_new: New deploy target
   label_deploy_target_plural: Deploy targets
+  label_github_comment_user: "GitHub actor"
   label_github_integration: GitHub Integration
+  label_github_webhook_secret: "Webhook secret"
   notice_deploy_target_created: Deploy target created
   notice_deploy_target_destroyed: Deploy target deleted
-  label_github_comment_user: "GitHub actor"
-  label_github_webhook_secret: "Webhook secret"
+  permission_introspection: Read running OpenProject core version and build SHA
+  permission_show_github_content: "Show GitHub content"
+  plugin_openproject_github_integration:
+    description: "Integrates OpenProject and GitHub for a better workflow"
+
+    name: "OpenProject GitHub Integration"
+  project_module_github: "GitHub"
+  text_deploy_target_api_key_info: >
+    An OpenProject [API key](docs_url)
+    belonging to a user who has the global introspection permission.
+  text_deploy_target_type_info: >
+    So far we only support OpenProject itself.
   text_github_comment_user_info: >
     The OpenProject user whose API key must be used to authenticate incoming webhook requests.
     When set, requests authenticated with any other user's credentials are rejected.
     This user also posts automated deploy-status comments on work packages. Defaults to the system user when not set.
-  text_github_webhook_secret_missing_warning: >
-    No webhook secret is configured. Any request to the GitHub webhook endpoint will be accepted
-    without verification, which may allow unauthorized actors to forge events. It is strongly
-    recommended to set a secret.
   text_github_webhook_secret_info: >
     A secret token shared with GitHub when configuring the webhook.
     When set, OpenProject verifies the X-Hub-Signature-256 header on every incoming request,
     rejecting payloads that do not match. Leave blank to skip verification (not recommended).
 
-  plugin_openproject_github_integration:
-    name: "OpenProject GitHub Integration"
-    description: "Integrates OpenProject and GitHub for a better workflow"
-
-  project_module_github: "GitHub"
-  permission_show_github_content: "Show GitHub content"
-  permission_introspection: Read running OpenProject core version and build SHA
-  text_deploy_target_type_info: >
-    So far we only support OpenProject itself.
-  text_deploy_target_api_key_info: >
-    An OpenProject [API key](docs_url)
-    belonging to a user who has the global introspection permission.
+  text_github_webhook_secret_missing_warning: >
+    No webhook secret is configured. Any request to the GitHub webhook endpoint will be accepted
+    without verification, which may allow unauthorized actors to forge events. It is strongly
+    recommended to set a secret.
   text_pull_request_deployed_to: "%{pr_link} deployed to %{deploy_target_link}"

--- a/modules/github_integration/config/locales/js-en.yml
+++ b/modules/github_integration/config/locales/js-en.yml
@@ -30,34 +30,34 @@
 en:
   js:
     github_integration:
-      work_packages:
-        tab_name: "GitHub"
-      tab_header:
-        title: "Pull requests"
-        copy_menu:
-          label: Git snippets
-          description: Copy git snippets to clipboard
-        git_actions:
-          branch_name: Branch name
-          commit_message: Commit message
-          cmd: Create branch with empty commit
-          title: Quick snippets for Git
-          copy_success: ✅ Copied!
-          copy_error: ❌ Copy failed!
-      tab_prs:
-        empty: There are no pull requests linked yet. Link an existing PR by using the code <code>OP#%{wp_id}</code> in the PR description or create a new PR.
-
       github_actions: Actions
       pull_requests:
-        message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} has been %{pr_state}."
         merged_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} has been %{pr_state} by %{github_user_link}."
+        message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} has been %{pr_state}."
         referenced_message: "Pull request #%{pr_number} %{pr_link} for %{repository_link} authored by %{github_user_link} referenced this work package."
         states:
-          opened: 'opened'
           closed: 'closed'
           draft: 'drafted'
           merged: 'merged'
+          opened: 'opened'
           ready_for_review: 'marked ready for review'
+      tab_header:
+        copy_menu:
+          description: Copy git snippets to clipboard
+          label: Git snippets
+        git_actions:
+          branch_name: Branch name
+          cmd: Create branch with empty commit
+          commit_message: Commit message
+          copy_error: ❌ Copy failed!
+          copy_success: ✅ Copied!
+          title: Quick snippets for Git
+        title: "Pull requests"
+      tab_prs:
+        empty: There are no pull requests linked yet. Link an existing PR by using the code <code>OP#%{wp_id}</code> in the PR description or create a new PR.
+
+      work_packages:
+        tab_name: "GitHub"
     work_packages:
       tabs:
         github: "GitHub"

--- a/modules/gitlab_integration/config/locales/en.yml
+++ b/modules/gitlab_integration/config/locales/en.yml
@@ -29,23 +29,12 @@
 
 ---
 en:
-  attributes:
-    commit: "Commit"
-    gitlab: "GitLab identifier"
-    gitlab_avatar_url: "Avatar URL"
-    gitlab_email: "GitLab Email"
-    gitlab_html_url: "GitLab HTML URL"
-    gitlab_merge_request: "Merge Request"
-    gitlab_name: "GitLab name"
-    gitlab_updated_at: "Updated at"
-    gitlab_user_avatar_url: "GitLab avatar URL"
-    gitlab_username: "GitLab username"
   activerecord:
     attributes:
-      gitlab_pipeline:
-        ci_details: "CI Details"
       gitlab_merge_request:
         labels: "Labels"
+      gitlab_pipeline:
+        ci_details: "CI Details"
     errors:
       models:
         gitlab_issue:
@@ -57,9 +46,90 @@ en:
             labels:
               invalid_schema: "must be an array of hashes with keys: color, title"
 
-  label_gitlab_integration: "GitLab Integration"
+  attributes:
+    commit: "Commit"
+    gitlab: "GitLab identifier"
+    gitlab_avatar_url: "Avatar URL"
+    gitlab_email: "GitLab Email"
+    gitlab_html_url: "GitLab HTML URL"
+    gitlab_merge_request: "Merge Request"
+    gitlab_name: "GitLab name"
+    gitlab_updated_at: "Updated at"
+    gitlab_user_avatar_url: "GitLab avatar URL"
+    gitlab_username: "GitLab username"
+  gitlab_integration:
+    issue_closed_referenced_comment: >
+      **Issue Closed:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
+      has been closed by [%{gitlab_user}](%{gitlab_user_url}).
+    issue_opened_referenced_comment: >
+      **Issue Opened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
+      has been opened by [%{gitlab_user}](%{gitlab_user_url}).
+    issue_reopened_referenced_comment: >
+      **Issue Reopened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
+      has been reopened by [%{gitlab_user}](%{gitlab_user_url}).
+    merge_request_closed_comment: >
+      **MR Closed:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
+      has been closed by [%{gitlab_user}](%{gitlab_user_url}).
+    merge_request_merged_comment: >
+      **MR Merged:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
+      has been merged by [%{gitlab_user}](%{gitlab_user_url}).
+    merge_request_opened_comment: >
+      **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
+      has been opened by [%{gitlab_user}](%{gitlab_user_url}).
+    merge_request_reopened_comment: >
+      **MR Reopened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
+      has been reopened by [%{gitlab_user}](%{gitlab_user_url}).
+    note_commit_referenced_comment: >
+      **Referenced in Commit:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
+      a Commit Note [%{commit_id}](%{commit_url}) on [%{repository}](%{repository_url}):
+
+      %{commit_note}
+    note_issue_commented_comment: >
+      **Commented in Issue:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
+      Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
+
+      %{issue_note}
+    note_issue_referenced_comment: >
+      **Referenced in Issue:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
+      Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
+
+      %{issue_note}
+    note_mr_commented_comment: >
+      **Commented in MR:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
+      Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
+
+      %{mr_note}
+    note_mr_referenced_comment: >
+      **Referenced in MR:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
+      Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
+
+      %{mr_note}
+    note_snippet_referenced_comment: >
+      **Referenced in Snippet:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
+      Snippet %{snippet_number} [%{snippet_title}](%{snippet_url}) on [%{repository}](%{repository_url}):
+
+      %{snippet_note}
+    push_multiple_commits_comment: >
+      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed multiple commits [%{commit_number}](%{commit_url})
+      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
+
+      %{commit_note}
+    push_single_commit_comment: >
+      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url})
+      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
+
+      %{commit_note}
+    push_single_commit_comment_with_ref: >
+      **Pushed in %{reference}:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url})
+      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
+
+      %{commit_note}
   label_gitlab_actor: "GitLab actor"
+  label_gitlab_integration: "GitLab Integration"
   label_gitlab_webhook_secret: "Webhook secret"
+  permission_show_gitlab_content: "Show GitLab content"
+
+  project_module_gitlab: "GitLab"
   text_gitlab_actor_info: >
     The OpenProject user whose API key must be used to authenticate incoming webhook requests.
     When set, requests authenticated with any other user's credentials are rejected.
@@ -72,74 +142,3 @@ en:
     No webhook secret is configured. Any request to the GitLab webhook endpoint will be accepted
     without verification, which may allow unauthorized actors to forge events. It is strongly
     recommended to set a secret.
-
-  project_module_gitlab: "GitLab"
-  permission_show_gitlab_content: "Show GitLab content"
-
-  gitlab_integration:
-    merge_request_opened_comment: >
-      **MR Opened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
-      has been opened by [%{gitlab_user}](%{gitlab_user_url}).
-    merge_request_closed_comment: >
-      **MR Closed:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
-      has been closed by [%{gitlab_user}](%{gitlab_user_url}).
-    merge_request_merged_comment: >
-      **MR Merged:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
-      has been merged by [%{gitlab_user}](%{gitlab_user_url}).
-    merge_request_reopened_comment: >
-      **MR Reopened:** Merge request %{mr_number} [%{mr_title}](%{mr_url}) for [%{repository}](%{repository_url})
-      has been reopened by [%{gitlab_user}](%{gitlab_user_url}).
-    note_commit_referenced_comment: >
-      **Referenced in Commit:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
-      a Commit Note [%{commit_id}](%{commit_url}) on [%{repository}](%{repository_url}):
-
-      %{commit_note}
-    note_mr_referenced_comment: >
-      **Referenced in MR:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
-      Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
-
-      %{mr_note}
-    note_mr_commented_comment: >
-      **Commented in MR:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
-      Merge Request %{mr_number} [%{mr_title}](%{mr_url}) on [%{repository}](%{repository_url}):
-
-      %{mr_note}
-    note_issue_referenced_comment: >
-      **Referenced in Issue:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
-      Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
-
-      %{issue_note}
-    note_issue_commented_comment: >
-      **Commented in Issue:** [%{gitlab_user}](%{gitlab_user_url}) commented this WP in
-      Issue %{issue_number} [%{issue_title}](%{issue_url}) on [%{repository}](%{repository_url}):
-
-      %{issue_note}
-    note_snippet_referenced_comment: >
-      **Referenced in Snippet:** [%{gitlab_user}](%{gitlab_user_url}) referenced this WP in
-      Snippet %{snippet_number} [%{snippet_title}](%{snippet_url}) on [%{repository}](%{repository_url}):
-
-      %{snippet_note}
-    issue_opened_referenced_comment: >
-      **Issue Opened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
-      has been opened by [%{gitlab_user}](%{gitlab_user_url}).
-    issue_closed_referenced_comment: >
-      **Issue Closed:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
-      has been closed by [%{gitlab_user}](%{gitlab_user_url}).
-    issue_reopened_referenced_comment: >
-      **Issue Reopened:** Issue %{issue_number} [%{issue_title}](%{issue_url}) for [%{repository}](%{repository_url})
-      has been reopened by [%{gitlab_user}](%{gitlab_user_url}).
-    push_single_commit_comment: >
-      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url})
-      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
-
-      %{commit_note}
-    push_single_commit_comment_with_ref: >
-      **Pushed in %{reference}:** [%{gitlab_user}](%{gitlab_user_url}) pushed [%{commit_number}](%{commit_url})
-      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
-
-      %{commit_note}
-    push_multiple_commits_comment: >
-      **Pushed in MR:** [%{gitlab_user}](%{gitlab_user_url}) pushed multiple commits [%{commit_number}](%{commit_url})
-      to [%{repository}](%{repository_url}) at %{commit_timestamp}:
-
-      %{commit_note}

--- a/modules/gitlab_integration/config/locales/js-en.yml
+++ b/modules/gitlab_integration/config/locales/js-en.yml
@@ -31,31 +31,31 @@
 en:
   js:
     gitlab_integration:
-      work_packages:
-        tab_name: "GitLab"
+      gitlab_pipelines: Pipelines
       tab_header_issue:
         title: "Issues"
       tab_header_mr:
-        title: "Merge requests"
-        create_mr:
-          label: Create MR
-          description: Create a Merge Request
         copy_menu:
-          label: Git snippets
           description: Copy git snippets to clipboard
+          label: Git snippets
+        create_mr:
+          description: Create a Merge Request
+          label: Create MR
         git_actions:
           branch_name: Branch name
-          commit_message: Commit message
           cmd: Create branch with empty commit
-          title: Quick snippets for Git
-          copy_success: ✅ Copied!
+          commit_message: Commit message
           copy_error: ❌ Copy failed!
+          copy_success: ✅ Copied!
+          title: Quick snippets for Git
+        title: "Merge requests"
       tab_issue:
         empty: There are no issues linked yet. Link an existing issue by using the code <code>OP#%{wp_id}</code> (or <code>PP#%{wp_id}</code> for private links) in the issue title/description or create a new issue.
       tab_mrs:
         empty: There are no merge requests linked yet. Link an existing MR by using the code <code>OP#%{wp_id}</code> (or <code>PP#%{wp_id}</code> for private links) in the MR title/description or create a new MR.
-      gitlab_pipelines: Pipelines
       updated_on: Updated on
+      work_packages:
+        tab_name: "GitLab"
     work_packages:
       tabs:
         gitlab: "GitLab"

--- a/modules/grids/config/locales/en.yml
+++ b/modules/grids/config/locales/en.yml
@@ -1,38 +1,38 @@
 ---
 en:
+  activerecord:
+    attributes:
+      grids/grid:
+        column_count: "Number of columns"
+        page: "Page"
+        row_count: "Number of rows"
+        scope: "Scope"
+        widgets: "Widgets"
+    errors:
+      models:
+        grids/grid:
+          end_before_start: 'end value needs to be larger than the start value.'
+          outside: 'is outside of the grid.'
+          overlaps: 'overlap.'
   grids:
     label_widget_in_grid: "Widget contained in Grid %{grid_name}"
 
     widgets:
       empty: "This widget is currently empty."
-      not_available: "This widget is not available."
-      subitems:
-        title: "Subitems"
-        no_results: "There are no visible children."
-        view_all_subitems: "View all subitems"
-        button_text: "Subitem"
       members:
-        title: "Members"
         no_results: "No visible members."
-        view_all_members: "View all members"
         show_members_count: "Show all %{count} members"
+        title: "Members"
+        view_all_members: "View all members"
         x_more:
           one: "and one more member."
           other: "and %{count} more members."
       news:
         no_results: "Nothing new to report."
 
-  activerecord:
-    attributes:
-      grids/grid:
-        page: "Page"
-        row_count: "Number of rows"
-        column_count: "Number of columns"
-        widgets: "Widgets"
-        scope: "Scope"
-    errors:
-      models:
-        grids/grid:
-          overlaps: 'overlap.'
-          outside: 'is outside of the grid.'
-          end_before_start: 'end value needs to be larger than the start value.'
+      not_available: "This widget is not available."
+      subitems:
+        button_text: "Subitem"
+        no_results: "There are no visible children."
+        title: "Subitems"
+        view_all_subitems: "View all subitems"

--- a/modules/grids/config/locales/js-en.yml
+++ b/modules/grids/config/locales/js-en.yml
@@ -3,60 +3,60 @@ en:
   js:
     grid:
       add_widget: 'Add widget'
-      widget_menu_label: 'Show menu options for %{widgetName} widget'
-      remove: 'Remove widget'
       configure: 'Configure widget'
+      remove: 'Remove widget'
+      widget_menu_label: 'Show menu options for %{widgetName} widget'
       widgets:
-        missing_permission: "You don't have the necessary permissions to view this widget."
-        not_available: "This widget is currently unavailable."
         custom_text:
           title: 'Custom text'
         documents:
-          title: 'Documents'
           no_results: 'No documents yet.'
+          title: 'Documents'
         members:
           title: 'Members'
+        missing_permission: "You don't have the necessary permissions to view this widget."
         news:
           title: 'News'
+        not_available: "This widget is currently unavailable."
         project_description:
           title: 'Description'
-        project_status:
-          title: 'Status'
-          not_started: 'Not started'
-          on_track: 'On track'
-          off_track: 'Off track'
-          at_risk: 'At risk'
-          not_set: 'Not set'
-          finished: 'Finished'
-          discontinued: 'Discontinued'
-        subprojects:
-          title: 'Subitems'
         project_favorites:
-          title: 'Favorite projects'
           no_results: >-
             You currently have no favorite projects. Add one or multiple projects
             as favorite through their overview or in a project list.
+          title: 'Favorite projects'
+        project_status:
+          at_risk: 'At risk'
+          discontinued: 'Discontinued'
+          finished: 'Finished'
+          not_set: 'Not set'
+          not_started: 'Not started'
+          off_track: 'Off track'
+          on_track: 'On track'
+          title: 'Status'
+        subprojects:
+          title: 'Subitems'
         time_entries_current_user:
-          title: 'My spent time'
           displayed_days: 'Days displayed in the widget:'
+          title: 'My spent time'
         time_entries_list:
-          title: 'Spent time (last 7 days)'
           no_results: 'No time entries for the last 7 days.'
+          title: 'Spent time (last 7 days)'
         work_packages_accountable:
           title: "Work packages I am accountable for"
         work_packages_assigned:
           title: 'Work packages assigned to me'
-        work_packages_created:
-          title: 'Work packages created by me'
-        work_packages_watched:
-          title: 'Work packages watched by me'
-        work_packages_table:
-          title: 'Work packages table'
-        work_packages_graph:
-          title: 'Work packages graph'
-          summary: "%{chartType} chart showing work packages which are %{description}."
         work_packages_calendar:
           title: 'Calendar'
+        work_packages_created:
+          title: 'Work packages created by me'
+        work_packages_graph:
+          summary: "%{chartType} chart showing work packages which are %{description}."
+          title: 'Work packages graph'
         work_packages_overview:
-          title: 'Work packages overview'
           placeholder: 'Click to edit ...'
+          title: 'Work packages overview'
+        work_packages_table:
+          title: 'Work packages table'
+        work_packages_watched:
+          title: 'Work packages watched by me'

--- a/modules/job_status/config/locales/en.yml
+++ b/modules/job_status/config/locales/en.yml
@@ -1,21 +1,21 @@
 ---
 en:
-  label_job_status_plural: "Job statuses"
-  plugin_openproject_job_status:
-    name: "OpenProject Job status"
-    description: "Listing and status of background jobs."
   job_status_dialog:
-    download_starts: 'The download should start automatically.'
     click_to_download: 'Or [click here](download_url) to download.'
-    title: 'Background job status'
-    redirect: 'You are being redirected.'
-    redirect_link: 'Please click here to continue.'
-    redirect_errors: 'Due to these errors, you will not be redirected automatically.'
+    download_starts: 'The download should start automatically.'
     errors: 'Something went wrong'
     generic_messages:
-      not_found: 'This job could not be found.'
-      in_queue: 'The job has been queued and will be processed shortly.'
-      in_process: 'The job is currently being processed.'
-      error: 'The job has failed to complete.'
       cancelled: 'The job has been cancelled due to an error.'
+      error: 'The job has failed to complete.'
+      in_process: 'The job is currently being processed.'
+      in_queue: 'The job has been queued and will be processed shortly.'
+      not_found: 'This job could not be found.'
       success: 'The job completed successfully.'
+    redirect: 'You are being redirected.'
+    redirect_errors: 'Due to these errors, you will not be redirected automatically.'
+    redirect_link: 'Please click here to continue.'
+    title: 'Background job status'
+  label_job_status_plural: "Job statuses"
+  plugin_openproject_job_status:
+    description: "Listing and status of background jobs."
+    name: "OpenProject Job status"

--- a/modules/ldap_groups/config/locales/en.yml
+++ b/modules/ldap_groups/config/locales/en.yml
@@ -1,38 +1,35 @@
 ---
 en:
-  ee:
-    upsell:
-      ldap_groups:
-        title: 'LDAP group synchronization'
-        description: 'Synchronize LDAP groups with OpenProject groups to manage users, change their permissions and facilitate user management across groups.'
-  plugin_openproject_ldap_groups:
-    name: "OpenProject LDAP groups"
-    description: "Synchronization of LDAP group memberships."
   activerecord:
     attributes:
-      ldap_groups/synchronized_group:
-        dn: 'DN'
-        auth_source: 'Auth source'
-        ldap_auth_source: 'LDAP connection'
-        sync_users: 'Sync users'
       ldap_groups/synchronized_filter:
-        filter_string: 'LDAP filter'
         auth_source: 'Auth source'
-        ldap_auth_source: 'LDAP connection'
-        group_name_attribute: "Group name attribute"
-        sync_users: 'Sync users'
         base_dn: "Search base DN"
+        filter_string: 'LDAP filter'
+        group_name_attribute: "Group name attribute"
+        ldap_auth_source: 'LDAP connection'
         member_lookup_attribute: "Group member attribute"
-    models:
-      ldap_groups/synchronized_group: 'Synchronized LDAP group'
-      ldap_groups/synchronized_filter: 'LDAP Group synchronization filter'
+        sync_users: 'Sync users'
+      ldap_groups/synchronized_group:
+        auth_source: 'Auth source'
+        dn: 'DN'
+        ldap_auth_source: 'LDAP connection'
+        sync_users: 'Sync users'
     errors:
       models:
         ldap_groups/synchronized_filter:
           must_contain_base_dn: "Filter base DN must be contained within the LDAP connection's base DN"
+    models:
+      ldap_groups/synchronized_filter: 'LDAP Group synchronization filter'
+      ldap_groups/synchronized_group: 'Synchronized LDAP group'
+  ee:
+    upsell:
+      ldap_groups:
+        description: 'Synchronize LDAP groups with OpenProject groups to manage users, change their permissions and facilitate user management across groups.'
+        title: 'LDAP group synchronization'
   ldap_groups:
-    label_menu_item: 'LDAP group synchronization'
     label_group_key: 'LDAP group filter key'
+    label_menu_item: 'LDAP group synchronization'
     label_synchronize: 'Discover LDAP groups'
     settings:
       name_attribute: 'LDAP groups name attribute'
@@ -40,25 +37,19 @@ en:
 
     synchronized_filters:
       add_new: 'Add synchronized LDAP filter'
-      singular: 'LDAP Group synchronization filter'
-      plural: 'LDAP Group synchronization filters'
-      label_n_groups_found:
-        one: "1 group found by the filter"
-        other: "%{count} groups found by the filter"
-        zero: "No groups were found by the filter"
       destroy:
-        title: 'Remove synchronized filter %{name}'
-        heading: 'Remove synchronized filter %{name}?'
         confirmation: "If you continue, the synchronized filter %{name} and all groups %{groups_count} created through it will be removed."
+        heading: 'Remove synchronized filter %{name}?'
         removed_groups: "Warning: This will remove the following groups from OpenProject and remove it from all projects!"
+        title: 'Remove synchronized filter %{name}'
         verification_html: "Enter the filter name %{name} to verify the deletion."
       form:
-        group_name_attribute_text: 'Enter the attribute of the LDAP group used for setting the OpenProject group name.'
-        filter_string_text: 'Enter the RFC4515 LDAP filter that returns groups in your LDAP to synchronize with OpenProject.'
         base_dn_text: >
           Enter the search base DN to use for this filter. It needs to be below the base DN of the selected LDAP connection.
 
           Leave this option empty to reuse the base DN of the connection
+        filter_string_text: 'Enter the RFC4515 LDAP filter that returns groups in your LDAP to synchronize with OpenProject.'
+        group_name_attribute_text: 'Enter the attribute of the LDAP group used for setting the OpenProject group name.'
         member_lookup_attribute_text: >
           Leave empty to use the default reverse lookup: OpenProject searches for users whose memberOf attribute matches the group DN.
           This requires the memberOf attribute to be present on user entries (Active Directory, OpenLDAP with memberof overlay).
@@ -67,13 +58,26 @@ en:
           Examples: "uniqueMember" (groupOfUniqueNames), "member" (groupOfNames).
           Use this for LDAP servers that do not maintain the memberOf attribute on user entries.
 
+      label_n_groups_found:
+        one: "1 group found by the filter"
+        other: "%{count} groups found by the filter"
+        zero: "No groups were found by the filter"
+      plural: 'LDAP Group synchronization filters'
+      singular: 'LDAP Group synchronization filter'
     synchronized_groups:
       add_new: 'Add synchronized LDAP group'
       destroy:
-        title: 'Remove synchronized group %{name}'
-        heading: 'Remove synchronized group %{name}?'
         confirmation: "If you continue, the synchronized group %{name} and all %{users_count} users synchronized through it will be removed."
+        heading: 'Remove synchronized group %{name}?'
         info: "The OpenProject group itself and members added outside this LDAP synchronization will not be removed."
+        title: 'Remove synchronized group %{name}'
+      form:
+        auth_source_text: 'Select which LDAP connection should be used.'
+        dn_text: 'Enter the full DN of the group in LDAP'
+        group_text: 'Select an existing OpenProject group that members of the LDAP group shall be synchronized with'
+        sync_users_text: >
+          If you enable this option, found users will also be automatically created in OpenProject.
+          Without it, only existing accounts in OpenProject will be added to groups.
       help_text_html: |
         This module allows you to set up a synchronization between LDAP and OpenProject groups.
         <br/>
@@ -86,16 +90,12 @@ en:
         Groups are synchronized hourly through a cron job.
         [Please see our documentation on this topic](docs_url).
 
-      no_results: 'No synchronized groups found.'
       no_members: 'This group has no synchronized members yet.'
+      no_results: 'No synchronized groups found.'
       plural: 'Synchronized LDAP groups'
       singular: 'Synchronized LDAP group'
-      form:
-        auth_source_text: 'Select which LDAP connection should be used.'
-        sync_users_text: >
-          If you enable this option, found users will also be automatically created in OpenProject.
-          Without it, only existing accounts in OpenProject will be added to groups.
-        dn_text: 'Enter the full DN of the group in LDAP'
-        group_text: 'Select an existing OpenProject group that members of the LDAP group shall be synchronized with'
       upsell:
         description: 'Take advantage of synchronised LDAP groups to manage users, change their permissions and facilitate user management across groups.'
+  plugin_openproject_ldap_groups:
+    description: "Synchronization of LDAP group memberships."
+    name: "OpenProject LDAP groups"

--- a/modules/meeting/config/locales/en.yml
+++ b/modules/meeting/config/locales/en.yml
@@ -29,97 +29,89 @@
 # English strings go here for Rails i18n
 ---
 en:
-  plugin_openproject_meeting:
-    name: "OpenProject Meeting"
-    description: >-
-      This module adds functions to support project meetings to OpenProject. Meetings can be
-      scheduled selecting invitees from the same project to take part in the meeting. An agenda can
-      be created and sent to the invitees. After the meeting, attendees can be selected and minutes
-      can be created based on the agenda. Finally, the minutes can be sent to all attendees and
-      invitees.
   activerecord:
     attributes:
       meeting:
-        type: "Meeting type"
-        location: "Location"
         duration: "Duration"
+        end_time: "End time"
+        location: "Location"
         notes: "Notes"
-        recurrence_start_time: "Scheduled start time"
-        participants: "Participants"
+        notify: "Send notifications"
         participant:
           one: "1 Participant"
           other: "%{count} Participants"
+        participants: "Participants"
+        participants_added: "Participants added:"
         participants_attended: "Attendees"
         participants_invited: "Invitees"
-        participants_added: "Participants added:"
         participants_removed: "Participants removed:"
         project: "Project"
+        recurrence_start_time: "Scheduled start time"
+        sharing: "Sharing"
         start_date: "Date"
         start_time: "Start time"
         start_time_hour: "Start time"
-        end_time: "End time"
         template: "Template"
-        notify: "Send notifications"
-        sharing: "Sharing"
+        type: "Meeting type"
       meeting_agenda_item:
-        title: "Title"
         author: "Author"
-        duration_in_minutes: "Duration"
         description: "Notes"
-        presenter: "Presenter"
+        duration_in_minutes: "Duration"
         item_type: "Type"
-        position: "Position"
         lock_version: "Lock version"
         notes: "Notes"
-      meeting_section:
-        title: "Title"
         position: "Position"
-      recurring_meeting:
+        presenter: "Presenter"
         title: "Title"
+      meeting_participant:
+        attended: "Attended"
+        invited: "Invited"
+        participation_status: "Participation status"
+      meeting_section:
+        position: "Position"
+        title: "Title"
+      recurring_meeting:
+        duration: "Duration"
+        end_after: "Meeting series ends"
+        end_date: "End date"
         frequency: "Frequency"
         interval: "Interval"
+        iterations: "Occurrences"
+        location: "Location"
         monthly_day: "Day of month"
         monthly_ordinal: "Position"
         monthly_weekday: "Weekday"
+        notify: "Send notifications"
         start_date: "Starts on"
         start_time: "Start time"
         start_time_hour: "Start time"
-        end_after: "Meeting series ends"
-        end_date: "End date"
-        iterations: "Occurrences"
         time_zone: "Time zone"
-        location: "Location"
-        duration: "Duration"
-        notify: "Send notifications"
+        title: "Title"
       recurring_meeting_interim_response:
         start_time: "Start time"
-      meeting_participant:
-        invited: "Invited"
-        attended: "Attended"
-        participation_status: "Participation status"
     errors:
+      messages:
+        invalid_time_format: "is not a valid time. Required format: HH:MM"
       models:
-        meeting_participant:
-          user_invalid: "is not a valid participant."
         meeting_agenda_item:
           section_not_belong_to_meeting: "Section does not belong to the same meeting."
           user_invalid: "is not a valid participant."
-        recurring_meeting_interim_response:
-          not_an_occurrence: "is not a valid occurrence time for this recurring meeting"
+        meeting_participant:
+          user_invalid: "is not a valid participant."
         recurring_meeting:
           must_cover_existing_meetings:
-            one: "There is one open meeting in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
-            other: "There are %{count} open meetings in the series that are not covered by the new schedule. Adjust the schedule to include all existing meetings."
             format: "%{message}"
 
-      messages:
-        invalid_time_format: "is not a valid time. Required format: HH:MM"
+            one: "There is one open meeting in the series that is not covered by the new schedule. Adjust the schedule to include all existing meetings."
+            other: "There are %{count} open meetings in the series that are not covered by the new schedule. Adjust the schedule to include all existing meetings."
+        recurring_meeting_interim_response:
+          not_an_occurrence: "is not a valid occurrence time for this recurring meeting"
     models:
-      recurring_meeting: "Recurring meeting"
       meeting: "One-time meeting"
-      meeting_agenda_item: "Agenda item"
       meeting_agenda: "Agenda"
+      meeting_agenda_item: "Agenda item"
       meeting_section: "Section"
+      recurring_meeting: "Recurring meeting"
       token/ical_meeting:
         one: "iCal Meeting subscription"
         other: "iCal Meeting subscription"
@@ -141,7 +133,12 @@ en:
           updated: "changed from %{old_value} to %{value}"
           updated_html: "changed from <i>%{old_value}</i> to <i>%{value}</i>"
 
+  caption_meeting_template_select: "Select a template to automatically copy its agenda items"
+  caption_template_project_select: "Please select the project in which to create this meeting template"
   description_attended: "attended"
+
+  error_notification: "Failed to send notification."
+  error_notification_with_errors: "Failed to send notification. The following recipients could not be notified: %{recipients}"
 
   events:
     meeting: Meeting edited
@@ -151,404 +148,433 @@ en:
     meeting_minutes: Meeting minutes edited
     meeting_minutes_created: Meeting minutes created
 
-  error_notification: "Failed to send notification."
-  error_notification_with_errors: "Failed to send notification. The following recipients could not be notified: %{recipients}"
+  label_add_work_package_to_meeting_dialog_button: "Add to meeting"
+  label_add_work_package_to_meeting_dialog_title: "Select meeting"
+  label_add_work_package_to_meeting_section_label: "Section"
+  label_added_as_outcome: "Added as outcome"
+  label_agenda_backlog: "Agenda backlog"
+  label_agenda_backlog_clear_title: "Clear agenda backlog?"
+  label_agenda_item_actions: "Agenda items actions"
+  label_agenda_item_add: "Add agenda item"
+  label_agenda_item_add_notes: "Add notes"
+  label_agenda_item_add_outcome: "Add outcome"
+  label_agenda_item_convert_to_work_package: "Convert to work package"
 
+  label_agenda_item_deleted_wp: "Deleted work package reference"
+  label_agenda_item_duplicate: "Duplicate"
+  label_agenda_item_duplicate_in_next: "Duplicate in next meeting"
+  label_agenda_item_duplicate_in_next_title: "Duplicate in next meeting?"
+  label_agenda_item_move: "Move"
+  label_agenda_item_move_down: "Move down"
+  label_agenda_item_move_to_backlog: "Move to backlog"
+  label_agenda_item_move_to_bottom: "Move to bottom"
+  label_agenda_item_move_to_current_meeting: "Move to current meeting"
+  label_agenda_item_move_to_next: "Move to next meeting"
+  label_agenda_item_move_to_next_title: "Move to next meeting?"
+  label_agenda_item_move_to_section: "Move to section"
+  label_agenda_item_move_to_top: "Move to top"
+  label_agenda_item_move_up: "Move up"
+  label_agenda_item_remove_from_agenda: "Remove from agenda"
+  label_agenda_item_remove_from_backlog: "Remove from backlog"
+  label_agenda_item_undisclosed_wp: "Work package #%{id} not visible"
+  label_agenda_item_work_package: "Agenda item work package"
+
+  label_agenda_item_work_package_add: "Add work package"
+  label_agenda_items: "Agenda items"
+  label_agenda_items_reordered: "reordered"
+
+  label_agenda_new_outcome: "New outcome"
+  label_agenda_outcome: "Outcome"
+  label_agenda_outcome_actions: "Agenda outcome actions"
+  label_agenda_outcome_delete: "Remove outcome"
+  label_agenda_outcome_edit: "Edit outcome"
+  label_all_meetings: "All meetings"
+  label_attended: "Attended"
+  label_attended_user: "Attended user"
+  label_backlog_clear: "Clear backlog"
+  label_backlog_clear_button: "Clear all"
+  label_created_by_me: "Created by me"
+  label_existing_work_package: "Existing work package"
+  label_icalendar: "Send iCalendar"
+  label_icalendar_download: "Download iCalendar event"
+  label_initial_meeting_details: "Meeting"
+  label_invitations: "Invitations"
+  label_invited_user: "Invited user"
+  label_involvement: "Involvement"
   label_meeting: "Meeting"
-  label_meeting_plural: "Meetings"
-  label_meeting_templates: "Templates"
-  label_meeting_template: "Template"
-  label_meeting_template_new: "New template"
-  label_meeting_template_create: "Create template"
-  label_meeting_template_delete: "Delete template"
-  label_meeting_template_edit: "Edit template"
+  label_meeting_actions: "Meeting actions"
+  label_meeting_agenda: "Agenda"
+  label_meeting_agenda_close: "Close the agenda to begin the Minutes"
+  label_meeting_close: "Close"
+  label_meeting_close_action: "Close meeting"
+  label_meeting_create: "Create meeting"
   label_meeting_create_from_template: "Create meeting from template"
+  label_meeting_created_by: "Created by"
+  label_meeting_date_and_time: "Date and time"
+  label_meeting_date_time: "Date/Time"
+  label_meeting_delete: "Delete meeting"
+  label_meeting_details: "Meeting details"
+  label_meeting_details_edit: "Edit meeting details"
+
+  label_meeting_diff: "Diff"
+  label_meeting_duplicate: "Duplicate meeting"
+  label_meeting_edit: "Edit Meeting"
+  label_meeting_edit_title: "Edit meeting title"
+  label_meeting_empty_action: "Add agenda item"
+
+  label_meeting_in_progress_action: "Start meeting"
+  label_meeting_index_delete: "Delete"
+  label_meeting_index_later: "Next week and later"
+  label_meeting_index_this_week: "Later this week"
+  label_meeting_index_today: "Today"
+  label_meeting_index_tomorrow: "Tomorrow"
+  label_meeting_last_updated: "Last updated"
+  label_meeting_minutes: "Minutes"
+  label_meeting_more:
+    one: "There is one more meeting."
+    other: "There are %{count} more meetings."
   label_meeting_new: "New Meeting"
   label_meeting_new_dynamic: "New one-time meeting"
   label_meeting_new_recurring: "New recurring meeting"
-  label_meeting_create: "Create meeting"
-  label_meeting_duplicate: "Duplicate meeting"
-  label_meeting_edit: "Edit Meeting"
-  label_meeting_agenda: "Agenda"
-  label_meeting_minutes: "Minutes"
-  label_meeting_close: "Close"
   label_meeting_open: "Open"
-  label_meeting_index_delete: "Delete"
+  label_meeting_open_action: "Open meeting"
   label_meeting_open_this_meeting: "Open this meeting"
-  label_meeting_agenda_close: "Close the agenda to begin the Minutes"
-  label_meeting_date_time: "Date/Time"
-  label_meeting_date_and_time: "Date and time"
-  label_meeting_diff: "Diff"
+  label_meeting_plural: "Meetings"
+  label_meeting_reload: "Reload"
+  label_meeting_reopen_action: "Reopen meeting"
+  label_meeting_selection_caption: "It is only possible to add this work package to an upcoming or an ongoing meeting."
   label_meeting_send_updates: "Send email calendar invite and updates"
   label_meeting_send_updates_caption: "Send out email invites to all participants of this meeting"
+  label_meeting_series: "Meeting series"
+  label_meeting_series_details: "Meeting series details"
+  label_meeting_state: "Meeting status"
+  label_meeting_state_agenda_created: "Agenda created"
+  label_meeting_state_cancelled: "Cancelled"
+  label_meeting_state_closed: "Closed"
+  label_meeting_state_draft: "Draft"
+  label_meeting_state_in_progress: "In progress"
+  label_meeting_state_open: "Open"
+  label_meeting_state_planned: "Planned"
+  label_meeting_state_skipped: "Skipped"
+  label_meeting_template: "Template"
+  label_meeting_template_create: "Create template"
+  label_meeting_template_delete: "Delete template"
+  label_meeting_template_edit: "Edit template"
+  label_meeting_template_new: "New template"
+  label_meeting_template_sharing: "Sharing"
+  label_meeting_template_sharing_descendants: "With subprojects"
+  label_meeting_template_sharing_none: "Only with this project"
+  label_meeting_template_sharing_system: "With all projects"
+  label_meeting_templates: "Templates"
+  label_my_meetings: "My meetings"
+  label_notify: "Send for review"
+  label_past_invitations: "Past invitations"
+  label_past_meetings: "Past meetings"
+  label_past_meetings_short: "Past"
+  label_recurring_filter: "Recurring filter"
+
   label_recurring_meeting: "Recurring meeting"
-  label_recurring_meeting_part_of: "Part of a meeting series"
-  label_recurring_meeting_new: "New recurring meeting"
-  label_recurring_meeting_plural: "Recurring meetings"
-  label_template: "Template"
-  label_recurring_meeting_view: "View meeting series"
-  label_recurring_meeting_create: "Open"
-  label_recurring_meeting_duplicate: "Duplicate as a one-time meeting"
   label_recurring_meeting_cancel: "Cancel this occurrence"
+  label_recurring_meeting_create: "Open"
   label_recurring_meeting_delete: "Delete occurrence"
-  label_recurring_meeting_restore: "Restore this occurrence"
-  label_recurring_meeting_schedule: "Schedule"
-  label_recurring_meeting_next_occurrence: "Next occurrence"
-  label_recurring_meeting_no_end_date: "There are more scheduled meetings (%{schedule})."
+  label_recurring_meeting_duplicate: "Duplicate as a one-time meeting"
   label_recurring_meeting_more:
     one: "There is one more scheduled meeting (%{schedule})."
     other: "There are %{count} more scheduled meetings (%{schedule})."
   label_recurring_meeting_more_past:
     one: "There is one more past meeting."
     other: "There are %{count} more past meetings."
-  label_recurring_meeting_show_more: "Show more"
+  label_recurring_meeting_new: "New recurring meeting"
+  label_recurring_meeting_next_occurrence: "Next occurrence"
+  label_recurring_meeting_no_end_date: "There are more scheduled meetings (%{schedule})."
+  label_recurring_meeting_part_of: "Part of a meeting series"
+  label_recurring_meeting_plural: "Recurring meetings"
+  label_recurring_meeting_restore: "Restore this occurrence"
+  label_recurring_meeting_schedule: "Schedule"
   label_recurring_meeting_series_create: "Create meeting series"
-  label_recurring_meeting_series_edit: "Edit meeting series"
   label_recurring_meeting_series_delete: "Delete meeting series"
+  label_recurring_meeting_series_edit: "Edit meeting series"
   label_recurring_meeting_series_end: "End meeting series"
   label_recurring_meeting_series_end_now: "End series now"
-  label_meeting_more:
-    one: "There is one more meeting."
-    other: "There are %{count} more meetings."
-  label_my_meetings: "My meetings"
-  label_all_meetings: "All meetings"
-  label_upcoming_meetings: "Upcoming meetings"
-  label_past_meetings: "Past meetings"
-  label_upcoming_meetings_short: "Upcoming"
-  label_past_meetings_short: "Past"
-  label_involvement: "Involvement"
-  label_invitations: "Invitations"
-  label_invited_user: "Invited user"
-  label_past_invitations: "Past invitations"
-  label_attended: "Attended"
-  label_attended_user: "Attended user"
-  label_created_by_me: "Created by me"
-  label_notify: "Send for review"
-  label_icalendar: "Send iCalendar"
-  label_icalendar_download: "Download iCalendar event"
-  label_view_meeting: "View meeting"
-  label_view_meeting_series: "View meeting series"
-  label_meeting_series: "Meeting series"
-  label_version: "Version"
-  label_time_zone: "Time zone"
+  label_recurring_meeting_show_more: "Show more"
+  label_recurring_meeting_view: "View meeting series"
+  label_section_rename: "Rename section"
+
+  label_section_selection_caption: "Choose a particular section of the agenda or add it to the backlog."
+  label_series_backlog: "Series backlog"
+  label_series_backlog_clear_title: "Clear series backlog?"
   label_start_date: "Start date"
   label_subscribe_icalendar: "Subscribe to calendar"
-  label_recurring_filter: "Recurring filter"
-
-  caption_meeting_template_select: "Select a template to automatically copy its agenda items"
-  caption_template_project_select: "Please select the project in which to create this meeting template"
-  placeholder_meeting_template_select_project_first: "Select a project first"
-  placeholder_meeting_template_no_templates_for_project: "No templates available for this project"
-
+  label_template: "Template"
+  label_time_zone: "Time zone"
+  label_upcoming_meetings: "Upcoming meetings"
+  label_upcoming_meetings_short: "Upcoming"
+  label_version: "Version"
+  label_view_meeting: "View meeting"
+  label_view_meeting_series: "View meeting series"
+  label_write_outcome: "Write outcome"
   meeting:
-    participants:
-      label:
-        participants: "Participants"
-        attended: "Attended"
-        mark_as_attended: "Mark as attended"
-        mark_all_as_attended: "Mark all as attended"
-        remove_participant: "Remove participant"
-        manage_participants: "Manage participants"
-        no_participants: "No participants"
-        show_all: "Show all"
-        apply_to_upcoming_meetings: "Apply these changes to all upcoming meetings in this series"
-      text:
-        template: "These participants will be invited automatically to all future meetings as they are created."
-        manage_participants: "Search for and add project members as participants to this meeting."
-        search_for_members: "Search for project members"
-      blankslate:
-        heading: "No participants"
-        description: "There are no participants yet."
     attachments:
       onetime_template: "These attached files will be included in all future meetings using this template."
       series_template: "These attached files will be included in all future meetings in the series."
       text: "Attached files are available to all meeting participants. You can also drag and drop these into agenda item notes."
+    blankslate:
+      desc: "You can create a new meeting or change filter criteria"
+      title: "There are no meetings to display"
+    copied: "Copied from Meeting #%{id}"
     copy:
-      title: "Copy meeting: %{title}"
-      attachments: "Copy attachments"
-      attachments_text: "Copy over all attached files to the new meeting"
       agenda: "Copy agenda"
       agenda_items: "Copy agenda items"
       agenda_text: "Copy the agenda of the old meeting"
+      attachments: "Copy attachments"
+      attachments_text: "Copy over all attached files to the new meeting"
       participants: "Copy list of participants"
+      title: "Copy meeting: %{title}"
       to_clipboard: "Copy link to clipboard"
+    delete_dialog:
+      occurrence:
+        confirm_button: "Cancel occurrence"
+        confirmation_message_html: >
+          Any meeting information not in the template will be lost.
+
+          Do you want to continue?
+        heading: "Cancel this meeting occurrence?"
+        title: "Cancel meeting occurrence"
+      occurrence_past:
+        confirm_button: "Delete occurrence"
+        confirmation_message_html: >
+          This action is not reversible. Please proceed with caution.
+        heading: "Delete this occurrence?"
+        title: "Delete occurrence"
+      one_time:
+        confirmation_message_html: >
+          This action is not reversible. Please proceed with caution.
+        heading: "Delete this meeting?"
+        template:
+          confirmation_message_html: >
+            This action is not reversible. Please proceed with caution. Existing meetings that were created using this template will not be affected.
+          heading: "Delete this template?"
+          title: "Delete template"
+        title: "Delete meeting"
     email:
+      cancelled:
+        date_time: "Scheduled date/time"
+        header: "Cancelled: Meeting '%{title}'"
+        header_occurrence: "Cancelled: Meeting occurrence '%{title}'"
+        header_series: "Cancelled: Meeting series '%{title}'"
+        summary: "'%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
+        summary_occurrence: "An occurrence of '%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
+        summary_series: "Meeting series '%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
+      ended:
+        header_series: "Ended: Meeting series '%{title}'"
+        summary_series: "Meeting series '%{title}' has been ended by %{actor}"
+      invited:
+        summary: "%{actor} has sent you an invitation for the meeting '%{title}'"
+      open_meeting_link: "Open meeting"
+      open_my_meetings_link: "Go to My meetings"
       send_emails: "Email participants"
       send_invitation_emails: >
         Send an email invitation immediately to the participants selected above. You can also do this manually at any time later.
       send_invitation_emails_structured: "Send an email invitation immediately to all participants. You can also do this manually at any time later."
-      open_meeting_link: "Open meeting"
-      open_my_meetings_link: "Go to My meetings"
       series:
-        title: "[%{project_name}] Meeting series '%{title}'"
         summary: "%{actor} has invited you to a new meeting series '%{title}'"
+        title: "[%{project_name}] Meeting series '%{title}'"
       series_updated:
-        title: "[%{project_name}] Meeting series '%{title}' has been updated"
-        summary: "Meeting series '%{title}' has been updated by %{actor}"
-        old_schedule: "Old schedule"
         new_schedule: "New schedule"
-      invited:
-        summary: "%{actor} has sent you an invitation for the meeting '%{title}'"
-      cancelled:
-        header: "Cancelled: Meeting '%{title}'"
-        header_occurrence: "Cancelled: Meeting occurrence '%{title}'"
-        header_series: "Cancelled: Meeting series '%{title}'"
-        summary_occurrence: "An occurrence of '%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
-        summary_series: "Meeting series '%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
-        summary: "'%{title}' has been cancelled by %{actor}, or you have been removed as a participant"
-        date_time: "Scheduled date/time"
-      ended:
-        header_series: "Ended: Meeting series '%{title}'"
-        summary_series: "Meeting series '%{title}' has been ended by %{actor}"
+        old_schedule: "Old schedule"
+        summary: "Meeting series '%{title}' has been updated by %{actor}"
+        title: "[%{project_name}] Meeting series '%{title}' has been updated"
       updated:
-        header: "Meeting '%{title}' has been updated"
-        summary: "Meeting '%{title}' has been updated by %{actor}"
+        added_participants: "Added"
         body: "The meeting '%{title}' has been updated by %{actor}."
-        old_title: "Old title"
+        header: "Meeting '%{title}' has been updated"
+        new_date_time: "New date/time"
+        new_location: "New location"
         new_title: "New title"
         old_date_time: "Old date/time"
-        new_date_time: "New date/time"
         old_location: "Old location"
-        new_location: "New location"
-        added_participants: "Added"
+        old_title: "Old title"
         removed_participants: "Removed"
+        summary: "Meeting '%{title}' has been updated by %{actor}"
+    export:
+      minutes:
+        author: "Author"
+        date: "Date"
+        footer_page_numbers: "P. %{current_page} of %{total_pages}"
+        location: "Location"
+        time: "Time"
+        title: "Minutes"
+      your_meeting_export: "Meeting is being exported"
+    export_pdf_dialog:
+      author:
+        caption: The author of the minutes will be displayed in the subtitle.
+        label: Author
+      description: Generate a printable PDF file of this meeting at the current state.
+      first_page_header_left:
+        caption: This text will appear on the first page at the left of the header.
+        label: First page header left
+      footer_text:
+        caption: This text will appear on every page at the center of the footer.
+        label: Footer text
+      include_attachments:
+        caption: A list containing the filenames of attachments will be appended at the end.
+        label: Include list of attachments
+      include_backlog:
+        caption: Backlog elements are not normally considered part of a meeting occurrence but you can choose to include them.
+        label: Include backlog
+      include_outcomes:
+        caption: If your agenda outcomes contain confidential information, you can choose to not include them in the export.
+        label: Include agenda outcomes
+      include_participants:
+        caption: A list of participants will be preset above the meeting agenda.
+        label: Include list of participants
+      submit_button: Download
+      templates:
+        default:
+          caption: The default template is suitable for most meetings and represent the current state.
+          label: Default
+        minutes:
+          caption: The minutes template is suitable for closed and archived meetings.
+          label: Minutes
+      title: Export PDF
+    ical_response:
+      meeting_not_found: "Meeting not found for the given UID."
+
+      update_failed: "Could not update participation status."
+    label_export_pdf: "Export PDF"
     label_mail_all_participants: "Send email invite to participants"
+    notifications:
+      dialog:
+        confirm_label:
+          disable: "Disable email updates"
+          enable: "Enable email updates"
+        message:
+          disable: "If they already had an invite for this meeting, it might no longer be accurate."
+          enable: "Once enabled, an email will be sent out immediately to all participants."
+        title:
+          disable: "Disable email calendar updates?"
+          enable: "Enable email calendar updates?"
+      disabled: "Participants will not receive email updates informing them of changes to the date, time or list of participants."
+      enabled: "All participants will receive updated calendar invites informing them of changes to date, time or list of participants."
+      sidepanel:
+        description:
+          change_via_template: "To change this, edit the series template."
+        title: "Email calendar updates"
+    participants:
+      blankslate:
+        description: "There are no participants yet."
+        heading: "No participants"
+      label:
+        apply_to_upcoming_meetings: "Apply these changes to all upcoming meetings in this series"
+        attended: "Attended"
+        manage_participants: "Manage participants"
+        mark_all_as_attended: "Mark all as attended"
+        mark_as_attended: "Mark as attended"
+        no_participants: "No participants"
+        participants: "Participants"
+        remove_participant: "Remove participant"
+        show_all: "Show all"
+      text:
+        manage_participants: "Search for and add project members as participants to this meeting."
+        search_for_members: "Search for project members"
+        template: "These participants will be invited automatically to all future meetings as they are created."
+    presentation_mode:
+      button_present: "Present"
+      current_item: "Current item"
+      exit: "Exit presentation"
+      next: "Next"
+      no_items: "No agenda items"
+      no_items_flash: "There are no agenda items to present."
+      previous: "Previous"
+      title: "Presentation Mode"
+      total_items: "%{current} of %{total}"
     types:
       one_time: "One-time"
       recurring: "Recurring"
       recurring_text: "Create meeting series with dynamic template for each occurrence."
       structured_text: "Organize your meeting as a dynamic list of agenda items, optionally linking them to a work package."
       structured_text_copy: "Copying a meeting will currently not copy the associated meeting agenda items, just the details"
-    copied: "Copied from Meeting #%{id}"
-    delete_dialog:
-      one_time:
-        title: "Delete meeting"
-        heading: "Delete this meeting?"
-        confirmation_message_html: >
-          This action is not reversible. Please proceed with caution.
-        template:
-          title: "Delete template"
-          heading: "Delete this template?"
-          confirmation_message_html: >
-            This action is not reversible. Please proceed with caution. Existing meetings that were created using this template will not be affected.
-      occurrence:
-        title: "Cancel meeting occurrence"
-        heading: "Cancel this meeting occurrence?"
-        confirmation_message_html: >
-          Any meeting information not in the template will be lost.
-
-          Do you want to continue?
-        confirm_button: "Cancel occurrence"
-      occurrence_past:
-        title: "Delete occurrence"
-        heading: "Delete this occurrence?"
-        confirmation_message_html: >
-          This action is not reversible. Please proceed with caution.
-        confirm_button: "Delete occurrence"
-    blankslate:
-      title: "There are no meetings to display"
-      desc: "You can create a new meeting or change filter criteria"
-    label_export_pdf: "Export PDF"
-    export:
-      your_meeting_export: "Meeting is being exported"
-      minutes:
-        footer_page_numbers: "P. %{current_page} of %{total_pages}"
-        author: "Author"
-        date: "Date"
-        time: "Time"
-        location: "Location"
-        title: "Minutes"
-    export_pdf_dialog:
-      title: Export PDF
-      description: Generate a printable PDF file of this meeting at the current state.
-      templates:
-        default:
-          label: Default
-          caption: The default template is suitable for most meetings and represent the current state.
-        minutes:
-          label: Minutes
-          caption: The minutes template is suitable for closed and archived meetings.
-      first_page_header_left:
-        label: First page header left
-        caption: This text will appear on the first page at the left of the header.
-      author:
-        label: Author
-        caption: The author of the minutes will be displayed in the subtitle.
-      include_participants:
-        label: Include list of participants
-        caption: A list of participants will be preset above the meeting agenda.
-      include_attachments:
-        label: Include list of attachments
-        caption: A list containing the filenames of attachments will be appended at the end.
-      include_backlog:
-        label: Include backlog
-        caption: Backlog elements are not normally considered part of a meeting occurrence but you can choose to include them.
-      include_outcomes:
-        label: Include agenda outcomes
-        caption: If your agenda outcomes contain confidential information, you can choose to not include them in the export.
-      footer_text:
-        label: Footer text
-        caption: This text will appear on every page at the center of the footer.
-      submit_button: Download
-    notifications:
-      disabled: "Participants will not receive email updates informing them of changes to the date, time or list of participants."
-      enabled: "All participants will receive updated calendar invites informing them of changes to date, time or list of participants."
-      sidepanel:
-        title: "Email calendar updates"
-        description:
-          change_via_template: "To change this, edit the series template."
-      dialog:
-        title:
-          enable: "Enable email calendar updates?"
-          disable: "Disable email calendar updates?"
-        message:
-          enable: "Once enabled, an email will be sent out immediately to all participants."
-          disable: "If they already had an invite for this meeting, it might no longer be accurate."
-        confirm_label:
-          enable: "Enable email updates"
-          disable: "Disable email updates"
-    presentation_mode:
-      title: "Presentation Mode"
-      button_present: "Present"
-      exit: "Exit presentation"
-      current_item: "Current item"
-      total_items: "%{current} of %{total}"
-      previous: "Previous"
-      next: "Next"
-      no_items: "No agenda items"
-      no_items_flash: "There are no agenda items to present."
-    ical_response:
-      update_failed: "Could not update participation status."
-      meeting_not_found: "Meeting not found for the given UID."
-
     widgets:
       blankslate:
-        heading: "No upcoming meetings"
         description: "Upcoming meetings you are participating in will appear here."
+        heading: "No upcoming meetings"
       view_details: "View all meetings"
-
-  meeting_section:
-    untitled_title: "Untitled section"
-    delete_confirmation: "Deleting the section will also delete all of its agenda items. Are you sure you want to do this?"
-    placeholder_title: "New section"
-    empty_text: "Drag items here or create a new one"
 
   meeting_participant:
     participation_status:
-      needs_action: "No response"
       accepted: "Accepted"
       declined: "Declined"
+      needs_action: "No response"
       tentative: "Maybe"
       unknown: "Unknown"
 
+  meeting_section:
+    delete_confirmation: "Deleting the section will also delete all of its agenda items. Are you sure you want to do this?"
+    empty_text: "Drag items here or create a new one"
+
+    placeholder_title: "New section"
+    untitled_title: "Untitled section"
+  my:
+    access_token:
+      created_dialog:
+        token/ical_meeting:
+          body: "Treat the following URL as you would a password. Anyone who has access to it can view all your meetings."
+          title: "An iCal meeting subscription token has been generated"
+      dialog:
+        token/ical_meeting:
+          create_button: "Create subscription"
+          dialog_body: "This token will generate an iCal subscription URL that lets you view all your meetings in an external calendar application."
+          dialog_title: "New iCal subscription token for meetings"
+          name_caption: 'You can name it after where you will use it, such as "My phone" or "Work computer".'
+          name_label: "Token name"
+      revocation:
+        token/ical_meeting:
+          notice_failure: "Failed to revoke iCalendar meeting subscription: %{error}"
+          notice_success: "The iCalendar meeting subscription has been revoked successfully."
+  my_account:
+    access_tokens:
+      token/ical_meeting:
+        add_button: "Subscribe to calendar"
+
+        blank_description: "You can create one using the button below."
+        blank_title: "No iCalendar meeting token"
+        disabled_text: "iCalendar meeting subscriptions are not enabled by the administrator. Please contact your administrator to use this feature."
+        table_title: "iCalendar meeting tokens"
+        text_hint: "iCalendar meeting tokens allow users to subscribe to all their meetings and view up-to-date meeting information in external clients."
+        title: "iCalendar for meetings"
+  notice_meeting_template_created: "Template successfully created"
+  notice_meeting_updated: "This page has been updated by someone else. Reload to view changes."
+
+  notice_successful_notification: "Email calendar update sent to all participants"
+  notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
+  permission_create_meetings: "Create meetings"
+  permission_delete_meetings: "Delete meetings"
+  permission_edit_meetings: "Edit meetings"
+  permission_manage_agendas: "Manage agendas"
+  permission_manage_agendas_explanation: "Allows creating, editing and removing agenda items"
+  permission_manage_outcomes: "Manage outcomes"
+  permission_send_meeting_invites_and_outcomes: "Send meeting invites and outcomes to participants"
+
+  permission_view_meetings: "View meetings"
+  placeholder_meeting_template_no_templates_for_project: "No templates available for this project"
+
+  placeholder_meeting_template_select_project_first: "Select a project first"
+  placeholder_section_select_meeting_first: "Meeting selection is required first"
+  plugin_openproject_meeting:
+    description: >-
+      This module adds functions to support project meetings to OpenProject. Meetings can be
+      scheduled selecting invitees from the same project to take part in the meeting. An agenda can
+      be created and sent to the invitees. After the meeting, attendees can be selected and minutes
+      can be created based on the agenda. Finally, the minutes can be sent to all attendees and
+      invitees.
+    name: "OpenProject Meeting"
+  project_module_meetings: "Meetings"
+
   recurring_meeting:
-    time_zone_difference_banner:
-      title: "Time zone difference"
-      description: >
-        The dates below are referencing the time zone of the meeting series (%{actual_zone}),
-        not your local time zone (%{user_zone}).
-    ended_blankslate:
-      title: "Meeting series ended"
-      message: "This meeting series has come to an end. There are no upcoming meetings. "
-      action: "You can still view past occurrences or edit the meeting series to extend it."
-    occurrence:
-      infoline: "This meeting is part of a recurring meeting series."
-      error_no_next: "There is no next occurrence for this meeting."
-      first_already_exists: "The first occurrence of this meeting series is already instantiated."
-      first_created: >
-        The first meeting has been successfuly created from template.
-        All future meetings will be created automatically at the time of the previous occurrence.
-    template:
-      button_finalize: "Open first meeting"
-      blank_title: "Your meeting series template is empty"
-      description: >
-        This template will be used whenever new meetings in the series get created.
-        You can add agenda items, participants, and attachments to this template.
-      label_view_template: "View template"
-      label_edit_template: "Edit template"
-      banner_html: >
-        You are currently editing a template of a meeting series: %{link}.
-        Every new occurrence of a meeting in the series will use this template.
-        Changes will not affect past or already-created meetings.
-      draft_banner_html: >
-        You are currently editing a template of a meeting series: %{link}.
-        Every new occurrence of a meeting in the series will use this template.
-        Changes will not affect past or already-created meetings.
-        No email invites will be sent in this current draft mode until you open the first meeting.
-    frequency:
-      x_daily:
-        one: "Every day"
-        other: "Every %{count} days"
-      x_weekly:
-        one: "Every week"
-        other: "Every %{count} weeks"
-      x_monthly:
-        one: "Every month"
-        other: "Every %{count} months"
-      monthly_day_of_month: "Day of month"
-      monthly_nth_weekday: "Monthly on a weekday"
-      every_weekday: "Every %{day_of_the_week}"
-      working_days: "Every working day"
-    monthly:
-      inflected_ordinal:
-        first: "first"
-        second: "second"
-        third: "third"
-        fourth: "fourth"
-        last: "last"
-      ordinal_options:
-        first: "First"
-        second: "Second"
-        third: "Third"
-        fourth: "Fourth"
-        last: "Last"
     actual_first_occurrence_mismatch_html: "The first occurrence of this series will be %{first_occurrence}"
     day_of_month_skipping_info: "Months with fewer than %{monthly_day} days will be skipped"
-    end_after:
-      never: "Never"
-      specific_date: "After a specific date"
-      iterations: "After a number of occurrences"
-    starts: "Starts"
-    in_words:
-      daily_interval: "Every %{interval} days"
-      working_days: "Every working day"
-      weekly: "Every week on %{weekday}"
-      weekly_interval: "Every %{interval} weeks on %{weekday}"
-      monthly_day: "Every month on the %{day}"
-      monthly_day_interval: "Every %{interval} months on the %{day}"
-      monthly_nth_weekday: "Every month on the %{ordinal} %{weekday}"
-      monthly_nth_weekday_interval: "Every %{interval} months on the %{ordinal} %{weekday}"
-      frequency: "%{base} at %{time}"
-      full: "%{base} at %{time}, ends on %{end_date}"
-      full_past: "%{base} at %{time}, ended on %{end_date}"
-      never_ending: "%{base} at %{time}"
-    open:
-      title: "Agenda opened"
-      subtitle: >
-        Open meetings have agendas that can be edited and show up in individual users’ ‘My meetings’ section.
-        Changes to the meeting series template do not affect already-open meeting occurrences.
-      blankslate:
-        title: "No open meetings at the moment"
-        desc: "You can manually open a planned meeting by clicking on the 'Open' button below"
-    planned:
-      title: "Planned"
-      subtitle: >
-        The following meetings are planned in the recurring meeting schedule but are not open yet.
-        Every time a planned meeting starts, the next one will automatically be opened for you.
-        You can also open planned meetings manually to import the template and start editing the agenda.
-      blankslate:
-        title: "No more planned meetings"
-        desc: >
-          There are no additional meetings planned in this series.
-          To schedule additional meetings or extend the series,
-          go to the template and edit meeting details to change the end date, frequency or interval.
     delete_dialog:
-      title: "Delete meeting series"
-      heading: "Permanently delete this meeting series?"
       confirmation_message_html:
-        zero: >
-          The meeting series <strong>%{title}</strong> does not have any meeting occurrences.
-          The series will be deleted for everyone. Please proceed with caution.
         one: >
           Deleting <strong>%{title}</strong> will also delete one occurrence in this series.
           This action is not reversible. Please proceed with caution.
@@ -556,231 +582,205 @@ en:
           Deleting <strong>%{title}</strong> will delete all %{count} occurrences in this series.
           This action is not reversible. Please proceed with caution.
 
+        zero: >
+          The meeting series <strong>%{title}</strong> does not have any meeting occurrences.
+          The series will be deleted for everyone. Please proceed with caution.
+      heading: "Permanently delete this meeting series?"
+      title: "Delete meeting series"
+    end_after:
+      iterations: "After a number of occurrences"
+      never: "Never"
+      specific_date: "After a specific date"
+    end_series_dialog:
+      title: "End meeting series"
+
+    ended_blankslate:
+      action: "You can still view past occurrences or edit the meeting series to extend it."
+      message: "This meeting series has come to an end. There are no upcoming meetings. "
+      title: "Meeting series ended"
+    frequency:
+      every_weekday: "Every %{day_of_the_week}"
+      monthly_day_of_month: "Day of month"
+      monthly_nth_weekday: "Monthly on a weekday"
+      working_days: "Every working day"
+      x_daily:
+        one: "Every day"
+        other: "Every %{count} days"
+      x_monthly:
+        one: "Every month"
+        other: "Every %{count} months"
+      x_weekly:
+        one: "Every week"
+        other: "Every %{count} weeks"
+    in_words:
+      daily_interval: "Every %{interval} days"
+      frequency: "%{base} at %{time}"
+      full: "%{base} at %{time}, ends on %{end_date}"
+      full_past: "%{base} at %{time}, ended on %{end_date}"
+      monthly_day: "Every month on the %{day}"
+      monthly_day_interval: "Every %{interval} months on the %{day}"
+      monthly_nth_weekday: "Every month on the %{ordinal} %{weekday}"
+      monthly_nth_weekday_interval: "Every %{interval} months on the %{ordinal} %{weekday}"
+      never_ending: "%{base} at %{time}"
+      weekly: "Every week on %{weekday}"
+      weekly_interval: "Every %{interval} weeks on %{weekday}"
+      working_days: "Every working day"
+    monthly:
+      inflected_ordinal:
+        first: "first"
+        fourth: "fourth"
+        last: "last"
+        second: "second"
+        third: "third"
+      ordinal_options:
+        first: "First"
+        fourth: "Fourth"
+        last: "Last"
+        second: "Second"
+        third: "Third"
+    occurrence:
+      error_no_next: "There is no next occurrence for this meeting."
+      first_already_exists: "The first occurrence of this meeting series is already instantiated."
+      first_created: >
+        The first meeting has been successfuly created from template.
+        All future meetings will be created automatically at the time of the previous occurrence.
+      infoline: "This meeting is part of a recurring meeting series."
+    open:
+      blankslate:
+        desc: "You can manually open a planned meeting by clicking on the 'Open' button below"
+        title: "No open meetings at the moment"
+      subtitle: >
+        Open meetings have agendas that can be edited and show up in individual users’ ‘My meetings’ section.
+        Changes to the meeting series template do not affect already-open meeting occurrences.
+      title: "Agenda opened"
+    planned:
+      blankslate:
+        desc: >
+          There are no additional meetings planned in this series.
+          To schedule additional meetings or extend the series,
+          go to the template and edit meeting details to change the end date, frequency or interval.
+        title: "No more planned meetings"
+      subtitle: >
+        The following meetings are planned in the recurring meeting schedule but are not open yet.
+        Every time a planned meeting starts, the next one will automatically be opened for you.
+        You can also open planned meetings manually to import the template and start editing the agenda.
+      title: "Planned"
     scheduled_delete_dialog:
-      title: "Cancel meeting occurrence"
-      heading: "Cancel this meeting occurrence?"
+      confirm_button: "Cancel occurrence"
       confirmation_message_html: >
         Any meeting information not in the template will be lost.
 
         Do you want to continue?
-      confirm_button: "Cancel occurrence"
-    end_series_dialog:
-      title: "End meeting series"
+      heading: "Cancel this meeting occurrence?"
+      title: "Cancel meeting occurrence"
+    starts: "Starts"
+    template:
+      banner_html: >
+        You are currently editing a template of a meeting series: %{link}.
+        Every new occurrence of a meeting in the series will use this template.
+        Changes will not affect past or already-created meetings.
+      blank_title: "Your meeting series template is empty"
+      button_finalize: "Open first meeting"
+      description: >
+        This template will be used whenever new meetings in the series get created.
+        You can add agenda items, participants, and attachments to this template.
+      draft_banner_html: >
+        You are currently editing a template of a meeting series: %{link}.
+        Every new occurrence of a meeting in the series will use this template.
+        Changes will not affect past or already-created meetings.
+        No email invites will be sent in this current draft mode until you open the first meeting.
+      label_edit_template: "Edit template"
+      label_view_template: "View template"
+    time_zone_difference_banner:
+      description: >
+        The dates below are referencing the time zone of the meeting series (%{actual_zone}),
+        not your local time zone (%{user_zone}).
+      title: "Time zone difference"
+  text_add_work_package_to_meeting_description: "A work package can be added to one or multiple meetings for discussion. Any notes concerning it are also visible here."
+  text_add_work_package_to_meeting_form: "The work package will be added to the selected meeting or backlog as an agenda item."
 
-  notice_successful_notification: "Email calendar update sent to all participants"
-  notice_meeting_template_created: "Template successfully created"
-  notice_timezone_missing: No time zone is set and %{zone} is assumed. To choose your time zone, please click here.
-  notice_meeting_updated: "This page has been updated by someone else. Reload to view changes."
+  text_agenda_backlog: >
+    This backlog is unique to this one-time meeting.
+    You can drag items in and out to add or remove them from the meeting agenda.
+  text_agenda_backlog_clear_description: >
+    Are you sure you want to remove all items currently in the agenda backlog? This action is not reversible.
+  text_agenda_item_dialog_skipping_cancelled_many: "%{count} cancelled meetings"
+  text_agenda_item_dialog_skipping_cancelled_one: "cancelled meeting on %{date}"
+  text_agenda_item_dialog_skipping_closed_many: "%{count} closed meetings"
+  text_agenda_item_dialog_skipping_closed_one: "closed meeting on %{date}"
+  text_agenda_item_dialog_skipping_note: "Note: Skipping %{details}."
+  text_agenda_item_duplicate_in_next_meeting: "Are you sure you want to add a copy of this agenda item to the next meeting, on %{date} at %{time}? Outcomes will not be duplicated."
+  text_agenda_item_duplicated_in_next_meeting: "Agenda item duplicated in the next meeting, on %{date}"
+  text_agenda_item_move_next_meeting: "This item will be moved to the next meeting on %{date} at %{time}."
+  text_agenda_item_moved_to_next_meeting: "Agenda item moved to the next meeting, on %{date}"
+  text_agenda_item_no_available_occurrence: "No upcoming occurrences are available."
+  text_agenda_item_no_notes: "No notes provided"
+  text_agenda_item_not_editable_anymore: "This agenda item is not editable anymore."
+  text_agenda_item_title: 'Agenda item "%{title}"'
+  text_agenda_work_package_deleted: "Agenda item for deleted work package"
+  text_backlog_clear_error: "One or more errors occurred while trying to clear the backlog."
 
-  permission_create_meetings: "Create meetings"
-  permission_edit_meetings: "Edit meetings"
-  permission_delete_meetings: "Delete meetings"
-  permission_view_meetings: "View meetings"
-  permission_manage_agendas: "Manage agendas"
-  permission_manage_agendas_explanation: "Allows creating, editing and removing agenda items"
-  permission_manage_outcomes: "Manage outcomes"
-  permission_send_meeting_invites_and_outcomes: "Send meeting invites and outcomes to participants"
-
-  project_module_meetings: "Meetings"
+  text_deleted_agenda_item: "Deleted agenda item"
 
   text_duration_in_hours: "Duration in hours"
+  text_email_updates_enabled: "Email calendar updates are enabled. All participants will receive updated invites via email when you make changes."
+
+  text_email_updates_muted: "Email calendar updates are muted. Participants will not receive updated invites via email when you make changes."
+  text_exit_draft_mode_dialog_subtitle: "You cannot return to draft mode once you schedule a meeting."
+  text_exit_draft_mode_dialog_template_subtitle: "You cannot return to draft mode after this."
+
+  text_exit_draft_mode_dialog_template_title: "Open the first occurrence of this meeting series?"
+  text_exit_draft_mode_dialog_title: "Open this meeting and send invites?"
   text_in_hours: "in hours"
   text_meeting_agenda_for_meeting: 'agenda for the meeting "%{meeting}"'
-  text_meeting_template_blank_slate_heading: "There are no templates to display"
-  text_meeting_template_blank_slate: "You can create a new template for one-time meetings"
-  text_meeting_series_end_early_heading: "Delete future occurrences?"
-  text_meeting_series_end_early: "Ending the series will delete any future open or scheduled meeting occurrences"
-  text_meeting_closing_are_you_sure: "Are you sure you want to close the meeting agenda?"
   text_meeting_agenda_open_are_you_sure: "This will overwrite all changes in the minutes! Do you want to continue?"
-  text_meeting_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
-  text_notificiation_invited: "This mail contains an ics entry for the meeting below:"
+  text_meeting_closed_description: "This meeting is closed. You cannot add/remove agenda items anymore."
+  text_meeting_closed_dropdown_description: "This meeting is closed. You cannot modify agenda items or outcomes anymore."
 
+  text_meeting_closing_are_you_sure: "Are you sure you want to close the meeting agenda?"
+  text_meeting_draft_banner: "You are currently in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
+  text_meeting_draft_description: "Prepare your agenda in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
+  text_meeting_empty_description1: "Start by adding agenda items below. Each item can be as simple as just a title, but you can also add additional details like duration and notes."
+  text_meeting_empty_description2: 'You can also add references to existing work packages. When you do, related notes will automatically be visible in the work package''s "Meetings" tab.'
+  text_meeting_empty_heading: "Your meeting is empty"
   text_meeting_ics_description: >-
     Link to meeting: %{url}
   text_meeting_ics_meeting_series_description: >-
     Link to meeting series: %{url}
+  text_meeting_in_progress_description: "You can modify the agenda, document outcomes for each item and track attendance for participants. Once the meeting is complete, you can mark it as closed to lock it."
+  text_meeting_in_progress_dropdown_description: "Document outcomes like information needs or decisions taken during the meeting."
+  text_meeting_minutes_for_meeting: 'minutes for the meeting "%{meeting}"'
+  text_meeting_not_editable_anymore: "This meeting is not editable anymore."
+  text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."
+
   text_meeting_occurrence_ics_description: >-
     Link to meeting occurrence: %{url}
 
     Link to meeting series: %{series_url}
-  text_meeting_empty_heading: "Your meeting is empty"
-  text_meeting_empty_description1: "Start by adding agenda items below. Each item can be as simple as just a title, but you can also add additional details like duration and notes."
-  text_meeting_empty_description2: 'You can also add references to existing work packages. When you do, related notes will automatically be visible in the work package''s "Meetings" tab.'
-  label_meeting_empty_action: "Add agenda item"
+  text_meeting_open_description: "You can add/remove agenda items and participants. Once the agenda is ready, mark it as in progress to document outcomes."
+  text_meeting_open_dropdown_description: "Any existing outcomes will remain but users will not be able to add new outcomes."
+  text_meeting_series_end_early: "Ending the series will delete any future open or scheduled meeting occurrences"
+  text_meeting_series_end_early_heading: "Delete future occurrences?"
+  text_meeting_template_blank_slate: "You can create a new template for one-time meetings"
+  text_meeting_template_blank_slate_heading: "There are no templates to display"
+  text_meeting_template_sharing_description: "This template can be shared with subprojects or other projects in this instance. Only the agenda items and attachments will be copied."
 
-  label_meeting_actions: "Meeting actions"
-  label_meeting_edit_title: "Edit meeting title"
-  label_meeting_delete: "Delete meeting"
-  label_meeting_created_by: "Created by"
-  label_meeting_last_updated: "Last updated"
-  label_meeting_reload: "Reload"
-  label_meeting_index_today: "Today"
-  label_meeting_index_tomorrow: "Tomorrow"
-  label_meeting_index_this_week: "Later this week"
-  label_meeting_index_later: "Next week and later"
-  label_agenda_items: "Agenda items"
-  label_agenda_items_reordered: "reordered"
+  text_notificiation_invited: "This mail contains an ics entry for the meeting below:"
 
-  label_agenda_item_add: "Add agenda item"
-  label_agenda_item_remove_from_agenda: "Remove from agenda"
-  label_agenda_item_remove_from_backlog: "Remove from backlog"
-  label_agenda_item_undisclosed_wp: "Work package #%{id} not visible"
-  label_agenda_item_deleted_wp: "Deleted work package reference"
-  label_agenda_item_actions: "Agenda items actions"
-  label_agenda_item_move_to_next_title: "Move to next meeting?"
-  label_agenda_item_move: "Move"
-  label_agenda_item_move_to_next: "Move to next meeting"
-  label_agenda_item_move_to_backlog: "Move to backlog"
-  label_agenda_item_move_to_current_meeting: "Move to current meeting"
-  label_agenda_item_move_to_section: "Move to section"
-  label_agenda_item_move_to_top: "Move to top"
-  label_agenda_item_move_to_bottom: "Move to bottom"
-  label_agenda_item_move_up: "Move up"
-  label_agenda_item_move_down: "Move down"
-  label_agenda_item_duplicate: "Duplicate"
-  label_agenda_item_duplicate_in_next: "Duplicate in next meeting"
-  label_agenda_item_duplicate_in_next_title: "Duplicate in next meeting?"
-  label_agenda_item_add_notes: "Add notes"
-  label_agenda_item_add_outcome: "Add outcome"
-  label_agenda_item_convert_to_work_package: "Convert to work package"
-
-  label_agenda_item_work_package_add: "Add work package"
-  label_agenda_item_work_package: "Agenda item work package"
-
-  label_section_rename: "Rename section"
-
-  label_agenda_outcome: "Outcome"
-  label_agenda_new_outcome: "New outcome"
-  label_agenda_outcome_actions: "Agenda outcome actions"
-  label_agenda_outcome_edit: "Edit outcome"
-  label_agenda_outcome_delete: "Remove outcome"
-  label_added_as_outcome: "Added as outcome"
-  label_write_outcome: "Write outcome"
-  label_existing_work_package: "Existing work package"
-  text_outcome_not_editable_anymore: "This outcome is not editable anymore."
+  text_onetime_meeting_template_banner: "You are currently editing a meeting template. You can use this template to create one-time meetings with a predefined agenda. Changes will not affect already-created meetings."
+  text_onetime_meeting_template_empty_description: "Add agenda items, sections and attachments here. They will be included in every meeting created using this template."
+  text_onetime_meeting_template_empty_heading: "This meeting template is empty"
   text_outcome_cannot_be_added: "An outcome can no longer be added."
 
-  label_backlog_clear: "Clear backlog"
-  label_backlog_clear_button: "Clear all"
-  text_backlog_clear_error: "One or more errors occurred while trying to clear the backlog."
-
-  label_agenda_backlog: "Agenda backlog"
-  text_agenda_backlog: >
-    This backlog is unique to this one-time meeting.
-    You can drag items in and out to add or remove them from the meeting agenda.
-  label_agenda_backlog_clear_title: "Clear agenda backlog?"
-  text_agenda_backlog_clear_description: >
-    Are you sure you want to remove all items currently in the agenda backlog? This action is not reversible.
-  label_series_backlog: "Series backlog"
+  text_outcome_not_editable_anymore: "This outcome is not editable anymore."
   text_series_backlog: >
     The backlog is shared with all occurrences of this series.
     You can drag items in and out to add or remove them from a particular meeting.
-  label_series_backlog_clear_title: "Clear series backlog?"
   text_series_backlog_clear_description: >
     This will remove all items in the series backlog, which is shared with all meetings in the series.
     Are you sure you want to continue? This action is not reversible.
 
-  text_agenda_item_title: 'Agenda item "%{title}"'
-  text_agenda_work_package_deleted: "Agenda item for deleted work package"
-  text_deleted_agenda_item: "Deleted agenda item"
-
-  label_initial_meeting_details: "Meeting"
-  label_meeting_details: "Meeting details"
-  label_meeting_series_details: "Meeting series details"
-  label_meeting_details_edit: "Edit meeting details"
-
-  label_meeting_state: "Meeting status"
-  label_meeting_state_draft: "Draft"
-  label_meeting_state_open: "Open"
-  label_meeting_state_closed: "Closed"
-  label_meeting_state_agenda_created: "Agenda created"
-  label_meeting_state_planned: "Planned"
-  label_meeting_state_cancelled: "Cancelled"
-  label_meeting_state_skipped: "Skipped"
-  label_meeting_state_in_progress: "In progress"
-  label_meeting_reopen_action: "Reopen meeting"
-  label_meeting_close_action: "Close meeting"
-  label_meeting_in_progress_action: "Start meeting"
-  label_meeting_open_action: "Open meeting"
-  text_meeting_draft_description: "Prepare your agenda in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
-  text_meeting_open_description: "You can add/remove agenda items and participants. Once the agenda is ready, mark it as in progress to document outcomes."
-  text_meeting_closed_description: "This meeting is closed. You cannot add/remove agenda items anymore."
-  text_meeting_in_progress_description: "You can modify the agenda, document outcomes for each item and track attendance for participants. Once the meeting is complete, you can mark it as closed to lock it."
-  text_meeting_open_dropdown_description: "Any existing outcomes will remain but users will not be able to add new outcomes."
-  text_meeting_in_progress_dropdown_description: "Document outcomes like information needs or decisions taken during the meeting."
-  text_meeting_closed_dropdown_description: "This meeting is closed. You cannot modify agenda items or outcomes anymore."
-
-  text_meeting_draft_banner: "You are currently in draft mode. This meeting will not send out any calendar updates or invites, even if you change meeting details or add/remove participants."
-  text_onetime_meeting_template_banner: "You are currently editing a meeting template. You can use this template to create one-time meetings with a predefined agenda. Changes will not affect already-created meetings."
-  text_onetime_meeting_template_empty_heading: "This meeting template is empty"
-  text_onetime_meeting_template_empty_description: "Add agenda items, sections and attachments here. They will be included in every meeting created using this template."
-  text_exit_draft_mode_dialog_title: "Open this meeting and send invites?"
-  text_exit_draft_mode_dialog_subtitle: "You cannot return to draft mode once you schedule a meeting."
-  text_exit_draft_mode_dialog_template_title: "Open the first occurrence of this meeting series?"
-  text_exit_draft_mode_dialog_template_subtitle: "You cannot return to draft mode after this."
-
-  label_meeting_template_sharing: "Sharing"
-  label_meeting_template_sharing_none: "Only with this project"
-  label_meeting_template_sharing_descendants: "With subprojects"
-  label_meeting_template_sharing_system: "With all projects"
-  text_meeting_template_sharing_description: "This template can be shared with subprojects or other projects in this instance. Only the agenda items and attachments will be copied."
-
-  text_meeting_not_editable_anymore: "This meeting is not editable anymore."
-  text_meeting_not_present_anymore: "This meeting was deleted. Please select another meeting."
-
-  label_add_work_package_to_meeting_dialog_title: "Select meeting"
-  label_add_work_package_to_meeting_section_label: "Section"
-  label_add_work_package_to_meeting_dialog_button: "Add to meeting"
-  label_meeting_selection_caption: "It is only possible to add this work package to an upcoming or an ongoing meeting."
-  label_section_selection_caption: "Choose a particular section of the agenda or add it to the backlog."
-  placeholder_section_select_meeting_first: "Meeting selection is required first"
-  text_add_work_package_to_meeting_form: "The work package will be added to the selected meeting or backlog as an agenda item."
-
-  text_add_work_package_to_meeting_description: "A work package can be added to one or multiple meetings for discussion. Any notes concerning it are also visible here."
-  text_agenda_item_no_notes: "No notes provided"
-  text_agenda_item_not_editable_anymore: "This agenda item is not editable anymore."
-  text_agenda_item_move_next_meeting: "This item will be moved to the next meeting on %{date} at %{time}."
-  text_agenda_item_moved_to_next_meeting: "Agenda item moved to the next meeting, on %{date}"
-  text_agenda_item_duplicate_in_next_meeting: "Are you sure you want to add a copy of this agenda item to the next meeting, on %{date} at %{time}? Outcomes will not be duplicated."
-  text_agenda_item_duplicated_in_next_meeting: "Agenda item duplicated in the next meeting, on %{date}"
-  text_work_package_has_no_upcoming_meeting_agenda_items: "This work package is not scheduled in an upcoming meeting agenda yet."
-  text_agenda_item_no_available_occurrence: "No upcoming occurrences are available."
-  text_agenda_item_dialog_skipping_note: "Note: Skipping %{details}."
-  text_agenda_item_dialog_skipping_cancelled_one: "cancelled meeting on %{date}"
-  text_agenda_item_dialog_skipping_cancelled_many: "%{count} cancelled meetings"
-  text_agenda_item_dialog_skipping_closed_one: "closed meeting on %{date}"
-  text_agenda_item_dialog_skipping_closed_many: "%{count} closed meetings"
   text_work_package_add_to_meeting_hint: 'Use the "Add to meeting" button to add this work package to an upcoming meeting.'
   text_work_package_has_no_past_meeting_agenda_items: "This work package was not added as an agenda item in a past meeting."
 
-  text_email_updates_muted: "Email calendar updates are muted. Participants will not receive updated invites via email when you make changes."
-  text_email_updates_enabled: "Email calendar updates are enabled. All participants will receive updated invites via email when you make changes."
-
-  my_account:
-    access_tokens:
-      token/ical_meeting:
-        blank_description: "You can create one using the button below."
-        blank_title: "No iCalendar meeting token"
-        title: "iCalendar for meetings"
-        table_title: "iCalendar meeting tokens"
-        text_hint: "iCalendar meeting tokens allow users to subscribe to all their meetings and view up-to-date meeting information in external clients."
-        disabled_text: "iCalendar meeting subscriptions are not enabled by the administrator. Please contact your administrator to use this feature."
-        add_button: "Subscribe to calendar"
-
-  my:
-    access_token:
-      dialog:
-        token/ical_meeting:
-          dialog_title: "New iCal subscription token for meetings"
-          dialog_body: "This token will generate an iCal subscription URL that lets you view all your meetings in an external calendar application."
-          create_button: "Create subscription"
-          name_label: "Token name"
-          name_caption: 'You can name it after where you will use it, such as "My phone" or "Work computer".'
-      created_dialog:
-        token/ical_meeting:
-          title: "An iCal meeting subscription token has been generated"
-          body: "Treat the following URL as you would a password. Anyone who has access to it can view all your meetings."
-      revocation:
-        token/ical_meeting:
-          notice_success: "The iCalendar meeting subscription has been revoked successfully."
-          notice_failure: "Failed to revoke iCalendar meeting subscription: %{error}"
+  text_work_package_has_no_upcoming_meeting_agenda_items: "This work package is not scheduled in an upcoming meeting agenda yet."

--- a/modules/openid_connect/config/locales/en.yml
+++ b/modules/openid_connect/config/locales/en.yml
@@ -1,163 +1,163 @@
 ---
 en:
-  plugin_openproject_openid_connect:
-    name: "OpenProject OpenID Connect"
-    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
-  logout_warning: >
-    You have been logged out. The contents of any form you submit may be lost.
-    Please [log in].
   activerecord:
     attributes:
       openid_connect/group_link:
         oidc_group_name: OpenID group identifier
       openid_connect/provider:
-        name: Name
-        slug: Unique identifier
-        display_name: Display name
+        acr_values: ACR values
+        authorization_endpoint: Authorization endpoint
+        claims: Claims
         client_id: Client ID
         client_secret: Client secret
-        groups_claim: Groups claim
-        group_regexes: Patterns (regular expressions)
-        secret: Secret
-        scope: Scope
-        sync_groups: Synchronize groups
-        grant_types_supported: Supported grant types
-        limit_self_registration: Limit self registration
-        authorization_endpoint: Authorization endpoint
-        userinfo_endpoint: User information endpoint
-        token_endpoint: Token endpoint
+        display_name: Display name
         end_session_endpoint: End session endpoint
-        post_logout_redirect_uri: Post logout redirect URI
-        jwks_uri: JWKS URI
-        issuer: Issuer
-        tenant: Tenant
-        metadata_url: Metadata URL
+        grant_types_supported: Supported grant types
+        group_regexes: Patterns (regular expressions)
+        groups_claim: Groups claim
         icon: Custom icon
-        claims: Claims
-        acr_values: ACR values
+        issuer: Issuer
+        jwks_uri: JWKS URI
+        limit_self_registration: Limit self registration
+        metadata_url: Metadata URL
+        name: Name
+        post_logout_redirect_uri: Post logout redirect URI
         redirect_url: Redirect URL
+        scope: Scope
+        secret: Secret
+        slug: Unique identifier
+        sync_groups: Synchronize groups
+        tenant: Tenant
+        token_endpoint: Token endpoint
+        userinfo_endpoint: User information endpoint
     errors:
       models:
         openid_connect/provider:
           attributes:
             metadata_url:
               format: "Discovery endpoint URL %{message}"
-              response_is_not_successful: " responds with %{status}."
               response_is_not_json: " does not return JSON body."
+              response_is_not_successful: " responds with %{status}."
               response_misses_required_attributes: " does not return required attributes. Missing attributes are: %{missing_attributes}."
           invalid_claims_essential: "does not define a boolean at %{attribute}."
           invalid_claims_location: "contain unsupported locations: %{invalid}. Supported locations are: %{supported}."
           invalid_claims_values: "does not define an array at %{attribute}."
           non_object_attribute: "does not define a JSON object at %{attribute}."
 
-  provider:
-    delete_warning:
-      input_delete_confirmation_html: Enter the provider name %{name} to confirm deletion.
-      irreversible_notice: Deleting an SSO provider is an irreversible action.
-      provider_html: 'Are you sure you want to delete the SSO provider %{name}? Be aware, that this will:'
-      delete_result_1: Remove the provider from the list of available providers.
-      delete_result_user_count:
-        zero: No users are currently using this provider. No further action is required.
-        one: "One user is currently still using this provider. They will need to be re-invited or logging in with another provider."
-        other: "%{count} users are currently still using this provider. They will need to be re-invited or logging in with another provider."
-      delete_result_direct: This provider is marked as a direct login provider. The setting will be removed and users will no longer be redirected to the provider for login.
-
+  logout_warning: >
+    You have been logged out. The contents of any form you submit may be lost.
+    Please [log in].
   openid_connect:
-    menu_title: OpenID providers
-    delete_title: "Delete OpenID Connect provider"
     delete_heading: "Delete this OpenID Connect provider?"
+    delete_title: "Delete OpenID Connect provider"
     group_links_heading: OpenID Connect group links
 
     groups:
       match_preview_component:
-        title: Extracted group names
         placeholder_none: No groups currently match the pattern.
+        title: Extracted group names
       match_preview_dialog_component:
         description: This allows you to test your regular expression pattern against sample data to verify that the group names you want extracted are indeed extracted properly. You can modify your pattern here but the test string and matches themselves will not be saved with the configuration.
-        group_names_label: Test group names
         group_names_description: Enter one group name per line as it would appear in the OIDC claim, to see how your regular expression patterns affect them.
+        group_names_label: Test group names
         show_button: Test pattern
         title: Test regular expressions
 
     instructions:
+      acr_values: >
+        Request non-essential claims in an easier format. See [our documentation on acr_values](docs_url) for more information.
+      claims: >
+        You can request additional claims for the userinfo and id token endpoints. Please see [our OpenID connect documentation](docs_url) for more information.
+      client_id: This is the client ID given to you by your OpenID Connect provider
+      client_secret: This is the client secret given to you by your OpenID Connect provider
+      display_name: The name of the provider. This will be displayed as the login button and in the list of providers.
       endpoint_url: The endpoint URL given to you by the OpenID Connect provider
       group_regexes: One regular expression pattern per line. Please read [the documentation](docs_url) for more information on how to do this.
       group_regexes_detail: Optionally define patterns using regular expressions to match group names from the groups claim. For example, entering a pattern like <code>^Level1/Level2/([\w/]+)$</code> will extract the group “Groupname/SubGroup” from a response including “Level1/Level2/GroupName/SubGroup”. If no pattern matches, the group is ignored. Leave empty to synchronize all groups using their full group name.
       group_regexes_testing: "Click on 'Test pattern' to test your regular expression pattern against sample OIDC userinfo."
       group_sync: Automatically extract and synchronise group membership information from the identity provider.
       groups_claim: Specify the name of the claim that's expected to indicate the group names that the user is a member of.
-      metadata_none: I don't have this information
-      metadata_url: I have a discovery endpoint URL
-      oidc_information: These values are needed to configure the OpenID Connect provider.
-      client_id: This is the client ID given to you by your OpenID Connect provider
-      client_secret: This is the client secret given to you by your OpenID Connect provider
       limit_self_registration: If enabled, users can only register using this provider if configuration on the provider's end allows it.
-      display_name: The name of the provider. This will be displayed as the login button and in the list of providers.
-      tenant: Please replace the default tenant with your own if applicable. See <a href=" https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri">this</a>.
-      scope: If you want to request custom scopes, you can add one or multiple scope values separated by spaces here. For more information, see the [OpenID Connect documentation](docs_url).
-      post_logout_redirect_uri: The URL the OpenID Connect provider should redirect to after a logout request.
-      claims: >
-        You can request additional claims for the userinfo and id token endpoints. Please see [our OpenID connect documentation](docs_url) for more information.
-      acr_values: >
-        Request non-essential claims in an easier format. See [our documentation on acr_values](docs_url) for more information.
-      mapping_login: >
-        Provide a custom mapping in the userinfo response to be used for the login attribute.
+      mapping_admin: >
+        Provide a custom mapping in the userinfo response to be used for the admin status.
+        It expects a boolean attribute to be returned.
       mapping_email: >
         Provide a custom mapping in the userinfo response to be used for the email attribute.
       mapping_first_name: >
         Provide a custom mapping in the userinfo response to be used for the first name.
       mapping_last_name: >
         Provide a custom mapping in the userinfo response to be used for the last name.
-      mapping_admin: >
-        Provide a custom mapping in the userinfo response to be used for the admin status.
-        It expects a boolean attribute to be returned.
-    settings:
+      mapping_login: >
+        Provide a custom mapping in the userinfo response to be used for the login attribute.
       metadata_none: I don't have this information
       metadata_url: I have a discovery endpoint URL
-      endpoint_url: Endpoint URL
+      oidc_information: These values are needed to configure the OpenID Connect provider.
+      post_logout_redirect_uri: The URL the OpenID Connect provider should redirect to after a logout request.
+      scope: If you want to request custom scopes, you can add one or multiple scope values separated by spaces here. For more information, see the [OpenID Connect documentation](docs_url).
+      tenant: Please replace the default tenant with your own if applicable. See <a href=" https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri">this</a>.
+    menu_title: OpenID providers
     providers:
-      label_providers: "Providers"
-      seeded_from_env: "This provider was seeded from the environment configuration. It cannot be edited."
-      google:
-        name: Google
-      microsoft_entra:
-        name: Microsoft Entra
+      client_details_description: Configuration details of OpenProject as an OIDC client
       custom:
         name: Custom
-      upsell:
-        title: "Single Sign-On (SSO) with OpenID connect"
-        description: Connect OpenProject to an OpenID connect identity provider
+      google:
+        name: Google
       label_add_new: Add a new OpenID provider
+      label_advanced_configuration: Advanced configuration
+      label_attribute_mapping: Attribute mapping
+      label_automatic_configuration: Automatic configuration
+      label_client_details: Client details
+      label_configuration_details: Metadata
       label_edit: Edit OpenID provider %{name}
-      label_empty_title: No OpenID providers configured yet.
       label_empty_description: Add a provider to see them here.
+      label_empty_title: No OpenID providers configured yet.
       label_group_mapping: Group mapping
       label_metadata: OpenID Connect Discovery Endpoint
-      label_automatic_configuration: Automatic configuration
       label_optional_configuration: Optional configuration
-      label_advanced_configuration: Advanced configuration
-      label_configuration_details: Metadata
-      label_client_details: Client details
-      label_attribute_mapping: Attribute mapping
-      notice_created: A new OpenID provider was successfully created.
-      client_details_description: Configuration details of OpenProject as an OIDC client
+      label_providers: "Providers"
+      microsoft_entra:
+        name: Microsoft Entra
       no_results_table: No providers have been defined yet.
+      notice_created: A new OpenID provider was successfully created.
       plural: OpenID providers
-      singular: OpenID provider
       section_texts:
+        attribute_mapping: Configure the mapping of attributes between OpenProject and the OpenID Connect provider.
+        claims: Request additional claims for the ID token or userinfo response.
+        configuration: Configuration details of the OpenID Connect provider
+        configuration_metadata: The information has been pre-filled using the supplied discovery endpoint. In most cases, they do not require editing.
+        display_name: The display name visible to users.
         group_mapping: Map group names provided by the identity provider to groups in OpenProject.
         metadata: Pre-fill configuration using an OpenID Connect discovery endpoint URL
         metadata_form_banner: Editing the discovery endpoint may override existing pre-filled metadata values.
-        metadata_form_title: OpenID Connect Discovery endpoint
         metadata_form_description: If your identity provider has a discovery endpoint URL. Use it below to pre-fill configuration.
-        configuration_metadata: The information has been pre-filled using the supplied discovery endpoint. In most cases, they do not require editing.
-        configuration: Configuration details of the OpenID Connect provider
-        display_name: The display name visible to users.
-        attribute_mapping: Configure the mapping of attributes between OpenProject and the OpenID Connect provider.
-        claims: Request additional claims for the ID token or userinfo response.
+        metadata_form_title: OpenID Connect Discovery endpoint
+      seeded_from_env: "This provider was seeded from the environment configuration. It cannot be edited."
       side_panel:
         information_component:
           backchannel_logout_url: Backchannel logout URL
+      singular: OpenID provider
+      upsell:
+        description: Connect OpenProject to an OpenID connect identity provider
+        title: "Single Sign-On (SSO) with OpenID connect"
     setting_instructions:
       limit_self_registration: >
         If enabled users can only register using this provider if the self registration setting allows for it.
+    settings:
+      endpoint_url: Endpoint URL
+      metadata_none: I don't have this information
+      metadata_url: I have a discovery endpoint URL
+  plugin_openproject_openid_connect:
+    description: "Adds OmniAuth OpenID Connect strategy providers to OpenProject."
+    name: "OpenProject OpenID Connect"
+  provider:
+    delete_warning:
+      delete_result_1: Remove the provider from the list of available providers.
+      delete_result_direct: This provider is marked as a direct login provider. The setting will be removed and users will no longer be redirected to the provider for login.
+
+      delete_result_user_count:
+        one: "One user is currently still using this provider. They will need to be re-invited or logging in with another provider."
+        other: "%{count} users are currently still using this provider. They will need to be re-invited or logging in with another provider."
+        zero: No users are currently using this provider. No further action is required.
+      input_delete_confirmation_html: Enter the provider name %{name} to confirm deletion.
+      irreversible_notice: Deleting an SSO provider is an irreversible action.
+      provider_html: 'Are you sure you want to delete the SSO provider %{name}? Be aware, that this will:'

--- a/modules/overviews/config/locales/en.yml
+++ b/modules/overviews/config/locales/en.yml
@@ -1,6 +1,6 @@
 ---
 en:
   overviews:
-    label_home: "%{workspace_type} home"
     label_dashboard: "Dashboard"
+    label_home: "%{workspace_type} home"
     label_overview: "Overview"

--- a/modules/recaptcha/config/locales/en.yml
+++ b/modules/recaptcha/config/locales/en.yml
@@ -2,26 +2,13 @@
 ---
 en:
   plugin_openproject_recaptcha:
-    name: "OpenProject ReCaptcha"
     description: "This module provides recaptcha checks during login."
+    name: "OpenProject ReCaptcha"
   recaptcha:
-    label_recaptcha: "reCAPTCHA"
     button_please_wait: 'Please wait ...'
-    verify_account: "Verify your account"
     error_captcha: "Your account could not be verified. Please contact an administrator."
+    label_recaptcha: "reCAPTCHA"
     settings:
-      website_key: 'Website key (May also be called "Site key")'
-      response_limit: 'Response limit for HCaptcha'
-      response_limit_text: 'The maximum number of characters to treat the HCaptcha response as valid.'
-      website_key_text: 'Enter the website key you created on the reCAPTCHA admin console for this domain.'
-      secret_key: 'Secret key'
-      secret_key_text: 'Enter the secret key you created on the reCAPTCHA admin console.'
-      type: 'Use reCAPTCHA'
-      type_disabled: 'Disable reCAPTCHA'
-      type_v2: 'reCAPTCHA v2'
-      type_v3: 'reCAPTCHA v3'
-      type_hcaptcha: 'HCaptcha'
-      type_turnstile: 'Cloudflare Turnstile™'
       captcha_description_html: >
         reCAPTCHA is a free service by Google that can be enabled for your OpenProject instance.
         If enabled, a captcha form will be rendered upon login for all users that have not verified a captcha yet.
@@ -34,3 +21,16 @@ en:
         <br/>
         Cloudflare Turnstile™ is another alternative that is more convenient for users while still providing the same level of security.
         See this link for more information: %{turnstile_link}
+      response_limit: 'Response limit for HCaptcha'
+      response_limit_text: 'The maximum number of characters to treat the HCaptcha response as valid.'
+      secret_key: 'Secret key'
+      secret_key_text: 'Enter the secret key you created on the reCAPTCHA admin console.'
+      type: 'Use reCAPTCHA'
+      type_disabled: 'Disable reCAPTCHA'
+      type_hcaptcha: 'HCaptcha'
+      type_turnstile: 'Cloudflare Turnstile™'
+      type_v2: 'reCAPTCHA v2'
+      type_v3: 'reCAPTCHA v3'
+      website_key: 'Website key (May also be called "Site key")'
+      website_key_text: 'Enter the website key you created on the reCAPTCHA admin console for this domain.'
+    verify_account: "Verify your account"

--- a/modules/reporting/config/locales/en.yml
+++ b/modules/reporting/config/locales/en.yml
@@ -28,76 +28,94 @@
 
 ---
 en:
-  plugin_openproject_reporting:
-    name: "OpenProject Reporting"
-    description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
-
   button_save_report_as: "Save report as..."
 
   comments: "Comment"
   cost_reports_title: "Time and costs"
-  label_cost_report: "Cost report"
-  label_cost_report_plural: "Cost reports"
-
   description_drill_down: "Show details"
   description_filter_selection: "Selection"
   description_multi_select: "Show multiselect"
   description_remove_filter: "Remove filter"
 
+  export:
+    cost_reports:
+      end_time: "End time"
+
+      start_time: "Start time"
+      title: "Your Cost Reports XLS export"
+    timesheet:
+      button: "Export PDF timesheet"
+      overview_per_user_day: "Overview: Hours per user per day"
+      overview_per_user_total: "Overview: Total hours per user"
+      sums_hours: Sums
+      time: "Time"
+      timesheet: "Timesheet"
+      title: "Your PDF timesheet export"
   information_restricted_depending_on_permission: "Depending on your permissions this page might contain restricted information."
 
   label_click_to_edit: "Click to edit."
   label_closed: "closed"
   label_columns: "Columns"
   label_cost_entry_attributes: "Cost entry attributes"
+  label_cost_report: "Cost report"
+  label_cost_report_plural: "Cost reports"
+
+  label_count: "Count"
   label_days_ago: "during the last days"
   label_entry: "Cost entry"
+  label_filter: "Filter"
+  label_filter_add: "Add Filter"
+  label_filter_plural: "Filters"
   label_filter_text: "Filter text"
   label_filter_value: "Value"
   label_filters: "Filter"
   label_greater: ">"
+  label_group_by: "Group by"
+  label_group_by_add: "Add Group-by Attribute"
+  label_inactive: "«inactive»"
   label_is_not_project_with_subprojects: "is not (includes subprojects)"
+  label_is_not_work_package_with_descendants: "is not (includes descendants)"
   label_is_project_with_subprojects: "is (includes subprojects)"
   label_is_work_package_with_descendants: "is (includes descendants)"
-  label_is_not_work_package_with_descendants: "is not (includes descendants)"
-  label_work_package_attributes: "Work package attributes"
   label_less: "<"
   label_logged_by_reporting: "Logged by"
   label_money: "Cash value"
   label_month_reporting: "Month (Spent)"
   label_new_report: "New cost report"
+  label_no: "No"
+  label_no_reports: "There are no cost reports yet."
+  label_none: "(no data)"
   label_open: "open"
   label_operator: "Operator"
   label_private_report_plural: "Private cost reports"
   label_progress_bar_explanation: "Generating report..."
   label_public_report_plural: "Public cost reports"
   label_really_delete_question: "Are you sure you want to delete this report?"
+  label_report: "Report"
   label_rows: "Rows"
   label_saving: "Saving ..."
   label_spent_on_reporting: "Date (Spent)"
   label_sum: "Sum"
   label_units: "Units"
   label_week_reporting: "Week (Spent)"
+  label_work_package_attributes: "Work package attributes"
   label_year_reporting: "Year (Spent)"
-  label_count: "Count"
-  label_filter: "Filter"
-  label_filter_add: "Add Filter"
-  label_filter_plural: "Filters"
-  label_group_by: "Group by"
-  label_group_by_add: "Add Group-by Attribute"
-  label_inactive: "«inactive»"
-  label_no: "No"
-  label_none: "(no data)"
-  label_no_reports: "There are no cost reports yet."
-  label_report: "Report"
   label_yes: "Yes"
 
   load_query_question: "Report will have %{size} table cells and may take some time to render. Do you still want to try rendering it?"
 
   permission_save_cost_reports: "Save public cost reports"
   permission_save_private_cost_reports: "Save private cost reports"
+  plugin_openproject_reporting:
+    description: "This plugin allows creating custom cost reports with filtering and grouping created by the OpenProject Time and costs plugin."
+
+    name: "OpenProject Reporting"
   project_module_reporting_module: "Cost reports"
 
+  reporting:
+    group_by:
+      selected_columns: "Selected columns"
+      selected_rows: "Selected rows"
   text_costs_are_rounded_note: "Displayed values are rounded. All calculations are based on the non-rounded values."
   toggle_multiselect: "activate/deactivate multiselect"
 
@@ -105,22 +123,3 @@ en:
 
   validation_failure_date: "is not a valid date"
   validation_failure_integer: "is not a valid integer"
-
-  export:
-    timesheet:
-      title: "Your PDF timesheet export"
-      button: "Export PDF timesheet"
-      timesheet: "Timesheet"
-      time: "Time"
-      sums_hours: Sums
-      overview_per_user_total: "Overview: Total hours per user"
-      overview_per_user_day: "Overview: Hours per user per day"
-    cost_reports:
-      title: "Your Cost Reports XLS export"
-      start_time: "Start time"
-      end_time: "End time"
-
-  reporting:
-    group_by:
-      selected_columns: "Selected columns"
-      selected_rows: "Selected rows"

--- a/modules/storages/config/locales/js-en.yml
+++ b/modules/storages/config/locales/js-en.yml
@@ -4,24 +4,76 @@ en:
   js:
     storages:
       authentication_error: "Authentication with %{storageType} failed"
-      link_files_in_storage: "Link files in %{storageType}"
-      link_existing_files: "Link existing files"
-      upload_files: "Upload files"
+      choose_location: "Choose location"
       drop_files: "Drop files here to upload them to %{name}."
       drop_or_click_files: "Drop files here or click to upload them to %{name}."
-      login: "%{storageType} login"
-      login_to: "Login to %{storageType}"
-      no_connection: "No %{storageType} connection"
-      open_storage: "Open %{storageType}"
-      select_location: "Select location"
-      choose_location: "Choose location"
-      new_folder: "New folder"
-
-      types:
-        nextcloud: "Nextcloud"
-        one_drive: "OneDrive"
-        sharepoint: "SharePoint"
-        default: "Storage"
+      file_links:
+        already_linked_directory: "This directory is already linked to this work package."
+        already_linked_file: "This file is already linked to this work package."
+        download: "Download %{fileName}"
+        empty: >
+          Currently there are no linked files to this work package. Start linking files with the action below or from
+          within %{storageType}.
+        link_uploaded_file_error: >
+          An error occurred linking the recently uploaded file '%{fileName}' to the work package %{workPackageId}.
+        open: "Open file on storage"
+        open_location: "Open file in location"
+        remove: "Remove file link"
+        remove_confirmation: >
+          Are you sure you want to unlink the file from this work package? Unlinking does not affect the original file
+          and only removes the connection to this work package.
+        remove_short: "Remove link"
+        select: "Select files"
+        select_all: "Select all"
+        selection:
+          one: "Link 1 file"
+          other: "Link %{count} files"
+          zero: "Select files to link"
+        success_create:
+          one: "Successfully created 1 file link."
+          other: "Successfully created %{count} file links."
+        tooltip:
+          not_found: "This file cannot be found."
+          not_logged_in: "Please log in to the storage to access this file."
+          view_not_allowed: "You have no permission to see this file."
+        upload_error:
+          403: >
+            Your file (%{fileName}) could not be uploaded due to system restrictions.
+            Please contact your administrator for more information.
+          413: >
+            Your file (%{fileName}) is bigger than what OpenProject can upload to %{storageType}.
+            You can upload it directly to %{storageType} first and then link the file.
+          507: >
+            Your file (%{fileName}) is bigger than the storage quota allows.
+            Contact your administrator to modify this quota.
+          default: >
+            Your file (%{fileName}) could not be uploaded.
+          detail:
+            nextcloud: >
+              Please check that the latest version of the Nextcloud App "OpenProject Integration" is installed and
+              contact your administrator for more information.
+      files:
+        already_existing_body: >
+          A file with the name "%{fileName}" already exists in the location where you are trying
+          to upload this file. What would you like to do?
+        already_existing_header: "This file already exists"
+        cannot_create_folder: Failed to create folder. Avoid using special characters and symbols and make sure the folder does not exist already.
+        directory_not_writeable: "You do not have permission to add files to this folder."
+        dragging_folder: "The upload to %{storageType} does not support folders."
+        dragging_many_files: "The upload to %{storageType} supports only one file at once."
+        empty_folder: "This folder is empty."
+        empty_folder_location_hint: "Click the button below to upload the file to this location."
+        file_not_selectable_location: "Selecting a file is not possible in the process of choosing a location."
+        managed_project_folder_no_access: >
+          You have no access yet to the managed project folder. Please wait a bit and try again.
+        managed_project_folder_not_available: >
+          The automatically managed project folder was not yet found. Please wait a bit, reload the page to fetch the
+          newest data, and try again.
+        project_folder_no_access: >
+          You have no access to the project folder. Please, contact your administrator to get access or
+          upload the file in another location.
+        upload_keep_both: "Keep both"
+        upload_replace: "Replace"
 
       information:
         authentication_error: "The request to %{storageType} could not be authenticated, that's an error."
@@ -37,71 +89,19 @@ en:
         suggest_logout: You can try whether logging out and back in fixes this problem.
         suggest_relink: You can try whether re-linking your account via the login button below fixes this problem.
 
-      files:
-        already_existing_header: "This file already exists"
-        already_existing_body: >
-          A file with the name "%{fileName}" already exists in the location where you are trying
-          to upload this file. What would you like to do?
-        directory_not_writeable: "You do not have permission to add files to this folder."
-        dragging_many_files: "The upload to %{storageType} supports only one file at once."
-        dragging_folder: "The upload to %{storageType} does not support folders."
-        empty_folder: "This folder is empty."
-        empty_folder_location_hint: "Click the button below to upload the file to this location."
-        file_not_selectable_location: "Selecting a file is not possible in the process of choosing a location."
-        project_folder_no_access: >
-          You have no access to the project folder. Please, contact your administrator to get access or
-          upload the file in another location.
-        managed_project_folder_not_available: >
-          The automatically managed project folder was not yet found. Please wait a bit, reload the page to fetch the
-          newest data, and try again.
-        managed_project_folder_no_access: >
-          You have no access yet to the managed project folder. Please wait a bit and try again.
-        cannot_create_folder: Failed to create folder. Avoid using special characters and symbols and make sure the folder does not exist already.
-        upload_keep_both: "Keep both"
-        upload_replace: "Replace"
+      link_existing_files: "Link existing files"
+      link_files_in_storage: "Link files in %{storageType}"
+      login: "%{storageType} login"
+      login_to: "Login to %{storageType}"
+      new_folder: "New folder"
 
-      file_links:
-        empty: >
-          Currently there are no linked files to this work package. Start linking files with the action below or from
-          within %{storageType}.
-        download: "Download %{fileName}"
-        open: "Open file on storage"
-        open_location: "Open file in location"
-        remove: "Remove file link"
-        remove_confirmation: >
-          Are you sure you want to unlink the file from this work package? Unlinking does not affect the original file
-          and only removes the connection to this work package.
-        remove_short: "Remove link"
-        select: "Select files"
-        select_all: "Select all"
-        selection:
-          zero: "Select files to link"
-          one: "Link 1 file"
-          other: "Link %{count} files"
-        success_create:
-          one: "Successfully created 1 file link."
-          other: "Successfully created %{count} file links."
-        upload_error:
-          default: >
-            Your file (%{fileName}) could not be uploaded.
-          403: >
-            Your file (%{fileName}) could not be uploaded due to system restrictions.
-            Please contact your administrator for more information.
-          413: >
-            Your file (%{fileName}) is bigger than what OpenProject can upload to %{storageType}.
-            You can upload it directly to %{storageType} first and then link the file.
-          507: >
-            Your file (%{fileName}) is bigger than the storage quota allows.
-            Contact your administrator to modify this quota.
-          detail:
-            nextcloud: >
-              Please check that the latest version of the Nextcloud App "OpenProject Integration" is installed and
-              contact your administrator for more information.
-        link_uploaded_file_error: >
-          An error occurred linking the recently uploaded file '%{fileName}' to the work package %{workPackageId}.
-        tooltip:
-          not_logged_in: "Please log in to the storage to access this file."
-          view_not_allowed: "You have no permission to see this file."
-          not_found: "This file cannot be found."
-        already_linked_file: "This file is already linked to this work package."
-        already_linked_directory: "This directory is already linked to this work package."
+      no_connection: "No %{storageType} connection"
+      open_storage: "Open %{storageType}"
+      select_location: "Select location"
+      types:
+        default: "Storage"
+
+        nextcloud: "Nextcloud"
+        one_drive: "OneDrive"
+        sharepoint: "SharePoint"
+      upload_files: "Upload files"

--- a/modules/team_planner/config/locales/en.yml
+++ b/modules/team_planner/config/locales/en.yml
@@ -1,25 +1,25 @@
 # English strings go here
 ---
 en:
-  plugin_openproject_team_planner:
-    name: "OpenProject Team Planner"
-    description: "Provides team planner views."
-
-  permission_view_team_planner: "View team planner"
-  permission_manage_team_planner: "Manage team planner"
-  project_module_team_planner_view: "Team planners"
-
   ee:
     feature_names:
       team_planner_view: "Team planner"
     upsell:
       team_planner_view:
-        title: "Team planner"
         description: "Get a complete overview of your team’s planning with Team Planner. Stretch, shorten and drag-and-drop work packages to modify dates, move them or change assignees."
 
+        title: "Team planner"
+  permission_manage_team_planner: "Manage team planner"
+  permission_view_team_planner: "View team planner"
+  plugin_openproject_team_planner:
+    description: "Provides team planner views."
+
+    name: "OpenProject Team Planner"
+  project_module_team_planner_view: "Team planners"
+
   team_planner:
-    label_team_planner: "Team planner"
-    label_new_team_planner: "New team planner"
-    label_create_new_team_planner: "Create new team planner"
-    label_team_planner_plural: "Team planners"
     label_assignees: "Assignees"
+    label_create_new_team_planner: "Create new team planner"
+    label_new_team_planner: "New team planner"
+    label_team_planner: "Team planner"
+    label_team_planner_plural: "Team planners"

--- a/modules/team_planner/config/locales/js-en.yml
+++ b/modules/team_planner/config/locales/js-en.yml
@@ -3,29 +3,29 @@
 en:
   js:
     team_planner:
-      add_existing: 'Add existing'
-      label_team_planner_plural: 'Team planners'
-      add_existing_title: 'Add existing work packages'
-      create_label: 'Team planner'
-      create_title: 'Create new team planner'
-      unsaved_title: 'Unnamed team planner'
-      no_data: 'Add assignees to set up your team planner.'
       add_assignee: 'Assignee'
-      remove_assignee: 'Remove assignee'
-      two_weeks: '2-week'
-      one_week: '1-week'
-      four_weeks: '4-week'
-      eight_weeks: '8-week'
-      work_week: 'Work week'
-      today: 'Today'
-      drag_here_to_remove: 'Drag here to remove assignee and start and end dates.'
+      add_existing: 'Add existing'
+      add_existing_title: 'Add existing work packages'
       cannot_drag_here: 'Cannot move the work package due to permissions or editing restrictions.'
       cannot_drag_to_non_working_day: 'This work package cannot start/finish on a non-working day.'
 
+      create_label: 'Team planner'
+      create_title: 'Create new team planner'
+      drag_here_to_remove: 'Drag here to remove assignee and start and end dates.'
+      eight_weeks: '8-week'
+      four_weeks: '4-week'
+      label_team_planner_plural: 'Team planners'
+      modify:
+        errors:
+          fallback: 'This work package cannot be edited.'
+          permission_denied: 'You do not have the necessary permissions to modify this.'
+      no_data: 'Add assignees to set up your team planner.'
+      one_week: '1-week'
       quick_add:
         empty_state: 'Use the search field to find work packages and drag them to the planner to assign it to someone and define start and end dates.'
         search_placeholder: 'Search...'
-      modify:
-        errors:
-          permission_denied: 'You do not have the necessary permissions to modify this.'
-          fallback: 'This work package cannot be edited.'
+      remove_assignee: 'Remove assignee'
+      today: 'Today'
+      two_weeks: '2-week'
+      unsaved_title: 'Unnamed team planner'
+      work_week: 'Work week'

--- a/modules/two_factor_authentication/config/locales/en.yml
+++ b/modules/two_factor_authentication/config/locales/en.yml
@@ -1,19 +1,12 @@
 # English strings go here for Rails i18n
 ---
 en:
-  plugin_openproject_two_factor_authentication:
-    name: "OpenProject Two-factor authentication"
-    description: >-
-      This OpenProject plugin authenticates your users using two-factor authentication by means of
-      one-time password through the TOTP standard (Google Authenticator) or sent to the user's cell
-      phone via SMS or voice call.
-
   activerecord:
     attributes:
       two_factor_authentication/device:
-        identifier: "Identifier"
-        default: "Use as default"
         channel: "Channel"
+        default: "Use as default"
+        identifier: "Identifier"
       two_factor_authentication/device/sms:
         phone_number: "Phone number"
       two_factor_authentication/device/webauthn:
@@ -33,32 +26,141 @@ en:
       two_factor_authentication/device/totp: "Authenticator application"
       two_factor_authentication/device/webauthn: "WebAuthn"
 
+  button_continue: "Continue"
+  button_make_default: "Mark as default"
+  button_otp_by_sms: "SMS"
+  button_otp_by_voice: "Voice call"
+  button_resend_otp_form: "Resend"
+  field_otp: "One-time password"
+  label_confirmed: "Confirmed"
+  label_otp_channel: "Delivery channel"
+  notice_account_has_no_phone: "No cell phone number is associated with your account."
+  notice_account_otp_expired: "The one-time password you entered expired."
+  notice_account_otp_invalid: "Invalid one-time password."
+  notice_account_otp_send_failed: "Your one-time password could not be sent."
+  notice_developer_strategy_otp: "Developer strategy generated the following one-time password: %{token} (Channel: %{channel})"
+  notice_phone_number_format: "Please enter the number in the following format: +XX XXXXXXXX."
+  plugin_openproject_two_factor_authentication:
+    description: >-
+      This OpenProject plugin authenticates your users using two-factor authentication by means of
+      one-time password through the TOTP standard (Google Authenticator) or sent to the user's cell
+      phone via SMS or voice call.
+
+    name: "OpenProject Two-factor authentication"
+  text_otp_not_receive: "Other verification methods"
+  text_send_otp_again: "Resend one-time password by:"
   two_factor_authentication:
+    admin:
+      all_devices_deleted: "All 2FA devices of this user have been deleted"
+      button_delete_all_devices: "Delete registered 2FA devices"
+      button_register_mobile_phone_for_user: "Register mobile phone"
+      delete_all_are_you_sure: "Are you sure you want to delete all 2FA devices for this user?"
+      no_devices_for_user: "No 2FA device has been registered for this user."
+      only_sms_allowed: "Only SMS delivery can be set up for other users."
+      self_edit_forbidden: "You may not edit your own 2FA devices on this path. Go to My Account > Two factor authentication instead."
+      self_edit_path_html: "To add or modify your own 2FA devices, please go to the [Two-factor authentication on your account page](self_edit_link)"
+      text_2fa_disabled: "The user did not set up a 2FA device through their 'My account page'"
+      text_2fa_enabled: "Upon every login, this user will be requested to enter a OTP token from their default 2FA device."
+    backup_codes:
+      generate:
+        keep_safe_as_password: "Important! Treat these codes as passwords."
+        keep_safe_warning: "Either save them in your password manager, or print this page and put in a safe place."
+        regenerate_warning: "Warning: If you have created backup codes before, they will be invalidated and will no longer work."
+
+        title: Generate backup codes
+      overview_description: |
+        If you are unable to access your two factor devices, you can use a backup code to regain access to your account.
+        Use the following button to generate a new set of backup codes.
+      plural: Backup codes
+      singular: Backup code
+    channel_unavailable: "The delivery channel %{channel} is unavailable."
+    devices:
+      2fa_from_input_html: Please enter the code from your <strong>%{device_name}</strong> to verify your identity.
+      2fa_from_webauthn_html: Please provide the WebAuthn device <strong>%{device_name}</strong>. If it is USB based make sure to plug it in and touch it. Then click the sign in button.
+      add_new: "Add new 2FA device"
+      button_complete_registration: "Complete 2FA registration"
+      cannot_delete_default: "Cannot delete default device"
+      confirm_default: "Confirm changing default device"
+      confirm_device: "Confirm device"
+      confirm_now: "Not confirmed, click here to activate"
+      confirm_send_failed: "Confirmation of your 2FA device failed."
+      deletion_are_you_sure: "Are you sure you want to delete this 2FA device?"
+      failed_to_delete: "Failed to delete 2FA device."
+      is_default_cannot_delete: "The device is marked as default and cannot be deleted due to an active security policy. Mark another device as default before deleting."
+      make_default_are_you_sure: "Are you sure you want to make this 2FA device your default?"
+      make_default_failed: "Failed to update the default 2FA device."
+      not_existing: "No 2FA device has been registered for your account."
+      register: "Register device"
+      registration_complete: "2FA device registration complete!"
+      registration_failed_token_invalid: "2FA device registration failed, the token was invalid."
+      registration_failed_update: "2FA device registration failed, the token was valid but the device could not be updated."
+      sms:
+        description: |
+          Receive 2FA code via a text message on your phone each time you log in.
+        redacted_identifier: "Mobile device (%{redacted_number})"
+        request_2fa_identifier: "%{redacted_identifier}, we sent you an authentication code via %{delivery_channel}"
+        title: "Mobile device"
+      text_confirm_to_change_default_html: "Please confirm changing your default device to <strong>%{new_identifier}</strong> by entering a one-time password from your current default device."
+      text_confirm_to_complete_html: "Please complete the registration of your device <strong>%{identifier}</strong> by entering a one-time password from your default device."
+      text_identifier: "You can give the device a custom identifier using this field."
+      totp:
+        account: "Account name / Issuer"
+        description: |
+          Use a one-time code generated by an authenticator like Authy or Google Authenticator.
+        provisioning_uri: "Provisioning URI"
+        question_cannot_scan: |
+          Unable to scan the code using your application?
+        secret_key: "Secret key"
+        setup: |
+          For setting up two-factor authentication with Google Authenticator, download the application from the Apple App store or Google Play Store.
+          After opening the app, you can scan the following QR code to register the device.
+        text_cannot_scan: |
+          If you can't scan the code, you can enter the entry manually using the following details:
+        time_based: "Time based"
+        title: "App-based authenticator"
+      webauthn:
+        description: Register a FIDO2 device (like YubiKey) or the secure enclave of your mobile device.
+        further_steps: After you have chosen a name, you can click the Continue button. Your browser will prompt you to present your WebAuthn device. When you have done so, you are done registering the device.
+        title: "WebAuthn"
     error_2fa_disabled: "2FA delivery has been disabled."
-    notice_not_writable: "2FA Settings were provided through environment variables and cannot be overwritten."
+    error_invalid_backup_code: "Invalid 2FA backup code"
+    error_is_enforced_not_active: "Configuration error: Two-factor authentication has been enforced, but no active strategies exist."
     error_no_device: "No registered 2FA device found for this user, despite being required for this instance."
     error_no_matching_strategy: "No matching 2FA strategy available for this user. Please contact your administratior."
-    error_is_enforced_not_active: "Configuration error: Two-factor authentication has been enforced, but no active strategies exist."
-    error_invalid_backup_code: "Invalid 2FA backup code"
-    channel_unavailable: "The delivery channel %{channel} is unavailable."
-    no_valid_phone_number: "No valid phone number exists."
-    label_device_type: "Device type"
+    forced_registration:
+      required_to_add_device: "An active security policy requires you to enable two-factor authentication. Please use the following form to register a device."
+
+    label_2fa_disabled: "Two-factor authentication not active"
+    label_2fa_enabled: "Two-factor authentication is active"
     label_default_device: "Default 2FA device"
     label_device: "2FA device"
+    label_device_type: "Device type"
     label_devices: "2FA devices"
-    label_2fa_enabled: "Two-factor authentication is active"
-    label_2fa_disabled: "Two-factor authentication not active"
-    text_otp_delivery_message_sms: "Your %{app_title} one-time password is %{token}"
-    text_otp_delivery_message_voice: "Your %{app_title} one-time password is: %{pause} %{token}. %{pause} I repeat: %{pause} %{token}"
-    text_2fa_enabled: "Upon every login, you will be requested to enter a OTP token from your default 2FA device."
-    text_2fa_disabled: "To enable two-factor authentication, use the button above to register a new 2FA device. If you already have a device, you need to make it a default."
+    label_two_factor_authentication: "Two-factor authentication"
+
     login:
-      enter_backup_code_title: Enter backup code
       enter_backup_code_text: Please enter a valid backup code from your list of codes in case you can no longer access your registered 2FA devices.
+      enter_backup_code_title: Enter backup code
       other_device: "Use another device or backup code"
+    message_bird:
+      sms_delivery_failed: "MessageBird SMS delivery failed."
+      voice_delivery_failed: "MessageBird voice call failed."
+
+    mobile_transmit_notification: "A one-time password has been sent to your cell phone."
+    no_valid_phone_number: "No valid phone number exists."
+    notice_not_writable: "2FA Settings were provided through environment variables and cannot be overwritten."
+    remember:
+      active_session_notice: >
+        Your account has an active remember cookie valid until %{expires_on}.
+        This cookie allows you to log in without a second factor to your account until that time.
+      clear_cookie: "Click here to remove all remembered 2FA sessions."
+      cookie_removed: "All remembered 2FA sessions have been removed."
+      dont_ask_again: "Create cookie to remember 2FA authentication on this client for %{days} days."
+      label: "Remember"
+      other_active_session_notice: Your account has an active remember cookie on another session.
     settings:
-      title: "2FA settings"
       current_configuration: "Current configuration"
+      failed_to_save_settings: "Failed to update 2FA settings: %{message}"
       label_active_strategies: "Active 2FA strategies"
       label_enforced: "Enforce 2FA"
       label_remember: "Remember 2FA login"
@@ -69,118 +171,16 @@ en:
       text_remember: |
         Set this to greater than zero to allow users to remember their 2FA authentication for the given number of days.
         They will not be requested to re-enter it during that period. Can only be set when not enforced by configuration.
-      failed_to_save_settings: "Failed to update 2FA settings: %{message}"
-    admin:
-      self_edit_path_html: "To add or modify your own 2FA devices, please go to the [Two-factor authentication on your account page](self_edit_link)"
-      self_edit_forbidden: "You may not edit your own 2FA devices on this path. Go to My Account > Two factor authentication instead."
-      no_devices_for_user: "No 2FA device has been registered for this user."
-      all_devices_deleted: "All 2FA devices of this user have been deleted"
-      delete_all_are_you_sure: "Are you sure you want to delete all 2FA devices for this user?"
-      button_delete_all_devices: "Delete registered 2FA devices"
-      button_register_mobile_phone_for_user: "Register mobile phone"
-      text_2fa_enabled: "Upon every login, this user will be requested to enter a OTP token from their default 2FA device."
-      text_2fa_disabled: "The user did not set up a 2FA device through their 'My account page'"
-      only_sms_allowed: "Only SMS delivery can be set up for other users."
-    backup_codes:
-      singular: Backup code
-      plural: Backup codes
-      overview_description: |
-        If you are unable to access your two factor devices, you can use a backup code to regain access to your account.
-        Use the following button to generate a new set of backup codes.
-      generate:
-        title: Generate backup codes
-        keep_safe_as_password: "Important! Treat these codes as passwords."
-        keep_safe_warning: "Either save them in your password manager, or print this page and put in a safe place."
-        regenerate_warning: "Warning: If you have created backup codes before, they will be invalidated and will no longer work."
-
-    devices:
-      add_new: "Add new 2FA device"
-      register: "Register device"
-      confirm_default: "Confirm changing default device"
-      confirm_device: "Confirm device"
-      confirm_now: "Not confirmed, click here to activate"
-      cannot_delete_default: "Cannot delete default device"
-      make_default_are_you_sure: "Are you sure you want to make this 2FA device your default?"
-      make_default_failed: "Failed to update the default 2FA device."
-      deletion_are_you_sure: "Are you sure you want to delete this 2FA device?"
-      registration_complete: "2FA device registration complete!"
-      registration_failed_token_invalid: "2FA device registration failed, the token was invalid."
-      registration_failed_update: "2FA device registration failed, the token was valid but the device could not be updated."
-      confirm_send_failed: "Confirmation of your 2FA device failed."
-      button_complete_registration: "Complete 2FA registration"
-      text_confirm_to_complete_html: "Please complete the registration of your device <strong>%{identifier}</strong> by entering a one-time password from your default device."
-      text_confirm_to_change_default_html: "Please confirm changing your default device to <strong>%{new_identifier}</strong> by entering a one-time password from your current default device."
-      text_identifier: "You can give the device a custom identifier using this field."
-      failed_to_delete: "Failed to delete 2FA device."
-      is_default_cannot_delete: "The device is marked as default and cannot be deleted due to an active security policy. Mark another device as default before deleting."
-      not_existing: "No 2FA device has been registered for your account."
-      2fa_from_input_html: Please enter the code from your <strong>%{device_name}</strong> to verify your identity.
-      2fa_from_webauthn_html: Please provide the WebAuthn device <strong>%{device_name}</strong>. If it is USB based make sure to plug it in and touch it. Then click the sign in button.
-      webauthn:
-        title: "WebAuthn"
-        description: Register a FIDO2 device (like YubiKey) or the secure enclave of your mobile device.
-        further_steps: After you have chosen a name, you can click the Continue button. Your browser will prompt you to present your WebAuthn device. When you have done so, you are done registering the device.
-      totp:
-        title: "App-based authenticator"
-        provisioning_uri: "Provisioning URI"
-        secret_key: "Secret key"
-        time_based: "Time based"
-        account: "Account name / Issuer"
-        setup: |
-          For setting up two-factor authentication with Google Authenticator, download the application from the Apple App store or Google Play Store.
-          After opening the app, you can scan the following QR code to register the device.
-        question_cannot_scan: |
-          Unable to scan the code using your application?
-        text_cannot_scan: |
-          If you can't scan the code, you can enter the entry manually using the following details:
-        description: |
-          Use a one-time code generated by an authenticator like Authy or Google Authenticator.
-      sms:
-        title: "Mobile device"
-        redacted_identifier: "Mobile device (%{redacted_number})"
-        request_2fa_identifier: "%{redacted_identifier}, we sent you an authentication code via %{delivery_channel}"
-        description: |
-          Receive 2FA code via a text message on your phone each time you log in.
+      title: "2FA settings"
     sns:
       delivery_failed: "SNS delivery failed:"
-    message_bird:
-      sms_delivery_failed: "MessageBird SMS delivery failed."
-      voice_delivery_failed: "MessageBird voice call failed."
-
     strategies:
-      totp: "Authenticator application"
-      sns: "Amazon SNS"
       resdt: "SMS Rest API"
+      sns: "Amazon SNS"
+      totp: "Authenticator application"
       webauthn: "WebAuthn"
 
-    mobile_transmit_notification: "A one-time password has been sent to your cell phone."
-    label_two_factor_authentication: "Two-factor authentication"
-
-    forced_registration:
-      required_to_add_device: "An active security policy requires you to enable two-factor authentication. Please use the following form to register a device."
-
-    remember:
-      active_session_notice: >
-        Your account has an active remember cookie valid until %{expires_on}.
-        This cookie allows you to log in without a second factor to your account until that time.
-      other_active_session_notice: Your account has an active remember cookie on another session.
-      label: "Remember"
-      clear_cookie: "Click here to remove all remembered 2FA sessions."
-      cookie_removed: "All remembered 2FA sessions have been removed."
-      dont_ask_again: "Create cookie to remember 2FA authentication on this client for %{days} days."
-  field_otp: "One-time password"
-  notice_account_otp_invalid: "Invalid one-time password."
-  notice_account_otp_expired: "The one-time password you entered expired."
-  notice_developer_strategy_otp: "Developer strategy generated the following one-time password: %{token} (Channel: %{channel})"
-  notice_account_otp_send_failed: "Your one-time password could not be sent."
-  notice_account_has_no_phone: "No cell phone number is associated with your account."
-  label_confirmed: "Confirmed"
-  button_continue: "Continue"
-  button_make_default: "Mark as default"
-  notice_phone_number_format: "Please enter the number in the following format: +XX XXXXXXXX."
-  text_otp_not_receive: "Other verification methods"
-  text_send_otp_again: "Resend one-time password by:"
-  button_resend_otp_form: "Resend"
-  button_otp_by_voice: "Voice call"
-  button_otp_by_sms: "SMS"
-  label_otp_channel: "Delivery channel"
+    text_2fa_disabled: "To enable two-factor authentication, use the button above to register a new 2FA device. If you already have a device, you need to make it a default."
+    text_2fa_enabled: "Upon every login, you will be requested to enter a OTP token from your default 2FA device."
+    text_otp_delivery_message_sms: "Your %{app_title} one-time password is %{token}"
+    text_otp_delivery_message_voice: "Your %{app_title} one-time password is: %{pause} %{token}. %{pause} I repeat: %{pause} %{token}"

--- a/modules/webhooks/config/locales/en.yml
+++ b/modules/webhooks/config/locales/en.yml
@@ -1,59 +1,39 @@
 ---
 en:
-  plugin_openproject_webhooks:
-    name: "OpenProject Webhooks"
-    description: "Provides a plug-in API to support OpenProject webhooks for better 3rd party integration."
-
   activerecord:
     attributes:
-      webhooks/webhook:
-        url: 'Payload URL'
-        secret: 'Signature secret'
-        events: 'Events'
-        enabled: 'Enabled'
-        projects: 'Enabled projects'
       webhooks/log:
         event_name: 'Event name'
-        url: 'Payload URL'
-        response_code: 'Response code'
         response_body: 'Response'
+        response_code: 'Response code'
+        url: 'Payload URL'
+      webhooks/webhook:
+        enabled: 'Enabled'
+        events: 'Events'
+        projects: 'Enabled projects'
+        secret: 'Signature secret'
+        url: 'Payload URL'
     models:
       webhooks/outgoing_webhook: "Outgoing webhook"
+  plugin_openproject_webhooks:
+    description: "Provides a plug-in API to support OpenProject webhooks for better 3rd party integration."
+
+    name: "OpenProject Webhooks"
   webhooks:
-    singular: Webhook
-    plural: Webhooks
-    resources:
-      time_entry:
-        name: "Time entry"
     outgoing:
-      no_results_table: No webhooks have been defined yet.
-      label_add_new: Add new webhook
-      label_edit: Edit webhook
-      label_x_events:
-        one: "1 event"
-        other: "%{count} events"
-        zero: "No events"
+      deliveries:
+        no_results_table: No deliveries have been made for this webhook in the past days.
+        time: 'Delivery time'
+        title: 'Recent deliveries'
       events:
-        created: "Created"
-        updated: "Updated"
         comment: "Comment"
+        created: "Created"
         internal_comment: "Internal comment"
+        updated: "Updated"
       explanation_html: >
         Upon the occurrence of an event like the creation of a work package or an update on a project, OpenProject will send a POST request to the configured web endpoints.
         Oftentimes, the event is sent after the [configured aggregation period](aggregation_path) has passed.
-      status:
-        enabled: 'Webhook is enabled'
-        disabled: 'Webhook is disabled'
-        enabled_text: 'The webhook will emit payloads for the defined events below.'
-        disabled_text: 'Click the edit button to activate the webhook.'
-      deliveries:
-        no_results_table: No deliveries have been made for this webhook in the past days.
-        title: 'Recent deliveries'
-        time: 'Delivery time'
       form:
-        introduction: >
-          Send a POST request to the payload URL below for any event in the project you're subscribed to.
-          Payload will correspond to the APIv3 representation of the object being modified.
         apiv3_doc_url: For more information, visit the API documentation
         description:
           placeholder: 'Optional description for the webhook.'
@@ -62,13 +42,33 @@ en:
             When checked, the webhook will trigger on the selected events. Uncheck to disable the webhook.
         events:
           title: 'Enabled events'
+        introduction: >
+          Send a POST request to the payload URL below for any event in the project you're subscribed to.
+          Payload will correspond to the APIv3 representation of the object being modified.
         project_ids:
-          title: 'Enabled projects'
-          description: 'Select for which projects this webhook should be executed for.'
           all: 'All projects'
+          description: 'Select for which projects this webhook should be executed for.'
           selected: 'Selected projects only'
-        selected_project_ids:
-          title: 'Selected projects'
+          title: 'Enabled projects'
         secret:
           description: >
             If set, this secret value is used by OpenProject to sign the webhook payload.
+        selected_project_ids:
+          title: 'Selected projects'
+      label_add_new: Add new webhook
+      label_edit: Edit webhook
+      label_x_events:
+        one: "1 event"
+        other: "%{count} events"
+        zero: "No events"
+      no_results_table: No webhooks have been defined yet.
+      status:
+        disabled: 'Webhook is disabled'
+        disabled_text: 'Click the edit button to activate the webhook.'
+        enabled: 'Webhook is enabled'
+        enabled_text: 'The webhook will emit payloads for the defined events below.'
+    plural: Webhooks
+    resources:
+      time_entry:
+        name: "Time entry"
+    singular: Webhook

--- a/modules/wikis/config/locales/en.yml
+++ b/modules/wikis/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
         token_exchange_scope: XWiki Scope
         url: Instance URL
         wiki_audience: XWiki Audience
-    errors: { }
+    errors: {}
     models:
       wikis/inline_page_link:
         one: Inline page link

--- a/modules/xls_export/config/locales/en.yml
+++ b/modules/xls_export/config/locales/en.yml
@@ -1,12 +1,5 @@
 ---
 en:
-  plugin_openproject_xls_export:
-    name: "OpenProject XLS Export"
-    description: "Export issue lists as Excel spreadsheets (.xls)."
-
-  export_to_excel: "Export XLS"
-  print_with_description: "Print preview with description"
-  sentence_separator_or: "or"
   different_formats: Different formats
 
   export:
@@ -15,6 +8,13 @@ en:
       xls_with_descriptions: "XLS with descriptions"
       xls_with_relations: "XLS with relations"
 
+  export_to_excel: "Export XLS"
+  plugin_openproject_xls_export:
+    description: "Export issue lists as Excel spreadsheets (.xls)."
+
+    name: "OpenProject XLS Export"
+  print_with_description: "Print preview with description"
+  sentence_separator_or: "or"
   xls_export:
     child_of: child of
     parent_of: parent of

--- a/script/i18n/requirements.txt
+++ b/script/i18n/requirements.txt
@@ -1,0 +1,6 @@
+# Runtime dependency for script/i18n/sort_locales.py and the lefthook pre-commit hook.
+# Install with: pip install -r script/i18n/requirements.txt
+ruamel.yaml==0.18.10
+
+# Running the tests additionally needs pytest (a dev-only tool, intentionally
+# not pinned here): pip install pytest && python3 -m pytest script/i18n/

--- a/script/i18n/sort_locales.py
+++ b/script/i18n/sort_locales.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Sort keys in OpenProject locale YAML files to satisfy yamllint's key-ordering.
+
+Sorts mapping keys recursively in Unicode codepoint order (matching yamllint's
+strcoll comparison under CI's C/POSIX locale for the ASCII keys these files use).
+Sequences and scalar values are left untouched. Comments, quoting and block
+scalars are preserved via ruamel.yaml round-trip.
+
+Usage:
+    python3 script/i18n/sort_locales.py FILE [FILE ...]
+"""
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+except ModuleNotFoundError:
+    sys.stderr.write(
+        "sort_locales.py requires ruamel.yaml. Install it with:\n"
+        "  pip install -r script/i18n/requirements.txt\n"
+    )
+    sys.exit(1)
+
+
+def make_yaml() -> YAML:
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml
+
+
+def _sort_key(key):
+    """Return the YAML scalar text yamllint compares against.
+
+    ruamel parses unquoted true/false/null as Python objects, but yamllint
+    compares the literal scalar text, so map them back to what gets written.
+    """
+    if isinstance(key, bool):
+        return "true" if key else "false"
+    if key is None:
+        return "null"
+    return str(key)
+
+
+def _bare(comment_line: str) -> str:
+    """'# foo' -> 'foo', '#foo' -> 'foo', '#' -> ''. ruamel's comment APIs re-add '# '."""
+    s = comment_line.lstrip()[1:]  # drop leading whitespace and the '#'
+    return s[1:] if s.startswith(" ") else s
+
+
+def _split_post(value: str):
+    """Split a ruamel post-comment token value into (eol, [own_lines]).
+
+    `eol` is the comment on the same line as the key's value (or None);
+    `own_lines` are the own-line comments that follow it (which visually
+    precede the next key). All returned text is bare (no leading '#').
+    """
+    segments = value.split("\n")
+    eol = None
+    own_lines = []
+    starts_inline = not value.startswith("\n")
+    for index, segment in enumerate(segments):
+        stripped = segment.strip()
+        if not stripped.startswith("#"):
+            continue
+        if index == 0 and starts_inline:
+            eol = _bare(stripped)
+        else:
+            own_lines.append(_bare(stripped))
+    return eol, own_lines
+
+
+def reanchor_comments(node, child_indent: int = 0) -> None:
+    """Re-attach own-line comments to the key they precede, so they travel
+    with that key when keys are reordered. Run before sort_node."""
+    if isinstance(node, CommentedMap):
+        for key in list(node.keys()):
+            reanchor_comments(node[key], child_indent + 2)
+
+        keys = list(node.keys())
+
+        # NOTE: we deliberately do NOT touch a mapping's leading comment
+        # (node.ca.comment). For nested mappings ruamel also stores that comment
+        # on the parent's `ca.items[key]`, which travels with the key on reorder;
+        # moving it here would render it twice. The only unanchored leading
+        # comment is the root document header, whose mapping has a single key
+        # (`en`) and never reorders.
+
+        # Each key's following own-line comments -> before the next key.
+        for index, key in enumerate(keys):
+            item = node.ca.items.get(key)
+            if not item or item[2] is None:
+                continue
+            eol, own_lines = _split_post(item[2].value)
+            if not own_lines or index + 1 >= len(keys):
+                continue  # nothing to move, or trailing comments at mapping end
+            node.ca.items[key][2] = None
+            if eol is not None:
+                node.yaml_add_eol_comment(eol, key)
+            node.yaml_set_comment_before_after_key(
+                keys[index + 1], before="\n".join(own_lines), indent=child_indent)
+
+    elif isinstance(node, CommentedSeq):
+        for item in node:
+            reanchor_comments(item, child_indent + 2)
+
+
+def sort_node(node) -> None:
+    """Recursively sort mapping keys in place by codepoint order."""
+    if isinstance(node, CommentedMap):
+        for key in list(node.keys()):
+            sort_node(node[key])
+        for key in sorted(node.keys(), key=_sort_key):
+            node.move_to_end(key)
+    elif isinstance(node, CommentedSeq):
+        for item in node:
+            sort_node(item)
+
+
+def flatten(node, prefix=()):
+    """Yield (path, value) for every leaf; order-independent."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from flatten(value, prefix + (str(key),))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from flatten(value, prefix + (f"[{index}]",))
+    else:
+        yield prefix, node
+
+
+def _normalize_eol_comment_spacing(text: str) -> str:
+    """Ensure at least 2 spaces before end-of-line comments (yamllint's
+    comments rule). Comment positions are taken from a ruamel parse, so a
+    '#' inside a string value is never touched."""
+    data = make_yaml().load(text)
+    targets = []  # (0-based line, 0-based column of '#')
+
+    def visit(node):
+        ca = getattr(node, "ca", None)
+        if ca is not None:
+            for _key, item in ca.items.items():
+                token = item[2] if item else None
+                if token is not None and not token.value.startswith("\n"):
+                    targets.append((token.start_mark.line, token.start_mark.column))
+        if isinstance(node, dict):
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, list):
+            for value in node:
+                visit(value)
+
+    if data is not None:
+        visit(data)
+
+    lines = text.split("\n")
+    for line_no, col in targets:
+        if line_no >= len(lines):
+            continue
+        line = lines[line_no]
+        if col < 1 or col > len(line) or line[col] != "#":
+            continue
+        start = col
+        while start > 0 and line[start - 1] == " ":
+            start -= 1
+        # only an end-of-line comment (content precedes the spaces), under-spaced
+        if start > 0 and (col - start) < 2:
+            lines[line_no] = line[:start] + "  " + line[col:]
+    return "\n".join(lines)
+
+
+def sort_file(path: str) -> None:
+    yaml = make_yaml()
+    text = Path(path).read_text()
+
+    # Preserve everything up to the root `en:` line verbatim: the license
+    # header and any `---` document-start marker. ruamel does not reliably
+    # round-trip pre-document leading comments, so we never hand them to it.
+    lines = text.splitlines(keepends=True)
+    body_start = next(
+        (i for i, line in enumerate(lines) if line.rstrip("\n") == "en:"), None)
+    if body_start is None:
+        return  # no recognizable root mapping; leave untouched
+    preamble = "".join(lines[:body_start])
+    body = "".join(lines[body_start:])
+
+    data = yaml.load(body)
+    if data is None:
+        return
+
+    before = dict(flatten(data))
+    reanchor_comments(data)
+    sort_node(data)
+    after = dict(flatten(data))
+    if before != after:
+        raise SystemExit(
+            f"{path}: refusing to write — sorting changed content, not just order"
+        )
+
+    buffer = io.StringIO()
+    yaml.dump(data, buffer)
+    body_out = _normalize_eol_comment_spacing(buffer.getvalue())
+    body_out = body_out.rstrip("\n") + "\n"  # exactly one trailing newline
+    Path(path).write_text(preamble + body_out)
+
+
+def main(argv: list[str]) -> int:
+    for path in argv[1:]:
+        sort_file(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/script/i18n/test_sort_locales.py
+++ b/script/i18n/test_sort_locales.py
@@ -1,0 +1,211 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import sort_locales  # noqa: E402
+
+
+def run_sort(tmp_path, text):
+    f = tmp_path / "en.yml"
+    f.write_text(text)
+    sort_locales.sort_file(str(f))
+    return f.read_text()
+
+
+def test_sorts_top_level_and_nested_keys(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  banana: \"B\"\n"
+        "  apple:\n"
+        "    zebra: 2\n"
+        "    aardvark: 1\n"
+    ))
+    assert out.index("apple:") < out.index("banana:")
+    assert out.index("aardvark:") < out.index("zebra:")
+
+
+def test_own_line_comment_before_non_first_key_moves_with_it(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  zebra: 1\n"
+        "  # note about alpha\n"
+        "  alpha: 2\n"
+    ))
+    assert out.index("alpha:") < out.index("zebra:")
+    # the comment travels with alpha and stays directly above it
+    assert "# note about alpha\n  alpha:" in out
+
+
+def test_leading_comment_before_first_key_stays_at_block_top(tmp_path):
+    # Documented behavior: a comment before the FIRST key of a mapping is
+    # treated as a block header and stays at the top after sorting, rather
+    # than following its original first key. (Dedent/first-key comments are
+    # not auto-relocated; they're hand-fixed during the one-time sort.)
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  # block header\n"
+        "  beta: 2\n"
+        "  alpha: 1\n"
+    ))
+    assert out.index("alpha:") < out.index("beta:")
+    assert out.index("# block header") < out.index("alpha:")
+
+
+def test_sorts_quoted_keys_by_unquoted_value(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  \"zzz\": 1\n"
+        "  \"import/jira\": 2\n"
+        "  aaa: 3\n"
+    ))
+    # codepoint order: aaa (97) < import/jira (105) < zzz (122)
+    assert out.index("aaa:") < out.index("import/jira") < out.index("zzz")
+    assert '"import/jira"' in out  # original quoting preserved
+
+
+def test_preserves_block_scalars(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  zebra: \"Z\"\n"
+        "  alpha: |\n"
+        "    multi\n"
+        "    line\n"
+    ))
+    assert out.index("alpha:") < out.index("zebra:")
+    assert "|" in out
+    assert "    multi\n    line" in out
+
+
+def test_multiline_comment_block_moves_with_following_key(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  zebra: 1\n"
+        "  # explains alpha line 1\n"
+        "  # explains alpha line 2\n"
+        "  alpha: 2\n"
+    ))
+    # the whole block stays directly above alpha, which sorts first
+    assert "# explains alpha line 1\n  # explains alpha line 2\n  alpha:" in out
+    assert out.index("alpha:") < out.index("zebra:")
+
+
+def test_eol_comment_stays_with_its_key_and_own_line_moves(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  zebra: 1  # eol on zebra\n"
+        "  # describes alpha\n"
+        "  alpha: 2\n"
+    ))
+    # eol comment remains on zebra's line; own-line comment moves above alpha
+    assert "zebra: 1  # eol on zebra" in out
+    assert "# describes alpha\n  alpha:" in out
+    assert out.index("alpha:") < out.index("zebra:")
+
+
+import pytest  # noqa: E402
+from ruamel.yaml import YAML  # noqa: E402
+
+
+def _load(text):
+    return YAML().load(text)
+
+
+def test_preserves_all_key_paths_and_values(tmp_path):
+    src = (
+        "en:\n"
+        "  user:\n"
+        "    display_format: \"Display format\"\n"
+        "    deletion: \"Deletion\"\n"
+        "  activities:\n"
+        "    index:\n"
+        "      title: \"T\"\n"
+    )
+    out = run_sort(tmp_path, src)
+    before = dict(sort_locales.flatten(_load(src)))
+    after = dict(sort_locales.flatten(_load(out)))
+    assert before == after  # same key-paths and values, order aside
+
+
+def test_duplicate_keys_raise(tmp_path):
+    with pytest.raises(Exception):
+        run_sort(tmp_path, (
+            "en:\n"
+            "  alpha: 1\n"
+            "  alpha: 2\n"
+        ))
+
+
+def _assert_keys_sorted(node):
+    if isinstance(node, dict):
+        keys = [sort_locales._sort_key(k) for k in node.keys()]
+        assert keys == sorted(keys), f"unsorted mapping: {keys}"
+        for value in node.values():
+            _assert_keys_sorted(value)
+    elif isinstance(node, list):
+        for value in node:
+            _assert_keys_sorted(value)
+
+
+def test_output_is_yamllint_ordered(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  gamma: 3\n"
+        "  alpha:\n"
+        "    delta: 1\n"
+        "    beta: 2\n"
+        "  bool_keys:\n"
+        "    true: t\n"
+        "    false: f\n"
+    ))
+    _assert_keys_sorted(_load(out))
+    # boolean keys sort as written: false before true
+    assert out.index("false:") < out.index("true:")
+
+
+def test_preserves_license_header_and_document_marker(tmp_path):
+    header = (
+        "#-- copyright\n"
+        "# OpenProject is an open source project management software.\n"
+        "#++\n"
+        "\n"
+        "---\n"
+    )
+    out = run_sort(tmp_path, header + (
+        "en:\n"
+        "  zebra: 1\n"
+        "  alpha: 2\n"
+    ))
+    # header + marker preserved verbatim and still at the very top
+    assert out.startswith(header)
+    assert out.index("alpha:") < out.index("zebra:")
+
+
+def test_single_trailing_newline(tmp_path):
+    out = run_sort(tmp_path, "en:\n  b: 1\n  a: 2\n\n\n")
+    assert out.endswith("\n")
+    assert not out.endswith("\n\n")
+
+
+def test_normalizes_eol_comment_spacing(tmp_path):
+    out = run_sort(tmp_path, (
+        "en:\n"
+        "  zebra: \"Z\" # one space before comment\n"
+        "  alpha: \"a # b is not a comment\"\n"
+    ))
+    # the real eol comment gets two spaces; the '#' inside the string is untouched
+    assert '"Z"  # one space before comment' in out
+    assert '"a # b is not a comment"' in out
+    assert out.index("alpha:") < out.index("zebra:")
+
+
+def test_idempotent(tmp_path):
+    src = (
+        "en:\n"
+        "  gamma: 3\n"
+        "  # note for alpha\n"
+        "  alpha: 1\n"
+        "  beta: 2\n"
+    )
+    once = run_sort(tmp_path, src)
+    twice = run_sort(tmp_path, once)
+    assert once == twice


### PR DESCRIPTION
# Ticket
<!-- Provide the link to respective work package -->

<!-- Contributors: Please check our PR guide: https://www.openproject.org/docs/development/code-review-guidelines/#preparing-your-pull-request before opening a PR. -->

<!-- Reviewers: Please check our Review guide: https://www.openproject.org/docs/development/code-review-guidelines/#reviewing -->

# What are you trying to accomplish?
<!-- Provide a description of the changes. -->

yamllint enforces alphabetical `key-ordering` on the locale files, but they were never setup that way — so adding keys kept tripping CI. This sorts them into compliant order and adds a lefthook pre-commit hook to keep them sorted; the existing reviewdog yamllint check stays the CI gate.

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

**Python + `ruamel.yaml`** — it round-trips comments, quoting and block scalars (Ruby's Psych mangles them; `yq` reformats and its sort doesn't match yamllint). yamllint is already Python here, so no new ecosystem.

**Two pre-passes before sorting** so a naive sort doesn't corrupt the files:
* the license header / `---` is split off and re-prepended verbatim (ruamel drops pre-document comments otherwise);
* own-line comments are re-anchored to the key they precede so they travel with it. Keys sort by literal scalar text, so `true`/`false` keys match yamllint.

**Safety:** the sorter aborts unless key-paths and values are identical before/after, so the big mechanical commit changes order only — never content (comments 551→551, headers intact, 0 yamllint errors).

**Side effects** of the ruamel round-trip (data-equivalent, yamllint-clean):
- multi-line flow arrays collapse onto one line;
- `~` renders as `null`.

Splitting `en.yml` into per-domain files is a deliberate follow-up, not part of this PR.

# Migration plan

1. Run that lefthook script on `dev` and merge;
2. Get that script on your open PR by cherry-picking the commit with the tooling, not the merged alphabetically-ordered `**/en.yml` to prevent conflicts;
3. The hook should reorder your `**/en.yml` with your changes and prevent any conflict with `dev`;
4. At that point, you should be able to rebase/merge your branch with `dev` as if nothing happened…

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
