### PR TITLE
[DREAM-724] Search input is not initially focused

### DIFF
--- a/app/components/header/projects/filterable_tree_view_component.html.erb
+++ b/app/components/header/projects/filterable_tree_view_component.html.erb
@@ -36,6 +36,7 @@ See COPYRIGHT and LICENSE files for more details.
           filter_input_arguments: { name: "filter",
                                     label: t(:label_filter),
                                     visually_hide_label: true,
+                                    autofocus: true,
                                     data: { test_selector: "op-header-project-select--search" } },
           no_results_node_arguments: { data: { test_selector: "op-header-project-select--no-results" },
                                        label: I18n.t("filterable_tree_view.no_results_text") }


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-724

# What are you trying to accomplish?
Automatically focus the search input when the project selector is opened

