### PR TITLE
[Resource Management] Allow editing Work on the WP from the Resource Planner

### DIFF
--- a/app/components/work_packages/progress/base_modal_component.rb
+++ b/app/components/work_packages/progress/base_modal_component.rb
@@ -59,15 +59,23 @@ module WorkPackages
 
       def initialize(work_package,
                      focused_field: nil,
-                     touched_field_map: {})
+                     touched_field_map: {},
+                     submit_path: nil)
         super()
 
         @work_package = work_package
         @focused_field = map_field(focused_field)
         @touched_field_map = touched_field_map
+        @submit_path = submit_path
       end
 
+      # Defaults to the core progress controller, but callers reusing the modal
+      # from another context (e.g. the resource planner) can point the form at
+      # their own endpoint. The live preview derives its URL from the form
+      # action too (`<action>/preview`), so a single override covers both.
       def submit_path
+        return @submit_path if @submit_path
+
         if work_package.new_record?
           url_for(controller: "work_packages/progress",
                   action: "create")

--- a/app/components/work_packages/progress/status_based/modal_body_component.rb
+++ b/app/components/work_packages/progress/status_based/modal_body_component.rb
@@ -34,7 +34,8 @@ module WorkPackages
       class ModalBodyComponent < BaseModalComponent # rubocop:disable OpenProject/AddPreviewForViewComponent
         def initialize(work_package,
                        focused_field: nil,
-                       touched_field_map: {})
+                       touched_field_map: {},
+                       submit_path: nil)
           super
 
           @mode = :status_based

--- a/app/components/work_packages/progress/work_based/modal_body_component.rb
+++ b/app/components/work_packages/progress/work_based/modal_body_component.rb
@@ -35,7 +35,8 @@ module WorkPackages
       class ModalBodyComponent < BaseModalComponent
         def initialize(work_package,
                        focused_field: nil,
-                       touched_field_map: {})
+                       touched_field_map: {},
+                       submit_path: nil)
           super
 
           @mode = :work_based

--- a/app/controllers/concerns/work_packages/progress/modal_params.rb
+++ b/app/controllers/concerns/work_packages/progress/modal_params.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# -- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+# ++
+
+module WorkPackages
+  module Progress
+    # Form glue shared by every controller that renders the progress modal:
+    # parses the hidden `*_touched` inputs so only fields the user actually
+    # edited are written, picks the mode-appropriate attributes, and builds the
+    # modal body component.
+    module ModalParams
+      extend ActiveSupport::Concern
+
+      ERROR_PRONE_ATTRIBUTES = %i[status_id
+                                  estimated_hours
+                                  remaining_hours
+                                  done_ratio].freeze
+
+      private
+
+      def progress_modal_component(submit_path: nil)
+        modal_class.new(@work_package,
+                        focused_field:,
+                        touched_field_map:,
+                        submit_path:)
+      end
+
+      def modal_class
+        if WorkPackage.status_based_mode?
+          WorkPackages::Progress::StatusBased::ModalBodyComponent
+        else
+          WorkPackages::Progress::WorkBased::ModalBodyComponent
+        end
+      end
+
+      def focused_field
+        params[:field]
+      end
+
+      def set_progress_attributes_to_work_package
+        WorkPackages::SetAttributesService
+          .new(user: current_user,
+               model: @work_package,
+               contract_class:)
+          .call(work_package_progress_params)
+      end
+
+      def contract_class
+        if @work_package.new_record?
+          WorkPackages::CreateContract
+        else
+          WorkPackages::UpdateContract
+        end
+      end
+
+      def work_package_progress_params
+        params.require(:work_package)
+              .slice(*allowed_touched_params)
+              .permit!
+      end
+
+      def allowed_touched_params
+        allowed_params.filter { touched?(it) }
+      end
+
+      def allowed_params
+        if WorkPackage.status_based_mode?
+          %i[estimated_hours status_id]
+        else
+          %i[estimated_hours remaining_hours done_ratio]
+        end
+      end
+
+      def touched?(field)
+        touched_field_map[:"#{field}_touched"]
+      end
+
+      # Tolerates a missing `work_package` param so the modal can be opened
+      # without carrying the form values along (e.g. from a context menu).
+      def touched_field_map
+        (params[:work_package] || ActionController::Parameters.new)
+          .slice("estimated_hours_touched",
+                 "remaining_hours_touched",
+                 "done_ratio_touched",
+                 "status_id_touched")
+          .transform_values { it == "true" }
+          .permit!
+      end
+
+      def extra_error_messages(service_call)
+        errors_not_handled_by_progress_modal = service_call.errors.reject do |error|
+          ERROR_PRONE_ATTRIBUTES.include?(error.attribute)
+        end
+
+        join_flash_messages(errors_not_handled_by_progress_modal.map(&:full_message))
+      end
+    end
+  end
+end

--- a/app/controllers/work_packages/progress_controller.rb
+++ b/app/controllers/work_packages/progress_controller.rb
@@ -31,11 +31,7 @@
 class WorkPackages::ProgressController < ApplicationController
   include OpTurbo::ComponentStream
   include FlashMessagesHelper
-
-  ERROR_PRONE_ATTRIBUTES = %i[status_id
-                              estimated_hours
-                              remaining_hours
-                              done_ratio].freeze
+  include WorkPackages::Progress::ModalParams
 
   layout false
   authorization_checked! :new, :edit, :preview, :create, :update
@@ -132,22 +128,6 @@ class WorkPackages::ProgressController < ApplicationController
            }
   end
 
-  def progress_modal_component
-    modal_class.new(@work_package, focused_field:, touched_field_map:)
-  end
-
-  def modal_class
-    if WorkPackage.status_based_mode?
-      WorkPackages::Progress::StatusBased::ModalBodyComponent
-    else
-      WorkPackages::Progress::WorkBased::ModalBodyComponent
-    end
-  end
-
-  def focused_field
-    params[:field]
-  end
-
   def find_work_package
     @work_package = WorkPackage.visible.find(params[:work_package_id])
   end
@@ -160,63 +140,7 @@ class WorkPackages::ProgressController < ApplicationController
     @work_package.clear_changes_information
   end
 
-  def touched_field_map
-    params.require(:work_package)
-          .slice("estimated_hours_touched",
-                 "remaining_hours_touched",
-                 "done_ratio_touched",
-                 "status_id_touched")
-          .transform_values { it == "true" }
-          .permit!
-  end
-
-  def work_package_progress_params
-    params.require(:work_package)
-          .slice(*allowed_touched_params)
-          .permit!
-  end
-
-  def allowed_touched_params
-    allowed_params.filter { touched?(it) }
-  end
-
-  def allowed_params
-    if WorkPackage.status_based_mode?
-      %i[estimated_hours status_id]
-    else
-      %i[estimated_hours remaining_hours done_ratio]
-    end
-  end
-
-  def touched?(field)
-    touched_field_map[:"#{field}_touched"]
-  end
-
-  def set_progress_attributes_to_work_package
-    WorkPackages::SetAttributesService
-      .new(user: current_user,
-           model: @work_package,
-           contract_class:)
-      .call(work_package_progress_params)
-  end
-
-  def contract_class
-    if @work_package.new_record?
-      WorkPackages::CreateContract
-    else
-      WorkPackages::UpdateContract
-    end
-  end
-
   def formatted_duration(hours)
     API::V3::Utilities::DateTimeFormatter.format_duration_from_hours(hours, allow_nil: true)
-  end
-
-  def extra_error_messages(service_call)
-    errors_not_handled_by_progress_modal = service_call.errors.reject do |error|
-      ERROR_PRONE_ATTRIBUTES.include?(error.attribute)
-    end
-
-    join_flash_messages(errors_not_handled_by_progress_modal.map(&:full_message))
   end
 end

--- a/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.html.erb
@@ -1,0 +1,40 @@
+<%#-- copyright
+OpenProject is an open source project management software.
+Copyright (C) the OpenProject GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License version 3.
+
+OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+Copyright (C) 2006-2013 Jean-Philippe Lang
+Copyright (C) 2010-2013 the ChiliProject Team
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+See COPYRIGHT and LICENSE files for more details.
+
+++#%>
+
+<%=
+  render(Primer::Alpha::Dialog.new(id: DIALOG_ID, title:, size: :medium_portrait)) do |dialog|
+    dialog.with_header(variant: :large)
+
+    dialog.with_body do
+      turbo_frame_tag("work_package_progress_modal") do
+        render(modal_component)
+      end
+    end
+  end
+%>

--- a/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.html.erb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.html.erb
@@ -32,7 +32,7 @@ See COPYRIGHT and LICENSE files for more details.
     dialog.with_header(variant: :large)
 
     dialog.with_body do
-      turbo_frame_tag("work_package_progress_modal") do
+      helpers.turbo_frame_tag("work_package_progress_modal") do
         render(modal_component)
       end
     end

--- a/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.rb
@@ -34,6 +34,8 @@ module ResourcePlannerViews::WorkPackageList
   # body keeps the `work_package_progress_modal` turbo frame the live preview
   # navigates, and carries its own submit button.
   class EditTotalWorkDialogComponent < ApplicationComponent
+    include OpTurbo::Streamable
+
     DIALOG_ID = "edit-total-work-dialog"
 
     def initialize(modal_component:)

--- a/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_list/edit_total_work_dialog_component.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ResourcePlannerViews::WorkPackageList
+  # Hosts the core progress modal inside a Primer dialog so a work package's
+  # work / remaining work / % complete can be edited from the list. The modal
+  # body keeps the `work_package_progress_modal` turbo frame the live preview
+  # navigates, and carries its own submit button.
+  class EditTotalWorkDialogComponent < ApplicationComponent
+    DIALOG_ID = "edit-total-work-dialog"
+
+    def initialize(modal_component:)
+      super
+
+      @modal_component = modal_component
+    end
+
+    private
+
+    attr_reader :modal_component
+
+    def title
+      I18n.t("resource_management.work_package_list.context_menu.edit_total_work")
+    end
+  end
+end

--- a/modules/resource_management/app/components/resource_planner_views/work_package_list/row_component.rb
+++ b/modules/resource_management/app/components/resource_planner_views/work_package_list/row_component.rb
@@ -129,7 +129,7 @@ module ResourcePlannerViews::WorkPackageList
                               scheme: :invisible)
 
         see_allocation_item(menu)
-        edit_total_work_item(menu)
+        edit_total_work_item(menu) if allowed_to_edit_work?
         add_user_group_item(menu)
 
         if manual?
@@ -153,8 +153,14 @@ module ResourcePlannerViews::WorkPackageList
     end
 
     def edit_total_work_item(menu)
-      menu.with_item(label: t("resource_management.work_package_list.context_menu.edit_total_work"),
-                     disabled: true) do |item|
+      menu.with_item(
+        label: t("resource_management.work_package_list.context_menu.edit_total_work"),
+        tag: :a,
+        href: helpers.edit_project_resource_planner_view_work_package_progress_path(
+          table.project, table.resource_planner, table.view, work_package
+        ),
+        content_arguments: { data: { controller: "async-dialog" } }
+      ) do |item|
         item.with_leading_visual_icon(icon: :pencil)
       end
     end
@@ -219,6 +225,10 @@ module ResourcePlannerViews::WorkPackageList
 
     def manual?
       table.manual?
+    end
+
+    def allowed_to_edit_work?
+      User.current.allowed_in_project?(:edit_work_packages, work_package.project)
     end
 
     def position_index

--- a/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+module ::ResourceManagement
+  # Edits a work package's progress (work / remaining work / % complete) from a
+  # resource planner work package list, reusing the core progress modal. The
+  # modal form posts back here so a successful save can close the dialog and
+  # refresh the list inline, instead of going through the Angular-driven core
+  # `WorkPackages::ProgressController` flow.
+  class WorkPackageProgressController < BaseController
+    include OpTurbo::ComponentStream
+    include FlashMessagesHelper
+    include PlannerViewContent
+    include WorkPackages::Progress::ModalParams
+
+    menu_item :resource_management
+
+    layout false
+
+    before_action :find_project_by_project_id
+    before_action :find_resource_planner
+    before_action :find_view
+    before_action :find_work_package
+    before_action :authorize
+    before_action :authorize_edit_work_package
+
+    authorization_checked! :edit, :update, :preview
+
+    def edit
+      respond_with_dialog ResourcePlannerViews::WorkPackageList::EditTotalWorkDialogComponent.new(
+        modal_component: progress_modal_component(submit_path: update_path)
+      )
+    end
+
+    def preview
+      set_progress_attributes_to_work_package
+
+      render template: "work_packages/progress/modal",
+             locals: { progress_modal_component: progress_modal_component(submit_path: update_path) }
+    end
+
+    def update
+      call = WorkPackages::UpdateService
+               .new(user: current_user, model: @work_package)
+               .call(work_package_progress_params)
+
+      call.success? ? render_update_success : render_update_failure(call)
+    end
+
+    private
+
+    def render_update_success
+      render_success_flash_message_via_turbo_stream(message: I18n.t(:notice_successful_update))
+      close_dialog_via_turbo_stream(
+        "##{ResourcePlannerViews::WorkPackageList::EditTotalWorkDialogComponent::DIALOG_ID}"
+      )
+      replace_via_turbo_stream(component: work_package_list_content(@view))
+      respond_with_turbo_streams
+    end
+
+    def render_update_failure(call)
+      extra_errors = extra_error_messages(call)
+      render_error_flash_message_via_turbo_stream(message: extra_errors) if extra_errors.present?
+
+      # `@work_package` already carries the rejected attributes and errors from
+      # the failed service call, so the modal re-renders with them in place.
+      update_via_turbo_stream(
+        component: progress_modal_component(submit_path: update_path),
+        method: "morph"
+      )
+      respond_with_turbo_streams(status: :unprocessable_entity)
+    end
+
+    def update_path
+      project_resource_planner_view_work_package_progress_path(
+        @project, @resource_planner, @view, @work_package
+      )
+    end
+
+    def find_resource_planner
+      @resource_planner = ResourcePlanner
+                            .visible(current_user)
+                            .where(project: @project)
+                            .with_children
+                            .find(params.expect(:resource_planner_id))
+    end
+
+    def find_view
+      @view = @resource_planner.children.find(params.expect(:view_id))
+    end
+
+    def find_work_package
+      @work_package = WorkPackage
+                        .visible(current_user)
+                        .where(project: @project)
+                        .find(params.expect(:work_package_id))
+    end
+
+    def authorize_edit_work_package
+      deny_access unless User.current.allowed_in_project?(:edit_work_packages, @project)
+    end
+  end
+end

--- a/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
+++ b/modules/resource_management/app/controllers/resource_management/work_package_progress_controller.rb
@@ -48,9 +48,10 @@ module ::ResourceManagement
     before_action :find_resource_planner
     before_action :find_view
     before_action :find_work_package
-    before_action :authorize
     before_action :authorize_edit_work_package
 
+    # The `.visible` finders above enforce read access (view_resource_planners /
+    # view_work_packages); `authorize_edit_work_package` gates the edit itself.
     authorization_checked! :edit, :update, :preview
 
     def edit

--- a/modules/resource_management/config/routes.rb
+++ b/modules/resource_management/config/routes.rb
@@ -54,6 +54,14 @@ Rails.application.routes.draw do
 
           delete "work_packages/:work_package_id", action: :remove_work_package, as: :remove_work_package
         end
+
+        resources :work_packages, only: [] do
+          resource :progress,
+                   only: %i[edit update],
+                   controller: "resource_management/work_package_progress" do
+            get :preview, on: :member
+          end
+        end
       end
 
       collection do

--- a/modules/resource_management/spec/components/resource_planner_views/work_package_list/row_component_spec.rb
+++ b/modules/resource_management/spec/components/resource_planner_views/work_package_list/row_component_spec.rb
@@ -89,6 +89,36 @@ RSpec.describe ResourcePlannerViews::WorkPackageList::RowComponent, type: :compo
     end
   end
 
+  context "with the edit-work-packages permission" do
+    shared_let(:editor) do
+      create(:user,
+             member_with_permissions: {
+               project => %i[view_resource_planners view_work_packages edit_work_packages]
+             })
+    end
+    let(:query) { automatic_query }
+
+    before { login_as(editor) }
+
+    it "offers the edit total work action linking to the progress dialog" do
+      expect(rendered).to have_text(I18n.t("#{i18n_ns}.edit_total_work"))
+      expect(rendered).to have_css(
+        "a[data-controller='async-dialog']" \
+        "[href='#{edit_project_resource_planner_view_work_package_progress_path(
+          project, resource_planner, view, work_packages.first
+        )}']"
+      )
+    end
+  end
+
+  context "without the edit-work-packages permission" do
+    let(:query) { automatic_query }
+
+    it "hides the edit total work action" do
+      expect(rendered).to have_no_text(I18n.t("#{i18n_ns}.edit_total_work"))
+    end
+  end
+
   context "with members allocated to the work package" do
     let(:query) { automatic_query }
     let(:member) { create(:user, firstname: "Michael", lastname: "Johnson") }

--- a/modules/resource_management/spec/requests/work_package_progress_spec.rb
+++ b/modules/resource_management/spec/requests/work_package_progress_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+#-- copyright
+# OpenProject is an open source project management software.
+# Copyright (C) the OpenProject GmbH
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See COPYRIGHT and LICENSE files for more details.
+#++
+
+require "spec_helper"
+
+RSpec.describe "WorkPackage progress requests", :skip_csrf, type: :rails_request do
+  shared_let(:project) { create(:project, enabled_module_names: %w[resource_management work_package_tracking]) }
+  shared_let(:user) do
+    create(:user,
+           member_with_permissions: {
+             project => %i[view_resource_planners view_work_packages edit_work_packages]
+           })
+  end
+  shared_let(:resource_planner) { create(:resource_planner, project:, principal: user, public: true) }
+  shared_let(:view) do
+    create(:resource_work_package_list, name: "Team work", parent: resource_planner, project:, principal: user)
+  end
+  shared_let(:work_package) { create(:work_package, project:, subject: "Build the thing") }
+
+  let(:edit_path) do
+    edit_project_resource_planner_view_work_package_progress_path(project, resource_planner, view, work_package)
+  end
+  let(:update_path) do
+    project_resource_planner_view_work_package_progress_path(project, resource_planner, view, work_package)
+  end
+  let(:preview_path) do
+    preview_project_resource_planner_view_work_package_progress_path(project, resource_planner, view, work_package)
+  end
+
+  before { login_as(user) }
+
+  describe "GET edit" do
+    it "renders the progress modal inside the edit dialog" do
+      get edit_path, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(ResourcePlannerViews::WorkPackageList::EditTotalWorkDialogComponent::DIALOG_ID)
+      expect(response.body).to include("work_package_progress_modal")
+      # The form posts back here, not to the core progress controller.
+      expect(response.body).to include(update_path)
+    end
+  end
+
+  describe "PATCH update" do
+    let(:params) do
+      {
+        "work_package" => {
+          "estimated_hours" => "42",
+          "remaining_hours" => "4h",
+          "done_ratio" => "90",
+          "estimated_hours_touched" => "true",
+          "remaining_hours_touched" => "true",
+          "done_ratio_touched" => "false"
+        }
+      }
+    end
+
+    it "applies the touched values, closes the dialog and refreshes the list" do
+      patch update_path, params:, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      work_package.reload
+      expect(work_package.estimated_hours).to eq(42)
+      expect(work_package.remaining_hours).to eq(4)
+
+      # The work package list content is re-rendered inline (its sub-header
+      # links back to the view's settings) and a success flash is shown.
+      expect(response.body).to include(edit_project_resource_planner_view_path(project, resource_planner, view))
+      expect(response).to have_turbo_stream action: "flash"
+    end
+
+    context "when a progress value is invalid" do
+      before { params["work_package"]["estimated_hours"] = "-1" }
+
+      it "replies 422 and re-renders the modal without persisting" do
+        patch update_path, params:, as: :turbo_stream
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_turbo_stream action: "update"
+        expect(work_package.reload.estimated_hours).to be_nil
+      end
+    end
+  end
+
+  describe "GET preview" do
+    let(:params) do
+      {
+        "field" => "work_package[estimated_hours]",
+        "work_package" => {
+          "estimated_hours" => "10",
+          "remaining_hours" => "",
+          "done_ratio" => "",
+          "estimated_hours_touched" => "true",
+          "remaining_hours_touched" => "false",
+          "done_ratio_touched" => "false"
+        }
+      }
+    end
+
+    it "renders the progress modal frame with derived values without persisting" do
+      get preview_path, params:, as: :turbo_stream
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("work_package_progress_modal")
+      expect(work_package.reload.estimated_hours).to be_nil
+    end
+  end
+
+  describe "authorization" do
+    context "without the edit_work_packages permission" do
+      shared_let(:viewer) do
+        create(:user, member_with_permissions: { project => %i[view_resource_planners view_work_packages] })
+      end
+
+      before { login_as(viewer) }
+
+      it "is forbidden" do
+        get edit_path, as: :turbo_stream
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the work package is not visible to the user" do
+      let(:other_project) { create(:project, enabled_module_names: %w[work_package_tracking]) }
+      let(:invisible_work_package) { create(:work_package, project: other_project) }
+      let(:invisible_path) do
+        edit_project_resource_planner_view_work_package_progress_path(
+          project, resource_planner, view, invisible_work_package
+        )
+      end
+
+      it "returns not found" do
+        get invisible_path, as: :turbo_stream
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/projects/OP/work_packages/OP-19206/activity

Wires up the `Edit total work` context menu item in the work package list view