### PR TITLE
Fix IFC direct upload callback failing on non-standard store paths

### DIFF
--- a/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
+++ b/modules/bim/app/controllers/bim/ifc_models/ifc_models_controller.rb
@@ -78,7 +78,7 @@ module Bim
       end
 
       def direct_upload_finished # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
-        attachment_id = attachment_id_from_key(request.params[:key])
+        attachment_id = session[:pending_ifc_model_attachment_id]
         unless callback_context_valid?(attachment_id)
           fail_direct_upload
           return
@@ -262,10 +262,6 @@ module Bim
         actual_payload = payload.with_indifferent_access.slice(:attachment_id, :project_id, :user_id, :nonce).with_indifferent_access
 
         actual_payload == expected_payload
-      end
-
-      def attachment_id_from_key(key)
-        key.to_s.match(%r{\Auploads/[^/]+/file/(\d+)/[^/]+\z})&.captures&.first
       end
 
       def fail_direct_upload


### PR DESCRIPTION
attachment_id_from_key used a regex anchored to `uploads/` which does not match store paths on SaaS instances where the store_dir is overridden with an instance-specific prefix (e.g. instance_qa_bim/...).

https://community.openproject.org/projects/STB/work_packages/STB-80/activity
