### PR TITLE
Retry failing specs visibility

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   all:
@@ -87,6 +88,18 @@ jobs:
         CAPYBARA_AWS_ACCESS_KEY_ID: "${{ secrets.CAPYBARA_AWS_ACCESS_KEY_ID }}"
         CAPYBARA_AWS_SECRET_ACCESS_KEY: "${{ secrets.CAPYBARA_AWS_SECRET_ACCESS_KEY }}"
       run: bin/ci run-features
+    - name: Report flaky specs
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if [ -f tmp/retried_specs.txt ]; then
+          echo "## Flaky specs" >> "$GITHUB_STEP_SUMMARY"
+          cat tmp/retried_specs.txt >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(printf '> [!WARNING]\n> Flaky specs\n\n'; cat tmp/retried_specs.txt)"
+          fi
+        fi
     - name: Save CI image to cache
       if: steps.cache_docker.outputs.cache-hit != 'true'
       run: mkdir -p cache/docker && docker save openproject/ci:v1 -o cache/docker/image.tar

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -175,6 +175,7 @@ run_features() {
 			exit 1
 		elif [ "$failed_count" -le 10 ]; then
 			echo "retrying $failed_count failed examples"
+			awk '$3 == "failed" {print "- `rspec " $1 "`"}' tmp/spec_examples.txt > tmp/retried_specs.txt
 			execute "bundle exec rspec --only-failures --format documentation {,modules/*/}spec/features/**/*_spec.rb"
 		else
 			echo "too many failures ($failed_count), not retrying"


### PR DESCRIPTION
First step of https://community.openproject.org/wp/OP-19484

Trying to make flaky specs that were successful on retry more visible using a comment + [a job summary](https://github.com/opf/openproject/actions/runs/27226749453/attempts/1#summary-80395867178)