### PR TITLE
[STC-805] Numeric ID showing in Gitlab tab on work packages without links to issues

### DIFF
--- a/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
+++ b/modules/gitlab_integration/frontend/module/tab-issue/tab-issue.component.ts
@@ -64,6 +64,6 @@ export class TabIssueComponent implements OnInit {
   }
 
   public getEmptyText() {
-    return this.I18n.t('js.gitlab_integration.tab_issue.empty',{ wp_id: this.workPackage.id });
+    return this.I18n.t('js.gitlab_integration.tab_issue.empty', { wp_id: this.workPackage.displayId });
   }
 }


### PR DESCRIPTION
https://community.openproject.org/projects/STC/work_packages/STC-805/activity#comment-1685033

Follows #23566 

<img width="718" height="299" alt="Screenshot 2026-06-09 at 2 18 13 PM" src="https://github.com/user-attachments/assets/31f4f504-729d-48e2-b009-21686c1835a3" />

