### PR TITLE
Docker Dev environment: trust step-ca certificates in GitLab via trusted-certs volume mount

### DIFF
--- a/docker/dev/gitlab/docker-compose.yml
+++ b/docker/dev/gitlab/docker-compose.yml
@@ -1,20 +1,31 @@
 services:
+  # Omnibus GitLab trusts every .crt in /etc/gitlab/trusted-certs during
+  # reconfigure, but it also rewrites permissions and rehash symlinks in that
+  # directory, so the step-ca root certificate is copied in rather than the
+  # CA volume being mounted there directly.
+  trusted-certs:
+    image: alpine:latest
+    restart: no
+    volumes:
+      - gitlab-etc:/etc/gitlab
+      - type: volume
+        source: step
+        target: /step-certs
+        read_only: true
+        volume:
+          subpath: certs
+    command: install -D -m 644 /step-certs/root_ca.crt /etc/gitlab/trusted-certs/root_ca.crt
+
   gitlab:
     image: gitlab/gitlab-ce:latest
     restart: no
+    depends_on:
+      trusted-certs:
+        condition: service_completed_successfully
     volumes:
       - gitlab-etc:/etc/gitlab
       - gitlab-logs:/var/log/gitlab
       - gitlab-opt:/var/opt/gitlab
-      # Omnibus GitLab trusts every .crt in /etc/gitlab/trusted-certs during
-      # reconfigure, so mounting the step-ca certs there lets webhooks reach the
-      # TLS-encrypted OpenProject host without freezing a full CA bundle.
-      - type: volume
-        source: step
-        target: /etc/gitlab/trusted-certs
-        read_only: true
-        volume:
-          subpath: certs
     environment:
       # Seeds the root password on first boot only; existing instances keep
       # their password (reset via gitlab-rake "gitlab:password:reset[root]")

--- a/docker/dev/gitlab/docker-compose.yml
+++ b/docker/dev/gitlab/docker-compose.yml
@@ -30,6 +30,15 @@ services:
       # Seeds the root password on first boot only; existing instances keep
       # their password (reset via gitlab-rake "gitlab:password:reset[root]")
       GITLAB_ROOT_PASSWORD: "${GITLAB_ROOT_PASSWORD:-openproject}"
+      # Without an external_url GitLab derives URLs from the ephemeral container
+      # hostname, which changes on every recreate and breaks all stored links
+      # (e.g. OpenProject integration records). TLS terminates at traefik, so
+      # nginx stays on plain HTTP.
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url "https://gitlab.${OPENPROJECT_DOCKER_DEV_TLD:-local}"
+        nginx['listen_port'] = 80
+        nginx['listen_https'] = false
+        letsencrypt['enable'] = false
     networks:
       - external
     extra_hosts:

--- a/docker/dev/gitlab/docker-compose.yml
+++ b/docker/dev/gitlab/docker-compose.yml
@@ -15,6 +15,10 @@ services:
         read_only: true
         volume:
           subpath: certs
+    environment:
+      # Seeds the root password on first boot only; existing instances keep
+      # their password (reset via gitlab-rake "gitlab:password:reset[root]")
+      GITLAB_ROOT_PASSWORD: "${GITLAB_ROOT_PASSWORD:-openproject}"
     networks:
       - external
     extra_hosts:

--- a/docker/dev/gitlab/docker-compose.yml
+++ b/docker/dev/gitlab/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   gitlab:
     image: gitlab/gitlab-ce:latest
@@ -8,14 +6,15 @@ services:
       - gitlab-etc:/etc/gitlab
       - gitlab-logs:/var/log/gitlab
       - gitlab-opt:/var/opt/gitlab
-      # Linux
-      - /etc/ssl/certs:/etc/ssl/certs:ro
-      - /usr/local/share/ca-certificates:/usr/local/share/ca-certificates:ro
-      # In case of MacOS, you need to mount the certs from the host machine
-      # having them previously bundled via `sudo update-ca-certificates`
-      #
-      # - ~/.step/certs:/etc/ssl/certs
-      # - ~/.step/certs:/usr/local/share/ca-certificates
+      # Omnibus GitLab trusts every .crt in /etc/gitlab/trusted-certs during
+      # reconfigure, so mounting the step-ca certs there lets webhooks reach the
+      # TLS-encrypted OpenProject host without freezing a full CA bundle.
+      - type: volume
+        source: step
+        target: /etc/gitlab/trusted-certs
+        read_only: true
+        volume:
+          subpath: certs
     networks:
       - external
     extra_hosts:
@@ -30,6 +29,9 @@ volumes:
   gitlab-etc:
   gitlab-logs:
   gitlab-opt:
+  step:
+    name: tls_step
+    external: true
 
 networks:
   external:

--- a/docker/dev/keycloak/docker-compose.yml
+++ b/docker/dev/keycloak/docker-compose.yml
@@ -37,8 +37,17 @@ services:
       - KC_DB_SCHEMA=public
       - KC_HOSTNAME=keycloak.${OPENPROJECT_DOCKER_DEV_TLD:-local}
       - KC_TRANSACTION_XA_ENABLED=false
+      # Keycloak scans this directory for PEM/PKCS12 truststore files on boot,
+      # so pointing it at the mounted step-ca certs lets it trust the local CA
+      # when talking to the TLS-encrypted OpenProject host.
+      - KC_TRUSTSTORE_PATHS=/etc/keycloak/trusted-certs
     volumes:
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+      - type: volume
+        source: step
+        target: /etc/keycloak/trusted-certs
+        read_only: true
+        volume:
+          subpath: certs
       - keycloak-data:/opt/keycloak/data/
       - ./themes/:/opt/keycloak/themes/
     labels:
@@ -51,6 +60,9 @@ services:
 volumes:
   keycloak-data:
   pgdata:
+  step:
+    name: tls_step
+    external: true
 
 networks:
   external:

--- a/docker/dev/tls/docker-compose.core-override.example.yml
+++ b/docker/dev/tls/docker-compose.core-override.example.yml
@@ -4,7 +4,11 @@ x-op-env-override: &environment
   OPENPROJECT_DEV_EXTRA_HOSTS: "${OPENPROJECT_DEV_HOST}"
   OPENPROJECT_HOST__NAME: "${OPENPROJECT_DEV_HOST}"
   OPENPROJECT_HTTPS: true
-  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  # The Debian base image keeps its public CA bundle in the default hashed cert
+  # directory, which OpenSSL still consults alongside SSL_CERT_FILE. Pointing
+  # SSL_CERT_FILE at the mounted step-ca root adds the local CA without losing
+  # public trust.
+  SSL_CERT_FILE: /step/certs/root_ca.crt
   # uncomment and set all the envs below to integrate keycloak with OpenProject
   # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_DISPLAY__NAME: Keycloak
   # OPENPROJECT_OPENID__CONNECT_KEYCLOAK_HOST: keycloak.${OPENPROJECT_DOCKER_DEV_TLD:-local}
@@ -34,13 +38,16 @@ services:
     networks:
       - external
     volumes:
-      # Debian/Arch
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Fedora
-      - /etc/pki/tls/certs/ca-bundle.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Mac OS
-      # - ~/.step/certs:/etc/ssl/certs
-      # - ~/.step/certs:/usr/local/share/ca-certificates
+      # OpenSSL reads SSL_CERT_FILE in addition to the image's public CA bundle,
+      # so mounting the step-ca certs here adds local-CA trust without dropping
+      # public trust. The step container writes these certs owned by uid 1000,
+      # so the dev user must share that uid to read them.
+      - type: volume
+        source: step
+        target: /step/certs
+        read_only: true
+        volume:
+          subpath: certs
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.openproject.rule=Host(`openproject.${OPENPROJECT_DOCKER_DEV_TLD:-local}`)"
@@ -52,30 +59,42 @@ services:
     networks:
       - external
     volumes:
-      # Debian/Arch
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Fedora
-      - /etc/pki/tls/certs/ca-bundle.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Mac OS
-      # - ~/.step/certs:/etc/ssl/certs
-      # - ~/.step/certs:/usr/local/share/ca-certificates
+      - type: volume
+        source: step
+        target: /step/certs
+        read_only: true
+        volume:
+          subpath: certs
 
   backend-test:
+    environment:
+      SSL_CERT_FILE: /step/certs/root_ca.crt
     # Connect the backend-test container to the same network as the backend for nextcloud HTTP interactions
     networks:
       - external
     volumes:
-      # Debian/Arch
-      - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Fedora
-      - /etc/pki/tls/certs/ca-bundle.crt:/etc/ssl/certs/ca-certificates.crt:ro
-      # Mac OS
-      # - ~/.step/certs:/etc/ssl/certs
-      # - ~/.step/certs:/usr/local/share/ca-certificates
+      - type: volume
+        source: step
+        target: /step/certs
+        read_only: true
+        volume:
+          subpath: certs
 
   frontend:
+    environment:
+      # Node appends NODE_EXTRA_CA_CERTS to its built-in roots, so the local CA
+      # is trusted alongside the public ones. Node is the only TLS client in this
+      # container, so it needs no OpenSSL bundle.
+      NODE_EXTRA_CA_CERTS: /step/certs/root_ca.crt
     networks:
       - external
+    volumes:
+      - type: volume
+        source: step
+        target: /step/certs
+        read_only: true
+        volume:
+          subpath: certs
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.openproject-assets.rule=Host(`openproject-assets.${OPENPROJECT_DOCKER_DEV_TLD:-local}`)"
@@ -86,4 +105,11 @@ services:
 networks:
   external:
     name: gateway
+    external: true
+
+# The step-ca certs live in the tls_step volume created by the TLS stack
+# (docker/dev/tls/docker-compose.yml), so bring that stack up first.
+volumes:
+  step:
+    name: tls_step
     external: true

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -321,6 +321,19 @@ docker compose --project-directory docker/dev/tls cp step:/home/step/certs/root_
 The installation of the certificate into the browser depends on the browser you are using, so you should check the docs
 for that specific browser.
 
+#### macOS
+
+On macOS, you need to add the generated root CA to the system keychain.
+
+```shell
+# Copy the root certificate out of the step container, then trust it system-wide.
+docker compose --project-directory docker/dev/tls cp step:/home/step/certs/root_ca.crt /tmp/root_ca.crt
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/root_ca.crt
+```
+
+This covers Safari, Chrome, and host CLI tools. Firefox keeps its own trust store, so import the certificate there
+separately as described under [Browser](#browser).
+
 #### Debian/Ubuntu
 
 On Debian, you need to add the generated root CA to system certificates bundle.

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -545,13 +545,11 @@ docker compose --project-directory docker/dev/gitlab up -d
 
 ### Initial password
 
-Once the GitLab service is started and running, you can access the initial `root` user password as follows:
+On first boot the `root` user password is seeded to `openproject` (configurable through the `GITLAB_ROOT_PASSWORD`
+environment variable, e.g. via an `.env` file next to the compose file). The seed only applies to fresh instances —
+GitLab instances initialized before this variable was set keep their generated password.
 
-```shell
-docker compose --project-directory docker/dev/gitlab exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
-```
-
-Should you need to reset your root password, execute the following command:
+Should you need to reset your root password (for example on a pre-existing instance), execute the following command:
 
 ```shell
 docker compose --project-directory docker/dev/gitlab exec -it gitlab gitlab-rake "gitlab:password:reset[root]"

--- a/docs/development/development-environment/docker/README.md
+++ b/docs/development/development-environment/docker/README.md
@@ -415,6 +415,12 @@ You need to specify, for each service, the `traefik` labels that define its HTTP
 An example configuration is provided in `docker/dev/tls/docker-compose.core-override.example.yml`.
 Copy its contents into your own `docker-compose.override.yml` in the repository root, and adjust hostnames if necessary.
 
+The example also makes the backend, worker, and frontend trust the local CA by mounting the `tls_step` volume's
+`certs` subpath read-only: the Ruby services read it through `SSL_CERT_FILE` and the frontend through
+`NODE_EXTRA_CA_CERTS`, both of which add the local CA on top of the public roots. The step container writes these
+certs as uid 1000, so your dev user needs the same uid to read them; otherwise trust the root CA on the host as
+described above.
+
 Ensure that both the `backend` and `frontend` services:
 - are attached to the same `networks` as `traefik`
 - have the appropriate `traefik` labels
@@ -458,8 +464,9 @@ docker compose up -d backend
 Some development tasks require you to run separate services that interact with OpenProject. For example, you might want
 to have Nextcloud running to test the Nextcloud-OpenProject integration. To do this, you'll need to follow some steps:
 
-1. Add the Nextcloud service to your `docker-compose.override.yml`, with the appropriate traefik labels, network, and
-   ca-bundle mounted.
+1. Add the Nextcloud service to your `docker-compose.override.yml`, with the appropriate traefik labels and network. If
+   the service needs to trust the local CA, mount the `tls_step` volume's `certs` subpath read-only and point the
+   service at it through its native trust mechanism (see the core and Keycloak overrides for examples).
 2. Make sure step-ca can reach it to validate it for SSH. In `docker/dev/tls/docker-compose.override.yml`, add the host
    to the `aliases` section of the traefik networking.
 


### PR DESCRIPTION
# Ticket

Part of the local TLS development setup.

# What are you trying to accomplish?

The local TLS development stack runs behind traefik with step-ca as a local certificate authority. Services that talk to the TLS-encrypted OpenProject host (and to each other) need to trust that local CA. Until now each service trusted it by bind-mounting the host's system CA bundle, which differed per operating system (Debian's `ca-certificates.crt`, Fedora's `ca-bundle.crt`, and a fiddly `~/.step/certs` dance on macOS that needed a manual `update-ca-certificates` run inside a container).

This change feeds every TLS-stack service from the `tls_step` volume that step-ca already populates, each through its own native trust mechanism, so trust no longer depends on the host OS layout.

GitLab's Omnibus image merges any `.crt` under `/etc/gitlab/trusted-certs` on reconfigure, but it also manages that directory (permission rewrites and rehash symlinks), so a one-shot helper service copies the root certificate into it from the CA volume before GitLab starts. Keycloak scans the directory named in `KC_TRUSTSTORE_PATHS` for PEM truststore files on boot, so the certs are mounted read-only and that variable points at them. The OpenProject backend, worker, and test containers set `SSL_CERT_FILE` to the mounted root CA, which OpenSSL reads on top of the image's public bundle rather than replacing it. The frontend sets `NODE_EXTRA_CA_CERTS`, which Node appends to its built-in roots. The GitLab service additionally seeds a known root password (`openproject`, overridable through `GITLAB_ROOT_PASSWORD`) on first boot, since the generated `initial_root_password` file gets deleted 24 hours after the first reconfigure and made password retrieval unreliable. The docker docs describe the volume-based mechanism for the core override and for adding a new service; the existing host-trust instructions for Linux stay, since trusting the root CA on the host is still the right move there.

# What approach did you choose and why?

The certs live in the `tls_step` volume, so every service mounts the volume's `certs` subpath read-only and consumes it through the trust mechanism its runtime already understands, rather than a one-size bundle mount. This keeps one source of truth and drops the per-OS variants.

One constraint is worth calling out: step-ca writes those certs owned by uid 1000 with no group or world access. GitLab (root) and Keycloak (uid 1000) read them directly. The OpenProject containers run as the host user (`DEV_UID=$(id -u)`), so on a host where that uid is not 1000 they cannot read the mounted certs and should fall back to trusting the root CA on the host. This is documented alongside the example override.

# Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)


