### PR TITLE
[AGILE-283] Rearrange "More" menu options for backlog/sprint items

### DIFF
--- a/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
+++ b/modules/backlogs/app/components/backlogs/work_package_card_menu_component.html.erb
@@ -69,52 +69,51 @@ See COPYRIGHT and LICENSE files for more details.
 
     if show_move_submenu?
       list.with_divider
-      list.with_item(
-        component_klass: Primer::Alpha::ActionMenu::SubMenuItem,
-        label: t(".action_menu.move_menu"),
-        select_variant: :none,
-        form_arguments: {}
-      ) do |move_menu|
-        move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
 
-        with_item_group(move_menu) do
-          build_move_menu(move_menu)
+      if show_move_to_inbox?
+        list.with_item(
+          id: dom_target(work_package, :menu, :move_to_inbox),
+          label: t(".action_menu.move_to_inbox"),
+          tag: :button,
+          href: move_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
+          form_arguments: { method: :put, inputs: [{ name: "target_id", value: "inbox" }] }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :inbox)
         end
+      end
 
-        with_item_group(move_menu) do
-          if show_move_to_inbox?
-            move_menu.with_item(
-              id: dom_target(work_package, :menu, :move_to_inbox),
-              label: t(".action_menu.move_to_inbox"),
-              tag: :button,
-              href: move_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
-              form_arguments: { method: :put, inputs: [{ name: "target_id", value: "inbox" }] }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :inbox)
-            end
-          end
+      if show_move_to_backlog_bucket?
+        list.with_item(
+          id: dom_target(work_package, :menu, :move_to_backlog_bucket),
+          label: t(".action_menu.move_to_backlog_bucket"),
+          href: move_to_bucket_dialog_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :package)
+        end
+      end
 
-          if show_move_to_backlog_bucket?
-            move_menu.with_item(
-              id: dom_target(work_package, :menu, :move_to_backlog_bucket),
-              label: t(".action_menu.move_to_backlog_bucket"),
-              href: move_to_bucket_dialog_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
-              content_arguments: { data: { controller: "async-dialog" } }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :package)
-            end
-          end
+      if show_move_to_sprint?
+        list.with_item(
+          id: dom_target(work_package, :menu, :move_to_sprint),
+          label: t(".action_menu.move_to_sprint"),
+          href: move_to_sprint_dialog_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
+          content_arguments: { data: { controller: "async-dialog" } }
+        ) do |item|
+          item.with_leading_visual_icon(icon: :zap)
+        end
+      end
 
-          if show_move_to_sprint?
-            move_menu.with_item(
-              id: dom_target(work_package, :menu, :move_to_sprint),
-              label: t(".action_menu.move_to_sprint"),
-              href: move_to_sprint_dialog_project_backlogs_work_package_path(project, work_package, all_backlogs_params),
-              content_arguments: { data: { controller: "async-dialog" } }
-            ) do |item|
-              item.with_leading_visual_icon(icon: :zap)
-            end
-          end
+      if show_move_items?
+        list.with_item(
+          component_klass: Primer::Alpha::ActionMenu::SubMenuItem,
+          label: t(".action_menu.move_menu"),
+          select_variant: :none,
+          form_arguments: {}
+        ) do |move_menu|
+          move_menu.with_leading_visual_icon(icon: :"op-arrow-in")
+
+          build_move_menu(move_menu)
         end
       end
     end

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -213,7 +213,7 @@ en:
         copy_work_package_id: "Copy work package ID"
         move_menu: "Move to position"
         move_to_backlog_bucket: "Move to backlog bucket"
-        move_to_inbox: "Move to inbox"
+        move_to_inbox: "Move to backlog inbox"
         move_to_sprint: "Move to sprint"
 
     work_package_is_closed: "Work package is done, when"

--- a/modules/backlogs/config/locales/en.yml
+++ b/modules/backlogs/config/locales/en.yml
@@ -211,7 +211,7 @@ en:
       action_menu:
         copy_url_to_clipboard: "Copy URL to clipboard"
         copy_work_package_id: "Copy work package ID"
-        move_menu: "Move"
+        move_menu: "Move to position"
         move_to_backlog_bucket: "Move to backlog bucket"
         move_to_inbox: "Move to inbox"
         move_to_sprint: "Move to sprint"

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -180,10 +180,10 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       expect(page).to have_css(".ActionList-sectionDivider")
     end
 
-    it "shows the Move submenu with incoming-arrow icon" do
+    it "shows the Move to position submenu with incoming-arrow icon" do
       render_component
 
-      expect(page).to have_selector(:menuitem, text: "Move")
+      expect(page).to have_selector(:menuitem, text: "Move to position")
       expect(page).to have_octicon(:"op-arrow-in")
     end
   end
@@ -300,10 +300,10 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
       context "when the work package is already in the inbox" do
         let(:sprint) { nil }
 
-        it "hides the Move submenu entirely" do
+        it "hides the Move to position submenu entirely" do
           render_component(open_sprints_exist: false, other_buckets_exist: false)
 
-          expect(page).to have_no_selector(:menuitem, text: "Move")
+          expect(page).to have_no_selector(:menuitem, text: "Move to position")
         end
       end
     end

--- a/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
+++ b/modules/backlogs/spec/components/backlogs/work_package_card_menu_component_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Backlogs::WorkPackageCardMenuComponent, type: :component do
     end
   end
 
-  describe "Move to inbox item" do
+  describe "Move to backlog inbox item" do
     context "when work package is in a sprint" do
       it "is shown with inbox icon" do
         render_component

--- a/modules/backlogs/spec/features/inbox_column_spec.rb
+++ b/modules/backlogs/spec/features/inbox_column_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       before { planning_page.visit! }
 
       it "moves the item to the bottom of the selected sprint" do
-        planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move to sprint", wait: false)
+        planning_page.click_in_work_package_menu(inbox_wp1, "Move to sprint", wait: false)
 
         within_modal "Move to sprint" do
           # Expect to have all sprints listed
@@ -281,7 +281,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
 
       context "when the target sprint is completed (race condition #73750)" do
         it "shows an error and does not move the item" do
-          planning_page.click_in_work_package_move_submenu(inbox_wp1, "Move to sprint", wait: false)
+          planning_page.click_in_work_package_menu(inbox_wp1, "Move to sprint", wait: false)
 
           within_modal "Move to sprint" do
             expect(page).to have_select("target_id", with_options: ["Sprint 1", "Sprint 2"])
@@ -466,7 +466,7 @@ RSpec.describe "Inbox column in sprint planning view", :js do
       planning_page.expect_no_inbox_show_more
 
       # Move an inbox item to the sprint via the dialog
-      planning_page.click_in_work_package_move_submenu(inbox_items.last, "Move to sprint", wait: false)
+      planning_page.click_in_work_package_menu(inbox_items.last, "Move to sprint", wait: false)
       within_modal "Move to sprint" do
         select sprint.name, from: "target_id"
         click_button "Move"

--- a/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe "Move to backlog", :js do
 
   current_user { user }
 
-  describe "Move to inbox" do
+  describe "Move to backlog inbox" do
     context "when in a sprint" do
       let!(:work_package) { create(:work_package, project:, sprint:) }
 
       it "moves the work package to the backlog inbox" do
         planning_page.visit!
-        planning_page.click_in_work_package_menu(work_package, "Move to inbox")
+        planning_page.click_in_work_package_menu(work_package, "Move to backlog inbox")
 
         planning_page.expect_work_package_not_in_sprint(work_package, sprint)
         planning_page.expect_inbox_item(work_package)
@@ -71,7 +71,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "moves the work package to the backlog inbox" do
         planning_page.visit!
-        planning_page.click_in_work_package_menu(work_package, "Move to inbox")
+        planning_page.click_in_work_package_menu(work_package, "Move to backlog inbox")
 
         planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
         planning_page.expect_inbox_item(work_package)

--- a/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
+++ b/modules/backlogs/spec/features/work_packages/move_to_backlog_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "moves the work package to the backlog inbox" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to inbox")
+        planning_page.click_in_work_package_menu(work_package, "Move to inbox")
 
         planning_page.expect_work_package_not_in_sprint(work_package, sprint)
         planning_page.expect_inbox_item(work_package)
@@ -71,7 +71,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "moves the work package to the backlog inbox" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to inbox")
+        planning_page.click_in_work_package_menu(work_package, "Move to inbox")
 
         planning_page.expect_work_package_not_in_backlog_bucket(work_package, bucket_a)
         planning_page.expect_inbox_item(work_package)
@@ -85,7 +85,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected bucket" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to backlog bucket")
+        planning_page.click_in_work_package_menu(work_package, "Move to backlog bucket")
 
         within_modal "Move to backlog bucket" do
           select bucket_b.name, from: "target_id"
@@ -104,7 +104,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected bucket" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to backlog bucket")
+        planning_page.click_in_work_package_menu(work_package, "Move to backlog bucket")
 
         within_modal "Move to backlog bucket" do
           select bucket_a.name, from: "target_id"
@@ -123,7 +123,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog excluding the current bucket, and moves to another bucket" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to backlog bucket")
+        planning_page.click_in_work_package_menu(work_package, "Move to backlog bucket")
 
         within_modal "Move to backlog bucket" do
           expect(page).to have_no_css("option", text: bucket_a.name)
@@ -151,7 +151,7 @@ RSpec.describe "Move to backlog", :js do
         planning_page.visit!
         planning_page.expect_work_package_in_sprint(work_package, sprint)
 
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to sprint", wait: false)
+        planning_page.click_in_work_package_menu(work_package, "Move to sprint", wait: false)
 
         within_modal "Move to sprint" do
           expect(page).to have_no_select("target_id", with_options: [sprint.name])
@@ -173,7 +173,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected sprint" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to sprint")
+        planning_page.click_in_work_package_menu(work_package, "Move to sprint")
 
         within_modal "Move to sprint" do
           select sprint.name, from: "target_id"
@@ -192,7 +192,7 @@ RSpec.describe "Move to backlog", :js do
 
       it "opens the dialog and moves the work package to the selected sprint" do
         planning_page.visit!
-        planning_page.click_in_work_package_move_submenu(work_package, "Move to sprint", wait: false)
+        planning_page.click_in_work_package_menu(work_package, "Move to sprint", wait: false)
 
         within_modal "Move to sprint" do
           select sprint.name, from: "target_id"

--- a/modules/backlogs/spec/support/pages/backlog.rb
+++ b/modules/backlogs/spec/support/pages/backlog.rb
@@ -298,6 +298,14 @@ module Pages
       dismiss_menu(work_package)
     end
 
+    def click_in_work_package_menu(work_package, item_name, wait: true)
+      within_work_package_menu(work_package) do |submenu|
+        wait_for_turbo_stream(wait:) do
+          submenu.find(:menuitem, text: item_name).click
+        end
+      end
+    end
+
     def within_work_package_move_submenu(work_package, &)
       within_work_package_menu(work_package) do |menu|
         yield open_move_submenu(menu)
@@ -581,7 +589,7 @@ module Pages
     end
 
     def open_move_submenu(menu)
-      move_item = menu.find(:menuitem, text: "Move")
+      move_item = menu.find(:menuitem, text: "Move to position")
       move_item.click
       page.find(:menu, id: move_item["aria-controls"])
     end


### PR DESCRIPTION
# Ticket
https://community.openproject.org/wp/AGILE-283
https://community.openproject.org/wp/AGILE-286

# What are you trying to accomplish?
Move the "Move to" menus one level up in the backlog work package actions.
Rename "Move to inbox" to "Move to backlog inbox"

## Screenshots
<details><summary>Screenshot for single work package in a bucket.</summary>
<p>

<img width="496" height="493" alt="image" src="https://github.com/user-attachments/assets/03f5831a-dd5c-4d5e-889a-0cbf97d71f1e" />

</p>
</details> 

<details><summary>Screenshot for multiple work packages in a sprint.</summary>
<p>

<img width="489" height="555" alt="image" src="https://github.com/user-attachments/assets/1f717f38-f7ef-45b5-9e57-d14f0fbf1b7f" />

</p>
</details> 

# What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Describe any alternative approaches you considered and why you discarded them. -->

# Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation in Lookbook (patterns, previews, etc)
- [ ] Tested major browsers (Chrome, Firefox, Edge, ...)
