### PR TITLE
[BNE-102] Documents: iOS Safari layout rendering error for hash mention

### DIFF
--- a/extensions/op-blocknote-hocuspocus/package-lock.json
+++ b/extensions/op-blocknote-hocuspocus/package-lock.json
@@ -12,7 +12,7 @@
         "@blocknote/server-util": "^0.51.3",
         "@hocuspocus/extension-logger": "^3.4.4",
         "@hocuspocus/server": "^3.4.0",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -3903,9 +3903,9 @@
       "license": "MIT"
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
-      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
+      "version": "0.1.2",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+      "integrity": "sha512-6uGRJ2SlIVq0LwNnb8KZXhX09fvwXzrkrtsoRVZUrZKKsRFCVd15bgOu/3DyOCvwztXj4h+6VP2N6PkzeCBpUA==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/extensions/op-blocknote-hocuspocus/package.json
+++ b/extensions/op-blocknote-hocuspocus/package.json
@@ -26,7 +26,7 @@
     "@blocknote/server-util": "^0.51.3",
     "@hocuspocus/extension-logger": "^3.4.4",
     "@hocuspocus/server": "^3.4.0",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
     "tsx": "^4.21.0"
   },
   "devDependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -107,7 +107,7 @@
         "ng2-dragula": "^6.0.0",
         "ngx-cookie-service": "^21.1.0",
         "observable-array": "0.0.4",
-        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+        "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
         "openapi-explorer": "^2.4.793",
         "pako": "^2.0.3",
         "qr-creator": "^1.0.0",
@@ -19205,9 +19205,9 @@
       }
     },
     "node_modules/op-blocknote-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
-      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
+      "version": "0.1.2",
+      "resolved": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+      "integrity": "sha512-6uGRJ2SlIVq0LwNnb8KZXhX09fvwXzrkrtsoRVZUrZKKsRFCVd15bgOu/3DyOCvwztXj4h+6VP2N6PkzeCBpUA==",
       "dependencies": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",
@@ -37224,8 +37224,8 @@
       }
     },
     "op-blocknote-extensions": {
-      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
-      "integrity": "sha512-4VO5Qf51Z8WQGD24AYhNmGHGGwnfnB3q8KwL48hWTifZq/9IL5rKpwKB+QkxvVUCaT8iwFYwB6QPzGgLJKRVFA==",
+      "version": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
+      "integrity": "sha512-6uGRJ2SlIVq0LwNnb8KZXhX09fvwXzrkrtsoRVZUrZKKsRFCVd15bgOu/3DyOCvwztXj4h+6VP2N6PkzeCBpUA==",
       "requires": {
         "@primer/octicons-react": "^19.20.0",
         "i18next": "^25.6.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -158,7 +158,7 @@
     "ng2-dragula": "^6.0.0",
     "ngx-cookie-service": "^21.1.0",
     "observable-array": "0.0.4",
-    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.1/op-blocknote-extensions-0.1.1.tgz",
+    "op-blocknote-extensions": "https://github.com/opf/op-blocknote-extensions/releases/download/v0.1.2/op-blocknote-extensions-0.1.2.tgz",
     "openapi-explorer": "^2.4.793",
     "pako": "^2.0.3",
     "qr-creator": "^1.0.0",


### PR DESCRIPTION

https://community.openproject.org/wp/BNE-102

Done by updating to the version of op-blocknote-extensions with the fix. See https://github.com/opf/op-blocknote-extensions/pull/153
