### PR TITLE
Add missing wait_for_turbo_stream after filter removal

### DIFF
--- a/spec/features/projects/lists/filters_spec.rb
+++ b/spec/features/projects/lists/filters_spec.rb
@@ -790,7 +790,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
         projects_page.expect_projects_not_listed(development_project)
         projects_page.expect_projects_in_order(project, public_project)
 
-        wait_for_turbo_stream { projects_page.remove_filter("project_phase_any") }
+        projects_page.remove_filter("project_phase_any")
 
         projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -801,7 +801,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
         projects_page.expect_projects_not_listed(development_project)
         projects_page.expect_projects_in_order(project, public_project)
 
-        wait_for_turbo_stream { projects_page.remove_filter("project_phase_any") }
+        projects_page.remove_filter("project_phase_any")
 
         projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -813,7 +813,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
         projects_page.expect_projects_not_listed(development_project)
         projects_page.expect_projects_in_order(project, public_project)
 
-        wait_for_turbo_stream { projects_page.remove_filter("project_phase_any") }
+        projects_page.remove_filter("project_phase_any")
 
         projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -824,7 +824,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
         projects_page.expect_projects_not_listed(development_project)
         projects_page.expect_projects_in_order(project, public_project)
 
-        wait_for_turbo_stream { projects_page.remove_filter("project_phase_any") }
+        projects_page.remove_filter("project_phase_any")
 
         projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -933,7 +933,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
           projects_page.expect_projects_not_listed(development_project, project)
           projects_page.expect_projects_in_order(public_project)
 
-          wait_for_turbo_stream { projects_page.remove_filter("project_finish_gate_#{gate.definition_id}") }
+          projects_page.remove_filter("project_finish_gate_#{gate.definition_id}")
 
           projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -944,7 +944,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
           projects_page.expect_projects_not_listed(development_project, project)
           projects_page.expect_projects_in_order(public_project)
 
-          wait_for_turbo_stream { projects_page.remove_filter("project_finish_gate_#{gate.definition_id}") }
+          projects_page.remove_filter("project_finish_gate_#{gate.definition_id}")
 
           projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -956,7 +956,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
           projects_page.expect_projects_not_listed(development_project, project)
           projects_page.expect_projects_in_order(public_project)
 
-          wait_for_turbo_stream { projects_page.remove_filter("project_finish_gate_#{gate.definition_id}") }
+          projects_page.remove_filter("project_finish_gate_#{gate.definition_id}")
 
           projects_page.expect_projects_in_order(development_project, project, public_project)
 
@@ -967,7 +967,7 @@ RSpec.describe "Projects list filters", :js, with_settings: { login_required?: f
           projects_page.expect_projects_not_listed(development_project, project)
           projects_page.expect_projects_in_order(public_project)
 
-          wait_for_turbo_stream { projects_page.remove_filter("project_finish_gate_#{gate.definition_id}") }
+          projects_page.remove_filter("project_finish_gate_#{gate.definition_id}")
 
           projects_page.expect_projects_in_order(development_project, project, public_project)
 

--- a/spec/support/components/common/filters.rb
+++ b/spec/support/components/common/filters.rb
@@ -126,7 +126,9 @@ module Components
         if name == "name_and_identifier"
           page.find_by_id("name_and_identifier").find(:xpath, "following-sibling::button").click
         else
-          page.find("li[data-filter-name='#{name}'] .filter_rem").click
+          wait_for_turbo_stream do
+            page.find("li[data-filter-name='#{name}'] .filter_rem").click
+          end
         end
       end
 


### PR DESCRIPTION
Trying to fix spec/features/projects/lists/filters_spec.rb

e.g. https://github.com/opf/openproject/actions/runs/27189038425/job/80264540589?pr=23531