### PR TITLE
[DREAM-715] Favourite projects are not visible when they are not on the root level

### DIFF
--- a/app/controllers/header/projects_controller.rb
+++ b/app/controllers/header/projects_controller.rb
@@ -162,7 +162,9 @@ class Header::ProjectsController < ApplicationController
   def sort_nodes(nodes)
     nodes.sort_by { |n| n[:project].name.downcase }.each do |node|
       node[:children] = sort_nodes(node[:children])
-      node[:expanded] = node[:children].any? { |c| c[:project].id == @current_project_id || c[:expanded] }
+      node[:expanded] = filter_mode == "favorited" || node[:children].any? do |c|
+        c[:project].id == @current_project_id || c[:expanded]
+      end
     end
   end
 end

--- a/spec/controllers/header/projects_controller_spec.rb
+++ b/spec/controllers/header/projects_controller_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe Header::ProjectsController do
           make_request
           expect(assigns(:favorited_ids)).to include(child_project.id)
         end
+
+        it "marks parent nodes as expanded" do
+          make_request
+          tree = assigns(:tree)
+          parent_node = tree.find { |n| n[:project] == parent_project }
+          expect(parent_node[:expanded]).to be(true)
+        end
       end
 
       context "when the user has no favorites" do


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/DREAM-715

# What are you trying to accomplish?
Always expand the hierarchy in "favorite" mode to avoid that they are not visible because the root node is collapsed

