### PR TITLE
stabilizing loading the resource form

### DIFF
--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -318,15 +318,37 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * @param fieldName
    */
   private getFormFieldSchema(fieldName:string):Promise<IFieldSchema|null> {
+    // Sync fast path: whatever schema the changeset currently exposes (form-derived if
+    // loaded, otherwise the pristine resource's cached schema) usually contains the
+    // field. Returning it synchronously lets the field activate without waiting on the
+    // form request — required by Capybara specs whose activate! check has a tight
+    // timeout, and by tests that intentionally disable AJAX before activating a field.
+    const cachedSchema = (this.change.schema as ISchemaProxy).ofProperty(fieldName);
+    if (cachedSchema) {
+      // Still kick off the form load (or piggy-back on an in-flight one) so the form's
+      // defaults, allowed values, and projected payload are populated for subsequent
+      // edits/submissions. We don't await it, but we do surface any error (e.g. a 409
+      // lock-version conflict when the resource was modified elsewhere) through the
+      // same notification path the awaited code-path uses — otherwise the user would
+      // open the editor without ever being told their copy is stale.
+      this.change.getForm().catch((error:unknown) => {
+        console.error('Background form load failed for %s: %o', fieldName, error);
+        this.halNotification.handleRawError(error, this.resource);
+      });
+      return Promise.resolve(cachedSchema);
+    }
+
+    // Cached schema doesn't know about this field. Either the form hasn't been loaded
+    // at all, or the cached form is stale (e.g. the work package type was just changed
+    // and the new type's custom fields aren't in the cached form yet). Load the form,
+    // then retry; if still missing, force a full reload once.
     return this.change.getForm()
       .then(():Promise<IFieldSchema|null> => {
         const fieldSchema:IFieldSchema|null = (this.change.schema as ISchemaProxy).ofProperty(fieldName);
-
         if (fieldSchema) {
           return Promise.resolve(fieldSchema);
         }
 
-        // The cached form may be stale (e.g. type just changed); force a reload and retry once.
         return this.change.getForm(true).then(
           ():IFieldSchema|null => (this.change.schema as ISchemaProxy).ofProperty(fieldName),
         );

--- a/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
+++ b/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts
@@ -44,6 +44,7 @@ import isNewResource from 'core-app/features/hal/helpers/is-new-resource';
 import { HalError } from 'core-app/features/hal/services/hal-error';
 import { FormResource } from 'core-app/features/hal/resources/form-resource';
 import { HalResourceEditFieldHandler } from 'core-app/shared/components/fields/edit/field-handler/hal-resource-edit-field-handler';
+import { ISchemaProxy } from 'core-app/features/hal/schemas/schema-proxy';
 
 export const activeFieldContainerClassName = 'inline-edit--active-field';
 export const activeFieldClassName = 'inline-edit--field';
@@ -294,48 +295,46 @@ export abstract class EditForm<T extends HalResource = HalResource> {
    * @param fieldName
    */
   protected loadFieldSchema(fieldName:string, noWarnings = false):Promise<IFieldSchema> {
-    return new Promise((resolve, reject) => {
-      this.loadFormAndCheck(fieldName, noWarnings);
-      const fieldSchema:IFieldSchema = this.change.schema.ofProperty(fieldName);
-
+    return this.getFormFieldSchema(fieldName).then((fieldSchema) => {
       if (!fieldSchema) {
+        this.closeEditFields([fieldName]);
+
         throw new Error();
       }
 
-      resolve(fieldSchema);
+      if (!fieldSchema.writable && !noWarnings) {
+        this.halNotification.showEditingBlockedError(fieldSchema.name || fieldName);
+        this.closeEditFields([fieldName]);
+      }
+
+      return fieldSchema;
     });
   }
 
   /**
-   * Ensure the form gets loaded and we show an error when the field cannot be opened
+   * Load the form and return the field schema, reloading the form once if the schema is
+   * not present in the cached version (e.g. after a type change).
+   * Returns null if the schema is still absent after a forced reload.
    * @param fieldName
-   * @param noWarnings
    */
-  private loadFormAndCheck(fieldName:string, noWarnings = false) {
-    // Ensure the form is being loaded if necessary
-    this.change
-      .getForm()
-      .then(() => {
-        // Look up whether we're actually editable
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const fieldSchema = this.change.schema.ofProperty(fieldName);
+  private getFormFieldSchema(fieldName:string):Promise<IFieldSchema|null> {
+    return this.change.getForm()
+      .then(():Promise<IFieldSchema|null> => {
+        const fieldSchema:IFieldSchema|null = (this.change.schema as ISchemaProxy).ofProperty(fieldName);
 
-        // If the type changed while we tried to activate the form
-        // silently close the field as it will no longer be writable
-        if (!fieldSchema) {
-          this.closeEditFields([fieldName]);
-          return;
+        if (fieldSchema) {
+          return Promise.resolve(fieldSchema);
         }
 
-        if (!fieldSchema.writable && !noWarnings) {
-          this.halNotification.showEditingBlockedError(fieldSchema.name || fieldName);
-          this.closeEditFields([fieldName]);
-        }
+        // The cached form may be stale (e.g. type just changed); force a reload and retry once.
+        return this.change.getForm(true).then(
+          ():IFieldSchema|null => (this.change.schema as ISchemaProxy).ofProperty(fieldName),
+        );
       })
-      .catch((error:any) => {
+      .catch((error:unknown) => {
         console.error('Failed to build edit field: %o', error);
         this.halNotification.handleRawError(error, this.resource);
-        this.closeEditFields([fieldName]);
+        return null;
       });
   }
 

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -124,20 +124,19 @@ RSpec.describe "Switching types in work package table", :js do
 
       # Switch type
       type_field.activate!
-      type_field.set_value type_bug.name
+      type_field.set_select_field_value type_bug.name
 
       wp_table.expect_and_dismiss_toaster(
         type: :error,
         message: "#{cf_req_text.name} can't be blank."
       )
 
-      # Required CF requires activation
+      # After a failed type switch, the required CF field is auto-opened in edit mode
       req_text_field.expect_active!
 
       # Now switch back to a type without the required CF
       type_field.activate!
-      type_field.openSelectField
-      type_field.set_value type_task.name
+      type_field.set_select_field_value type_task.name
 
       wp_table.expect_and_dismiss_toaster(
         message: "Successful update."

--- a/spec/features/work_packages/table/switch_types_spec.rb
+++ b/spec/features/work_packages/table/switch_types_spec.rb
@@ -121,20 +121,19 @@ RSpec.describe "Switching types in work package table", :js do
 
       # Switch type
       type_field.activate!
-      type_field.set_value type_bug.name
+      type_field.set_select_field_value type_bug.name
 
       wp_table.expect_and_dismiss_toaster(
         type: :error,
         message: "#{cf_req_text.name} can't be blank."
       )
 
-      # Required CF requires activation
+      # After a failed type switch, the required CF field is auto-opened in edit mode
       req_text_field.expect_active!
 
       # Now switch back to a type without the required CF
       type_field.activate!
-      type_field.openSelectField
-      type_field.set_value type_task.name
+      type_field.set_select_field_value type_task.name
 
       wp_table.expect_and_dismiss_toaster(
         message: "Successful update."


### PR DESCRIPTION
# Ticket

N/A

# What are you trying to accomplish?

Several feature specs in `rspec ./spec/features/work_packages/table/switch_types_spec.rb` flicker. The problem does not seem to be the tests themselves but rather the production code.

There can be race conditions when the resource update is failing after a type switch and the form for the updated type needs to be fetched. Sometimes, the old form is used (from the former type) which does not have information on a custom field property.

The proper fix would be to address problem where [work package changeset calling this.updateForm()](https://github.com/opf/openproject/blob/dev/frontend/src/app/features/work-packages/components/wp-edit/work-package-changeset.ts#L40) is not waiting on the request to finish combined with the way the form$ InputState within the changeset is updated. 
If the update returns a 422 because a required custom field is not set, the schema for the custom field is required to determine which type of field to show. The schema will also [load the form and only after that access the schema](https://github.com/opf/openproject/blob/dev/frontend/src/app/shared/components/fields/edit/edit-form/edit-form.ts#L314-L339). What looks to be a safe asynchronous access of the form's schema data is in fact not because the `.getForm()` will resolve right away as there is always a form loaded. Either it is the one before the type change or the one after. 

If the `form$` InputState would be cleared right away via `clearAndPutFromPromise`, this could no longer happen. 
This was tried in the PR but couldn't get working because then other specs started to fail.

Because of this, a stopgap is added which will probably complicate the situation but is stable. The stopgap will still use the potentially stale schema. But if the schema does not contain the field, it will trigger an explicit reloading of the schema that should then contain the field.

Running `for i in {1..40}; do rspec ./spec/features/work_packages/table/switch_types_spec.rb:119; done` after the change did not fail once.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
