### PR TITLE
Adapt to latest OpenProject plugin for XWiki

### DIFF
--- a/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/internal/canonical_page_info.rb
+++ b/modules/wikis/app/services/wikis/adapters/providers/xwiki/queries/internal/canonical_page_info.rb
@@ -57,14 +57,8 @@ module Wikis
               def perform_request(reference, auth_strategy:, &)
                 authenticated(auth_strategy) do |http|
                   handle_response(
-                    # This query is implemented as a PUT on the XWiki side, because it dynamically creates the
-                    # stable identifier that it returns. Passing an empty JSON body is also required for the
-                    # endpoint to not raise an error 🤷
                     http.with(headers: { "Content-Type": "application/json" })
-                        .put(
-                          rest_url("openproject/documents", query: { docRef: reference.to_s }),
-                          body: "{}"
-                        ),
+                        .get(rest_url("openproject/documents", query: { docRef: reference.to_s })),
                     &
                   )
                 end

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/internal/canonical_page_info_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/internal/canonical_page_info_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::Internal::CanonicalPageInfo, :webmock do
+RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::Internal::CanonicalPageInfo, :disable_ssrf_filter, :webmock do
   it "is not registered" do
     expect(Wikis::Adapters::Registry.resolve("xwiki.queries.page_info")).not_to eq(described_class)
   end
@@ -69,7 +69,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::Internal::CanonicalPa
       let(:absolute_url) { "https://xwiki.local/bin/view/MySpace/SubSpace/PageName" }
 
       before do
-        stub_request(:put, page_url)
+        stub_request(:get, page_url)
           .to_return(status: 200, body: { id: "foo", title: "Nested Page", xwikiAbsoluteUrl: absolute_url }.to_json,
                      headers: { "Content-Type" => "application/json" })
       end
@@ -93,38 +93,38 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::Internal::CanonicalPa
     end
 
     context "when the page is not found" do
-      before { stub_request(:put, page_url).to_return(status: 404, body: "") }
+      before { stub_request(:get, page_url).to_return(status: 404, body: "") }
 
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :not_found)) }
     end
 
     context "when access is unauthorized" do
-      before { stub_request(:put, page_url).to_return(status: 401, body: "") }
+      before { stub_request(:get, page_url).to_return(status: 401, body: "") }
 
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :unauthorized)) }
     end
 
     context "when access is forbidden" do
-      before { stub_request(:put, page_url).to_return(status: 403, body: "") }
+      before { stub_request(:get, page_url).to_return(status: 403, body: "") }
 
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :unauthorized)) }
     end
 
     context "when XWiki returns a non-2xx status" do
-      before { stub_request(:put, page_url).to_return(status: 500, body: "Internal Server Error") }
+      before { stub_request(:get, page_url).to_return(status: 500, body: "Internal Server Error") }
 
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :request_failed)) }
     end
 
     context "when a network error occurs" do
-      before { stub_request(:put, page_url).to_timeout }
+      before { stub_request(:get, page_url).to_timeout }
 
       it { is_expected.to be_failure.and have_attributes(failure: have_attributes(code: :connection_error)) }
     end
 
     context "when the response body is not valid JSON" do
       before do
-        stub_request(:put, page_url)
+        stub_request(:get, page_url)
           .to_return(status: 200, body: "not json", headers: { "Content-Type" => "application/json" })
       end
 
@@ -133,7 +133,7 @@ RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::Internal::CanonicalPa
 
     context "when the response body is unexpected JSON" do
       before do
-        stub_request(:put, page_url)
+        stub_request(:get, page_url)
           .to_return(status: 200, body: { error: "An error occured" }.to_json, headers: { "Content-Type" => "application/json" })
       end
 

--- a/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/stable_page_info_spec.rb
+++ b/modules/wikis/spec/services/wikis/adapters/providers/xwiki/queries/stable_page_info_spec.rb
@@ -31,7 +31,7 @@
 require "spec_helper"
 require_module_spec_helper
 
-RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::StablePageInfo, :webmock do
+RSpec.describe Wikis::Adapters::Providers::XWiki::Queries::StablePageInfo, :disable_ssrf_filter, :webmock do
   it "is registered" do
     expect(Wikis::Adapters::Registry.resolve("xwiki.queries.page_info")).to eq(described_class)
   end

--- a/spec/support/fixtures/vcr_cassettes/xwiki/canonical_page_info.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/canonical_page_info.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: put
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:Main.WebHome
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: US-ASCII
+      string: ''
     headers:
       User-Agent:
       - OpenProject 17.6.0 HTTPX Client
@@ -15,14 +15,12 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Content-Length:
-      - '2'
       Authorization:
       - Bearer <SECRET>
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Content-Language:
       - en
@@ -31,11 +29,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 06:30:56 GMT
+      - Wed, 10 Jun 2026 06:33:47 GMT
       Set-Cookie:
-      - JSESSIONID=E1711FFA64B3AFE5CBB3FA5881A7138D; Path=/; HttpOnly
+      - JSESSIONID=CF23A6F34156F21FFE50CB86F0F6138C; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -69,5 +67,5 @@ http_interactions:
         creating //your// own applications with [[App Within Minutes>>AppWithinMinutes]]
         (AWM). \n\nAWM will take care of making it easy for you and your users to
         create and manage the data.\n)))\n)))","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Main","name":"Main","type":"space","url":"https://xwiki.local/bin/view/Main/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Main/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 06:30:56 GMT
+  recorded_at: Wed, 10 Jun 2026 06:33:47 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/query_exact_match.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/query_exact_match.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:07 GMT
       Set-Cookie:
-      - JSESSIONID=86BECC608B1C5FD09A32A74836CAEA4E; Path=/; HttpOnly
+      - JSESSIONID=3CFCEFF117A41EAA3750970A7F16701F; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -42,14 +42,14 @@ http_interactions:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page/pages/WebHome","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null}],"type":"page","id":"xwiki:Test
         Page.WebHome","pageFullName":"Test Page.WebHome","title":"Test Page for RSpec","wiki":"xwiki","space":"Test
-        Page","pageName":"WebHome","modified":1780386902000,"author":"xwiki:XWiki.admin","authorName":null,"version":"4.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":36.06842,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+        Page","pageName":"WebHome","modified":1780386902000,"author":"xwiki:XWiki.admin","authorName":null,"version":"4.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":33.28312,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
+  recorded_at: Wed, 10 Jun 2026 06:23:07 GMT
 - request:
-    method: put
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:Test%20Page.WebHome
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: US-ASCII
+      string: ''
     headers:
       User-Agent:
       - OpenProject 17.6.0 HTTPX Client
@@ -59,14 +59,12 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Content-Length:
-      - '2'
       Authorization:
       - Bearer <SECRET>
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Content-Language:
       - en
@@ -75,11 +73,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:07 GMT
       Set-Cookie:
-      - JSESSIONID=D0C7401B4A9ADC6FF35E556801B050B3; Path=/; HttpOnly
+      - JSESSIONID=09FC7BC444F1E3C1FD3FBCF984C38AC7; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -94,5 +92,5 @@ http_interactions:
         URL Shortener.","content":"This is a test page that I created with my own
         hands.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
         Page","name":"Test Page","type":"space","url":"https://xwiki.local/bin/view/Test%20Page/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+  recorded_at: Wed, 10 Jun 2026 06:23:07 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/query_no_match.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/query_no_match.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:31 GMT
+      - Wed, 10 Jun 2026 06:23:07 GMT
       Set-Cookie:
-      - JSESSIONID=732467DE0A76FD79B8958EC80B2E9BB2; Path=/; HttpOnly
+      - JSESSIONID=6653CAF1A1F9B748F41B143F534D9C38; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
-  recorded_at: Fri, 05 Jun 2026 08:53:31 GMT
+  recorded_at: Wed, 10 Jun 2026 06:23:07 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/query_partial_match.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/query_partial_match.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:31 GMT
+      - Wed, 10 Jun 2026 06:23:07 GMT
       Set-Cookie:
-      - JSESSIONID=61B575D9D2898F806A6569BC6F465501; Path=/; HttpOnly
+      - JSESSIONID=948F6FD6FE46127D21A904F5B4B572C4; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -42,14 +42,14 @@ http_interactions:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/Test%20Page/pages/WebHome","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null}],"type":"page","id":"xwiki:Test
         Page.WebHome","pageFullName":"Test Page.WebHome","title":"Test Page for RSpec","wiki":"xwiki","space":"Test
-        Page","pageName":"WebHome","modified":1780386902000,"author":"xwiki:XWiki.admin","authorName":null,"version":"4.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":15.390617,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
-  recorded_at: Fri, 05 Jun 2026 08:53:31 GMT
+        Page","pageName":"WebHome","modified":1780386902000,"author":"xwiki:XWiki.admin","authorName":null,"version":"4.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":16.572105,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
+  recorded_at: Wed, 10 Jun 2026 06:23:07 GMT
 - request:
-    method: put
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:Test%20Page.WebHome
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: US-ASCII
+      string: ''
     headers:
       User-Agent:
       - OpenProject 17.6.0 HTTPX Client
@@ -59,14 +59,12 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Content-Length:
-      - '2'
       Authorization:
       - Bearer <SECRET>
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Content-Language:
       - en
@@ -75,11 +73,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:07 GMT
       Set-Cookie:
-      - JSESSIONID=753A9D110C6DC9393E3350EA056BBC05; Path=/; HttpOnly
+      - JSESSIONID=53060762864FA5DFC002D5F089BD0319; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -94,5 +92,5 @@ http_interactions:
         URL Shortener.","content":"This is a test page that I created with my own
         hands.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
         Page","name":"Test Page","type":"space","url":"https://xwiki.local/bin/view/Test%20Page/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+  recorded_at: Wed, 10 Jun 2026 06:23:07 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/query_quoted_match.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/query_quoted_match.yml
@@ -27,29 +27,29 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:06 GMT
       Set-Cookie:
-      - JSESSIONID=0A832E95AF62319A728E2D94FF402FD2; Path=/; HttpOnly
+      - JSESSIONID=53DEB144D1160E37FDBE016C6783652A; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
       - 18.3.0
       Content-Length:
-      - '891'
+      - '892'
     body:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/%22Quoted%22%20pages%20can%20be%20tricky/pages/WebHome","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null}],"type":"page","id":"xwiki:\"Quoted\"
         pages can be tricky.WebHome","pageFullName":"\"Quoted\" pages can be tricky.WebHome","title":"\"Quoted\"
-        pages can be tricky","wiki":"xwiki","space":"\"Quoted\" pages can be tricky","pageName":"WebHome","modified":1780387197000,"author":"xwiki:XWiki.admin","authorName":null,"version":"1.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":46.0744,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+        pages can be tricky","wiki":"xwiki","space":"\"Quoted\" pages can be tricky","pageName":"WebHome","modified":1780387197000,"author":"xwiki:XWiki.admin","authorName":null,"version":"1.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":47.94951,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
+  recorded_at: Wed, 10 Jun 2026 06:23:06 GMT
 - request:
-    method: put
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:%22Quoted%22%20pages%20can%20be%20tricky.WebHome
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: US-ASCII
+      string: ''
     headers:
       User-Agent:
       - OpenProject 17.6.0 HTTPX Client
@@ -59,14 +59,12 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Content-Length:
-      - '2'
       Authorization:
       - Bearer <SECRET>
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Content-Language:
       - en
@@ -75,11 +73,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:06 GMT
       Set-Cookie:
-      - JSESSIONID=8074F7A06BEFB236927D7E9858A4D266; Path=/; HttpOnly
+      - JSESSIONID=F53BDBC8DBB650A2E09E519DDCFF22D9; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -95,5 +93,5 @@ http_interactions:
         URL Shortener.","content":"When the page title contains quotes, it''s harder
         to exactly match their page title.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"\"Quoted\"
         pages can be tricky","name":"\"Quoted\" pages can be tricky","type":"space","url":"https://xwiki.local/bin/view/%22Quoted%22%20pages%20can%20be%20tricky/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/%22Quoted%22%20pages%20can%20be%20tricky/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+  recorded_at: Wed, 10 Jun 2026 06:23:06 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/query_unquoted_match.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/query_unquoted_match.yml
@@ -27,29 +27,29 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:06 GMT
       Set-Cookie:
-      - JSESSIONID=85EDC4821BCF449B0D29798F3AD7D750; Path=/; HttpOnly
+      - JSESSIONID=E76D665AE92EA9DECFE756E8101CE2BD; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
       - 18.3.0
       Content-Length:
-      - '891'
+      - '892'
     body:
       encoding: UTF-8
       string: '{"links":[],"searchResults":[{"links":[{"href":"https://xwiki.local/rest/wikis/xwiki/spaces/%22Quoted%22%20pages%20can%20be%20tricky/pages/WebHome","rel":"http://www.xwiki.org/rel/page","type":null,"hrefLang":null}],"type":"page","id":"xwiki:\"Quoted\"
         pages can be tricky.WebHome","pageFullName":"\"Quoted\" pages can be tricky.WebHome","title":"\"Quoted\"
-        pages can be tricky","wiki":"xwiki","space":"\"Quoted\" pages can be tricky","pageName":"WebHome","modified":1780387197000,"author":"xwiki:XWiki.admin","authorName":null,"version":"1.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":46.0744,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+        pages can be tricky","wiki":"xwiki","space":"\"Quoted\" pages can be tricky","pageName":"WebHome","modified":1780387197000,"author":"xwiki:XWiki.admin","authorName":null,"version":"1.1","language":null,"className":null,"objectNumber":null,"filename":null,"score":47.94951,"object":null,"hierarchy":null}],"template":"https://xwiki.local/rest/?q={solrquery}(&number={number})(&start={start})(&orderField={fieldname}(&order={asc|desc}))(&distinct=1)(&prettyNames={false|true})(&wikis={wikis})(&className={classname})"}'
+  recorded_at: Wed, 10 Jun 2026 06:23:06 GMT
 - request:
-    method: put
+    method: get
     uri: https://xwiki.local/rest/openproject/documents?docRef=xwiki:%22Quoted%22%20pages%20can%20be%20tricky.WebHome
     body:
-      encoding: UTF-8
-      string: "{}"
+      encoding: US-ASCII
+      string: ''
     headers:
       User-Agent:
       - OpenProject 17.6.0 HTTPX Client
@@ -59,14 +59,12 @@ http_interactions:
       - gzip, deflate
       Content-Type:
       - application/json
-      Content-Length:
-      - '2'
       Authorization:
       - Bearer <SECRET>
   response:
     status:
-      code: 202
-      message: Accepted
+      code: 200
+      message: OK
     headers:
       Content-Language:
       - en
@@ -75,11 +73,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 08:53:32 GMT
+      - Wed, 10 Jun 2026 06:23:06 GMT
       Set-Cookie:
-      - JSESSIONID=6C4E5F9B0CF3BAD764856C1C7DD0F8DD; Path=/; HttpOnly
+      - JSESSIONID=ABB17E4169B041D4223B7F1C381AD0BE; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -95,5 +93,5 @@ http_interactions:
         URL Shortener.","content":"When the page title contains quotes, it''s harder
         to exactly match their page title.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"\"Quoted\"
         pages can be tricky","name":"\"Quoted\" pages can be tricky","type":"space","url":"https://xwiki.local/bin/view/%22Quoted%22%20pages%20can%20be%20tricky/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/%22Quoted%22%20pages%20can%20be%20tricky/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 08:53:32 GMT
+  recorded_at: Wed, 10 Jun 2026 06:23:06 GMT
 recorded_with: VCR 6.4.0

--- a/spec/support/fixtures/vcr_cassettes/xwiki/stable_page_info.yml
+++ b/spec/support/fixtures/vcr_cassettes/xwiki/stable_page_info.yml
@@ -27,11 +27,11 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 05 Jun 2026 06:33:33 GMT
+      - Wed, 10 Jun 2026 06:31:21 GMT
       Set-Cookie:
-      - JSESSIONID=20FFAE29A62BFE6CEC0152BB7FC0ADB6; Path=/; HttpOnly
+      - JSESSIONID=39C7519D8EAC0C8BA141B8F2519873C0; Path=/; HttpOnly
       Xwiki-Form-Token:
-      - ON8xsHlEpixyujzpUPNupg
+      - L5DY6HB46AhTFvPuxIu0Cg
       Xwiki-User:
       - xwiki:XWiki.admin
       Xwiki-Version:
@@ -46,5 +46,5 @@ http_interactions:
         URL Shortener.","content":"This is a test page that I created with my own
         hands.","clazz":null,"objects":null,"attachments":null,"hierarchy":{"items":[{"label":"xwiki","name":"xwiki","type":"wiki","url":"https://xwiki.local/bin/view/Main/"},{"label":"Test
         Page","name":"Test Page","type":"space","url":"https://xwiki.local/bin/view/Test%20Page/"},{"label":"WebHome","name":"WebHome","type":"document","url":"https://xwiki.local/bin/view/Test%20Page/"}]},"rights":[],"renderedContent":null}'
-  recorded_at: Fri, 05 Jun 2026 06:33:33 GMT
+  recorded_at: Wed, 10 Jun 2026 06:31:21 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
This now allows to fetch canonical page infos using GET and should return a 404 if a page with the given name does not exist.