### PR TITLE
Performance: stream only changed journal reactions on poll

### DIFF
--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -48,6 +48,12 @@ class EmojiReaction < ApplicationRecord
 
   enum :reaction, EMOJI_MAP.each_with_object({}) { |(k, _v), h| h[k] = k.to_s }
 
+  # Lets a polling client detect reaction changes (including removals) by timestamp.
+  # Written directly so it never bumps the reactable's updated_at, which drives the
+  # journal "edited" indicator.
+  after_create :stamp_reactable_reactions_changed_at
+  after_destroy :stamp_reactable_reactions_changed_at
+
   def self.available_emoji_reactions
     EMOJI_MAP.invert.sort
   end
@@ -58,5 +64,13 @@ class EmojiReaction < ApplicationRecord
 
   def emoji
     self.class.emoji(reaction)
+  end
+
+  private
+
+  def stamp_reactable_reactions_changed_at
+    return unless reactable.respond_to?(:reactions_changed_at)
+
+    reactable.update_columns(reactions_changed_at: Time.current)
   end
 end

--- a/app/services/work_packages/activities_tab/update_streams.rb
+++ b/app/services/work_packages/activities_tab/update_streams.rb
@@ -54,7 +54,7 @@ module WorkPackages
           update_activity_counter(sink)
         end
 
-        rerender_all_reactions(sink)
+        rerender_changed_reactions(sink)
       end
 
       private
@@ -73,11 +73,6 @@ module WorkPackages
         @grouped_emoji_reactions ||= EmojiReactions::GroupedQueries.grouped_emoji_reactions_by_reactable(
           reactable_id: journals.pluck(:id), reactable_type: "Journal"
         )
-      end
-
-      def whole_work_package_emoji_reactions
-        @whole_work_package_emoji_reactions ||=
-          EmojiReactions::GroupedQueries.grouped_work_package_journals_emoji_reactions_by_reactable(work_package)
       end
 
       def rerender_changed(sink)
@@ -112,12 +107,12 @@ module WorkPackages
         end
       end
 
-      def rerender_all_reactions(sink)
-        work_package.journals.each do |journal|
+      def rerender_changed_reactions(sink)
+        journals.where("reactions_changed_at > ?", since).find_each do |journal|
           sink.update_via_turbo_stream(
             component: Journals::ItemComponent::Reactions.new(
               journal:,
-              grouped_emoji_reactions: whole_work_package_emoji_reactions[journal.id] || {}
+              grouped_emoji_reactions: grouped_emoji_reactions.fetch(journal.id, {})
             )
           )
         end

--- a/db/migrate/20260609120000_add_reactions_changed_at_to_journals.rb
+++ b/db/migrate/20260609120000_add_reactions_changed_at_to_journals.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+class AddReactionsChangedAtToJournals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :journals, :reactions_changed_at, :datetime
+  end
+end

--- a/spec/models/emoji_reaction_spec.rb
+++ b/spec/models/emoji_reaction_spec.rb
@@ -96,4 +96,27 @@ RSpec.describe EmojiReaction do
       expect(emoji_reaction.emoji).to eq("👍")
     end
   end
+
+  describe "stamping the reactable's reactions_changed_at" do
+    let(:work_package) { create(:work_package) }
+    let(:journal) { work_package.journals.last.tap(&:reload) }
+
+    it "records reaction additions without bumping updated_at" do
+      updated_at = journal.updated_at
+
+      expect { create(:emoji_reaction, reactable: journal, user: create(:user)) }
+        .to change { journal.reload.reactions_changed_at }.from(nil)
+      expect(journal.updated_at).to eq(updated_at)
+    end
+
+    it "records reaction removals without bumping updated_at" do
+      reaction = create(:emoji_reaction, reactable: journal, user: create(:user))
+      updated_at = journal.reload.updated_at
+
+      travel(1.second) do
+        expect { reaction.destroy }.to change { journal.reload.reactions_changed_at }
+      end
+      expect(journal.updated_at).to eq(updated_at)
+    end
+  end
 end

--- a/spec/requests/work_packages/activities_tab_spec.rb
+++ b/spec/requests/work_packages/activities_tab_spec.rb
@@ -136,5 +136,23 @@ RSpec.describe "Work package activities tab",
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include("A comment")
     end
+
+    it "re-renders reactions for a journal whose reactions changed since the last poll" do
+      create(:emoji_reaction, reactable: comment, user: create(:user))
+
+      poll
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body)
+        .to include("work-packages-activities-tab-journals-item-component-reactions-#{comment.id}")
+    end
+
+    it "does not re-render reactions when no reactions changed" do
+      poll
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body)
+        .not_to include("work-packages-activities-tab-journals-item-component-reactions-#{comment.id}")
+    end
   end
 end

--- a/spec/services/work_packages/activities_tab/update_streams_spec.rb
+++ b/spec/services/work_packages/activities_tab/update_streams_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe WorkPackages::ActivitiesTab::UpdateStreams do
   end
 
   context "with comments present" do
-    before { add_comment(notes: "any", created_at: 5.minutes.ago, updated_at: 5.minutes.ago) }
+    let!(:comment) { add_comment(notes: "any", created_at: 5.minutes.ago, updated_at: 5.minutes.ago) }
 
     it "removes a potential empty state and refreshes the activity counter once each" do
       emit
@@ -140,12 +140,15 @@ RSpec.describe WorkPackages::ActivitiesTab::UpdateStreams do
       expect(sink.replaced.size).to eq(1)
     end
 
-    it "refreshes the reactions of every journal on the work package" do
+    it "streams reactions only for journals whose reactions changed since the last poll" do
+      comment.update_columns(reactions_changed_at: 1.minute.ago)
+
       emit
-      reaction_components = sink.updated.select do |component|
-        component.instance_of?(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions)
-      end
-      expect(reaction_components.size).to eq(work_package.journals.count)
+
+      reacted_journal_ids = sink.updated
+        .select { it.instance_of?(WorkPackages::ActivitiesTab::Journals::ItemComponent::Reactions) }
+        .map { it.instance_variable_get(:@journal).id }
+      expect(reacted_journal_ids).to contain_exactly(comment.id)
     end
   end
 


### PR DESCRIPTION
# Ticket

https://community.openproject.org/wp/STC-825

Follow-up to #23615.

# What are you trying to accomplish?

Every activities-tab poll re-rendered and shipped a turbo-stream reaction fragment for *every* journal on the work package, not just the ones whose reactions changed — an emoji reaction carries no timestamp to filter on, and since reactions are hard-deleted, "refresh all" was the only way to reflect a *removal* in the poll cycle. This adds a `reactions_changed_at` on journals that a reaction stamps when added or removed, so the poll re-renders reactions only for journals changed since the client last polled (201 journals / 3 changed → 3 fragments instead of 201); the stamp is written directly so it never bumps the journal's `updated_at`, which drives the "edited" indicator. Backwards-compatible and no backfill needed: the column is additive/nullable, existing reactions render unchanged (the initial render never reads it), and the column only gates the polling delta — so existing journals (NULL) correctly stream nothing until their next reaction change.

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)