### PR TITLE
Move project menu list into an async call, avoiding the same repeated calls per project

### DIFF
--- a/app/components/admin/custom_fields/custom_field_projects/row_component.rb
+++ b/app/components/admin/custom_fields/custom_field_projects/row_component.rb
@@ -38,8 +38,8 @@ module Admin
           "project-#{project.id}"
         end
 
-        def more_menu_items
-          @more_menu_items ||= [more_menu_detach_project].compact
+        def menu_items
+          @menu_items ||= [more_menu_detach_project].compact
         end
 
         private

--- a/app/components/projects/row_actions_component.html.erb
+++ b/app/components/projects/row_actions_component.html.erb
@@ -1,0 +1,15 @@
+<%=
+  render(Primer::Alpha::ActionMenu::List.new(menu_id:)) do |menu|
+    menu_items.each do |item|
+      item => { scheme:, label:, icon:, **button_options }
+      menu.with_item(
+        scheme:,
+        label:,
+        test_selector: "project-list-row--action-menu-item",
+        content_arguments: button_options
+      ) do |list_item|
+        list_item.with_leading_visual_icon(icon:) if icon
+      end
+    end
+  end
+%>

--- a/app/components/projects/row_actions_component.rb
+++ b/app/components/projects/row_actions_component.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module Projects
+  class RowActionsComponent < ApplicationComponent
+    def self.menu_id(project)
+      "project-#{project.id}-action-menu"
+    end
+
+    def initialize(project:, params:)
+      super()
+      @project = project
+      @params = params
+    end
+
+    def menu_id
+      self.class.menu_id(project)
+    end
+
+    def menu_items
+      [
+        subproject_item,
+        settings_item,
+        activity_item,
+        favorite_item,
+        unfavorite_item,
+        archive_item,
+        unarchive_item,
+        copy_item,
+        delete_item
+      ].compact
+    end
+
+    private
+
+    attr_reader :project, :params
+
+    def currently_favorited?
+      @currently_favorited ||= Favorite.exists?(user: User.current, favorited_type: "Project", favorited_id: project.id)
+    end
+
+    def subproject_item
+      return unless User.current.allowed_in_project?(:add_subprojects, project)
+
+      {
+        scheme: :default,
+        icon: :plus,
+        label: I18n.t(:label_subproject_new),
+        href: new_project_path(parent_id: project.id)
+      }
+    end
+
+    def settings_item
+      return unless User.current.allowed_in_project?(
+        { controller: "/projects/settings/general", action: "show", project_id: project.id },
+        project
+      )
+
+      {
+        scheme: :default,
+        icon: :gear,
+        label: I18n.t(:label_project_settings),
+        href: project_settings_general_path(project),
+        data: { turbo: false }
+      }
+    end
+
+    def activity_item
+      return unless User.current.allowed_in_project?(:view_project_activity, project)
+
+      {
+        scheme: :default,
+        icon: :check,
+        label: I18n.t(:label_project_activity),
+        href: project_activity_index_path(project, event_types: ["project_details"])
+      }
+    end
+
+    def favorite_item
+      return if currently_favorited? || project.archived?
+
+      {
+        scheme: :default,
+        icon: "star",
+        href: helpers.build_favorite_path(project, format: :html),
+        data: { "turbo-method": :post },
+        label: I18n.t(:button_favorite),
+        aria: { label: I18n.t(:button_favorite) }
+      }
+    end
+
+    def unfavorite_item
+      return unless currently_favorited?
+      return if project.archived?
+
+      {
+        scheme: :default,
+        icon: "star-fill",
+        href: helpers.build_favorite_path(project, format: :html),
+        data: { "turbo-method": :delete },
+        classes: "op-primer--star-icon",
+        label: I18n.t(:button_unfavorite),
+        aria: { label: I18n.t(:button_unfavorite) }
+      }
+    end
+
+    def archive_item
+      return unless User.current.allowed_in_project?(:archive_project, project) && project.active?
+
+      {
+        scheme: :default,
+        icon: :lock,
+        label: I18n.t(:button_archive),
+        href: project_archive_path(project, status: params[:status]),
+        data: {
+          turbo_method: :post,
+          turbo_confirm: I18n.t("project.archive.are_you_sure", name: project.name)
+        }
+      }
+    end
+
+    def unarchive_item
+      return unless User.current.admin? && project.archived? && (project.parent.nil? || project.parent.active?)
+
+      {
+        scheme: :default,
+        icon: :unlock,
+        label: I18n.t(:button_unarchive),
+        href: project_archive_path(project, status: params[:status]),
+        data: { turbo_method: :delete }
+      }
+    end
+
+    def copy_item
+      return unless User.current.allowed_in_project?(:copy_projects, project) && !project.archived?
+
+      {
+        scheme: :default,
+        icon: :copy,
+        label: I18n.t(:button_copy),
+        href: copy_project_path(project),
+        data: { turbo: false }
+      }
+    end
+
+    def delete_item
+      return unless User.current.admin
+
+      {
+        scheme: :danger,
+        icon: :trash,
+        label: I18n.t(:button_delete),
+        href: confirm_destroy_project_path(project),
+        data: { turbo_stream: true }
+      }
+    end
+  end
+end

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -277,19 +277,29 @@ module Projects
     def button_links
       # The action menu is currently only relevant for logged in users
       # short-circuiting this call for anonymous users, which often hit our projects page.
-      return [] unless User.current.logged?
+      return [] if !User.current.logged? || menu_items&.empty?
 
-      [action_menu]
+      if menu_items
+        [action_menu(items: menu_items)]
+      else
+        [action_menu(src: menu_href)]
+      end
     end
 
-    def action_menu
-      render(
-        Primer::Alpha::ActionMenu.new(
-          menu_id: Projects::RowActionsComponent.menu_id(project),
-          src: menu_project_path(project, status: params[:status]),
-          test_selector: "project-list-row--action-menu"
-        )
-      ) do |menu|
+    # Subclasses can override inline `menu_items` or `menu_href` in order to control
+    # what is displayed in the action menu.
+    def menu_items = nil
+    def menu_href = menu_project_path(project, status: params[:status])
+
+    def action_menu(src: nil, items: nil)
+      raise ArgumentError, "provide either src: or items:, not both" if src && items
+      raise ArgumentError, "provide either src: or items:" unless src || items
+
+      render(Primer::Alpha::ActionMenu.new(
+               menu_id: Projects::RowActionsComponent.menu_id(project),
+               test_selector: "project-list-row--action-menu",
+               src:
+             )) do |menu|
         menu.with_show_button(
           scheme: :invisible,
           size: :small,
@@ -297,6 +307,15 @@ module Projects
           "aria-label": t(:label_open_menu),
           tooltip_direction: :w
         )
+        items&.each do |action_options|
+          action_options => { scheme:, label:, icon:, **button_options }
+          menu.with_item(scheme:,
+                         label:,
+                         test_selector: "project-list-row--action-menu-item",
+                         content_arguments: button_options) do |item|
+            item.with_leading_visual_icon(icon:) if icon
+          end
+        end
       end
     end
 

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -274,155 +274,28 @@ module Projects
     end
 
     def button_links
-      if more_menu_items.empty?
-        []
-      else
-        [action_menu]
-      end
+      # The action menu is currently only relevant for logged in users
+      # short-circuiting this call for anonymous users, which often hit our projects page.
+      return [] unless User.current.logged?
+
+      [action_menu]
     end
 
     def action_menu
-      render(Primer::Alpha::ActionMenu.new(test_selector: "project-list-row--action-menu")) do |menu|
-        menu.with_show_button(scheme: :invisible,
-                              size: :small,
-                              icon: :"kebab-horizontal",
-                              "aria-label": t(:label_open_menu),
-                              tooltip_direction: :w)
-        more_menu_items.each do |action_options|
-          action_options => { scheme:, label:, icon:, **button_options }
-          menu.with_item(scheme:,
-                         label:,
-                         test_selector: "project-list-row--action-menu-item",
-                         content_arguments: button_options) do |item|
-            item.with_leading_visual_icon(icon:) if icon
-          end
-        end
-      end
-    end
-
-    def more_menu_items
-      @more_menu_items ||= [more_menu_subproject_item,
-                            more_menu_settings_item,
-                            more_menu_activity_item,
-                            more_menu_favorite_item,
-                            more_menu_unfavorite_item,
-                            more_menu_archive_item,
-                            more_menu_unarchive_item,
-                            more_menu_copy_item,
-                            more_menu_delete_item].compact
-    end
-
-    def more_menu_favorite_item
-      return if currently_favorited? || project.archived?
-
-      {
-        scheme: :default,
-        icon: "star",
-        href: helpers.build_favorite_path(project, format: :html),
-        data: { "turbo-method": :post },
-        label: I18n.t(:button_favorite),
-        aria: { label: I18n.t(:button_favorite) }
-      }
-    end
-
-    def more_menu_unfavorite_item
-      return if !currently_favorited? || project.archived?
-
-      {
-        scheme: :default,
-        icon: "star-fill",
-        size: :medium,
-        href: helpers.build_favorite_path(project, format: :html),
-        data: { "turbo-method": :delete },
-        classes: "op-primer--star-icon",
-        label: I18n.t(:button_unfavorite),
-        aria: { label: I18n.t(:button_unfavorite) }
-      }
-    end
-
-    def more_menu_subproject_item
-      if User.current.allowed_in_project?(:add_subprojects, project)
-        {
-          scheme: :default,
-          icon: :plus,
-          label: I18n.t(:label_subproject_new),
-          href: new_project_path(parent_id: project.id)
-        }
-      end
-    end
-
-    def more_menu_settings_item
-      if User.current.allowed_in_project?({ controller: "/projects/settings/general", action: "show", project_id: project.id },
-                                          project)
-        {
-          scheme: :default,
-          icon: :gear,
-          label: I18n.t(:label_project_settings),
-          href: project_settings_general_path(project),
-          data: { turbo: false }
-        }
-      end
-    end
-
-    def more_menu_activity_item
-      if User.current.allowed_in_project?(:view_project_activity, project)
-        {
-          scheme: :default,
-          icon: :check,
-          label: I18n.t(:label_project_activity),
-          href: project_activity_index_path(project, event_types: ["project_details"])
-        }
-      end
-    end
-
-    def more_menu_archive_item
-      if User.current.allowed_in_project?(:archive_project, project) && project.active?
-        {
-          scheme: :default,
-          icon: :lock,
-          label: I18n.t(:button_archive),
-          href: project_archive_path(project, status: params[:status]),
-          data: {
-            turbo_method: :post,
-            turbo_confirm: t("project.archive.are_you_sure", name: project.name)
-          }
-        }
-      end
-    end
-
-    def more_menu_unarchive_item
-      if User.current.admin? && project.archived? && (project.parent.nil? || project.parent.active?)
-        {
-          scheme: :default,
-          icon: :unlock,
-          label: I18n.t(:button_unarchive),
-          href: project_archive_path(project, status: params[:status]),
-          data: { turbo_method: :delete }
-        }
-      end
-    end
-
-    def more_menu_copy_item
-      if User.current.allowed_in_project?(:copy_projects, project) && !project.archived?
-        {
-          scheme: :default,
-          icon: :copy,
-          label: I18n.t(:button_copy),
-          href: copy_project_path(project),
-          data: { turbo: false }
-        }
-      end
-    end
-
-    def more_menu_delete_item
-      if User.current.admin
-        {
-          scheme: :danger,
-          icon: :trash,
-          label: I18n.t(:button_delete),
-          href: confirm_destroy_project_path(project),
-          data: { turbo_stream: true }
-        }
+      render(
+        Primer::Alpha::ActionMenu.new(
+          menu_id: Projects::RowActionsComponent.menu_id(project),
+          src: menu_project_path(project, status: params[:status]),
+          test_selector: "project-list-row--action-menu"
+        )
+      ) do |menu|
+        menu.with_show_button(
+          scheme: :invisible,
+          size: :small,
+          icon: :"kebab-horizontal",
+          "aria-label": t(:label_open_menu),
+          tooltip_direction: :w
+        )
       end
     end
 

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -49,7 +49,8 @@ module Projects
       ""
     end
 
-    def favorited # rubocop:disable Metrics/AbcSize
+    def favorited # rubocop:disable Metrics/AbcSize,Metrics/PerceivedComplexity
+      return nil unless User.current.logged?
       return nil if project.archived?
 
       render(Primer::Beta::IconButton.new(

--- a/app/components/projects/row_component.rb
+++ b/app/components/projects/row_component.rb
@@ -289,7 +289,7 @@ module Projects
     # Subclasses can override inline `menu_items` or `menu_href` in order to control
     # what is displayed in the action menu.
     def menu_items = nil
-    def menu_href = menu_project_path(project, status: params[:status])
+    def menu_href = list_row_menu_project_path(project, status: params[:status])
 
     def action_menu(src: nil, items: nil)
       raise ArgumentError, "provide either src: or items:, not both" if src && items

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -38,7 +38,7 @@ class ProjectsController < ApplicationController
   before_action :find_project_including_archived, only: %i[destroy destroy_info]
   before_action :load_query_or_deny_access, only: %i[index]
   before_action :authorize,
-                only: %i[copy_form copy deactivate_work_package_attachments export_project_initiation_pdf]
+                only: %i[copy_form copy deactivate_work_package_attachments export_project_initiation_pdf menu]
   before_action :authorize_global, only: %i[new create]
   before_action :require_admin, only: %i[destroy destroy_info]
   before_action :find_optional_parent, only: :new
@@ -93,6 +93,10 @@ class ProjectsController < ApplicationController
         render turbo_stream: turbo_streams
       end
     end
+  end
+
+  def menu
+    render Projects::RowActionsComponent.new(project: @project, params:), layout: false
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,17 +34,19 @@ class ProjectsController < ApplicationController
   menu_item :overview
   menu_item :roadmap, only: :roadmap
 
-  before_action :find_project, except: %i[index new create destroy destroy_info]
-  before_action :find_project_including_archived, only: %i[destroy destroy_info]
+  before_action :find_project, except: %i[index new create menu destroy destroy_info]
+  before_action :find_project_including_archived, only: %i[menu destroy destroy_info]
   before_action :load_query_or_deny_access, only: %i[index]
   before_action :authorize,
-                only: %i[copy_form copy deactivate_work_package_attachments export_project_initiation_pdf menu]
+                only: %i[copy_form copy deactivate_work_package_attachments export_project_initiation_pdf]
   before_action :authorize_global, only: %i[new create]
   before_action :require_admin, only: %i[destroy destroy_info]
+  before_action :require_admin_or_active_project, only: :menu
   before_action :find_optional_parent, only: :new
   before_action :find_optional_template, only: %i[new create]
 
   no_authorization_required! :index
+  authorization_checked! :menu
 
   include SortHelper
   include PaginationHelper
@@ -185,6 +187,12 @@ class ProjectsController < ApplicationController
   end
 
   private
+
+  def require_admin_or_active_project
+    return authorize unless @project.archived?
+
+    render_403 message: :notice_not_authorized_archived_project unless current_user.admin?
+  end
 
   def find_project_including_archived
     # The actions that use this method are only accessible to admins, so we can show them archived projects as well and

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,19 +34,19 @@ class ProjectsController < ApplicationController
   menu_item :overview
   menu_item :roadmap, only: :roadmap
 
-  before_action :find_project, except: %i[index new create menu destroy destroy_info]
-  before_action :find_project_including_archived, only: %i[menu destroy destroy_info]
+  before_action :find_project, except: %i[index new create list_row_menu destroy destroy_info]
+  before_action :find_project_including_archived, only: %i[list_row_menu destroy destroy_info]
   before_action :load_query_or_deny_access, only: %i[index]
   before_action :authorize,
                 only: %i[copy_form copy deactivate_work_package_attachments export_project_initiation_pdf]
   before_action :authorize_global, only: %i[new create]
   before_action :require_admin, only: %i[destroy destroy_info]
-  before_action :require_admin_or_active_project, only: :menu
+  before_action :require_admin_or_active_project, only: :list_row_menu
   before_action :find_optional_parent, only: :new
   before_action :find_optional_template, only: %i[new create]
 
   no_authorization_required! :index
-  authorization_checked! :menu
+  authorization_checked! :list_row_menu
 
   include SortHelper
   include PaginationHelper
@@ -97,7 +97,7 @@ class ProjectsController < ApplicationController
     end
   end
 
-  def menu
+  def list_row_menu
     render Projects::RowActionsComponent.new(project: @project, params:), layout: false
   end
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -118,7 +118,7 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin
 
       map.permission :view_project,
-                     { projects: %i[show] },
+                     { projects: %i[show menu] },
                      permissible_on: :project,
                      public: true
 

--- a/config/initializers/permissions.rb
+++ b/config/initializers/permissions.rb
@@ -118,7 +118,7 @@ Rails.application.reloader.to_prepare do
                      require: :loggedin
 
       map.permission :view_project,
-                     { projects: %i[show menu] },
+                     { projects: %i[show list_row_menu] },
                      permissible_on: :project,
                      public: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,8 @@ Rails.application.routes.draw do
 
       get "export_project_initiation", to: "projects#export_project_initiation_pdf"
 
+      get :menu
+
       get :copy, to: "projects#copy_form"
       post :copy
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,7 +401,7 @@ Rails.application.routes.draw do
 
       get "export_project_initiation", to: "projects#export_project_initiation_pdf"
 
-      get :menu
+      get :list_row_menu
 
       get :copy, to: "projects#copy_form"
       post :copy

--- a/modules/costs/app/components/admin/cost_types/cost_type_projects/row_component.rb
+++ b/modules/costs/app/components/admin/cost_types/cost_type_projects/row_component.rb
@@ -38,8 +38,8 @@ module Admin
           "project-#{project.id}"
         end
 
-        def more_menu_items
-          @more_menu_items ||= [more_menu_detach_project].compact
+        def menu_items
+          @menu_items ||= [more_menu_detach_project].compact
         end
 
         private

--- a/modules/storages/app/components/storages/project_storages/projects/row_component.rb
+++ b/modules/storages/app/components/storages/project_storages/projects/row_component.rb
@@ -39,10 +39,13 @@ module Storages::ProjectStorages::Projects
       I18n.t("project_storages.project_folder_mode.#{project_folder_mode}")
     end
 
-    def more_menu_items
-      return [] unless can_view_more_menu_items?
-
-      @more_menu_items ||= [more_menu_edit_project_storage, more_menu_detach_project].compact
+    def menu_items
+      @menu_items ||=
+        if can_view_more_menu_items?
+          [more_menu_edit_project_storage, more_menu_detach_project].compact
+        else
+          []
+        end
     end
 
     private

--- a/spec/components/projects/row_actions_component_spec.rb
+++ b/spec/components/projects/row_actions_component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "rails_helper"
+
+RSpec.describe Projects::RowActionsComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:project) { build_stubbed(:project, name: "My Project No. 1", identifier: "myproject_no_1") }
+  let(:user) { build_stubbed(:user) }
+
+  current_user { user }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(project:, params: {}))
+  end
+
+  describe "menu items" do
+    context "when the user has no project permissions" do
+      it "renders only the favorite item", :aggregate_failures do
+        expect(rendered_component).to have_selector :menuitem, count: 1
+        expect(rendered_component).to have_selector :menuitem, text: "Add to favorites"
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:user) { build_stubbed(:admin) }
+
+      it "renders all applicable items", :aggregate_failures do
+        expect(rendered_component).to have_selector :menuitem, count: 7
+        expect(rendered_component).to have_selector :menuitem, text: "New subproject"
+        expect(rendered_component).to have_selector :menuitem, text: "Project settings"
+        expect(rendered_component).to have_selector :menuitem, text: "Project activity"
+        expect(rendered_component).to have_selector :menuitem, text: "Add to favorites"
+        expect(rendered_component).to have_selector :menuitem, text: "Archive"
+        expect(rendered_component).to have_selector :menuitem, text: "Copy"
+        expect(rendered_component).to have_selector :menuitem, text: "Delete" do |link|
+          expect(link[:href]).to eq confirm_destroy_project_path(project)
+          expect(link[:"data-turbo-stream"]).to eq "true"
+        end
+      end
+    end
+  end
+
+  describe ".menu_id" do
+    it "returns a stable id based on the project" do
+      expect(described_class.menu_id(project)).to eq "project-#{project.id}-action-menu"
+    end
+  end
+end

--- a/spec/components/projects/row_component_spec.rb
+++ b/spec/components/projects/row_component_spec.rb
@@ -61,40 +61,17 @@ RSpec.describe Projects::RowComponent, type: :component do
   end
 
   describe "Menu" do
-    context "when the user has no project edit permissions" do
-      it "renders a Primer ActionMenu (single variant)" do
-        expect(subject).to have_element "action-menu", "data-select-variant": "none"
-      end
+    context "when the user is anonymous" do
+      let(:user) { build_stubbed(:anonymous) }
 
-      it "renders menu items", :aggregate_failures do
-        expect(rendered_component).to have_menu do |menu|
-          expect(menu).to have_selector :menuitem, count: 1
-          expect(menu).to have_selector :menuitem, text: "Add to favorites"
-        end
+      it "renders no action menu" do
+        expect(rendered_component).not_to have_element "action-menu"
       end
     end
 
-    context "when the user has project edit permissions" do
-      let(:user) { build_stubbed(:admin) }
-
-      it "renders a Primer ActionMenu (single variant)" do
-        expect(subject).to have_element "action-menu", "data-select-variant": "none"
-      end
-
-      it "renders menu items", :aggregate_failures do
-        expect(rendered_component).to have_menu do |menu|
-          expect(menu).to have_selector :menuitem, count: 7
-          expect(menu).to have_selector :menuitem, text: "New subproject"
-          expect(menu).to have_selector :menuitem, text: "Project settings"
-          expect(menu).to have_selector :menuitem, text: "Project activity"
-          expect(menu).to have_selector :menuitem, text: "Add to favorites"
-          expect(menu).to have_selector :menuitem, text: "Archive"
-          expect(menu).to have_selector :menuitem, text: "Copy"
-          expect(menu).to have_selector :menuitem, text: "Delete" do |link|
-            expect(link[:href]).to eq confirm_destroy_project_path(project)
-            expect(link[:"data-turbo-stream"]).to eq "true"
-          end
-        end
+    context "when the user is logged in" do
+      it "renders an async Primer ActionMenu shell" do
+        expect(rendered_component).to have_element "action-menu"
       end
     end
   end


### PR DESCRIPTION
Ticket: https://community.openproject.org/wp/OP-19536

The action menu of the project list is currently rendered inline for every project eagerly, which has a significant chunk of render time, especially since a lot of permission checks are involved.

For non-logged-in users, this render time is completely useless, which is why we can also shortcut the menu entirely.

Edit by Attila:
The `RowComponent` is inherited in various places which still define inline menu items. The implementation is updated to handle both inline menu items and a menu url provided.