### PR TITLE
Performance: collapse re-notified journal polling into two queries

### DIFF
--- a/app/services/work_packages/activities_tab/update_streams.rb
+++ b/app/services/work_packages/activities_tab/update_streams.rb
@@ -89,15 +89,19 @@ module WorkPackages
       end
 
       def rerender_renotified(sink)
+        journals.where(id: renotified_journal_ids).find_each do |journal|
+          emit_item_show(sink, journal)
+        end
+      end
+
+      def renotified_journal_ids
         Notification
-          .where(journal_id: journals.pluck(:id))
+          .where(journal_id: journals.select(:id))
           .where(recipient_id: User.current.id)
           .where("notifications.updated_at > ?", since)
-          .find_each do |notification|
-            next if editing?(notification.journal_id)
-
-            emit_item_show(sink, journals.find(notification.journal_id))
-          end
+          .where.not(journal_id: editing_journal_ids)
+          .distinct
+          .pluck(:journal_id)
       end
 
       def insert_latest(sink)


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-825

Follow-up to #23615. No dedicated work package.

# What are you trying to accomplish?

The activities tab polls for updates while it's open. On each poll, the re-notification branch (`rerender_renotified_journals`) re-renders any journal whose notification was refreshed since the last poll. It did that by loading every one of the work package's journal ids into Ruby to feed the notification filter, then issuing a separate journal lookup for each matching notification — a classic N+1 that grows with notification volume on a hot, repeating path.

It now filters notifications with a journal subquery, collects the affected journal ids in one statement, and loads those journals in a single query. The "currently editing" exclusion moves into SQL too, so a journal the user is mid-edit on is never streamed over the top of them.

# What approach did you choose and why?

The decisive cost was round-trips, not any single query's plan, so the goal was collapsing the count. Measured against 1,000 journals / 5,400 notifications (200 re-notified), with the tables `ANALYZE`d so the planner had real statistics:

- **Queries on the full path: 202 → 2**
- **Notification filter:** a single Hash Semi Join (recipient-id index scan + journals scan), 30 shared buffers, ~0.35 ms — no id list shuttled between Ruby and Postgres.

Both filter shapes are sub-millisecond; net database work is comparable because the previous code paid the same journals scan in its separate `pluck`. The improvement is the eliminated per-notification lookups.

Coverage for this path (the re-render and the editing-skip) lands with the parent refactor PR, so the behaviour is pinned independently of the query shape.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)